### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Note: there seems to be a lot of contention about the usefulness of CODEOWNERS.
+# We should make sure to have a discussion before making code owners more widespread, as it
+# potentially causes a lot of extra noise for developers.
+#
+# See https://about.sourcegraph.com/blog/a-different-way-to-think-about-code-ownership/
+# See https://bionic.fullstory.com/taming-github-codeowners-with-bots/
+
+# We want to make sure any changes to workflows are closely monitored, as they may have non-obvious
+# security implications.
+#
+# See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+/.github/workflows/ @devinrsmith


### PR DESCRIPTION
Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners