### PR TITLE
Upload check-ci results as artifact

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -35,12 +35,9 @@ jobs:
           arguments: --scan quick
           gradle-version: wrapper
 
-      - name: Publish Test Results
-        uses: scacap/action-surefire-report@v1
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
         if: always()
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
         with:
-          check_name: check-ci test report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          name: check-ci-results
+          path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/long-check-ci.yml
+++ b/.github/workflows/long-check-ci.yml
@@ -34,12 +34,9 @@ jobs:
           arguments: --scan --continue check
           gradle-version: wrapper
 
-      - name: Publish Test Results
-        uses: scacap/action-surefire-report@v1
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
         if: always()
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
         with:
-          check_name: long-check-ci test report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          name: long-check-ci-results
+          path: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/publish-check-ci.yml
+++ b/.github/workflows/publish-check-ci.yml
@@ -1,0 +1,48 @@
+name: Publish Check CI results
+
+# WARNING:
+# workflow_run provides read-write repo token and access to secrets.
+# Do *not* merge changes to this file without the proper review.
+# We should only be running trusted code here.
+on:
+  workflow_run:
+    workflows: ["Check CI"]
+    types:
+      - completed
+
+jobs:
+  # Job based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  publish-check-ci:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # Unfortunately, the official actions/download-artifact action is very limited in scope.
+      # Can't use it yet in this context, https://github.com/actions/download-artifact/issues/60
+      - name: Download artifact
+        uses: actions/github-script@v3.1.1
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "check-ci-results"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/check-ci-results.zip', Buffer.from(download.data));
+      - run: unzip check-ci-results.zip
+      - name: Publish Test Results
+        uses: scacap/action-surefire-report@v1.0.9
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+        with:
+          check_name: check-ci test report
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/publish-long-check-ci.yml
+++ b/.github/workflows/publish-long-check-ci.yml
@@ -1,0 +1,48 @@
+name: Publish Long CI results
+
+# WARNING:
+# workflow_run provides read-write repo token and access to secrets.
+# Do *not* merge changes to this file without the proper review.
+# We should only be running trusted code here.
+on:
+  workflow_run:
+    workflows: ["Long Check CI"]
+    types:
+      - completed
+
+jobs:
+  # Job based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  publish-long-check-ci:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # Unfortunately, the official actions/download-artifact action is very limited in scope.
+      # Can't use it yet in this context, https://github.com/actions/download-artifact/issues/60
+      - name: Download artifact
+        uses: actions/github-script@v3.1.1
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "long-check-ci-results"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/long-check-ci-results.zip', Buffer.from(download.data));
+      - run: unzip long-check-ci-results.zip
+      - name: Publish Test Results
+        uses: scacap/action-surefire-report@v1.0.9
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+        with:
+          check_name: long-check-ci test report
+          report_paths: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
Unfortunately, I don't think there is an easy way to test out the publishing side without actually merging it, since the workflow_run event is based on the *default* branch, and not the merging branch.