### PR TITLE
Fail workflows if the unit test reports have failures

### DIFF
--- a/.github/scripts/fail-on-xml-failures.sh
+++ b/.github/scripts/fail-on-xml-failures.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# TODO (core#567)
+# Would be great to replace this with an official action, since this is fragile.
+if [[ $(find . -type f -path "*/build/test-results/*" -name "TEST-*.xml" -exec sed -n '2p' {} \; | grep -v "failures=\"0\"" | head --bytes 1 | wc --bytes) -ne 0 ]]; then
+    echo "Found XML unit test failures, exiting with 1"
+    exit 1
+fi

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -35,6 +35,10 @@ jobs:
           arguments: --scan quick
           gradle-version: wrapper
 
+      - name: Check for xml failures
+        run: |
+          ./.github/scripts/fail-on-xml-failures.sh
+        
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/long-check-ci.yml
+++ b/.github/workflows/long-check-ci.yml
@@ -34,6 +34,10 @@ jobs:
           arguments: --scan --continue check
           gradle-version: wrapper
 
+      - name: Check for xml failures
+        run: |
+          ./.github/scripts/fail-on-xml-failures.sh
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
         if: always()


### PR DESCRIPTION
Right now, we are relying on our *publishing* side to post failure annotations instead of the actual wokrflow itself failing out. The actual workflow failing is much preferred, as we have badges for them, and it provides more immediate and true feedback to the PRs.