### PR TITLE
Do not return null from SortedRanges.invert on invalid argument.  Towards #544.

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/utils/sortedranges/SortedRanges.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/sortedranges/SortedRanges.java
@@ -4878,12 +4878,16 @@ public abstract class SortedRanges extends RefCountedCow<SortedRanges> implement
             return TreeIndexImpl.EMPTY;
         }
         if (keys instanceof SingleRange) {
-            return invertRangeOnNew(keys.ixFirstKey(), keys.ixLastKey(), maxPosition);
-        }
-        final Index.RangeIterator rit = keys.ixRangeIterator();
-        final TreeIndexImplSequentialBuilder builder = new TreeIndexImplSequentialBuilder();
-        if (invertOnNew(rit, builder, maxPosition)) {
-            return builder.getTreeIndexImpl();
+            final TreeIndexImpl r = invertRangeOnNew(keys.ixFirstKey(), keys.ixLastKey(), maxPosition);
+            if (r != null) {
+                return r;
+            }
+        } else {
+            final Index.RangeIterator rit = keys.ixRangeIterator();
+            final TreeIndexImplSequentialBuilder builder = new TreeIndexImplSequentialBuilder();
+            if (invertOnNew(rit, builder, maxPosition)) {
+                return builder.getTreeIndexImpl();
+            }
         }
         throw new IllegalArgumentException("keys argument has elements not in the index");
     }


### PR DESCRIPTION
Ensure we throw instead of returning null; one path through SR.ixInvertOnNew was returning null.