### PR TITLE
Rename project to Deephaven Community Core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ allprojects*.tasks*.withType(JavaCompile)*.configureEach {
 
 subprojects {
     Project p ->
-    p.group = 'iris'
+    p.group = 'io.deephaven'
     p.version = globalVersion
     p.plugins.apply('io.deephaven.java-conventions')
     License.createFrom(p).register(p)

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ allprojects*.tasks*.withType(JavaCompile)*.configureEach {
 
 subprojects {
     Project p ->
-    p.group = 'io.deephaven'
+    p.group = 'iris'
     p.version = globalVersion
     p.plugins.apply('io.deephaven.java-conventions')
     License.createFrom(p).register(p)

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,8 @@ plugins {
 
 gradle.ext.buildStartTime = new Date()
 
+rootProject.name='Deephaven Community Core'
+
 String[] bins = ['configs', 'test-configs' ]
 
 String[] mods = [ 'Util', 'Numerics', 'TableLogger', 'DB', 'Plot',
@@ -48,9 +50,6 @@ pyMods.each {
         include(name)
         project(":$name").projectDir = file(dir)
 }
-
-// the name of the root project is the default groupId used for published artifacts.
-rootProject.name='deephaven'
 
 include 'fishconfig-local'
 include 'DHProcess'

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,7 +50,7 @@ pyMods.each {
 }
 
 // the name of the root project is the default groupId used for published artifacts.
-rootProject.name='iris'
+rootProject.name='deephaven'
 
 include 'fishconfig-local'
 include 'DHProcess'


### PR DESCRIPTION
Right now our javadoc says "iris API". This change will make it show "Deephaven Community Core API".