### PR TITLE
remove the need to use 'call' on Groovy closures in Query Strings

### DIFF
--- a/DB/src/main/java/io/deephaven/db/tables/lang/DBLanguageParser.java
+++ b/DB/src/main/java/io/deephaven/db/tables/lang/DBLanguageParser.java
@@ -356,15 +356,16 @@ public final class DBLanguageParser extends GenericVisitorAdapter<Class, DBLangu
         final ArrayList<Method> acceptableMethods = new ArrayList<>();
 
         if (scope==null){
-            for (final Class classImport : staticImports){
-                for (Method method : classImport.getDeclaredMethods()){
+            for (final Class classImport : staticImports) {
+                for (Method method : classImport.getDeclaredMethods()) {
                     possiblyAddExecutable(acceptableMethods, method, methodName, paramTypes, parameterizedTypes);
                 }
             }
-            // for Python func call syntax without the explicit 'call' keyword, check if it is defined in Query scope
+            // for Python function/Groovy closure call syntax without the explicit 'call' keyword, check if it is defined in Query scope
             if (acceptableMethods.size() == 0) {
-                if ( variables.get(methodName) == PythonScopeJpyImpl.CallableWrapper.class) {
-                    for (Method method : PythonScopeJpyImpl.CallableWrapper.class.getDeclaredMethods()) {
+                Class methodCls = variables.get(methodName);
+                if (methodCls == PythonScopeJpyImpl.CallableWrapper.class || methodCls == groovy.lang.Closure.class) {
+                    for (Method method : methodCls.getDeclaredMethods()) {
                         possiblyAddExecutable(acceptableMethods, method, "call", paramTypes, parameterizedTypes);
                     }
                 }
@@ -576,6 +577,16 @@ public final class DBLanguageParser extends GenericVisitorAdapter<Class, DBLangu
     }
 
     private static <EXECUTABLE_TYPE extends Executable> Boolean isMoreSpecificExecutable(final EXECUTABLE_TYPE e1, final EXECUTABLE_TYPE e2) {
+
+        // var args (variable arity) methods always go after fixed arity methods when determining the proper overload
+        // https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.12.2
+        if (e1.isVarArgs() && !e2.isVarArgs()) {
+            return true;
+        }
+        if (e2.isVarArgs() && !e1.isVarArgs()) {
+            return false;
+        }
+
         final Class[] e1ParamTypes = e1.getParameterTypes();
         final Class[] e2ParamTypes = e2.getParameterTypes();
 
@@ -1515,8 +1526,9 @@ public final class DBLanguageParser extends GenericVisitorAdapter<Class, DBLangu
 
         expressions=convertParameters(method, argumentTypes, expressionTypes, parameterizedTypes, expressions);
 
-        if (method.getDeclaringClass() == PythonScopeJpyImpl.CallableWrapper.class) {
-            if (scope == null) { // python func call
+        Class methodCls = method.getDeclaringClass();
+        if (methodCls == PythonScopeJpyImpl.CallableWrapper.class || methodCls == groovy.lang.Closure.class) {
+            if (scope == null) { // python func call or Groovy closure call
                /*  python func call
                     1. the func is defined at the main module level and already wrapped in CallableWrapper
                     2. the func will be called via CallableWrapper.call() method

--- a/DB/src/main/java/io/deephaven/db/tables/lang/DBLanguageParser.java
+++ b/DB/src/main/java/io/deephaven/db/tables/lang/DBLanguageParser.java
@@ -1333,7 +1333,7 @@ public final class DBLanguageParser extends GenericVisitorAdapter<Class, DBLangu
         } else { // 'scope' was *not* a class; call accept() on it to print it and find its type.
             try {
                 // The incoming VisitArgs might have a "casting context", meaning that it wants us to cast to
-                // the proper type at the end. But we have a scope, and that scope needs to be evaluateid in
+                // the proper type at the end. But we have a scope, and that scope needs to be evaluated in
                 // a non-casting context. So we provide that here.
                 scopeType = scopeExpr.accept(this, printer.cloneWithCastingContext(null));
             } catch (RuntimeException e) {

--- a/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
@@ -6,6 +6,7 @@ import io.deephaven.configuration.Configuration;
 import io.deephaven.db.exceptions.OperationException;
 import io.deephaven.db.exceptions.QueryCancellationException;
 import io.deephaven.db.tables.Table;
+import io.deephaven.db.tables.libs.QueryLibrary;
 import io.deephaven.db.tables.live.LiveTableMonitor;
 import io.deephaven.db.tables.select.QueryScope;
 import io.deephaven.db.tables.utils.LiveWidget;
@@ -27,6 +28,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import static io.deephaven.db.util.PythonScopeJpyImpl.CallableWrapper;
 
 /**
  * A ScriptSession that uses a JPy cpython interpreter internally.
@@ -80,6 +83,10 @@ public class PythonDeephavenSession extends AbstractScriptSession implements Scr
                 runScript(script);
             }
         }
+
+        QueryLibrary.setCurrent(queryLibrary);
+        QueryLibrary.importClass(org.jpy.PyObject.class);
+
     }
 
     /**

--- a/DB/src/main/java/io/deephaven/db/util/PythonScopeJpyImpl.java
+++ b/DB/src/main/java/io/deephaven/db/util/PythonScopeJpyImpl.java
@@ -60,7 +60,7 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
     public static class CallableWrapper {
         private PyObject pyObject;
 
-        private CallableWrapper(PyObject pyObject) {
+        public CallableWrapper(PyObject pyObject) {
             this.pyObject = pyObject;
         }
 


### PR DESCRIPTION
this is follow-up enhancement of #482 for Groovy closure call in Query strings