### PR TITLE
Ensure generated formula code handles prev correctly for i,ii in ticking tables. Fixes #544

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/select/DhFormulaColumn.java
+++ b/DB/src/main/java/io/deephaven/db/v2/select/DhFormulaColumn.java
@@ -515,17 +515,17 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
                         "final OrderedKeys __orderedKeys[[ADDITIONAL_CHUNK_ARGS]])"), CodeGenerator.block(
                         "final [[DEST_CHUNK_TYPE]] __typedDestination = __destination.[[DEST_AS_CHUNK_METHOD]]();",
                         CodeGenerator.optional("maybeCreateIOrII",
-                                "try (final Index prev = __usePrev ? __index.getPrevIndex() : null)", CodeGenerator.block(
-                                        "try (final Index inverted = ((prev != null) ? prev : __index).invert(__orderedKeys.asIndex()))", CodeGenerator.block(
-                                                CodeGenerator.optional("maybeCreateI",
-                                                        "__context.__iChunk.setSize(0);",
-                                                        "inverted.forAllLongs(l -> __context.__iChunk.add(__intSize(l)));"
-                                                ),
-                                                CodeGenerator.optional("maybeCreateII",
-                                                        "inverted.fillKeyIndicesChunk(__context.__iiChunk);"
-                                                )
+                                "try (final Index prev = __usePrev ? __index.getPrevIndex() : null;", CodeGenerator.indent(
+                                     "final Index inverted = ((prev != null) ? prev : __index).invert(__orderedKeys.asIndex()))"), CodeGenerator.block(
+                                            CodeGenerator.optional("maybeCreateI",
+                                                    "__context.__iChunk.setSize(0);",
+                                                    "inverted.forAllLongs(l -> __context.__iChunk.add(__intSize(l)));"
+                                            ),
+                                            CodeGenerator.optional("maybeCreateII",
+                                                    "inverted.fillKeyIndicesChunk(__context.__iiChunk);"
+                                            )
                                         )
-                                )),
+                                ),
                         CodeGenerator.repeated("getChunks",
                                 "final [[CHUNK_TYPE]] __chunk__col__[[COL_SOURCE_NAME]] = __sources[[[SOURCE_INDEX]]].[[AS_CHUNK_METHOD]]();"
                         ),

--- a/DB/src/main/java/io/deephaven/db/v2/utils/codegen/CodeGenerator.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/codegen/CodeGenerator.java
@@ -50,15 +50,6 @@ public abstract class CodeGenerator {
     /**
      * Same "tail wagging the dog" comment applies.
      */
-    public static CodeGenerator optionalOr(Object... args) {
-        final String tag = (String)args[0];
-        final String tag2 = (String)args[1];
-        return new OptionalOr(tag, tag2, CodeGenerator.createSlice(args, 2));
-    }
-
-    /**
-     * Same "tail wagging the dog" comment applies.
-     */
     public static CodeGenerator repeated(Object... args) {
         final String tag = (String)args[0];
         return new Repeated(tag, CodeGenerator.createSlice(args, 1));
@@ -371,7 +362,7 @@ final class Indent extends CodeGenerator {
     }
 }
 
-class Optional extends CodeGenerator {
+final class Optional extends CodeGenerator {
     private final String tag;
     private final CodeGenerator inner;
     private boolean active;
@@ -380,7 +371,7 @@ class Optional extends CodeGenerator {
         this(tag, inner, false);
     }
 
-    protected Optional(String tag, CodeGenerator inner, boolean active) {
+    private Optional(String tag, CodeGenerator inner, boolean active) {
         this.tag = tag;
         this.inner = inner;
         this.active = active;
@@ -431,42 +422,10 @@ class Optional extends CodeGenerator {
     public String tag() {
         return tag;
     }
-    protected CodeGenerator inner() {
-        return inner;
-    }
-    protected boolean active() {
-        return active;
-    }
 
     @Override
     public CodeGenerator freezeHelper() {
         return active ? inner : Container.EMPTY;
-    }
-}
-
-final class OptionalOr extends Optional {
-    private final String tag2;
-
-    OptionalOr(String tag1, String tag2, CodeGenerator inner) {
-        this(tag1, tag2, inner, false);
-    }
-
-    OptionalOr(String tag1, String tag2, CodeGenerator inner, boolean active) {
-        super(tag1, inner, active);
-        this.tag2 = tag2;
-    }
-
-    @Override
-    public CodeGenerator cloneMe() {
-        return new OptionalOr(tag(), tag2, inner().cloneMe(), active());
-    }
-
-    @Override
-    public void gatherOptionals(String tag, List<Optional> allOptionals) {
-        if (tag.equals(tag()) || tag.equals(tag2)) {
-            allOptionals.add(this);
-        }
-        inner().gatherOptionals(tag, allOptionals);
     }
 }
 

--- a/DB/src/main/java/io/deephaven/db/v2/utils/codegen/CodeGenerator.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/codegen/CodeGenerator.java
@@ -50,6 +50,15 @@ public abstract class CodeGenerator {
     /**
      * Same "tail wagging the dog" comment applies.
      */
+    public static CodeGenerator optionalOr(Object... args) {
+        final String tag = (String)args[0];
+        final String tag2 = (String)args[1];
+        return new OptionalOr(tag, tag2, CodeGenerator.createSlice(args, 2));
+    }
+
+    /**
+     * Same "tail wagging the dog" comment applies.
+     */
     public static CodeGenerator repeated(Object... args) {
         final String tag = (String)args[0];
         return new Repeated(tag, CodeGenerator.createSlice(args, 1));
@@ -362,7 +371,7 @@ final class Indent extends CodeGenerator {
     }
 }
 
-final class Optional extends CodeGenerator {
+class Optional extends CodeGenerator {
     private final String tag;
     private final CodeGenerator inner;
     private boolean active;
@@ -371,7 +380,7 @@ final class Optional extends CodeGenerator {
         this(tag, inner, false);
     }
 
-    Optional(String tag, CodeGenerator inner, boolean active) {
+    protected Optional(String tag, CodeGenerator inner, boolean active) {
         this.tag = tag;
         this.inner = inner;
         this.active = active;
@@ -422,10 +431,42 @@ final class Optional extends CodeGenerator {
     public String tag() {
         return tag;
     }
+    protected CodeGenerator inner() {
+        return inner;
+    }
+    protected boolean active() {
+        return active;
+    }
 
     @Override
     public CodeGenerator freezeHelper() {
         return active ? inner : Container.EMPTY;
+    }
+}
+
+final class OptionalOr extends Optional {
+    private final String tag2;
+
+    OptionalOr(String tag1, String tag2, CodeGenerator inner) {
+        this(tag1, tag2, inner, false);
+    }
+
+    OptionalOr(String tag1, String tag2, CodeGenerator inner, boolean active) {
+        super(tag1, inner, active);
+        this.tag2 = tag2;
+    }
+
+    @Override
+    public CodeGenerator cloneMe() {
+        return new OptionalOr(tag(), tag2, inner().cloneMe(), active());
+    }
+
+    @Override
+    public void gatherOptionals(String tag, List<Optional> allOptionals) {
+        if (tag.equals(tag()) || tag.equals(tag2)) {
+            allOptionals.add(this);
+        }
+        inner().gatherOptionals(tag, allOptionals);
     }
 }
 

--- a/DB/src/main/java/io/deephaven/db/v2/utils/sortedranges/SortedRanges.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/sortedranges/SortedRanges.java
@@ -4878,12 +4878,16 @@ public abstract class SortedRanges extends RefCountedCow<SortedRanges> implement
             return TreeIndexImpl.EMPTY;
         }
         if (keys instanceof SingleRange) {
-            return invertRangeOnNew(keys.ixFirstKey(), keys.ixLastKey(), maxPosition);
-        }
-        final Index.RangeIterator rit = keys.ixRangeIterator();
-        final TreeIndexImplSequentialBuilder builder = new TreeIndexImplSequentialBuilder();
-        if (invertOnNew(rit, builder, maxPosition)) {
-            return builder.getTreeIndexImpl();
+            final TreeIndexImpl r = invertRangeOnNew(keys.ixFirstKey(), keys.ixLastKey(), maxPosition);
+            if (r != null) {
+                return r;
+            }
+        } else {
+            final Index.RangeIterator rit = keys.ixRangeIterator();
+            final TreeIndexImplSequentialBuilder builder = new TreeIndexImplSequentialBuilder();
+            if (invertOnNew(rit, builder, maxPosition)) {
+                return builder.getTreeIndexImpl();
+            }
         }
         throw new IllegalArgumentException("keys argument has elements not in the index");
     }

--- a/DB/src/test/java/io/deephaven/db/v2/QueryTableTest.java
+++ b/DB/src/test/java/io/deephaven/db/v2/QueryTableTest.java
@@ -2865,7 +2865,7 @@ public class QueryTableTest extends QueryTableTestBase {
     }
 
     public void testRegressionIssue544() {
-        // The expresion that fails in the console is:
+        // The expression that fails in the console is:
         // x = merge(newTable(byteCol("Q", (byte)0)), timeTable("00:00:01").view("Q=(byte)(i%2)"))
         //    .tail(1)
         //    .view("Q=Q*i")

--- a/DB/src/test/java/io/deephaven/db/v2/QueryTableTest.java
+++ b/DB/src/test/java/io/deephaven/db/v2/QueryTableTest.java
@@ -39,6 +39,7 @@ import io.deephaven.UncheckedDeephavenException;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.Assert;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -2861,5 +2862,31 @@ public class QueryTableTest extends QueryTableTestBase {
         listener.close(); // we typically grab and ref-count this for testing
 
         Assert.assertNull(update.added);
+    }
+
+    public void testRegressionIssue544() {
+        // The expresion that fails in the console is:
+        // x = merge(newTable(byteCol("Q", (byte)0)), timeTable("00:00:01").view("Q=(byte)(i%2)"))
+        //    .tail(1)
+        //    .view("Q=Q*i")
+        //    .sumBy()
+        //
+        // The exception we were getting was: java.lang.IllegalArgumentException: keys argument has elements not in the index
+        //
+        final Table t0 = newTable(byteCol("Q", (byte) 0));
+        final QueryTable t1 = TstUtils.testRefreshingTable(i(), intCol("T"));
+        final Table t2 = t1.view("Q=(byte)(i%2)");
+        final Table result = merge(t0, t2).tail(1).view("Q=Q*i").sumBy();
+        int i = 1;
+        for (int step = 0; step < 2; ++step) {
+            final int key = i++;
+            LiveTableMonitor.DEFAULT.runWithinUnitTestCycle(() -> {
+                final Index addIndex = i(key);
+                addToTable(t1, addIndex, intCol("T", key));
+                t1.notifyListeners(addIndex, i(), i());
+                TableTools.show(result);
+            });
+        }
+        assertEquals(0, getUpdateErrors().size());
     }
 }

--- a/DB/src/test/java/io/deephaven/db/v2/select/FormulaSample.java
+++ b/DB/src/test/java/io/deephaven/db/v2/select/FormulaSample.java
@@ -162,12 +162,11 @@ public class FormulaSample extends io.deephaven.db.v2.select.Formula {
             final WritableChunk<? super Attributes.Values> __destination,
             final OrderedKeys __orderedKeys, LongChunk<? extends Attributes.Values> __chunk__col__II, IntChunk<? extends Attributes.Values> __chunk__col__I) {
         final WritableLongChunk<? super Attributes.Values> __typedDestination = __destination.asWritableLongChunk();
-        try (final Index prev = __usePrev ? __index.getPrevIndex() : null) {
-            try (final Index inverted = ((prev != null) ? prev : __index).invert(__orderedKeys.asIndex())) {
-                __context.__iChunk.setSize(0);
-                inverted.forAllLongs(l -> __context.__iChunk.add(__intSize(l)));
-                inverted.fillKeyIndicesChunk(__context.__iiChunk);
-            }
+        try (final Index prev = __usePrev ? __index.getPrevIndex() : null;
+                final Index inverted = ((prev != null) ? prev : __index).invert(__orderedKeys.asIndex())) {
+            __context.__iChunk.setSize(0);
+            inverted.forAllLongs(l -> __context.__iChunk.add(__intSize(l)));
+            inverted.fillKeyIndicesChunk(__context.__iiChunk);
         }
         final int[] __chunkPosHolder = new int[] {0};
         if (__lazyResultCache != null) {

--- a/DB/src/test/java/io/deephaven/db/v2/select/FormulaSample.java
+++ b/DB/src/test/java/io/deephaven/db/v2/select/FormulaSample.java
@@ -98,8 +98,9 @@ public class FormulaSample extends io.deephaven.db.v2.select.Formula {
 
     @Override
     public long getLong(final long k) {
-        final int i = __intSize(__index.find(k));
-        final long ii = __index.find(k);
+        final long findResult = __index.find(k);
+        final int i = __intSize(findResult);
+        final long ii = findResult;
         final long __temp0 = II.getLong(k);
         final int __temp1 = I.getInt(k);
         if (__lazyResultCache != null) {
@@ -111,8 +112,9 @@ public class FormulaSample extends io.deephaven.db.v2.select.Formula {
 
     @Override
     public long getPrevLong(final long k) {
-        final int i = __intSize(__index.find(k));
-        final long ii = __index.find(k);
+        final long findResult = __index.getPrevIndex().find(k);
+        final int i = __intSize(findResult);
+        final long ii = findResult;
         final long __temp0 = II.getPrevLong(k);
         final int __temp1 = I.getPrevInt(k);
         if (__lazyResultCache != null) {
@@ -142,7 +144,7 @@ public class FormulaSample extends io.deephaven.db.v2.select.Formula {
         final FormulaFillContext __typedContext = (FormulaFillContext)__context;
         final LongChunk<? extends Attributes.Values> __chunk__col__II = this.II.getChunk(__typedContext.__subContextII, __orderedKeys).asLongChunk();
         final IntChunk<? extends Attributes.Values> __chunk__col__I = this.I.getChunk(__typedContext.__subContextI, __orderedKeys).asIntChunk();
-        fillChunkHelper(__typedContext, __destination, __orderedKeys, __chunk__col__II, __chunk__col__I);
+        fillChunkHelper(false, __typedContext, __destination, __orderedKeys, __chunk__col__II, __chunk__col__I);
     }
 
     @Override
@@ -150,16 +152,17 @@ public class FormulaSample extends io.deephaven.db.v2.select.Formula {
         final FormulaFillContext __typedContext = (FormulaFillContext)__context;
         final LongChunk<? extends Attributes.Values> __chunk__col__II = this.II.getPrevChunk(__typedContext.__subContextII, __orderedKeys).asLongChunk();
         final IntChunk<? extends Attributes.Values> __chunk__col__I = this.I.getPrevChunk(__typedContext.__subContextI, __orderedKeys).asIntChunk();
-        fillChunkHelper(__typedContext, __destination, __orderedKeys, __chunk__col__II, __chunk__col__I);
+        fillChunkHelper(true, __typedContext, __destination, __orderedKeys, __chunk__col__II, __chunk__col__I);
     }
 
-    private void fillChunkHelper(final FormulaFillContext __context,
+    private void fillChunkHelper(final boolean __usePrev, final FormulaFillContext __context,
             final WritableChunk<? super Attributes.Values> __destination,
             final OrderedKeys __orderedKeys, LongChunk<? extends Attributes.Values> __chunk__col__II, IntChunk<? extends Attributes.Values> __chunk__col__I) {
         final WritableLongChunk<? super Attributes.Values> __typedDestination = __destination.asWritableLongChunk();
+        final Index inverted = (__usePrev ? __index.getPrevIndex() : __index).invert(__orderedKeys.asIndex());
         __context.__iChunk.setSize(0);
-        __index.invert(__orderedKeys.asIndex()).forAllLongs(l -> __context.__iChunk.add(__intSize(l)));
-        __index.invert(__orderedKeys.asIndex()).fillKeyIndicesChunk(__context.__iiChunk);
+        inverted.forAllLongs(l -> __context.__iChunk.add(__intSize(l)));
+        inverted.fillKeyIndicesChunk(__context.__iiChunk);
         final int[] __chunkPosHolder = new int[] {0};
         if (__lazyResultCache != null) {
             __orderedKeys.forAllLongs(k -> {

--- a/DB/src/test/java/io/deephaven/db/v2/select/TestFormulaColumnGeneration.java
+++ b/DB/src/test/java/io/deephaven/db/v2/select/TestFormulaColumnGeneration.java
@@ -20,10 +20,10 @@ public class TestFormulaColumnGeneration {
     // code only needs to be run when the formula generation code changes, and only after
     // some human believes that the code is correct. When that happens the process
     // is:
-    // 1. Once the formula generation code is believed to be correct, uncomment this "Test"
-    // 2. Run it once to generate new "golden master" files.
+    // 1. Once the formula generation code is believed to be correct, uncomment @Test for this test case below.
+    // 2. Run this test case once to generate new "golden master" files.
     // 3. Comment this "test" back out
-    // 4. Confirm that the modified files pass "validateFiles".
+    // 4. Confirm that the modified files pass the "validateFiles" case.
     // 4. Check in the modified "golden master" files.
     // @Test
     public void generateFiles() throws FileNotFoundException {


### PR DESCRIPTION
New unit test case that fails without this change added to QueryTableTest.
TestFormulaColumnGenerator ran and FormulaSample was generated, and tested.