### PR TITLE
Fix IllegalStateException in TwoValuesContainer triggered from Index.insert(Chunk). Fixes #652.

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/utils/RspBitmapSequentialBuilder.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/RspBitmapSequentialBuilder.java
@@ -89,6 +89,9 @@ public class RspBitmapSequentialBuilder implements TreeIndexImpl.SequentialBuild
 
     @Override
     public void appendTreeIndexImpl(final long shiftAmount, final TreeIndexImpl ix, final boolean acquire) {
+        if (ix.ixIsEmpty()) {
+            return;
+        }
         if (!(ix instanceof RspBitmap) || rb == null) {
             ix.ixForEachLongRange((final long start, final long end) -> {
                 appendRange(start + shiftAmount, end + shiftAmount);

--- a/DB/src/main/java/io/deephaven/db/v2/utils/TreeIndexImplSequentialBuilder.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/TreeIndexImplSequentialBuilder.java
@@ -71,6 +71,9 @@ public class TreeIndexImplSequentialBuilder extends RspBitmapSequentialBuilder {
 
     @Override
     public void appendTreeIndexImpl(final long shiftAmount, final TreeIndexImpl ix, final boolean acquire) {
+        if (ix.ixIsEmpty()) {
+            return;
+        }
         if (!(ix instanceof RspBitmap) || rb == null) {
             ix.ixForEachLongRange((final long start, final long end) -> {
                 appendRange(start + shiftAmount, end + shiftAmount);

--- a/DB/src/main/java/io/deephaven/db/v2/utils/rsp/RspBitmap.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/rsp/RspBitmap.java
@@ -244,20 +244,22 @@ public class RspBitmap extends RspArray<RspBitmap> implements TreeIndexImpl {
                 if (firstValue == key) {
                     return null;
                 }
-                if (firstValue + 1 < key) {
-                    final short keyLowBits = lowBitsAsShort(key);
-                    final short firstValueLowBits = lowBitsAsShort(firstValue);
-                    return new TwoValuesContainer(firstValueLowBits, keyLowBits);
+                final long left, right;
+                if (firstValue < key) {
+                    left = firstValue;
+                    right = key;
+                } else {
+                    left = key;
+                    right = firstValue;
                 }
-                if (firstValue + 1 == key) {
-                    final int start = lowBitsAsInt(firstValue);
-                    final int end = lowBitsAsInt(key);
+                if (left + 1 == right) {
+                    final int start = lowBitsAsInt(left);
+                    final int end = lowBitsAsInt(right);
                     return new SingleRangeContainer(start, end + 1);
                 }
-                // firstValue + 1 > key
-                final short keyLowBits = lowBitsAsShort(key);
-                final short firstValueLowBits = lowBitsAsShort(firstValue);
-                return new TwoValuesContainer(keyLowBits, firstValueLowBits);
+                final short leftLow = lowBitsAsShort(left);
+                final short rightLow = lowBitsAsShort(right);
+                return new TwoValuesContainer(leftLow, rightLow);
             }
             final short firstValueLowBits = lowBitsAsShort(firstValue);
             return container.iset(firstValueLowBits);

--- a/DB/src/test/java/io/deephaven/db/v2/utils/rsp/RspBitmapTest.java
+++ b/DB/src/test/java/io/deephaven/db/v2/utils/rsp/RspBitmapTest.java
@@ -4209,4 +4209,16 @@ public class RspBitmapTest {
         assertEquals(3, result.get(2));
         assertEquals(rb.getCardinality() - 1, result.get(picks.getCardinality() - 1));
     }
+
+    @Test
+    public void testAddValuesUnsafeRegression() {
+        RspBitmap rb = new RspBitmap();
+        rb = rb.add(3);
+        final WritableLongChunk<OrderedKeyIndices> chunk = WritableLongChunk.makeWritableChunk(4);
+        chunk.setSize(0);
+        chunk.add(4);
+        chunk.add(BLOCK_SIZE + 10);
+        // we saw: "java.lang.IllegalStateException: iv1=3, iv2=4"
+        rb.addValuesUnsafeNoWriteCheck(chunk, 0, 2);
+    }
 }


### PR DESCRIPTION
Also added empty check to RspBitmapSequentialBuildder.appendTreeIndexImpl to avoid https://deephaven.atlassian.net/browse/DH-11182