### PR TITLE
Explicitly set 'local-build' tag for docker images

### DIFF
--- a/Generators/Generators.gradle
+++ b/Generators/Generators.gradle
@@ -195,7 +195,7 @@ if (PyEnv.pythonEnabled(project)) {
         }
 
         parentContainers = [project(':deephaven-jpy').tasks.findByName("buildDockerForRuntime")]// deephaven/java-and-python
-        imageName = 'deephaven/pydocs'
+        imageName = 'deephaven/pydocs:local-build'
         copyOut {
             into("$devRoot/Integrations/python/deephaven")
             preserve {// only overwrite doc and docCustom directories

--- a/Integrations/build.gradle
+++ b/Integrations/build.gradle
@@ -71,7 +71,7 @@ task prepareDockerForWheel(type: Sync) {
 def buildDockerForWheel = Docker.registerDockerImage(project, 'buildDockerForWheel') {
     dependsOn prepareDockerForWheel
     buildArgs.put('DEEPHAVEN_VERSION', "${project.version}")
-    images.add('deephaven/deephaven-wheel')
+    images.add('deephaven/deephaven-wheel:local-build')
     target.set('build')
 }
 
@@ -80,9 +80,9 @@ def buildDockerForWheel = Docker.registerDockerImage(project, 'buildDockerForWhe
  */
 task deephavenPythonDockerfile(type: Dockerfile) {
     destFile.set layout.buildDirectory.file('deephaven-python-docker/Dockerfile')
-    from new Dockerfile.From('deephaven/deephaven-jpy-wheel').withStage('deephaven-jpy-wheel')
-    from new Dockerfile.From('deephaven/deephaven-wheel').withStage('deephaven-wheel')
-    from new Dockerfile.From('deephaven/java-and-python')
+    from new Dockerfile.From('deephaven/deephaven-jpy-wheel:local-build').withStage('deephaven-jpy-wheel')
+    from new Dockerfile.From('deephaven/deephaven-wheel:local-build').withStage('deephaven-wheel')
+    from new Dockerfile.From('deephaven/java-and-python:local-build')
 
     copyFile(new Dockerfile.CopyFile('/usr/src/app/dist', '.').withStage('deephaven-jpy-wheel'))
     copyFile(new Dockerfile.CopyFile('/usr/src/app/dist', '.').withStage('deephaven-wheel'))
@@ -102,7 +102,7 @@ Docker.registerDockerImage(project, 'buildDeephavenPython') {
 
     inputDir.set layout.buildDirectory.dir('deephaven-python-docker')
 
-    images.add('deephaven/runtime-base')
+    images.add('deephaven/runtime-base:local-build')
 }
 
 /**
@@ -151,7 +151,7 @@ if (PyEnv.pythonEnabled(project)) {
 
         dockerfile {
             // set up the container, env vars - things that aren't likely to change
-            from 'deephaven/runtime-base'
+            from 'deephaven/runtime-base:local-build'
             runCommand '''set -eux; \\
                           pip3 install unittest-xml-reporting==3.0.4;\\
                           mkdir -p /out/report;\\

--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -170,7 +170,7 @@ class Docker {
     static TaskProvider<? extends Task> registerDockerTask(Project project, String taskName, Action<? super DockerTaskConfig> action) {
         // create instance, assign defaults
         DockerTaskConfig cfg = new DockerTaskConfig();
-        cfg.imageName = "deephaven/${taskName}"
+        cfg.imageName = "deephaven/${taskName}:local-build"
 
         // ask for more configuration
         action.execute(cfg);

--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -23,6 +23,8 @@ import org.gradle.util.ConfigureUtil
  */
 @CompileStatic
 class Docker {
+    private static final String LOCAL_BUILD_TAG = 'local-build'
+
     /**
      * Helper method to make sure we rebuild the image if it is out of date. At
      * present, is only applicable if there are tags to set on the image
@@ -65,6 +67,7 @@ class Docker {
      * DSL object to describe a docker task
      */
     static class DockerTaskConfig {
+
         private Action<? super CopySpec> copyIn;
         private Action<? super Sync> copyOut;
         private File dockerfileFile;
@@ -147,6 +150,12 @@ class Docker {
         boolean showLogsOnSuccess;
     }
 
+    private static void validateImageName(String imageName) {
+        if (!imageName.endsWith(":${LOCAL_BUILD_TAG}")) {
+            throw new IllegalArgumentException("imageName '${imageName}' is invalid, it must be tagged with '${LOCAL_BUILD_TAG}'")
+        }
+    }
+
     /**
      * Creates a task to run docker to do some work in a container rather than in the hosted environment.
      *
@@ -170,10 +179,12 @@ class Docker {
     static TaskProvider<? extends Task> registerDockerTask(Project project, String taskName, Action<? super DockerTaskConfig> action) {
         // create instance, assign defaults
         DockerTaskConfig cfg = new DockerTaskConfig();
-        cfg.imageName = "deephaven/${taskName}:local-build"
+        cfg.imageName = "deephaven/${taskName}:${LOCAL_BUILD_TAG}"
 
         // ask for more configuration
-        action.execute(cfg);
+        action.execute(cfg)
+
+        validateImageName(cfg.imageName)
 
         String dockerContainerName = "$taskName-container-${UUID.randomUUID()}"
         String dockerCopyLocation = "${project.buildDir}/$taskName-tmp-copy"
@@ -363,6 +374,8 @@ class Docker {
         TaskProvider<DockerBuildImage> makeImage = project.tasks.register(taskName, DockerBuildImage) { buildImage ->
             action.execute(buildImage)
             if (buildImage.images) {
+                buildImage.images.get().forEach { String imageName -> validateImageName(imageName) }
+
                 // apply fix, since tags don't work properly
                 buildImage.outputs.upToDateWhen {
                     isImageUpToDate(buildImage)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.8"
 
 services:
   grpc-api:
-    image: deephaven/grpc-api
+    image: deephaven/grpc-api:local-build
 
     environment:
       # https://bugs.openjdk.java.net/browse/JDK-8230305
@@ -42,7 +42,7 @@ services:
           memory: 1G
 
   web:
-    image: deephaven/web
+    image: deephaven/web:local-build
     expose:
       - "80"
     deploy:
@@ -53,7 +53,7 @@ services:
 
   # Should only be used for non-production deployments, see grpc-proxy/README.md for more info
   grpc-proxy:
-    image: deephaven/grpc-proxy
+    image: deephaven/grpc-proxy:local-build
     environment:
       - BACKEND_ADDR=grpc-api:8080
     depends_on:
@@ -70,7 +70,7 @@ services:
   envoy:
     # A reverse proxy configured for no SSL on localhost. It fronts the requests
     # for the static content and the websocket proxy.
-    image: deephaven/envoy
+    image: deephaven/envoy:local-build
     depends_on:
       - web
       - grpc-proxy

--- a/envoy/build.gradle
+++ b/envoy/build.gradle
@@ -20,5 +20,5 @@ task prepareDocker(type: Sync) {
 
 task buildDocker(type: DockerBuildImage) {
     dependsOn prepareDocker
-    images.add('deephaven/envoy')
+    images.add('deephaven/envoy:local-build')
 }

--- a/gradle/deephaven-jpy.gradle
+++ b/gradle/deephaven-jpy.gradle
@@ -54,14 +54,14 @@ project(':deephaven-jpy') {
   Docker.registerDockerImage(project, 'buildDockerForRuntime') {
     dependsOn prepareDocker
     buildArgs.put('DEEPHAVEN_VERSION', "${project.version}")
-    images.add('deephaven/java-and-python')
+    images.add('deephaven/java-and-python:local-build')
     target.set('runtime_reqs')
   }
 
   Docker.registerDockerImage(project, 'buildDockerForWheel') {
     dependsOn prepareDocker
     buildArgs.put('DEEPHAVEN_VERSION', "${project.version}")
-    images.add('deephaven/deephaven-jpy-wheel')
+    images.add('deephaven/deephaven-jpy-wheel:local-build')
 
     target.set('build')
   }

--- a/grpc-api/server/docker/build.gradle
+++ b/grpc-api/server/docker/build.gradle
@@ -29,7 +29,7 @@ docker {
 
   javaApplication {
     mainClassName = 'io.deephaven.grpc_api.runner.Main'
-    images = [ "${project.property('grpc-api-docker.imageName')}:latest" ]
+    images = [ "${project.property('grpc-api-docker.imageName')}" ]
     baseImage = project.property('grpc-api-docker.baseImage')
     maintainer = 'Devin Smith "devinsmith@deephaven.io"'
     ports = [ 8080 ]

--- a/grpc-api/server/docker/gradle.properties
+++ b/grpc-api/server/docker/gradle.properties
@@ -1,5 +1,5 @@
-grpc-api-docker.imageName=deephaven/grpc-api
-grpc-api-docker.baseImage=deephaven/runtime-base
+grpc-api-docker.imageName=deephaven/grpc-api:local-build
+grpc-api-docker.baseImage=deephaven/runtime-base:local-build
 grpc-api-docker.vendor=Deephaven Data Labs
 grpc-api-docker.title=Deephaven gRPC API
 grpc-api-docker.description=The Deephaven API - TODO

--- a/grpc-proxy/build.gradle
+++ b/grpc-proxy/build.gradle
@@ -20,5 +20,5 @@ task prepareDocker(type: Sync) {
 
 task buildDocker(type: DockerBuildImage) {
   dependsOn prepareDocker
-  images.add('deephaven/grpc-proxy')
+  images.add('deephaven/grpc-proxy:local-build')
 }

--- a/proto/proto-backplane-grpc/Dockerfile
+++ b/proto/proto-backplane-grpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM deephaven/protoc
+FROM deephaven/protoc:local-build
 
 COPY src/main/proto /includes
 

--- a/proto/proto-backplane-grpc/build.gradle
+++ b/proto/proto-backplane-grpc/build.gradle
@@ -13,7 +13,7 @@ TaskProvider<Task> generateProtobuf = Docker.registerDockerTask(project, 'genera
   }
   parentContainers = [ project(':protoc').tasks.findByName('buildDocker') ]
   containerOutPath = '/generated'
-  imageName = 'deephaven/proto-backplane-grpc'
+  imageName = 'deephaven/proto-backplane-grpc:local-build'
   copyOut {
     into('build/generated/source/proto/main')
   }

--- a/proto/raw-js-openapi/Dockerfile
+++ b/proto/raw-js-openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM deephaven/proto-backplane-grpc AS proto-backplane-grpc
+FROM deephaven/proto-backplane-grpc:local-build AS proto-backplane-grpc
 
 FROM docker.io/library/node:14.16.0 AS sources
 WORKDIR /usr/src/app

--- a/proto/raw-js-openapi/build.gradle
+++ b/proto/raw-js-openapi/build.gradle
@@ -28,7 +28,7 @@ Docker.registerDockerTask(project, 'webpackSources') {
         from ('../package-lock.json')
 
     }
-    imageName = 'deephaven/js-out'
+    imageName = 'deephaven/js-out:local-build'
     containerOutPath = '/usr/src/app/raw-js-openapi/build/js-out'
     copyOut {
         into(webpackSourcesLocation)

--- a/protoc/build.gradle
+++ b/protoc/build.gradle
@@ -12,5 +12,5 @@ task prepareDocker(type: Sync) {
 
 Docker.registerDockerImage(project, 'buildDocker') {
     dependsOn prepareDocker
-    images.add('deephaven/protoc')
+    images.add('deephaven/protoc:local-build')
 }

--- a/py/jpy-integration/build.gradle
+++ b/py/jpy-integration/build.gradle
@@ -137,7 +137,7 @@ if (!PyEnv.pythonEnabled(project)) {
       parentContainers = [project(':Integrations').tasks.findByName('buildDeephavenPython')] // deephaven/runtime-base
       dockerfile {
         // base image with default java, python, wheels
-        from 'deephaven/runtime-base'
+        from 'deephaven/runtime-base:local-build'
 
         // set up the project
         copyFile 'project', '/project'
@@ -167,9 +167,9 @@ if (!PyEnv.pythonEnabled(project)) {
         }
       }
       parentContainers = [project(':Integrations').tasks.findByName('buildDeephavenPython')] // deephaven/runtime-base
-      imageName = 'deephaven/jpy-integration-java-to-python-tests'
+      imageName = 'deephaven/jpy-integration-java-to-python-tests:local-build'
       dockerfile {
-        from 'deephaven/runtime-base'
+        from 'deephaven/runtime-base:local-build'
 
         copyFile 'classpath', '/classpath'
       }
@@ -218,10 +218,10 @@ if (!PyEnv.pythonEnabled(project)) {
         }
       }
       parentContainers = [project(':Integrations').tasks.findByName('buildDeephavenPython')] // deephaven/runtime-base
-      imageName = 'deephaven/jpy-integration-python-to-java-tests'
+      imageName = 'deephaven/jpy-integration-python-to-java-tests:local-build'
       dockerfile {
         // set up the container, env vars - things that aren't likely to change
-        from 'deephaven/runtime-base'
+        from 'deephaven/runtime-base:local-build'
         runCommand '''set -eux; \\
                         pip3 install unittest-xml-reporting==3.0.4;\\
                         mkdir /out;'''

--- a/sphinx/docker/Dockerfile
+++ b/sphinx/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Start with an image that has what we need to build the documentation
 # A better image would be something with the wheels, but not named as the base grpc-api image
-FROM deephaven/runtime-base
+FROM deephaven/runtime-base:local-build
 
 # install sphinx
 RUN set -eux; \

--- a/sphinx/sphinx.gradle
+++ b/sphinx/sphinx.gradle
@@ -27,7 +27,7 @@ if (!PyEnv.pythonEnabled(project)) {
         }
 //        dockerfile = project.file('Dockerfile') // not needed with the above from 'docker'
         parentContainers = [project(':Integrations').tasks.findByName('buildDeephavenPython')] // deephaven/runtime-base
-        imageName = 'deephaven/sphinx'
+        imageName = 'deephaven/sphinx:local-build'
         containerOutPath = '/build'
         copyOut {
             into docBuildDir

--- a/web/client-ide/client-ide.gradle
+++ b/web/client-ide/client-ide.gradle
@@ -47,6 +47,6 @@ task prepareDocker(type: Sync) {
 Docker.registerDockerImage(project, 'buildDocker') {
     inputs.files([prepareDocker, dhide, jsOut].each { t -> t.outputs.files })
     //buildArgs.put('DEEPHAVEN_VERSION', "${project.version}")
-    images.add('deephaven/web')
+    images.add('deephaven/web:local-build')
 }
 

--- a/web/client-ide/docker/Dockerfile
+++ b/web/client-ide/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM deephaven/dhide as dhide
+FROM deephaven/dhide:local-build as dhide
 
-FROM deephaven/js-out as js-out
+FROM deephaven/js-out:local-build as js-out
 
 FROM docker.io/library/nginx:1.19.7
 COPY --from=dhide /usr/src/app/package/build /usr/share/nginx/html/ide

--- a/web/client-ui/client-ui.gradle
+++ b/web/client-ui/client-ui.gradle
@@ -7,7 +7,7 @@ Docker.registerDockerTask(project, 'ideClient') {
         from file('Dockerfile')
     }
     containerOutPath = '/usr/src/app/package/build'
-    imageName = 'deephaven/dhide'
+    imageName = 'deephaven/dhide:local-build'
     copyOut {
         into "${buildDir}/dhide"
     }


### PR DESCRIPTION
I think we're going to want to tag our highest versioned docker releases with the rolling `latest` tag.

I'd like to be explicit with a docker tag, proposed here as `local-build`, so we don't accidentally pull down external artifacts during the CI (nor local build) process. (By default, with no tag set, `latest` is assumed by docker.)

As another point, if we ever publish `local-build`, that should be a red flag that something is wrong with the publishing / release process.