### PR TITLE
removed the use of DH's own numba annotations, fixes #630

### DIFF
--- a/DB/src/main/java/io/deephaven/db/tables/lang/DBLanguageParser.java
+++ b/DB/src/main/java/io/deephaven/db/tables/lang/DBLanguageParser.java
@@ -367,7 +367,7 @@ public final class DBLanguageParser extends GenericVisitorAdapter<Class, DBLangu
             // for Python function/Groovy closure call syntax without the explicit 'call' keyword, check if it is defined in Query scope
             if (acceptableMethods.size() == 0) {
                 final Class methodClass = variables.get(methodName);
-                if (isPotentialImplicitCall(methodClass)) {
+                if (methodClass != null && isPotentialImplicitCall(methodClass)) {
                     for (Method method : methodClass.getMethods()) {
                         possiblyAddExecutable(acceptableMethods, method, "call", paramTypes, parameterizedTypes);
                     }
@@ -1533,7 +1533,7 @@ public final class DBLanguageParser extends GenericVisitorAdapter<Class, DBLangu
 
         Class methodClass = variables.get(n.getName());
         if (methodClass == NumbaCallableWrapper.class) {
-            parsePyNumbaVectorizedFunc(n, expressions, expressionTypes);
+            checkPyNumbaVectorizedFunc(n, expressions, expressionTypes);
         }
 
         expressions=convertParameters(method, argumentTypes, expressionTypes, parameterizedTypes, expressions);
@@ -1575,10 +1575,10 @@ public final class DBLanguageParser extends GenericVisitorAdapter<Class, DBLangu
         return calculateMethodReturnTypeUsingGenerics(method, expressionTypes, parameterizedTypes);
     }
 
-    private void parsePyNumbaVectorizedFunc(MethodCallExpr n, Expression[] expressions, Class[] expressionTypes) {
+    private void checkPyNumbaVectorizedFunc(MethodCallExpr n, Expression[] expressions, Class[] expressionTypes) {
         if (n.getParentNode() != null) {
             throw new RuntimeException("Numba vectorized function can't be used in an expression.");
-        };
+        }
         final QueryScope queryScope = QueryScope.getDefaultInstance();
         for (Param param : queryScope.getParams(queryScope.getParamNames())) {
             if (param.getName().equals(n.getName())) {

--- a/DB/src/main/java/io/deephaven/db/util/PythonScopeJpyImpl.java
+++ b/DB/src/main/java/io/deephaven/db/util/PythonScopeJpyImpl.java
@@ -10,12 +10,14 @@ import java.util.stream.Stream;
 
 public class PythonScopeJpyImpl implements PythonScope<PyObject> {
     private final PyDictWrapper dict;
-    private static PyObject NumbaVectorizedFuncType;
+    private static PyObject NUMBA_VECTORIZED_FUNC_TYPE;
+    // this assumes that the Python interpreter won't be re-initialized during a session, if this turns out to be a
+    // false assumption, then we'll need to make this initialization code 'python restart' proof.
     {
         try {
-            NumbaVectorizedFuncType = PyModule.importModule("numba.np.ufunc.dufunc").getAttribute("DUFunc");
+            NUMBA_VECTORIZED_FUNC_TYPE = PyModule.importModule("numba.np.ufunc.dufunc").getAttribute("DUFunc");
         } catch (Exception e) {
-            NumbaVectorizedFuncType = null;
+            NUMBA_VECTORIZED_FUNC_TYPE = null;
         }
     }
 
@@ -104,7 +106,7 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
 
     private static CallableWrapper wrapCallable(PyObject pyObject) {
         // check if this is a numba vectorized function
-        if (pyObject.getType().equals(NumbaVectorizedFuncType)) {
+        if (pyObject.getType().equals(NUMBA_VECTORIZED_FUNC_TYPE)) {
             List<PyObject> params = pyObject.getAttribute("types").asList();
             if (params.isEmpty()) {
                 throw new IllegalArgumentException("numba vectorized function must have an explicit signature.");

--- a/DB/src/main/java/io/deephaven/db/util/PythonScopeJpyImpl.java
+++ b/DB/src/main/java/io/deephaven/db/util/PythonScopeJpyImpl.java
@@ -10,14 +10,15 @@ import java.util.stream.Stream;
 
 public class PythonScopeJpyImpl implements PythonScope<PyObject> {
     private final PyDictWrapper dict;
-    private static PyObject NUMBA_VECTORIZED_FUNC_TYPE;
+    private static final PyObject NUMBA_VECTORIZED_FUNC_TYPE = getNumbaVectorizedFuncType();
+
     // this assumes that the Python interpreter won't be re-initialized during a session, if this turns out to be a
     // false assumption, then we'll need to make this initialization code 'python restart' proof.
-    {
+    private static PyObject getNumbaVectorizedFuncType() {
         try {
-            NUMBA_VECTORIZED_FUNC_TYPE = PyModule.importModule("numba.np.ufunc.dufunc").getAttribute("DUFunc");
+            return PyModule.importModule("numba.np.ufunc.dufunc").getAttribute("DUFunc");
         } catch (Exception e) {
-            NUMBA_VECTORIZED_FUNC_TYPE = null;
+            return null;
         }
     }
 

--- a/DB/src/main/java/io/deephaven/db/v2/select/DhFormulaColumn.java
+++ b/DB/src/main/java/io/deephaven/db/v2/select/DhFormulaColumn.java
@@ -192,9 +192,6 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
         // check if this is a column to be created with a numba vectorized function
         for (Param param : params) {
             if (param.getValue().getClass() == NumbaCallableWrapper.class) {
-                if (params.length > 1) {
-                    throw new RuntimeException("...4");
-                }
                 NumbaCallableWrapper numbaCallableWrapper = (NumbaCallableWrapper) param.getValue();
                 formulaColumnPython = FormulaColumnPython.create(this.columnName,
                         DeephavenCompatibleFunction.create(numbaCallableWrapper.getPyObject(),

--- a/DB/src/main/java/io/deephaven/db/v2/select/DhFormulaColumn.java
+++ b/DB/src/main/java/io/deephaven/db/v2/select/DhFormulaColumn.java
@@ -11,6 +11,8 @@ import io.deephaven.db.tables.select.QueryScope;
 import io.deephaven.db.tables.utils.DBTimeUtils;
 import io.deephaven.db.tables.utils.QueryPerformanceNugget;
 import io.deephaven.db.tables.utils.QueryPerformanceRecorder;
+import io.deephaven.db.util.PythonScopeJpyImpl;
+import io.deephaven.db.util.PythonScopeJpyImpl.NumbaCallableWrapper;
 import io.deephaven.db.util.caching.C14nUtil;
 import io.deephaven.db.v2.select.codegen.FormulaAnalyzer;
 import io.deephaven.db.v2.select.codegen.JavaKernelBuilder;
@@ -18,6 +20,8 @@ import io.deephaven.db.v2.select.codegen.RichType;
 import io.deephaven.db.v2.select.formula.FormulaFactory;
 import io.deephaven.db.v2.select.formula.FormulaKernelFactory;
 import io.deephaven.db.v2.select.formula.FormulaSourceDescriptor;
+import io.deephaven.db.v2.select.python.DeephavenCompatibleFunction;
+import io.deephaven.db.v2.select.python.FormulaColumnPython;
 import io.deephaven.db.v2.sources.ColumnSource;
 import io.deephaven.db.v2.sources.chunk.ChunkType;
 import io.deephaven.db.v2.utils.codegen.CodeGenerator;
@@ -50,6 +54,12 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
     private FormulaAnalyzer.Result analyzedFormula;
     private String timeInstanceVariables;
     private Map<String, Class> timeNewVariables = null;
+
+    public FormulaColumnPython getFormulaColumnPython() {
+        return formulaColumnPython;
+    }
+
+    private FormulaColumnPython formulaColumnPython;
 
     /**
      * Create a formula column for the given formula string.
@@ -178,6 +188,23 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
         } catch (Exception e) {
             throw new FormulaCompilationException("Formula compilation error for: " + formulaString, e);
         }
+
+        // check if this is a column to be created with a numba vectorized function
+        for (Param param : params) {
+            if (param.getValue().getClass() == NumbaCallableWrapper.class) {
+                if (params.length > 1) {
+                    throw new RuntimeException("...4");
+                }
+                NumbaCallableWrapper numbaCallableWrapper = (NumbaCallableWrapper) param.getValue();
+                formulaColumnPython = FormulaColumnPython.create(this.columnName,
+                        DeephavenCompatibleFunction.create(numbaCallableWrapper.getPyObject(),
+                                numbaCallableWrapper.getReturnType(), this.analyzedFormula.sourceDescriptor.sources,
+                                true));
+                formulaColumnPython.initDef(columnDefinitionMap);
+                return formulaColumnPython.usedColumns;
+            }
+        }
+
         return usedColumns;
     }
 

--- a/DB/src/main/java/io/deephaven/db/v2/select/SwitchColumn.java
+++ b/DB/src/main/java/io/deephaven/db/v2/select/SwitchColumn.java
@@ -9,6 +9,7 @@ import io.deephaven.db.tables.ColumnDefinition;
 import io.deephaven.db.tables.Table;
 import io.deephaven.db.tables.select.MatchPair;
 import io.deephaven.db.tables.utils.DBNameValidator;
+import io.deephaven.db.v2.select.python.FormulaColumnPython;
 import io.deephaven.db.v2.sources.ColumnSource;
 import io.deephaven.db.v2.sources.WritableSource;
 import io.deephaven.db.v2.utils.Index;
@@ -66,7 +67,12 @@ public class SwitchColumn implements SelectColumn {
                 realColumn = FormulaColumn.createFormulaColumn(columnName, expression, parser);
             }
         }
-        return realColumn.initDef(columnDefinitionMap);
+        List<String> usedColumns = realColumn.initDef(columnDefinitionMap);
+        if (realColumn instanceof DhFormulaColumn) {
+            FormulaColumnPython formulaColumnPython = ((DhFormulaColumn) realColumn).getFormulaColumnPython();
+            realColumn = formulaColumnPython != null ? formulaColumnPython: realColumn;
+        }
+        return usedColumns;
     }
 
     @Override


### PR DESCRIPTION
- no need to have DH's own annotations for numba vectorized functions (not removed)
- make the syntax for calling numba vectorized function the same as for calling the plain Python functions in column query strings
- added semantics check to ensure the proper use of numba vectorized functions in column query strings (a number of restrictions apply)