### PR TITLE
upgrade docker info for release prep

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -28,6 +28,11 @@ jobs:
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.vendor=Deephaven Data Labs
+            org.opencontainers.image.title=Deephaven Core
+            org.opencontainers.image.description=Deephaven Core
+            org.opencontainers.image.licenses=Deephaven Community License Agreement 1.0
 
       - name: Set up Docker Buildx
         id: buildx
@@ -89,6 +94,11 @@ jobs:
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.vendor=Deephaven Data Labs
+            org.opencontainers.image.title=Deephaven gRPC Web Proxy
+            org.opencontainers.image.description=Deephaven gRPC web proxy, for the improbable-eng grpc to grpc-web/websocket proxy
+            org.opencontainers.image.licenses=Apache-2.0
 
       - name: Set up Docker Buildx
         id: buildx
@@ -146,6 +156,11 @@ jobs:
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.vendor=Deephaven Data Labs
+            org.opencontainers.image.title=Deephaven Envoy
+            org.opencontainers.image.description=Deephaven envoy proxy
+            org.opencontainers.image.licenses=Apache-2.0
 
       - name: Set up Docker Buildx
         id: buildx
@@ -197,7 +212,12 @@ jobs:
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
- 
+          labels: |
+            org.opencontainers.image.vendor=Deephaven Data Labs
+            org.opencontainers.image.title=Deephaven Web
+            org.opencontainers.image.description=Deephaven web
+            org.opencontainers.image.licenses=Deephaven Community License Agreement 1.0
+
       # note: this uses Zulu and not AdoptOpenJDK or other. should make sure we build and test on the same one...
       - name: Setup JDK
         id: setup-java

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -21,13 +21,14 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3.3.0
         with:
           images: ghcr.io/deephaven/grpc-api
-          tag-semver: |
-            {{version}}
-            {{major}}.{{minor}}
-          label-custom: |
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
             org.opencontainers.image.title=deephaven/grpc-api
             org.opencontainers.image.description=Deephaven grpc-api
 
@@ -108,12 +109,13 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3.3.0
         with:
           images: ghcr.io/deephaven/grpc-proxy
-          tag-semver: |
-            {{version}}
-            {{major}}.{{minor}}
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -164,13 +166,14 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3.3.0
         with:
           images: ghcr.io/deephaven/envoy
-          tag-semver: |
-            {{version}}
-            {{major}}.{{minor}}
-          label-custom: |
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
             org.opencontainers.image.title=deephaven/envoy
             org.opencontainers.image.description=Deephaven Envoy
 
@@ -217,13 +220,14 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3.3.0
         with:
           images: ghcr.io/deephaven/web
-          tag-semver: |
-            {{version}}
-            {{major}}.{{minor}}
-          label-custom: |
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
             org.opencontainers.image.title=deephaven/web
             org.opencontainers.image.description=Deephaven web
  

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -23,7 +23,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3.3.0
         with:
-          images: ghcr.io/deephaven/grpc-api
+          images: ghcr.io/${{ github.repository_owner }}/grpc-api
           tags: |
             type=edge,branch=main
             type=semver,pattern={{version}}
@@ -87,7 +87,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3.3.0
         with:
-          images: ghcr.io/deephaven/grpc-proxy
+          images: ghcr.io/${{ github.repository_owner }}/grpc-proxy
           tags: |
             type=edge,branch=main
             type=semver,pattern={{version}}
@@ -144,7 +144,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3.3.0
         with:
-          images: ghcr.io/deephaven/envoy
+          images: ghcr.io/${{ github.repository_owner }}/envoy
           tags: |
             type=edge,branch=main
             type=semver,pattern={{version}}
@@ -198,7 +198,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3.3.0
         with:
-          images: ghcr.io/deephaven/web
+          images: ghcr.io/${{ github.repository_owner }}/web
           tags: |
             type=edge,branch=main
             type=semver,pattern={{version}}

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.3.0
         with:
           install: true
           driver: docker
@@ -95,7 +95,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.3.0
         with:
           install: true
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.3.0
         with:
           install: true
 
@@ -216,7 +216,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.3.0
         with:
           install: true
           driver: docker

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties
         run: |
@@ -105,7 +105,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties
         run: |
@@ -165,7 +165,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties
         run: |
@@ -227,7 +227,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties
         run: |

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -63,7 +63,7 @@ jobs:
       # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
       # https://github.com/docker/buildx/pull/535
       - name: Docker build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
@@ -120,7 +120,7 @@ jobs:
           gradle-version: wrapper
 
       - name: Docker build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
@@ -180,7 +180,7 @@ jobs:
           gradle-version: wrapper
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
@@ -242,7 +242,7 @@ jobs:
           gradle-version: wrapper
 
       - name: Docker build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.5.0
         with:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -28,9 +28,6 @@ jobs:
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-          labels: |
-            org.opencontainers.image.title=deephaven/grpc-api
-            org.opencontainers.image.description=Deephaven grpc-api
 
       - name: Set up Docker Buildx
         id: buildx
@@ -149,9 +146,6 @@ jobs:
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-          labels: |
-            org.opencontainers.image.title=deephaven/envoy
-            org.opencontainers.image.description=Deephaven Envoy
 
       - name: Set up Docker Buildx
         id: buildx
@@ -203,9 +197,6 @@ jobs:
             type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-          labels: |
-            org.opencontainers.image.title=deephaven/web
-            org.opencontainers.image.description=Deephaven web
  
       # note: this uses Zulu and not AdoptOpenJDK or other. should make sure we build and test on the same one...
       - name: Setup JDK

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties
@@ -104,7 +104,7 @@ jobs:
         uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties
@@ -164,7 +164,7 @@ jobs:
         uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties
@@ -226,7 +226,7 @@ jobs:
         uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup gradle properties

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
@@ -223,7 +223,7 @@ jobs:
 
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.9.0
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -37,10 +37,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           install: true
-
-          # By default, the driver is "docker-container".
-          # We want to use the "docker" driver, so that the tagged images from one step can be used
-          # by subsequent steps.
           driver: docker
 
       - name: Login to ghcr.io
@@ -50,20 +46,6 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_PAT }}
-
-# Docker cache doesn't seem to be working. Not sure why.
-# During the export cache step for Docker build, we are getting
-# level=error msg="(*service).Write failed" error="rpc error: code = Canceled desc = context canceled" expected="sha256:e1cf0ed900810d12941c8478ee6c6f8d159db5bb6c3afeeb7863c798f29cc37a" ref="sha256:e1cf0ed900810d12941c8478ee6c6f8d159db5bb6c3afeeb7863c798f29cc37a" total=2214
-# And during the start for next Docker build, we are getting
-# level=warning msg="local cache import at /tmp/.buildx-cache not found due to err: could not read /tmp/.buildx-cache/index.json: open /tmp/.buildx-cache/index.json: no such file or directory"
-#      - name: Cache Docker layers
-#        uses: actions/cache@v2
-#        with:
-#          path: /tmp/.buildx-cache
-#          key: ${{ runner.os }}-buildx-grpc-api-${{ github.sha }}
-#          restore-keys: |
-#            ${{ runner.os }}-buildx-grpc-api-
-#            ${{ runner.os }}-buildx-
 
       - name: Setup gradle properties
         run: |
@@ -88,12 +70,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: ./grpc-api/server/docker/build/docker/
           push: ${{ github.event_name != 'pull_request' }}
-
-      # Workaround for https://github.com/docker/build-push-action/issues/252
-#      - name: Move cache
-#        run:
-#          rm -rf /tmp/.buildx-cache
-#          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   grpc-proxy:
     runs-on: ubuntu-20.04
@@ -243,10 +219,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           install: true
-
-          # By default, the driver is "docker-container".
-          # We want to use the "docker" driver, so that the tagged images from one step can be used
-          # by subsequent steps.
           driver: docker
 
       - name: Login to ghcr.io
@@ -277,3 +249,13 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: ./web/client-ide/build/docker/
           push: ${{ github.event_name != 'pull_request' }}
+
+
+### Notes about `driver: docker`
+###
+### By default, the driver used is `docker-container`. This does not allow the Dockerfile to
+### reference images that were built in earlier steps. Since our grpc-api and web Dockerfiles
+### reference earlier images (built during the gradle step), we need to change the driver to
+### `docker`.
+###
+### See https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#driver

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -4,9 +4,3 @@ COPY contents/ /
 RUN set -eux; \
     mv /envoy.yaml /etc/envoy/envoy.yaml; \
     chmod go+r /etc/envoy/envoy.yaml
-
-LABEL org.opencontainers.image.vendor="Deephaven Data Labs" \
-  org.opencontainers.image.title="Deephaven envoy" \
-  org.opencontainers.image.description="Deephaven envoy proxy" \
-  org.opencontainers.image.source="https://github.com/deephaven/deephaven-core" \
-  org.opencontainers.image.licenses="Apache-2.0"

--- a/grpc-api/server/docker/build.gradle
+++ b/grpc-api/server/docker/build.gradle
@@ -70,20 +70,6 @@ docker {
 
     volume("/data")
     volume("/cache")
-
-    // https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
-    label([
-        'org.opencontainers.image.vendor': "${project.property('grpc-api-docker.vendor')}",
-        'org.opencontainers.image.title': "${project.property('grpc-api-docker.title')}",
-        'org.opencontainers.image.description': "${project.property('grpc-api-docker.description')}",
-        'org.opencontainers.image.source': "${project.property('grpc-api-docker.source')}",
-        'org.opencontainers.image.licenses': "${project.property('grpc-api-docker.licenses')}",
-        'org.opencontainers.image.version': "${project.version}",
-        //'org.opencontainers.image.revision': "${sha}",
-        // todo: do we even want this? causes invalidation every single build, and makes builds non-reproducible
-        // consider sourcing this from a file instead?
-        //'org.opencontainers.image.created': "${Instant.now()}"
-    ])
   }
 }
 

--- a/grpc-api/server/docker/gradle.properties
+++ b/grpc-api/server/docker/gradle.properties
@@ -1,7 +1,2 @@
 grpc-api-docker.imageName=deephaven/grpc-api
 grpc-api-docker.baseImage=deephaven/runtime-base
-grpc-api-docker.vendor=Deephaven Data Labs
-grpc-api-docker.title=Deephaven gRPC API
-grpc-api-docker.description=The Deephaven API - TODO
-grpc-api-docker.source=https://github.com/deephaven/deephaven-core
-grpc-api-docker.licenses=Deephaven Community License

--- a/grpc-proxy/Dockerfile
+++ b/grpc-proxy/Dockerfile
@@ -16,9 +16,3 @@ RUN set -eux; \
 EXPOSE 8080 8443
 
 ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]
-
-LABEL org.opencontainers.image.vendor="Deephaven Data Labs" \
-  org.opencontainers.image.title="Deephaven gRPC web proxy" \
-  org.opencontainers.image.description="Deephaven gRPC web proxy, for the improbable-eng grpc to grpc-web/websocket proxy" \
-  org.opencontainers.image.source="https://github.com/deephaven/deephaven-core" \
-  org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
In summary:

* Explicit versions for the docker actions
* Using GITHUB_TOKEN instead of PAT (security improvement available as of docker/login-action@v1.9.0)
* Move labels as responsibility of CI actions instead of gradle (easier to manage ATM)
* Setup docker image tagging as follows:
  - All docker images stemming from pushes to `main` will get the `edge` tag.
  - All docker images stemming from a tag `vX.Y.Z` will get the tags `X.Y.Z` and `X.Y`.
* Fork support - users can easily publish to `ghcr.io/<username>/<abc>`