### PR TITLE
Stop exposing server-created export as a long

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
@@ -463,8 +463,8 @@ public class SessionState extends LivenessArtifact {
         /**
          * @return the export id or NON_EXPORT_ID if it does not have one
          */
-        public long getExportId() {
-            return exportId;
+        public Ticket getExportId() {
+            return exportIdToTicket(exportId);
         }
 
         /**

--- a/grpc-api/src/test/java/io/deephaven/grpc_api/session/SessionStateTest.java
+++ b/grpc-api/src/test/java/io/deephaven/grpc_api/session/SessionStateTest.java
@@ -8,6 +8,7 @@ import io.deephaven.db.util.liveness.LivenessScope;
 import io.deephaven.db.util.liveness.LivenessScopeStack;
 import io.deephaven.grpc_api.util.TestControlledScheduler;
 import io.deephaven.proto.backplane.grpc.ExportNotification;
+import io.deephaven.proto.backplane.grpc.Ticket;
 import io.deephaven.util.SafeCloseable;
 import io.deephaven.util.auth.AuthContext;
 import io.grpc.stub.StreamObserver;
@@ -550,10 +551,10 @@ public class SessionStateTest {
         }
 
         private void validateNotificationQueue(final SessionState.ExportObject<?> export, final ExportNotification.State... states) {
-            final long exportId = export.getExportId();
+            final Ticket exportId = export.getExportId();
 
             final List<ExportNotification.State> foundStates = notifications.stream()
-                    .filter(n -> getExportId(n) == exportId)
+                    .filter(n -> n.getTicket().equals(exportId))
                     .map(ExportNotification::getExportState)
                     .collect(Collectors.toList());
             boolean error = foundStates.size() != states.length;

--- a/grpc-api/src/test/java/io/deephaven/grpc_api/table/ExportTableUpdateListenerTest.java
+++ b/grpc-api/src/test/java/io/deephaven/grpc_api/table/ExportTableUpdateListenerTest.java
@@ -12,6 +12,7 @@ import io.deephaven.db.v2.ShiftAwareListener;
 import io.deephaven.db.v2.TstUtils;
 import io.deephaven.db.v2.utils.Index;
 import io.deephaven.db.v2.utils.IndexShiftData;
+import io.deephaven.proto.backplane.grpc.Ticket;
 import io.deephaven.util.SafeCloseable;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.util.auth.AuthContext;
@@ -218,8 +219,8 @@ public class ExportTableUpdateListenerTest {
         });
 
         final ExportedTableUpdateMessage msg = expectBatch(1).getUpdates(0);
-        final long updateId = SessionState.ticketToExportId(msg.getExportId());
-        Assert.eq(updateId, "updateId", t1.getExportId(), "t1.getExportId()");
+        final Ticket updateId = msg.getExportId();
+        Assert.equals(updateId, "updateId", t1.getExportId(), "t1.getExportId()");
         Assert.eq(msg.getSize(), "msg.getSize()", 42);
         Assert.eqFalse(msg.getUpdateFailureMessage().isEmpty(), "msg.getUpdateFailureMessage().isEmpty()");
 
@@ -320,12 +321,12 @@ public class ExportTableUpdateListenerTest {
         });
     }
 
-    private void expectBatchWithSizes(final long exportId, final long... sizes) {
+    private void expectBatchWithSizes(final Ticket exportId, final long... sizes) {
         final ExportedTableUpdateBatchMessage batch = expectBatch(sizes.length);
         for (int i = 0; i < sizes.length; ++i) {
             final ExportedTableUpdateMessage msg = batch.getUpdates(i);
-            final long updateId = SessionState.ticketToExportId(msg.getExportId());
-            Assert.eq(updateId, "updateId", exportId, "exportId");
+            final Ticket updateId = msg.getExportId();
+            Assert.equals(updateId, "updateId", exportId, "exportId");
             Assert.eq(msg.getSize(), "msg.getSize()", sizes[i]);
             Assert.eqTrue(msg.getUpdateFailureMessage().isEmpty(), "msg.getUpdateFailureMessage().isEmpty()");
         }


### PR DESCRIPTION
This makes it easier to use this feature to make a ticket and ETCR, and
will help in the future if we change the layout of a ticket.

Partial #41