### PR TITLE
Add support for reading Parquet logical type timestamp with millis and micros units. #743

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/locations/local/ReadOnlyParquetTableLocation.java
+++ b/DB/src/main/java/io/deephaven/db/v2/locations/local/ReadOnlyParquetTableLocation.java
@@ -247,8 +247,8 @@ class ReadOnlyParquetTableLocation extends AbstractTableLocation<TableKey, Parqu
         @Override
         public Optional<ToPage<ATTR, ?>> visit(LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampLogicalType) {
 
-            if (timestampLogicalType.isAdjustedToUTC() && timestampLogicalType.getUnit() == LogicalTypeAnnotation.TimeUnit.NANOS) {
-                return Optional.of(ToDBDateTimePage.create(componentType));
+            if (timestampLogicalType.isAdjustedToUTC()) {
+                return Optional.of(ToDBDateTimePage.create(componentType, timestampLogicalType.getUnit()));
             }
 
             throw new TableDataException("Timestamp column is not UTC or is not nanoseconds " + name);

--- a/DB/src/main/java/io/deephaven/db/v2/locations/local/ReadOnlyParquetTableLocation.java
+++ b/DB/src/main/java/io/deephaven/db/v2/locations/local/ReadOnlyParquetTableLocation.java
@@ -246,7 +246,6 @@ class ReadOnlyParquetTableLocation extends AbstractTableLocation<TableKey, Parqu
 
         @Override
         public Optional<ToPage<ATTR, ?>> visit(LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampLogicalType) {
-
             if (timestampLogicalType.isAdjustedToUTC()) {
                 return Optional.of(ToDBDateTimePage.create(componentType, timestampLogicalType.getUnit()));
             }

--- a/DB/src/main/java/io/deephaven/db/v2/locations/parquet/topage/ToDBDateTimePage.java
+++ b/DB/src/main/java/io/deephaven/db/v2/locations/parquet/topage/ToDBDateTimePage.java
@@ -3,23 +3,38 @@ package io.deephaven.db.v2.locations.parquet.topage;
 import io.deephaven.db.tables.dbarrays.DbArray;
 import io.deephaven.db.tables.dbarrays.DbArrayDirect;
 import io.deephaven.db.tables.utils.DBDateTime;
+import io.deephaven.db.tables.utils.DBTimeUtils;
 import io.deephaven.db.v2.sources.chunk.Attributes;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.jetbrains.annotations.NotNull;
 
-public class ToDBDateTimePage<ATTR extends Attributes.Any> extends ToLongPage<ATTR> {
+public abstract class ToDBDateTimePage<ATTR extends Attributes.Any> extends ToLongPage<ATTR> {
 
-    private static ToDBDateTimePage INSTANCE = new ToDBDateTimePage<>();
+    private static final ToDBDateTimePage MILLIS_INSTANCE = new ToDBDateTimePageMillis<>();
+    private static final ToDBDateTimePage MICROS_INSTANCE = new ToDBDateTimePageMicros<>();
+    private static final ToDBDateTimePage NANOS_INSTANCE = new ToDBDateTimePageNanos<>();
 
-    public static <ATTR extends Attributes.Any> ToDBDateTimePage<ATTR> create(@NotNull Class<?> nativeType) {
+    public static <ATTR extends Attributes.Any> ToDBDateTimePage<ATTR> create(@NotNull final Class<?> nativeType, final LogicalTypeAnnotation.TimeUnit unit) {
         if (DBDateTime.class.equals(nativeType)) {
-            //noinspection unchecked
-            return INSTANCE;
+            switch(unit) {
+                case MILLIS:
+                    //noinspection unchecked
+                    return MILLIS_INSTANCE;
+                case MICROS:
+                    //noinspection unchecked
+                    return MICROS_INSTANCE;
+                case NANOS:
+                    //noinspection unchecked
+                    return NANOS_INSTANCE;
+                default:
+                    throw new IllegalArgumentException("Unsupported unit=" + unit);
+            }
         }
 
-        throw new IllegalArgumentException("The native type for a Int column is " + nativeType.getCanonicalName());
+        throw new IllegalArgumentException("The native type for a DBDateTime column is " + nativeType.getCanonicalName());
     }
 
-    private ToDBDateTimePage() {}
+    protected ToDBDateTimePage() {}
 
     @Override
     @NotNull
@@ -27,15 +42,38 @@ public class ToDBDateTimePage<ATTR extends Attributes.Any> extends ToLongPage<AT
         return DBDateTime.class;
     }
 
+    protected abstract DBDateTime toDBDateTime(final long v);
+
     @Override
     @NotNull
-    public DbArray<DBDateTime> makeDbArray(long [] result) {
+    public DbArray<DBDateTime> makeDbArray(long[] result) {
         DBDateTime[] to = new DBDateTime[result.length];
 
         for (int i = 0; i < result.length; ++i) {
-            to[i] = new DBDateTime(result[i]);
+            to[i] = toDBDateTime(result[i]);
         }
 
         return new DbArrayDirect<>(to);
+    }
+
+    private static final class ToDBDateTimePageMillis<ATTR extends Attributes.Any> extends ToDBDateTimePage<ATTR> {
+        @Override
+        protected DBDateTime toDBDateTime(final long v) {
+            return DBTimeUtils.millisToTime(v);
+        }
+    }
+
+    private static final class ToDBDateTimePageMicros<ATTR extends Attributes.Any> extends ToDBDateTimePage<ATTR> {
+        @Override
+        protected DBDateTime toDBDateTime(final long v) {
+            return DBTimeUtils.microsToTime(v);
+        }
+    }
+
+    private static final class ToDBDateTimePageNanos<ATTR extends Attributes.Any> extends ToDBDateTimePage<ATTR> {
+        @Override
+        protected DBDateTime toDBDateTime(final long v) {
+            return new DBDateTime(v);
+        }
     }
 }

--- a/DB/src/main/java/io/deephaven/db/v2/locations/parquet/topage/ToDBDateTimePage.java
+++ b/DB/src/main/java/io/deephaven/db/v2/locations/parquet/topage/ToDBDateTimePage.java
@@ -52,7 +52,7 @@ public abstract class ToDBDateTimePage<ATTR extends Attributes.Any> extends ToLo
     private static final ToDBDateTimePage<?> MICROS_INSTANCE = fromUnitToNanos(DBTimeUtils::microsToNanos);
     private static final ToDBDateTimePage<?> NANOS_INSTANCE = fromUnitToNanos(ToDBDateTimePage::longIdentity);
 
-    public static ToDBDateTimePage<?> create(@NotNull final Class<?> nativeType, final LogicalTypeAnnotation.TimeUnit unit) {
+    public static ToDBDateTimePage create(@NotNull final Class<?> nativeType, final LogicalTypeAnnotation.TimeUnit unit) {
         if (DBDateTime.class.equals(nativeType)) {
             switch(unit) {
                 case MILLIS:

--- a/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetReaderUtil.java
+++ b/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetReaderUtil.java
@@ -191,7 +191,6 @@ public class ParquetReaderUtil {
                         case NANOS:
                             return Optional.of(io.deephaven.db.tables.utils.DBDateTime.class);
                     }
-                    return Optional.of(io.deephaven.db.tables.utils.DBDateTime.class);
                 }
                 errorString.setValue("TimestampLogicalType,isAdjustedToUTC=" + timestampLogicalType.isAdjustedToUTC() + ",unit=" + timestampLogicalType.getUnit());
                 return Optional.empty();

--- a/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetReaderUtil.java
+++ b/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetReaderUtil.java
@@ -184,7 +184,13 @@ public class ParquetReaderUtil {
 
             @Override
             public Optional<Class<?>> visit(final LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampLogicalType) {
-                if (timestampLogicalType.isAdjustedToUTC() && timestampLogicalType.getUnit().equals(LogicalTypeAnnotation.TimeUnit.NANOS)) {
+                if (timestampLogicalType.isAdjustedToUTC()) {
+                    switch(timestampLogicalType.getUnit()) {
+                        case MILLIS:
+                        case MICROS:
+                        case NANOS:
+                            return Optional.of(io.deephaven.db.tables.utils.DBDateTime.class);
+                    }
                     return Optional.of(io.deephaven.db.tables.utils.DBDateTime.class);
                 }
                 errorString.setValue("TimestampLogicalType,isAdjustedToUTC=" + timestampLogicalType.isAdjustedToUTC() + ",unit=" + timestampLogicalType.getUnit());


### PR DESCRIPTION
We need both page support for them and small schema loading changes.  The code is coming from work that Paul and Ryan did in the DHE `pjc_IDS-7514` branch.