### PR TITLE
Do not register script session as global except in the grpc worker.

### DIFF
--- a/DB/src/main/java/io/deephaven/db/util/AbstractScriptSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/AbstractScriptSession.java
@@ -46,7 +46,7 @@ public abstract class AbstractScriptSession extends LivenessArtifact implements 
     protected final QueryLibrary queryLibrary;
     protected final CompilerTools.Context compilerContext;
 
-    protected AbstractScriptSession() {
+    protected AbstractScriptSession(boolean isDefaultScriptSession) {
         manage(livenessScope);
         final UUID scriptCacheId = UuidCreator.getRandomBased();
         classCacheDirectory = new File(CLASS_CACHE_LOCATION, UuidCreator.toString(scriptCacheId));
@@ -69,12 +69,7 @@ public abstract class AbstractScriptSession extends LivenessArtifact implements 
             }
         };
 
-        //
-        // This is a temporary work around to other short comings related to {@link QueryScope},
-        // {@link io.deephaven.compilertools.CompilerTools.Context}, and {@link io.deephaven.db.tables.libs.QueryLibrary}
-        // not yet able to consistently support multiple-script-sessions.
-        //
-        if (!(this instanceof NoLanguageDeephavenSession)) {
+        if (isDefaultScriptSession) {
             CompilerTools.setDefaultContext(compilerContext);
             QueryScope.setDefaultScope(queryScope);
             QueryLibrary.setDefaultLibrary(queryLibrary);

--- a/DB/src/main/java/io/deephaven/db/util/GroovyDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/GroovyDeephavenSession.java
@@ -119,6 +119,12 @@ public class GroovyDeephavenSession extends AbstractScriptSession implements Scr
     private transient SourceClosure sourceOnceClosure;
 
     public GroovyDeephavenSession(final RunScripts runScripts) throws IOException {
+        this(runScripts, false);
+    }
+
+    public GroovyDeephavenSession(final RunScripts runScripts, boolean isDefaultScriptSession) throws IOException {
+        super(isDefaultScriptSession);
+
         this.scriptFinder = new ScriptFinder(DEFAULT_SCRIPT_PATH);
 
         groovyShell.setVariable("__groovySession", this);

--- a/DB/src/main/java/io/deephaven/db/util/NoLanguageDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/NoLanguageDeephavenSession.java
@@ -25,6 +25,8 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession implements
     }
 
     public NoLanguageDeephavenSession(final String scriptType) {
+        super(false);
+
         this.scriptType = scriptType;
         variables = new LinkedHashMap<>();
     }

--- a/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
@@ -58,8 +58,20 @@ public class PythonDeephavenSession extends AbstractScriptSession implements Scr
      * @param runInitScripts if init scripts should be executed
      * @throws IOException if an IO error occurs running initialization scripts
      */
-    @SuppressWarnings("unused")
     public PythonDeephavenSession(boolean runInitScripts) throws IOException {
+        this(runInitScripts, false);
+    }
+
+    /**
+     * Create a Python ScriptSession.
+     *
+     * @param runInitScripts if init scripts should be executed
+     * @param isDefaultScriptSession true if this is in the default context of a worker jvm
+     * @throws IOException if an IO error occurs running initialization scripts
+     */
+    public PythonDeephavenSession(boolean runInitScripts, boolean isDefaultScriptSession) throws IOException {
+        super(isDefaultScriptSession);
+
         JpyInit.init(log);
         PythonEvaluatorJpy jpy = PythonEvaluatorJpy.withGlobalCopy();
         evaluator = jpy;
@@ -96,6 +108,8 @@ public class PythonDeephavenSession extends AbstractScriptSession implements Scr
      * scope, such as an IPython kernel session.
      */
     public PythonDeephavenSession(PythonScope<?> scope) {
+        super(false);
+
         this.scope = scope;
         this.evaluator = null;
         this.scriptFinder = null;

--- a/DB/src/main/java/io/deephaven/db/util/ScalaDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/ScalaDeephavenSession.java
@@ -79,7 +79,9 @@ public class ScalaDeephavenSession extends AbstractScriptSession implements Scri
         }
     }
 
-    public ScalaDeephavenSession(@SuppressWarnings("unused") boolean runInitScripts) {
+    public ScalaDeephavenSession(@SuppressWarnings("unused") boolean runInitScripts, boolean isDefaultScriptSession) {
+        super(isDefaultScriptSession);
+
         errorHandler = new ErrorHandler();
         GenericRunnerSettings settings = new GenericRunnerSettings(errorHandler);
         ((MutableSettings.BooleanSetting) settings.usejavacp()).v_$eq(true);

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/console/groovy/GroovyConsoleSessionModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/console/groovy/GroovyConsoleSessionModule.java
@@ -23,7 +23,7 @@ public class GroovyConsoleSessionModule {
     @Provides
     GroovyDeephavenSession bindGroovySession(final RunScripts runScripts) {
         try {
-            return new GroovyDeephavenSession(runScripts);
+            return new GroovyDeephavenSession(runScripts, true);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/console/python/PythonConsoleSessionModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/console/python/PythonConsoleSessionModule.java
@@ -22,7 +22,7 @@ public class PythonConsoleSessionModule {
     @Provides
     PythonDeephavenSession bindPythonSession() {
         try {
-            return new PythonDeephavenSession(true);
+            return new PythonDeephavenSession(true, true);
         } catch (IOException e) {
             //can't happen since we pass false
             throw new UncheckedIOException(e);


### PR DESCRIPTION
This re-enables the ability to use ScriptSessions in unit tests by restricting the initialization of the global session to the worker instead of always inside of the AbstractScriptSession constructor.

This contributes to #734.