### PR TITLE
Add server notebook storage support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,9 @@ services:
     image: deephaven/web:local-build
     expose:
       - "80"
+    # TODO: Adding this volume to the web for notebooks... maybe want a different path?
+    volumes:
+      - ./docker/core/data:/data
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
     image: deephaven/web:local-build
     expose:
       - "80"
-    # TODO: Adding this volume to the web for notebooks... maybe want a different path?
     volumes:
       - ./docker/core/data:/data
     deploy:

--- a/envoy/contents/envoy.yaml
+++ b/envoy/contents/envoy.yaml
@@ -38,6 +38,9 @@ static_resources:
                         - match: # JS API lives in this path
                             prefix: "/jsapi"
                           route: { cluster: web }
+                        - match: # Notebook file storage at this path
+                            prefix: "/notebooks"
+                          route: { cluster: web }
                         - match: # Any GRPC call is assumed to be forwarded to the real service
                             prefix: "/"
                             grpc: {}

--- a/web/client-ide/client-ide.gradle
+++ b/web/client-ide/client-ide.gradle
@@ -42,6 +42,8 @@ task prepareDocker(type: Sync) {
     }
     from 'docker/Dockerfile'
     from 'nginx/default.conf'
+    from 'nginx/nginx.conf'
+    from 'nginx/init-notebooks.sh'
 }
 
 Docker.registerDockerImage(project, 'buildDocker') {

--- a/web/client-ide/client-ide.gradle
+++ b/web/client-ide/client-ide.gradle
@@ -43,7 +43,7 @@ task prepareDocker(type: Sync) {
     from 'docker/Dockerfile'
     from 'nginx/default.conf'
     from 'nginx/nginx.conf'
-    from 'nginx/init-notebooks.sh'
+    from 'nginx/99-init-notebooks.sh'
 }
 
 Docker.registerDockerImage(project, 'buildDocker') {

--- a/web/client-ide/docker/Dockerfile
+++ b/web/client-ide/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM docker.io/library/nginx:1.19.7
 
 # these installs are necessary to enable webdav class 2
 # https://github.com/arut/nginx-dav-ext-module
-RUN set-eux; \
+RUN set -eux; \
     apt-get update; \
     apt-get install -y nginx-extras libnginx-mod-http-dav-ext;
 

--- a/web/client-ide/docker/Dockerfile
+++ b/web/client-ide/docker/Dockerfile
@@ -3,8 +3,16 @@ FROM deephaven/dhide:local-build as dhide
 FROM deephaven/js-out:local-build as js-out
 
 FROM docker.io/library/nginx:1.19.7
+
+# these installs are necessary because to enable webdav class 2
+# https://github.com/arut/nginx-dav-ext-module
+RUN apt-get update && apt-get install -y nginx-extras libnginx-mod-http-dav-ext
+
 COPY --from=dhide /usr/src/app/package/build /usr/share/nginx/html/ide
 COPY --from=js-out /usr/src/app/raw-js-openapi/build/js-out /usr/share/nginx/html/jsapi
 COPY licenses/ /
 COPY dhapi /usr/share/nginx/html/jsapi
-COPY default.conf /etc/nginx/conf.d
+COPY default.conf /etc/nginx/conf.d/
+COPY nginx.conf /etc/nginx/
+COPY init-notebooks.sh /docker-entrypoint.d
+

--- a/web/client-ide/docker/Dockerfile
+++ b/web/client-ide/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM deephaven/js-out:local-build as js-out
 
 FROM docker.io/library/nginx:1.19.7
 
-# these installs are necessary because to enable webdav class 2
+# these installs are necessary to enable webdav class 2
 # https://github.com/arut/nginx-dav-ext-module
 RUN apt-get update && apt-get install -y nginx-extras libnginx-mod-http-dav-ext
 

--- a/web/client-ide/docker/Dockerfile
+++ b/web/client-ide/docker/Dockerfile
@@ -6,7 +6,9 @@ FROM docker.io/library/nginx:1.19.7
 
 # these installs are necessary to enable webdav class 2
 # https://github.com/arut/nginx-dav-ext-module
-RUN apt-get update && apt-get install -y nginx-extras libnginx-mod-http-dav-ext
+RUN set-eux; \
+    apt-get update; \
+    apt-get install -y nginx-extras libnginx-mod-http-dav-ext;
 
 COPY --from=dhide /usr/src/app/package/build /usr/share/nginx/html/ide
 COPY --from=js-out /usr/src/app/raw-js-openapi/build/js-out /usr/share/nginx/html/jsapi
@@ -14,5 +16,6 @@ COPY licenses/ /
 COPY dhapi /usr/share/nginx/html/jsapi
 COPY default.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
-COPY init-notebooks.sh /docker-entrypoint.d
+COPY 99-init-notebooks.sh /docker-entrypoint.d
 
+VOLUME /tmp

--- a/web/client-ide/nginx/99-init-notebooks.sh
+++ b/web/client-ide/nginx/99-init-notebooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+mkdir -p /data/notebooks
+chown nginx /data/notebooks

--- a/web/client-ide/nginx/default.conf
+++ b/web/client-ide/nginx/default.conf
@@ -13,6 +13,26 @@ server {
         index  index.html index.htm;
     }
 
+    location /notebooks/ {
+        root                  /data;
+        autoindex   on;
+
+        # enable creating directories without trailing slash
+        set $x $uri$request_method;
+        if ($x ~ [^/]MKCOL$) {
+            rewrite ^(.*)$ $1/;
+        }
+
+        client_body_temp_path /tmp/client_temp;
+
+        dav_methods PUT DELETE MKCOL COPY MOVE;
+        dav_ext_methods PROPFIND OPTIONS LOCK UNLOCK;
+        dav_ext_lock zone=notebooks;
+
+        dav_access  user:rw group:rw all:rw;
+        create_full_put_path  on;
+    }
+
     # redirect server error pages to the static page /50x.html
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {

--- a/web/client-ide/nginx/init-notebooks.sh
+++ b/web/client-ide/nginx/init-notebooks.sh
@@ -1,0 +1,5 @@
+set -eux
+
+mkdir -p /data/notebooks
+mkdir -p /tmp
+chown nginx /data/notebooks

--- a/web/client-ide/nginx/init-notebooks.sh
+++ b/web/client-ide/nginx/init-notebooks.sh
@@ -1,5 +1,0 @@
-set -eux
-
-mkdir -p /data/notebooks
-mkdir -p /tmp
-chown nginx /data/notebooks

--- a/web/client-ide/nginx/nginx.conf
+++ b/web/client-ide/nginx/nginx.conf
@@ -29,6 +29,10 @@ http {
 
     #gzip  on;
 
+    # Define a shared zone for lock storage that is 10mb
+    # This is the default suggested in the examples, and should be large enough for us
+    # We are not expecting files to stay locked for long
+    # https://github.com/arut/nginx-dav-ext-module#id8
     dav_ext_lock_zone zone=notebooks:10m;
 
     include /etc/nginx/conf.d/*.conf;

--- a/web/client-ide/nginx/nginx.conf
+++ b/web/client-ide/nginx/nginx.conf
@@ -1,0 +1,35 @@
+user  nginx;
+worker_processes  1;
+
+# This is important! because it loads several dav module with this.
+include /etc/nginx/modules-enabled/*.conf;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    dav_ext_lock_zone zone=notebooks:10m;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
- Added nginx module for hosting notebooks
- Notebooks are stored in the data/notebooks directory
- docker/core/data now mounted as a volume in web container
- Automatically creates notebooks folder and sets permissions so nginx to own

Fix #719 