### PR TITLE
improve the performance of tableToDataFrame() 

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/IndexedDataColumn.java
+++ b/DB/src/main/java/io/deephaven/db/v2/IndexedDataColumn.java
@@ -159,6 +159,8 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
         final byte[] result = new byte[rangeIndex.intSize("getBytes")];
         try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
             columnSource.fillChunk(context, WritableByteChunk.writableChunkWrap(result), rangeIndex);
+        } finally {
+            rangeIndex.close();
         }
         return result;
     }
@@ -196,6 +198,8 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
         final char[] result = new char[rangeIndex.intSize("getChars")];
         try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
             columnSource.fillChunk(context, WritableCharChunk.writableChunkWrap(result), rangeIndex);
+        } finally {
+            rangeIndex.close();
         }
         return result;
     }
@@ -233,6 +237,8 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
         final double[] result = new double[rangeIndex.intSize("getDoubles")];
         try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
             columnSource.fillChunk(context, WritableDoubleChunk.writableChunkWrap(result), rangeIndex);
+        } finally {
+            rangeIndex.close();
         }
         return result;
     }
@@ -270,6 +276,8 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
         final float[] result = new float[rangeIndex.intSize("getFloats")];
         try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
             columnSource.fillChunk(context, WritableFloatChunk.writableChunkWrap(result), rangeIndex);
+        } finally {
+            rangeIndex.close();
         }
         return result;
     }
@@ -307,6 +315,8 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
         final int[] result = new int[rangeIndex.intSize("getInts")];
         try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
             columnSource.fillChunk(context, WritableIntChunk.writableChunkWrap(result), rangeIndex);
+        } finally {
+            rangeIndex.close();
         }
         return result;
     }
@@ -344,6 +354,8 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
         final long[] result = new long[rangeIndex.intSize("getLongs")];
         try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
             columnSource.fillChunk(context, WritableLongChunk.writableChunkWrap(result), rangeIndex);
+        } finally {
+            rangeIndex.close();
         }
         return result;
     }
@@ -381,6 +393,8 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
         final short[] result = new short[rangeIndex.intSize("getShorts")];
         try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
             columnSource.fillChunk(context, WritableShortChunk.writableChunkWrap(result), rangeIndex);
+        } finally {
+            rangeIndex.close();
         }
         return result;
     }

--- a/DB/src/main/java/io/deephaven/db/v2/IndexedDataColumn.java
+++ b/DB/src/main/java/io/deephaven/db/v2/IndexedDataColumn.java
@@ -7,6 +7,7 @@ package io.deephaven.db.v2;
 import io.deephaven.base.Procedure;
 import io.deephaven.db.tables.DataColumn;
 import io.deephaven.db.tables.Table;
+import io.deephaven.db.v2.sources.chunk.*;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.db.v2.iterators.*;
 import io.deephaven.db.v2.sources.*;
@@ -156,14 +157,9 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
     public byte[] getBytes(final long startPosInclusive, final long endPosExclusive) {
         final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
         final byte[] result = new byte[rangeIndex.intSize("getBytes")];
-        //noinspection unchecked
-        new ByteColumnIterator(rangeIndex, (ColumnSource<Byte>)columnSource).forEachRemaining(new Procedure.UnaryByte() {
-            private int vi = 0;
-            @Override
-            public void call(final byte value) {
-                result[vi++] = value;
-            }
-        });
+        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+            columnSource.fillChunk(context, WritableByteChunk.writableChunkWrap(result), rangeIndex);
+        }
         return result;
     }
 
@@ -198,14 +194,9 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
     public char[] getChars(final long startPosInclusive, final long endPosExclusive) {
         final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
         final char[] result = new char[rangeIndex.intSize("getChars")];
-        //noinspection unchecked
-        new CharacterColumnIterator(rangeIndex, (ColumnSource<Character>)columnSource).forEachRemaining(new Procedure.UnaryChar() {
-            private int vi = 0;
-            @Override
-            public void call(final char value) {
-                result[vi++] = value;
-            }
-        });
+        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+            columnSource.fillChunk(context, WritableCharChunk.writableChunkWrap(result), rangeIndex);
+        }
         return result;
     }
 
@@ -240,14 +231,9 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
     public double[] getDoubles(final long startPosInclusive, final long endPosExclusive) {
         final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
         final double[] result = new double[rangeIndex.intSize("getDoubles")];
-        //noinspection unchecked
-        new DoubleColumnIterator(rangeIndex, (ColumnSource<Double>)columnSource).forEachRemaining(new DoubleConsumer() {
-            private int vi = 0;
-            @Override
-            public void accept(final double value) {
-                result[vi++] = value;
-            }
-        });
+        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+            columnSource.fillChunk(context, WritableDoubleChunk.writableChunkWrap(result), rangeIndex);
+        }
         return result;
     }
 
@@ -282,14 +268,9 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
     public float[] getFloats(final long startPosInclusive, final long endPosExclusive) {
         final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
         final float[] result = new float[rangeIndex.intSize("getFloats")];
-        //noinspection unchecked
-        new FloatColumnIterator(rangeIndex, (ColumnSource<Float>)columnSource).forEachRemaining(new Procedure.UnaryFloat() {
-            private int vi = 0;
-            @Override
-            public void call(final float value) {
-                result[vi++] = value;
-            }
-        });
+        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+            columnSource.fillChunk(context, WritableFloatChunk.writableChunkWrap(result), rangeIndex);
+        }
         return result;
     }
 
@@ -324,14 +305,9 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
     public int[] getInts(final long startPosInclusive, final long endPosExclusive) {
         final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
         final int[] result = new int[rangeIndex.intSize("getInts")];
-        //noinspection unchecked
-        new IntegerColumnIterator(rangeIndex, (ColumnSource<Integer>)columnSource).forEachRemaining(new IntConsumer() {
-            private int vi = 0;
-            @Override
-            public void accept(final int value) {
-                result[vi++] = value;
-            }
-        });
+        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+            columnSource.fillChunk(context, WritableIntChunk.writableChunkWrap(result), rangeIndex);
+        }
         return result;
     }
 
@@ -366,14 +342,9 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
     public long[] getLongs(final long startPosInclusive, final long endPosExclusive) {
         final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
         final long[] result = new long[rangeIndex.intSize("getLongs")];
-        //noinspection unchecked
-        new LongColumnIterator(rangeIndex, (ColumnSource<Long>)columnSource).forEachRemaining(new LongConsumer() {
-            private int vi = 0;
-            @Override
-            public void accept(final long value) {
-                result[vi++] = value;
-            }
-        });
+        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+            columnSource.fillChunk(context, WritableLongChunk.writableChunkWrap(result), rangeIndex);
+        }
         return result;
     }
 
@@ -408,14 +379,9 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
     public short[] getShorts(final long startPosInclusive, final long endPosExclusive) {
         final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
         final short[] result = new short[rangeIndex.intSize("getShorts")];
-        //noinspection unchecked
-        new ShortColumnIterator(rangeIndex, (ColumnSource<Short>)columnSource).forEachRemaining(new Procedure.UnaryShort() {
-            private int vi = 0;
-            @Override
-            public void call(final short value) {
-                result[vi++] = value;
-            }
-        });
+        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+            columnSource.fillChunk(context, WritableShortChunk.writableChunkWrap(result), rangeIndex);
+        }
         return result;
     }
 

--- a/DB/src/main/java/io/deephaven/db/v2/IndexedDataColumn.java
+++ b/DB/src/main/java/io/deephaven/db/v2/IndexedDataColumn.java
@@ -155,14 +155,12 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
 
     @Override
     public byte[] getBytes(final long startPosInclusive, final long endPosExclusive) {
-        final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
-        final byte[] result = new byte[rangeIndex.intSize("getBytes")];
-        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+        try (final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
+             final ChunkSource.FillContext context = columnSource.makeFillContext(rangeIndex.intSize("getBytes"), null)) {
+            final byte[] result = new byte[rangeIndex.intSize("getBytes")];
             columnSource.fillChunk(context, WritableByteChunk.writableChunkWrap(result), rangeIndex);
-        } finally {
-            rangeIndex.close();
+            return result;
         }
-        return result;
     }
 
     @Override
@@ -194,14 +192,12 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
 
     @Override
     public char[] getChars(final long startPosInclusive, final long endPosExclusive) {
-        final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
-        final char[] result = new char[rangeIndex.intSize("getChars")];
-        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+         try (final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
+             final ChunkSource.FillContext context = columnSource.makeFillContext(rangeIndex.intSize("getChars"), null)) {
+            final char[] result = new char[rangeIndex.intSize("getChars")];
             columnSource.fillChunk(context, WritableCharChunk.writableChunkWrap(result), rangeIndex);
-        } finally {
-            rangeIndex.close();
+            return result;
         }
-        return result;
     }
 
     @Override
@@ -233,14 +229,12 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
 
     @Override
     public double[] getDoubles(final long startPosInclusive, final long endPosExclusive) {
-        final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
-        final double[] result = new double[rangeIndex.intSize("getDoubles")];
-        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+        try (final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
+             final ChunkSource.FillContext context = columnSource.makeFillContext(rangeIndex.intSize("getDoubles"), null)) {
+            final double[] result = new double[rangeIndex.intSize("getDoubles")];
             columnSource.fillChunk(context, WritableDoubleChunk.writableChunkWrap(result), rangeIndex);
-        } finally {
-            rangeIndex.close();
+            return result;
         }
-        return result;
     }
 
     @Override
@@ -272,14 +266,12 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
 
     @Override
     public float[] getFloats(final long startPosInclusive, final long endPosExclusive) {
-        final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
-        final float[] result = new float[rangeIndex.intSize("getFloats")];
-        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+       try (final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
+             final ChunkSource.FillContext context = columnSource.makeFillContext(rangeIndex.intSize("getFloats"), null)) {
+            final float[] result = new float[rangeIndex.intSize("getFloats")];
             columnSource.fillChunk(context, WritableFloatChunk.writableChunkWrap(result), rangeIndex);
-        } finally {
-            rangeIndex.close();
+            return result;
         }
-        return result;
     }
 
     @Override
@@ -311,14 +303,12 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
 
     @Override
     public int[] getInts(final long startPosInclusive, final long endPosExclusive) {
-        final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
-        final int[] result = new int[rangeIndex.intSize("getInts")];
-        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+        try (final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
+             final ChunkSource.FillContext context = columnSource.makeFillContext(rangeIndex.intSize("getInts"), null)) {
+            final int[] result = new int[rangeIndex.intSize("getInts")];
             columnSource.fillChunk(context, WritableIntChunk.writableChunkWrap(result), rangeIndex);
-        } finally {
-            rangeIndex.close();
+            return result;
         }
-        return result;
     }
 
     @Override
@@ -350,14 +340,12 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
 
     @Override
     public long[] getLongs(final long startPosInclusive, final long endPosExclusive) {
-        final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
-        final long[] result = new long[rangeIndex.intSize("getLongs")];
-        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+        try (final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
+             final ChunkSource.FillContext context = columnSource.makeFillContext(rangeIndex.intSize("getLongs"), null)) {
+            final long[] result = new long[rangeIndex.intSize("getLongs")];
             columnSource.fillChunk(context, WritableLongChunk.writableChunkWrap(result), rangeIndex);
-        } finally {
-            rangeIndex.close();
+            return result;
         }
-        return result;
     }
 
     @Override
@@ -389,14 +377,12 @@ public class IndexedDataColumn<TYPE> implements DataColumn<TYPE> {
 
     @Override
     public short[] getShorts(final long startPosInclusive, final long endPosExclusive) {
-        final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
-        final short[] result = new short[rangeIndex.intSize("getShorts")];
-        try (final ChunkSource.FillContext context = columnSource.makeFillContext(result.length, null)) {
+        try (final Index rangeIndex = getSubIndexByPos(startPosInclusive, endPosExclusive);
+             final ChunkSource.FillContext context = columnSource.makeFillContext(rangeIndex.intSize("getShorts"), null)) {
+            final short[] result = new short[rangeIndex.intSize("getShorts")];
             columnSource.fillChunk(context, WritableShortChunk.writableChunkWrap(result), rangeIndex);
-        } finally {
-            rangeIndex.close();
+            return result;
         }
-        return result;
     }
 
     @Override

--- a/Integrations/python/deephaven/java_to_python.py
+++ b/Integrations/python/deephaven/java_to_python.py
@@ -559,7 +559,7 @@ def tableToDataFrame(table, convertNulls=NULL_CONVERSION.ERROR, categoricals=Non
     if not categoricalSet.issubset(columnNames):
         raise KeyError("Categorical set -{}- not contained in column names set -{}".format(categoricals, columnNames))
 
-    data = {}
+    data = []
     useColumnNames = []
     for columnName in columnNames:
         logging.info("Column {} get.....;".format(columnName))
@@ -573,5 +573,5 @@ def tableToDataFrame(table, convertNulls=NULL_CONVERSION.ERROR, categoricals=Non
                             "type {}".format(columnName, table.getColumn(columnName).getType().getName()))
         else:
             useColumnNames.append(columnName)
-            data[columnName] = series
-    return pandas.DataFrame(data=data, columns=useColumnNames, copy=False)
+            data.append(series)
+    return pandas.DataFrame(data=numpy.stack([d.array for d in data], axis=1), columns=useColumnNames, copy=False)

--- a/Integrations/python/deephaven/java_to_python.py
+++ b/Integrations/python/deephaven/java_to_python.py
@@ -559,7 +559,7 @@ def tableToDataFrame(table, convertNulls=NULL_CONVERSION.ERROR, categoricals=Non
     if not categoricalSet.issubset(columnNames):
         raise KeyError("Categorical set -{}- not contained in column names set -{}".format(categoricals, columnNames))
 
-    data = []
+    data = {}
     useColumnNames = []
     for columnName in columnNames:
         logging.info("Column {} get.....;".format(columnName))
@@ -573,5 +573,10 @@ def tableToDataFrame(table, convertNulls=NULL_CONVERSION.ERROR, categoricals=Non
                             "type {}".format(columnName, table.getColumn(columnName).getType().getName()))
         else:
             useColumnNames.append(columnName)
-            data.append(series)
-    return pandas.DataFrame(data=numpy.stack([d.array for d in data], axis=1), columns=useColumnNames, copy=False)
+            data[columnName] = series
+
+    dtype_set = set([v.dtype for k, v in data.items()])
+    if len(dtype_set) == 1:
+        return pandas.DataFrame(data=numpy.stack([v.array for k, v in data.items()], axis=1), columns=useColumnNames, copy=False)
+    else:
+        return pandas.DataFrame(data=data, columns=useColumnNames, copy=False)


### PR DESCRIPTION
Two changes:
1. use the most performant DataFrame() constructor - this brings  the majority of performance gain (3+ times)
2. chunk-copying of DH data - this adds another 10 - 20% gain in speed

Combined together, the original test case shows on-par performances between the two approaches. There are other things we could do such as  'smart snapshotting' etc. which should further improve the performance for extracting data out of DH. It is certainly an important area for DH to work efficiently with other data technologies, but it can certainly be addressed at some point in the future.
