### PR TITLE
Snapshot: manage snapshotTable for liveness

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/snapshot/SnapshotInternalListener.java
+++ b/DB/src/main/java/io/deephaven/db/v2/snapshot/SnapshotInternalListener.java
@@ -37,6 +37,7 @@ public class SnapshotInternalListener extends BaseTable.ShiftAwareListenerImpl {
         this.resultLeftColumns = resultLeftColumns;
         this.resultRightColumns = resultRightColumns;
         this.resultIndex = resultIndex;
+        manage(snapshotTable);
     }
 
     @Override


### PR DESCRIPTION
If we do not manage the snapshot table then it may lose liveness before the result table is finished with the snapshot table (test included).