### PR TITLE
Update Web UI v0.1.7

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,10 +2,10 @@ FROM docker.io/library/node:14.16.0 AS node
 WORKDIR /usr/src/app
 
 FROM node as build
-ARG WEB_VERSION=0.1.5
+ARG WEB_VERSION=0.1.7
 
 # Pull in the published package from npmjs and extract is
 RUN set -eux; \
     npm pack @deephaven/code-studio@${WEB_VERSION}; \
-    tar -xf deephaven-code-studio-${WEB_VERSION}.tgz; \
+    tar --touch -xf deephaven-code-studio-${WEB_VERSION}.tgz; \
     rm deephaven-code-studio-${WEB_VERSION}.tgz;


### PR DESCRIPTION
Also update tar extraction to update modified date when extracting, so cache doesn't get stuck. The modified date of all npm packages is set to a fixed date in 1985, and nginx only uses the file size and modified date when calculating the etag. Now it updates the modified date when it extracts the npm package, and now that the modified date updates, a new etag gets generated correctly. Fixes #766 . 
