### PR TITLE
Fix writing empty tables; fix missing beginning magic number. Fixes #855

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/locations/local/ReadOnlyParquetTableLocation.java
+++ b/DB/src/main/java/io/deephaven/db/v2/locations/local/ReadOnlyParquetTableLocation.java
@@ -63,7 +63,11 @@ class ReadOnlyParquetTableLocation extends AbstractTableLocation<TableKey, Parqu
         this.parquetFile = parquetFile;
         try {
             ParquetFileReader parquetFileReader = new ParquetFileReader(parquetFile.getPath(), cachedChannelProvider, -1);
-            rowGroupReader = parquetFileReader.getRowGroup(0);
+            if (parquetFileReader.fileMetaData.getRow_groups().isEmpty()) {
+                rowGroupReader = null;
+            } else {
+                rowGroupReader = parquetFileReader.getRowGroup(0);
+            }
 
             columns = new HashMap<>();
             for (ColumnDescriptor column : parquetFileReader.getSchema().getColumns()) {
@@ -82,7 +86,7 @@ class ReadOnlyParquetTableLocation extends AbstractTableLocation<TableKey, Parqu
             throw new TableDataException("Can't read parquet file", except);
         }
 
-        handleUpdate(rowGroupReader.numRows(), parquetFile.lastModified());
+        handleUpdate(rowGroupReader == null ? 0 : rowGroupReader.numRows(), parquetFile.lastModified());
     }
 
     @Override

--- a/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetTableWriter.java
+++ b/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetTableWriter.java
@@ -228,15 +228,18 @@ public class ParquetTableWriter {
 
         final Table t = pretransformTable(table, definition);
 
-        RowGroupWriter rowGroupWriter = parquetFileWriter.addRowGroup(t.size());
-        // noinspection rawtypes
-        for (Map.Entry<String, ? extends ColumnSource> nameToSource : t.getColumnSourceMap().entrySet()) {
-            String name = nameToSource.getKey();
-            ColumnSource<?> columnSource = nameToSource.getValue();
-            try {
-                writeColumnSource(t.getIndex(), rowGroupWriter, name, columnSource, definition.getColumn(name), writeInstructions);
-            } catch (IllegalAccessException  e) {
-                throw new RuntimeException("Failed to write column " + name, e);
+        final long nrows = t.size();
+        if (nrows > 0) {
+            RowGroupWriter rowGroupWriter = parquetFileWriter.addRowGroup(nrows);
+            // noinspection rawtypes
+            for (Map.Entry<String, ? extends ColumnSource> nameToSource : t.getColumnSourceMap().entrySet()) {
+                String name = nameToSource.getKey();
+                ColumnSource<?> columnSource = nameToSource.getValue();
+                try {
+                    writeColumnSource(t.getIndex(), rowGroupWriter, name, columnSource, definition.getColumn(name), writeInstructions);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException("Failed to write column " + name, e);
+                }
             }
         }
 
@@ -441,10 +444,6 @@ public class ParquetTableWriter {
                         repeatCount.add(newBuffer);
                     }
                 }
-            }
-            if (keyCount.intValue() == 0) {
-                keys[0][0] = toParquetPrimitive.apply("");
-                keyCount.increment();
             }
             columnWriter.addDictionaryPage(keys[0], keyCount.intValue());
             Iterator<IntBuffer> repeatCountIt = repeatCount == null ? null : repeatCount.iterator();

--- a/DB/src/test/java/io/deephaven/db/v2/parquet/ParquetTableReadWriteTest.java
+++ b/DB/src/test/java/io/deephaven/db/v2/parquet/ParquetTableReadWriteTest.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import org.junit.experimental.categories.Category;
 
+import static org.junit.Assert.*;
+
 @Category(OutOfBandTest.class)
 public class ParquetTableReadWriteTest {
 
@@ -145,6 +147,17 @@ public class ParquetTableReadWriteTest {
         ParquetTools.writeTable(tableToSave, tableToSave.getDefinition(), dest);
         final Table fromDisk = ParquetTools.readTable(dest);
         TstUtils.assertTableEquals(tableToSave, fromDisk);
+    }
+
+    @Test
+    public void emptyTrivialTable() {
+        final Table t = TableTools.emptyTable(0).select("A = i");
+        assertEquals(int.class, t.getDefinition().getColumn("A").getDataType());
+        final File dest = new File(rootFile, "ParquetTest_emptyTrivialTable.parquet");
+        ParquetTools.writeTable(t, dest);
+        final Table fromDisk = ParquetTools.readTable(dest);
+        TstUtils.assertTableEquals(t, fromDisk);
+        assertEquals(t.getDefinition(), fromDisk.getDefinition());
     }
 
     @Test

--- a/Parquet/src/main/java/io/deephaven/parquet/ParquetFileReader.java
+++ b/Parquet/src/main/java/io/deephaven/parquet/ParquetFileReader.java
@@ -87,7 +87,13 @@ public class ParquetFileReader {
     }
 
     public RowGroupReader getRowGroup(int groupNumber) {
-        return new RowGroupReaderImpl(fileMetaData.getRow_groups().get(groupNumber), channelsProvider, rootPath,codecFactory,type,getSchema());
+        return new RowGroupReaderImpl(
+                fileMetaData.getRow_groups().get(groupNumber),
+                channelsProvider,
+                rootPath,
+                codecFactory,
+                type,
+                getSchema());
     }
 
     private static MessageType fromParquetSchema(List<SchemaElement> schema, List<ColumnOrder> columnOrders) {


### PR DESCRIPTION
Turns out what we were missing was the initial magic number (ref: https://github.com/apache/parquet-format#file-format)

With that, all the hacks for things like "dictionaries mysteriously don't work at offset zero" can go away (_facepalm_, _despair_).

Before this change, our "zero rows" writes would show up in the output of parquet-cli like:

```
cfs@erke 23:14:09 ~/github/parquet-mr
$ /l/parquet-cli/1.12.1/bin/parquet-cli pages ~/dh/oss3/io.deephaven.db.v2.parquet.ParquetTableReadWriteTest_root/ParquetTest_emptyFlatParquet_test.parquet
Unknown error
java.lang.RuntimeException: Illegal row group of 0 rows
        at org.apache.parquet.hadoop.ParquetFileReader.readNextRowGroup(ParquetFileReader.java:902)
        at org.apache.parquet.cli.commands.ShowPagesCommand.run(ShowPagesCommand.java:98)
        at org.apache.parquet.cli.Main.run(Main.java:155)
        at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:76)
        at org.apache.parquet.cli.Main.main(Main.java:185)
```

Interestingly, parquet-cli meta will show the illegal row group of zero rows without complaining on that file:

```
cfs@erke 23:11:20 ~/github/parquet-mr
$ /l/parquet-cli/1.12.1/bin/parquet-cli meta ~/dh/oss3/io.deephaven.db.v2.parquet.ParquetTableReadWriteTest_root/ParquetTest_emptyFlatParquet_test.parquet
  
File path:  /a0/h/cfs/dh/oss3/io.deephaven.db.v2.parquet.ParquetTableReadWriteTest_root/ParquetTest_emptyFlatParquet_test.parquet
Created by: parquet-mr version 1.12.0 (build db75a6815f2ba1d1ee89d1a90aeb296f1f3a8f20)
Properties:
  dh_codec_data_type:someSerializable: io.deephaven.db.v2.parquet.ParquetTableWriter$SomeSillyTest
       dh_codec_name:someSerializable: io.deephaven.util.codec.SerializableCodec
Schema:
message root {
  optional binary someStringColumn (STRING);
  optional binary nonNullString (STRING);
  optional binary nonNullPolyString (STRING);
  optional int32 someIntColumn (INTEGER(32,true));
  optional int64 someLongColumn;
  optional double someDoubleColumn;
  optional float someFloatColumn;
  optional boolean someBoolColumn;
  optional int32 someShortColumn (INTEGER(16,true));
  optional int32 someByteColumn (INTEGER(8,true));
  optional int32 someCharColumn (INTEGER(16,false));
  optional int64 someTime (TIMESTAMP(NANOS,true));
  optional binary someKey (STRING);
  optional binary nullKey (STRING);
  optional binary someSerializable;
} 
  

Row group 0:  count: 0  Infinity TB records  start: -1  total: 95 B
--------------------------------------------------------------------------------
                   type      encodings count     avg size   nulls   min / max
someStringColumn   BINARY    S RR_     0         Infinity TB 0
nonNullString      BINARY    S RR_     0         Infinity TB 0
nonNullPolyString  BINARY    S RR_     0         Infinity TB 0
someIntColumn      INT32     S RR      0         NaN B      0
someLongColumn     INT64     S RR      0         NaN B      0
someDoubleColumn   DOUBLE    S RR      0         NaN B      0
someFloatColumn    FLOAT     S RR      0         NaN B      0
someBoolColumn     BOOLEAN   S RR      0         NaN B      0
someShortColumn    INT32     S RR      0         NaN B      0
someByteColumn     INT32     S RR      0         NaN B      0
someCharColumn     INT32     S RR      0         NaN B      0
someTime           INT64     S RR      0         NaN B      0
someKey            BINARY    S RR_     0         Infinity TB 0
nullKey            BINARY    S RR_     0         Infinity TB 0
someSerializable   BINARY    S RR      0         NaN B      0

```

What we get now in the output of meta is just the Schema, and no rowgroup information (because there isn't any).
