### PR TITLE
Remove @JsMethod from JsTable and JsTreeTable features that do not currently work.

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/ide/shared/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/ide/shared/IdeSession.java
@@ -64,6 +64,8 @@ public class IdeSession extends HasEventHandling {
         return table;
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    @JsIgnore
     public Promise<JsTreeTable> getTreeTable(String name) {
         return connection.getTreeTable(name, result);
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -559,7 +559,8 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }
         return Promise.resolve(new JsTable(this));
     }
-
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public Promise<JsTotalsTable> getTotalsTable(Object config) {
         // fetch the handle and wrap it in a new jstable. listen for changes
         // on the parent table, and re-fetch each time.
@@ -567,6 +568,8 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         return fetchTotals(config, this::lastVisibleState);
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public JsTotalsTableConfig getTotalsTableConfig() {
         // we want to communicate to the JS dev that there is no default config, so we allow
         // returning null here, rather than a default config. They can then easily build a
@@ -686,6 +689,8 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public Promise<JsTotalsTable> getGrandTotalsTable(Object config) {
         // As in getTotalsTable, but this time we want to skip any filters - this could mean use the
         // most-derived table which has no filter, or the least-derived table which has all custom columns.
@@ -700,6 +705,8 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         });
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public Promise<JsTreeTable> rollup(Object configObject) {
         Objects.requireNonNull(configObject, "Table.rollup configuration");
         final JsRollupConfig config;
@@ -717,6 +724,8 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }, "rollup " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public Promise<JsTreeTable> treeTable(Object configObject) {
         Objects.requireNonNull(configObject, "Table.treeTable configuration");
         final JsTreeTableConfig config;
@@ -836,6 +845,8 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }).refetch();
     }
 
+    // TODO: #697: Column statistic support
+    // @JsMethod
     public Promise<JsColumnStatistics> getColumnStatistics(Column column) {
         return Callbacks.<ColumnStatistics, String>promise(null, c -> {
 //            workerConnection.getServer().getColumnStatisticsForTable(state().getHandle(), column.getName(), c);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -561,7 +561,7 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
     }
     // TODO: #37: Need SmartKey support for this functionality
     // @JsMethod
-    public Promise<JsTotalsTable> getTotalsTable(Object config) {
+    public Promise<JsTotalsTable> getTotalsTable(/* @JsOptional */Object config) {
         // fetch the handle and wrap it in a new jstable. listen for changes
         // on the parent table, and re-fetch each time.
 
@@ -691,7 +691,7 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
 
     // TODO: #37: Need SmartKey support for this functionality
     // @JsMethod
-    public Promise<JsTotalsTable> getGrandTotalsTable(Object config) {
+    public Promise<JsTotalsTable> getGrandTotalsTable(/* @JsOptional */Object config) {
         // As in getTotalsTable, but this time we want to skip any filters - this could mean use the
         // most-derived table which has no filter, or the least-derived table which has all custom columns.
         // Currently, these two mean the same thing.

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -560,27 +560,24 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         return Promise.resolve(new JsTable(this));
     }
 
-// TODO: #37: Need SmartKey support for this functionality
-//    @JsMethod
-//    public Promise<JsTotalsTable> getTotalsTable(@JsOptional Object config) {
-//        // fetch the handle and wrap it in a new jstable. listen for changes
-//        // on the parent table, and re-fetch each time.
-//
-//        return fetchTotals(config, this::lastVisibleState);
-//    }
-//
-//    @JsProperty
-//    public JsTotalsTableConfig getTotalsTableConfig() {
-//        // we want to communicate to the JS dev that there is no default config, so we allow
-//        // returning null here, rather than a default config. They can then easily build a
-//        // default config, but without this ability, there is no way to indicate that the
-//        // config omitted a totals table
-//        String config = lastVisibleState().getTableDef().getAttributes().getTotalsTableConfig();
-//        if (config == null) {
-//            return null;
-//        }
-//        return JsTotalsTableConfig.parse(config);
-//    }
+    public Promise<JsTotalsTable> getTotalsTable(Object config) {
+        // fetch the handle and wrap it in a new jstable. listen for changes
+        // on the parent table, and re-fetch each time.
+
+        return fetchTotals(config, this::lastVisibleState);
+    }
+
+    public JsTotalsTableConfig getTotalsTableConfig() {
+        // we want to communicate to the JS dev that there is no default config, so we allow
+        // returning null here, rather than a default config. They can then easily build a
+        // default config, but without this ability, there is no way to indicate that the
+        // config omitted a totals table
+        String config = lastVisibleState().getTableDef().getAttributes().getTotalsTableConfig();
+        if (config == null) {
+            return null;
+        }
+        return JsTotalsTableConfig.parse(config);
+    }
 
     private Promise<JsTotalsTable> fetchTotals(Object config, JsProvider<ClientTableState> state) {
 
@@ -689,61 +686,57 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }
     }
 
-// TODO: #37: Need SmartKey support for this functionality
-//    @JsMethod
-//    public Promise<JsTotalsTable> getGrandTotalsTable(@JsOptional Object config) {
-//        // As in getTotalsTable, but this time we want to skip any filters - this could mean use the
-//        // most-derived table which has no filter, or the least-derived table which has all custom columns.
-//        // Currently, these two mean the same thing.
-//        return fetchTotals(config, ()->{
-//            ClientTableState unfiltered = state();
-//            while (!unfiltered.getFilters().isEmpty()) {
-//                unfiltered = unfiltered.getPrevious();
-//                assert unfiltered != null : "no table is unfiltered, even base table!";
-//            }
-//            return unfiltered;
-//        });
-//    }
-//
-//    @JsMethod
-//    public Promise<JsTreeTable> rollup(Object configObject) {
-//        Objects.requireNonNull(configObject, "Table.rollup configuration");
-//        final JsRollupConfig config;
-//        if (configObject instanceof JsRollupConfig) {
-//            config = (JsRollupConfig)configObject;
-//        } else {
-//            config = new JsRollupConfig(Js.cast(configObject));
-//        }
-//        return workerConnection.newState((c, state, metadata) -> {
-////            RollupTableRequest rollupRequest = config.buildRequest();
-////            rollupRequest.setTable(state().getHandle());
-////            rollupRequest.setResultHandle(state.getHandle());
-////            workerConnection.getServer().rollup(rollupRequest, c);
-//            throw new UnsupportedOperationException("rollup");
-//        }, "rollup " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
-//    }
+    public Promise<JsTotalsTable> getGrandTotalsTable(Object config) {
+        // As in getTotalsTable, but this time we want to skip any filters - this could mean use the
+        // most-derived table which has no filter, or the least-derived table which has all custom columns.
+        // Currently, these two mean the same thing.
+        return fetchTotals(config, ()->{
+            ClientTableState unfiltered = state();
+            while (!unfiltered.getFilters().isEmpty()) {
+                unfiltered = unfiltered.getPrevious();
+                assert unfiltered != null : "no table is unfiltered, even base table!";
+            }
+            return unfiltered;
+        });
+    }
 
-//    @JsMethod
-//    public Promise<JsTreeTable> treeTable(Object configObject) {
-//        Objects.requireNonNull(configObject, "Table.treeTable configuration");
-//        final JsTreeTableConfig config;
-//        if (configObject instanceof JsTreeTableConfig) {
-//            config = (JsTreeTableConfig) configObject;
-//        } else {
-//            config = new JsTreeTableConfig(Js.cast(configObject));
-//        }
-//        return workerConnection.newState((c, state, metadata) -> {
-////            workerConnection.getServer().treeTable(
-////                    state().getHandle(),
-////                    state.getHandle(),
-////                    config.idColumn,
-////                    config.parentColumn,
-////                    config.promoteOrphansToRoot,
-////                    c
-////            );
-//            throw new UnsupportedOperationException("treeTable");
-//        }, "treeTable " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
-//    }
+    public Promise<JsTreeTable> rollup(Object configObject) {
+        Objects.requireNonNull(configObject, "Table.rollup configuration");
+        final JsRollupConfig config;
+        if (configObject instanceof JsRollupConfig) {
+            config = (JsRollupConfig)configObject;
+        } else {
+            config = new JsRollupConfig(Js.cast(configObject));
+        }
+        return workerConnection.newState((c, state, metadata) -> {
+//            RollupTableRequest rollupRequest = config.buildRequest();
+//            rollupRequest.setTable(state().getHandle());
+//            rollupRequest.setResultHandle(state.getHandle());
+//            workerConnection.getServer().rollup(rollupRequest, c);
+            throw new UnsupportedOperationException("rollup");
+        }, "rollup " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
+    }
+
+    public Promise<JsTreeTable> treeTable(Object configObject) {
+        Objects.requireNonNull(configObject, "Table.treeTable configuration");
+        final JsTreeTableConfig config;
+        if (configObject instanceof JsTreeTableConfig) {
+            config = (JsTreeTableConfig) configObject;
+        } else {
+            config = new JsTreeTableConfig(Js.cast(configObject));
+        }
+        return workerConnection.newState((c, state, metadata) -> {
+//            workerConnection.getServer().treeTable(
+//                    state().getHandle(),
+//                    state.getHandle(),
+//                    config.idColumn,
+//                    config.parentColumn,
+//                    config.promoteOrphansToRoot,
+//                    c
+//            );
+            throw new UnsupportedOperationException("treeTable");
+        }, "treeTable " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
+    }
 
     @JsMethod
     public Promise<JsTable> freeze() {
@@ -843,15 +836,13 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }).refetch();
     }
 
-// TODO: #697: Column statistic support
-//    @JsMethod
-//    public Promise<JsColumnStatistics> getColumnStatistics(Column column) {
-//        return Callbacks.<ColumnStatistics, String>promise(null, c -> {
-////            workerConnection.getServer().getColumnStatisticsForTable(state().getHandle(), column.getName(), c);
-//            throw new UnsupportedOperationException("getColumnStatistics");
-//        }).then(
-//                tableStatics -> Promise.resolve(new JsColumnStatistics(tableStatics)));
-//    }
+    public Promise<JsColumnStatistics> getColumnStatistics(Column column) {
+        return Callbacks.<ColumnStatistics, String>promise(null, c -> {
+//            workerConnection.getServer().getColumnStatisticsForTable(state().getHandle(), column.getName(), c);
+            throw new UnsupportedOperationException("getColumnStatistics");
+        }).then(
+                tableStatics -> Promise.resolve(new JsColumnStatistics(tableStatics)));
+    }
 
     public void maybeRevive(ClientTableState state) {
         if (isSuppress()) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -209,19 +209,6 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         return hasInputTable;
     }
 
-    @JsProperty
-    public JsTotalsTableConfig getTotalsTableConfig() {
-        // we want to communicate to the JS dev that there is no default config, so we allow
-        // returning null here, rather than a default config. They can then easily build a
-        // default config, but without this ability, there is no way to indicate that the
-        // config omitted a totals table
-        String config = lastVisibleState().getTableDef().getAttributes().getTotalsTableConfig();
-        if (config == null) {
-            return null;
-        }
-        return JsTotalsTableConfig.parse(config);
-    }
-
     @JsMethod
     public Promise<JsInputTable> inputTable() {
         if (!hasInputTable) {
@@ -573,13 +560,27 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         return Promise.resolve(new JsTable(this));
     }
 
-    @JsMethod
-    public Promise<JsTotalsTable> getTotalsTable(@JsOptional Object config) {
-        // fetch the handle and wrap it in a new jstable. listen for changes
-        // on the parent table, and re-fetch each time.
-
-        return fetchTotals(config, this::lastVisibleState);
-    }
+// TODO: #37: Need SmartKey support for this functionality
+//    @JsMethod
+//    public Promise<JsTotalsTable> getTotalsTable(@JsOptional Object config) {
+//        // fetch the handle and wrap it in a new jstable. listen for changes
+//        // on the parent table, and re-fetch each time.
+//
+//        return fetchTotals(config, this::lastVisibleState);
+//    }
+//
+//    @JsProperty
+//    public JsTotalsTableConfig getTotalsTableConfig() {
+//        // we want to communicate to the JS dev that there is no default config, so we allow
+//        // returning null here, rather than a default config. They can then easily build a
+//        // default config, but without this ability, there is no way to indicate that the
+//        // config omitted a totals table
+//        String config = lastVisibleState().getTableDef().getAttributes().getTotalsTableConfig();
+//        if (config == null) {
+//            return null;
+//        }
+//        return JsTotalsTableConfig.parse(config);
+//    }
 
     private Promise<JsTotalsTable> fetchTotals(Object config, JsProvider<ClientTableState> state) {
 
@@ -688,60 +689,61 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }
     }
 
-    @JsMethod
-    public Promise<JsTotalsTable> getGrandTotalsTable(@JsOptional Object config) {
-        // As in getTotalsTable, but this time we want to skip any filters - this could mean use the
-        // most-derived table which has no filter, or the least-derived table which has all custom columns.
-        // Currently, these two mean the same thing.
-        return fetchTotals(config, ()->{
-            ClientTableState unfiltered = state();
-            while (!unfiltered.getFilters().isEmpty()) {
-                unfiltered = unfiltered.getPrevious();
-                assert unfiltered != null : "no table is unfiltered, even base table!";
-            }
-            return unfiltered;
-        });
-    }
+// TODO: #37: Need SmartKey support for this functionality
+//    @JsMethod
+//    public Promise<JsTotalsTable> getGrandTotalsTable(@JsOptional Object config) {
+//        // As in getTotalsTable, but this time we want to skip any filters - this could mean use the
+//        // most-derived table which has no filter, or the least-derived table which has all custom columns.
+//        // Currently, these two mean the same thing.
+//        return fetchTotals(config, ()->{
+//            ClientTableState unfiltered = state();
+//            while (!unfiltered.getFilters().isEmpty()) {
+//                unfiltered = unfiltered.getPrevious();
+//                assert unfiltered != null : "no table is unfiltered, even base table!";
+//            }
+//            return unfiltered;
+//        });
+//    }
+//
+//    @JsMethod
+//    public Promise<JsTreeTable> rollup(Object configObject) {
+//        Objects.requireNonNull(configObject, "Table.rollup configuration");
+//        final JsRollupConfig config;
+//        if (configObject instanceof JsRollupConfig) {
+//            config = (JsRollupConfig)configObject;
+//        } else {
+//            config = new JsRollupConfig(Js.cast(configObject));
+//        }
+//        return workerConnection.newState((c, state, metadata) -> {
+////            RollupTableRequest rollupRequest = config.buildRequest();
+////            rollupRequest.setTable(state().getHandle());
+////            rollupRequest.setResultHandle(state.getHandle());
+////            workerConnection.getServer().rollup(rollupRequest, c);
+//            throw new UnsupportedOperationException("rollup");
+//        }, "rollup " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
+//    }
 
-    @JsMethod
-    public Promise<JsTreeTable> rollup(Object configObject) {
-        Objects.requireNonNull(configObject, "Table.rollup configuration");
-        final JsRollupConfig config;
-        if (configObject instanceof JsRollupConfig) {
-            config = (JsRollupConfig)configObject;
-        } else {
-            config = new JsRollupConfig(Js.cast(configObject));
-        }
-        return workerConnection.newState((c, state, metadata) -> {
-//            RollupTableRequest rollupRequest = config.buildRequest();
-//            rollupRequest.setTable(state().getHandle());
-//            rollupRequest.setResultHandle(state.getHandle());
-//            workerConnection.getServer().rollup(rollupRequest, c);
-            throw new UnsupportedOperationException("rollup");
-        }, "rollup " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
-    }
-
-    @JsMethod
-    public Promise<JsTreeTable> treeTable(Object configObject) {
-        Objects.requireNonNull(configObject, "Table.treeTable configuration");
-        final JsTreeTableConfig config;
-        if (configObject instanceof JsTreeTableConfig) {
-            config = (JsTreeTableConfig) configObject;
-        } else {
-            config = new JsTreeTableConfig(Js.cast(configObject));
-        }
-        return workerConnection.newState((c, state, metadata) -> {
-//            workerConnection.getServer().treeTable(
-//                    state().getHandle(),
-//                    state.getHandle(),
-//                    config.idColumn,
-//                    config.parentColumn,
-//                    config.promoteOrphansToRoot,
-//                    c
-//            );
-            throw new UnsupportedOperationException("treeTable");
-        }, "treeTable " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
-    }
+//    @JsMethod
+//    public Promise<JsTreeTable> treeTable(Object configObject) {
+//        Objects.requireNonNull(configObject, "Table.treeTable configuration");
+//        final JsTreeTableConfig config;
+//        if (configObject instanceof JsTreeTableConfig) {
+//            config = (JsTreeTableConfig) configObject;
+//        } else {
+//            config = new JsTreeTableConfig(Js.cast(configObject));
+//        }
+//        return workerConnection.newState((c, state, metadata) -> {
+////            workerConnection.getServer().treeTable(
+////                    state().getHandle(),
+////                    state.getHandle(),
+////                    config.idColumn,
+////                    config.parentColumn,
+////                    config.promoteOrphansToRoot,
+////                    c
+////            );
+//            throw new UnsupportedOperationException("treeTable");
+//        }, "treeTable " + Global.JSON.stringify(config)).refetch(this, workerConnection.metadata()).then(state -> new JsTreeTable(state, workerConnection).finishFetch());
+//    }
 
     @JsMethod
     public Promise<JsTable> freeze() {
@@ -841,14 +843,15 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }).refetch();
     }
 
-    @JsMethod
-    public Promise<JsColumnStatistics> getColumnStatistics(Column column) {
-        return Callbacks.<ColumnStatistics, String>promise(null, c -> {
-//            workerConnection.getServer().getColumnStatisticsForTable(state().getHandle(), column.getName(), c);
-            throw new UnsupportedOperationException("getColumnStatistics");
-        }).then(
-                tableStatics -> Promise.resolve(new JsColumnStatistics(tableStatics)));
-    }
+// TODO: #697: Column statistic support
+//    @JsMethod
+//    public Promise<JsColumnStatistics> getColumnStatistics(Column column) {
+//        return Callbacks.<ColumnStatistics, String>promise(null, c -> {
+////            workerConnection.getServer().getColumnStatisticsForTable(state().getHandle(), column.getName(), c);
+//            throw new UnsupportedOperationException("getColumnStatistics");
+//        }).then(
+//                tableStatics -> Promise.resolve(new JsColumnStatistics(tableStatics)));
+//    }
 
     public void maybeRevive(ClientTableState state) {
         if (isSuppress()) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -856,30 +856,31 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         });
     }
 
-    @JsMethod
-    public Promise<JsTotalsTableConfig> getTotalsTableConfig() {
-        // we want to communicate to the JS dev that there is no default config, so we allow
-        // returning null here, rather than a default config. They can then easily build a
-        // default config, but without this ability, there is no way to indicate that the
-        // config omitted a totals table
-        return sourceTable.then(t -> Promise.resolve(t.getTotalsTableConfig()));
-    }
-
-    @JsMethod
-    public Promise<JsTotalsTable> getTotalsTable(@JsOptional Object config) {
-        return sourceTable.then(t -> {
-            //if this is the first time it is used, it might not be filtered correctly, so check that the filters match up.
-            if (!t.getFilter().asList().equals(getFilter().asList())) {
-                t.applyFilter(getFilter().asList().toArray(new FilterCondition[0]));
-            }
-            return Promise.resolve(t.getTotalsTable(config));
-        });
-    }
-
-    @JsMethod
-    public Promise<JsTotalsTable> getGrandTotalsTable(@JsOptional Object config) {
-        return sourceTable.then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
-    }
+// TODO: #37: Need SmartKey support for this functionality
+//    @JsMethod
+//    public Promise<JsTotalsTableConfig> getTotalsTableConfig() {
+//        // we want to communicate to the JS dev that there is no default config, so we allow
+//        // returning null here, rather than a default config. They can then easily build a
+//        // default config, but without this ability, there is no way to indicate that the
+//        // config omitted a totals table
+//        return sourceTable.then(t -> Promise.resolve(t.getTotalsTableConfig()));
+//    }
+//
+//    @JsMethod
+//    public Promise<JsTotalsTable> getTotalsTable(@JsOptional Object config) {
+//        return sourceTable.then(t -> {
+//            //if this is the first time it is used, it might not be filtered correctly, so check that the filters match up.
+//            if (!t.getFilter().asList().equals(getFilter().asList())) {
+//                t.applyFilter(getFilter().asList().toArray(new FilterCondition[0]));
+//            }
+//            return Promise.resolve(t.getTotalsTable(config));
+//        });
+//    }
+//
+//    @JsMethod
+//    public Promise<JsTotalsTable> getGrandTotalsTable(@JsOptional Object config) {
+//        return sourceTable.then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
+//    }
 
     /**
      * Indicates that the connect to the server has been reestablished, and the treetable should

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -856,31 +856,27 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         });
     }
 
-// TODO: #37: Need SmartKey support for this functionality
-//    @JsMethod
-//    public Promise<JsTotalsTableConfig> getTotalsTableConfig() {
-//        // we want to communicate to the JS dev that there is no default config, so we allow
-//        // returning null here, rather than a default config. They can then easily build a
-//        // default config, but without this ability, there is no way to indicate that the
-//        // config omitted a totals table
-//        return sourceTable.then(t -> Promise.resolve(t.getTotalsTableConfig()));
-//    }
-//
-//    @JsMethod
-//    public Promise<JsTotalsTable> getTotalsTable(@JsOptional Object config) {
-//        return sourceTable.then(t -> {
-//            //if this is the first time it is used, it might not be filtered correctly, so check that the filters match up.
-//            if (!t.getFilter().asList().equals(getFilter().asList())) {
-//                t.applyFilter(getFilter().asList().toArray(new FilterCondition[0]));
-//            }
-//            return Promise.resolve(t.getTotalsTable(config));
-//        });
-//    }
-//
-//    @JsMethod
-//    public Promise<JsTotalsTable> getGrandTotalsTable(@JsOptional Object config) {
-//        return sourceTable.then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
-//    }
+    public Promise<JsTotalsTableConfig> getTotalsTableConfig() {
+        // we want to communicate to the JS dev that there is no default config, so we allow
+        // returning null here, rather than a default config. They can then easily build a
+        // default config, but without this ability, there is no way to indicate that the
+        // config omitted a totals table
+        return sourceTable.then(t -> Promise.resolve(t.getTotalsTableConfig()));
+    }
+
+    public Promise<JsTotalsTable> getTotalsTable(Object config) {
+        return sourceTable.then(t -> {
+            //if this is the first time it is used, it might not be filtered correctly, so check that the filters match up.
+            if (!t.getFilter().asList().equals(getFilter().asList())) {
+                t.applyFilter(getFilter().asList().toArray(new FilterCondition[0]));
+            }
+            return Promise.resolve(t.getTotalsTable(config));
+        });
+    }
+
+    public Promise<JsTotalsTable> getGrandTotalsTable(Object config) {
+        return sourceTable.then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
+    }
 
     /**
      * Indicates that the connect to the server has been reestablished, and the treetable should

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -856,8 +856,7 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         });
     }
 
-    // TODO: #37: Need SmartKey support for this functionality
-    // @JsMethod
+    @JsMethod
     public Promise<JsTotalsTableConfig> getTotalsTableConfig() {
         // we want to communicate to the JS dev that there is no default config, so we allow
         // returning null here, rather than a default config. They can then easily build a

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -856,6 +856,8 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         });
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public Promise<JsTotalsTableConfig> getTotalsTableConfig() {
         // we want to communicate to the JS dev that there is no default config, so we allow
         // returning null here, rather than a default config. They can then easily build a
@@ -864,6 +866,8 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         return sourceTable.then(t -> Promise.resolve(t.getTotalsTableConfig()));
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public Promise<JsTotalsTable> getTotalsTable(Object config) {
         return sourceTable.then(t -> {
             //if this is the first time it is used, it might not be filtered correctly, so check that the filters match up.
@@ -874,6 +878,8 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         });
     }
 
+    // TODO: #37: Need SmartKey support for this functionality
+    // @JsMethod
     public Promise<JsTotalsTable> getGrandTotalsTable(Object config) {
         return sourceTable.then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -866,9 +866,8 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         return sourceTable.then(t -> Promise.resolve(t.getTotalsTableConfig()));
     }
 
-    // TODO: #37: Need SmartKey support for this functionality
-    // @JsMethod
-    public Promise<JsTotalsTable> getTotalsTable(Object config) {
+    @JsMethod
+    public Promise<JsTotalsTable> getTotalsTable(@JsOptional Object config) {
         return sourceTable.then(t -> {
             //if this is the first time it is used, it might not be filtered correctly, so check that the filters match up.
             if (!t.getFilter().asList().equals(getFilter().asList())) {
@@ -878,9 +877,8 @@ public class JsTreeTable extends HasEventHandling implements HasLifecycle {
         });
     }
 
-    // TODO: #37: Need SmartKey support for this functionality
-    // @JsMethod
-    public Promise<JsTotalsTable> getGrandTotalsTable(Object config) {
+    @JsMethod
+    public Promise<JsTotalsTable> getGrandTotalsTable(@JsOptional Object config) {
         return sourceTable.then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
     }
 


### PR DESCRIPTION
- Related to #37 and #697, there is some table functionality that does not work yet.
- Comment out the methods that do not currently work (shouldn't have an API that doesn't work).
- UI checks for the presence of the method for whether to show the option or not. When they are added back, they should appear in the UI again. See https://github.com/deephaven/web-client-ui/issues/136
