### PR TITLE
Fix missing SharedContext reset in stream first/last by chunked operators

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/by/StreamFirstByChunkedOperator.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/StreamFirstByChunkedOperator.java
@@ -169,6 +169,7 @@ public class StreamFirstByChunkedOperator extends StreamFirstOrLastByChunkedOper
                         final Chunk<? extends Values> inputChunk = inputColumns[ci].getChunk(inputContexts[ci], sliceSources);
                         outputColumns[ci].fillFromChunk(outputContexts[ci], inputChunk, sliceDestinations);
                     }
+                    inputSharedContext.reset();
                 }
             }
         }

--- a/DB/src/main/java/io/deephaven/db/v2/by/StreamLastByChunkedOperator.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/StreamLastByChunkedOperator.java
@@ -160,6 +160,7 @@ public class StreamLastByChunkedOperator extends StreamFirstOrLastByChunkedOpera
                         permuteKernels[ci].permute(inputChunk, sourceIndicesOrder, outputChunks[ci]);
                         outputColumns[ci].fillFromChunk(outputContexts[ci], outputChunks[ci], sliceDestinations);
                     }
+                    inputSharedContext.reset();
                 }
             }
         }


### PR DESCRIPTION
Fixes issue introduced in #977 