### PR TITLE
SessionState: fix NPE caused by cancel/exec race

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
@@ -764,8 +764,10 @@ public class SessionState {
          * Performs the actual export on a scheduling thread.
          */
         private void doExport() {
+            final Callable<T> capturedExport;
             synchronized (this) {
-                if (state != ExportNotification.State.QUEUED || session.isExpired()) {
+                capturedExport = exportMain;
+                if (state != ExportNotification.State.QUEUED || session.isExpired() || capturedExport == null) {
                     return; // had a cancel race with client
                 }
             }
@@ -779,16 +781,18 @@ public class SessionState {
 
                 evaluationNumber = QueryPerformanceRecorder.getInstance().startQuery("session=" + session.sessionId + ",exportId=" + logIdentity);
                 try {
-                    setResult(exportMain.call());
+                    setResult(capturedExport.call());
                 } finally {
                     shouldLog = QueryPerformanceRecorder.getInstance().endQuery();
                 }
             } catch (final Exception err) {
                 exception = err;
                 synchronized (this) {
-                    errorId = UuidCreator.toString(UuidCreator.getRandomBased());
-                    log.error().append("Internal Error '").append(errorId).append("' ").append(err).endl();
-                    setState(ExportNotification.State.FAILED);
+                    if (!isExportStateTerminal(state)) {
+                        errorId = UuidCreator.toString(UuidCreator.getRandomBased());
+                        log.error().append("Internal Error '").append(errorId).append("' ").append(err).endl();
+                        setState(ExportNotification.State.FAILED);
+                    }
                 }
             } finally {
                 if (exception != null && queryProcessingResults != null) {


### PR DESCRIPTION
The thread that is about to export the object checks to make sure it can still export it by doing a null check under a lock. After releasing the lock it uses the value it just null-checked.