### PR TITLE
Downgrade Alpine to avoid a DNS issue on older mac docker installs

### DIFF
--- a/grpc-proxy/Dockerfile
+++ b/grpc-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/alpine:3.13
+FROM docker.io/library/alpine:3.12
 
 COPY contents/ .
 
@@ -6,6 +6,7 @@ ENV GRPCWEBPROXY_VERSION=v0.13.0
 
 # Note(deephaven-core#599): Consider moving grpcwebproxy DL into gradle
 RUN set -eux; \
+    mkdir /app; \
     apk add --no-cache tini; \
     wget -q "https://github.com/improbable-eng/grpc-web/releases/download/${GRPCWEBPROXY_VERSION}/grpcwebproxy-${GRPCWEBPROXY_VERSION}-linux-x86_64.zip"; \
     sha256sum -c checksums.txt; \

--- a/grpc-proxy/Dockerfile
+++ b/grpc-proxy/Dockerfile
@@ -1,3 +1,5 @@
+# Deliberately using old alpine, see issue #1034 in deephaven-core
+# See also alpinelinux/docker-alpine#155
 FROM docker.io/library/alpine:3.12
 
 COPY contents/ .


### PR DESCRIPTION
Apparently in older linux kernels or docker installs (the alpine bug report isn't sure which), DNS sometimes doesn't work, and we can't build this image since github.com fails to resolve in the second line of this `RUN`.

In Alpine 3.12, unzip doesn't create the directory automatically, so we need to make it ahead of time.

Alpine 3.12 EOLs May 1, 2022, we should update by then, decide that we aren't concerned with older kernels (or docker installs), or pick a different image for this proxy.

https://github.com/alpinelinux/docker-alpine/issues/155

cc @hythloda 