### PR TITLE
Query Engine: Port fix for DH-11484 (naturalJoin does not detect duplicates when right table is live and left is static)

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/IncrementalChunkedNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/IncrementalChunkedNaturalJoinStateManager.java
@@ -747,10 +747,13 @@ class IncrementalChunkedNaturalJoinStateManager
         final boolean isLeftSide = leftRedirections != null;
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // the chunk of source indices that are parallel to the sourceChunks
+             final WritableLongChunk<KeyIndices> workingLeftRedirections = isLeftSide ? WritableLongChunk.makeWritableChunk(bc.chunkSize) : null
+             // endregion build initialization try
+        ) {
             // region build initialization
-            // the chunk of source indices that are parallel to the sourceChunks
-            final WritableLongChunk<KeyIndices> workingLeftRedirections = isLeftSide ? WritableLongChunk.makeWritableChunk(bc.chunkSize) : null;
             // endregion build initialization
 
             // chunks to write through to the table key sources
@@ -1094,9 +1097,6 @@ class IncrementalChunkedNaturalJoinStateManager
                 hashSlotOffset += chunkOk.size();
             }
             // region post build loop
-            if (isLeftSide) {
-                workingLeftRedirections.close();
-            }
             // endregion post build loop
         }
     }
@@ -2040,29 +2040,34 @@ class IncrementalChunkedNaturalJoinStateManager
     @Override
     public String keyString(long slot) {
         final WritableChunk<Values>[] keyChunk = getWritableKeyChunks(1);
-        final WritableLongChunk<KeyIndices> slotChunk = WritableLongChunk.makeWritableChunk(1);
-        if (isOverflowLocation(slot)) {
-            slotChunk.set(0, hashLocationToOverflowLocation(slot));
-            final ColumnSource.FillContext[] contexts = makeFillContexts(overflowKeySources, null, 1);
-            try {
-                fillOverflowKeys(contexts, keyChunk, slotChunk);
-            } finally {
-                for (Context c : contexts) {
-                    c.close();
+        try (final WritableLongChunk<KeyIndices> slotChunk = WritableLongChunk.makeWritableChunk(1)) {
+            if (isOverflowLocation(slot)) {
+                slotChunk.set(0, hashLocationToOverflowLocation(slot));
+                final ColumnSource.FillContext[] contexts = makeFillContexts(overflowKeySources, null, 1);
+                try {
+                    fillOverflowKeys(contexts, keyChunk, slotChunk);
+                } finally {
+                    for (Context c : contexts) {
+                        c.close();
+                    }
+                }
+            } else {
+                slotChunk.set(0, slot);
+                final ColumnSource.FillContext[] contexts = makeFillContexts(keySources, null, 1);
+                try {
+                    fillKeys(contexts, keyChunk, slotChunk);
+                } finally {
+                    for (Context c : contexts) {
+                        c.close();
+                    }
                 }
             }
-        } else {
-            slotChunk.set(0, slot);
-            final ColumnSource.FillContext[] contexts = makeFillContexts(keySources, null, 1);
-            try {
-                fillKeys(contexts, keyChunk, slotChunk);
-            } finally {
-                for (Context c : contexts) {
-                    c.close();
-                }
+            return ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, keyChunk, 0);
+        } finally {
+            for (WritableChunk<Values> chunk : keyChunk) {
+                chunk.close();
             }
         }
-        return ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, keyChunk, 0);
     }
 
     // endregion extraction functions

--- a/DB/src/main/java/io/deephaven/db/v2/IncrementalChunkedNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/IncrementalChunkedNaturalJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/LeftOnlyIncrementalChunkedCrossJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/LeftOnlyIncrementalChunkedCrossJoinStateManager.java
@@ -635,7 +635,10 @@ class LeftOnlyIncrementalChunkedCrossJoinStateManager
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // endregion build initialization
 

--- a/DB/src/main/java/io/deephaven/db/v2/LeftOnlyIncrementalChunkedCrossJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/LeftOnlyIncrementalChunkedCrossJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/ReplicateHashTable.java
+++ b/DB/src/main/java/io/deephaven/db/v2/ReplicateHashTable.java
@@ -244,8 +244,18 @@ public class ReplicateHashTable {
 
         final String sourcePackage = sourceClass.getPackage().getName();
         final String destinationPackage = destinationClass.getPackage().getName();
-        final String rewritePackage = rewrittenLines.get(0).replace(sourcePackage, destinationPackage);
-        rewrittenLines.set(0, rewritePackage);
+
+        int packageLine;
+        for (packageLine = 0; packageLine < 10; ++packageLine) {
+            if (rewrittenLines.get(packageLine).startsWith("package")) {
+                final String rewritePackage = rewrittenLines.get(packageLine).replace(sourcePackage, destinationPackage);
+                rewrittenLines.set(packageLine, rewritePackage);
+                break;
+            }
+        }
+        if (packageLine == 10) {
+            throw new RuntimeException("Could not find package line to rewrite for " + destinationClass);
+        }
 
         FileUtils.writeLines(destinationFile, rewrittenLines);
         System.out.println("Wrote: " + destinationPath);

--- a/DB/src/main/java/io/deephaven/db/v2/ReplicateHashTable.java
+++ b/DB/src/main/java/io/deephaven/db/v2/ReplicateHashTable.java
@@ -105,8 +105,8 @@ public class ReplicateHashTable {
         doReplicate(IncrementalChunkedNaturalJoinStateManager.class, IncrementalChunkedOperatorAggregationStateManager.class, allowMissingDestinations, Collections.singletonList("dumpTable"));
 
         // Incremental NJ -> Incremental By -> Static By
-        doReplicate(IncrementalChunkedByAggregationStateManager.class, StaticChunkedByAggregationStateManager.class, allowMissingDestinations, Arrays.asList("dumpTable", "prev", "decorationProbe"));
         doReplicate(IncrementalChunkedNaturalJoinStateManager.class, IncrementalChunkedByAggregationStateManager.class, allowMissingDestinations, Arrays.asList("dumpTable", "allowUpdateWriteThroughState"));
+        doReplicate(IncrementalChunkedByAggregationStateManager.class, StaticChunkedByAggregationStateManager.class, allowMissingDestinations, Arrays.asList("dumpTable", "prev", "decorationProbe"));
     }
 
     private static class RegionedFile {

--- a/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedAsOfJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedAsOfJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedAsOfJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedAsOfJoinStateManager.java
@@ -612,7 +612,10 @@ class RightIncrementalChunkedAsOfJoinStateManager
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // endregion build initialization
 

--- a/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedCrossJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedCrossJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedCrossJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedCrossJoinStateManager.java
@@ -906,7 +906,10 @@ class RightIncrementalChunkedCrossJoinStateManager
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             final OrderedKeys.Iterator prevOkIt = prevIndex == null ? null : prevIndex.getOrderedKeysIterator();
             if (prevIndex != null) {

--- a/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedNaturalJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/RightIncrementalChunkedNaturalJoinStateManager.java
@@ -471,7 +471,10 @@ class RightIncrementalChunkedNaturalJoinStateManager
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // the destination hash slots for each left-hand-side entry
             final WritableLongChunk<KeyIndices> sourceChunkLeftHashSlots = WritableLongChunk.makeWritableChunk(bc.chunkSize);
@@ -1282,35 +1285,48 @@ class RightIncrementalChunkedNaturalJoinStateManager
     @Override
     public String keyString(long slot) {
         final WritableChunk<Values>[] keyChunk = getWritableKeyChunks(1);
-        final WritableLongChunk<KeyIndices> slotChunk = WritableLongChunk.makeWritableChunk(1);
-        if (isOverflowLocation(slot)) {
-            slotChunk.set(0, hashLocationToOverflowLocation(slot));
-            final ColumnSource.FillContext[] contexts = makeFillContexts(overflowKeySources, null, 1);
-            try {
-                fillOverflowKeys(contexts, keyChunk, slotChunk);
-            } finally {
-                for (Context c : contexts) {
-                    c.close();
+        try (final WritableLongChunk<KeyIndices> slotChunk = WritableLongChunk.makeWritableChunk(1)) {
+            if (isOverflowLocation(slot)) {
+                slotChunk.set(0, hashLocationToOverflowLocation(slot));
+                final ColumnSource.FillContext[] contexts = makeFillContexts(overflowKeySources, null, 1);
+                try {
+                    fillOverflowKeys(contexts, keyChunk, slotChunk);
+                } finally {
+                    for (Context c : contexts) {
+                        c.close();
+                    }
+                }
+            } else {
+                slotChunk.set(0, slot);
+                final ColumnSource.FillContext[] contexts = makeFillContexts(keySources, null, 1);
+                try {
+                    fillKeys(contexts, keyChunk, slotChunk);
+                } finally {
+                    for (Context c : contexts) {
+                        c.close();
+                    }
                 }
             }
-        } else {
-            slotChunk.set(0, slot);
-            final ColumnSource.FillContext[] contexts = makeFillContexts(keySources, null, 1);
-            try {
-                fillKeys(contexts, keyChunk, slotChunk);
-            } finally {
-                for (Context c : contexts) {
-                    c.close();
-                }
+            return ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, keyChunk, 0);
+        } finally {
+            for (WritableChunk<Values> chunk : keyChunk) {
+                chunk.close();
             }
         }
-        return ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, keyChunk, 0);
     }
 
     RedirectionIndex buildRedirectionIndexFromHashSlot(QueryTable leftTable, boolean exactMatch, LongArraySource leftHashSlots, JoinControl.RedirectionType redirectionType) {
-        return buildRedirectionIndex(leftTable, exactMatch, position -> getStateValue(leftHashSlots, position), redirectionType);
+        return buildRedirectionIndex(leftTable, exactMatch, position -> getRightSide(leftHashSlots, position), redirectionType);
     }
 
+    private long getRightSide(final LongArraySource leftHashSlots, final long position) {
+        final long stateValue = getStateValue(leftHashSlots, position);
+        if (stateValue == DUPLICATE_RIGHT_VALUE) {
+            final long hashSlot = leftHashSlots.getLong(position);
+            throw new IllegalStateException("Duplicate right key for " + keyString(hashSlot));
+        }
+        return stateValue;
+    }
 
     RedirectionIndex buildRedirectionIndexFromHashSlotGrouped(QueryTable leftTable, ObjectArraySource<Index> indexSource, int groupingSize, boolean exactMatch, LongArraySource leftHashSlots, JoinControl.RedirectionType redirectionType) {
         switch (redirectionType) {
@@ -1427,7 +1443,7 @@ class RightIncrementalChunkedNaturalJoinStateManager
     }
 
     // region getStateValue
-    private long getStateValue(LongArraySource hashSlots, long locationInHashSlots) {
+    private long getStateValue(final LongArraySource hashSlots, final long locationInHashSlots) {
         final long hashSlot = hashSlots.getLong(locationInHashSlots);
         if (isOverflowLocation(hashSlot)) {
             return overflowRightIndexSource.getLong(hashLocationToOverflowLocation(hashSlot));

--- a/DB/src/main/java/io/deephaven/db/v2/SimpleUniqueStaticNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/SimpleUniqueStaticNaturalJoinStateManager.java
@@ -93,7 +93,7 @@ class SimpleUniqueStaticNaturalJoinStateManager extends StaticNaturalJoinStateMa
                     final long existingRight = rightIndexSource.getLong(tableLocation);
 
                     if (existingRight == DUPLICATE_RIGHT_VALUE) {
-                        throw new RuntimeException("More than one right side mapping for key " + keySourcesForErrorMessages[0].get(leftIndex.get(offset + ii)));
+                        throw new IllegalStateException("More than one right side mapping for key " + keySourcesForErrorMessages[0].get(leftIndex.get(offset + ii)));
                     }
                     leftRedirections.set(offset + ii, existingRight);
                 }

--- a/DB/src/main/java/io/deephaven/db/v2/StaticChunkedAsOfJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/StaticChunkedAsOfJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/StaticChunkedAsOfJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/StaticChunkedAsOfJoinStateManager.java
@@ -540,7 +540,10 @@ class StaticChunkedAsOfJoinStateManager
         buildCookieSource.ensureCapacity(tableSize);
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // endregion build initialization
 

--- a/DB/src/main/java/io/deephaven/db/v2/StaticChunkedCrossJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/StaticChunkedCrossJoinStateManager.java
@@ -589,7 +589,10 @@ class StaticChunkedCrossJoinStateManager
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // endregion build initialization
 

--- a/DB/src/main/java/io/deephaven/db/v2/StaticChunkedCrossJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/StaticChunkedCrossJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/StaticChunkedNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/StaticChunkedNaturalJoinStateManager.java
@@ -1059,7 +1059,7 @@ class StaticChunkedNaturalJoinStateManager
                             // I don't love this individual access approach; but we don't otherwise know if we are going
                             // to be writing to the thing twice.  We could alternatively sort these.
                             if (rightIndexSource.getLong(pc.tableLocationsChunk.get(ii)) != NO_RIGHT_ENTRY_VALUE) {
-                                throw new RuntimeException("More than one right side mapping for " + ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, sourceKeyChunks, ii));
+                                throw new IllegalStateException("More than one right side mapping for " + ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, sourceKeyChunks, ii));
                             }
 
                             // we know that there is no right hand side, so we should set it to our value!
@@ -1126,7 +1126,7 @@ class StaticChunkedNaturalJoinStateManager
                                 final long rightValue = rightKeyIndices.get(pc.chunkPositionsForFetches.get(ii));
                                 final long existingRightValue = overflowRightIndexSource.getLong(overflowLocation);
                                 if (existingRightValue != NO_RIGHT_ENTRY_VALUE) {
-                                    throw new RuntimeException("More than one right side mapping for " + ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, sourceKeyChunks, pc.chunkPositionsForFetches.get(ii)));
+                                    throw new IllegalStateException("More than one right side mapping for " + ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, sourceKeyChunks, pc.chunkPositionsForFetches.get(ii)));
                                 }
                                 overflowRightIndexSource.set(overflowLocation, rightValue);
                             }
@@ -1149,7 +1149,7 @@ class StaticChunkedNaturalJoinStateManager
                     for (int ii = 0; ii < workingLeftRedirections.size(); ++ii) {
                         final long leftRedirection = workingLeftRedirections.get(ii);
                         if (leftRedirection == DUPLICATE_RIGHT_VALUE) {
-                            throw new RuntimeException("More than one right side mapping for " + ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, sourceKeyChunks, ii));
+                            throw new IllegalStateException("More than one right side mapping for " + ChunkUtils.extractKeyStringFromChunks(keyChunkTypes, sourceKeyChunks, ii));
                         }
                         leftRedirections.set(hashSlotOffset + ii, leftRedirection);
                     }

--- a/DB/src/main/java/io/deephaven/db/v2/StaticChunkedNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/StaticChunkedNaturalJoinStateManager.java
@@ -378,7 +378,10 @@ class StaticChunkedNaturalJoinStateManager
         final boolean isLeftSide = resultSource != null;
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // the chunk of right indices that are parallel to the sourceChunks
             final WritableLongChunk<OrderedKeyIndices> rightSourceIndexKeys;

--- a/DB/src/main/java/io/deephaven/db/v2/StaticChunkedNaturalJoinStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/StaticChunkedNaturalJoinStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/SymbolTableCombiner.java
+++ b/DB/src/main/java/io/deephaven/db/v2/SymbolTableCombiner.java
@@ -481,7 +481,10 @@ class SymbolTableCombiner
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             final WritableIntChunk<Attributes.KeyIndices> sourceResultIdentifiers = WritableIntChunk.makeWritableChunk((int)Math.min(CHUNK_SIZE, buildIndex.size()));
             // endregion build initialization

--- a/DB/src/main/java/io/deephaven/db/v2/SymbolTableCombiner.java
+++ b/DB/src/main/java/io/deephaven/db/v2/SymbolTableCombiner.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedByAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedByAggregationStateManager.java
@@ -527,7 +527,10 @@ class IncrementalChunkedByAggregationStateManager
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // Index keys extracted from the input index, parallel to the sourceKeyChunks
             final WritableLongChunk<OrderedKeyIndices> sourceChunkIndexKeys = WritableLongChunk.makeWritableChunk(bc.chunkSize);

--- a/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedByAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedByAggregationStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2.by;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedOperatorAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedOperatorAggregationStateManager.java
@@ -503,7 +503,10 @@ class IncrementalChunkedOperatorAggregationStateManager
 
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // endregion build initialization
 

--- a/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedOperatorAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/IncrementalChunkedOperatorAggregationStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2.by;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedByAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedByAggregationStateManager.java
@@ -466,7 +466,10 @@ class StaticChunkedByAggregationStateManager
         // region build start
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // Index keys extracted from the input index, parallel to the sourceKeyChunks
             final WritableLongChunk<OrderedKeyIndices> sourceChunkIndexKeys = WritableLongChunk.makeWritableChunk(bc.chunkSize);

--- a/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedByAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedByAggregationStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2.by;
 
 import io.deephaven.base.verify.Require;

--- a/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedOperatorAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedOperatorAggregationStateManager.java
@@ -486,7 +486,10 @@ class StaticChunkedOperatorAggregationStateManager
         bc.duplicatePositions.setSize(0);
         // endregion build start
 
-        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator()) {
+        try (final OrderedKeys.Iterator okIt = buildIndex.getOrderedKeysIterator();
+             // region build initialization try
+             // endregion build initialization try
+        ) {
             // region build initialization
             // endregion build initialization
 

--- a/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedOperatorAggregationStateManager.java
+++ b/DB/src/main/java/io/deephaven/db/v2/by/StaticChunkedOperatorAggregationStateManager.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.db.v2.by;
 
 import io.deephaven.base.verify.Require;


### PR DESCRIPTION
Closes #1012 