### PR TITLE
Add a layouts directory adjacent to the notebooks directory

### DIFF
--- a/envoy/contents/envoy.yaml
+++ b/envoy/contents/envoy.yaml
@@ -41,6 +41,9 @@ static_resources:
                         - match: # Notebook file storage at this path
                             prefix: "/notebooks"
                           route: { cluster: web }
+                        - match: # Application mode layout storage at this path
+                            prefix: "/layouts"
+                          route: { cluster: web }
                         - match: # Any GRPC call is assumed to be forwarded to the real service
                             prefix: "/"
                             grpc: {}

--- a/web/client-ide/nginx/99-init-notebooks.sh
+++ b/web/client-ide/nginx/99-init-notebooks.sh
@@ -5,3 +5,6 @@ set -o nounset
 
 mkdir -p /data/notebooks
 chown nginx /data/notebooks
+
+mkdir -p /data/layouts
+chown nginx /data/layouts

--- a/web/client-ide/nginx/default.conf
+++ b/web/client-ide/nginx/default.conf
@@ -13,9 +13,15 @@ server {
         index  index.html index.htm;
     }
 
-    location /notebooks/ {
+    location ~ ^/(notebooks|layouts)/ {
         root                  /data;
         autoindex   on;
+
+        # Uncomment the next few lines to disable CORS
+        # Useful for local development
+        # add_header Access-Control-Allow-Origin * always;
+        # add_header Access-Control-Allow-Methods * always;
+        # add_header Access-Control-Allow-Headers * always;
 
         # enable creating directories without trailing slash
         set $x $uri$request_method;


### PR DESCRIPTION
Create the `docker/core/data/layouts` directory to keep seeded layouts files. We will need user/developer facing documentation on this directory and how to store files in it.

Partial #695 