### PR TITLE
JS API Error handling

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
@@ -300,7 +300,7 @@ public class ArrowFlightUtil {
                     resultTable.dropReference();
                     GrpcUtil.safelyExecute(observer::onCompleted);
                     return resultTable;
-                }), () -> GrpcUtil.safelyError(observer, Code.INTERNAL, "Do put could not be sealed"));
+                }), () -> GrpcUtil.safelyError(observer, Code.DATA_LOSS, "Do put could not be sealed"));
             });
         }
 
@@ -496,7 +496,7 @@ public class ArrowFlightUtil {
             }
 
             if (!subscriptionFound) {
-                throw GrpcUtil.statusRuntimeException(Code.INTERNAL, "Subscription was not found.");
+                throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND, "Subscription was not found.");
             }
         }
 

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/console/ConsoleServiceGrpcImpl.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/console/ConsoleServiceGrpcImpl.java
@@ -231,13 +231,13 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
                         ScriptSession scriptSession = exportedConsole.get();
                         String tableName = request.getTableName();
                         if (!scriptSession.hasVariableName(tableName)) {
-                            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "No value exists with name " + tableName);
+                            throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND, "No value exists with name " + tableName);
                         }
 
                         // Explicit typecheck to catch any wrong-type-ness right away
                         Object result = scriptSession.unwrapObject(scriptSession.getVariable(tableName));
                         if (!(result instanceof Table)) {
-                            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Value bound to name " + tableName + " is not a Table");
+                            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "Value bound to name " + tableName + " is not a Table");
                         }
 
                         // Apply preview columns TODO core#107 move to table service
@@ -371,12 +371,12 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
 
                         String figureName = request.getFigureName();
                         if (!scriptSession.hasVariableName(figureName)) {
-                            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "No value exists with name " + figureName);
+                            throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND, "No value exists with name " + figureName);
                         }
 
                         Object result = scriptSession.unwrapObject(scriptSession.getVariable(figureName));
                         if (!(result instanceof FigureWidget)) {
-                            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Value bound to name " + figureName + " is not a FigureWidget");
+                            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "Value bound to name " + figureName + " is not a FigureWidget");
                         }
                         FigureWidget widget = (FigureWidget) result;
 

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
@@ -1165,7 +1165,7 @@ public class SessionState {
                 final String dependentStr = dependentExportId == null ? ""
                         : (" (related parent export id: " + dependentExportId + ")");
                 errorHandler.onError(StatusProto.toStatusRuntimeException(Status.newBuilder()
-                        .setCode(Code.INTERNAL.getNumber())
+                        .setCode(Code.FAILED_PRECONDITION.getNumber())
                         .setMessage("Details Logged w/ID '" + errorContext + "'" + dependentStr)
                         .build()));
             }));

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/util/BrowserStream.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/util/BrowserStream.java
@@ -73,7 +73,7 @@ public class BrowserStream<T extends BrowserStream.MessageBase> implements Close
     public void onMessageReceived(T message) {
         synchronized (this) {
             if (halfClosedSeq != -1 && message.sequence > halfClosedSeq) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Sequence sent after half close: closed seq=" + halfClosedSeq + " recv seq=" + message.sequence);
+                throw GrpcUtil.statusRuntimeException(Code.ABORTED, "Sequence sent after half close: closed seq=" + halfClosedSeq + " recv seq=" + message.sequence);
             }
 
             if (message.isHalfClosed) {
@@ -85,7 +85,7 @@ public class BrowserStream<T extends BrowserStream.MessageBase> implements Close
 
             if (mode == Mode.IN_ORDER) {
                 if (message.sequence < nextSeq) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Duplicate sequence sent: next seq=" + nextSeq + " recv seq=" + message.sequence);
+                    throw GrpcUtil.statusRuntimeException(Code.OUT_OF_RANGE, "Duplicate sequence sent: next seq=" + nextSeq + " recv seq=" + message.sequence);
                 }
                 boolean queueMsg = false;
                 if (processingMessage) {

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/util/GrpcUtil.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/util/GrpcUtil.java
@@ -49,7 +49,7 @@ public class GrpcUtil {
     }
 
     public static StatusRuntimeException securelyWrapError(final Logger log, final Throwable err) {
-        return securelyWrapError(log, err, Code.INTERNAL);
+        return securelyWrapError(log, err, Code.INVALID_ARGUMENT);
     }
 
     public static StatusRuntimeException securelyWrapError(final Logger log, final Throwable err, final Code statusCode) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -337,6 +337,7 @@ public class WorkerConnection {
                 if (fail != null) {
                     //TODO set a flag so others know not to try until we re-trigger initial auth
                     //TODO re-trigger auth
+                    checkStatus((ResponseStreamWrapper.Status) fail);
                     return;
                 }
                 // mark the new token, schedule a new check
@@ -1185,9 +1186,7 @@ public class WorkerConnection {
 
                 notifyLog(logItem);
             });
-            logStream.onEnd(status -> {
-                //TODO handle reconnect
-            });
+            logStream.onEnd(this::checkStatus);
         } else {
             pastLogs.forEach(callback::apply);
         }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -25,6 +25,8 @@ import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.console_pb.Fe
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.console_pb.LogSubscriptionData;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.console_pb.LogSubscriptionRequest;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.console_pb_service.ConsoleServiceClient;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.session_pb.ExportNotification;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.session_pb.ExportNotificationRequest;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.session_pb.HandshakeRequest;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.session_pb.HandshakeResponse;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.session_pb_service.SessionServiceClient;
@@ -141,6 +143,7 @@ public class WorkerConnection {
     private final JsSet<JsConsumer<LogItem>> logCallbacks = new JsSet<>();
 
     private final Map<ClientTableState, ResponseStreamWrapper<FlightData>> subscriptionStreams = new HashMap<>();
+    private ResponseStreamWrapper<ExportedTableUpdateMessage> exportNotifications;
 
     private Map<TableMapHandle, TableMap> tableMaps = new HashMap<>();
 
@@ -258,6 +261,7 @@ public class WorkerConnection {
 
 //                // start a heartbeat to check if connection is properly alive
 //                ping(success.getAuthSessionToken());
+            startExportNotificationsStream();
 
             return Promise.resolve(handshakeResponse);
         }, fail -> {
@@ -283,6 +287,39 @@ public class WorkerConnection {
             info.failureHandled("Failed to connect: " + failure);
             return null;
         });
+    }
+
+    public void checkStatus(ResponseStreamWrapper.Status status) {
+        //TODO provide simpler hooks to retry auth, restart the stream
+        if (status.getCode() == Code.OK) {
+            // success, ignore
+        } else if (status.getCode() == Code.Unauthenticated) {
+            // TODO re-create session once?
+            // for now treating this as fatal, UI should encourage refresh to try again
+            info.notifyConnectionError(status);
+        } else if (status.getCode() == Code.Internal || status.getCode() == Code.Unknown) {
+            // for now treating these as fatal also
+            info.notifyConnectionError(status);
+        } else if (status.getCode() == Code.Unavailable) {
+            // TODO skip re-authing for now, just backoff and try again
+        } // others probably are meaningful to the caller
+    }
+
+    private void startExportNotificationsStream() {
+        if (exportNotifications != null) {
+            exportNotifications.cancel();
+        }
+        exportNotifications = ResponseStreamWrapper.of(tableServiceClient.exportedTableUpdates(new ExportedTableUpdatesRequest(), metadata()));
+        exportNotifications.onData(update -> {
+            if (update.getUpdateFailureMessage() != null && !update.getUpdateFailureMessage().isEmpty()) {
+                exportedTableUpdateMessageError(new TableTicket(update.getExportId().getTicket_asU8()), update.getUpdateFailureMessage());
+            } else {
+                exportedTableUpdateMessage(new TableTicket(update.getExportId().getTicket_asU8()), java.lang.Long.parseLong(update.getSize()));
+            }
+        });
+
+        // any export notification error is bad news
+        exportNotifications.onStatus(this::checkStatus);
     }
 
     private void authUpdate(HandshakeResponse handshakeResponse) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/batch/RequestBatcher.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/batch/RequestBatcher.java
@@ -236,7 +236,6 @@ public class RequestBatcher {
 
             ResponseStreamWrapper<ExportedTableCreationResponse> batchStream = ResponseStreamWrapper.of(connection.tableServiceClient().batch(request, connection.metadata()));
             batchStream.onData(response -> {
-                DomGlobal.console.log("onData", this, request.toObject(), response.toObject());
                 TableReference resultid = response.getResultId();
                 if (!resultid.hasTicket()) {
                     // thanks for telling us, but we don't at this time have a nice way to indicate this
@@ -292,7 +291,6 @@ public class RequestBatcher {
             });
 
             batchStream.onEnd(status -> {
-                DomGlobal.console.log("onEnd", this, request.toObject(), status);
                 // request is complete
                 if (status.getCode() == Code.OK) {
                     resolve.onInvoke((Void) null);


### PR DESCRIPTION
Added basic error handling, but not proper reconnects or reauth. Three error types are handled for the main streams or polling calls:
 * auth failure which suggests either that the server was restarted or the session timed out somehow - in either case, a new auth is required to resume working
 * Code.INTERNAL, which our grpc-web client library will pass in cases where the response doesn't make sense (broken payloads)
 * Code.UNKNOWN, which our grpc-web client library will pass in cases where the transport doesn't seem to work (no response before connection died)

A new event was added, temporarily, to inform the UI that we are giving up if one of these happens, and the page needs to be reloaded. This will be removed when we have proper reconnect, and inform the UI again that the reconnect succeeded or failed.

Also modified a few errors being sent from the server to hopefully better reflect the intent of the gRPC status codes, and avoid using "INTERNAL" when "something bad" happens.

The UI will need a few small changes to handle this, and to handle a few cases where API calls can fail but not be registered in the UI.

Fixes #1065, but #730 needs to formally address this.