### PR TITLE
Properly use liveness API for dynamic non-refreshing nodes in SessionState exports

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
@@ -448,7 +448,7 @@ public class ArrowFlightUtil {
                     updateIntervalMs = DEFAULT_UPDATE_INTERVAL_MS;
                 }
                 bmp = table.getResult(operationFactory.create(table, updateIntervalMs));
-                if (DynamicNode.notDynamicOrIsRefreshing(bmp)) {
+                if (bmp.isRefreshing()) {
                     manage(bmp);
                 }
             } else {

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
@@ -18,7 +18,10 @@ import io.deephaven.configuration.Configuration;
 import io.deephaven.datastructures.util.CollectionUtil;
 import io.deephaven.db.tables.Table;
 import io.deephaven.db.util.LongSizedDataStructure;
+import io.deephaven.db.util.liveness.Liveness;
+import io.deephaven.db.util.liveness.LivenessReferent;
 import io.deephaven.db.util.liveness.SingletonLivenessManager;
+import io.deephaven.db.v2.DynamicNode;
 import io.deephaven.db.v2.QueryTable;
 import io.deephaven.db.v2.sources.chunk.ChunkType;
 import io.deephaven.db.v2.utils.BarrageMessage;
@@ -445,7 +448,9 @@ public class ArrowFlightUtil {
                     updateIntervalMs = DEFAULT_UPDATE_INTERVAL_MS;
                 }
                 bmp = table.getResult(operationFactory.create(table, updateIntervalMs));
-                manage(bmp);
+                if (DynamicNode.notDynamicOrIsRefreshing(bmp)) {
+                    manage(bmp);
+                }
             } else {
                 GrpcUtil.safelyError(listener, Code.FAILED_PRECONDITION, "Ticket ("
                         + ExportTicketHelper.toReadableString(subscriptionRequest.ticketAsByteBuffer())

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/session/SessionState.java
@@ -451,8 +451,6 @@ public class SessionState {
      * @apiNote Non-exports do not publish state changes.
      */
     public final static class ExportObject<T> extends LivenessArtifact {
-        private final Exception creationTag = log.isDebugEnabled() ? new Exception("creationTag") : null;
-
         private final int exportId;
         private final String logIdentity;
         private final SessionState session;
@@ -539,10 +537,10 @@ public class SessionState {
 
             if (log.isDebugEnabled()) {
                 final Exception e = new RuntimeException();
-                final LogEntry entry = log.debug().append(e).append("\n").append(session.logPrefix).append("export '").append(logIdentity)
+                final LogEntry entry = log.debug().append(e).nl().append(session.logPrefix).append("export '").append(logIdentity)
                         .append("' has ").append(dependentCount).append(" dependencies remaining: ");
                 for (ExportObject<?> parent : parents) {
-                    entry.append("\n\t").append(parent.logIdentity).append(" is ").append(parent.getState().name());
+                    entry.nl().append('\t').append(parent.logIdentity).append(" is ").append(parent.getState().name());
                 }
                 entry.endl();
             }
@@ -803,11 +801,11 @@ public class SessionState {
                     setResult(capturedExport.call());
                 } finally {
                     shouldLog = QueryPerformanceRecorder.getInstance().endQuery();
-                }
 
-                if (isNonExport()) {
-                    // we force non-exports to remain live until they are resolved
-                    dropReference();
+                    if (isNonExport()) {
+                        // we force non-exports to remain live until they are resolved
+                        dropReference();
+                    }
                 }
             } catch (final Exception err) {
                 exception = err;


### PR DESCRIPTION
The query:
```groovy
t = emptyTable(10000).update("I = ii")
```

Would display the first page, but any viewport changes would throw an exception due to incorrect usage of LivenessReferent API. It was easily triggered using SSL, could not reproduce using the grpc-web proxy.