### PR TITLE
Force jvm to load class in desired package

### DIFF
--- a/DB/src/test/java/io/deephaven/db/tables/lang/TestDBLanguageParser.java
+++ b/DB/src/test/java/io/deephaven/db/tables/lang/TestDBLanguageParser.java
@@ -5,6 +5,7 @@
 package io.deephaven.db.tables.lang;
 
 import io.deephaven.base.Pair;
+import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.Require;
 import io.deephaven.base.testing.BaseArrayTestCase;
 import io.deephaven.db.tables.Table;
@@ -40,7 +41,11 @@ public class TestDBLanguageParser extends BaseArrayTestCase {
     public void setUp() throws Exception {
         packageImports = new HashSet<>();
         packageImports.add(Package.getPackage("java.lang"));
-        packageImports.add(Package.getPackage("io.deephaven.db.tables"));
+
+        // Package.getPackage returns null if the class loader has yet to see a class from that package; force a load
+        Package tablePackage = Table.class.getPackage();
+        Assert.equals(tablePackage.getName(), "tablePackage.getName()", "io.deephaven.db.tables");
+        packageImports.add(tablePackage);
 
         classImports = new HashSet<>();
         classImports.add(Color.class);


### PR DESCRIPTION
Isolated, each test in DBLanguageParser fail during setup because `io.deephaven.db.tables` has not yet been seen by the class loader. This forcefully loads a known class, and verifies the package, to get enable debugging these tests one at a time.