### PR TITLE
CrossJoin cardinality calculation may overflow integer

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/CrossJoinHelper.java
+++ b/DB/src/main/java/io/deephaven/db/v2/CrossJoinHelper.java
@@ -379,8 +379,8 @@ public class CrossJoinHelper {
                         }
 
                         // Generate shift data; build up result index changes for all but added left
-                        final long prevCardinality = 1 << prevRightBits;
-                        final long currCardinality = 1 << currRightBits;
+                        final long prevCardinality = 1L << prevRightBits;
+                        final long currCardinality = 1L << currRightBits;
                         final IndexShiftData.Builder shiftBuilder = new IndexShiftData.Builder();
                         final Index.SequentialBuilder toRemoveFromResultIndex = Index.FACTORY.getSequentialBuilder();
                         final Index.SequentialBuilder toInsertIntoResultIndex = Index.FACTORY.getSequentialBuilder();


### PR DESCRIPTION
This will only trigger if the right table's largest-group cardinality exceeds 32 bits (super unlikely...)