### PR TITLE
Add DynamicTableWriter to the deephaven module

### DIFF
--- a/Integrations/python/deephaven/TableManipulation/__init__.py
+++ b/Integrations/python/deephaven/TableManipulation/__init__.py
@@ -8,13 +8,14 @@ Functionality to display and modify tables.
 
 import jpy
 
-__all__ = ['ColumnRenderersBuilder', 'DistinctFormatter', 'DownsampledWhereFilter', 'LayoutHintBuilder',
-           'SmartKey', 'SortPair', 'TotalsTableBuilder', 'WindowCheck']
+__all__ = ['ColumnRenderersBuilder', 'DistinctFormatter', 'DownsampledWhereFilter', 'DynamicTableWriter', 
+           'LayoutHintBuilder', 'SmartKey', 'SortPair', 'TotalsTableBuilder', 'WindowCheck']
 
 # None until the first successful _defineSymbols() call
 ColumnRenderersBuilder = None   #: Class to build and parse the directive for Table.COLUMN_RENDERERS_ATTRIBUTE (io.deephaven.db.v2.ColumnRenderersBuilder).
 DistinctFormatter = None        #: Class to create distinct and unique coloration for each unique input value (io.deephaven.db.util.DBColorUtil$DistinctFormatter).
 DownsampledWhereFilter = None   #: Class to downsample time series data by calculating the bin intervals for values, and then using upperBin and lastBy to select the last row for each bin (io.deephaven.db.v2.select.DownsampledWhereFilter).
+DynamicTableWriter = None       #: Class to create a TableWriter object {@link io.deephaven.db.v2.utils.DynamicTableWriter}
 LayoutHintBuilder = None        #: Builder class for use in assembling layout hints suitable for use with {@link io.deephaven.db.tables.Table#layoutHints(LayoutHintBuilder)} or {@link io.deephaven.db.tables.Table#layoutHints(String)} (io.deephaven.db.tables.utils.LayoutHintBuilder).
 SmartKey = None                 #: A datastructure key class, where more than one value can be used as the key (io.deephaven.datastructures.util.SmartKey).
 TotalsTableBuilder = None       #: Class to define the default aggregations and display for a totals table (io.deephaven.db.v2.TotalsTableBuilder).
@@ -31,13 +32,14 @@ def _defineSymbols():
     if not jpy.has_jvm():
         raise SystemError("No java functionality can be used until the JVM has been initialized through the jpy module")
 
-    global ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, LayoutHintBuilder, \
-        SmartKey, TotalsTableBuilder, SortPair
+    global ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, DynamicTableWriter, \
+        LayoutHintBuilder, SmartKey, TotalsTableBuilder, SortPair
 
     if ColumnRenderersBuilder is None:
         # This will raise an exception if the desired object is not the classpath
         ColumnRenderersBuilder = jpy.get_type('io.deephaven.db.v2.ColumnRenderersBuilder')
         DistinctFormatter = jpy.get_type('io.deephaven.db.util.DBColorUtil$DistinctFormatter')
+        DynamicTableWriter = jpy.get_type('io.deephaven.db.v2.utils.DynamicTableWriter')
         DownsampledWhereFilter = jpy.get_type('io.deephaven.db.v2.select.DownsampledWhereFilter')
         LayoutHintBuilder = jpy.get_type('io.deephaven.db.tables.utils.LayoutHintBuilder')
         SmartKey = jpy.get_type('io.deephaven.datastructures.util.SmartKey')

--- a/Integrations/python/deephaven/__init__.py
+++ b/Integrations/python/deephaven/__init__.py
@@ -35,7 +35,7 @@ Additionally, the following methods have been imported into the main deephaven n
        convertToJavaHashSet, convertToJavaHashMap
 
 * from TableManipulation import ColumnRenderersBuilder, DistinctFormatter,
-       DownsampledWhereFilter, LayoutHintBuilder,
+       DownsampledWhereFilter, DynamicTableWriter, LayoutHintBuilder,  
        SmartKey, SortPair, TotalsTableBuilder, WindowCheck
 
 For ease of namespace population in a python console, consider::
@@ -57,8 +57,8 @@ __all__ = [
     "convertToJavaArray", "convertToJavaList", "convertToJavaArrayList", "convertToJavaHashSet",
     "convertToJavaHashMap",  # from conversion_utils
 
-    'ColumnRenderersBuilder', 'DistinctFormatter', 'DownsampledWhereFilter', 'LayoutHintBuilder',
-    'SmartKey', 'SortPair', 'TotalsTableBuilder', 'WindowCheck',  # from TableManipulation
+    'ColumnRenderersBuilder', 'DistinctFormatter', 'DownsampledWhereFilter', 'DynamicTableWriter', 
+    'LayoutHintBuilder', 'SmartKey', 'SortPair', 'TotalsTableBuilder', 'WindowCheck',  # from TableManipulation
 
     "cals", "caf", "dbtu", "figw", "mavg", "npy", "plt", "pt", "ttools", "tloggers"  # subpackages with abbreviated names
 ]
@@ -115,10 +115,10 @@ def initialize():
 
     import deephaven.TableManipulation
     deephaven.TableManipulation._defineSymbols()
-    global ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, LayoutHintBuilder, \
-        SmartKey, SortPair, TotalsTableBuilder
+    global ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, DynamicTableWriter, \
+        LayoutHintBuilder, SmartKey, SortPair, TotalsTableBuilder
     from deephaven.TableManipulation import ColumnRenderersBuilder, DistinctFormatter, \
-        DownsampledWhereFilter, LayoutHintBuilder, SmartKey, SortPair, \
+        DownsampledWhereFilter, DynamicTableWriter, LayoutHintBuilder, SmartKey, SortPair, \
         TotalsTableBuilder
 
     WindowCheck._defineSymbols()


### PR DESCRIPTION
DynamicTableWriter should be a part of the base deephaven module.  This replaces the following:

`DynamicTableWriter = jpy.get_type("io.deephaven.db.v2.utils.DynamicTableWriter")`

with

`from deephaven import DynamicTableWriter`