### PR TITLE
Fix CODEOWNERS references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,10 @@
 # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 /.github/workflows/ @devinrsmith @jcferretti @JamesXNelson
 
-CODE_OF_CONDUCT.md @chipkent
-CONTRIBUTING.md @chipkent
-LICENSE.md @chipkent
-NOTICE.md @chipkent
-README.md @chipkent @rcaudy @margaretkennedy
-TRIAGE.md @chipkent
+/CODE_OF_CONDUCT.md @chipkent
+/CONTRIBUTING.md @chipkent
+/LICENSE.md @chipkent
+/NOTICE.md @chipkent
+/README.md @chipkent @rcaudy @margaretkennedy
+/TRIAGE.md @chipkent
 /licenses @chipkent


### PR DESCRIPTION
Anytime a README.md is changes, Chip, Ryan, and Margaret are blocking reviewers. This should not be the case when a subproject has a README.md.