### PR TITLE
Disable envoy websocket timeout

### DIFF
--- a/envoy/contents/envoy.yaml
+++ b/envoy/contents/envoy.yaml
@@ -22,7 +22,7 @@ static_resources:
                 codec_type: AUTO
                 upgrade_configs:
                  - upgrade_type: websocket
-
+                stream_idle_timeout: 0s
                 route_config:
                   name: local_route
                   virtual_hosts:


### PR DESCRIPTION
This is analogous to how we disable grpc stream timeout, and should
possibly be reconsidered in the future.

Fixes #1131