### PR TITLE
Disambiguate DynamicTableWriter constructors taking an array from the point of view of jpy.

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/utils/AsyncErrorLogger.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/AsyncErrorLogger.java
@@ -26,8 +26,7 @@ public class AsyncErrorLogger {
                     ColumnHeader.ofString("SourceQueryDescription"),
                     ColumnHeader.of("Cause", Exception.class),
                     ColumnHeader.ofString("WorkerName"),
-                    ColumnHeader.ofString("HostName")
-            ));
+                    ColumnHeader.ofString("HostName")));
     private static final RowSetter<DBDateTime> timeSetter = tableWriter.getSetter("Time");
     private static final RowSetter<Integer> evaluationNumberSetter = tableWriter.getSetter("EvaluationNumber");
     private static final RowSetter<Integer> operationNumberSetter = tableWriter.getSetter("OperationNumber");

--- a/DB/src/main/java/io/deephaven/db/v2/utils/DynamicTableWriter.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/DynamicTableWriter.java
@@ -65,7 +65,7 @@ public class DynamicTableWriter implements TableWriter {
 
     // This constructor is no longer public to simplify access from python: jpy cannot resolve
     // calls with arguments of list type when there is more than one alternative with array element type
-    // on the java side.  Prefer the constructor taking qst.table.TableHeader or an array of qst.type.Type
+    // on the java side. Prefer the constructor taking qst.table.TableHeader or an array of qst.type.Type
     // objects.
     @SuppressWarnings("WeakerAccess")
     DynamicTableWriter(
@@ -92,7 +92,7 @@ public class DynamicTableWriter implements TableWriter {
 
     // This constructor is no longer public to simplify access from python: jpy cannot resolve
     // calls with arguments of list type when there is more than one alternative with array element type
-    // on the java side.  Prefer the constructor taking qst.table.TableHeader or an array of qst.type.Type
+    // on the java side. Prefer the constructor taking qst.table.TableHeader or an array of qst.type.Type
     // objects.
     DynamicTableWriter(final String[] columnNames, final Class<?>[] columnTypes) {
         this(columnNames, columnTypes, Collections.emptyMap());


### PR DESCRIPTION
With two public constructors looking like:

```
DynamicTableWriter(final String[] columnNames, final Class<?>[] columnTypes)
DynamicTableWriter(final String[] columnNames, final Type<?>[] columnTypes)
```

jpy can't tell which to call with a list for the second argument:

```
r-Scheduler-Serial-1 | i.d.g.s.SessionState      | Internal Error '17a7b995-3319-470d-9452-7e0fadac8722' java.lang.RuntimeException: Error in Python interpreter:
Type: <class 'RuntimeError'>
Value: ambiguous Java method call, too many matching method overloads found
```

Creating an intermediate jpy.array on the python side works, but is a clunky API to be forced on users (see image attached).
Since we want to move to qst and away from Class anyway, I am making the constructors package-private, and replacing their use with the TableHeader based one.

![Selection_095](https://user-images.githubusercontent.com/37232625/131039053-2f1c38f4-2359-43ea-8e9e-bf118398f9c6.png)

