### PR TITLE
ScriptSession#setVariable require subclasses to notify old vs new Value

### DIFF
--- a/DB/src/main/java/io/deephaven/db/util/AbstractScriptSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/AbstractScriptSession.java
@@ -172,14 +172,16 @@ public abstract class AbstractScriptSession extends LivenessScope implements Scr
         }
     }
 
-    @Override
-    public synchronized void setVariable(String name, Object value) {
-        if (changeListener != null) {
-            Changes changes = new Changes();
-            applyVariableChangeToDiff(changes, name, getVariable(name, null), value);
-            if (!changes.isEmpty()) {
-                changeListener.onScopeChanges(this, changes);
-            }
+    protected synchronized void notifyVariableChange(String name, @Nullable Object oldValue,
+            @Nullable Object newValue) {
+        if (changeListener == null) {
+            return;
+        }
+
+        Changes changes = new Changes();
+        applyVariableChangeToDiff(changes, name, oldValue, newValue);
+        if (!changes.isEmpty()) {
+            changeListener.onScopeChanges(this, changes);
         }
     }
 

--- a/DB/src/main/java/io/deephaven/db/util/AbstractScriptSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/AbstractScriptSession.java
@@ -134,7 +134,8 @@ public abstract class AbstractScriptSession extends LivenessScope implements Scr
         return diff;
     }
 
-    private void applyVariableChangeToDiff(final Changes diff, String name, Object fromValue, Object toValue) {
+    private void applyVariableChangeToDiff(final Changes diff, String name,
+            @Nullable Object fromValue, @Nullable Object toValue) {
         fromValue = unwrapObject(fromValue);
         final ExportedObjectType fromType = ExportedObjectType.fromObject(fromValue);
         if (!fromType.isDisplayable()) {

--- a/DB/src/main/java/io/deephaven/db/util/DelegatingScriptSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/DelegatingScriptSession.java
@@ -50,6 +50,7 @@ public class DelegatingScriptSession implements ScriptSession {
         return diff;
     }
 
+    @NotNull
     @Override
     public Object getVariable(String name) throws QueryScope.MissingVariableException {
         return delegate.getVariable(name);

--- a/DB/src/main/java/io/deephaven/db/util/GroovyDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/GroovyDeephavenSession.java
@@ -26,6 +26,7 @@ import io.deephaven.util.annotations.VisibleForTesting;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.tools.GroovyClass;
+import org.jetbrains.annotations.Nullable;
 
 import javax.tools.JavaFileObject;
 import java.io.File;
@@ -596,7 +597,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession implements Scr
     /**
      * I factored out this horrible snippet of code from the updateClassLoader, to isolate the badness. I can't think of
      * a replacement that doesn't involve regex matching.
-     * 
+     *
      * @param s The string to evaluate
      * @return Whether s can be parsed as an int.
      */
@@ -627,9 +628,10 @@ public class GroovyDeephavenSession extends AbstractScriptSession implements Scr
     }
 
     @Override
-    public void setVariable(String name, Object value) {
-        super.setVariable(name, value);
-        groovyShell.getContext().setVariable(NameValidator.validateQueryParameterName(name), value);
+    public void setVariable(String name, @Nullable Object newValue) {
+        final Object oldValue = getVariable(name, null);
+        groovyShell.getContext().setVariable(NameValidator.validateQueryParameterName(name), newValue);
+        notifyVariableChange(name, oldValue, newValue);
     }
 
     public Binding getBinding() {
@@ -794,9 +796,9 @@ public class GroovyDeephavenSession extends AbstractScriptSession implements Scr
     // present
     /*
      * public static class Calendars implements InitScript {
-     * 
+     *
      * @Override public String getScriptPath() { return "groovy/2-calendars.groovy"; }
-     * 
+     *
      * @Override public int priority() { return 2; } }
      */
 

--- a/DB/src/main/java/io/deephaven/db/util/GroovyDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/GroovyDeephavenSession.java
@@ -26,6 +26,7 @@ import io.deephaven.util.annotations.VisibleForTesting;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.tools.GroovyClass;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.tools.JavaFileObject;
@@ -175,6 +176,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession implements Scr
         executedScripts.add(script);
     }
 
+    @NotNull
     @Override
     public Object getVariable(String name) throws QueryScope.MissingVariableException {
         try {

--- a/DB/src/main/java/io/deephaven/db/util/NoLanguageDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/NoLanguageDeephavenSession.java
@@ -3,6 +3,7 @@ package io.deephaven.db.util;
 import io.deephaven.db.tables.select.QueryScope;
 import io.deephaven.db.util.scripts.ScriptPathLoader;
 import io.deephaven.db.util.scripts.ScriptPathLoaderState;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -37,6 +38,7 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession implements
         return new QueryScope.SynchronizedScriptSessionImpl(this);
     }
 
+    @NotNull
     @Override
     public Object getVariable(String name) throws QueryScope.MissingVariableException {
         final Object var = variables.get(name);

--- a/DB/src/main/java/io/deephaven/db/util/NoLanguageDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/NoLanguageDeephavenSession.java
@@ -80,9 +80,10 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession implements
     }
 
     @Override
-    public void setVariable(String name, Object value) {
-        super.setVariable(name, value);
-        variables.put(name, value);
+    public void setVariable(String name, @Nullable Object newValue) {
+        Object oldValue = getVariable(name, null);
+        variables.put(name, newValue);
+        notifyVariableChange(name, oldValue, newValue);
     }
 
     @Override

--- a/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
@@ -16,6 +16,7 @@ import io.deephaven.db.util.scripts.ScriptPathLoaderState;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.util.annotations.VisibleForTesting;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jpy.KeyError;
 import org.jpy.PyDictWrapper;
@@ -149,6 +150,7 @@ public class PythonDeephavenSession extends AbstractScriptSession implements Scr
         }
     }
 
+    @NotNull
     @Override
     public Object getVariable(String name) throws QueryScope.MissingVariableException {
         return scope

--- a/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/PythonDeephavenSession.java
@@ -16,6 +16,7 @@ import io.deephaven.db.util.scripts.ScriptPathLoaderState;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.util.annotations.VisibleForTesting;
+import org.jetbrains.annotations.Nullable;
 import org.jpy.KeyError;
 import org.jpy.PyDictWrapper;
 import org.jpy.PyObject;
@@ -125,7 +126,7 @@ public class PythonDeephavenSession extends AbstractScriptSession implements Scr
     /**
      * Finds the specified script; and runs it as a file, or if it is a stream writes it to a temporary file in order to
      * run it.
-     * 
+     *
      * @param script the script's name
      * @throws IOException if an error occurs reading or writing the script
      */
@@ -190,18 +191,19 @@ public class PythonDeephavenSession extends AbstractScriptSession implements Scr
     }
 
     @Override
-    public void setVariable(String name, Object value) {
-        super.setVariable(name, value);
-        PyDictWrapper globals = scope.globals();
-        if (value == null) {
+    public void setVariable(String name, @Nullable Object newValue) {
+        final Object oldValue = getVariable(name, null);
+        final PyDictWrapper globals = scope.globals();
+        if (newValue == null) {
             try {
                 globals.delItem(name);
             } catch (KeyError key) {
                 // ignore
             }
         } else {
-            globals.setItem(name, value);
+            globals.setItem(name, newValue);
         }
+        notifyVariableChange(name, oldValue, newValue);
     }
 
     @Override

--- a/DB/src/main/java/io/deephaven/db/util/ScalaDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/ScalaDeephavenSession.java
@@ -189,15 +189,16 @@ public class ScalaDeephavenSession extends AbstractScriptSession implements Scri
     }
 
     @Override
-    public void setVariable(String name, Object value) {
-        super.setVariable(name, value);
-        if (value == null) {
+    public void setVariable(String name, @Nullable Object newValue) {
+        final Object oldValue = getVariable(name, null);
+        if (newValue == null) {
             interpreter.beQuietDuring(
                     () -> interpreter.bind(new NamedParamClass(name, Object.class.getCanonicalName(), null)));
         } else {
-            final String type = value.getClass().getCanonicalName();
-            interpreter.beQuietDuring(() -> interpreter.bind(new NamedParamClass(name, type, value)));
+            final String type = newValue.getClass().getCanonicalName();
+            interpreter.beQuietDuring(() -> interpreter.bind(new NamedParamClass(name, type, newValue)));
         }
+        notifyVariableChange(name, oldValue, newValue);
     }
 
     @Override

--- a/DB/src/main/java/io/deephaven/db/util/ScalaDeephavenSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/ScalaDeephavenSession.java
@@ -7,6 +7,7 @@ import io.deephaven.db.util.scripts.ScriptPathLoader;
 import io.deephaven.db.util.scripts.ScriptPathLoaderState;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import scala.Option;
 import scala.collection.JavaConverters;
@@ -117,6 +118,7 @@ public class ScalaDeephavenSession extends AbstractScriptSession implements Scri
         return new QueryScope.SynchronizedScriptSessionImpl(this);
     }
 
+    @NotNull
     @Override
     public Object getVariable(String name) throws QueryScope.MissingVariableException {
         Option<Object> value = interpreter.valueOfTerm(name);

--- a/DB/src/main/java/io/deephaven/db/util/ScriptSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/ScriptSession.java
@@ -9,6 +9,7 @@ import io.deephaven.db.util.liveness.LivenessNode;
 import io.deephaven.db.util.liveness.ReleasableLivenessManager;
 import io.deephaven.db.util.scripts.ScriptPathLoader;
 import io.deephaven.db.util.scripts.ScriptPathLoaderState;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
@@ -23,11 +24,14 @@ import java.util.function.Supplier;
 public interface ScriptSession extends ReleasableLivenessManager, LivenessNode {
     /**
      * Retrieve a variable from the script session's bindings.
+     * <p/>
+     * Please use {@link ScriptSession#getVariable(String, Object)} if you expect the variable may not exist.
      *
      * @param name the variable to retrieve
      * @return the variable
      * @throws QueryScope.MissingVariableException if the variable does not exist
      */
+    @NotNull
     Object getVariable(String name) throws QueryScope.MissingVariableException;
 
     /**

--- a/DB/src/main/java/io/deephaven/db/util/ScriptSession.java
+++ b/DB/src/main/java/io/deephaven/db/util/ScriptSession.java
@@ -45,7 +45,7 @@ public interface ScriptSession extends ReleasableLivenessManager, LivenessNode {
     /**
      * A {@link VariableProvider} instance, for services like autocomplete which may want a limited "just the variables"
      * view of our session state.
-     * 
+     *
      * @return a VariableProvider instance backed by the global/binding context of this script session.
      */
     VariableProvider getVariableProvider();
@@ -110,7 +110,7 @@ public interface ScriptSession extends ReleasableLivenessManager, LivenessNode {
 
     /**
      * Check if the scope has the given variable name
-     * 
+     *
      * @param name the variable name
      * @return True iff the scope has the given variable name
      */
@@ -122,7 +122,7 @@ public interface ScriptSession extends ReleasableLivenessManager, LivenessNode {
      * @param name the variable name to set
      * @param value the new value of the variable
      */
-    void setVariable(String name, Object value);
+    void setVariable(String name, @Nullable Object value);
 
     /**
      * @return a textual description of this script session's language for use in messages.
@@ -153,7 +153,7 @@ public interface ScriptSession extends ReleasableLivenessManager, LivenessNode {
 
     /**
      * Sets the scriptPathLoader that is in use for this session.
-     * 
+     *
      * @param scriptPathLoader a supplier of a script path loader
      * @param caching whether the source operation should cache results
      */


### PR DESCRIPTION
The pattern of invoking `super.setVariable` is brittle, and the listener assumes the change(s) already happened. This fixes an error call to `getVariable` when the application field listener was trying to process a create via `ConsoleService#bindTableToVariable`.