### PR TITLE
Add no-cache headers to responses from the web

### DIFF
--- a/web/client-ide/nginx/default.conf
+++ b/web/client-ide/nginx/default.conf
@@ -11,6 +11,16 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+
+        # Caching is taken care of by etags
+        expires -1;
+        add_header Cache-Control 'no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0';
+    }
+
+    # .chunk.* files are safe to cache, as they contain a sha in their file name
+    location ~* \.chunk.(?:css|js)$ {
+        expires 1y;
+        add_header Cache-Control 'public, immutable, max-age=31536000';
     }
 
     location ~ ^/(notebooks|layouts)/ {

--- a/web/client-ide/nginx/default.conf
+++ b/web/client-ide/nginx/default.conf
@@ -13,8 +13,9 @@ server {
         index  index.html index.htm;
 
         # Caching is taken care of by etags
+        # Settings expires -1 also sets the 'no-cache' Cache-Control header (http://nginx.org/en/docs/http/ngx_http_headers_module.html)
         expires -1;
-        add_header Cache-Control 'no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0';
+        add_header Cache-Control 'must-revalidate, max-age=0';
     }
 
     # .chunk.* files are safe to cache, as they contain a sha in their file name


### PR DESCRIPTION
- index.html, dh-core.js, and dh-internal.js were being loaded from memory, as the cache for them hadn't expired
- Instead, add a no-cache header to everything except for *.chunk.* files, which can safely be cached

Fixes #1184 