### PR TITLE
Expand sphinx wiring to produce docs for pydeephaven

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -87,7 +87,7 @@ jobs:
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: pythonDocs
-          arguments: --scan sphinx:pythonDocs
+          arguments: --scan sphinx:pythonDocs sphinx:pydeephavenDocs
           gradle-version: wrapper
 
       - name: Deploy Python Docs
@@ -97,6 +97,18 @@ jobs:
           switches: -avzr --delete
           path: sphinx/build/docs/
           remote_path: deephaven-core/pydoc/
+          remote_host: ${{ secrets.DOCS_HOST }}
+          remote_port: ${{ secrets.DOCS_PORT }}
+          remote_user: ${{ secrets.DOCS_USER }}
+          remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
+
+      - name: Deploy Client Python Docs
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: burnett01/rsync-deployments@4.1
+        with:
+          switches: -avzr --delete
+          path: sphinx/build/pyclient-docs/
+          remote_path: deephaven-core/client-api/python/
           remote_host: ${{ secrets.DOCS_HOST }}
           remote_port: ${{ secrets.DOCS_PORT }}
           remote_user: ${{ secrets.DOCS_USER }}

--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -185,7 +185,7 @@ class Docker {
     static TaskProvider<? extends Task> registerDockerTask(Project project, String taskName, Action<? super DockerTaskConfig> action) {
         // create instance, assign defaults
         DockerTaskConfig cfg = new DockerTaskConfig();
-        cfg.imageName = "deephaven/${taskName}:${LOCAL_BUILD_TAG}"
+        cfg.imageName = "deephaven/${taskName.replaceAll(/\B[A-Z]/) { String str -> '-' + str }.toLowerCase()}:${LOCAL_BUILD_TAG}"
 
         // ask for more configuration
         action.execute(cfg)

--- a/pyclient/docs/source/conf.py
+++ b/pyclient/docs/source/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 

--- a/sphinx/sphinx.gradle
+++ b/sphinx/sphinx.gradle
@@ -1,44 +1,73 @@
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 
 plugins {
     id 'com.bmuschko.docker-remote-api'
 }
 
+description = 'Generates docs for the python libraries provided in Deephaven Core'
+
 evaluationDependsOn ':Integrations'
 
-boolean java8 = JavaVersion.current().isJava8()
-List<Object> dependsList
-dependsList = [':Generators:generateFigureImmutable',
-                          ':Generators:generatePythonFigureWrapper',
-                          ':Generators:generatePythonIntegrationStaticMethods',
-]
-def sourceDir = "$projectDir/source"
-def docBuildDir = "$buildDir/docs"
+def sphinxDockerfile = tasks.register('sphinxDockerfile', Dockerfile) {
+    destFile.set layout.buildDirectory.file('sphinx-image/Dockerfile')
+    from 'deephaven/runtime-base:local-build'
 
-TaskProvider<? extends Task> pyDoc
+    runCommand '''set -eux; \\ 
+                  pip3 install sphinx==3.5.4 sphinx-autodoc-typehints==1.12.0 pyarrow==5.0.0 protobuf==3.17.3 grpcio==1.39.0 bitstring==3.1.9
+                  '''
+}
+def sphinxImage = Docker.registerDockerImage(project, 'sphinx') {
+    inputs.files sphinxDockerfile.get().outputs.files
+    inputDir.set layout.buildDirectory.dir('sphinx-image')
+    inputs.files project(':Integrations').tasks.findByName('buildDeephavenPython').outputs.files // deephaven/runtime-base
+    images.add('deephaven/sphinx:local-build')
+}
 
-pyDoc = Docker.registerDockerTask(project, "pythonDocs") {
-    copyIn {
-        from 'docker'
-        from(sourceDir) {
-            into 'source'
+def makePyDocTask = { name, archiveBaseName, sourcePaths, outDirPath ->
+
+    TaskProvider<? extends Task> pyDoc = Docker.registerDockerTask(project, name) {
+        copyIn {
+            sourcePaths.each { entry ->
+                from(entry.key) {
+                    into entry.value
+                }
+            }
+        }
+        dockerfile {
+            from 'deephaven/sphinx:local-build'
+
+            copyFile('.', '/project')
+
+            runCommand '''set -eux; \\
+                       mkdir /build; \\
+                       cd /project; \\
+                       sphinx-build -b html source /build
+                       '''
+        }
+        parentContainers = [sphinxImage.get()]
+        containerOutPath = '/build'
+        copyOut {
+            into outDirPath
         }
     }
-//        dockerfile = project.file('Dockerfile') // not needed with the above from 'docker'
-    parentContainers = [project(':Integrations').tasks.findByName('buildDeephavenPython')] // deephaven/runtime-base
-    imageName = 'deephaven/sphinx:local-build'
-    containerOutPath = '/build'
-    copyOut {
-        into docBuildDir
+
+    project.tasks.register "${name}Tar", Tar, {
+        Tar tar ->
+            tar.from(outDirPath)
+            tar.dependsOn(pyDoc)
+            tar.archiveBaseName.set(archiveBaseName)
     }
 }
 
-pyDoc.configure {
-    dependsOn dependsList
+def pythonDocs = makePyDocTask('pythonDocs', 'dh-python-docs', ["$projectDir/source":'source'], "$buildDir/docs")
+//TODO why do docs depend on this, but the wheel itself doesn't? makes more sense to depend on assert, right?
+project.tasks.named('pythonDocsMakeImage').configure {
+    dependsOn ':Generators:generateFigureImmutable'
+    dependsOn ':Generators:generatePythonFigureWrapper'
+    dependsOn ':Generators:generatePythonIntegrationStaticMethods'
 }
 
-project.tasks.register 'pythonDocsTar', Tar, {
-    Tar tar ->
-        tar.from(docBuildDir)
-        tar.dependsOn(pyDoc)
-        tar.archiveBaseName.set("dh-python-docs")
-}
+makePyDocTask('pydeephavenDocs', 'pydeephaven', [
+        ("$rootDir/pyclient/docs/source".toString()):'source',
+        ("$rootDir/pyclient/pydeephaven".toString()):'pydeephaven'
+], "$buildDir/pyclient-docs")


### PR DESCRIPTION
CI will now deploy pydeephaven docs after building them. These share as
much of their docker wiring as possible, which means the jpy dh wheel is
installed when building docs for pydeephaven, and arrow/grpc/etc are
installed for the deephaven server py bindings.

Image names will be adjusted now to match the expected docker pattern.

The pydeephaven setup.py no longer works when run natively, we can
restore this behavior if necessary.