### PR TITLE
Convert JS API examples to python

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/public/index.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/index.html
@@ -14,6 +14,7 @@ Welcome to the Deephaven JS API. This page has the api loaded, open the browser 
 <!--    <li><a href="grpc.html">Raw GRPC sample in JS</a></li>-->
 <!--    <li><a href="simple.html">JS API analog of the SimpleDeephavenClient</a></li>-->
     <li><a href="console.html">JS API analog of the ConsoleClient</a></li>
+    <li><a href="table_basic.html">Create a table and display the contents</a></li>
     <li><a href="table_viewport.html">Create a table and display a viewport of it, with paging buttons</a></li>
     <li><a href="table_filter.html">Create a table and display a viewport of it, with a filter context menu</a></li>
     <li><a href="table_sort.html">Create a table and display a viewport of it, with clickable headers to sort</a></li>

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Deephaven JS API table viewport and updates</title>
+    <title>Deephaven JS API display basic table</title>
     <script src="dh-internal.js" type="text/javascript"></script>
     <script src="dh-core.js" type="text/javascript"></script>
     <link href="basic.css" rel="stylesheet" type="text/css" />
@@ -15,7 +15,7 @@
 <body>
 
 <h3>Table data</h3>
-<table id="simpleTable" />
+<table id="simpleTable"></table>
 
 <script>
 (async () => {
@@ -28,7 +28,7 @@
     // Run code that will create a static table with 10 rows and three columns, I, J, K
     await ide.runCode(`
 from deephaven.TableTools import emptyTable
-remoteTable = emptyTable(10).updateView("I=i", "J=I*I", "K=i%2==0?\`Hello\`:\`World\`")
+remoteTable = emptyTable(10).updateView('I=i', 'J=I*I', 'K=i%2==0?"Hello":"World"')
     `)
 
     // Retrieve the JS Table object

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
@@ -34,25 +34,20 @@ remoteTable = emptyTable(10).updateView("I=i", "J=I*I", "K=i%2==0?\`Hello\`:\`Wo
     // Retrieve the JS Table object
     var table = await ide.getTable('remoteTable');
 
-    // Retrieve the element to append the table to
-    var tableElement = document.getElementById('simpleTable');
-
-    // Create a header element and append it to the document
+    // Create a table header element with the table columns
     var header = document.createElement('thead');
     var headerRow = document.createElement('tr');
-    table.columns.forEach(columnDef => {
+    table.columns.forEach(column => {
         // build a very simple header
         var td = document.createElement('td');
-        td.innerText = columnDef.name;
+        td.innerText = column.name;
         headerRow.appendChild(td);
     });
     header.appendChild(headerRow);
-    tableElement.appendChild(header);
 
-    // Set the viewport to view the full ten rows. Bottom row is inclusive, and starts at zero index.
+    // Set the viewport and extract data to build the table body.
+    // Since the bottom of the viewport specified is inclusive and the table is ten rows, we only need specific `0,9`.
     table.setViewport(0, 9)
-
-    // Extract the viewport data and build a table for it
     var tbody = document.createElement('tbody');
     var viewportData = await table.getViewportData()
     var rows = viewportData.rows;
@@ -65,7 +60,11 @@ remoteTable = emptyTable(10).updateView("I=i", "J=I*I", "K=i%2==0?\`Hello\`:\`Wo
         }
         tbody.appendChild(tr);
     }
-    simpleTable.appendChild(tbody);
+
+    // Retrieve the element to append the table to
+    var tableElement = document.getElementById('simpleTable');
+    tableElement.appendChild(header);
+    tableElement.appendChild(tbody);
 })();
 </script>
 </body>

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Deephaven JS API table viewport and updates</title>
+    <script src="dh-internal.js" type="text/javascript"></script>
+    <script src="dh-core.js" type="text/javascript"></script>
+    <link href="basic.css" rel="stylesheet" type="text/css" />
+    <style>
+        table { border-spacing: 0; }
+        thead td { font-weight: bold; border-bottom: 1px solid black; }
+        tbody td { border-bottom: 1px solid gray; padding: 4px; }
+    </style>
+</head>
+<body>
+
+<h3>Table data</h3>
+<table id="simpleTable" />
+
+<script>
+(async () => {
+    // Open a connection to the server
+    var connection = new dh.IdeConnection(window.location.protocol + "//" + window.location.host);
+
+    // Start a python session
+    var ide = await connection.startSession("python");
+
+    // Run code that will create a static table with 10 rows and three columns, I, J, K
+    await ide.runCode(`
+from deephaven.TableTools import emptyTable
+remoteTable = emptyTable(10).updateView("I=i", "J=I*I", "K=i%2==0?\`Hello\`:\`World\`")
+    `)
+
+    // Retrieve the JS Table object
+    var table = await ide.getTable('remoteTable');
+
+    // Retrieve the element to append the table to
+    var tableElement = document.getElementById('simpleTable');
+
+    // Create a header element and append it to the document
+    var header = document.createElement('thead');
+    var headerRow = document.createElement('tr');
+    table.columns.forEach(columnDef => {
+        // build a very simple header
+        var td = document.createElement('td');
+        td.innerText = columnDef.name;
+        headerRow.appendChild(td);
+    });
+    header.appendChild(headerRow);
+    tableElement.appendChild(header);
+
+    // Set the viewport to view the full ten rows. Bottom row is inclusive, and starts at zero index.
+    table.setViewport(0, 9)
+
+    // Extract the viewport data and build a table for it
+    var tbody = document.createElement('tbody');
+    var viewportData = await table.getViewportData()
+    var rows = viewportData.rows;
+    for (var i = 0; i < rows.length; i++) {
+        var tr = document.createElement('tr');
+        for (var j = 0; j < table.columns.length; j++) {
+            var td = document.createElement('td');
+            td.textContent = rows[i].get(table.columns[j]);
+            tr.appendChild(td);
+        }
+        tbody.appendChild(tr);
+    }
+    simpleTable.appendChild(tbody);
+})();
+</script>
+</body>
+</html>

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
@@ -153,9 +153,12 @@
   (async () => {
       connection = new dh.IdeConnection(window.location.protocol + "//" + window.location.host);
 
-      ide = await connection.startSession("groovy");
+      ide = await connection.startSession("python");
 
-      await ide.runCode('remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")')
+      await ide.runCode(`
+from deephaven.TableTools import timeTable
+remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")
+      `)
 
       openTable(await ide.getTable('remoteTable'));
   })();

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_sort.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_sort.html
@@ -25,9 +25,12 @@
       (async () => {
         connection = new dh.IdeConnection(window.location.protocol + "//" + window.location.host);
 
-        ide = await connection.startSession("groovy");
+        ide = await connection.startSession("python");
 
-        await ide.runCode('remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")')
+        await ide.runCode(`
+from deephaven.TableTools import timeTable
+remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")
+        `)
 
         openTable(await ide.getTable('remoteTable'));
       })();

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_viewport.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_viewport.html
@@ -33,9 +33,12 @@ var PAGE_SIZE = 20;
 (async () => {
     connection = new dh.IdeConnection(window.location.protocol + "//" + window.location.host);
 
-    ide = await connection.startSession("groovy");
+    ide = await connection.startSession("python");
 
-    await ide.runCode('remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")')
+    await ide.runCode(`
+from deephaven.TableTools import timeTable
+remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")
+    `)
 
     openTable(await ide.getTable('remoteTable'));
 


### PR DESCRIPTION
- By default, deephaven-core runs Python
- Examples were in Groovy. Convert them to Python to work with default config
- Add a new basic example that simple opens a static table and outputs the data. This super simple example will be referenced from the tutorials in the docs.
- Fixes #904
