### PR TITLE
Fix case insensitive string filters

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterFactory.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterFactory.java
@@ -173,7 +173,7 @@ public class FilterFactory implements FilterVisitor<SelectFilter> {
             if (literal.getValueCase() == Literal.ValueCase.NANO_TIME_VALUE) {
                 values[i] = "'" + new DBDateTime(literal.getNanoTimeValue()).toString(DBTimeZone.TZ_DEFAULT) + "'";
             } else {
-                values[i] = FilterPrinter.printNoEscape(literal);
+                values[i] = FilterPrinter.print(literal);
             }
         }
         return new MatchFilter(caseSensitivity(caseSensitivity), matchType(matchType), reference.getColumnName(),

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterFactory.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterFactory.java
@@ -173,7 +173,7 @@ public class FilterFactory implements FilterVisitor<SelectFilter> {
             if (literal.getValueCase() == Literal.ValueCase.NANO_TIME_VALUE) {
                 values[i] = "'" + new DBDateTime(literal.getNanoTimeValue()).toString(DBTimeZone.TZ_DEFAULT) + "'";
             } else {
-                values[i] = FilterPrinter.print(literal);
+                values[i] = FilterPrinter.printNoEscape(literal);
             }
         }
         return new MatchFilter(caseSensitivity(caseSensitivity), matchType(matchType), reference.getColumnName(),

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterPrinter.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterPrinter.java
@@ -16,18 +16,11 @@ public class FilterPrinter implements FilterVisitor<Void> {
         return visitor.sb.toString();
     }
 
-    public static String print(Literal literal) {
-        FilterPrinter visitor = new FilterPrinter(true);
-        visitor.onLiteral(literal);
-
-        return visitor.sb.toString();
-    }
-
     public static String printNoEscape(Literal literal) {
         FilterPrinter visitor = new FilterPrinter(false);
         visitor.onLiteral(literal);
 
-        return visitor.sb.toString();
+        return "\"" + visitor.sb.toString() + "\"";
     }
 
     public FilterPrinter(boolean escapeStrings) {

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterPrinter.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/table/ops/filter/FilterPrinter.java
@@ -16,6 +16,13 @@ public class FilterPrinter implements FilterVisitor<Void> {
         return visitor.sb.toString();
     }
 
+    public static String print(Literal literal) {
+        FilterPrinter visitor = new FilterPrinter(true);
+        visitor.onLiteral(literal);
+
+        return visitor.sb.toString();
+    }
+
     public static String printNoEscape(Literal literal) {
         FilterPrinter visitor = new FilterPrinter(false);
         visitor.onLiteral(literal);

--- a/grpc-api/src/test/java/io/deephaven/grpc_api/table/ops/filter/FilterPrinterTest.java
+++ b/grpc-api/src/test/java/io/deephaven/grpc_api/table/ops/filter/FilterPrinterTest.java
@@ -47,10 +47,9 @@ public class FilterPrinterTest {
         rotateAndAssert(longBits);
     }
 
-
     private static void assertSameValue(double expected) {
         Literal literal = lit(expected);
-        String str = FilterPrinter.printNoEscape(literal);
+        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
 
         // test magic values that make sense in java, but Double.parseDouble won't accept directly
         if (Double.isNaN(expected)) {
@@ -74,9 +73,16 @@ public class FilterPrinterTest {
     private static void assertSameValue(long expected) {
         assertTrue("Must be in the range that a double value can represent", Math.abs(expected) < (1L << 53));
         Literal literal = lit(expected);
-        String str = FilterPrinter.printNoEscape(literal);
+        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
 
         assertEquals(Long.toString(expected), str);
+    }
+
+    private static String removeQuotes(String quotedStr) {
+        assertTrue(quotedStr.length() >= 2);
+        assertEquals(quotedStr.charAt(0), '"');
+        assertEquals(quotedStr.charAt(quotedStr.length() - 1), '"');
+        return quotedStr.substring(1, quotedStr.length() - 1);
     }
 
     private static void rotateAndAssert(long longBits) {


### PR DESCRIPTION
- When doing a egIgnoreCase filter, the filter gets created on a different path. In that path, strings were not being escaped as they should be.
- Partial #733
- Fixes web-client-ui#190
