### PR TITLE
Reduce verbosity of UNAUTHENTICATED calls from alternative GrpcUtil.rpcWrapper

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/util/GrpcUtil.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/util/GrpcUtil.java
@@ -21,7 +21,7 @@ public class GrpcUtil {
     /**
      * Utility to avoid errors escaping to the stream, to make sure the server log and client both see the message if
      * there is an error, and if the error was not meant to propagate to a gRPC client, obfuscates it.
-     * 
+     *
      * @param log the current class's logger
      * @param response the responseStream used to send messages to the client
      * @param lambda the code to safely execute
@@ -46,7 +46,7 @@ public class GrpcUtil {
     /**
      * Utility to avoid errors escaping to the stream, to make sure the server log and client both see the message if
      * there is an error, and if the error was not meant to propagate to a gRPC client, obfuscates it.
-     * 
+     *
      * @param log the current class's logger
      * @param response the responseStream used to send messages to the client
      * @param lambda the code to safely execute
@@ -57,7 +57,11 @@ public class GrpcUtil {
         try (final SafeCloseable ignored = LivenessScopeStack.open()) {
             return lambda.call();
         } catch (final StatusRuntimeException err) {
-            log.error().append(err).endl();
+            if (err.getStatus().equals(Status.UNAUTHENTICATED)) {
+                log.debug().append("ignoring unauthenticated request: ").append(err).endl();
+            } else {
+                log.error().append(err).endl();
+            }
             safelyError(response, err);
         } catch (final InterruptedException err) {
             Thread.currentThread().interrupt();

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/util/GrpcUtil.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/util/GrpcUtil.java
@@ -33,7 +33,7 @@ public class GrpcUtil {
             lambda.run();
         } catch (final StatusRuntimeException err) {
             if (err.getStatus().equals(Status.UNAUTHENTICATED)) {
-                log.debug().append("ignoring unauthenticated request: ").append(err).endl();
+                log.info().append("ignoring unauthenticated request").endl();
             } else {
                 log.error().append(err).endl();
             }
@@ -58,7 +58,7 @@ public class GrpcUtil {
             return lambda.call();
         } catch (final StatusRuntimeException err) {
             if (err.getStatus().equals(Status.UNAUTHENTICATED)) {
-                log.debug().append("ignoring unauthenticated request: ").append(err).endl();
+                log.info().append("ignoring unauthenticated request").endl();
             } else {
                 log.error().append(err).endl();
             }


### PR DESCRIPTION
We reduced the log spam from the more commonly used GrpcUtil.rcpWrapper path, but I missed this one for some reason.