### PR TITLE
Support parquet date and time logical type annotations.  Fixes #1253.

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/locations/parquet/local/ParquetColumnLocation.java
+++ b/DB/src/main/java/io/deephaven/db/v2/locations/parquet/local/ParquetColumnLocation.java
@@ -712,5 +712,20 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
 
             return Optional.empty();
         }
+
+        @Override
+        public Optional<ToPage<ATTR, ?>> visit(
+                LogicalTypeAnnotation.DateLogicalTypeAnnotation dateLogicalType) {
+            return Optional.of(ToIntPage.create(componentType));
+        }
+
+        @Override
+        public Optional<ToPage<ATTR, ?>> visit(
+                LogicalTypeAnnotation.TimeLogicalTypeAnnotation timeLogicalType) {
+            if (timeLogicalType.getUnit() == LogicalTypeAnnotation.TimeUnit.MILLIS) {
+                return Optional.of(ToIntPage.create(componentType));
+            }
+            return Optional.of(ToLongPage.create(componentType));
+        }
     }
 }

--- a/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetSchemaReader.java
+++ b/DB/src/main/java/io/deephaven/db/v2/parquet/ParquetSchemaReader.java
@@ -331,14 +331,15 @@ public class ParquetSchemaReader {
 
             @Override
             public Optional<Class<?>> visit(final LogicalTypeAnnotation.DateLogicalTypeAnnotation dateLogicalType) {
-                errorString.setValue("DateLogicalType");
-                return Optional.empty();
+                return Optional.of(int.class);
             }
 
             @Override
             public Optional<Class<?>> visit(final LogicalTypeAnnotation.TimeLogicalTypeAnnotation timeLogicalType) {
-                errorString.setValue("TimeLogicalType, isAdjustedToUTC=" + timeLogicalType.isAdjustedToUTC());
-                return Optional.empty();
+                if (timeLogicalType.getUnit() == LogicalTypeAnnotation.TimeUnit.MILLIS) {
+                    return Optional.of(int.class);
+                }
+                return Optional.of(long.class);
             }
 
             @Override


### PR DESCRIPTION
Just loading the values as int or long is much better than throwing an exception and bailing.