### PR TITLE
Fix the link to the ref docs in readme

### DIFF
--- a/pyclient/README.md
+++ b/pyclient/README.md
@@ -57,4 +57,4 @@ $ pip3 install dist/pydeephaven-0.4.2-py3-none-any.whl
 * https://arrow.apache.org/docs/python/index.html
 
 ## API Reference
-[start here] https://deephaven.io/core/docs/clientapis/python
+[start here] https://deephaven.io/core/client-api/python/

--- a/pyclient/pydeephaven/session.py
+++ b/pyclient/pydeephaven/session.py
@@ -25,6 +25,9 @@ class Session:
     methods for asking the server to create tables, import Arrow data into tables, merge tables, run Python scripts, and
     execute queries.
 
+    Session objects can be used in Python with statement so that whatever happens in the with statement block, they
+    are guaranteed to be closed upon exit.
+
     Attributes:
         tables (list[str]): names of the tables available in the server after running scripts
         is_alive (bool): check if the session is still alive (may refresh the session)
@@ -70,6 +73,14 @@ class Session:
         self._keep_alive_timer = None
 
         self._connect()
+
+    def __enter__(self):
+        if not self.is_connected:
+            self._connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     @property
     def tables(self):


### PR DESCRIPTION
Don has made https://deephaven.io/core/client-api/python/ live, so need to replace the placeholder in the readme. will need to upload to PYPI as well.