### PR TITLE
C++ Client: documentation and sample code

### DIFF
--- a/cpp-examples/.gitignore
+++ b/cpp-examples/.gitignore
@@ -1,0 +1,3 @@
+*~
+cmake-build-debug
+cmake-build-release

--- a/cpp-examples/cleanup/CMakeLists.txt
+++ b/cpp-examples/cleanup/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(cleanup)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(deephaven REQUIRED)
+
+find_package(Arrow REQUIRED)
+find_package(ArrowFlight REQUIRED HINTS ${Arrow_DIR})
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(cleanup main.cc)
+
+target_link_libraries(cleanup deephaven::client)

--- a/cpp-examples/cleanup/main.cc
+++ b/cpp-examples/cleanup/main.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2020 Deephaven Data Labs and Patent Pending
+ */
+#include <iostream>
+#include "deephaven/client/highlevel/client.h"
+
+using deephaven::client::highlevel::NumCol;
+using deephaven::client::highlevel::Client;
+using deephaven::client::highlevel::TableHandle;
+using deephaven::client::highlevel::TableHandleManager;
+
+// This example shows explicit QueryTable cleanup using destructors/RAII.
+void doit(const TableHandleManager &manager) {
+  auto table = manager.emptyTable(10).update("X = ii % 2", "Y = ii");
+  auto [x, y] = table.getCols<NumCol, NumCol>("X", "Y");
+  // This example will dispose each table individually.
+
+  auto t1 = table.where(y < 5);
+  std::cout << "This is t1:\n" << t1.stream(true) << '\n';
+
+  {
+    TableHandle t2Copy;
+    {
+      auto t2 = t1.countBy(x);
+      std::cout << "This is t2:\n" << t2.stream(true) << '\n';
+
+      t2Copy = t2;
+
+      // The variable 't2' will be destructed here, but the server resource will stay alive
+      // because 't2Copy' is still live.
+    }
+    std::cout << "t2Copy still alive:\n" << t2Copy.stream(true) << '\n';
+
+    // t2Copy will be destructed here. As it is the last owner of the server resource,
+    // the server resource will be released here.
+  }
+
+  // t1 and the TableHandleManger will be destructed here.
+}
+
+int main() {
+  const char *server = "localhost:10000";
+  auto client = Client::connect(server);
+  auto manager = client.getManager();
+
+  try {
+    doit(manager);
+  } catch (const std::runtime_error &e) {
+    std::cerr << "Caught exception: " << e.what() << '\n';
+  }
+}

--- a/cpp-examples/create_table_with_arrow_flight/CMakeLists.txt
+++ b/cpp-examples/create_table_with_arrow_flight/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(arrow_flight_maker)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(deephaven REQUIRED)
+
+find_package(Arrow REQUIRED)
+find_package(ArrowFlight REQUIRED HINTS ${Arrow_DIR})
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(arrow_flight_maker main.cc)
+
+target_link_libraries(arrow_flight_maker deephaven::client)

--- a/cpp-examples/create_table_with_arrow_flight/main.cc
+++ b/cpp-examples/create_table_with_arrow_flight/main.cc
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016-2020 Deephaven Data Labs and Patent Pending
+ */
+#include <iostream>
+#include "deephaven/client/highlevel/client.h"
+#include "deephaven/client/utility/table_maker.h"
+
+using deephaven::client::highlevel::NumCol;
+using deephaven::client::highlevel::Client;
+using deephaven::client::highlevel::TableHandle;
+using deephaven::client::highlevel::TableHandleManager;
+using deephaven::client::utility::flight::statusOrDie;
+using deephaven::client::utility::flight::valueOrDie;
+using deephaven::client::utility::TableMaker;
+
+// This example shows how to use the Arrow Flight client to make a simple table.
+void doit(const TableHandleManager &manager) {
+  // 1. Build schema
+  arrow::SchemaBuilder schemaBuilder;
+
+  // 2. Add "Symbol" column (type: string) to schema
+  auto symbolMetadata = std::make_shared<arrow::KeyValueMetadata>();
+  statusOrDie(symbolMetadata->Set("deephaven:type", "java.lang.String"), "KeyValueMetadata::Set");
+  auto symbolField = std::make_shared<arrow::Field>("Symbol",
+      std::make_shared<arrow::StringType>(), true, std::move(symbolMetadata));
+  statusOrDie(schemaBuilder.AddField(symbolField), "SchemaBuilder::AddField");
+
+  // 3. Add "Price" column (type: double) to schema
+  auto priceMetadata = std::make_shared<arrow::KeyValueMetadata>();
+  statusOrDie(priceMetadata->Set("deephaven:type", "double"), "KeyValueMetadata::Set");
+  auto priceField = std::make_shared<arrow::Field>("Price",
+      std::make_shared<arrow::StringType>(), true, std::move(priceMetadata));
+  statusOrDie(schemaBuilder.AddField(priceField), "SchemaBuilder::AddField");
+
+  // 4. Schema is done
+  auto schema = valueOrDie(schemaBuilder.Finish(), "Failed to create schema");
+
+  // 5. Prepare symbol and price data
+  std::vector<std::string> symbols{"FB", "AAPL", "NFLX", "GOOG"};
+  std::vector<double> prices{101.1, 102.2, 103.3, 104.4};
+  auto numRows = static_cast<int64_t>(symbols.size());
+  if (numRows != prices.size()) {
+    throw std::runtime_error("sizes don't match");
+  }
+
+  // 6. Move data to Arrow column builders
+  arrow::StringBuilder symbolBuilder;
+  arrow::DoubleBuilder priceBuilder;
+  symbolBuilder.AppendValues(symbols);
+  priceBuilder.AppendValues(prices);
+
+  // 7. Get Arrow columns from builders
+  std::vector<std::shared_ptr<arrow::Array>> columns = {
+      valueOrDie(symbolBuilder.Finish(), "symbolBuilder.Finish()"),
+      valueOrDie(priceBuilder.Finish(), "priceBuilder.Finish()")
+  };
+
+  // 8. Get a Deephaven "FlightWrapper" object to access Arrow Flight
+  auto wrapper = manager.createFlightWrapper();
+
+  // 9. Set up the destination path. In this case, the table named "tempTable"
+  std::string tableName = "tempTable";
+  auto fd = arrow::flight::FlightDescriptor::Path({"scope", tableName});
+
+  // 10. DoPut takes FlightCallOptions, which need to at least contain the Deephaven
+  // authentication headers for this session.
+  arrow::flight::FlightCallOptions options;
+  wrapper.addAuthHeaders(&options);
+
+  // 11. Perform the doPut
+  std::unique_ptr<arrow::flight::FlightStreamWriter> fsw;
+  std::unique_ptr<arrow::flight::FlightMetadataReader> fmr;
+  statusOrDie(wrapper.flightClient()->DoPut(options, fd, schema, &fsw, &fmr), "DoPut failed");
+
+  // 12. Make a RecordBatch containing both the schema and the data
+  auto batch = arrow::RecordBatch::Make(schema, numRows, std::move(columns));
+  statusOrDie(fsw->WriteRecordBatch(*batch), "WriteRecordBatch failed");
+  statusOrDie(fsw->DoneWriting(), "DoneWriting failed");
+
+  // 13. Read back a metadata message (ignored), then close the Writer
+  std::shared_ptr<arrow::Buffer> buf;
+  statusOrDie(fmr->ReadMetadata(&buf), "ReadMetadata failed");
+  statusOrDie(fsw->Close(), "Close failed");
+
+  // 14. Use Deephaven high level operations to fetch the table and print it
+  auto table = manager.fetchTable(tableName);
+  std::cout << "table is:\n" << table.stream(true) << std::endl;
+}
+
+int main() {
+  const char *server = "localhost:10000";
+  auto client = Client::connect(server);
+  auto manager = client.getManager();
+
+  try {
+    doit(manager);
+  } catch (const std::runtime_error &e) {
+    std::cerr << "Caught exception: " << e.what() << '\n';
+  }
+}

--- a/cpp-examples/create_table_with_table_maker/CMakeLists.txt
+++ b/cpp-examples/create_table_with_table_maker/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(table_maker)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(deephaven REQUIRED)
+
+find_package(Arrow REQUIRED)
+find_package(ArrowFlight REQUIRED HINTS ${Arrow_DIR})
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(table_maker main.cc)
+
+target_link_libraries(table_maker deephaven::client)

--- a/cpp-examples/create_table_with_table_maker/main.cc
+++ b/cpp-examples/create_table_with_table_maker/main.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2020 Deephaven Data Labs and Patent Pending
+ */
+#include <iostream>
+#include "deephaven/client/highlevel/client.h"
+#include "deephaven/client/utility/table_maker.h"
+
+using deephaven::client::highlevel::NumCol;
+using deephaven::client::highlevel::Client;
+using deephaven::client::highlevel::TableHandle;
+using deephaven::client::highlevel::TableHandleManager;
+using deephaven::client::utility::TableMaker;
+
+// This example shows how to use the TableMaker wrapper to make a simple table.
+void doit(const TableHandleManager &manager) {
+  TableMaker tm;
+  std::vector<std::string> symbols{"FB", "AAPL", "NFLX", "GOOG"};
+  std::vector<double> prices{101.1, 102.2, 103.3, 104.4};
+  tm.addColumn("Symbol", symbols);
+  tm.addColumn("Price", prices);
+  auto table = tm.makeTable(manager, "myTable");
+
+  std::cout << "table is:\n" << table.stream(true) << std::endl;
+}
+
+int main() {
+  const char *server = "localhost:10000";
+  auto client = Client::connect(server);
+  auto manager = client.getManager();
+
+  try {
+    doit(manager);
+  } catch (const std::runtime_error &e) {
+    std::cerr << "Caught exception: " << e.what() << '\n';
+  }
+}

--- a/cpp-examples/doc/.gitignore
+++ b/cpp-examples/doc/.gitignore
@@ -1,0 +1,1 @@
+sphinxoutput/

--- a/cpp-examples/doc/Makefile
+++ b/cpp-examples/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/cpp-examples/doc/_static/placeholder.txt
+++ b/cpp-examples/doc/_static/placeholder.txt
@@ -1,0 +1,2 @@
+This directory is currently empty. This file exists so that the directory
+will be created by git.

--- a/cpp-examples/doc/_templates/placeholder.txt
+++ b/cpp-examples/doc/_templates/placeholder.txt
@@ -1,0 +1,2 @@
+This directory is currently empty. This file exists so that the directory
+will be created by git.

--- a/cpp-examples/doc/conf.py
+++ b/cpp-examples/doc/conf.py
@@ -1,0 +1,62 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Deephaven C++ Examples'
+copyright = '2021, Deephaven Data Labs'
+author = 'Deephaven Data Labs'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'breathe', 'sphinx.ext.intersphinx' ]
+
+intersphinx_mapping = {
+    'dhclient': (
+        'http://client.virtual-uk.com/',
+        'http://client.virtual-uk.com/objects.inv'
+    )
+}
+
+breathe_projects = { "Deephaven C++ Client": "./doxygenoutput/xml" }
+breathe_default_project = "Deephaven C++ Client"
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'furo'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/cpp-examples/doc/create_table_with_arrow_flight.rst
+++ b/cpp-examples/doc/create_table_with_arrow_flight.rst
@@ -1,0 +1,118 @@
+Creating a table with Arrow Flight
+==================================
+
+Client programs that create tables using
+`Arrow Flight RPC <https://arrow.apache.org/docs/cpp/flight.html>`__
+typically follow the below recipe:
+
+1. Get a :cpp:class:`FlightWrapper <deephaven::client::highlevel::FlightWrapper>` class via
+   :cpp:func:`TableHandleManager::createFlightWrapper <deephaven::client::highlevel::TableHandleManager::createFlightWrapper>`
+2. For calls like Arrow ``DoPut`` that take an ``arrow::Flight::FlightCallOptions``, endow that object with
+   Deephaven authentication headers via
+   :cpp:func:`FlightWrapper::addAuthHeaders <deephaven::client::highlevel::FlightWrapper::addAuthHeaders()>`
+3. Get a pointer to the ``arrow::flight::FlightClient`` from
+   :cpp:func:`FlightWrapper::flightClient <deephaven::client::highlevel::FlightWrapper::flightClient()>`
+4. Then perform the operations as described in
+   `Arrow Flight RPC <https://arrow.apache.org/docs/cpp/flight.html>`__   
+
+Consider the following program from ``cpp-examples/create_table_with_arrow_flight``:
+
+.. code:: c++
+
+  #include <iostream>
+  #include "deephaven/client/highlevel/client.h"
+  #include "deephaven/client/utility/table_maker.h"
+
+  using deephaven::client::highlevel::NumCol;
+  using deephaven::client::highlevel::Client;
+  using deephaven::client::highlevel::TableHandle;
+  using deephaven::client::highlevel::TableHandleManager;
+  using deephaven::client::utility::flight::statusOrDie;
+  using deephaven::client::utility::flight::valueOrDie;
+  using deephaven::client::utility::TableMaker;
+
+  // This example shows how to use the Arrow Flight client to make a simple table.
+  void doit(const TableHandleManager &manager) {
+    // 1. Build schema
+    arrow::SchemaBuilder schemaBuilder;
+
+    // 2. Add "Symbol" column (type: string) to schema
+    auto symbolMetadata = std::make_shared<arrow::KeyValueMetadata>();
+    statusOrDie(symbolMetadata->Set("deephaven:type", "java.lang.String"), "KeyValueMetadata::Set");
+    auto symbolField = std::make_shared<arrow::Field>("Symbol",
+	std::make_shared<arrow::StringType>(), true, std::move(symbolMetadata));
+    statusOrDie(schemaBuilder.AddField(symbolField), "SchemaBuilder::AddField");
+
+    // 3. Add "Price" column (type: double) to schema
+    auto priceMetadata = std::make_shared<arrow::KeyValueMetadata>();
+    statusOrDie(priceMetadata->Set("deephaven:type", "double"), "KeyValueMetadata::Set");
+    auto priceField = std::make_shared<arrow::Field>("Price",
+	std::make_shared<arrow::StringType>(), true, std::move(priceMetadata));
+    statusOrDie(schemaBuilder.AddField(priceField), "SchemaBuilder::AddField");
+
+    // 4. Schema is done
+    auto schema = valueOrDie(schemaBuilder.Finish(), "Failed to create schema");
+
+    // 5. Prepare symbol and price data
+    std::vector<std::string> symbols{"FB", "AAPL", "NFLX", "GOOG"};
+    std::vector<double> prices{101.1, 102.2, 103.3, 104.4};
+    auto numRows = static_cast<int64_t>(symbols.size());
+    if (numRows != prices.size()) {
+      throw std::runtime_error("sizes don't match");
+    }
+
+    // 6. Move data to Arrow column builders
+    arrow::StringBuilder symbolBuilder;
+    arrow::DoubleBuilder priceBuilder;
+    symbolBuilder.AppendValues(symbols);
+    priceBuilder.AppendValues(prices);
+
+    // 7. Get Arrow columns from builders
+    std::vector<std::shared_ptr<arrow::Array>> columns = {
+	valueOrDie(symbolBuilder.Finish(), "symbolBuilder.Finish()"),
+	valueOrDie(priceBuilder.Finish(), "priceBuilder.Finish()")
+    };
+
+    // 8. Get a Deephaven "FlightWrapper" object to access Arrow Flight
+    auto wrapper = manager.createFlightWrapper();
+
+    // 9. Set up the destination path. In this case, the table named "tempTable"
+    std::string tableName = "tempTable";
+    auto fd = arrow::flight::FlightDescriptor::Path({"scope", tableName});
+
+    // 10. DoPut takes FlightCallOptions, which need to at least contain the Deephaven
+    // authentication headers for this session.
+    arrow::flight::FlightCallOptions options;
+    wrapper.addAuthHeaders(&options);
+
+    // 11. Perform the doPut
+    std::unique_ptr<arrow::flight::FlightStreamWriter> fsw;
+    std::unique_ptr<arrow::flight::FlightMetadataReader> fmr;
+    statusOrDie(wrapper.flightClient()->DoPut(options, fd, schema, &fsw, &fmr), "DoPut failed");
+
+    // 12. Make a RecordBatch containing both the schema and the data
+    auto batch = arrow::RecordBatch::Make(schema, numRows, std::move(columns));
+    statusOrDie(fsw->WriteRecordBatch(*batch), "WriteRecordBatch failed");
+    statusOrDie(fsw->DoneWriting(), "DoneWriting failed");
+
+    // 13. Read back a metadata message (ignored), then close the Writer
+    std::shared_ptr<arrow::Buffer> buf;
+    statusOrDie(fmr->ReadMetadata(&buf), "ReadMetadata failed");
+    statusOrDie(fsw->Close(), "Close failed");
+
+    // 14. Use Deephaven high level operations to fetch the table and print it
+    auto table = manager.fetchTable(tableName);
+    std::cout << "table is:\n" << table.stream(true) << std::endl;
+  }
+
+  int main() {
+    const char *server = "localhost:10000";
+    auto client = Client::connect(server);
+    auto manager = client.getManager();
+
+    try {
+      doit(manager);
+    } catch (const std::runtime_error &e) {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+    }
+  }

--- a/cpp-examples/doc/create_table_with_tablemaker.rst
+++ b/cpp-examples/doc/create_table_with_tablemaker.rst
@@ -1,0 +1,65 @@
+Creating a table with TableMaker
+================================
+
+The
+:cpp:class:`TableMaker <deephaven::client::utility::TableMaker>`
+is a utility class that helps simplify the task of creating small tables.
+It is useful for prototyping and for creating small programs when you
+don't want to concern yourself with the full power and flexibility
+of ``arrow::flight::doPut()``.
+
+Client programs that create tables using
+:cpp:class:`TableMaker <deephaven::client::utility::TableMaker>`
+typically follow the below recipe:
+
+1. Default-construct a :cpp:class:`TableMaker <deephaven::client::utility::TableMaker>`
+2. Add columns one a time with :cpp:func:`addColumn <deephaven::client::utility::TableMaker::addColumn()>`
+3. Create the table with :cpp:func:`makeTable <deephaven::client::utility::TableMaker::makeTable()>`
+
+Consider the following program from ``cpp-examples/make_table``:
+
+.. code:: c++
+
+  #include <iostream>
+  #include "deephaven/client/highlevel/client.h"
+  #include "deephaven/client/utility/table_maker.h"
+
+  using deephaven::client::highlevel::NumCol;
+  using deephaven::client::highlevel::Client;
+  using deephaven::client::highlevel::TableHandle;
+  using deephaven::client::highlevel::TableHandleManager;
+  using deephaven::client::utility::TableMaker;
+
+  // This example shows how to use the TableMaker wrapper to make a simple table.
+  void doit(const TableHandleManager &manager) {
+    TableMaker tm;
+    std::vector<std::string> symbols{"FB", "AAPL", "NFLX", "GOOG"};
+    std::vector<double> prices{101.1, 102.2, 103.3, 104.4};
+    tm.addColumn("Symbol", symbols);
+    tm.addColumn("Price", prices);
+    auto table = tm.makeTable(manager, "myTable");
+
+    std::cout << "table is:\n" << table.stream(true) << std::endl;
+  }
+
+  int main() {
+    const char *server = "localhost:10000";
+    auto client = Client::connect(server);
+    auto manager = client.getManager();
+
+    try {
+      doit(manager);
+    } catch (const std::runtime_error &e) {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+    }
+  }
+
+This is the output of the program::
+
+  table is:
+  Symbol  Price
+  FB      101.1
+  AAPL    102.2
+  NFLX    103.3
+  GOOG    104.4
+

--- a/cpp-examples/doc/fluent.rst
+++ b/cpp-examples/doc/fluent.rst
@@ -1,0 +1,441 @@
+The Fluent Interface
+====================
+
+The Deephaven client has numerous methods that take expressions (e.g.
+:cpp:func:`TableHandle::select <deephaven::client::highlevel::TableHandle::select>` or
+:cpp:func:`TableHandle::view <deephaven::client::highlevel::TableHandle::view>`),
+boolean conditions (e.g.
+:cpp:func:`TableHandle::where <deephaven::client::highlevel::TableHandle::where>`),
+column names (e.g.
+:cpp:func:`TableHandle::sort <deephaven::client::highlevel::TableHandle::sort>`),
+and so on.  These methods generally come in two flavors: a string version and a more
+structured *typed* version. The reason both flavors exist
+is because the string versions are convenient and simple to use for small programs, whereas the
+typed versions are typically more maintainable in larger programs.
+
+Consider these two ways of doing a
+:cpp:func:`TableHandle::where <deephaven::client::highlevel::TableHandle::where>`,
+using literal strings versus using the "fluent" syntax.
+
+.. code:: c++
+
+  auto table = tableManager.fetchTable("trades");
+  auto filtered1 = table.where("ImportDate == `2017-11-01` && Ticker == `AAPL`");
+  
+  auto (importDate, ticker) = table.getColumns<StrCol, StrCol>("ImportDate", "Ticker");
+  var filtered2 = table.where(importDate == "2017-11-01" && ticker == "AAPL");
+
+The advantage of the ``filtered1`` query is that it is simple and compact.  On the other hand,
+the advantage of the ``filtered2`` query is that it is able to do much more error checking
+at compile time. Consider the following query syntax errors:
+
+.. code:: c++
+
+  // typo in Ticker
+  auto filtered1 = table.where(
+      "ImportDate == `2017-11-01` && Thicker == `AAPL`");
+  // nonsensical string multiplication
+  auto filtered1 = table.where(
+      "ImportDate == `2017-11-01` && Ticker * 12 == `AAPL`");
+  // extra closing parenthesis
+  auto filtered1 = table.Where(
+      "(ImportDate == `2017-11-01`) && (Ticker == `AAPL`))");
+
+Because the code is using the literal string syntax, these errors would not be caught until the
+server attempted to parse and execute them. However, none of the corresponding fluent versions
+will even *compile*!
+
+.. code:: c++
+
+  auto (importDate, ticker) =
+      table.getColumns<StrCol, StrCol>("ImportDate", "Ticker");
+  // typo in Ticker
+  auto filtered2 = table.where(
+      importDate == "2017-11-01" && thicker == "AAPL");
+  // nonsensical string multiplication
+  auto filtered2 = table.where(
+      importDate == "2017-11-01" && ticker * 12 == "AAPL");
+  // extra closing parenthesis
+  auto filtered2 = table.where(
+      (importDate == "2017-11-01") && (ticker * 12) == "AAPL"));
+
+
+How the fluent syntax works
+---------------------------
+
+The fluent syntax uses certain C++ types along with operator overloading to build up an abstract
+syntax tree of your expression on the client side. Then, library methods pass that tree to the
+server to be executed. Because the fluent syntax is built on top of C++ syntax, it needs to be legal
+according to the rules of C++. One advantage of following C# syntax is that many potential errors are
+caught at compile time, or even sooner, e.g. by the programmer's IDE.
+
+Consider the following code fragment:
+
+.. code:: c++
+
+  auto (a, b, c, d) =
+      table.getColumns<NumCol, NumCol, NumCol, NumCol>("A", "B", "C", "D");
+  auto filtered = table.where(a + b + c <= d);
+
+The transformation of the expression into an abstract syntax tree is done automatically by the
+compiler. Basically, infix operators like ``+`` and ``<=`` are transformed into method calls, and
+certain implicit type conversions are performed. Below is a sketch of the equivalent code after the
+infix operators are transformed to method calls:
+
+.. code:: c++
+
+  NumericExpression temp1 = operator+(a, b);
+  NumericExpression temp2 = operator+(temp1, c);
+  BooleanExpression temp3 = operator<=(temp2, d);
+
+
+Building expressions with the fluent syntax
+-------------------------------------------
+
+The fluent syntax is designed to capture the kinds of "natural" expressions one would write in
+a programming language. Rather than formally describing the syntax here, we instead provide an
+informal description.
+
+There are basically four kinds of expressions in the system:
+:cpp:class:`NumericExpression <deephaven::client::highlevel::NumericExpression>`,
+:cpp:class:`StringExpression <deephaven::client::highlevel::StringExpression>`,
+:cpp:class:`DateTimeExpression <deephaven::client::highlevel::DateTimeExpression>`, and
+:cpp:class:`BooleanExpression <deephaven::client::highlevel::BooleanExpression>`.
+These model the four types of expressions we want to represent in the system.
+
+In typical usage, client programs do not explicitly declare variables of these types. Instead,
+these objects are created as anonymous temporaries (as the intermediate results of overloaded
+operators) which are then consumed by other operators or by Deephaven methods like
+:cpp:func:`TableHandle::select <deephaven::client::highlevel::TableHandle::select>` or
+:cpp:func:`TableHandle::where <deephaven::client::highlevel::TableHandle::where>`.
+
+Local vs Remote Evaluation
+--------------------------
+
+Because the fluent syntax interoperates with ordinary C++ expression syntax, it might not be readily
+apparent which parts of a complicated C++ expression are executed locally on the client machine,
+and which parts are participating in an expression tree to be evaluated on the server. Generally,
+the rules are:
+
+Evaluated locally
+^^^^^^^^^^^^^^^^^
+
+* Numeric literals
+* Variables
+* Method calls
+* Unary and binary operators involving the above
+
+Evaluated at the server
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* Column terminals
+* Local values implicitly converted into Fluent values
+* Unary operators, binary operators, and certain special methods involving Fluent expressions
+
+Note that both of these definitions are intentionally recursive in nature. Also note that when
+one of the arguments to a binary operator is a Fluent expression, the other argument will be
+implicitly converted to a Fluent expression.
+
+Consider the following examples:
+
+.. code:: c++
+
+  auto table = tableManager.fetchTable("trades");
+  auto (importDate, ticker, close) =
+      table.GetColumns<StrCol, StrCol, NumCol>("ImportDate", "Ticker", "Close");
+  auto t0 = table.where(importDate == "2017-11-01" && ticker == "AAPL");
+
+  var x = 1;
+
+  int myFunc(int arg)
+  {
+      return arg + 10;
+  }
+
+  // Equivalent Deephaven Code Studio expression is "Result = 100 + Close"
+  var t1a = t0.select((100 + close).as("Result"));
+  // Equivalent Deephaven Code Studio expression is "Result = 300 + Close"
+  var t2a = t0.select((100 + 200 + close).as("Result"));
+  // Equivalent Deephaven Code Studio expression is "Result = 101 + Close"
+  var t3a = t0.select((100 + x + close).as("Result"));
+  // Equivalent Deephaven Code Studio expression is "Result = 111 + Close"
+  var t4a = t0.select((100 + myFunc(x) + close).as("Result"));
+
+A binary operator with at least one
+:cpp:class:`NumericExpression <deephaven::client::highlevel::NumericExpression>`
+yields a
+:cpp:class:`NumericExpression <deephaven::client::highlevel::NumericExpression>`.
+Because binary operators like left-to-right associativity, mathematically equivalent
+but differently-ordered expressions get sent to the server as a different tree:
+
+.. code:: c++
+
+  // Equivalent Deephaven Code Studio expression is "Result = Close + 100"
+  auto t1b = t0.select((close + 100).as("Result"));
+  // Equivalent Deephaven Code Studio expression is "Result = (Close + 100) + 200"
+  auto t2b = t0.select((close + 100 + 200).as("Result"));
+  // Equivalent Deephaven Code Studio expression is "Result = (Close + 100) + 1"
+  auto t3b = t0.select((close + 100 + x).as("Result"));
+  // Equivalent Deephaven Code Studio expression is "Result = (Close + 100) + 11"
+  auto t4b = t0.Select((close + 100 + myFunc(x)).as("Result"));
+
+Note that the library is does *not* collapse `(Close + 100) + 11` into the mathematically-equivalent
+`(Close + 111)`. This difference is largely of academic interest, because the final result is the
+same due to the commutative property of addition. It would probably matter only in cases of numeric
+over/underflow.
+
+Building Fluent Expressions
+---------------------------
+
+In more advanced use cases, users may want to write methods that derive fluent expressions from
+other fluent expressions. Some programming languages call such methods "combinators".  In
+this simple example we write an ``add5`` function that yields the fluent expression ``e + 5`` for
+whatever expression ``e`` is passed into it:
+
+.. code:: c++
+
+  NumericExpression add5(NumericExpression e)
+  {
+      return e + 5;
+  }
+
+  // Equivalent Deephaven Code Studio expression is "Result = (Close * Volume) + 5"
+  auto t1 = t0.select(add5(close * volume).as("Result"));
+
+NumericExpression
+^^^^^^^^^^^^^^^^^
+
+:cpp:class:`NumericExpression <deephaven::client::highlevel::NumericExpression>`
+objects are either ``Numeric terminals`` or the result of an operator applied to
+some combination of `Numeric terminals` and
+:cpp:class:`NumericExpression <deephaven::client::highlevel::NumericExpression>` objects.
+
+``Numeric terminals`` are:
+
+* C# numeric literals of various primitive types such as ``3`` and ``-8.2``
+* Client-side numeric variables such as `int x`` or ``double x``
+* Client-side numeric expressions such as ``x * 2 + 5``
+* Numeric columns, which are typically obtained from a call like
+  :cpp:func:`getCols <deephaven::client::highlevel::TableHandle::getCols>`.
+
+The operators are the the usual unary arithmetic operators ``+``, ``-``, ``~``, and
+the usual binary operators ``+``, ``-``, ``*``, ``/``, ``%``, ``&``, ``|``, ``^``.
+
+In this example, the table ``t1`` contains two columns: the ``Ticker`` column and a ``Result``
+columns which holds the product ``Price * Volume + 12``. Notice that in a
+:cpp:func:`TableHandle::select <deephaven::client::highlevel::TableHandle::select>`
+statement, when we are creating a new column that is the result of a calculation, we need to give that new column
+a name (using the
+:cpp:func:`Expression::as <deephaven::client::highlevel::Expression::as>`
+method).
+In general, the fluent syntax ``expr.as("X")``
+corresponds to Deephaven Code Studio expression ``X = expr``.
+
+.. code:: c++
+
+  auto table = tableManager.fetchTable("trades");
+  auto (importDate, ticker, close, volume) =
+      table.getColumns<StrCol, StrCol, NumCol, NumCol>("ImportDate", "Ticker",
+      "Close", "Volume");
+  auto t0 = table.where(importDate == "2017-11-01" && ticker == "AAPL");
+  auto t1 = t0.select(ticker, (close * volume).As("Result"));
+  // string literal equivalent
+  auto t1_literal = t0.Select("Ticker", "Result = Close * Volume");
+
+StringExpression
+^^^^^^^^^^^^^^^^
+
+:cpp:class:`StringExpression <deephaven::client::highlevel::StringExpression>`
+objects are either ``String terminals``
+or the result of the `+` operator applied to some combination of ``String terminals`` and
+:cpp:class:`StringExpression <deephaven::client::highlevel::StringExpression>` objects.
+
+``String terminals`` are:
+
+* C++ numeric literals like ``"hello"``.
+* Client-side string variables such as ``string x``.
+* Client-side string expressions such as ``x + "QQQ"``
+* String columns, which are typically obtained from a call like
+  :cpp:func:`getCols <deephaven::client::highlevel::TableHandle::getCols>`.
+
+Example:
+
+.. code:: c++
+
+  auto t2 = t0.select(ticker, (ticker + "XYZ").as("Result"));
+  auto t2_literal = t0.select("Ticker", "Result = Ticker + `XYZ`");
+
+:cpp:class:`StringExpression <deephaven::client::highlevel::StringExpression>`
+provides four additional methods that work on
+:cpp:class:`StringExpression <deephaven::client::highlevel::StringExpression>`
+objects. These operations have the semantics described in the Deephaven documentation, and they yield
+:cpp:class:`BooleanExpression <deephaven::client::highlevel::BooleanExpression>`
+(described in the :ref:`BooleanExpression` subsection). For example:
+
+.. code:: c++
+
+  var t1 = t0.where(ticker.startsWith("AA"));
+  var t1_literal = t0.where("ticker.startsWith(`AA`)");
+  var t2 = t0.where(ticker.matches(".*P.*"));
+  var t2_literal = t0.where("ticker.matches(`.*P.*`)");
+
+DateTimeExpression
+^^^^^^^^^^^^^^^^^^
+
+`DBDateTime terminals` are:
+
+* C++ string literals, variables or string expressions in Deephaven
+  :cpp:class:`StringExpression <deephaven::client::highlevel::DBDateTime>`
+  format, e.g. ``"2020-03-01T09:45:00.123456 NY"``.
+* Client-side variables/expressions of type
+  :cpp:class:`StringExpression <deephaven::client::highlevel::DBDateTime>`
+
+:cpp:class:`StringExpression <deephaven::client::highlevel::DBDateTime>`
+is the standard Deephaven Date/Time type, representing nanoseconds since January 1, 1970 UTC.
+
+.. _BooleanExpression:
+
+BooleanExpression
+^^^^^^^^^^^^^^^^^
+
+:cpp:class:`BooleanExpression <deephaven::client::highlevel::BooleanExpression>`
+objets can be used to represent expressions involving boolean-valued columns (e.g.
+``!boolCol1 || boolCol2``) but more commonly, they are used to represent the result of
+relational operators applied to other expression types.
+:cpp:class:`BooleanExpression <deephaven::client::highlevel::BooleanExpression>` objects
+support the unary ``!``, as well as the binary operators ``&&`` and ``||`` and their cousins
+``&`` and ``|``.
+
+Note that the shortcutting operators ``&&`` and ``||`` do not exhibit their usual shortcutting behavior
+when used with Deephaven fluent expressions. Because the value of either side of the expression isn't
+knowable until it is evaluated at the server, it is not possible (nor even particularly meaningful)
+to do shortcutting on the client.
+As a consequence of this, ``&&`` is a synonym for the (non-shortcutting) boolean ``&`` operator; likewise
+``||`` is a synonym for the non-shortcutting boolean ``|`` operator.
+
+For example, in ``t1 = t0.where(col0 < 5 && col1 > 12)`` we would send the whole expression to
+the server for evaluation. There would be no attempt to first determine the "truth" of
+``col0 < 5`` (a concept that doesn't even make much sense anyway in the context of a full column of
+data) in order to try shortcut the evaluation of ``col1 > 12``.
+
+This example creates two boolean-valued columns and does simplistic filtering on them:
+
+.. code:: c++
+
+  // TODO(kosak): This example doesn't work yet. Need BoolCol and boolean literals
+  auto empty = manager.emptyTable(5, {}, {});
+  auto t = empty.update( ((BooleanExpression)true).as("A"),
+      ((BooleanExpression)false).as("B"));
+  // Deephaven Code Studio equivalent
+  auto t_literal = empty.Update("A = true", "B = false");
+  auto (a, b) = t.GetColumns<BoolCol, BoolCol>("A", "B");
+  auto t2 = t.where(a);
+  auto t3 = t.where(a && b);
+
+More commonly,
+:cpp:class:`BooleanExpression <deephaven::client::highlevel::BooleanExpression>`  
+are created as the result of relational operators on other expressions. For example we might say
+
+.. code:: c++
+
+  std::vector<int> aValues{10, 20, 30};	  
+  std::vector<std::string> sValues{"x", "y", "z"};
+  TableMaker tm;
+  tm.addColumn("A", aValues);
+  tm.addColumn("S", sValues);
+  auto temp = tm.makeTable(manager);
+  auto a = temp.getNumCol("A");
+  auto result = temp.where(a > 15);
+
+Here ``a > 15`` applies the ``>`` operator to two
+:cpp:class:`NumericExpression <deephaven::client::highlevel::NumericExpression>` objects
+yielding a
+:cpp:class:`BooleanExpression <deephaven::client::highlevel::BooleanExpression>`  
+suitable for passing to the
+:cpp:func:`TableHandle <deephaven::client::highlevel::TableHandle::where>`  
+method and being evaluated on the server. The library supports the usual relational
+operators (``<``, ``<=``, ``==``, ``>=``, ``>``, ``!=``) on
+:cpp:class:`NumericExpression <deephaven::client::highlevel::NumericExpression>`,
+:cpp:class:`StringExpression <deephaven::client::highlevel::StringExpression>`, and
+:cpp:class:`DateTimeExpression <deephaven::client::highlevel::DateTimeExpression>`; meanwhile
+:cpp:class:`BooleanExpression <deephaven::client::highlevel::BooleanExpression>`
+itself supports only ``==`` and ``!=``.
+
+Column Terminals
+^^^^^^^^^^^^^^^^
+
+A Column Terminal is used to represent a database column symbolically, so it can be used in a
+fluent invocation such as ``t.where(a > 5)``. 
+To do this, the program needs to know the name of
+the database column (in this example, "A") as well as its type (in this example,
+:cpp:class:`NumCol <deephaven::client::highlevel::NumCol>`).
+
+.. code:: c++
+
+  auto a = temp.getCol<NumCol>("A");
+
+The Column Terminal types are:
+
+* :cpp:class:`NumCol <deephaven::client::highlevel::NumCol>`
+* :cpp:class:`StrCol <deephaven::client::highlevel::StrCol>`
+* :cpp:class:`DateTimeCol <deephaven::client::highlevel::DateTimeCol>`
+* :cpp:class:`BoolCol <deephaven::client::highlevel::BoolCol>`
+
+Note that the single fluent type
+:cpp:class:`NumCol <deephaven::client::highlevel::NumCol>`
+stands in for all the
+numeric types (``short``, ``int``, ``double``, and so on). This does *not* mean that the server represents
+all these types as the same thing, or that there is some kind of loss of precision involved. Rather
+it is simply a reflection of the fact that the numeric types generally interoperate with each other
+and support all the same operators; from the point of view of the fluent layer, when building an
+abstract syntax tree for an expression like ``x + y`` for evaluation at the server, it's not necessary
+to know the exact types of ``x`` and ``y`` at this point, other than knowing that they behave like
+numbers.
+
+The syntax for creating a single Column Terminal is
+
+.. code:: c++
+
+  auto col = table.getXXX(name);
+
+where ``getXXX`` is one of `
+:cpp:func:`getNumCol <deephaven::client::highlevel::TableHandle::getNumCol>`,
+:cpp:func:`getStrCol <deephaven::client::highlevel::TableHandle::getStrCol>`,
+:cpp:func:`getDateTimeCol <deephaven::client::highlevel::TableHandle::getDateTimeCol>`,
+or     
+:cpp:func:`getBoolCol <deephaven::client::highlevel::TableHandle::getBoolCol>`,
+and ``name`` is the name of the column.
+
+To conveniently bind more than one column at a time, the program can use
+:cpp:func:`getCols <deephaven::client::highlevel::TableHandle::getCols>`.
+
+For example this statement binds three columns at once:
+
+.. code:: c++
+
+  auto (importDate, ticker, close) =
+    table.getCols<StrCol, StrCol, NumCol>("ImportDate", "Ticker", "Close");
+
+SelectColumns
+^^^^^^^^^^^^^
+
+A
+:cpp:class:`SelectColumn <deephaven::client::highlevel::SelectColumn>`
+is an object suitable to be passed to a
+:cpp:func:`select <deephaven::client::highlevel::TableHandle::select>`,
+:cpp:func:`update <deephaven::client::highlevel::TableHandle::update>`,
+:cpp:func:`view <deephaven::client::highlevel::TableHandle::view>`, or
+:cpp:func:`updateView <deephaven::client::highlevel::TableHandle::updateView>`
+method. It either needs to either refer to an already-existing column,
+or it is an expression bound to a column name, which will cause a new column
+to be created. Examples:
+
+.. code:: c++
+
+  // Assume "close" is already a column, so we can use it directly
+  auto t1 = t0.select(close);
+  // "100 + close" is an expression; to turn it into a SelectColumn
+  // we need to bind it to a new column name with the "as" method.
+  auto t2 = t0.select((100 + close).as("Result"));
+  // The above would be expressed in the Deephaven Code Studio as:
+  var t2_literal = t0.select("Result = 100 + Close")

--- a/cpp-examples/doc/getting_started.rst
+++ b/cpp-examples/doc/getting_started.rst
@@ -1,0 +1,83 @@
+Getting Started
+===============
+
+Installation
+------------
+
+1. Install the Deephaven library and the packages it depends on. Instructions
+   for doing so are in the Deephaven repo in ``cpp-client/README.md``.
+2. Confirm that you are able to build and run the "Hello, WOrld" example
+   program provided in the Deephaven Examples repo in the directory
+   ``hello_world``
+3. The file ``hello_world/CMakeLists.txt`` shows how to use CMake to build
+   your project with the Deephaven Client library. You can use this as a
+   starting point for your own projects.
+
+Hello, World
+------------
+
+Deephaven client programs typically follow this recipe:
+
+1. Connect to the server with
+   :cpp:func:`Client::connect <deephaven::client::highlevel::Client::connect>`
+   providing the server hostname and port.
+2. Call
+   :cpp:func:`Client.getManager <deephaven::client::highlevel::Client::getManager>`
+   to get a
+   :cpp:class:`TableHandleManager <deephaven::client::highlevel::TableHandleManager>`.
+3. Use that
+   :cpp:class:`TableHandleManager <deephaven::client::highlevel::TableHandleManager>`
+   to create, access, or modify tables in the system.
+4. Clean up resources automatically when the variables exit their scopes.
+
+This is the "Hello, World" example from the file ``hello_world/main.cc``.
+
+.. code:: c++
+
+  #include <iostream>
+  #include "deephaven/client/highlevel/client.h"
+
+  using deephaven::client::highlevel::Client;
+
+  int main() {
+    const char *server = "localhost:10000";
+    auto client = Client::connect(server);
+    auto manager = client.getManager();
+    auto table = manager.emptyTable(10);
+    auto t2 = table.update("ABC = ii + 100");
+    std::cout << t2.stream(true) << '\n';
+
+    return 0;
+  }
+
+This is the corresponding ``CMakeLists.txt``:
+
+.. code:: cmake
+
+  cmake_minimum_required(VERSION 3.16)
+  project(hello_world)
+
+  set(CMAKE_CXX_STANDARD 17)
+
+  find_package(deephaven REQUIRED)
+
+  find_package(absl REQUIRED)
+  find_package(Arrow REQUIRED)
+  find_package(ArrowFlight REQUIRED HINTS ${Arrow_DIR})
+  find_package(Protobuf REQUIRED)
+  find_package(gRPC REQUIRED)
+  find_package(Threads REQUIRED)
+
+  add_executable(hello_world main.cc)
+
+  target_link_libraries(hello_world deephaven::client)
+
+To build and run the example, type
+
+.. code:: bash
+
+  cd cpp_examples/hello_world
+  mkdir build && cd build
+  cmake ..
+  make -j8
+  ./hello_world

--- a/cpp-examples/doc/index.rst
+++ b/cpp-examples/doc/index.rst
@@ -1,0 +1,27 @@
+Deephaven C++ Client
+====================
+
+The Deephaven C++ Client Library provides a high-level interface to Deephaven
+functionality. The library...
+
+* Provides a "fluent" syntax which provides a more convenient and less
+  error-prone way of expressing expressions and conditionals, with much of the
+  syntax checking being done at compile time.
+* Performs operations asynchronously, automatically managing dependencies
+  between operations, without burdening the caller with managing callback
+  state.
+* Provides a shared ownership model so that objects like
+  :cpp:class:`TableHandle <deephaven::client::highlevel::TableHandle>`
+  can be manipulated like value types (e.g. freely copied). Their corresponding
+  server resources will be cleaned up when last one goes out of scope.
+
+Contents
+========
+
+.. toctree::
+   :maxdepth: 2
+ 
+   getting_started
+   resource_mgmt
+   input_output
+   fluent

--- a/cpp-examples/doc/input_output.rst
+++ b/cpp-examples/doc/input_output.rst
@@ -1,0 +1,21 @@
+Getting Data Into and Out of Deephaven
+======================================
+
+The Deephaven system uses the
+`Arrow Flight RPC <https://arrow.apache.org/docs/cpp/flight.html>`__
+to move data into and out of tables. Clients that want to read or write data
+will obtain Arrow ``FlightStreamReader`` or ``FlightStreamWriter``, as
+appropriate, and read or write their to that object.
+
+Tables are created and populated using Arrow Flight's ``DoPut`` functionality.
+``DoPut`` is powerful and flexible, but it may be daunting for first-time
+users. To help users get started, we we provide a helper class called
+:cpp:class:`TableMaker <deephaven::client::utility::TableMaker>`.
+This class provides a simpler interface for creating small tables.
+Likewise, we provide a method for streaming a table to a ``std::ostream``.
+
+.. toctree::
+
+  create_table_with_tablemaker
+  create_table_with_arrow_flight
+  read_data_with_arrow_flight

--- a/cpp-examples/doc/make.bat
+++ b/cpp-examples/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/cpp-examples/doc/read_data_with_arrow_flight.rst
+++ b/cpp-examples/doc/read_data_with_arrow_flight.rst
@@ -1,0 +1,88 @@
+Reading Data with Arrow Flight
+==============================
+
+Client programs that read tables using
+`Arrow Flight RPC <https://arrow.apache.org/docs/cpp/flight.html>`__
+typically follow the below recipe:
+
+1. Get a ``shared_ptr`` to a ``arrow::flight::FlightStreamReader`` via
+   :cpp:func:`TableHandle::getFlightStreamReader <deephaven::client::highlevel::TableHandle::getFlightStreamReader>`
+2. Read the data using operations as described in
+   `Arrow Flight RPC <https://arrow.apache.org/docs/cpp/flight.html>`__   
+
+Consider the following program from ``cpp-examples/read_table_with_arrow_flight``:
+
+.. code:: c++
+	  
+  #include <iostream>
+  #include "deephaven/client/highlevel/client.h"
+  #include "deephaven/client/utility/table_maker.h"
+  #include "deephaven/client/utility/utility.h"
+
+  using deephaven::client::highlevel::NumCol;
+  using deephaven::client::highlevel::Client;
+  using deephaven::client::highlevel::TableHandle;
+  using deephaven::client::highlevel::TableHandleManager;
+  using deephaven::client::utility::flight::statusOrDie;
+  using deephaven::client::utility::TableMaker;
+
+  TableHandle makeTable(const TableHandleManager &manager) {
+    TableMaker tm;
+    std::vector<std::string> symbols{"FB", "AAPL", "NFLX", "GOOG"};
+    std::vector<double> prices{101.1, 102.2, 103.3, 104.4};
+    tm.addColumn("Symbol", symbols);
+    tm.addColumn("Price", prices);
+    return tm.makeTable(manager, "myTable");
+  }
+
+  void dumpSymbolColumn(const TableHandle &tableHandle) {
+    auto fsr = tableHandle.getFlightStreamReader();
+    while (true) {
+      arrow::flight::FlightStreamChunk chunk;
+      statusOrDie(fsr->Next(&chunk), "FlightStreamReader::Next()");
+      if (chunk.data == nullptr) {
+	break;
+      }
+
+      auto symbolChunk = chunk.data->GetColumnByName("Symbol");
+      if (symbolChunk == nullptr) {
+	throw std::runtime_error("Symbol column not found");
+      }
+      auto priceChunk = chunk.data->GetColumnByName("Price");
+      if (priceChunk == nullptr) {
+	throw std::runtime_error("Price column not found");
+      }
+
+      auto symbolAsStringArray = std::dynamic_pointer_cast<arrow::StringArray>(symbolChunk);
+      auto priceAsDoubleArray = std::dynamic_pointer_cast<arrow::DoubleArray>(priceChunk);
+      if (symbolAsStringArray == nullptr) {
+	throw std::runtime_error("symbolChunk was not an arrow::StringArray");
+      }
+      if (priceAsDoubleArray == nullptr) {
+	throw std::runtime_error("priceChunk was not an arrow::DoubleArray");
+      }
+
+      if (symbolAsStringArray->length() != priceAsDoubleArray->length()) {
+	throw std::runtime_error("Lengths differ");
+      }
+
+      for (int64_t i = 0; i < symbolAsStringArray->length(); ++i) {
+	auto symbol = symbolAsStringArray->GetView(i);
+	auto price = priceAsDoubleArray->Value(i);
+	std::cout << symbol << ' ' << price << '\n';
+      }
+    }
+  }
+
+  int main() {
+    const char *server = "localhost:10000";
+    auto client = Client::connect(server);
+    auto manager = client.getManager();
+
+    try {
+      auto table = makeTable(manager);
+      dumpSymbolColumn(table);
+    } catch (const std::runtime_error &e) {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+    }
+  }

--- a/cpp-examples/doc/resource_mgmt.rst
+++ b/cpp-examples/doc/resource_mgmt.rst
@@ -1,0 +1,68 @@
+Resource Management
+===================
+
+Generally, the types in the system behave as value types and are reference
+counted internally. This means that they can be freely copied, those copies
+behave interchangeably, and any server-side resources are cleaned up when
+the last shared owner of an underlying resource is destructed.
+
+Consider the following program from the file ``cleanup/main.cc``:
+
+.. code:: c++
+
+  #include <iostream>
+  #include "deephaven/client/highlevel/client.h"
+
+  using deephaven::client::highlevel::NumCol;
+  using deephaven::client::highlevel::Client;
+  using deephaven::client::highlevel::TableHandle;
+  using deephaven::client::highlevel::TableHandleManager;
+
+  // This example shows explicit QueryTable cleanup using destructors/RAII.
+  void doit(const TableHandleManager &manager) {
+    auto table = manager.emptyTable(10).update("X = ii % 2", "Y = ii");
+    auto [x, y] = table.getCols<NumCol, NumCol>("X", "Y");
+    // This example will dispose each table individually.
+
+    auto t1 = table.where(y < 5);
+    std::cerr << "This is t1:\n" << t1.stream(true) << '\n';
+
+    {
+      TableHandle t2Copy;
+      {
+	auto t2 = t1.countBy(x);
+	std::cerr << "This is t2:\n" << t2.stream(true) << '\n';
+
+	t2Copy = t2;
+
+	// The variable 't2' will be destructed here, but the server resource will stay alive
+	// because 't2Copy' is still live.
+      }
+      std::cerr << "t2Copy still alive:\n" << t2Copy.stream(true) << '\n';
+
+      // t2Copy will be destructed here. As it is the last owner of the server resource,
+      // the server resource will be released here.
+    }
+
+    // t1 and the TableHandleManger will be destructed here.
+  }
+
+  int main() {
+    const char *server = "localhost:10000";
+    auto client = Client::connect(server);
+    auto manager = client.getManager();
+
+    try {
+      doit(manager);
+    } catch (const std::runtime_error &e) {
+      std::cerr << "Caught exception: " << e.what() << '\n';
+    }
+  }
+
+At the end of the inner block for ``doit()``, the destructor for ``t2`` runs.
+However, the corresponding server resource is not yet released, because
+``t2Copy`` is still live. At the end of the middle block, the destructor for
+``t2Copy`` runs, and this will actually release the server resource. At the
+end of the outer block, the destructor for ``t1`` runs and its resources
+are released. Finally at the end of ``main()`` the destructor for ``client``
+runs, the client is shut down, and the program terminates.

--- a/cpp-examples/hello_world/CMakeLists.txt
+++ b/cpp-examples/hello_world/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(hello_world)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(deephaven REQUIRED)
+
+find_package(Arrow REQUIRED)
+find_package(ArrowFlight REQUIRED HINTS ${Arrow_DIR})
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(hello_world main.cc)
+
+target_link_libraries(hello_world deephaven::client)

--- a/cpp-examples/hello_world/main.cc
+++ b/cpp-examples/hello_world/main.cc
@@ -1,0 +1,15 @@
+#include <iostream>
+#include "deephaven/client/highlevel/client.h"
+
+using deephaven::client::highlevel::Client;
+
+int main() {
+  const char *server = "localhost:10000";
+  auto client = Client::connect(server);
+  auto manager = client.getManager();
+  auto table = manager.emptyTable(10);
+  auto t2 = table.update("ABC = ii + 100");
+  std::cout << t2.stream(true) << '\n';
+
+  return 0;
+}

--- a/cpp-examples/read_table_with_arrow_flight/CMakeLists.txt
+++ b/cpp-examples/read_table_with_arrow_flight/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(table_reader)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(deephaven REQUIRED)
+
+find_package(Arrow REQUIRED)
+find_package(ArrowFlight REQUIRED HINTS ${Arrow_DIR})
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+find_package(Threads REQUIRED)
+
+add_executable(table_reader main.cc)
+
+target_link_libraries(table_reader deephaven::client)

--- a/cpp-examples/read_table_with_arrow_flight/main.cc
+++ b/cpp-examples/read_table_with_arrow_flight/main.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016-2020 Deephaven Data Labs and Patent Pending
+ */
+#include <iostream>
+#include "deephaven/client/highlevel/client.h"
+#include "deephaven/client/utility/table_maker.h"
+#include "deephaven/client/utility/utility.h"
+
+using deephaven::client::highlevel::NumCol;
+using deephaven::client::highlevel::Client;
+using deephaven::client::highlevel::TableHandle;
+using deephaven::client::highlevel::TableHandleManager;
+using deephaven::client::utility::flight::statusOrDie;
+using deephaven::client::utility::TableMaker;
+
+TableHandle makeTable(const TableHandleManager &manager) {
+  TableMaker tm;
+  std::vector<std::string> symbols{"FB", "AAPL", "NFLX", "GOOG"};
+  std::vector<double> prices{101.1, 102.2, 103.3, 104.4};
+  tm.addColumn("Symbol", symbols);
+  tm.addColumn("Price", prices);
+  return tm.makeTable(manager, "myTable");
+}
+
+void dumpSymbolColumn(const TableHandle &tableHandle) {
+  auto fsr = tableHandle.getFlightStreamReader();
+  while (true) {
+    arrow::flight::FlightStreamChunk chunk;
+    statusOrDie(fsr->Next(&chunk), "FlightStreamReader::Next()");
+    if (chunk.data == nullptr) {
+      break;
+    }
+
+    auto symbolChunk = chunk.data->GetColumnByName("Symbol");
+    if (symbolChunk == nullptr) {
+      throw std::runtime_error("Symbol column not found");
+    }
+    auto priceChunk = chunk.data->GetColumnByName("Price");
+    if (priceChunk == nullptr) {
+      throw std::runtime_error("Price column not found");
+    }
+
+    auto symbolAsStringArray = std::dynamic_pointer_cast<arrow::StringArray>(symbolChunk);
+    auto priceAsDoubleArray = std::dynamic_pointer_cast<arrow::DoubleArray>(priceChunk);
+    if (symbolAsStringArray == nullptr) {
+      throw std::runtime_error("symbolChunk was not an arrow::StringArray");
+    }
+    if (priceAsDoubleArray == nullptr) {
+      throw std::runtime_error("priceChunk was not an arrow::DoubleArray");
+    }
+
+    if (symbolAsStringArray->length() != priceAsDoubleArray->length()) {
+      throw std::runtime_error("Lengths differ");
+    }
+
+    for (int64_t i = 0; i < symbolAsStringArray->length(); ++i) {
+      auto symbol = symbolAsStringArray->GetView(i);
+      auto price = priceAsDoubleArray->Value(i);
+      std::cout << symbol << ' ' << price << '\n';
+    }
+  }
+}
+
+int main() {
+  const char *server = "localhost:10000";
+  auto client = Client::connect(server);
+  auto manager = client.getManager();
+
+  try {
+    auto table = makeTable(manager);
+    dumpSymbolColumn(table);
+  } catch (const std::runtime_error &e) {
+    std::cerr << "Caught exception: " << e.what() << '\n';
+  }
+}


### PR DESCRIPTION
This is documentation and sample code for the C++ examples repo.

Notes:
1. I actually don't think this pull request belongs in this repo. I think it belongs in some other cpp-examples repo, which may or may not have been created yet.
2. The website named in the "intersphinx_mapping" clause needs to be updated

I've tested this documentation on Ubuntu 20.04 by doing the following:
```
$ sudo apt install doxygen flex bison cmake python python3-pip texlive-font-utils texlive-latex-extra texlive-extra-utils graphviz
# sphinx versions >= 4.1.0 don't like my variadic templates
$ pip install breathe sphinx==4.0.3 furo
$ cd cpp-client/doc
$ doxygen && sphinx-build -n . sphinxoutput
$ cd ../../cpp-examples/doc    # this repo
$ sphinx-build -n . sphinxoutput
```

Then I copy the first dir (cpp-client/doc/sphinxoutput) to my test website http://client.virtual-uk.com/
And I copy the second dir (cpp-examples/doc/sphinxoutput) to my other test website http://examples.virtual-uk.com/

And the second one links back to the first and it looks right.
