### PR TITLE
Build and test pydeephaven as part of gradle 

### DIFF
--- a/Integrations/build.gradle
+++ b/Integrations/build.gradle
@@ -2,7 +2,7 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 
 plugins {
     id 'com.bmuschko.docker-remote-api'
-    id 'com.avast.gradle.docker-compose' version '0.14.9'
+    id 'com.avast.gradle.docker-compose'
 }
 
 evaluationDependsOn ':deephaven-jpy'
@@ -131,7 +131,11 @@ def runInDocker = { String name, List<String> command ->
         parentContainers = [tasks.findByName('buildDeephavenPython')] // deephaven/runtime-base
 
         imageName = 'deephaven/py-integrations:local-build'
-        network = 'integrations_default'
+
+        network = dockerCompose.projectName.toLowerCase() + '_default'
+        containerDependencies.dependsOn = dockerCompose.upTask
+        containerDependencies.finalizedBy = dockerCompose.downTask
+
         dockerfile {
             // set up the container, env vars - things that aren't likely to change
             from 'deephaven/runtime-base:local-build'
@@ -172,13 +176,7 @@ pyFunctionalTest.configure({
 })
 tasks.getByName('check').dependsOn(pyFunctionalTest)
 
-dockerCompose.isRequiredBy(pyTest)
-dockerCompose.isRequiredBy(pyFunctionalTest)
-
+// Using Integrations/docker-compose.yml, this will start redpanda and wait until it is running before letting tests proceed.
 dockerCompose {
-    waitForTcpPortsTimeout = java.time.Duration.ofMinutes(2)
-    waitForHealthyStateTimeout = java.time.Duration.ofMinutes(1)
-    // Avoid compose project mangling: we are depending on the default
-    // name for the compose network (matching the directory name)
-    projectName=null
+    waitForTcpPortsTimeout = Duration.ofMinutes(2)
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     compile 'com.bmuschko:gradle-docker-plugin:6.7.0'
 
+    compile ('com.avast.gradle:gradle-docker-compose-plugin:0.14.9')
+
     compile('com.netflix.nebula:gradle-ospackage-plugin:8.3.0')
 
     compile "gradle.plugin.com.jetbrains.python:gradle-python-envs:0.0.30"

--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -155,8 +155,17 @@ class Docker {
          */
         boolean showLogsOnSuccess;
     }
+    /**
+     * Describes relationships between this set of tasks and other external tasks.
+     */
     static class TaskDependencies {
+        /**
+         * Indicates tasks that must have been successfully completed before the container can start.
+         */
         Object dependsOn;
+        /**
+         * Indicates tasks that should run after the container has stopped.
+         */
         Object finalizedBy;
     }
 

--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -72,6 +72,7 @@ class Docker {
         private Action<? super Sync> copyOut;
         private File dockerfileFile;
         private Action<? super Dockerfile> dockerfileAction;
+        private TaskDependencies containerDependencies = new TaskDependencies();
 
         /**
          * Files that need to be copied in to the image.
@@ -128,9 +129,8 @@ class Docker {
         String imageName;
 
         /**
-         * Tag to apply the network to the container.
+         * Name of the docker network which the container should be attached to.
          */
-
         String network;
 
         /**
@@ -154,6 +154,10 @@ class Docker {
          * when it fails. Set this flag to always show logs, even when entrypoint is successful.
          */
         boolean showLogsOnSuccess;
+    }
+    static class TaskDependencies {
+        Object dependsOn;
+        Object finalizedBy;
     }
 
     private static void validateImageName(String imageName) {
@@ -261,6 +265,10 @@ class Docker {
                     hostConfig.network.set(cfg.network)
                 }
 
+                if (cfg.containerDependencies.dependsOn) {
+                    dependsOn(cfg.containerDependencies.dependsOn)
+                }
+
                 targetImageId makeImage.get().getImageId()
                 containerName.set(dockerContainerName)
             }
@@ -273,6 +281,11 @@ class Docker {
                 //TODO wire this up to not even run if the container doesn't exist
                 dependsOn createContainer
                 targetContainerId dockerContainerName
+
+                if (cfg.containerDependencies.finalizedBy) {
+                    finalizedBy(cfg.containerDependencies.finalizedBy)
+                }
+
                 onError { t ->
                     // ignore, container might not exist
                 }

--- a/buildSrc/src/main/groovy/io/deephaven/tools/docker/WaitForHealthyContainer.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/tools/docker/WaitForHealthyContainer.groovy
@@ -1,0 +1,66 @@
+package io.deephaven.tools.docker
+
+import com.bmuschko.gradle.docker.tasks.container.DockerExistingContainer
+import com.github.dockerjava.api.command.InspectContainerCmd
+import com.github.dockerjava.api.command.InspectContainerResponse
+import groovy.transform.CompileStatic
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+@CompileStatic
+class WaitForHealthyContainer extends DockerExistingContainer {
+    /**
+     * Wait timeout in seconds.
+     */
+    @Input
+    @Optional
+    final Property<Integer> awaitStatusTimeout = project.objects.property(Integer)
+
+    /**
+     * Interval between each check in milliseconds.
+     */
+    @Input
+    @Optional
+    final Property<Integer> checkInterval = project.objects.property(Integer)
+
+    @Override
+    void runRemoteCommand() {
+        logger.quiet "Waiting for container with ID '${containerId.get()}' to be healthy."
+
+        InspectContainerCmd command = dockerClient.inspectContainerCmd(containerId.get())
+        long deadline = System.currentTimeMillis() + awaitStatusTimeout.getOrElse(30) * 1000
+        long sleepInterval = checkInterval.getOrElse(500)
+
+        while(!check(deadline, command)) {
+            sleep(sleepInterval)
+        }
+    }
+
+
+    private boolean check(Long deadline, InspectContainerCmd command) {
+        if (deadline && System.currentTimeMillis() > deadline) {
+            throw new GradleException('Health check timeout expired')
+        }
+
+        InspectContainerResponse response = command.exec()
+        InspectContainerResponse.ContainerState state = response.state
+        if (!state.running) {
+            throw new GradleException("Container with ID '${getContainerId()}' is not running")
+        }
+
+        String healthStatus
+        if (state.health) {
+            healthStatus = state.health.status
+        } else {
+            logger.quiet 'HEALTHCHECK instruction was not used to build this image. Falling back to generic Status of container...'
+            healthStatus = state.status
+        }
+
+        if (nextHandler) {
+            nextHandler.execute(healthStatus)
+        }
+        return healthStatus ==~ /(healthy|running)/
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ services:
       file: docker-compose-common.yml
       service: grpc-proxy
     depends_on:
-      - grpc-api
+      grpc-api:
+        condition: service_healthy
 
   envoy:
     # A reverse proxy configured for no SSL on localhost. It fronts the requests
@@ -37,6 +38,9 @@ services:
       file: docker-compose-common.yml
       service: envoy
     depends_on:
-      - web
-      - grpc-proxy
-      - grpc-api
+      grpc-api:
+        condition: service_healthy
+      grpc-proxy:
+        condition: service_started
+      web:
+        condition: service_started

--- a/grpc-api/server/docker/build.gradle
+++ b/grpc-api/server/docker/build.gradle
@@ -67,10 +67,18 @@ docker {
   dockerCreateDockerfile {
     //volume("/app/resources")
 
+    runCommand('''set -eux;\\
+                  GRPC_HEALTH_PROBE_VERSION=v0.3.1;\\
+                  curl -L -o /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64; \\
+                  chmod +x /bin/grpc_health_probe
+                  ''')
+
     copyFile('licenses/', '/')
 
     volume("/data")
     volume("/cache")
+
+    instruction('HEALTHCHECK --interval=3s --timeout=10s CMD /bin/grpc_health_probe -addr=localhost:8080 -connect-timeout=10s')
   }
 }
 

--- a/grpc-api/server/docker/build.gradle
+++ b/grpc-api/server/docker/build.gradle
@@ -78,7 +78,20 @@ docker {
     volume("/data")
     volume("/cache")
 
-    instruction('HEALTHCHECK --interval=3s --timeout=10s CMD /bin/grpc_health_probe -addr=localhost:8080 -connect-timeout=10s')
+    // Breakdown of the following command:
+    //   * Wait 3 seconds before checking the status of the container after each test.
+    //   * After three failing checks, mark the container as failed.
+    //   * The HEALTHCHECK will wait 11 seconds for a result, but the grpc_health_probe process
+    //     will time out after only 10 seconds of trying to connect. This one second leaves room
+    //     for the grpc probe to have a delay starting up, and gives some visiblity into this
+    //     failure mode (via docker inspect, but only until that failure stales out).
+    //   * If grpc_health_probe fails with any non-zero exit code, normalize to 1.
+    // The net effect is that the server will have 3s until the earliest possible success, and
+    // 33-36s until it is considered to have failed startup (so downstream docker-compose services
+    // will not attempt to start). If the server is running but trying to shut down, failure will
+    // occur within about 9s, as the port will connect correctly, but respond that it isn't
+    // available.
+    instruction('HEALTHCHECK --interval=3s --retries=3 --timeout=11s CMD /bin/grpc_health_probe -addr=localhost:8080 -connect-timeout=10s || exit 1')
   }
 }
 

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/healthcheck/HealthCheckModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/healthcheck/HealthCheckModule.java
@@ -18,8 +18,7 @@ public class HealthCheckModule {
         HealthStatusManager healthStatusManager = new HealthStatusManager();
         ProcessEnvironment.getGlobalShutdownManager().registerTask(
                 ShutdownManager.OrderingCategory.FIRST,
-                healthStatusManager::enterTerminalState
-        );
+                healthStatusManager::enterTerminalState);
 
         return healthStatusManager;
     }

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/healthcheck/HealthCheckModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/healthcheck/HealthCheckModule.java
@@ -1,0 +1,32 @@
+package io.deephaven.grpc_api.healthcheck;
+
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoSet;
+import io.deephaven.util.process.ProcessEnvironment;
+import io.deephaven.util.process.ShutdownManager;
+import io.grpc.BindableService;
+import io.grpc.protobuf.services.HealthStatusManager;
+
+import javax.inject.Singleton;
+
+@Module
+public class HealthCheckModule {
+    @Provides
+    @Singleton
+    public HealthStatusManager bindHealthStatusManager() {
+        HealthStatusManager healthStatusManager = new HealthStatusManager();
+        ProcessEnvironment.getGlobalShutdownManager().registerTask(
+                ShutdownManager.OrderingCategory.FIRST,
+                healthStatusManager::enterTerminalState
+        );
+
+        return healthStatusManager;
+    }
+
+    @Provides
+    @IntoSet
+    BindableService bindHealthServiceImpl(HealthStatusManager healthStatusManager) {
+        return healthStatusManager.getHealthService();
+    }
+}

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerComponent.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerComponent.java
@@ -3,6 +3,7 @@ package io.deephaven.grpc_api.runner;
 import dagger.BindsInstance;
 import dagger.Component;
 import io.deephaven.grpc_api.appmode.AppMode;
+import io.deephaven.grpc_api.healthcheck.HealthCheckModule;
 import io.deephaven.grpc_api.session.SessionService;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
@@ -18,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 @Singleton
 @Component(modules = {
         DeephavenApiServerModule.class,
+        HealthCheckModule.class,
         ServerBuilderModule.class
 })
 public interface DeephavenApiServerComponent {

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerModule.java
@@ -11,7 +11,6 @@ import io.deephaven.grpc_api.auth.AuthContextModule;
 import io.deephaven.grpc_api.console.ConsoleModule;
 import io.deephaven.grpc_api.console.groovy.GroovyConsoleSessionModule;
 import io.deephaven.grpc_api.console.python.PythonConsoleSessionModule;
-import io.deephaven.grpc_api.healthcheck.HealthCheckModule;
 import io.deephaven.grpc_api.log.LogModule;
 import io.deephaven.grpc_api.session.SessionModule;
 import io.deephaven.grpc_api.table.TableModule;
@@ -42,7 +41,6 @@ import java.util.concurrent.TimeUnit;
         AppModeModule.class,
         ArrowModule.class,
         AuthContextModule.class,
-        HealthCheckModule.class,
         LogModule.class,
         SessionModule.class,
         TableModule.class,

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerModule.java
@@ -11,6 +11,7 @@ import io.deephaven.grpc_api.auth.AuthContextModule;
 import io.deephaven.grpc_api.console.ConsoleModule;
 import io.deephaven.grpc_api.console.groovy.GroovyConsoleSessionModule;
 import io.deephaven.grpc_api.console.python.PythonConsoleSessionModule;
+import io.deephaven.grpc_api.healthcheck.HealthCheckModule;
 import io.deephaven.grpc_api.log.LogModule;
 import io.deephaven.grpc_api.session.SessionModule;
 import io.deephaven.grpc_api.table.TableModule;
@@ -41,6 +42,7 @@ import java.util.concurrent.TimeUnit;
         AppModeModule.class,
         ArrowModule.class,
         AuthContextModule.class,
+        HealthCheckModule.class,
         LogModule.class,
         SessionModule.class,
         TableModule.class,

--- a/pyclient/build.gradle
+++ b/pyclient/build.gradle
@@ -1,7 +1,15 @@
+import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+import com.bmuschko.gradle.docker.tasks.network.DockerCreateNetwork
+import com.bmuschko.gradle.docker.tasks.network.DockerRemoveNetwork
+import io.deephaven.tools.docker.WaitForHealthyContainer
+
 plugins {
     id 'com.bmuschko.docker-remote-api'
 }
 
+// Build the pydeephaven wheel from sources in a vanilla docker container
 Docker.registerDockerTask(project, 'buildPyClient') {
     copyIn {
         from('requirements.txt') {
@@ -26,5 +34,79 @@ Docker.registerDockerTask(project, 'buildPyClient') {
     containerOutPath = '/project/dist'
     copyOut {
         into 'build/wheel'
+    }
+}
+
+// Start up a docker container for the grpc-api, then run pydeephaven test
+evaluationDependsOn(':grpc-api-server-docker')
+String randomSuffix = UUID.randomUUID().toString();
+String dockerContainerName = "pydeephaven-test-container-${randomSuffix}"
+String dockerNetworkName = "pydeephaven-network-${randomSuffix}"
+def createDeephavenGrpcApiNetwork = tasks.register('createDeephavenGrpcApiNetwork', DockerCreateNetwork) {
+    networkName.set dockerNetworkName
+}
+def removeDeephavenGrpcApiNetwork = tasks.register('removeDeephavenGrpcApiNetwork', DockerRemoveNetwork) {
+    networkId.set dockerNetworkName
+}
+
+def createDeephavenGrpcApi = tasks.register('createDeephavenGrpcApi', DockerCreateContainer) {
+    def grpcApiImage = project(':grpc-api-server-docker').tasks.named('dockerBuildImage');
+    dependsOn grpcApiImage, createDeephavenGrpcApiNetwork
+    targetImageId grpcApiImage.get().getImageId()
+    containerName.set dockerContainerName
+    hostConfig.network.set dockerNetworkName
+}
+def startDeephavenGrpcApi = tasks.register('startDeephavenGrpcApi', DockerStartContainer) {
+    dependsOn createDeephavenGrpcApi
+    containerId.set dockerContainerName
+}
+def waitForHealthy = tasks.register('waitForHealthy', WaitForHealthyContainer) {
+    dependsOn startDeephavenGrpcApi
+
+    awaitStatusTimeout.set 20
+    checkInterval.set 100
+
+    containerId.set dockerContainerName
+}
+def stopDeephavenGrpcApi = tasks.register('stopDeephavenGrpcApi', DockerRemoveContainer) {
+    dependsOn createDeephavenGrpcApi
+    finalizedBy removeDeephavenGrpcApiNetwork
+
+    targetContainerId dockerContainerName
+    force.set true
+    removeVolumes.set true
+
+//    onError { t ->
+//        // ignore, container might not exist
+//    }
+}
+tasks.getByName('check').dependsOn Docker.registerDockerTask(project, 'testPyClient') {
+    copyIn {
+        from('pydeephaven') {
+            into 'project/pydeephaven'
+        }
+        from('tests') {
+            into 'project/tests'
+        }
+    }
+//    parentContainers = [  ]
+    containerDependencies.dependsOn = [waitForHealthy, createDeephavenGrpcApiNetwork]
+    containerDependencies.finalizedBy = stopDeephavenGrpcApi
+    network = dockerNetworkName
+    dockerfile {
+        from('docker.io/library/python:3.7.10')
+        runCommand '''set -eux; \\
+                      pip3 install unittest-xml-reporting==3.0.4 pyarrow==5.0.0 protobuf==3.17.3 grpcio==1.39.0 bitstring==3.1.9 pandas==1.2.5;\\
+                      mkdir -p /out/report'''
+        environmentVariable 'DH_HOST', dockerContainerName
+        environmentVariable 'DH_PORT', '8080'
+
+        copyFile('project', '/project')
+        workingDir('/project')
+    }
+
+    entrypoint = ['python', '-m', 'xmlrunner', 'discover', 'tests', '-v', '-o', '/out/report']
+    copyOut {
+        into layout.buildDirectory.dir('test-results')
     }
 }

--- a/pyclient/build.gradle
+++ b/pyclient/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'com.bmuschko.docker-remote-api'
+}
+
+Docker.registerDockerTask(project, 'buildPyClient') {
+    copyIn {
+        from('requirements.txt') {
+            into 'project'
+        }
+        from('setup.py') {
+            into 'project'
+        }
+        from('README.md') {
+            into 'project'
+        }
+        from('pydeephaven') {
+            into 'project/pydeephaven'
+        }
+    }
+    dockerfile {
+        from('docker.io/library/python:3.7.10')
+        copyFile('project', '/project')
+        workingDir('/project')
+        runCommand('python3 setup.py bdist_wheel')
+    }
+    containerOutPath = '/project/dist'
+    copyOut {
+        into 'build/wheel'
+    }
+}

--- a/pyclient/build.gradle
+++ b/pyclient/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // Build the pydeephaven wheel from sources in a vanilla docker container
-Docker.registerDockerTask(project, 'buildPyClient') {
+tasks.getByName('build').dependsOn(Docker.registerDockerTask(project, 'buildPyClient') {
     copyIn {
         from('requirements.txt') {
             into 'project'
@@ -35,7 +35,7 @@ Docker.registerDockerTask(project, 'buildPyClient') {
     copyOut {
         into 'build/wheel'
     }
-}
+})
 
 // Start up a docker container for the grpc-api, then run pydeephaven test
 evaluationDependsOn(':grpc-api-server-docker')
@@ -80,7 +80,7 @@ def stopDeephavenGrpcApi = tasks.register('stopDeephavenGrpcApi', DockerRemoveCo
 //        // ignore, container might not exist
 //    }
 }
-tasks.getByName('check').dependsOn Docker.registerDockerTask(project, 'testPyClient') {
+tasks.getByName('check').dependsOn(Docker.registerDockerTask(project, 'testPyClient') {
     copyIn {
         from('pydeephaven') {
             into 'project/pydeephaven'
@@ -109,4 +109,4 @@ tasks.getByName('check').dependsOn Docker.registerDockerTask(project, 'testPyCli
     copyOut {
         into layout.buildDirectory.dir('test-results')
     }
-}
+})

--- a/pyclient/pydeephaven/session.py
+++ b/pyclient/pydeephaven/session.py
@@ -58,7 +58,7 @@ class Session:
 
         self.port = port
         if not port:
-            self.port = os.environ.get("DH_PORT", 10000)
+            self.port = int(os.environ.get("DH_PORT", 10000))
 
         self.is_connected = False
         self.session_token = None

--- a/pyclient/pydeephaven/session.py
+++ b/pyclient/pydeephaven/session.py
@@ -54,11 +54,11 @@ class Session:
 
         self.host = host
         if not host:
-            self.host = os.environ.get("DHCE_HOST", "localhost")
+            self.host = os.environ.get("DH_HOST", "localhost")
 
         self.port = port
         if not port:
-            self.port = os.environ.get("DHCE_PORT", 10000)
+            self.port = os.environ.get("DH_PORT", 10000)
 
         self.is_connected = False
         self.session_token = None

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ Map<String, String> pyMods = [
         'py36': 'py/py36',
         'py37': 'py/py37',
         'sphinx': 'sphinx',
+        'pyclient': 'pyclient',
 ]
 
 // Include our modules


### PR DESCRIPTION
This patch does several things:
 * Review and tweaks to kafka+python test patch #1155 
 * Introduces gRPC health check to the grpc-api project, and adds a HEALTHCHECK to its docker image
 * Adds support for pyclient/ to be built and tested in gradle

This last point is ostensibly the purpose of the patch, but the first two are related or helpful prerequisites. Note that pyclient's test wiring could probably more concisely be a docker-compose.yml, but at the "cost" of making a docker-compose with only one service in it, just to get its cleanup and network setup more cheaply. Instead, it probably makes more sense to continue to iterate on this work for other client builds and tests.