### PR TITLE
Add DBPeriod to deephaven.Types and deephaven.DBTimeUtils

### DIFF
--- a/Generators/src/main/java/io/deephaven/pythonPreambles/DBTimeUtilsPreamble.txt
+++ b/Generators/src/main/java/io/deephaven/pythonPreambles/DBTimeUtilsPreamble.txt
@@ -21,6 +21,7 @@ import wrapt
 _java_type_ = None  # None until the first define_symbols() call
 DBTimeZone = None  #: Deephaven timezone class (io.deephaven.db.tables.utils.DBTimeZone).
 DBDateTime = None  #: Deephaven date-time class (io.deephaven.db.tables.utils.DBDateTime).
+DBPeriod = None    #: Deephaven time period class (io.deephaven.db.tables.utils.DBPeriod).
 
 SECOND = 1000000000  #: One second in nanoseconds.
 MINUTE = 60*SECOND   #: One minute in nanoseconds.
@@ -40,14 +41,14 @@ def _defineSymbols():
     if not jpy.has_jvm():
         raise SystemError("No java functionality can be used until the JVM has been initialized through the jpy module")
 
-    global _java_type_, DBTimeZone
+    global _java_type_, DBTimeZone, DBDateTime, DBPeriod
     if _java_type_ is not None:
         return
     # This will raise an exception if the desired object is not the classpath
     _java_type_ = jpy.get_type("io.deephaven.db.tables.utils.DBTimeUtils")
     DBTimeZone = jpy.get_type("io.deephaven.db.tables.utils.DBTimeZone")
     DBDateTime = jpy.get_type("io.deephaven.db.tables.utils.DBDateTime")
-
+    DBPeriod = jpy.get_type("io.deephaveb.db.tables.utils.DBPeriod")
 
 # every module method should be decorated with @_passThrough
 @wrapt.decorator

--- a/Generators/src/main/java/io/deephaven/pythonPreambles/DBTimeUtilsPreamble.txt
+++ b/Generators/src/main/java/io/deephaven/pythonPreambles/DBTimeUtilsPreamble.txt
@@ -48,7 +48,7 @@ def _defineSymbols():
     _java_type_ = jpy.get_type("io.deephaven.db.tables.utils.DBTimeUtils")
     DBTimeZone = jpy.get_type("io.deephaven.db.tables.utils.DBTimeZone")
     DBDateTime = jpy.get_type("io.deephaven.db.tables.utils.DBDateTime")
-    DBPeriod = jpy.get_type("io.deephaveb.db.tables.utils.DBPeriod")
+    DBPeriod = jpy.get_type("io.deephaven.db.tables.utils.DBPeriod")
 
 # every module method should be decorated with @_passThrough
 @wrapt.decorator

--- a/Integrations/python/deephaven/DBTimeUtils/__init__.py
+++ b/Integrations/python/deephaven/DBTimeUtils/__init__.py
@@ -27,6 +27,7 @@ import wrapt
 _java_type_ = None  # None until the first define_symbols() call
 DBTimeZone = None  #: Deephaven timezone class (io.deephaven.db.tables.utils.DBTimeZone).
 DBDateTime = None  #: Deephaven date-time class (io.deephaven.db.tables.utils.DBDateTime).
+DBPeriod = None    #: Deephaven time period class (io.deephaven.db.tables.utils.DBPeriod).
 
 SECOND = 1000000000  #: One second in nanoseconds.
 MINUTE = 60*SECOND   #: One minute in nanoseconds.
@@ -46,14 +47,14 @@ def _defineSymbols():
     if not jpy.has_jvm():
         raise SystemError("No java functionality can be used until the JVM has been initialized through the jpy module")
 
-    global _java_type_, DBTimeZone
+    global _java_type_, DBTimeZone, DBDateTime, DBPeriod
     if _java_type_ is not None:
         return
     # This will raise an exception if the desired object is not the classpath
     _java_type_ = jpy.get_type("io.deephaven.db.tables.utils.DBTimeUtils")
     DBTimeZone = jpy.get_type("io.deephaven.db.tables.utils.DBTimeZone")
     DBDateTime = jpy.get_type("io.deephaven.db.tables.utils.DBDateTime")
-
+    DBPeriod = jpy.get_type("io.deephaveb.db.tables.utils.DBPeriod")
 
 # every module method should be decorated with @_passThrough
 @wrapt.decorator

--- a/Integrations/python/deephaven/DBTimeUtils/__init__.py
+++ b/Integrations/python/deephaven/DBTimeUtils/__init__.py
@@ -54,7 +54,7 @@ def _defineSymbols():
     _java_type_ = jpy.get_type("io.deephaven.db.tables.utils.DBTimeUtils")
     DBTimeZone = jpy.get_type("io.deephaven.db.tables.utils.DBTimeZone")
     DBDateTime = jpy.get_type("io.deephaven.db.tables.utils.DBDateTime")
-    DBPeriod = jpy.get_type("io.deephaveb.db.tables.utils.DBPeriod")
+    DBPeriod = jpy.get_type("io.deephaven.db.tables.utils.DBPeriod")
 
 # every module method should be decorated with @_passThrough
 @wrapt.decorator

--- a/Integrations/python/deephaven/Types.py
+++ b/Integrations/python/deephaven/Types.py
@@ -63,7 +63,7 @@ float32_array = None
 double_array = None
 float64_array = None
 string_array = None
-java_types = None
+_type2jtype = None
 
 
 def _typeFromJavaClassName(name : str):
@@ -81,7 +81,7 @@ def _defineSymbols():
         string, bigdecimal, stringset, datetime, timeperiod, \
         byte_array, short_array, int16_array, int_array, int32_array, long_array, int64_array, \
         float_array, single_array, float32_array, double_array, float64_array, string_array, \
-        java_types
+        _type2jtype
 
     if _table_tools_ is None:
         # This will raise an exception if the desired object is not the classpath
@@ -131,7 +131,7 @@ def _defineSymbols():
         float64_array = double_array
         string_array = DataType(string.arrayType())
 
-        java_types = {
+        _type2jtype = {
             bool_ : jpy.get_type('java.lang.Boolean'),
             byte : jpy.get_type('byte'),
             short : jpy.get_type('short'),
@@ -192,7 +192,7 @@ def _jclassFromType(data_type : DataType):
 def _jpyTypeFromType(data_type : DataType):
     if data_type is None:
         return None
-    jpy_type = java_types.get(data_type, None)
+    jpy_type = _type2jtype.get(data_type, None)
     if jpy_type is not None:
         return jpy_type
     jclass = _jclassFromType(data_type)

--- a/Integrations/python/deephaven/Types.py
+++ b/Integrations/python/deephaven/Types.py
@@ -49,6 +49,7 @@ string = None
 bigdecimal = None
 stringset = None
 datetime = None
+timeperiod = None
 byte_array = None
 short_array = None
 int16_array = None
@@ -77,7 +78,7 @@ def _defineSymbols():
         _qst_column_, _qst_newtable_, _qst_type_, _table_, \
         DataType, bool_, byte, short, int16, char, int_, int32, long_, int64, \
         float_, single, float32, double, float64, \
-        string, bigdecimal, stringset, datetime, \
+        string, bigdecimal, stringset, datetime, timeperiod, \
         byte_array, short_array, int16_array, int_array, int32_array, long_array, int64_array, \
         float_array, single_array, float32_array, double_array, float64_array, string_array, \
         _type2jtype
@@ -113,6 +114,7 @@ def _defineSymbols():
         bigdecimal = _typeFromJavaClassName('java.math.BigDecimal')
         stringset =  _typeFromJavaClassName('io.deephaven.db.tables.libs.StringSet')
         datetime = _typeFromJavaClassName('io.deephaven.db.tables.utils.DBDateTime')
+        timeperiod = _typeFromJavaClassName('io.deephaven.db.tables.utils.DBPeriod')
 
         # Array types.
         byte_array = DataType(byte.arrayType())
@@ -141,6 +143,7 @@ def _defineSymbols():
             bigdecimal : jpy.get_type('java.math.BigDecimal'),
             stringset : jpy.get_type('io.deephaven.db.tables.libs.StringSet'),
             datetime : jpy.get_type('io.deephaven.db.tables.utils.DBDateTime'),
+            timeperiod : jpy.get_type('io.deephaven.db.tables.utils.DBPeriod'),
             byte_array : jpy.get_type('[B'),
             short_array : jpy.get_type('[S'),
             int_array : jpy.get_type('[I'),

--- a/Integrations/python/deephaven/Types.py
+++ b/Integrations/python/deephaven/Types.py
@@ -63,7 +63,7 @@ float32_array = None
 double_array = None
 float64_array = None
 string_array = None
-_type2jtype = None
+java_types = None
 
 
 def _typeFromJavaClassName(name : str):
@@ -81,7 +81,7 @@ def _defineSymbols():
         string, bigdecimal, stringset, datetime, timeperiod, \
         byte_array, short_array, int16_array, int_array, int32_array, long_array, int64_array, \
         float_array, single_array, float32_array, double_array, float64_array, string_array, \
-        _type2jtype
+        java_types
 
     if _table_tools_ is None:
         # This will raise an exception if the desired object is not the classpath
@@ -131,7 +131,7 @@ def _defineSymbols():
         float64_array = double_array
         string_array = DataType(string.arrayType())
 
-        _type2jtype = {
+        java_types = {
             bool_ : jpy.get_type('java.lang.Boolean'),
             byte : jpy.get_type('byte'),
             short : jpy.get_type('short'),
@@ -192,7 +192,7 @@ def _jclassFromType(data_type : DataType):
 def _jpyTypeFromType(data_type : DataType):
     if data_type is None:
         return None
-    jpy_type = _type2jtype.get(data_type, None)
+    jpy_type = java_types.get(data_type, None)
     if jpy_type is not None:
         return jpy_type
     jclass = _jclassFromType(data_type)


### PR DESCRIPTION
This adds DBPeriod to deephaven.Types.

In order to get the Java class, use the following code snippet:

```
import deephaven.Types as dht

DBPeriod = dht._type2jtype[dht.timeperiod]
```

Another option:

```
import deephaven.Types as dht
from deephaven.Types import _type2jtype as jtypes

DBPeriod = jtypes[dht.timeperiod]
```