### PR TITLE
Avoid leaving behind a failed consumer.

### DIFF
--- a/Kafka/src/main/java/io/deephaven/kafka/ingest/KafkaIngester.java
+++ b/Kafka/src/main/java/io/deephaven/kafka/ingest/KafkaIngester.java
@@ -279,8 +279,8 @@ public class KafkaIngester {
             final long beforePoll = System.nanoTime();
             final long nextReport = lastReportNanos + reportIntervalNanos;
             final long remainingNanos = beforePoll > nextReport ? 0 : (nextReport - beforePoll);
-            boolean noMore = pollOnce(Duration.ofNanos(remainingNanos));
-            if (noMore) {
+            boolean more = pollOnce(Duration.ofNanos(remainingNanos));
+            if (!more) {
                 log.error().append(logPrefix)
                         .append("Stopping due to errors (").append(messagesWithErr)
                         .append(" messages with error out of ").append(messagesProcessed).append(" messages processed)")
@@ -308,19 +308,19 @@ public class KafkaIngester {
     /**
      *
      * @param timeout
-     * @return true if we should abort the consumer thread.
+     * @return True if we should continue processing messages; false if we should abort the consumer thread.
      */
     private boolean pollOnce(final Duration timeout) {
         final ConsumerRecords<?, ?> records;
         try {
             records = consumer.poll(timeout);
         } catch (WakeupException we) {
-            // we interpret this as a signal to stop.
-            return false;
+            // we interpret a wakeup as a signal to stop /this/ poll.
+            return true;
         } catch (Exception ex) {
             log.error().append(logPrefix).append("Exception while polling for Kafka messages:").append(ex)
                     .append(", aborting.");
-            return true;
+            return false;
         }
 
         for (final TopicPartition topicPartition : records.partitions()) {
@@ -346,12 +346,12 @@ public class KafkaIngester {
                     consumer.acceptFailure(ex);
                     log.error().append(logPrefix)
                             .append("Max number of errors exceeded, aborting " + this + " consumer thread.");
-                    return true;
+                    return false;
                 }
                 continue;
             }
             messagesProcessed += partitionRecords.size();
         }
-        return false;
+        return true;
     }
 }

--- a/Kafka/src/main/java/io/deephaven/kafka/ingest/KafkaIngester.java
+++ b/Kafka/src/main/java/io/deephaven/kafka/ingest/KafkaIngester.java
@@ -320,7 +320,7 @@ public class KafkaIngester {
         } catch (Exception ex) {
             log.error().append(logPrefix).append("Exception while polling for Kafka messages:").append(ex)
                     .append(", aborting.");
-            return false;
+            return true;
         }
 
         for (final TopicPartition topicPartition : records.partitions()) {


### PR DESCRIPTION
See code; if we return false at this point, the consumer never recovers without further intervention in the KafkaConsumer state; having one failed message should be recoverable but we need to explore how to make that happen, I created a separate issue for it https://github.com/deephaven/deephaven-core/issues/1325