### PR TITLE
Avoid log4j dropping warnings in the console for dependent libraries.

### DIFF
--- a/log-factory/sinks/log-to-slf4j/build.gradle
+++ b/log-factory/sinks/log-to-slf4j/build.gradle
@@ -7,5 +7,6 @@ dependencies {
 	// internal logger, that is in service of the ServiceLoader - and if consumers should not need
 	// access to the internal logger.
 	implementation project(':log-factory')
+	compileOnly 'org.slf4j:slf4j-api:1.7.30' // users must provide their own impl and slf4j config
 	compileOnly 'ch.qos.logback:logback-classic:1.2.3' // so we can attach an interceptor, if supported
 }


### PR DESCRIPTION
Thanks to Devin for the idea behind how to fix this.   In the example below, our dependency to Apache HttpClient from the Kafka module triggers a warning the first time it is used when we are making the first call to `consumeToTable` on the console.

Without this fix:

![Deephaven - Google Chrome_107](https://user-images.githubusercontent.com/37232625/134235238-58afcc64-990a-4d96-a1a3-67d4de3aef65.png)

With this fix:

![Deephaven - Google Chrome_106](https://user-images.githubusercontent.com/37232625/134235247-e47223fa-3924-4f88-9325-c5d4ac046cd2.png)

