### PR TITLE
Move default nginx root outside of first location

### DIFF
--- a/web/client-ide/nginx/default.conf
+++ b/web/client-ide/nginx/default.conf
@@ -8,8 +8,8 @@ server {
     # Redirect from / to the IDE
     rewrite ^/$ /ide/ redirect;
 
+    root   /usr/share/nginx/html;
     location / {
-        root   /usr/share/nginx/html;
         index  index.html index.htm;
 
         # Caching is taken care of by etags


### PR DESCRIPTION
According to https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#root-inside-location-block

It is bad practice to declare the primary `root` inside of each `location` of an nginx.conf.

Note that this block does not specify a location, but should share the same location as the `/` location.
```
    location ~* \.chunk.(?:css|js)$ {
        expires 1y;
        add_header Cache-Control 'public, immutable, max-age=31536000';
    }
```

Took me a hot minute to find out why I couldn't fetch static resources from a non-default location.