### PR TITLE
Don't print out on our re-directed stdout/stderr, print out on the or…

### DIFF
--- a/Base/src/main/java/io/deephaven/base/system/StandardStreamState.java
+++ b/Base/src/main/java/io/deephaven/base/system/StandardStreamState.java
@@ -42,16 +42,16 @@ public class StandardStreamState {
         if (!outReceivers.isEmpty()) {
             PrintStream out = adapt(outReceivers);
             if (out != System.out) {
+                System.out.println("# New System.out configured");
                 System.setOut(out);
-                out.println("# New System.out configured");
             }
         }
 
         if (!errReceivers.isEmpty()) {
             PrintStream err = adapt(errReceivers);
             if (err != System.err) {
+                System.err.println("# New System.err configured");
                 System.setErr(err);
-                err.println("# New System.err configured");
             }
         }
     }


### PR DESCRIPTION
…iginal stdout/stderr. This will ensure we don't redirect these messages to the web console.