### PR TITLE
Rework QueryConstants to add missing values and to remove improper values

### DIFF
--- a/DB/src/main/java/io/deephaven/libs/primitives/ByteNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/ByteNumericPrimitives.java
@@ -1903,7 +1903,7 @@ public class ByteNumericPrimitives {
             return NULL_BYTE;
         }
 
-        byte val = NEG_INF_BYTE;
+        byte val = MIN_BYTE;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             byte c = values.get(i);
@@ -1927,7 +1927,7 @@ public class ByteNumericPrimitives {
             return NULL_BYTE;
         }
 
-        byte val = NEG_INF_BYTE;
+        byte val = MIN_BYTE;
         long count = 0;
         for (byte c : values) {
             if (!BytePrimitives.isNull(c)) {
@@ -1950,7 +1950,7 @@ public class ByteNumericPrimitives {
             return NULL_BYTE;
         }
 
-        byte val = NEG_INF_BYTE;
+        byte val = MIN_BYTE;
         long count = 0;
         for (Byte c : values) {
             if (!(c == null || BytePrimitives.isNull(c))) {
@@ -1973,7 +1973,7 @@ public class ByteNumericPrimitives {
             return NULL_BYTE;
         }
 
-        byte val = POS_INF_BYTE;
+        byte val = MAX_BYTE;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             byte c = values.get(i);
@@ -1997,7 +1997,7 @@ public class ByteNumericPrimitives {
             return NULL_BYTE;
         }
 
-        byte val = POS_INF_BYTE;
+        byte val = MAX_BYTE;
         long count = 0;
         for (byte c : values) {
             if (!BytePrimitives.isNull(c)) {
@@ -2020,7 +2020,7 @@ public class ByteNumericPrimitives {
             return NULL_BYTE;
         }
 
-        byte val = POS_INF_BYTE;
+        byte val = MAX_BYTE;
         long count = 0;
         for (Byte c : values) {
             if (!(c == null || BytePrimitives.isNull(c))) {
@@ -2192,7 +2192,7 @@ public class ByteNumericPrimitives {
             return NULL_INT;
         }
 
-        byte val = NEG_INF_BYTE;
+        byte val = MIN_BYTE;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2232,7 +2232,7 @@ public class ByteNumericPrimitives {
             return NULL_INT;
         }
 
-        byte val = NEG_INF_BYTE;
+        byte val = MIN_BYTE;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
@@ -2258,7 +2258,7 @@ public class ByteNumericPrimitives {
             return NULL_INT;
         }
 
-        byte val = POS_INF_BYTE;
+        byte val = MAX_BYTE;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2298,7 +2298,7 @@ public class ByteNumericPrimitives {
             return NULL_INT;
         }
 
-        byte val = POS_INF_BYTE;
+        byte val = MAX_BYTE;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/DB/src/main/java/io/deephaven/libs/primitives/DoubleNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/DoubleNumericPrimitives.java
@@ -1817,7 +1817,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = NEG_INF_DOUBLE;
+        double val = NEGATIVE_INFINITY_DOUBLE;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             double c = values.get(i);
@@ -1841,7 +1841,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = NEG_INF_DOUBLE;
+        double val = NEGATIVE_INFINITY_DOUBLE;
         long count = 0;
         for (double c : values) {
             if (!(Double.isNaN(c) || DoublePrimitives.isNull(c))) {
@@ -1864,7 +1864,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = NEG_INF_DOUBLE;
+        double val = NEGATIVE_INFINITY_DOUBLE;
         long count = 0;
         for (Double c : values) {
             if (!(c == null || Double.isNaN(c) || DoublePrimitives.isNull(c))) {
@@ -1887,7 +1887,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = POS_INF_DOUBLE;
+        double val = MAX_DOUBLE;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             double c = values.get(i);
@@ -1911,7 +1911,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = POS_INF_DOUBLE;
+        double val = MAX_DOUBLE;
         long count = 0;
         for (double c : values) {
             if (!(Double.isNaN(c) || DoublePrimitives.isNull(c))) {
@@ -1934,7 +1934,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = POS_INF_DOUBLE;
+        double val = MAX_DOUBLE;
         long count = 0;
         for (Double c : values) {
             if (!(c == null || Double.isNaN(c) || DoublePrimitives.isNull(c))) {
@@ -2102,7 +2102,7 @@ public class DoubleNumericPrimitives {
             return NULL_INT;
         }
 
-        double val = NEG_INF_DOUBLE;
+        double val = NEGATIVE_INFINITY_DOUBLE;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
@@ -2152,7 +2152,7 @@ public class DoubleNumericPrimitives {
             return NULL_INT;
         }
 
-        double val = POS_INF_DOUBLE;
+        double val = MAX_DOUBLE;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/DB/src/main/java/io/deephaven/libs/primitives/DoubleNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/DoubleNumericPrimitives.java
@@ -1887,7 +1887,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = MAX_DOUBLE;
+        double val = POSITIVE_INFINITY_DOUBLE;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             double c = values.get(i);
@@ -1911,7 +1911,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = MAX_DOUBLE;
+        double val = POSITIVE_INFINITY_DOUBLE;
         long count = 0;
         for (double c : values) {
             if (!(Double.isNaN(c) || DoublePrimitives.isNull(c))) {
@@ -1934,7 +1934,7 @@ public class DoubleNumericPrimitives {
             return NULL_DOUBLE;
         }
 
-        double val = MAX_DOUBLE;
+        double val = POSITIVE_INFINITY_DOUBLE;
         long count = 0;
         for (Double c : values) {
             if (!(c == null || Double.isNaN(c) || DoublePrimitives.isNull(c))) {
@@ -2152,7 +2152,7 @@ public class DoubleNumericPrimitives {
             return NULL_INT;
         }
 
-        double val = MAX_DOUBLE;
+        double val = POSITIVE_INFINITY_DOUBLE;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/DB/src/main/java/io/deephaven/libs/primitives/FloatNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/FloatNumericPrimitives.java
@@ -1884,7 +1884,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = MAX_FLOAT;
+        float val = POSITIVE_INFINITY_FLOAT;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             float c = values.get(i);
@@ -1908,7 +1908,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = MAX_FLOAT;
+        float val = POSITIVE_INFINITY_FLOAT;
         long count = 0;
         for (float c : values) {
             if (!(Float.isNaN(c) || FloatPrimitives.isNull(c))) {
@@ -1931,7 +1931,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = MAX_FLOAT;
+        float val = POSITIVE_INFINITY_FLOAT;
         long count = 0;
         for (Float c : values) {
             if (!(c == null || Float.isNaN(c) || FloatPrimitives.isNull(c))) {
@@ -2149,7 +2149,7 @@ public class FloatNumericPrimitives {
             return NULL_INT;
         }
 
-        float val = MAX_FLOAT;
+        float val = POSITIVE_INFINITY_FLOAT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/DB/src/main/java/io/deephaven/libs/primitives/FloatNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/FloatNumericPrimitives.java
@@ -1814,7 +1814,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = NEG_INF_FLOAT;
+        float val = NEGATIVE_INFINITY_FLOAT;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             float c = values.get(i);
@@ -1838,7 +1838,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = NEG_INF_FLOAT;
+        float val = NEGATIVE_INFINITY_FLOAT;
         long count = 0;
         for (float c : values) {
             if (!(Float.isNaN(c) || FloatPrimitives.isNull(c))) {
@@ -1861,7 +1861,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = NEG_INF_FLOAT;
+        float val = NEGATIVE_INFINITY_FLOAT;
         long count = 0;
         for (Float c : values) {
             if (!(c == null || Float.isNaN(c) || FloatPrimitives.isNull(c))) {
@@ -1884,7 +1884,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = POS_INF_FLOAT;
+        float val = MAX_FLOAT;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             float c = values.get(i);
@@ -1908,7 +1908,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = POS_INF_FLOAT;
+        float val = MAX_FLOAT;
         long count = 0;
         for (float c : values) {
             if (!(Float.isNaN(c) || FloatPrimitives.isNull(c))) {
@@ -1931,7 +1931,7 @@ public class FloatNumericPrimitives {
             return NULL_FLOAT;
         }
 
-        float val = POS_INF_FLOAT;
+        float val = MAX_FLOAT;
         long count = 0;
         for (Float c : values) {
             if (!(c == null || Float.isNaN(c) || FloatPrimitives.isNull(c))) {
@@ -2099,7 +2099,7 @@ public class FloatNumericPrimitives {
             return NULL_INT;
         }
 
-        float val = NEG_INF_FLOAT;
+        float val = NEGATIVE_INFINITY_FLOAT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
@@ -2149,7 +2149,7 @@ public class FloatNumericPrimitives {
             return NULL_INT;
         }
 
-        float val = POS_INF_FLOAT;
+        float val = MAX_FLOAT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/DB/src/main/java/io/deephaven/libs/primitives/IntegerNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/IntegerNumericPrimitives.java
@@ -1903,7 +1903,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = NEG_INF_INT;
+        int val = MIN_INT;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             int c = values.get(i);
@@ -1927,7 +1927,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = NEG_INF_INT;
+        int val = MIN_INT;
         long count = 0;
         for (int c : values) {
             if (!IntegerPrimitives.isNull(c)) {
@@ -1950,7 +1950,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = NEG_INF_INT;
+        int val = MIN_INT;
         long count = 0;
         for (Integer c : values) {
             if (!(c == null || IntegerPrimitives.isNull(c))) {
@@ -1973,7 +1973,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = POS_INF_INT;
+        int val = MAX_INT;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             int c = values.get(i);
@@ -1997,7 +1997,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = POS_INF_INT;
+        int val = MAX_INT;
         long count = 0;
         for (int c : values) {
             if (!IntegerPrimitives.isNull(c)) {
@@ -2020,7 +2020,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = POS_INF_INT;
+        int val = MAX_INT;
         long count = 0;
         for (Integer c : values) {
             if (!(c == null || IntegerPrimitives.isNull(c))) {
@@ -2192,7 +2192,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = NEG_INF_INT;
+        int val = MIN_INT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2232,7 +2232,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = NEG_INF_INT;
+        int val = MIN_INT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
@@ -2258,7 +2258,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = POS_INF_INT;
+        int val = MAX_INT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2298,7 +2298,7 @@ public class IntegerNumericPrimitives {
             return NULL_INT;
         }
 
-        int val = POS_INF_INT;
+        int val = MAX_INT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/DB/src/main/java/io/deephaven/libs/primitives/LongNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/LongNumericPrimitives.java
@@ -1903,7 +1903,7 @@ public class LongNumericPrimitives {
             return NULL_LONG;
         }
 
-        long val = NEG_INF_LONG;
+        long val = MIN_LONG;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             long c = values.get(i);
@@ -1927,7 +1927,7 @@ public class LongNumericPrimitives {
             return NULL_LONG;
         }
 
-        long val = NEG_INF_LONG;
+        long val = MIN_LONG;
         long count = 0;
         for (long c : values) {
             if (!LongPrimitives.isNull(c)) {
@@ -1950,7 +1950,7 @@ public class LongNumericPrimitives {
             return NULL_LONG;
         }
 
-        long val = NEG_INF_LONG;
+        long val = MIN_LONG;
         long count = 0;
         for (Long c : values) {
             if (!(c == null || LongPrimitives.isNull(c))) {
@@ -1973,7 +1973,7 @@ public class LongNumericPrimitives {
             return NULL_LONG;
         }
 
-        long val = POS_INF_LONG;
+        long val = MAX_LONG;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             long c = values.get(i);
@@ -1997,7 +1997,7 @@ public class LongNumericPrimitives {
             return NULL_LONG;
         }
 
-        long val = POS_INF_LONG;
+        long val = MAX_LONG;
         long count = 0;
         for (long c : values) {
             if (!LongPrimitives.isNull(c)) {
@@ -2020,7 +2020,7 @@ public class LongNumericPrimitives {
             return NULL_LONG;
         }
 
-        long val = POS_INF_LONG;
+        long val = MAX_LONG;
         long count = 0;
         for (Long c : values) {
             if (!(c == null || LongPrimitives.isNull(c))) {
@@ -2192,7 +2192,7 @@ public class LongNumericPrimitives {
             return NULL_INT;
         }
 
-        long val = NEG_INF_LONG;
+        long val = MIN_LONG;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2232,7 +2232,7 @@ public class LongNumericPrimitives {
             return NULL_INT;
         }
 
-        long val = NEG_INF_LONG;
+        long val = MIN_LONG;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
@@ -2258,7 +2258,7 @@ public class LongNumericPrimitives {
             return NULL_INT;
         }
 
-        long val = POS_INF_LONG;
+        long val = MAX_LONG;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2298,7 +2298,7 @@ public class LongNumericPrimitives {
             return NULL_INT;
         }
 
-        long val = POS_INF_LONG;
+        long val = MAX_LONG;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/DB/src/main/java/io/deephaven/libs/primitives/ShortNumericPrimitives.java
+++ b/DB/src/main/java/io/deephaven/libs/primitives/ShortNumericPrimitives.java
@@ -1900,7 +1900,7 @@ public class ShortNumericPrimitives {
             return NULL_SHORT;
         }
 
-        short val = NEG_INF_SHORT;
+        short val = MIN_SHORT;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             short c = values.get(i);
@@ -1924,7 +1924,7 @@ public class ShortNumericPrimitives {
             return NULL_SHORT;
         }
 
-        short val = NEG_INF_SHORT;
+        short val = MIN_SHORT;
         long count = 0;
         for (short c : values) {
             if (!ShortPrimitives.isNull(c)) {
@@ -1947,7 +1947,7 @@ public class ShortNumericPrimitives {
             return NULL_SHORT;
         }
 
-        short val = NEG_INF_SHORT;
+        short val = MIN_SHORT;
         long count = 0;
         for (Short c : values) {
             if (!(c == null || ShortPrimitives.isNull(c))) {
@@ -1970,7 +1970,7 @@ public class ShortNumericPrimitives {
             return NULL_SHORT;
         }
 
-        short val = POS_INF_SHORT;
+        short val = MAX_SHORT;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
             short c = values.get(i);
@@ -1994,7 +1994,7 @@ public class ShortNumericPrimitives {
             return NULL_SHORT;
         }
 
-        short val = POS_INF_SHORT;
+        short val = MAX_SHORT;
         long count = 0;
         for (short c : values) {
             if (!ShortPrimitives.isNull(c)) {
@@ -2017,7 +2017,7 @@ public class ShortNumericPrimitives {
             return NULL_SHORT;
         }
 
-        short val = POS_INF_SHORT;
+        short val = MAX_SHORT;
         long count = 0;
         for (Short c : values) {
             if (!(c == null || ShortPrimitives.isNull(c))) {
@@ -2189,7 +2189,7 @@ public class ShortNumericPrimitives {
             return NULL_INT;
         }
 
-        short val = NEG_INF_SHORT;
+        short val = MIN_SHORT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2229,7 +2229,7 @@ public class ShortNumericPrimitives {
             return NULL_INT;
         }
 
-        short val = NEG_INF_SHORT;
+        short val = MIN_SHORT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {
@@ -2255,7 +2255,7 @@ public class ShortNumericPrimitives {
             return NULL_INT;
         }
 
-        short val = POS_INF_SHORT;
+        short val = MAX_SHORT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.length; i++) {
@@ -2295,7 +2295,7 @@ public class ShortNumericPrimitives {
             return NULL_INT;
         }
 
-        short val = POS_INF_SHORT;
+        short val = MAX_SHORT;
         int index = -1;
         long count = 0;
         for (int i = 0; i < values.size(); i++) {

--- a/Util/src/main/java/io/deephaven/util/QueryConstants.java
+++ b/Util/src/main/java/io/deephaven/util/QueryConstants.java
@@ -12,6 +12,7 @@ public class QueryConstants {
 
     /////////////////////////////////////////////////////////////////
 
+
     /**
      * Null boolean value.
      */
@@ -27,44 +28,19 @@ public class QueryConstants {
     public static final char NULL_CHAR = Character.MAX_VALUE - 1;
 
     /**
-     * Null byte value.
+     * Null boxed Character value.
      */
-    public static final byte NULL_BYTE = Byte.MIN_VALUE;
-
-    /**
-     * Null short value.
-     */
-    public static final short NULL_SHORT = Short.MIN_VALUE;
-    
-    /**
-     * Null int value.
-     */
-    public static final int NULL_INT = Integer.MIN_VALUE;
-
-    /**
-     * Null long value.
-     */
-    public static final long NULL_LONG = Long.MIN_VALUE;
-
-    /**
-     * Null float value.
-     */
-    public static final float NULL_FLOAT = -Float.MAX_VALUE;
-
-    /**
-     * Null double value.
-     */
-    public static final double NULL_DOUBLE = -Double.MAX_VALUE;
+    @SuppressWarnings("unused")
+    public static final Character NULL_CHAR_BOXED = NULL_CHAR;
 
 
     /////////////////////////////////////////////////////////////////
 
 
     /**
-     * Null boxed Character value.
+     * Null byte value.
      */
-    @SuppressWarnings("unused")
-    public static final Character NULL_CHAR_BOXED = NULL_CHAR;
+    public static final byte NULL_BYTE = Byte.MIN_VALUE;
 
     /**
      * Null boxed Byte value.
@@ -73,39 +49,29 @@ public class QueryConstants {
     public static final Byte NULL_BYTE_BOXED = NULL_BYTE;
 
     /**
-     * Null boxed Short value.
+     * Maximum value of type byte.
      */
-    @SuppressWarnings("unused")
-    public static final Short NULL_SHORT_BOXED = NULL_SHORT;
+    public static final byte MAX_BYTE = Byte.MAX_VALUE;
 
     /**
-     * Null boxed Integer value.
+     * Minimum value of type byte.
      */
-    public static final Integer NULL_INT_BOXED = NULL_INT;
-
-    /**
-     * Null boxed Long value.
-     */
-    public static final Long NULL_LONG_BOXED = NULL_LONG;
-
-    /**
-     * Null boxed Float value.
-     */
-    public static final Float NULL_FLOAT_BOXED = NULL_FLOAT;
-
-    /**
-     * Null boxed Double value.
-     */
-    public static final Double NULL_DOUBLE_BOXED = NULL_DOUBLE;
+    public static final byte MIN_BYTE = Byte.MIN_VALUE + 1;
 
 
     /////////////////////////////////////////////////////////////////
 
 
     /**
-     * Maximum value of type byte.
+     * Null short value.
      */
-    public static final byte MAX_BYTE = Byte.MAX_VALUE;
+    public static final short NULL_SHORT = Short.MIN_VALUE;
+    
+    /**
+     * Null boxed Short value.
+     */
+    @SuppressWarnings("unused")
+    public static final Short NULL_SHORT_BOXED = NULL_SHORT;
 
     /**
      * Maximum value of type short.
@@ -113,9 +79,47 @@ public class QueryConstants {
     public static final short MAX_SHORT = Short.MAX_VALUE;
 
     /**
+     * Minimum value of type short.
+     */
+    public static final short MIN_SHORT = Short.MIN_VALUE + 1;
+
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Null int value.
+     */
+    public static final int NULL_INT = Integer.MIN_VALUE;
+
+    /**
+     * Null boxed Integer value.
+     */
+    public static final Integer NULL_INT_BOXED = NULL_INT;
+
+    /**
      * Maximum value of type int.
      */
     public static final int MAX_INT = Integer.MAX_VALUE;
+
+    /**
+     * Minimum value of type int.
+     */
+    public static final int MIN_INT = Integer.MIN_VALUE + 1;
+
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Null long value.
+     */
+    public static final long NULL_LONG = Long.MIN_VALUE;
+
+    /**
+     * Null boxed Long value.
+     */
+    public static final Long NULL_LONG_BOXED = NULL_LONG;
 
     /**
      * Maximum value of type long.
@@ -123,38 +127,28 @@ public class QueryConstants {
     public static final long MAX_LONG = Long.MAX_VALUE;
 
     /**
-     * Maximum finite value of type float.
+     * Minimum value of type long.
      */
-    public static final float MAX_FLOAT = Float.MAX_VALUE;
-
-    /**
-     * Maximum finite value of type double.
-     */
-    public static final double MAX_DOUBLE = Double.MAX_VALUE;
+    public static final long MIN_LONG = Long.MIN_VALUE + 1;
 
 
     /////////////////////////////////////////////////////////////////
 
 
     /**
-     * Minimum value of type byte.
+     * Null float value.
      */
-    public static final byte MIN_BYTE = Byte.MIN_VALUE + 1;
+    public static final float NULL_FLOAT = -Float.MAX_VALUE;
 
     /**
-     * Minimum value of type short.
+     * Null boxed Float value.
      */
-    public static final short MIN_SHORT = Short.MIN_VALUE + 1;
+    public static final Float NULL_FLOAT_BOXED = NULL_FLOAT;
 
     /**
-     * Minimum value of type int.
+     * Maximum finite value of type float.
      */
-    public static final int MIN_INT = Integer.MIN_VALUE + 1;
-
-    /**
-     * Minimum value of type long.
-     */
-    public static final long MIN_LONG = Long.MIN_VALUE + 1;
+    public static final float MAX_FLOAT = Float.MAX_VALUE;
 
     /**
      * Minimum finite value of type float.
@@ -162,27 +156,9 @@ public class QueryConstants {
     public static final float MIN_FLOAT = Float.valueOf("-0x1.fffffdp127");
 
     /**
-     * Minimum finite value of type double.
-     */
-    public static final double MIN_DOUBLE = Double.valueOf("-0x1.ffffffffffffep1023");
-
-
-    /////////////////////////////////////////////////////////////////
-
-
-    /**
      * Positive infinity of type float.
      */
     public static final float POSITIVE_INFINITY_FLOAT = Float.POSITIVE_INFINITY;
-
-    /**
-     * Positive infinity of type double.
-     */
-    public static final double POSITIVE_INFINITY_DOUBLE = Double.POSITIVE_INFINITY;
-
-
-    /////////////////////////////////////////////////////////////////
-
 
     /**
      * Negative infinity of type float.
@@ -190,18 +166,42 @@ public class QueryConstants {
     public static final float NEGATIVE_INFINITY_FLOAT = Float.NEGATIVE_INFINITY;
 
     /**
-     * Negative infinity of type double.
+     * Not-a-Number (NaN) of type float.
      */
-    public static final double NEGATIVE_INFINITY_DOUBLE = Double.NEGATIVE_INFINITY;
-
+    public static final float NAN_FLOAT = Float.NaN;
 
     /////////////////////////////////////////////////////////////////
 
 
     /**
-     * Not-a-Number (NaN) of type float.
+     * Null double value.
      */
-    public static final float NAN_FLOAT = Float.NaN;
+    public static final double NULL_DOUBLE = -Double.MAX_VALUE;
+
+    /**
+     * Null boxed Double value.
+     */
+    public static final Double NULL_DOUBLE_BOXED = NULL_DOUBLE;
+
+    /**
+     * Maximum finite value of type double.
+     */
+    public static final double MAX_DOUBLE = Double.MAX_VALUE;
+
+    /**
+     * Minimum finite value of type double.
+     */
+    public static final double MIN_DOUBLE = Double.valueOf("-0x1.ffffffffffffep1023");
+
+    /**
+     * Positive infinity of type double.
+     */
+    public static final double POSITIVE_INFINITY_DOUBLE = Double.POSITIVE_INFINITY;
+
+    /**
+     * Negative infinity of type double.
+     */
+    public static final double NEGATIVE_INFINITY_DOUBLE = Double.NEGATIVE_INFINITY;
 
     /**
      * Not-a-Number (NaN) of type double.

--- a/Util/src/main/java/io/deephaven/util/QueryConstants.java
+++ b/Util/src/main/java/io/deephaven/util/QueryConstants.java
@@ -9,6 +9,8 @@ public class QueryConstants {
      */
     protected QueryConstants() {}
 
+    //todo document
+
     public static final Boolean NULL_BOOLEAN = null;
     public static final char NULL_CHAR = Character.MAX_VALUE - 1;
     public static final byte NULL_BYTE = Byte.MIN_VALUE;
@@ -29,17 +31,26 @@ public class QueryConstants {
     public static final Float NULL_FLOAT_BOXED = NULL_FLOAT;
     public static final Double NULL_DOUBLE_BOXED = NULL_DOUBLE;
 
-    public static final byte POS_INF_BYTE = Byte.MAX_VALUE;
-    public static final short POS_INF_SHORT = Short.MAX_VALUE;
-    public static final int POS_INF_INT = Integer.MAX_VALUE;
-    public static final long POS_INF_LONG = Long.MAX_VALUE;
-    public static final float POS_INF_FLOAT = Float.POSITIVE_INFINITY;
-    public static final double POS_INF_DOUBLE = Double.POSITIVE_INFINITY;
+    public static final byte MAX_BYTE = Byte.MAX_VALUE;
+    public static final short MAX_SHORT = Short.MAX_VALUE;
+    public static final int MAX_INT = Integer.MAX_VALUE;
+    public static final long MAX_LONG = Long.MAX_VALUE;
+    public static final float MAX_FLOAT = Float.MAX_VALUE;
+    public static final double MAX_DOUBLE = Double.MAX_VALUE;
 
-    public static final byte NEG_INF_BYTE = Byte.MIN_VALUE;
-    public static final short NEG_INF_SHORT = Short.MIN_VALUE + 1;
-    public static final int NEG_INF_INT = Integer.MIN_VALUE + 1;
-    public static final long NEG_INF_LONG = Long.MIN_VALUE + 1;
-    public static final float NEG_INF_FLOAT = Float.NEGATIVE_INFINITY;
-    public static final double NEG_INF_DOUBLE = Double.NEGATIVE_INFINITY;
+    public static final byte MIN_BYTE = Byte.MIN_VALUE + 1;
+    public static final short MIN_SHORT = Short.MIN_VALUE + 1;
+    public static final int MIN_INT = Integer.MIN_VALUE + 1;
+    public static final long MIN_LONG = Long.MIN_VALUE + 1;
+    public static final float MIN_FLOAT = Float.valueOf("-0x1.fffffdp127");
+    public static final double MIN_DOUBLE = Double.valueOf("-0x1.ffffffffffffep1023");
+
+    public static final float POSITIVE_INFINITY_FLOAT = Float.POSITIVE_INFINITY;
+    public static final double POSITIVE_INFINITY_DOUBLE = Double.POSITIVE_INFINITY;
+
+    public static final float NEGATIVE_INFINITY_FLOAT = Float.NEGATIVE_INFINITY;
+    public static final double NEGATIVE_INFINITY_DOUBLE = Double.NEGATIVE_INFINITY;
+
+    public static final float NAN_FLOAT = Float.NaN;
+    public static final double NAN_DOUBLE = Double.NaN;
 }

--- a/Util/src/main/java/io/deephaven/util/QueryConstants.java
+++ b/Util/src/main/java/io/deephaven/util/QueryConstants.java
@@ -1,56 +1,210 @@
 package io.deephaven.util;
 
 /**
- * Constants for null and infinite values within the Deephaven engine.
+ * Constants for primitive types within the Deephaven engine.  These constants include null values, ranges of values, infinite values, and NaN values.
  */
 public class QueryConstants {
     /**
      * This class should not be instantiated.
      */
-    protected QueryConstants() {}
+    private QueryConstants() {}
 
-    //todo document
 
+    /////////////////////////////////////////////////////////////////
+
+    /**
+     * Null boolean value.
+     */
     public static final Boolean NULL_BOOLEAN = null;
+
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Null char value.
+     */
     public static final char NULL_CHAR = Character.MAX_VALUE - 1;
+
+    /**
+     * Null byte value.
+     */
     public static final byte NULL_BYTE = Byte.MIN_VALUE;
+
+    /**
+     * Null short value.
+     */
     public static final short NULL_SHORT = Short.MIN_VALUE;
+    
+    /**
+     * Null int value.
+     */
     public static final int NULL_INT = Integer.MIN_VALUE;
+
+    /**
+     * Null long value.
+     */
     public static final long NULL_LONG = Long.MIN_VALUE;
+
+    /**
+     * Null float value.
+     */
     public static final float NULL_FLOAT = -Float.MAX_VALUE;
+
+    /**
+     * Null double value.
+     */
     public static final double NULL_DOUBLE = -Double.MAX_VALUE;
 
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Null boxed Character value.
+     */
     @SuppressWarnings("unused")
     public static final Character NULL_CHAR_BOXED = NULL_CHAR;
+
+    /**
+     * Null boxed Byte value.
+     */
     @SuppressWarnings("unused")
     public static final Byte NULL_BYTE_BOXED = NULL_BYTE;
+
+    /**
+     * Null boxed Short value.
+     */
     @SuppressWarnings("unused")
     public static final Short NULL_SHORT_BOXED = NULL_SHORT;
+
+    /**
+     * Null boxed Integer value.
+     */
     public static final Integer NULL_INT_BOXED = NULL_INT;
+
+    /**
+     * Null boxed Long value.
+     */
     public static final Long NULL_LONG_BOXED = NULL_LONG;
+
+    /**
+     * Null boxed Float value.
+     */
     public static final Float NULL_FLOAT_BOXED = NULL_FLOAT;
+
+    /**
+     * Null boxed Double value.
+     */
     public static final Double NULL_DOUBLE_BOXED = NULL_DOUBLE;
 
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Maximum value of type byte.
+     */
     public static final byte MAX_BYTE = Byte.MAX_VALUE;
+
+    /**
+     * Maximum value of type short.
+     */
     public static final short MAX_SHORT = Short.MAX_VALUE;
+
+    /**
+     * Maximum value of type int.
+     */
     public static final int MAX_INT = Integer.MAX_VALUE;
+
+    /**
+     * Maximum value of type long.
+     */
     public static final long MAX_LONG = Long.MAX_VALUE;
+
+    /**
+     * Maximum finite value of type float.
+     */
     public static final float MAX_FLOAT = Float.MAX_VALUE;
+
+    /**
+     * Maximum finite value of type double.
+     */
     public static final double MAX_DOUBLE = Double.MAX_VALUE;
 
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Minimum value of type byte.
+     */
     public static final byte MIN_BYTE = Byte.MIN_VALUE + 1;
+
+    /**
+     * Minimum value of type short.
+     */
     public static final short MIN_SHORT = Short.MIN_VALUE + 1;
+
+    /**
+     * Minimum value of type int.
+     */
     public static final int MIN_INT = Integer.MIN_VALUE + 1;
+
+    /**
+     * Minimum value of type long.
+     */
     public static final long MIN_LONG = Long.MIN_VALUE + 1;
+
+    /**
+     * Minimum finite value of type float.
+     */
     public static final float MIN_FLOAT = Float.valueOf("-0x1.fffffdp127");
+
+    /**
+     * Minimum finite value of type double.
+     */
     public static final double MIN_DOUBLE = Double.valueOf("-0x1.ffffffffffffep1023");
 
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Positive infinity of type float.
+     */
     public static final float POSITIVE_INFINITY_FLOAT = Float.POSITIVE_INFINITY;
+
+    /**
+     * Positive infinity of type double.
+     */
     public static final double POSITIVE_INFINITY_DOUBLE = Double.POSITIVE_INFINITY;
 
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Negative infinity of type float.
+     */
     public static final float NEGATIVE_INFINITY_FLOAT = Float.NEGATIVE_INFINITY;
+
+    /**
+     * Negative infinity of type double.
+     */
     public static final double NEGATIVE_INFINITY_DOUBLE = Double.NEGATIVE_INFINITY;
 
+
+    /////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Not-a-Number (NaN) of type float.
+     */
     public static final float NAN_FLOAT = Float.NaN;
+
+    /**
+     * Not-a-Number (NaN) of type double.
+     */
     public static final double NAN_DOUBLE = Double.NaN;
 }


### PR DESCRIPTION
QueryConstants contains values that should not exist, such as `NEG_INF_BYTE` and is missing values such as `NaN`.  These inconsistencies are resolved in this PR.

Resolves #1218 .