### PR TITLE
Docker tasks should always tell gradle if they have changes

### DIFF
--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -326,22 +326,28 @@ class Docker {
         }
 
         if (!cfg.copyOut) {
-            // make a wrap-up task to clean up the task work, wait until things are finished, since we have nothing to copy out
+            // Make a wrap-up task to clean up the task work, wait until things are finished, since we have nothing to copy out
             return project.tasks.register(taskName) { task ->
                 task.with {
                     if (cfg.entrypoint) {
                         dependsOn containerFinished, containerLogs
                         doLast {
-                            // there was an entrypoint specified, if the command was not successful kill the build once
-                            // we're done copying output
+                            // There was an entrypoint specified, if the command was not successful kill the build once
+                            // we're done copying output. Note that this means the output is actually thrown away (aside
+                            // from being writen to the log this build)
                             if (containerFinished.get().exitCode != 0) {
                                 throw new GradleException("Command '${cfg.entrypoint.join(' ')}' failed with exit code ${containerFinished.get().exitCode}, check logs for details")
                             }
+                            logger.quiet('Entrypoint has been executed, but no output is copied out.')
                         }
                     } else {
                         dependsOn createContainer
                     }
                     finalizedBy removeContainer
+
+                    // We need to declare some output so that other tasks can correctly depend on this. Whether or not
+                    // there is an entrypoint, the last accessible output is the build image, so declare that
+                    outputs.files makeImage.get().outputs.files
                 }
             }
         }


### PR DESCRIPTION
Previously, if there was no copyOut, a docker task would not declare any
outputs, so downstream tasks would not know if they had to re-run. This
change explicitly marks the built image as the output, and logs a
message in case an entrypoint running despite its output being ignored.

Fixes #1408