### PR TITLE
ArrowFlight: ignore messages that have no app_metadata set instead of NPE

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/arrow/ArrowFlightUtil.java
@@ -398,7 +398,8 @@ public class ArrowFlightUtil {
             GrpcUtil.rpcWrapper(log, listener, () -> {
                 MessageInfo message = parseProtoMessage(request);
                 synchronized (this) {
-                    if (message.app_metadata.magic() != BarrageStreamGenerator.FLATBUFFER_MAGIC
+                    if (message.app_metadata == null
+                            || message.app_metadata.magic() != BarrageStreamGenerator.FLATBUFFER_MAGIC
                             || message.app_metadata.msgType() != BarrageMessageType.BarrageSubscriptionRequest) {
                         log.warn().append(myPrefix).append("received a message without app_metadata").endl();
                         return;


### PR DESCRIPTION
Apparently C++ Client automatically sends a FlightDescriptor at the time a DoExchange is opened. The documentation around this gRPC API is different... but we can work around by ignoring that first message.