### PR TITLE
More friendly utility methods for arrow::Status and arrow::Result

### DIFF
--- a/cpp-client/deephaven/client/include/public/deephaven/client/utility/table_maker.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/utility/table_maker.h
@@ -188,7 +188,7 @@ const char *TypeConverterTraits<std::optional<T>>::deephavenTypeName =
 
 template<typename T>
 TypeConverter TypeConverter::createNew(const std::vector<T> &values) {
-  using deephaven::client::utility::flight::statusOrDie;
+  using deephaven::client::utility::okOrThrow;
   using deephaven::client::utility::stringf;
 
   typedef TypeConverterTraits<T> traits_t;
@@ -200,9 +200,9 @@ TypeConverter TypeConverter::createNew(const std::vector<T> &values) {
     bool valid;
     const auto *containedValue = tryGetContainedValue(&value, &valid);
     if (valid) {
-      statusOrDie(builder.Append(*containedValue), "builder.AppendValue");
+      okOrThrow(DEEPHAVEN_EXPR_MSG(builder.Append(*containedValue)));
     } else {
-      statusOrDie(builder.AppendNull(), "builder.AppendNull");
+      okOrThrow(DEEPHAVEN_EXPR_MSG(builder.AppendNull()));
     }
   }
   auto builderRes = builder.Finish();
@@ -210,7 +210,7 @@ TypeConverter TypeConverter::createNew(const std::vector<T> &values) {
     auto message = stringf("Error building array of type %o: %o", traits_t::deephavenTypeName,
         builderRes.status().ToString());
   }
-  auto array = builderRes.ValueOrDie();
+  auto array = builderRes.ValueUnsafe();
   return TypeConverter(std::move(dataType), traits_t::deephavenTypeName, std::move(array));
 }
 }  // namespace internal

--- a/cpp-client/deephaven/client/src/highlevel/client.cc
+++ b/cpp-client/deephaven/client/src/highlevel/client.cc
@@ -32,7 +32,7 @@ using deephaven::client::utility::SimpleOstringstream;
 using deephaven::client::utility::SFCallback;
 using deephaven::client::utility::separatedList;
 using deephaven::client::utility::stringf;
-using deephaven::client::utility::flight::statusOrDie;
+using deephaven::client::utility::okOrThrow;
 
 namespace deephaven {
 namespace client {
@@ -425,7 +425,7 @@ std::shared_ptr<arrow::flight::FlightStreamReader> FlightWrapper::getFlightStrea
   arrow::flight::Ticket tkt;
   tkt.ticket = table.impl()->ticket().ticket();
 
-  statusOrDie(server->flightClient()->DoGet(options, tkt, &fsr), "FlightClient::DoGet");
+  okOrThrow(DEEPHAVEN_EXPR_MSG(server->flightClient()->DoGet(options, tkt, &fsr)));
   return fsr;
 }
 
@@ -564,7 +564,7 @@ void printTableData(std::ostream &s, const TableHandle &tableHandle, bool wantHe
 
   while (true) {
     arrow::flight::FlightStreamChunk chunk;
-    statusOrDie(fsr->Next(&chunk), "FlightStreamReader::Next()");
+    okOrThrow(DEEPHAVEN_EXPR_MSG(fsr->Next(&chunk)));
     if (chunk.data == nullptr) {
       break;
     }

--- a/cpp-client/deephaven/client/src/utility/utility.cc
+++ b/cpp-client/deephaven/client/src/utility/utility.cc
@@ -92,16 +92,14 @@ std::shared_ptr<std::vector<std::shared_ptr<std::string>>> stringVecToShared(std
   return result;
 }
 
-namespace flight {
-void statusOrDie(const arrow::Status &status, const char *message) {
+void okOrThrow(const arrow::Status &status, const char *message) {
   if (status.ok()) {
     return;
   }
 
-  auto msg = stringf("Error: %o. %o", message, status.ToString());
+  auto msg = stringf("Status: %o. Caller message: %o", status, message != nullptr ? message : "(none)");
   throw std::runtime_error(msg);
 }
-}  // namespace flight
 
 namespace {
 void dumpTillPercentOrEnd(ostream &result, const char **fmt) {

--- a/cpp-client/tests/aggregates_example.cc
+++ b/cpp-client/tests/aggregates_example.cc
@@ -19,8 +19,6 @@ using deephaven::client::highlevel::SortPair;
 using deephaven::client::highlevel::DeephavenConstants;
 using deephaven::client::utility::streamf;
 using deephaven::client::utility::stringf;
-using deephaven::client::utility::flight::statusOrDie;
-using deephaven::client::utility::flight::valueOrDie;
 
 namespace deephaven {
 namespace client {

--- a/cpp-client/tests/select_example.cc
+++ b/cpp-client/tests/select_example.cc
@@ -30,8 +30,6 @@ using deephaven::client::highlevel::TableHandle;
 using deephaven::client::utility::streamf;
 using deephaven::client::utility::stringf;
 using deephaven::client::utility::TableMaker;
-using deephaven::client::utility::flight::statusOrDie;
-using deephaven::client::utility::flight::valueOrDie;
 
 namespace deephaven {
 namespace client {

--- a/cpp-client/tests/test_util.cc
+++ b/cpp-client/tests/test_util.cc
@@ -10,8 +10,8 @@ namespace client {
 namespace tests {
 
 using deephaven::client::highlevel::TableHandle;
-using deephaven::client::utility::flight::statusOrDie;
-using deephaven::client::utility::flight::valueOrDie;
+using deephaven::client::utility::okOrThrow;
+using deephaven::client::utility::valueOrThrow;
 using deephaven::client::utility::streamf;
 using deephaven::client::utility::stringf;
 using deephaven::client::utility::TableMaker;
@@ -175,8 +175,8 @@ void compareTableHelper(int depth, const std::shared_ptr<arrow::Table> &table,
       continue;
     }
 
-    const auto lItem = valueOrDie(lChunk->GetScalar(lChunkIndex), "GetScalar");
-    const auto rItem = valueOrDie(rChunk->GetScalar(rChunkIndex), "GetScalar");
+    const auto lItem = valueOrThrow(DEEPHAVEN_EXPR_MSG(lChunk->GetScalar(lChunkIndex)));
+    const auto rItem = valueOrThrow(DEEPHAVEN_EXPR_MSG(rChunk->GetScalar(rChunkIndex)));
 
     if (!lItem->Equals(rItem)) {
       auto message = stringf("Column %o: Columns differ at element %o: %o vs %o",
@@ -195,7 +195,7 @@ void compareTableHelper(int depth, const std::shared_ptr<arrow::Table> &table,
 std::shared_ptr<arrow::Table> basicValidate(const TableHandle &table, int expectedColumns) {
   auto fsr = table.getFlightStreamReader();
   std::shared_ptr<arrow::Table> arrowTable;
-  statusOrDie(fsr->ReadAll(&arrowTable), "FlightStreamReader::ReadAll");
+  okOrThrow(DEEPHAVEN_EXPR_MSG(fsr->ReadAll(&arrowTable)));
 
   if (expectedColumns != arrowTable->num_columns()) {
     auto message = stringf("Expected %o columns, but table actually has %o columns",


### PR DESCRIPTION
* Rename (statusOrDie, valueOrDie) to (okOrThrow, valueOrThrow)
* Introduce a helper macro to help generate informative "message@file:line" messages.
* Make informative messages optional.