### PR TITLE
[jsapi] Set rollback to null to enable orphan cleanup

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/batch/RequestBatcher.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/batch/RequestBatcher.java
@@ -256,6 +256,13 @@ public class RequestBatcher {
                     ClientTableState state = allStates().filter(
                             cts -> cts.getHandle().makeTicket().getTicket_asB64().equals(ticket.getTicket_asB64()))
                             .first();
+
+                    if (state.isEmpty()) {
+                        // nobody cares about this state anymore
+                        JsLog.debug("Ignoring empty state", state);
+                        return;
+                    }
+
                     state.getHandle().setState(TableTicket.State.FAILED);
                     for (JsTable table : allInterestedTables().filter(t -> t.state() == state)) {
                         // fire the failed event

--- a/web/client-api/src/main/java/io/deephaven/web/client/state/ActiveTableBinding.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/state/ActiveTableBinding.java
@@ -164,12 +164,10 @@ public class ActiveTableBinding implements HasTableState<ClientTableState> {
                 if (table.getBinding() == sub) {
                     // we were the head of the table, go back and find a good node
                     sub.rollback();
-                    sub.setRollback(null);
                 }
+                sub.setRollback(null);
             }, () -> {
-                if (table.isAlive() && table.getBinding() == sub) {
-                    sub.setRollback(null);
-                }
+                sub.setRollback(null);
             });
         }
         return sub;

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
@@ -18,12 +18,16 @@
 <table id="simpleTable"></table>
 
 <script>
+var table;
+var connection;
+var ide;
+
 (async () => {
     // Open a connection to the server
-    var connection = new dh.IdeConnection(window.location.protocol + "//" + window.location.host);
+    connection = new dh.IdeConnection(window.location.protocol + "//" + window.location.host);
 
     // Start a python session
-    var ide = await connection.startSession("python");
+    ide = await connection.startSession("python");
 
     // Run code that will create a static table with 10 rows and three columns, I, J, K
     await ide.runCode(`
@@ -32,7 +36,7 @@ remoteTable = emptyTable(10).updateView('I=i', 'J=I*I', 'K=i%2==0?"Hello":"World
     `)
 
     // Retrieve the JS Table object
-    var table = await ide.getTable('remoteTable');
+    table = await ide.getTable('remoteTable');
 
     // Create a table header element with the table columns
     var header = document.createElement('thead');


### PR DESCRIPTION
Previously, rollbacks were not nulled out, in an attempt to avoid losing useful information as the table transitioned between states. Bug reports that applied to these old changes were used to test this commit; this does not alter their behavior (though I could not test the dashboard related bug).

Now, when an operation reaches a terminal state, its rollback should be cleared so that it is eligible for cleanup if it ever becomes an orphan.

While testing I also came across an additional CTS assertion error. Failed requests must not attempt to set their client state as running. If a table reaches a terminal state, it must always have its rollback nulled out, to avoid leaking the rollback.

Minor test change to `table_basic.html` to use global variables so that they are easily accessible from the developer console.

Fixes #1471 