### PR TITLE
Upgrade runtime images to JDK17, fixes #1369

### DIFF
--- a/DB-test/build.gradle
+++ b/DB-test/build.gradle
@@ -38,7 +38,9 @@ dependencies {
 def gradleWrapper = tasks.register("dockerGradleInit", Wrapper.class) { wrapper ->
   wrapper.scriptFile "${buildDir}/template-project/gradlew"
   wrapper.jarFile "${buildDir}/template-project/gradle/wrapper/gradle-wrapper.jar"
+  wrapper.gradleVersion '7.2'
 }
+
 tasks.getByName('check').dependsOn Docker.registerDockerTask(project, 'test-in-docker') {
   copyIn {
     dependsOn gradleWrapper
@@ -65,7 +67,7 @@ tasks.getByName('check').dependsOn Docker.registerDockerTask(project, 'test-in-d
     copyFile 'project', '/project'
     workingDir '/project'
     // run once with no actual classes, so that gradle is preinstalled and cached
-    runCommand '/project/gradlew'
+    runCommand '/project/gradlew --version'
     copyFile 'classpath', '/classpath'
     copyFile 'classes', '/classes'
   }

--- a/buildSrc/src/main/groovy/io.deephaven.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-conventions.gradle
@@ -6,7 +6,7 @@ def archivesBaseNamePrefix = 'deephaven-'
 
 def compilerVersion = Integer.parseInt((String)project.findProperty('compilerVersion') ?: '17')
 def languageLevel = Integer.parseInt((String)project.findProperty('languageLevel') ?: '8')
-def runtimeVersion = Integer.parseInt((String)project.findProperty('runtimeVersion') ?: '8')
+def runtimeVersion = Integer.parseInt((String)project.findProperty('runtimeVersion') ?: '17')
 def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRuntimeVersion') ?: '17')
 
 if (languageLevel > compilerVersion) {

--- a/buildSrc/src/main/groovy/io.deephaven.java-open-nio.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-open-nio.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
 }
 
-def runtimeVersion = Integer.parseInt((String)project.findProperty('runtimeVersion') ?: '8')
+def runtimeVersion = Integer.parseInt((String)project.findProperty('runtimeVersion') ?: '17')
 def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRuntimeVersion') ?: '17')
 
 //    Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field long java.nio.Buffer.address accessible: module java.base does not "opens java.nio" to unnamed module @5a42bbf4
@@ -22,8 +22,7 @@ if (runtimeVersion > 8) {
     defaultJvmOpts += ['--add-opens', 'java.base/java.nio=ALL-UNNAMED']
   }
 
-  // TODO(deephaven-core#1369): Upgrade runtime images to JDK17
-  // configure DockerJavaApplication, update docker images with runtime version
+  // TODO(deephaven-core#1493): add-opens Docker application based on plugin conventions
 }
 
 if (testRuntimeVersion > 8) {

--- a/grpc-api/server/docker/build.gradle
+++ b/grpc-api/server/docker/build.gradle
@@ -54,6 +54,10 @@ docker {
         '-XX:MinRAMPercentage=70.0',
         // the percentage of system memory that the JVM will use as maximum
         '-XX:MaxRAMPercentage=80.0',
+
+        // TODO(deephaven-core#1493): add-opens Docker application based on plugin conventions
+        '--add-opens', 'java.base/java.nio=ALL-UNNAMED',
+
         '-XshowSettings:vm'
     ]
   }

--- a/py/jpy-integration/build.gradle
+++ b/py/jpy-integration/build.gradle
@@ -115,6 +115,7 @@ Closure<TaskProvider<Task>> gradleTestInDocker = { String taskName, SourceSet so
   def gradleWrapper = tasks.register("${taskName}GradleInit", Wrapper.class) { wrapper ->
     wrapper.scriptFile "${buildDir}/template-project/gradlew"
     wrapper.jarFile "${buildDir}/template-project/gradle/wrapper/gradle-wrapper.jar"
+    wrapper.gradleVersion '7.2'
   }
   return Docker.registerDockerTask(project, taskName) {
     copyIn {
@@ -142,7 +143,7 @@ Closure<TaskProvider<Task>> gradleTestInDocker = { String taskName, SourceSet so
       copyFile 'project', '/project'
       workingDir '/project'
       // run once with no actual classes, so that gradle is preinstalled and cached
-      runCommand '/project/gradlew'
+      runCommand '/project/gradlew --version'
       copyFile 'classpath', '/classpath'
       copyFile 'classes', '/classes'
     }

--- a/py/jpy/Dockerfile
+++ b/py/jpy/Dockerfile
@@ -1,8 +1,29 @@
-# azul/zulu-open-jdk-debian bumped OS versions
-# https://github.com/zulu-openjdk/zulu-openjdk/commit/8e242a8838b8a5f068193719695b2ed918d402c5
-# which causes downstream dependency failures (no more python3.7 for example).
-# For now, we are pinning to a known working version, which used to be their 8u302 tag.
-FROM docker.io/azul/zulu-openjdk-debian@sha256:75c283c625e4403fbf10a60642fc2fcac70b5ac55213f77c6453bbe1fda4a8c7 as runtime_reqs
+FROM debian:buster-slim as java_base
+ARG ZULU_REPO_VER=1.0.0-3
+RUN set -eux; \
+    if [ -f /etc/dpkg/dpkg.cfg.d/docker ]; then \
+        # if this file exists, we're likely in "debian:xxx-slim", and locales are thus being excluded so we need to remove that exclusion (since we need locales)
+        grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
+        sed -ri '/\/usr\/share\/locale/d' /etc/dpkg/dpkg.cfg.d/docker; \
+        ! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
+    fi; \
+    apt-get -qq update; \
+    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl; \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8; \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9; \
+    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb; \
+    dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb; \
+    apt-get -qq update; \
+    apt-get -qq -y dist-upgrade; \
+    mkdir -p /usr/share/man/man1; \
+    apt-get -qq -y --no-install-recommends install zulu17-jdk-headless=17.0.*; \
+    apt-get -qq -y purge gnupg software-properties-common curl; \
+    apt -y autoremove; \
+    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb \
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV JAVA_HOME=/usr/lib/jvm/zulu17-ca-amd64
+
+FROM java_base as runtime_reqs
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -15,9 +36,10 @@ RUN set -eux; \
 
 FROM runtime_reqs as build_reqs
 RUN set -eux; \
+    echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list; \
     apt-get update; \
+    apt-get install -y --no-install-recommends -t buster-backports maven; \
     apt-get install -y --no-install-recommends \
-      maven \
       build-essential \
       python3.7-dev \
       python3-wheel \

--- a/py/jpy/Dockerfile
+++ b/py/jpy/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     apt-get -qq update; \
     apt-get -qq -y dist-upgrade; \
     mkdir -p /usr/share/man/man1; \
-    apt-get -qq -y --no-install-recommends install zulu17-jdk-headless=17.0.*; \
+    apt-get -qq -y --no-install-recommends install zulu17-jdk-headless=17*; \
     apt-get -qq -y purge gnupg software-properties-common curl; \
     apt -y autoremove; \
     rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb

--- a/py/jpy/Dockerfile
+++ b/py/jpy/Dockerfile
@@ -19,7 +19,7 @@ RUN set -eux; \
     apt-get -qq -y --no-install-recommends install zulu17-jdk-headless=17.0.*; \
     apt-get -qq -y purge gnupg software-properties-common curl; \
     apt -y autoremove; \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb \
+    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ENV JAVA_HOME=/usr/lib/jvm/zulu17-ca-amd64
 


### PR DESCRIPTION
Notes:
 * Follow up #1493: add-opens Docker application based on plugin conventions
 * The base buster maven package does not correctly handle JDK17, needed to install a newer version from buster-backports
 * The zulu17-jdk-headless base image is installed instead of relying on Azul; this allows us to stay on buster (important atm for python3.7), but to also fix a locales issue (https://github.com/zulu-openjdk/zulu-openjdk/issues/71).