### PR TITLE
Choose generic versions for Java version in CI

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -13,17 +13,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -99,17 +99,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -181,17 +181,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -287,17 +287,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -18,17 +18,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -15,24 +15,25 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
+      # TODO(deephaven-core#1513): Remove non-LTS JDK 15 as part of javadocs process
       - name: Setup JDK 15
         id: setup-java-15
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '15.0.4'
+          java-version: '15'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -76,24 +77,25 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
+      # TODO(deephaven-core#1513): Remove non-LTS JDK 15 as part of javadocs process
       - name: Setup JDK 15
         id: setup-java-15
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '15.0.4'
+          java-version: '15'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -142,9 +144,9 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Set JAVA_HOME

--- a/.github/workflows/long-check-ci.yml
+++ b/.github/workflows/long-check-ci.yml
@@ -15,17 +15,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV

--- a/.github/workflows/nightly-benchmarks.yml
+++ b/.github/workflows/nightly-benchmarks.yml
@@ -16,17 +16,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -19,17 +19,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -95,17 +95,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -171,17 +171,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
@@ -247,17 +247,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -13,17 +13,17 @@ jobs:
 
       - name: Setup JDK 11
         id: setup-java-11
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
 
       - name: Setup JDK 17
         id: setup-java-17
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: '17.0.0'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV

--- a/build.gradle
+++ b/build.gradle
@@ -324,6 +324,7 @@ apply plugin: 'io.deephaven.java-conventions'
 String javaDocOverviewLocation = 'build/docs/overview.html'
 tasks.register 'allJavadoc', Javadoc, {
     Javadoc jdoc ->
+        // TODO(deephaven-core#1513): Remove non-LTS JDK 15 as part of javadocs process
         jdoc.javadocTool = javaToolchains.javadocToolFor{it ->
             // Javadoc version >=11 is needed for search
             // Javadoc version >12 is needed to avoid javadoc bugs in linking with modules


### PR DESCRIPTION
By choosing a less specific version, we can take advantage of the pre-installed JVMs as part of the Github runner's image, https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java.

In that vein as well, "AdoptOpenJDK" is now "Adoptium" / "Temurin", and so to take advantage of cache we need to choose that.

JDK 17 should be pre-installed as part of https://github.com/actions/virtual-environments/issues/4085

See https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/

Follow up, #1513