### PR TITLE
Update to latest gradle-docker plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         exclude group: 'org.codehaus.groovy'
     }
 
-    compile 'com.bmuschko:gradle-docker-plugin:6.7.0'
+    compile 'com.bmuschko:gradle-docker-plugin:7.1.0'
 
     compile ('com.avast.gradle:gradle-docker-compose-plugin:0.14.9')
 


### PR DESCRIPTION
This will add support for the platform flag to be passed to docker build and run. This is now possible to upgrade since we have Java 11 as the baseline to run our gradle build at all.