### PR TITLE
DHLearn: Scatterer: Cast first to PyObject before casting to provided type

### DIFF
--- a/Integrations/src/main/java/io/deephaven/integrations/learn/Scatterer.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/learn/Scatterer.java
@@ -47,10 +47,8 @@ public class Scatterer {
         String[] queryStrings = new String[outputs.length];
 
         for (int i = 0; i < outputs.length; i++) {
-            // TODO: TICKET #1026: Replace typeString with the following once ticket #1009 is resolved:
-            // final String typeString = outputs[i].getType() == null ? "" : "(" + outputs[i].getType() + ")";
+            final String typeString = outputs[i].getType() == null ? "" : "(" + outputs[i].getType() + ")(PyObject)";
 
-            final String typeString = "";
             queryStrings[i] = String.format("%s = %s (__scatterer.scatter(%d, %s))", outputs[i].getColName(),
                     typeString, i, futureOffsetColName);
         }


### PR DESCRIPTION
JJ's DHLearn example doesn't work because this `scatter` method returns Object instead of PyObject. Thus the method that is picked is a `Object` -> (double) cast. Which means that the PyObject fails when attempting to be converted to Double.

If Scatterer is only to be used from python, then we could forcefully cast to PyObject before the type.

If Scatterer is to be used also from Groovy, then we might need to do some custom casting in `scatter` iff the result value is an instance of PyObject.

The important bits of JJ's example is this:
```python
# A function to extract a result
def get_results(data, idx):
    return data[idx]

result = learn.learn(
    table = source,
    model_func = sum_columns,
    inputs = [learn.Input(["X", "Y"], table_to_array)],
    outputs = [learn.Output("Z", get_results, "double")],
    batch_size = 1000
```

Where that get_results method is treated as `Function<Object[], Object>` instead of `Function<Object[], PyObject>`.