### PR TITLE
Make IndexUtilities.equals work for ReadOnlyIndex arguments.

### DIFF
--- a/DB/src/main/java/io/deephaven/db/v2/utils/IndexUtilities.java
+++ b/DB/src/main/java/io/deephaven/db/v2/utils/IndexUtilities.java
@@ -116,10 +116,10 @@ public class IndexUtilities {
     }
 
     static boolean equals(final ReadOnlyIndex index, final Object other) {
-        if (!(other instanceof Index)) {
+        if (!(other instanceof ReadOnlyIndex)) {
             return false;
         }
-        final Index otherIndex = (Index) other;
+        final ReadOnlyIndex otherIndex = (ReadOnlyIndex) other;
         return index.size() == otherIndex.size() && IndexUtilities.equalsDeepImpl(index, otherIndex);
     }
 


### PR DESCRIPTION
Charles reported (thanks).
