### PR TITLE
Simplify server startup and dagger usage

### DIFF
--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServer.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServer.java
@@ -23,6 +23,10 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Entrypoint for the Deephaven gRPC server, starting the various engine and script components, running any specified
+ * application, and enabling the gRPC endpoints to be accessed by consumers.
+ */
 public class DeephavenApiServer {
     private static final Logger log = LoggerFactory.getLogger(DeephavenApiServer.class);
 
@@ -57,7 +61,17 @@ public class DeephavenApiServer {
         return server;
     }
 
-    public void start() throws IOException, ClassNotFoundException, InterruptedException {
+    /**
+     * Starts the various server components, and blocks until the gRPC server has shut down. That shutdown is mediated
+     * by the ShutdownManager, and will call the gRPC server to shut it down when the process is itself shutting down.
+     * Only once that is complete will this method return.
+     *
+     * @throws IOException thrown in event of an error with logging, finding and running an application, and starting
+     *         the gRPC service.
+     * @throws ClassNotFoundException thrown if a class can't be found while finding and running an application.
+     * @throws InterruptedException thrown if this thread is interrupted while blocking for the server to halt.
+     */
+    public void run() throws IOException, ClassNotFoundException, InterruptedException {
         // Stop accepting new gRPC requests.
         ProcessEnvironment.getGlobalShutdownManager().registerTask(ShutdownManager.OrderingCategory.FIRST,
                 server::shutdown);

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerComponent.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerComponent.java
@@ -2,19 +2,11 @@ package io.deephaven.grpc_api.runner;
 
 import dagger.BindsInstance;
 import dagger.Component;
-import io.deephaven.grpc_api.appmode.AppMode;
 import io.deephaven.grpc_api.healthcheck.HealthCheckModule;
-import io.deephaven.grpc_api.session.SessionService;
-import io.deephaven.internal.log.LoggerFactory;
-import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
-import io.deephaven.util.process.ShutdownManager;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.IOException;
 import java.io.PrintStream;
-import java.util.concurrent.TimeUnit;
 
 @Singleton
 @Component(modules = {
@@ -24,16 +16,12 @@ import java.util.concurrent.TimeUnit;
 })
 public interface DeephavenApiServerComponent {
 
-    @Singleton
     DeephavenApiServer getServer();
-
-    @Singleton
-    SessionService getSessionService();
 
     @Component.Builder
     interface Builder {
         @BindsInstance
-        Builder withPort(@Named("grpc.port") int port);
+        Builder withPort(@Named("http.port") int port);
 
         @BindsInstance
         Builder withSchedulerPoolSize(@Named("scheduler.poolSize") int numThreads);
@@ -47,25 +35,6 @@ public interface DeephavenApiServerComponent {
         @BindsInstance
         Builder withErr(@Named("err") PrintStream err);
 
-        @BindsInstance
-        Builder withAppMode(AppMode appMode);
-
         DeephavenApiServerComponent build();
-    }
-
-    static void startMain(PrintStream out, PrintStream err)
-            throws IOException, InterruptedException, ClassNotFoundException {
-        final DeephavenApiServerComponent injector = DaggerDeephavenApiServerComponent
-                .builder()
-                .withPort(8080)
-                .withSchedulerPoolSize(4)
-                .withSessionTokenExpireTmMs(300000) // defaults to 5 min
-                .withOut(out)
-                .withErr(err)
-                .withAppMode(AppMode.currentMode())
-                .build();
-        final DeephavenApiServer server = injector.getServer();
-        final SessionService sessionService = injector.getSessionService();
-        DeephavenApiServer.start(server, sessionService);
     }
 }

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerInProcessComponent.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerInProcessComponent.java
@@ -2,19 +2,11 @@ package io.deephaven.grpc_api.runner;
 
 import dagger.BindsInstance;
 import dagger.Component;
-import io.deephaven.grpc_api.appmode.AppMode;
-import io.deephaven.grpc_api.session.SessionService;
-import io.deephaven.internal.log.LoggerFactory;
-import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
-import io.deephaven.util.process.ShutdownManager;
 import io.grpc.ManagedChannelBuilder;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.IOException;
 import java.io.PrintStream;
-import java.util.concurrent.TimeUnit;
 
 @Singleton
 @Component(modules = {
@@ -23,11 +15,7 @@ import java.util.concurrent.TimeUnit;
 })
 public interface DeephavenApiServerInProcessComponent {
 
-    @Singleton
     DeephavenApiServer getServer();
-
-    @Singleton
-    SessionService getSessionService();
 
     ManagedChannelBuilder<?> channelBuilder();
 
@@ -45,9 +33,6 @@ public interface DeephavenApiServerInProcessComponent {
 
         @BindsInstance
         Builder withErr(@Named("err") PrintStream err);
-
-        @BindsInstance
-        Builder withAppMode(AppMode appMode);
 
         DeephavenApiServerInProcessComponent build();
     }

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/DeephavenApiServerModule.java
@@ -5,6 +5,7 @@ import dagger.Provides;
 import dagger.multibindings.ElementsIntoSet;
 import io.deephaven.db.tables.live.LiveTableMonitor;
 import io.deephaven.db.v2.sources.chunk.util.pools.MultiChunkPool;
+import io.deephaven.grpc_api.appmode.AppMode;
 import io.deephaven.grpc_api.appmode.AppModeModule;
 import io.deephaven.grpc_api.arrow.ArrowModule;
 import io.deephaven.grpc_api.auth.AuthContextModule;
@@ -81,6 +82,12 @@ public class DeephavenApiServerModule {
     @ElementsIntoSet
     static Set<ServerInterceptor> primeInterceptors() {
         return Collections.emptySet();
+    }
+
+    @Provides
+    @Singleton
+    public static AppMode provideAppMode() {
+        return AppMode.currentMode();
     }
 
     @Provides

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/Main.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/Main.java
@@ -58,6 +58,6 @@ public class Main {
                 .withErr(PrintStreamGlobals.getErr())
                 .build()
                 .getServer()
-                .start();
+                .run();
     }
 }

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/Main.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/Main.java
@@ -44,6 +44,20 @@ public class Main {
                 ProcessEnvironment.basicInteractiveProcessInitialization(config, Main.class.getName(), log);
         Thread.setDefaultUncaughtExceptionHandler(processEnvironment.getFatalErrorReporter());
 
-        DeephavenApiServerComponent.startMain(PrintStreamGlobals.getOut(), PrintStreamGlobals.getErr());
+        // defaults to 5 minutes
+        int httpSessionExpireMs = config.getIntegerWithDefault("http.session.durationMs", 300000);
+        int httpPort = config.getIntegerWithDefault("http.port", 8080);
+        int schedulerPoolSize = config.getIntegerWithDefault("scheduler.poolSize", 4);
+
+        DaggerDeephavenApiServerComponent
+                .builder()
+                .withPort(httpPort)
+                .withSchedulerPoolSize(schedulerPoolSize)
+                .withSessionTokenExpireTmMs(httpSessionExpireMs)
+                .withOut(PrintStreamGlobals.getOut())
+                .withErr(PrintStreamGlobals.getErr())
+                .build()
+                .getServer()
+                .start();
     }
 }

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/runner/ServerBuilderModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/runner/ServerBuilderModule.java
@@ -10,7 +10,7 @@ import javax.inject.Named;
 public class ServerBuilderModule {
 
     @Provides
-    static ServerBuilder<?> serverBuilder(final @Named("grpc.port") int port) {
+    static ServerBuilder<?> serverBuilder(final @Named("http.port") int port) {
         return ServerBuilder.forPort(port);
     }
 }

--- a/grpc-api/src/test/java/io/deephaven/grpc_api/runner/DeephavenApiServerTestBase.java
+++ b/grpc-api/src/test/java/io/deephaven/grpc_api/runner/DeephavenApiServerTestBase.java
@@ -44,7 +44,6 @@ public abstract class DeephavenApiServerTestBase {
                 .withSessionTokenExpireTmMs(sessionTokenExpireTmMs())
                 .withOut(System.out)
                 .withErr(System.err)
-                .withAppMode(AppMode.API_ONLY)
                 .build();
 
         server = serverComponent.getServer();


### PR DESCRIPTION
This is a first step towards making the http server for grpc
replacable with Jetty.

Partial #1270