### PR TITLE
Conditional Formatting - Throw an error if multiple formats of the same type are set

### DIFF
--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/CustomColumnDescriptor.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/CustomColumnDescriptor.java
@@ -1,10 +1,7 @@
 package io.deephaven.web.shared.data;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * We still send plain strings to the server and receive plain strings from the client.
@@ -95,9 +92,15 @@ public class CustomColumnDescriptor implements Serializable {
     }
 
     public static List<CustomColumnDescriptor> from(String[] newCustomColumns) {
+        final Set<String> descriptorNames = new HashSet<>();
         final List<CustomColumnDescriptor> list = new ArrayList<>();
         for (String col : newCustomColumns) {
-            list.add(new CustomColumnDescriptor().setExpression(col));
+            CustomColumnDescriptor descriptor = new CustomColumnDescriptor().setExpression(col);
+            if (descriptorNames.contains(descriptor.getName())) {
+                throw new IllegalArgumentException("Duplicate custom column: " + descriptor.getName());
+            }
+            descriptorNames.add(descriptor.getName());
+            list.add(descriptor);
         }
         return list;
     }

--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/CustomColumnDescriptor.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/CustomColumnDescriptor.java
@@ -96,10 +96,9 @@ public class CustomColumnDescriptor implements Serializable {
         final List<CustomColumnDescriptor> list = new ArrayList<>();
         for (String col : newCustomColumns) {
             CustomColumnDescriptor descriptor = new CustomColumnDescriptor().setExpression(col);
-            if (descriptorNames.contains(descriptor.getName())) {
+            if (!descriptorNames.add(descriptor.getName())) {
                 throw new IllegalArgumentException("Duplicate custom column: " + descriptor.getName());
             }
-            descriptorNames.add(descriptor.getName());
             list.add(descriptor);
         }
         return list;


### PR DESCRIPTION
When multiple formats for the same column are set, it only takes the last one. Instead of allowing the user to do something wrong and be confused why it doesn't work, throw.

Related to #1375 