### PR TITLE
added combo_agg to Deephaven, fixes #1632

### DIFF
--- a/Integrations/python/deephaven/__init__.py
+++ b/Integrations/python/deephaven/__init__.py
@@ -410,3 +410,11 @@ def doLocked(f, lock_type="shared"):
         UpdateGraphProcessor.DEFAULT.sharedLock().doLocked(ThrowingRunnable(f))
     else:
         raise ValueError("Unsupported lock type: lock_type={}".format(lock_type))
+
+
+def combo_agg(agg_list):
+    _JArrayList = jpy.get_type("java.util.ArrayList")
+    j_agg_list = _JArrayList(len(agg_list))
+    for agg in agg_list:
+        j_agg_list.add(agg)
+    return j_agg_list


### PR DESCRIPTION
Example:

```
from deephaven.TableTools import newTable, stringCol, intCol, doubleCol
from deephaven import Aggregation, combo_agg
Arrays = jpy.get_type("java.util.Arrays")

source = newTable(
stringCol("X", "A", "B", "A", "C", "B", "A", "B", "B", None),
stringCol("Y", "M", "N", None, "N", "P", "M", None, "P", "M"),
intCol("Number", 55, 76, 20, 130, 230, 50, 73, 137, 214),
)

aggs =  combo_agg([Aggregation.AggAvg("Number")])

result = source.aggBy(aggs, "X")
```