### PR TITLE
Fix ModelFarm race conditions and unit tests

### DIFF
--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
@@ -56,7 +56,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
          * Performs an operation using data from a query.
          *
          * @param usePrev Whether to use the previous data at a given row key when retrieving data (i.e. if
-         *                {@code true}, use {@link ColumnSource#getPrev} instead of {@link ColumnSource#get}).
+         *        {@code true}, use {@link ColumnSource#getPrev} instead of {@link ColumnSource#get}).
          */
         void retrieveData(boolean usePrev);
 
@@ -151,7 +151,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
      * Create a multithreaded resource to execute data driven models.
      *
      * @param nThreads number of worker threads.
-     * @param model    model to execute.
+     * @param model model to execute.
      */
     @SuppressWarnings("WeakerAccess")
     protected ModelFarmBase(final int nThreads, final Model<DATATYPE> model) {
@@ -183,7 +183,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
     /**
      * Interface for getting the most recent row data for a unique identifier.
      *
-     * @param <KEYTYPE>  unique ID key type
+     * @param <KEYTYPE> unique ID key type
      * @param <DATATYPE> data type
      */
     @FunctionalInterface
@@ -193,7 +193,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
          *
          * @param key unique identifier
          * @return most recent row data for the unique identifier, or null, if there is no data for the unique
-         * identifier.
+         *         identifier.
          */
         DATATYPE get(final KEYTYPE key);
     }

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
@@ -56,7 +56,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
          * Performs an operation using data from a query.
          *
          * @param usePrev Whether to use the previous data at a given row key when retrieving data (i.e. if
-         *        {@code true}, use {@link ColumnSource#getPrev} instead of {@link ColumnSource#get}).
+         *                {@code true}, use {@link ColumnSource#getPrev} instead of {@link ColumnSource#get}).
          */
         void retrieveData(boolean usePrev);
 
@@ -151,7 +151,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
      * Create a multithreaded resource to execute data driven models.
      *
      * @param nThreads number of worker threads.
-     * @param model model to execute.
+     * @param model    model to execute.
      */
     @SuppressWarnings("WeakerAccess")
     protected ModelFarmBase(final int nThreads, final Model<DATATYPE> model) {
@@ -183,7 +183,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
     /**
      * Interface for getting the most recent row data for a unique identifier.
      *
-     * @param <KEYTYPE> unique ID key type
+     * @param <KEYTYPE>  unique ID key type
      * @param <DATATYPE> data type
      */
     @FunctionalInterface
@@ -193,7 +193,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
          *
          * @param key unique identifier
          * @return most recent row data for the unique identifier, or null, if there is no data for the unique
-         *         identifier.
+         * identifier.
          */
         DATATYPE get(final KEYTYPE key);
     }
@@ -340,8 +340,8 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
                 timeout == Long.MAX_VALUE ? Long.MAX_VALUE : System.currentTimeMillis() + unit.toMillis(timeout);
         boolean allThreadsTerminated = false;
 
-        while (!allThreadsTerminated && System.currentTimeMillis() < timeoutMillis) {
-            synchronized (ModelFarmBase.this) {
+        synchronized (ModelFarmBase.this) {
+            while (!allThreadsTerminated && System.currentTimeMillis() < timeoutMillis) {
                 if (!threads.isEmpty()) {
                     try {
                         // Wait for the state to change. (The last thread to exit will update the state to TERMINATED.)
@@ -357,6 +357,8 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
                             throw new RuntimeException("Interrupted while awaiting ModelFarm termination.", e);
                         }
                     }
+                } else {
+                    allThreadsTerminated = true;
                 }
             }
         }

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
@@ -341,11 +341,13 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
         boolean allThreadsTerminated = false;
 
         synchronized (ModelFarmBase.this) {
-            while (!allThreadsTerminated && System.currentTimeMillis() < timeoutMillis) {
+            long currentTime = System.currentTimeMillis();
+
+            while (!allThreadsTerminated && currentTime < timeoutMillis) {
                 if (!threads.isEmpty()) {
                     try {
                         // Wait for the state to change. (The last thread to exit will update the state to TERMINATED.)
-                        ModelFarmBase.this.wait(timeoutMillis - System.currentTimeMillis());
+                        ModelFarmBase.this.wait(timeoutMillis - currentTime);
 
                         if (threads.isEmpty()) {
                             allThreadsTerminated = true;
@@ -360,6 +362,8 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
                 } else {
                     allThreadsTerminated = true;
                 }
+
+                currentTime = System.currentTimeMillis();
             }
         }
 

--- a/ModelFarm/src/test/java/io/deephaven/modelfarm/TestModelFarm.java
+++ b/ModelFarm/src/test/java/io/deephaven/modelfarm/TestModelFarm.java
@@ -22,7 +22,7 @@ import static io.deephaven.util.QueryConstants.NULL_LONG;
 public class TestModelFarm extends TestCase {
 
     private final long testShutdownTimeoutSecs =
-            Configuration.getInstance().getIntegerWithDefault("TestModelFarm.testShutdownTimeoutSecs", 5);
+            Configuration.getInstance().getIntegerWithDefault("TestModelFarm.testShutdownTimeoutSecs", 1);
     private final int nModelFarmThreadsDefault = 8;
 
     /**

--- a/ModelFarm/src/test/java/io/deephaven/modelfarm/TestModelFarm.java
+++ b/ModelFarm/src/test/java/io/deephaven/modelfarm/TestModelFarm.java
@@ -22,7 +22,7 @@ import static io.deephaven.util.QueryConstants.NULL_LONG;
 public class TestModelFarm extends TestCase {
 
     private final long testShutdownTimeoutSecs =
-            Configuration.getInstance().getIntegerWithDefault("TestModelFarm.testShutdownTimeoutSecs", 1);
+            Configuration.getInstance().getIntegerWithDefault("TestModelFarm.testShutdownTimeoutSecs", 5);
     private final int nModelFarmThreadsDefault = 8;
 
     /**
@@ -80,7 +80,7 @@ public class TestModelFarm extends TestCase {
         // Test awaitTermination(), without calling terminate().
         // This should return true, since threads are finished.
         latchThreadComplete.countDown();
-        boolean terminated = modelFarmTick.awaitTermination(5000, TimeUnit.MILLISECONDS);
+        boolean terminated = modelFarmTick.awaitTermination(testShutdownTimeoutSecs, TimeUnit.SECONDS);
         Require.eqTrue(terminated, "terminated");
         Require.eq(modelFarmTick.getState(), "modelFarmTick.getState()", ModelFarmBase.State.TERMINATED);
 
@@ -120,7 +120,7 @@ public class TestModelFarm extends TestCase {
         // Test awaitTermination() before calling terminate(). This should return false, since terminate() was not
         // called, and the ModelFarm should not drain its work queue since the threads have not been completed.
         {
-            boolean terminated = modelFarmTick.awaitTermination(5000, TimeUnit.MILLISECONDS);
+            boolean terminated = modelFarmTick.awaitTermination(testShutdownTimeoutSecs, TimeUnit.SECONDS);
             Require.eqFalse(terminated, "terminated");
             Require.eq(modelFarmTick.getState(), "modelFarmTick.getState()", ModelFarmBase.State.SHUTDOWN);
         }


### PR DESCRIPTION
ModelFarm shutdown methods have a race condition that triggered occasional unit test failures.  Bugs were also found in the unit tests.

Resolves #1641 
Resolves #1150