### PR TITLE
Ensure the wrong number of parameters in a call to deephaven.ParquetTools.writeTable generates an error.

### DIFF
--- a/Generators/src/main/java/io/deephaven/pythonPreambles/ParquetToolsPreamble.txt
+++ b/Generators/src/main/java/io/deephaven/pythonPreambles/ParquetToolsPreamble.txt
@@ -109,6 +109,7 @@ def _custom_writeTable(*args):
         return _java_type_.writeTable(args[0], getFileObject(args[1]))
     elif len(args) == 3:
         return _java_type_.writeTable(args[0], getFileObject(args[1]),  getattr(_java_type_, args[2]))
+    raise Exception('Wrong number of arguments: {}'.format(len(args)))
 
 
 def _custom_writeTables(sources, tableDefinition, destinations):

--- a/Integrations/python/deephaven/ParquetTools/__init__.py
+++ b/Integrations/python/deephaven/ParquetTools/__init__.py
@@ -115,6 +115,7 @@ def _custom_writeTable(*args):
         return _java_type_.writeTable(args[0], getFileObject(args[1]))
     elif len(args) == 3:
         return _java_type_.writeTable(args[0], getFileObject(args[1]),  getattr(_java_type_, args[2]))
+    raise Exception('Wrong number of arguments: {}'.format(len(args)))
 
 
 def _custom_writeTables(sources, tableDefinition, destinations):


### PR DESCRIPTION
As it is right now, and due to a mistake in an earlier change on that file, a call to `deephaven.ParquetTools.writeTable` with the wrong number of parameters (eg, 1, like just the filename or just the table name), silently does nothing instead of alerting the user
that something is wrong; this was not intentional and is misleading, eg, a user can mistake the (wrongful) no output for success.
I noticed this recently after having fell myself to that trap in some debugging session: I forgot one argument and for a while couldn't understand what was going on when the file was not showing up.