### PR TITLE
Move `dephaven.learn` RowSet generation to use a builder.

### DIFF
--- a/Integrations/src/main/java/io/deephaven/integrations/learn/Computer.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/learn/Computer.java
@@ -92,7 +92,7 @@ public class Computer {
             offset = -1;
         }
 
-        current.insertRowKey(k);
+        current.addRowKey(k);
         offset += 1;
 
         final FutureOffset fo = new FutureOffset(current, offset);


### PR DESCRIPTION
RowSet generation can be more efficient by using builders.

Resolves #1653 