### PR TITLE
Cleaned up Python sort syntax.

### DIFF
--- a/Integrations/python/deephaven/TableManipulation/__init__.py
+++ b/Integrations/python/deephaven/TableManipulation/__init__.py
@@ -13,6 +13,7 @@ __all__ = ['Aggregation', 'ColumnRenderersBuilder', 'DistinctFormatter', 'Downsa
 
 # None until the first successful _defineSymbols() call
 Aggregation = None       #: Class to supply helpers for constructing aggregations
+ColumnName = None               #: Class to represent a column name
 ColumnRenderersBuilder = None   #: Class to build and parse the directive for Table.COLUMN_RENDERERS_ATTRIBUTE (io.deephaven.engine.util.ColumnRenderersBuilder).
 DistinctFormatter = None        #: Class to create distinct and unique coloration for each unique input value (io.deephaven.engine.util.ColorUtil$DistinctFormatter).
 DownsampledWhereFilter = None   #: Class to downsample time series data by calculating the bin intervals for values, and then using upperBin and lastBy to select the last row for each bin (io.deephaven.engine.table.impl.select.DownsampledWhereFilter).
@@ -33,12 +34,13 @@ def _defineSymbols():
     if not jpy.has_jvm():
         raise SystemError("No java functionality can be used until the JVM has been initialized through the jpy module")
 
-    global Aggregation, ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, DynamicTableWriter, \
+    global Aggregation, ColumnName, ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, DynamicTableWriter, \
         LayoutHintBuilder, Replayer, SmartKey, SortColumn, TotalsTableBuilder
 
     if Aggregation is None:
         # This will raise an exception if the desired object is not the classpath
         Aggregation = jpy.get_type('io.deephaven.api.agg.Aggregation')
+        ColumnName = jpy.get_type("io.deephaven.api.ColumnName")
         ColumnRenderersBuilder = jpy.get_type('io.deephaven.engine.util.ColumnRenderersBuilder')
         DistinctFormatter = jpy.get_type('io.deephaven.engine.util.ColorUtil$DistinctFormatter')
         DownsampledWhereFilter = jpy.get_type('io.deephaven.engine.table.impl.select.DownsampledWhereFilter')

--- a/Integrations/python/deephaven/__init__.py
+++ b/Integrations/python/deephaven/__init__.py
@@ -97,7 +97,7 @@ from .Plot import figure_wrapper as figw
 
 from .csv import read as read_csv
 from .csv import write as write_csv
-from .conversion_utils import convertToJavaList as asList
+from .conversion_utils import convertToJavaList as as_list
 
 # NB: this must be defined BEFORE importing .jvm_init or .start_jvm (circular import)
 def initialize():

--- a/Integrations/python/deephaven/__init__.py
+++ b/Integrations/python/deephaven/__init__.py
@@ -32,7 +32,7 @@ Additionally, the following methods have been imported into the main deephaven n
 * from conversion_utils import convertToJavaArray, convertToJavaList, convertToJavaArrayList,
        convertToJavaHashSet, convertToJavaHashMap
 
-* from TableManipulation import Aggregation, ColumnRenderersBuilder, DistinctFormatter,
+* from TableManipulation import Aggregation, ColumnName, ColumnRenderersBuilder, DistinctFormatter,
        DownsampledWhereFilter, DynamicTableWriter, LayoutHintBuilder,  
        Replayer, SmartKey, SortColumn, TotalsTableBuilder, WindowCheck
 
@@ -55,7 +55,7 @@ __all__ = [
     "convertToJavaArray", "convertToJavaList", "convertToJavaArrayList", "convertToJavaHashSet",
     "convertToJavaHashMap",  # from conversion_utils
 
-    'Aggregation', 'ColumnRenderersBuilder', 'DistinctFormatter', 'DownsampledWhereFilter', 'DynamicTableWriter',
+    'Aggregation', 'ColumnName', 'ColumnRenderersBuilder', 'DistinctFormatter', 'DownsampledWhereFilter', 'DynamicTableWriter',
     'LayoutHintBuilder', 'Replayer', 'SmartKey', 'SortColumn', 'TotalsTableBuilder', 'WindowCheck',  # from TableManipulation
 
     "cals", "af", "dtu", "figw", "mavg", "plt", "pt", "ttools", "tloggers",  # subpackages with abbreviated names
@@ -97,7 +97,7 @@ from .Plot import figure_wrapper as figw
 
 from .csv import read as read_csv
 from .csv import write as write_csv
-
+from .conversion_utils import convertToJavaList as asList
 
 # NB: this must be defined BEFORE importing .jvm_init or .start_jvm (circular import)
 def initialize():
@@ -124,9 +124,9 @@ def initialize():
 
     import deephaven.TableManipulation
     deephaven.TableManipulation._defineSymbols()
-    global Aggregation, ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, DynamicTableWriter, \
+    global Aggregation, ColumnName, ColumnRenderersBuilder, DistinctFormatter, DownsampledWhereFilter, DynamicTableWriter, \
         LayoutHintBuilder, Replayer, SmartKey, SortColumn, TotalsTableBuilder
-    from deephaven.TableManipulation import Aggregation, ColumnRenderersBuilder, DistinctFormatter, \
+    from deephaven.TableManipulation import Aggregation, ColumnName, ColumnRenderersBuilder, DistinctFormatter, \
         DownsampledWhereFilter, DynamicTableWriter, LayoutHintBuilder, Replayer, SmartKey, \
         SortColumn, TotalsTableBuilder
 
@@ -415,6 +415,12 @@ def doLocked(f, lock_type="shared"):
 
 
 def combo_agg(agg_list):
+    """
+    Combines aggregations.
+
+    :param agg_list: list of aggregations
+    :return: combined aggregations
+    """
     _JArrayList = jpy.get_type("java.util.ArrayList")
     j_agg_list = _JArrayList(len(agg_list))
     for agg in agg_list:


### PR DESCRIPTION
Cleaned up the syntax.  This is ok for the v1 python API.  The v2 API can take more drastic steps to achieve better syntax.

Resolves #1662 

Current syntax:
```
from deephaven.TableTools import newTable, stringCol, intCol, doubleCol
from deephaven import SortColumn
Arrays = jpy.get_type("java.util.Arrays")
ColumnName = jpy.get_type("io.deephaven.api.ColumnName")

source = newTable(
    stringCol("Letter", "A", "D", "B", "E", "D", "A"),
    intCol("Number", 6, 7, 1, 4, 2, 4),
    doubleCol("Percent", .25, .75, .15, .80, .25, .75)
)

sort_columns = Arrays.asList(
    SortColumn.asc(ColumnName.of("Letter")),
    SortColumn.desc(ColumnName.of("Number"))
)

result= source.sort(sort_columns)
```

New syntax:
```
from deephaven.TableTools import newTable, stringCol, intCol, doubleCol
from deephaven import SortColumn, ColumnName, asList

source = newTable(
    stringCol("Letter", "A", "D", "B", "E", "D", "A"),
    intCol("Number", 6, 7, 1, 4, 2, 4),
    doubleCol("Percent", .25, .75, .15, .80, .25, .75)
)

sort_columns = asList(
    SortColumn.asc(ColumnName.of("Letter")),
    SortColumn.desc(ColumnName.of("Number"))
)

result= source.sort(sort_columns)
```