### PR TITLE
Added tests for avro mappings in consume. Reworked somewhat the impl.

### DIFF
--- a/Integrations/python/deephaven/ConsumeKafka.py
+++ b/Integrations/python/deephaven/ConsumeKafka.py
@@ -11,7 +11,7 @@ import wrapt
 import deephaven.Types as dh
 
 from deephaven.conversion_utils import \
-    _dictToFun, _dictToMap, _dictToProperties, IDENTITY, _isStr
+    _dictToFunWithIdentity, _dictToFunWithDefault, _dictToMap, _dictToProperties, _isStr
 
 from deephaven.Types import _jclassFromType
 
@@ -224,11 +224,11 @@ def avro(schema, schema_version:str = None, mapping:dict = None, mapping_only:di
     if mapping is not None:
         have_mapping = True
         # when providing 'mapping', fields names not given are mapped as identity
-        mapping = _dictToFun(mapping, default_value=IDENTITY)
+        mapping = _dictToFunWithIdentity(mapping)
     elif mapping_only is not None:
         have_mapping = True
         # when providing 'mapping_only', fields not given are ignored.
-        mapping = _dictToFun(mapping_only, default_value=None)
+        mapping = _dictToFunWithDefault(mapping_only, None)
     else:
         have_mapping = False
     if _isStr(schema):

--- a/Integrations/python/deephaven/ProduceKafka.py
+++ b/Integrations/python/deephaven/ProduceKafka.py
@@ -9,7 +9,7 @@ import wrapt
 import deephaven.Types as dh
 
 from deephaven.conversion_utils import _isJavaType, _isStr, \
-    _typeFromName, _dictToProperties, _dictToMap, _seqToSet, IDENTITY
+    _typeFromName, _dictToProperties, _dictToMap, _seqToSet
 
 # None until the first _defineSymbols() call
 _java_type_ = None

--- a/Integrations/python/deephaven/conversion_utils.py
+++ b/Integrations/python/deephaven/conversion_utils.py
@@ -30,13 +30,12 @@ _jprops_ = None
 _jmap_ = None
 _jset_ = None
 _python_tools_ = None
-IDENTITY = None
 
 def _defineSymbols():
     if not jpy.has_jvm():
         raise SystemError("No java functionality can be used until the JVM has been initialized through the jpy module")
 
-    global _table_tools_, _col_def_, _jprops_, _jmap_, _jset_, _python_tools_, IDENTITY
+    global _table_tools_, _col_def_, _jprops_, _jmap_, _jset_, _python_tools_
     if _table_tools_ is None:
         # This will raise an exception if the desired object is not the classpath
         _table_tools_ = jpy.get_type("io.deephaven.engine.util.TableTools")
@@ -45,7 +44,6 @@ def _defineSymbols():
         _jmap_ = jpy.get_type("java.util.HashMap")
         _jset_ = jpy.get_type("java.util.HashSet")
         _python_tools_ = jpy.get_type("io.deephaven.integrations.python.PythonTools")
-        IDENTITY = object()  # Ensure IDENTITY is unique.
 
 
 # every method that depends on symbols defined via _defineSymbols() should be decorated with @_passThrough
@@ -1107,8 +1105,11 @@ def _seqToSet(s):
     return r
 
 @_passThrough
-def _dictToFun(dict_mapping, default_value):
+def _dictToFunWithIdentity(dict_mapping):
     java_map = _dictToMap(dict_mapping)
-    if default_value is IDENTITY:
-        return _python_tools_.functionFromMapWithIdentityDefaults(java_map)
+    return _python_tools_.functionFromMapWithIdentityDefaults(java_map)
+
+@_passThrough
+def _dictToFunWithDefault(dict_mapping, default_value):
+    java_map = _dictToMap(dict_mapping)
     return _python_tools_.functionFromMapWithDefault(java_map, default_value)


### PR DESCRIPTION
I had to eliminate the use of `IDENTITY` as a constant imported from `conversion_utils` in `ConsumeKafka.py`.  The issue I ran into is that in test mode, the value of `IDENTITY` ended up being `None`, instead of a distinct object that would be initialized if `_defineSymbols` was called correctly; somehow in testing this setup is not working.   Essentially I think using symbols defined initially as `None` and later redefined via `_defineSymbols` doesn't work in testing when done cross-imports.

Anyway, I eliminated the need for the `IDENTITY` constant by separating `_dictToFun` in two methods, one that would have an identity default (with a single parameter) and another one that takes the desired default as a second argument.