### PR TITLE
Fixed Python sort syntax.

### DIFF
--- a/Integrations/python/deephaven/__init__.py
+++ b/Integrations/python/deephaven/__init__.py
@@ -413,20 +413,7 @@ def doLocked(f, lock_type="shared"):
         raise ValueError("Unsupported lock type: lock_type={}".format(lock_type))
 
 
-def combo_agg(agg_list):
-    """
-    Combines aggregations.
-
-    :param agg_list: list of aggregations
-    :return: combined aggregations
-    """
-    _JArrayList = jpy.get_type("java.util.ArrayList")
-    j_agg_list = _JArrayList(len(agg_list))
-    for agg in agg_list:
-        j_agg_list.add(agg)
-    return j_agg_list
-
-def as_list(*values):
+def as_list(values):
     """
     Creates a Java list containing the values.
 

--- a/Integrations/python/deephaven/__init__.py
+++ b/Integrations/python/deephaven/__init__.py
@@ -97,7 +97,6 @@ from .Plot import figure_wrapper as figw
 
 from .csv import read as read_csv
 from .csv import write as write_csv
-from .conversion_utils import convertToJavaList as as_list
 
 # NB: this must be defined BEFORE importing .jvm_init or .start_jvm (circular import)
 def initialize():
@@ -426,3 +425,17 @@ def combo_agg(agg_list):
     for agg in agg_list:
         j_agg_list.add(agg)
     return j_agg_list
+
+def as_list(*values):
+    """
+    Creates a Java list containing the values.
+
+    :param values: values
+    :return: Java list containing the values.
+    """
+    _JArrayList = jpy.get_type("java.util.ArrayList")
+    j_list = _JArrayList(len(values))
+    for value in values:
+        j_list.add(value)
+    return j_list
+

--- a/Integrations/python/test/test_sort.py
+++ b/Integrations/python/test/test_sort.py
@@ -17,10 +17,10 @@ class SortTestCase(TestCase):
             intCol("C", 1, 2, 3, 4, 5, 6),
         )
 
-        sort_columns = as_list(
+        sort_columns = as_list([
             SortColumn.asc(ColumnName.of("A")),
             SortColumn.desc(ColumnName.of("B"))
-        )
+        ])
 
         actual = source.sort(sort_columns)
 

--- a/Integrations/python/test/test_sort.py
+++ b/Integrations/python/test/test_sort.py
@@ -1,0 +1,39 @@
+#
+#   Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+#
+
+# Test python sort syntax
+
+import unittest
+from unittest import TestCase
+from deephaven import as_list, SortColumn, ColumnName
+from deephaven.TableTools import newTable, intCol, diff
+
+class SortTestCase(TestCase):
+    def test_sort_syntax(self):
+        source = newTable(
+            intCol("A", 1, 2, 3, 1, 2, 3),
+            intCol("B", 0, 1, 0, 1, 0, 1),
+            intCol("C", 1, 2, 3, 4, 5, 6),
+        )
+
+        sort_columns = as_list(
+            SortColumn.asc(ColumnName.of("A")),
+            SortColumn.desc(ColumnName.of("B"))
+        )
+
+        actual = source.sort(sort_columns)
+
+        target = newTable(
+            intCol("A", 1, 1, 2, 2, 3, 3),
+            intCol("B", 1, 0, 1, 0, 1, 0),
+            intCol("C", 4, 1, 2, 5, 6, 3),
+        )
+
+        diff_string = diff(actual, target, 1)
+        self.assertEqual("", diff_string)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed Python sort syntax.  `as_list` did not work as intended.

Resolves #1668 