### PR TITLE
Check the docker registry directories for gradle.properties.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -249,9 +249,11 @@ project(':docker-java-and-python').projectDir = file('docker/java-and-python')
 include(':docker-runtime-base')
 project(':docker-runtime-base').projectDir = file('docker/runtime-base')
 
-file("${rootDir}/docker/registry").list().each {name ->
-    include(":docker-${name}")
-    project(":docker-${name}").projectDir = file("${rootDir}/docker/registry/${name}")
+file("${rootDir}/docker/registry").list().each { name ->
+    if (file("${rootDir}/docker/registry/${name}/gradle.properties").exists()) {
+        include(":docker-${name}")
+        project(":docker-${name}").projectDir = file("${rootDir}/docker/registry/${name}")
+    }
 }
 
 // Apply "vanity naming" (look for .gradle files matching ProjectName/ProjectName.gradle)


### PR DESCRIPTION
Otherwise, project may become unbuildable if you check out a branch that has a new registry, and then checkout a branch that doesn't have that registry.