### PR TITLE
Update python requirements.txt

### DIFF
--- a/docker/java-and-python/src/main/docker/requirements.txt
+++ b/docker/java-and-python/src/main/docker/requirements.txt
@@ -1,3 +1,3 @@
 pip==21.3.1
-setuptools==59.0.1
+setuptools==59.5.0
 wheel==0.37.0


### PR DESCRIPTION
Ran instructions in

* docker/java-and-python/src/main/docker/Dockerfile
* docker/runtime-base/src/main/docker/Dockerfile

Note: there are no changes in the runtime-base requirements - even though numpy is out of date, it looks like the latest version of numba places the requirement on an earlier version of numpy.