### PR TITLE
Update web to v0.7.2

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,7 +2,7 @@ FROM deephaven/node:local-build AS node
 WORKDIR /usr/src/app
 
 FROM node as build
-ARG WEB_VERSION=0.7.1-alpha.0
+ARG WEB_VERSION=0.7.2
 
 # Pull in the published package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
We were still on an alpha version after 0.7.0. See [release notes](https://github.com/deephaven/web-client-ui/releases) for [v0.7.1](https://github.com/deephaven/web-client-ui/releases/tag/v0.7.1) and [v0.7.2](https://github.com/deephaven/web-client-ui/releases/tag/v0.7.2) for complete list of updates.