### PR TITLE
Reduce scope of dependencies for faster/simplier rebuilds

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-conventions.gradle
@@ -106,5 +106,5 @@ jar {
 }
 
 configurations {
-  testOutput.extendsFrom testRuntime
+  testOutput.extendsFrom testRuntimeClasspath
 }

--- a/extensions/barrage/build.gradle
+++ b/extensions/barrage/build.gradle
@@ -7,20 +7,20 @@ configurations {
     testCompile.extendsFrom irisDbTest
 }
 
-description = 'An extension integrating Barrage with Deephavens Table Model'
+description = 'An extension integrating Barrage with Deephaven\'s Table Model'
 
 dependencies {
-    api project(':Base')
-    api project(':Util')
+    implementation project(':Base')
+    implementation project(':Util')
     api project(':engine-table')
-    api project(':proto:proto-backplane-grpc-flight')
-    api project(':log-factory')
+    implementation project(':proto:proto-backplane-grpc-flight')
+    implementation project(':log-factory')
     api "io.deephaven.barrage:barrage-format:0.3.0"
 
-    Classpaths.inheritFlatbuffer(project, 'api')
+    Classpaths.inheritFlatbuffer(project, 'implementation')
 
-    Classpaths.inheritArrow(project, 'arrow-vector', 'api')
-    Classpaths.inheritArrow(project, 'arrow-format', 'api')
+    Classpaths.inheritArrow(project, 'arrow-vector', 'implementation')
+    Classpaths.inheritArrow(project, 'arrow-format', 'implementation')
 
     Classpaths.inheritImmutables(project)
 

--- a/grpc-api/grpc-api.gradle
+++ b/grpc-api/grpc-api.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'java'
+    id 'java-library'
 }
 
 configurations {
     // custom configuration, sourceset, test task to keep flight-core off the main/test classpath
-    flightTestCompile.extendsFrom(testCompile)
+    flightTestCompile.extendsFrom(testImplementation)
 }
 
 sourceSets {
@@ -20,25 +20,25 @@ sourceSets {
 }
 
 dependencies {
-    compile project(':engine-table'),
-            project(':extensions-csv'),
-            project(':extensions-parquet-table'),
-            project(':Util'),
-            project(':java-client-barrage-dagger'),
-            project(':proto:proto-backplane-grpc-flight'),
-            project(':open-api-lang-tools'),
-            project(':log-factory'),
-            project(':application-mode'),
-            'com.github.f4b6a3:uuid-creator:3.6.0'
+    implementation project(':engine-table')
+    implementation project(':extensions-csv')
+    implementation project(':extensions-parquet-table')
+    implementation project(':Util')
+    api project(':java-client-barrage-dagger')
+    implementation project(':proto:proto-backplane-grpc-flight')
+    implementation project(':open-api-lang-tools')
+    implementation project(':log-factory')
+    implementation project(':application-mode')
+    implementation 'com.github.f4b6a3:uuid-creator:3.6.0'
 
-    Classpaths.inheritFlatbuffer(project, 'compile')
+    Classpaths.inheritFlatbuffer(project, 'implementation')
 
     Classpaths.inheritDagger(project)
     Classpaths.inheritDagger(project, /* test */ true)
 
-    compile project(':Plot')
+    implementation project(':Plot')
 
-    compile project(':ClientSupport')
+    implementation project(':ClientSupport')
 
     if ('true' == project.findProperty('extensions.classgraph.enabled')) {
         runtimeOnly project(':extensions-classgraph')
@@ -47,7 +47,7 @@ dependencies {
         runtimeOnly project(':extensions-suanshu')
     }
 
-    testCompile TestTools.projectDependency(project, 'engine-table'),
+    testImplementation TestTools.projectDependency(project, 'engine-table'),
                 TestTools.projectDependency(project, 'Util')
 
     runtimeOnly project(':Numerics'),
@@ -59,7 +59,7 @@ dependencies {
     Classpaths.inheritSlf4j(project, 'slf4j-simple', 'testRuntimeOnly')
 
     // it is essential that this is only added to the classpath for flightTestCompile
-    Classpaths.inheritArrow(project, 'flight-grpc', 'flightTestCompile')
+    Classpaths.inheritArrow(project, 'flight-core', 'flightTestCompile')
 }
 
 // testOutOfBand: non-parallel, not a engine test, not isolated

--- a/grpc-api/src/test/java/io/deephaven/grpc_api/runner/DeephavenApiServerTestBase.java
+++ b/grpc-api/src/test/java/io/deephaven/grpc_api/runner/DeephavenApiServerTestBase.java
@@ -4,7 +4,6 @@ import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.liveness.LivenessScope;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.grpc_api.DeephavenChannel;
-import io.deephaven.grpc_api.appmode.AppMode;
 import io.deephaven.io.logger.LogBuffer;
 import io.deephaven.io.logger.LogBufferGlobal;
 import io.deephaven.util.SafeCloseable;

--- a/java-client/session-dagger/build.gradle
+++ b/java-client/session-dagger/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     Classpaths.inheritAssertJ(project)
 
     testImplementation TestTools.projectDependency(project, 'grpc-api')
+    testImplementation project(':java-client-flight')
+    testImplementation project(':proto:proto-backplane-grpc-flight')
     testImplementation project(':log-to-slf4j')
 }
 

--- a/proto/proto-backplane-grpc-flight/build.gradle
+++ b/proto/proto-backplane-grpc-flight/build.gradle
@@ -6,7 +6,7 @@ description = 'The Deephaven proto-backplane-grpc-flight'
 
 dependencies {
     api project(':proto:proto-backplane-grpc')
-    Classpaths.inheritArrow(project, 'flight-grpc', 'api')
+    Classpaths.inheritArrow(project, 'flight-core', 'api')
 }
 
 apply plugin: 'io.deephaven.java-publishing-conventions'


### PR DESCRIPTION
This is an attempt to use implementation when we can over api (or compile), to better force projects to explicitly declare the dependencies they use and export. The effect of this will be fewer recompiles when not necessary, smaller classpaths for those compiles (which can make them faster), and better parallelization (due to a sparser dependency graph).

The "new" dependencies introduced in this commit were ones that were transitive before with no need to be (i.e. not part of the actual API, but exposed anyway). Some of these are negotiable, like what should the grpc-api project actually expose to downstream projects - this is just a proposal that appears to build as-is, cherry-picked from the jetty work, to make that eventual merge smaller.

Partial #1270