### PR TITLE
Simplify the default configuration to reflect how we run.

### DIFF
--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/RunChartDownsample.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/RunChartDownsample.java
@@ -7,6 +7,7 @@ import io.deephaven.engine.table.ModifiedColumnSet;
 import io.deephaven.engine.table.TableUpdate;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.time.DateTime;
 import io.deephaven.hash.KeyedLongObjectHash;
 import io.deephaven.hash.KeyedLongObjectHashMap;
@@ -14,7 +15,6 @@ import io.deephaven.hash.KeyedLongObjectKey;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.*;
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
  * make nulls result in fewer items in the result table
  */
 public class RunChartDownsample implements Function<Table, Table> {
-    private static final Logger log = ProcessEnvironment.getDefaultLog(RunChartDownsample.class);
+    private static final Logger log = LoggerFactory.getLogger(RunChartDownsample.class);
 
     public static final int CHUNK_SIZE = Configuration.getInstance().getIntegerWithDefault("chunkSize", 1 << 14);
 

--- a/FishUtil/src/main/java/io/deephaven/util/process/BaseProcessEnvironment.java
+++ b/FishUtil/src/main/java/io/deephaven/util/process/BaseProcessEnvironment.java
@@ -63,14 +63,4 @@ public abstract class BaseProcessEnvironment implements ProcessEnvironment {
     public final String getMainClassName() {
         return mainClassName;
     }
-
-    @Override
-    public final Logger getLog() {
-        if (!Boolean.getBoolean("LoggerFactory.silenceOnProcessEnvironment")) {
-            log.warn(new RuntimeException("Trace"))
-                    .append("Logger being fetched via ProcessEnvironment instead of io.deephaven.internal.log.LoggerFactory")
-                    .endl();
-        }
-        return log;
-    }
 }

--- a/FishUtil/src/main/java/io/deephaven/util/process/ProcessEnvironment.java
+++ b/FishUtil/src/main/java/io/deephaven/util/process/ProcessEnvironment.java
@@ -8,8 +8,6 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.configuration.PropertyException;
 import io.deephaven.io.logger.Logger;
-import io.deephaven.io.logger.StreamLoggerImpl;
-import io.deephaven.internal.log.LoggerFactory;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -41,13 +39,6 @@ public interface ProcessEnvironment {
      * @return The main class name
      */
     String getMainClassName();
-
-    /**
-     * Access a shared Logger.
-     *
-     * @return The Logger
-     */
-    Logger getLog();
 
     /**
      * Hook for setting up an installation-specific environment for a given process.
@@ -124,32 +115,6 @@ public interface ProcessEnvironment {
 
     static String getGlobalMainClassName() {
         return get().getMainClassName();
-    }
-
-    static Logger getGlobalLog() {
-        return get().getLog();
-    }
-
-    /**
-     * Get the global log if a global process environment has been installed, or else a logger that will output to
-     * {@link System#out}.
-     * 
-     * @return A logger that can safely be used by code that doesn't otherwise have access to one
-     */
-    static Logger getDefaultLog() {
-        final ProcessEnvironment processEnvironment = ProcessEnvironment.tryGet();
-        return processEnvironment != null ? processEnvironment.getLog() : new StreamLoggerImpl();
-    }
-
-    /**
-     * Get the global log if a global process environment has been installed, or else a
-     * {@link LoggerFactory#getLogger(Class)} for the given class.
-     * 
-     * @return A logger that can safely be used by code that doesn't otherwise have access to one
-     */
-    static Logger getDefaultLog(Class<?> clazz) {
-        final ProcessEnvironment processEnvironment = ProcessEnvironment.tryGet();
-        return processEnvironment != null ? processEnvironment.getLog() : LoggerFactory.getLogger(clazz);
     }
 
     /**

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ConditionalModels.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ConditionalModels.java
@@ -6,7 +6,7 @@ package io.deephaven.modelfarm;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.configuration.Configuration;
-import io.deephaven.util.process.ProcessEnvironment;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.modelfarm.ModelMultiExec.Models;
 
 import java.util.ArrayList;
@@ -26,7 +26,7 @@ import java.util.function.Function;
  */
 public class ConditionalModels<DATA_TYPE, STATE_TYPE, KEY_TYPE> implements Models<DATA_TYPE> {
 
-    private static final io.deephaven.io.logger.Logger log = ProcessEnvironment.getDefaultLog(ConditionalModels.class);
+    private static final io.deephaven.io.logger.Logger log = LoggerFactory.getLogger(ConditionalModels.class);
     private static final boolean LOG_PERF =
             Configuration.getInstance().getBooleanWithDefault("ModelFarm.logConditionalModelsPerformance", false);
 

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmOnDemand.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmOnDemand.java
@@ -9,8 +9,8 @@ import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
 import io.deephaven.engine.table.impl.NotificationStepSource;
 import io.deephaven.util.FunctionalInterfaces;
 
@@ -33,7 +33,7 @@ public class ModelFarmOnDemand<KEYTYPE, DATATYPE, ROWDATAMANAGERTYPE extends Row
 
     private static final boolean LOG_PERF =
             Configuration.getInstance().getBooleanWithDefault("ModelFarm.logModelFarmOnDemandPerformance", false);
-    private static final Logger log = ProcessEnvironment.getDefaultLog(ModelFarmOnDemand.class);
+    private static final Logger log = LoggerFactory.getLogger(ModelFarmOnDemand.class);
     private static final FunctionalInterfaces.ThrowingBiConsumer<QueryDataRetrievalOperation, NotificationStepSource, RuntimeException> DO_LOCKED_FUNCTION =
             getDoLockedConsumer(GetDataLockType.UGP_READ_LOCK);
 

--- a/Net/src/main/java/io/deephaven/net/impl/nio/NIODriver.java
+++ b/Net/src/main/java/io/deephaven/net/impl/nio/NIODriver.java
@@ -18,7 +18,6 @@ import io.deephaven.io.logger.Logger;
 import io.deephaven.io.sched.Scheduler;
 import io.deephaven.io.sched.TimedJob;
 import io.deephaven.io.sched.YASchedulerImpl;
-import io.deephaven.util.process.ProcessEnvironment;
 
 public class NIODriver implements Runnable {
     private static Logger log;
@@ -94,14 +93,7 @@ public class NIODriver implements Runnable {
      */
     public static void init() {
         if (!initialized) {
-            final Logger log;
-            final ProcessEnvironment processEnvironment = ProcessEnvironment.tryGet();
-            if (processEnvironment == null) {
-                log = LoggerFactory.getLogger(NIODriver.class);
-            } else {
-                log = processEnvironment.getLog();
-            }
-            init(log);
+            init(LoggerFactory.getLogger(NIODriver.class));
         }
     }
 

--- a/docker/server-slim/src/main/docker/image-bootstrap.properties
+++ b/docker/server-slim/src/main/docker/image-bootstrap.properties
@@ -1,9 +1,5 @@
 Configuration.rootFile=grpc-api.prop
-io.deephaven.configuration.PropertyInputStreamLoader.override=io.deephaven.configuration.PropertyInputStreamLoaderTraditional
-LoggerFactory.silenceOnProcessEnvironment=true
 workspace=.
 devroot=.
-stdout.toLogBuffer=true
-stderr.toLogBuffer=true
 
 deephaven.console.type=groovy

--- a/docker/server/src/main/configure/image-bootstrap.properties
+++ b/docker/server/src/main/configure/image-bootstrap.properties
@@ -1,7 +1,3 @@
 Configuration.rootFile=grpc-api.prop
-io.deephaven.configuration.PropertyInputStreamLoader.override=io.deephaven.configuration.PropertyInputStreamLoaderTraditional
-LoggerFactory.silenceOnProcessEnvironment=true
 workspace=.
 devroot=.
-stdout.toLogBuffer=true
-stderr.toLogBuffer=true

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
@@ -36,12 +36,6 @@ import java.util.Collection;
 public abstract class SourceTable extends RedefinableTable {
 
     /**
-     * Static log instance for use in trace.
-     */
-    private static final Logger log = ProcessEnvironment.tryGet() == null ? LoggerFactory.getLogger(SourceTable.class)
-            : ProcessEnvironment.getGlobalLog();
-
-    /**
      * Component factory. Mostly held for redefinitions.
      */
     final SourceTableComponentFactory componentFactory;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
@@ -7,6 +7,7 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.lang.QueryLanguageParser;
 import io.deephaven.engine.table.lang.QueryScopeParam;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.vector.ObjectVector;
 import io.deephaven.engine.table.lang.QueryLibrary;
@@ -14,7 +15,6 @@ import io.deephaven.engine.table.lang.QueryScope;
 import io.deephaven.engine.table.impl.select.python.DeephavenCompatibleFunction;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -27,7 +27,7 @@ import static io.deephaven.engine.util.PythonScopeJpyImpl.NumbaCallableWrapper;
 import static io.deephaven.engine.table.impl.select.DhFormulaColumn.COLUMN_SUFFIX;
 
 public abstract class AbstractConditionFilter extends WhereFilterImpl {
-    private static final Logger log = ProcessEnvironment.getDefaultLog(AbstractConditionFilter.class);
+    private static final Logger log = LoggerFactory.getLogger(AbstractConditionFilter.class);
     final Map<String, String> outerToInnerNames;
     final Map<String, String> innerToOuterNames;
     @NotNull

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AutoTuningIncrementalReleaseFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AutoTuningIncrementalReleaseFilter.java
@@ -5,10 +5,10 @@
 package io.deephaven.engine.table.impl.select;
 
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.time.DateTime;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.util.clock.RealTimeClock;
-import io.deephaven.util.process.ProcessEnvironment;
 import io.deephaven.time.ClockTimeProvider;
 import io.deephaven.engine.updategraph.TerminalNotification;
 import io.deephaven.time.TimeProvider;
@@ -190,7 +190,8 @@ public class AutoTuningIncrementalReleaseFilter extends BaseIncrementalReleaseFi
     @ScriptApi
     public AutoTuningIncrementalReleaseFilter(long initialSize, long initialRelease, double targetFactor,
             boolean verbose, TimeProvider timeProvider) {
-        this(ProcessEnvironment.getDefaultLog(), initialSize, initialRelease, targetFactor, verbose, timeProvider);
+        this(LoggerFactory.getLogger(AutoTuningIncrementalReleaseFilter.class), initialSize, initialRelease,
+                targetFactor, verbose, timeProvider);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AutoTuningIncrementalReleaseFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AutoTuningIncrementalReleaseFilter.java
@@ -96,6 +96,8 @@ import java.text.DecimalFormat;
  * </pre>
  */
 public class AutoTuningIncrementalReleaseFilter extends BaseIncrementalReleaseFilter {
+    private static final Logger log = LoggerFactory.getLogger(AutoTuningIncrementalReleaseFilter.class);
+
     @NotNull
     private final TimeProvider timeProvider;
     private final long initialRelease;
@@ -190,8 +192,7 @@ public class AutoTuningIncrementalReleaseFilter extends BaseIncrementalReleaseFi
     @ScriptApi
     public AutoTuningIncrementalReleaseFilter(long initialSize, long initialRelease, double targetFactor,
             boolean verbose, TimeProvider timeProvider) {
-        this(LoggerFactory.getLogger(AutoTuningIncrementalReleaseFilter.class), initialSize, initialRelease,
-                targetFactor, verbose, timeProvider);
+        this(log, initialSize, initialRelease, targetFactor, verbose, timeProvider);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilterFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilterFactory.java
@@ -6,10 +6,10 @@ package io.deephaven.engine.table.impl.select;
 
 import io.deephaven.base.Pair;
 import io.deephaven.engine.table.lang.QueryScope;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.time.DateTime;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.util.AbstractExpressionFactory;
 import io.deephaven.engine.util.ExpressionParser;
@@ -37,7 +37,7 @@ import static io.deephaven.engine.table.impl.select.SelectFactoryConstants.*;
  */
 public class WhereFilterFactory {
 
-    private static final Logger log = ProcessEnvironment.getDefaultLog(WhereFilterFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(WhereFilterFactory.class);
 
     private static final ExpressionParser<WhereFilter> parser = new ExpressionParser<>();
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RowSetShiftDataExpander.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RowSetShiftDataExpander.java
@@ -10,10 +10,10 @@ import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.TableUpdateListener;
 import io.deephaven.engine.table.ModifiedColumnSet;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.log.impl.LogOutputStringImpl;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.util.SafeCloseable;
-import io.deephaven.util.process.ProcessEnvironment;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
@@ -224,7 +224,7 @@ public class RowSetShiftDataExpander implements SafeCloseable {
                 .append(LogOutput::nl).append("\tremovedIntersectCurrent=").append(removedIntersectCurrent)
                 .append(LogOutput::nl).append("\t    modifiedMinusCurrent=").append(modifiedMinusCurrent).toString();
 
-        final Logger log = ProcessEnvironment.getDefaultLog();
+        final Logger log = LoggerFactory.getLogger(RowSetShiftDataExpander.class);
         log.error().append(indexUpdateErrorMessage).endl();
 
         if (serializedIndices != null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RowSetShiftDataExpander.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RowSetShiftDataExpander.java
@@ -27,6 +27,8 @@ import java.util.function.BiConsumer;
  */
 public class RowSetShiftDataExpander implements SafeCloseable {
 
+    private static final Logger log = LoggerFactory.getLogger(RowSetShiftDataExpander.class);
+
     private final RowSet added;
     private final RowSet removed;
     private final WritableRowSet modified;
@@ -224,7 +226,6 @@ public class RowSetShiftDataExpander implements SafeCloseable {
                 .append(LogOutput::nl).append("\tremovedIntersectCurrent=").append(removedIntersectCurrent)
                 .append(LogOutput::nl).append("\t    modifiedMinusCurrent=").append(modifiedMinusCurrent).toString();
 
-        final Logger log = LoggerFactory.getLogger(RowSetShiftDataExpander.class);
         log.error().append(indexUpdateErrorMessage).endl();
 
         if (serializedIndices != null) {

--- a/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
@@ -16,6 +16,7 @@ import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.time.DateTime;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.time.TimeProvider;
@@ -36,7 +37,6 @@ import io.deephaven.engine.table.impl.util.*;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.io.util.NullOutputStream;
 import io.deephaven.util.annotations.ScriptApi;
-import io.deephaven.util.process.ProcessEnvironment;
 import io.deephaven.util.type.ArrayTypeUtils;
 
 import java.io.*;
@@ -58,7 +58,7 @@ import java.util.stream.Stream;
 @SuppressWarnings("unused")
 public class TableTools {
 
-    private static final Logger staticLog_ = ProcessEnvironment.getDefaultLog(TableTools.class);
+    private static final Logger staticLog_ = LoggerFactory.getLogger(TableTools.class);
 
     // Public so it can be used from user scripts
     @SuppressWarnings("WeakerAccess")

--- a/engine/table/src/main/java/io/deephaven/engine/util/WorkerPythonEnvironment.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/WorkerPythonEnvironment.java
@@ -3,8 +3,8 @@ package io.deephaven.engine.util;
 import io.deephaven.base.FileUtils;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.configuration.Configuration;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
 import io.deephaven.engine.table.lang.QueryScope;
 import io.deephaven.engine.util.jpy.JpyInit;
 import org.jpy.PyObject;
@@ -36,7 +36,7 @@ public enum WorkerPythonEnvironment {
      * Runs the init script specified by WorkerPythonEnvironment.initScript.
      */
     WorkerPythonEnvironment() {
-        log = ProcessEnvironment.getGlobalLog();
+        log = LoggerFactory.getLogger(WorkerPythonEnvironment.class);
 
         JpyInit.init(log);
         PythonEvaluatorJpy jpy = PythonEvaluatorJpy.withGlobalCopy();

--- a/engine/table/src/main/java/io/deephaven/engine/util/config/InputTableStatusListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/config/InputTableStatusListener.java
@@ -1,7 +1,7 @@
 package io.deephaven.engine.util.config;
 
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
-import io.deephaven.util.process.ProcessEnvironment;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -13,7 +13,7 @@ public interface InputTableStatusListener {
      * A Simple implementation that does nothing on success, and logs an error on failure
      */
     InputTableStatusListener DEFAULT = new InputTableStatusListener() {
-        final Logger log = ProcessEnvironment.getDefaultLog(InputTableStatusListener.class);
+        final Logger log = LoggerFactory.getLogger(InputTableStatusListener.class);
 
         @Override
         public void onError(Throwable t) {

--- a/engine/table/src/main/java/io/deephaven/engine/util/parametrized/TableSupplier.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/parametrized/TableSupplier.java
@@ -6,9 +6,9 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.TableMap;
 import io.deephaven.engine.util.TableTools;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.util.annotations.ScriptApi;
-import io.deephaven.util.process.ProcessEnvironment;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.ref.WeakReference;
@@ -75,7 +75,7 @@ public class TableSupplier extends LivenessArtifact implements InvocationHandler
         return method.getName().startsWith(FILTER_OPERATION_PREFIX);
     }
 
-    private final Logger log = ProcessEnvironment.getDefaultLog(TableSupplier.class);
+    private final Logger log = LoggerFactory.getLogger(TableSupplier.class);
 
     /**
      * The source table used to generate the supplied table

--- a/engine/table/src/main/java/io/deephaven/engine/util/parametrized/TableSupplier.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/parametrized/TableSupplier.java
@@ -75,7 +75,7 @@ public class TableSupplier extends LivenessArtifact implements InvocationHandler
         return method.getName().startsWith(FILTER_OPERATION_PREFIX);
     }
 
-    private final Logger log = LoggerFactory.getLogger(TableSupplier.class);
+    private static final Logger log = LoggerFactory.getLogger(TableSupplier.class);
 
     /**
      * The source table used to generate the supplied table

--- a/engine/updategraph/src/main/java/io/deephaven/engine/liveness/RetainedReferenceTracker.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/liveness/RetainedReferenceTracker.java
@@ -4,9 +4,9 @@ import io.deephaven.base.cache.RetentionCache;
 import io.deephaven.base.reference.WeakCleanupReference;
 import io.deephaven.engine.util.reference.CleanupReferenceProcessorInstance;
 import io.deephaven.hash.KeyedObjectHashSet;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.util.Utils;
 import io.deephaven.util.datastructures.hash.IdentityKeyedObjectKey;
-import io.deephaven.util.process.ProcessEnvironment;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.ref.SoftReference;
@@ -60,8 +60,10 @@ final class RetainedReferenceTracker<TYPE extends LivenessManager> extends WeakC
         impl = enforceStrongReachability ? new StrongImpl() : new WeakImpl();
         outstandingCount.getAndIncrement();
         if (Liveness.DEBUG_MODE_ENABLED) {
-            ProcessEnvironment.getDefaultLog().info().append("Creating ").append(Utils.REFERENT_FORMATTER, this)
-                    .append(" at ").append(new LivenessDebugException()).endl();
+            LoggerFactory.getLogger(RetainedReferenceTracker.class).info()
+                    .append("Creating ").append(Utils.REFERENT_FORMATTER, this)
+                    .append(" at ").append(new LivenessDebugException())
+                    .endl();
         }
     }
 

--- a/engine/updategraph/src/main/java/io/deephaven/engine/liveness/RetainedReferenceTracker.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/liveness/RetainedReferenceTracker.java
@@ -5,6 +5,7 @@ import io.deephaven.base.reference.WeakCleanupReference;
 import io.deephaven.engine.util.reference.CleanupReferenceProcessorInstance;
 import io.deephaven.hash.KeyedObjectHashSet;
 import io.deephaven.internal.log.LoggerFactory;
+import io.deephaven.io.logger.Logger;
 import io.deephaven.util.Utils;
 import io.deephaven.util.datastructures.hash.IdentityKeyedObjectKey;
 import org.jetbrains.annotations.NotNull;
@@ -44,6 +45,8 @@ final class RetainedReferenceTracker<TYPE extends LivenessManager> extends WeakC
     private static final ThreadLocal<SoftReference<Queue<WeakReference<? extends LivenessReferent>>>> tlSavedQueueReference =
             new ThreadLocal<>();
 
+    private static final Logger log = LoggerFactory.getLogger(RetainedReferenceTracker.class);
+
     private final Impl impl;
 
     @SuppressWarnings("FieldMayBeFinal") // We are using an AtomicIntegerFieldUpdater (via reflection) to change this
@@ -60,7 +63,7 @@ final class RetainedReferenceTracker<TYPE extends LivenessManager> extends WeakC
         impl = enforceStrongReachability ? new StrongImpl() : new WeakImpl();
         outstandingCount.getAndIncrement();
         if (Liveness.DEBUG_MODE_ENABLED) {
-            LoggerFactory.getLogger(RetainedReferenceTracker.class).info()
+            log.info()
                     .append("Creating ").append(Utils.REFERENT_FORMATTER, this)
                     .append(" at ").append(new LivenessDebugException())
                     .endl();

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/LogicalClock.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/LogicalClock.java
@@ -5,7 +5,7 @@
 package io.deephaven.engine.updategraph;
 
 import io.deephaven.base.verify.Assert;
-import io.deephaven.util.process.ProcessEnvironment;
+import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.util.annotations.TestUseOnly;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -142,7 +142,7 @@ public enum LogicalClock {
             return;
         }
         if (value == updatingCycleValue) {
-            ProcessEnvironment.getDefaultLog(LogicalClock.class).warn()
+            LoggerFactory.getLogger(LogicalClock.class).warn()
                     .append("LogicalClock cycle was not completed in normal operation, value=").append(value).endl();
             completeUpdateCycle();
             return;

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/LogicalClock.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/LogicalClock.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.updategraph;
 
 import io.deephaven.base.verify.Assert;
 import io.deephaven.internal.log.LoggerFactory;
+import io.deephaven.io.logger.Logger;
 import io.deephaven.util.annotations.TestUseOnly;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -27,6 +28,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public enum LogicalClock {
 
     DEFAULT;
+
+    private static final Logger log = LoggerFactory.getLogger(LogicalClock.class);
 
     /**
      * The state component of a logical timestamp.
@@ -142,7 +145,7 @@ public enum LogicalClock {
             return;
         }
         if (value == updatingCycleValue) {
-            LoggerFactory.getLogger(LogicalClock.class).warn()
+            log.warn()
                     .append("LogicalClock cycle was not completed in normal operation, value=").append(value).endl();
             completeUpdateCycle();
             return;

--- a/grpc-api-client/console/src/main/java/io/deephaven/grpc_api/example/ConsoleClient.java
+++ b/grpc-api-client/console/src/main/java/io/deephaven/grpc_api/example/ConsoleClient.java
@@ -47,8 +47,6 @@ public class ConsoleClient {
     public static void main(final String[] args) throws Exception {
         // Assign properties that need to be set to even turn on
         System.setProperty("Configuration.rootFile", "grpc-api.prop");
-        System.setProperty("io.deephaven.configuration.PropertyInputStreamLoader.override",
-                "io.deephaven.configuration.PropertyInputStreamLoaderTraditional");
 
         final String sessionType = System.getProperty("console.sessionType", "groovy");
         log.info().append("Session type ").append(sessionType).endl();

--- a/grpc-api/server/native/src/main/resources/bootstrap.properties
+++ b/grpc-api/server/native/src/main/resources/bootstrap.properties
@@ -1,7 +1,3 @@
 Configuration.rootFile=grpc-api-native.prop
-io.deephaven.configuration.PropertyInputStreamLoader.override=io.deephaven.configuration.PropertyInputStreamLoaderTraditional
-LoggerFactory.silenceOnProcessEnvironment=true
 workspace=.
 devroot=.
-stdout.toLogBuffer=true
-stderr.toLogBuffer=true

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/log/LogModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/log/LogModule.java
@@ -48,8 +48,8 @@ public interface LogModule {
     @Provides
     @Singleton // StreamToLogBuffer maintains state
     static StreamToLogBuffer providesStreamToLogBuffer(LogBuffer logBuffer) {
-        final boolean toStdout = "true".equals(System.getProperty("stdout.toLogBuffer", "true"));
-        final boolean toStderr = "true".equals(System.getProperty("stderr.toLogBuffer", "true"));
+        final boolean toStdout = Boolean.parseBoolean(System.getProperty("stdout.toLogBuffer", "true"));
+        final boolean toStderr = Boolean.parseBoolean(System.getProperty("stderr.toLogBuffer", "true"));
         // TODO (core#90): Add configuration and documentation for LogBufferOutputStream
         return new StreamToLogBuffer(logBuffer, toStdout, toStderr, 256, 1 << 19); // 512 KiB
     }

--- a/grpc-api/src/main/java/io/deephaven/grpc_api/log/LogModule.java
+++ b/grpc-api/src/main/java/io/deephaven/grpc_api/log/LogModule.java
@@ -48,8 +48,8 @@ public interface LogModule {
     @Provides
     @Singleton // StreamToLogBuffer maintains state
     static StreamToLogBuffer providesStreamToLogBuffer(LogBuffer logBuffer) {
-        final boolean toStdout = Boolean.getBoolean("stdout.toLogBuffer");
-        final boolean toStderr = Boolean.getBoolean("stderr.toLogBuffer");
+        final boolean toStdout = "true".equals(System.getProperty("stdout.toLogBuffer", "true"));
+        final boolean toStderr = "true".equals(System.getProperty("stderr.toLogBuffer", "true"));
         // TODO (core#90): Add configuration and documentation for LogBufferOutputStream
         return new StreamToLogBuffer(logBuffer, toStdout, toStderr, 256, 1 << 19); // 512 KiB
     }

--- a/log-factory/src/main/java/io/deephaven/internal/log/LoggerFactory.java
+++ b/log-factory/src/main/java/io/deephaven/internal/log/LoggerFactory.java
@@ -8,7 +8,7 @@ public interface LoggerFactory {
     }
 
     static Logger getLogger(Class<?> clazz) {
-        return getInstance().create(clazz.getName()); // todo
+        return getInstance().create(clazz.getName());
     }
 
     static LoggerFactory getInstance() {

--- a/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerCompleterMixin.groovy
+++ b/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerCompleterMixin.groovy
@@ -1,9 +1,9 @@
 package io.deephaven.lang.completion
 
 import io.deephaven.engine.util.VariableProvider
+import io.deephaven.internal.log.LoggerFactory
 import io.deephaven.io.logger.Logger
 import io.deephaven.proto.backplane.script.grpc.CompletionItem
-import io.deephaven.util.process.ProcessEnvironment
 import io.deephaven.lang.parse.ParsedDocument
 
 /**
@@ -12,7 +12,7 @@ trait ChunkerCompleterMixin extends ChunkerParseTestMixin {
 
     Set<CompletionItem> performSearch(ParsedDocument doc, int from, VariableProvider vars) {
 
-        Logger log = ProcessEnvironment.getDefaultLog(CompletionHandler)
+        Logger log = LoggerFactory.getLogger(CompletionHandler)
 
         ChunkerCompleter completer = new ChunkerCompleter(log, vars)
 

--- a/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerCompletionHandlerTest.groovy
+++ b/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerCompletionHandlerTest.groovy
@@ -3,10 +3,10 @@ package io.deephaven.lang.completion
 import io.deephaven.engine.table.ColumnDefinition
 import io.deephaven.engine.table.TableDefinition
 import io.deephaven.engine.util.VariableProvider
+import io.deephaven.internal.log.LoggerFactory
 import io.deephaven.io.logger.Logger
 import io.deephaven.proto.backplane.script.grpc.ChangeDocumentRequest.TextDocumentContentChangeEvent
 import io.deephaven.proto.backplane.script.grpc.CompletionItem
-import io.deephaven.util.process.ProcessEnvironment
 import io.deephaven.engine.table.Table
 import io.deephaven.lang.parse.CompletionParser
 import spock.lang.Specification
@@ -125,7 +125,7 @@ u = t.'''
         String src = "t ="
         doc = p.parse(src)
 
-        ProcessEnvironment.getDefaultLog(CompletionHandler)
+        LoggerFactory.getLogger(CompletionHandler)
         VariableProvider variables = Mock(VariableProvider) {
             _ * getVariableNames() >> ['emptyTable']
             0 * _
@@ -141,7 +141,7 @@ u = t.'''
 
     def "Completion should work correctly after making edits"() {
         given:
-        Logger log = ProcessEnvironment.getDefaultLog(CompletionHandler)
+        Logger log = LoggerFactory.getLogger(CompletionHandler)
         CompletionParser p = new CompletionParser()
         String uri = "testing://"
         String src1 = """a = 1

--- a/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerParseTestMixin.groovy
+++ b/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerParseTestMixin.groovy
@@ -3,6 +3,7 @@ package io.deephaven.lang.completion
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import io.deephaven.engine.util.VariableProvider
+import io.deephaven.internal.log.LoggerFactory
 import io.deephaven.io.logger.Logger
 import io.deephaven.lang.generated.Node
 import io.deephaven.lang.generated.Token
@@ -11,7 +12,6 @@ import io.deephaven.lang.parse.ParsedDocument
 import io.deephaven.proto.backplane.script.grpc.CompletionItem
 import io.deephaven.proto.backplane.script.grpc.CompletionItemOrBuilder
 import io.deephaven.proto.backplane.script.grpc.Position
-import io.deephaven.util.process.ProcessEnvironment
 import spock.lang.Specification
 
 /**
@@ -55,7 +55,7 @@ trait ChunkerParseTestMixin {
 
     @CompileDynamic
     String doCompletion(String command, int completionPos, int resultIndex) {
-        Logger log = ProcessEnvironment.getDefaultLog(CompletionHandler)
+        Logger log = LoggerFactory.getLogger(CompletionHandler)
 
         ChunkerCompleter completer = new ChunkerCompleter(log, variables)
         parse(command)

--- a/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ColumnExpressionCompletionHandlerTest.groovy
+++ b/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ColumnExpressionCompletionHandlerTest.groovy
@@ -1,9 +1,9 @@
 package io.deephaven.lang.completion
 
 import io.deephaven.engine.util.VariableProvider
+import io.deephaven.internal.log.LoggerFactory
 import io.deephaven.io.logger.Logger
 import io.deephaven.proto.backplane.script.grpc.CompletionItem
-import io.deephaven.util.process.ProcessEnvironment
 import io.deephaven.engine.table.Table
 import io.deephaven.engine.table.TableDefinition
 import io.deephaven.time.DateTime
@@ -26,7 +26,7 @@ class ColumnExpressionCompletionHandlerTest extends Specification implements Chu
             CompletionParser p = new CompletionParser()
             doc = p.parse(src)
 
-            Logger log = ProcessEnvironment.getDefaultLog(CompletionHandler)
+            Logger log = LoggerFactory.getLogger(CompletionHandler)
         VariableProvider variables = Mock(VariableProvider) {
                 (0..1) * getVariableNames() >> ['t']
                 (0..1) * getVariableType('t') >> Table
@@ -74,7 +74,7 @@ t = t.updateView ( 'D
 """
         doc = p.parse(src)
 
-        Logger log = ProcessEnvironment.getDefaultLog(CompletionHandler)
+        Logger log = LoggerFactory.getLogger(CompletionHandler)
         VariableProvider variables = Mock() {
             (0..1) * getTableDefinition('t') >> new TableDefinition([String, Long, Integer], ['Date', 'Delta', 'NotMeThough'])
             (0..1) * getVariableType('t') >> Table
@@ -113,7 +113,7 @@ t = t.update('A=') .update( 'B=')
 """
         doc = p.parse(src)
 
-        Logger log = ProcessEnvironment.getDefaultLog(CompletionHandler)
+        Logger log = LoggerFactory.getLogger(CompletionHandler)
         VariableProvider variables = Mock(VariableProvider) {
             _ * getTableDefinition('t') >> new TableDefinition([Long, Integer], ['A1', 'A2'])
             0 * _
@@ -170,7 +170,7 @@ t = newTable(
 t.where('"""
         doc = p.parse(src)
 
-        Logger log = ProcessEnvironment.getDefaultLog(CompletionHandler)
+        Logger log = LoggerFactory.getLogger(CompletionHandler)
         VariableProvider variables = Mock(VariableProvider) {
             _ * getTableDefinition('t') >> null
             0 * _


### PR DESCRIPTION
Callers can no longer get the logs from ProcessEnvironment.