### PR TITLE
Configure cache dir

### DIFF
--- a/docker/server-slim/src/main/docker/image-bootstrap.properties
+++ b/docker/server-slim/src/main/docker/image-bootstrap.properties
@@ -8,4 +8,3 @@ stderr.toLogBuffer=true
 
 deephaven.console.type=groovy
 deephaven.cache.dir=/cache
-java.io.tmpdir=/cache/tmp

--- a/docker/server-slim/src/main/docker/image-bootstrap.properties
+++ b/docker/server-slim/src/main/docker/image-bootstrap.properties
@@ -7,3 +7,5 @@ stdout.toLogBuffer=true
 stderr.toLogBuffer=true
 
 deephaven.console.type=groovy
+deephaven.cache.dir=/cache
+java.io.tmpdir=/cache/tmp

--- a/docker/server/src/main/configure/image-bootstrap.properties
+++ b/docker/server/src/main/configure/image-bootstrap.properties
@@ -5,3 +5,6 @@ workspace=.
 devroot=.
 stdout.toLogBuffer=true
 stderr.toLogBuffer=true
+
+deephaven.cache.dir=/cache
+java.io.tmpdir=/cache/tmp

--- a/docker/server/src/main/configure/image-bootstrap.properties
+++ b/docker/server/src/main/configure/image-bootstrap.properties
@@ -7,4 +7,3 @@ stdout.toLogBuffer=true
 stderr.toLogBuffer=true
 
 deephaven.cache.dir=/cache
-java.io.tmpdir=/cache/tmp

--- a/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
@@ -9,7 +9,6 @@ import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.api.util.NameValidator;
 import io.deephaven.base.FileUtils;
 import io.deephaven.compilertools.CompilerTools;
-import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.lang.QueryLibrary;
@@ -31,11 +30,11 @@ import java.util.*;
  * evaluateScript which handles liveness and diffs in a consistent way.
  */
 public abstract class AbstractScriptSession extends LivenessScope implements ScriptSession, VariableProvider {
-    public static final String CLASS_CACHE_LOCATION = Configuration.getInstance()
-            .getStringWithDefault("ScriptSession.classCacheDirectory", "/tmp/dh_class_cache");
+
+    private static final Path CLASS_CACHE_LOCATION = CacheDir.get().resolve("dh_class_cache");
 
     public static void createScriptCache() {
-        final File classCacheDirectory = new File(CLASS_CACHE_LOCATION);
+        final File classCacheDirectory = CLASS_CACHE_LOCATION.toFile();
         createOrClearDirectory(classCacheDirectory);
     }
 
@@ -61,7 +60,7 @@ public abstract class AbstractScriptSession extends LivenessScope implements Scr
         this.changeListener = changeListener;
 
         final UUID scriptCacheId = UuidCreator.getRandomBased();
-        classCacheDirectory = new File(CLASS_CACHE_LOCATION, UuidCreator.toString(scriptCacheId));
+        classCacheDirectory = CLASS_CACHE_LOCATION.resolve(UuidCreator.toString(scriptCacheId)).toFile();
         createOrClearDirectory(classCacheDirectory);
 
         queryScope = newQueryScope();

--- a/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
@@ -31,7 +31,7 @@ import java.util.*;
  */
 public abstract class AbstractScriptSession extends LivenessScope implements ScriptSession, VariableProvider {
 
-    private static final Path CLASS_CACHE_LOCATION = CacheDir.get().resolve("dh_class_cache");
+    private static final Path CLASS_CACHE_LOCATION = CacheDir.get().resolve("script-session-classes");
 
     public static void createScriptCache() {
         final File classCacheDirectory = CLASS_CACHE_LOCATION.toFile();
@@ -59,6 +59,7 @@ public abstract class AbstractScriptSession extends LivenessScope implements Scr
     protected AbstractScriptSession(@Nullable Listener changeListener, boolean isDefaultScriptSession) {
         this.changeListener = changeListener;
 
+        // TODO(deephaven-core#1713): Introduce instance-id concept
         final UUID scriptCacheId = UuidCreator.getRandomBased();
         classCacheDirectory = CLASS_CACHE_LOCATION.resolve(UuidCreator.toString(scriptCacheId)).toFile();
         createOrClearDirectory(classCacheDirectory);

--- a/engine/table/src/main/java/io/deephaven/engine/util/CacheDir.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/CacheDir.java
@@ -1,0 +1,32 @@
+package io.deephaven.engine.util;
+
+import java.nio.file.Path;
+
+public final class CacheDir {
+    private static final String DEEPHAVEN_CACHE_DIR = "deephaven.cache.dir";
+    private static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
+
+    private static final Path cacheDir;
+
+    static {
+        final String deephavenCacheDir = System.getProperty(DEEPHAVEN_CACHE_DIR);
+        if (deephavenCacheDir != null) {
+            cacheDir = Path.of(deephavenCacheDir);
+        } else {
+            cacheDir = Path.of(System.getProperty(JAVA_IO_TMPDIR), "deephaven-cache");
+        }
+    }
+
+    /**
+     * Return the value for the system property {@value DEEPHAVEN_CACHE_DIR} if it is present.
+     *
+     * <p>
+     * Otherwise, return "%s/deephaven-cache", parameterized from the value of the system property
+     * {@value JAVA_IO_TMPDIR}.
+     *
+     * @return the cache dir
+     */
+    public static Path get() {
+        return cacheDir;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/util/CacheDir.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/CacheDir.java
@@ -1,7 +1,14 @@
 package io.deephaven.engine.util;
 
+import io.deephaven.configuration.Configuration;
+
 import java.nio.file.Path;
 
+/**
+ * The cache directory is a directory that the application may use for storing data with "cache-like" semantics.
+ * Cache-like data is data that may be preserved across restarts, but the application logic should not make the
+ * assumptions that the data will be available.
+ */
 public final class CacheDir {
     private static final String DEEPHAVEN_CACHE_DIR = "deephaven.cache.dir";
     private static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
@@ -9,19 +16,19 @@ public final class CacheDir {
     private static final Path cacheDir;
 
     static {
-        final String deephavenCacheDir = System.getProperty(DEEPHAVEN_CACHE_DIR);
-        if (deephavenCacheDir != null) {
-            cacheDir = Path.of(deephavenCacheDir);
+        final Configuration config = Configuration.getInstance();
+        if (config.hasProperty(DEEPHAVEN_CACHE_DIR)) {
+            cacheDir = Path.of(config.getProperty(DEEPHAVEN_CACHE_DIR));
         } else {
-            cacheDir = Path.of(System.getProperty(JAVA_IO_TMPDIR), "deephaven-cache");
+            cacheDir = Path.of(System.getProperty(JAVA_IO_TMPDIR), "deephaven", "cache");
         }
     }
 
     /**
-     * Return the value for the system property {@value DEEPHAVEN_CACHE_DIR} if it is present.
+     * Return the value for the configuration {@value DEEPHAVEN_CACHE_DIR} if it is present.
      *
      * <p>
-     * Otherwise, return "%s/deephaven-cache", parameterized from the value of the system property
+     * Otherwise, return "%s/deephaven/cache", parameterized from the value of the system property
      * {@value JAVA_IO_TMPDIR}.
      *
      * @return the cache dir

--- a/engine/time/src/main/java/io/deephaven/time/calendar/Calendars.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/Calendars.java
@@ -131,7 +131,7 @@ public class Calendars implements Map<String, BusinessCalendar> {
                     final File calendarFile = inputStreamToFile(inputStream);
                     final BusinessCalendar businessCalendar = DefaultBusinessCalendar.getInstance(calendarFile);
                     addCalendar(businessCalendar);
-                    calendarFile.deleteOnExit();
+                    calendarFile.delete();
                 } else {
                     logger.warn("Could not open " + filePath + " from classpath");
                     throw new RuntimeException("Could not open " + filePath + " from classpath");


### PR DESCRIPTION
We should not be writing to a container's `/tmp` directory in docker, unless it's a docker volume.

Our docker images declare a `/cache` volume, so we should:

1. Set `-Djava.io.tmpdir=/cache/tmp` so that any java code using temporary files will inherit a docker volume backed tmp space
2. Introduce `-Ddeephaven.cache.dir` so that those who want more explicit "cache" space (instead of "tmp" space), can take advantage of it. (Only `AbstractScriptSession` atm, but others could use it in the future.)

