### PR TITLE
Add runtime dependency to grpc-netty for java-client-session-examples

### DIFF
--- a/java-client/session-examples/build.gradle
+++ b/java-client/session-examples/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     Classpaths.inheritGrpcPlatform(project, 'implementation')
     implementation 'io.grpc:grpc-core'
+    runtimeOnly 'io.grpc:grpc-netty'
 
     Classpaths.inheritJUnitPlatform(project)
     Classpaths.inheritAssertJ(project)


### PR DESCRIPTION
Fixes this error: io.grpc.ManagedChannelProvider$ProviderNotFoundException: No functional channel service provider found. Try adding a dependency on the grpc-okhttp, grpc-netty, or grpc-netty-shaded artifact