### PR TITLE
gRPC websocket streams should close sanely

### DIFF
--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebSocketServerStream.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebSocketServerStream.java
@@ -137,11 +137,6 @@ public class WebSocketServerStream {
         }
     }
 
-    @OnClose
-    public void onClose(CloseReason closeReason) {
-        stream.transportReportStatus(Status.CANCELLED);// remote end hung up
-    }
-
     private String methodName() {
         return websocketSession.getRequestURI().getPath().substring(1);
     }

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebsocketStreamImpl.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebsocketStreamImpl.java
@@ -201,6 +201,7 @@ public class WebsocketStreamImpl extends AbstractServerStream {
                             ByteBuffer.wrap(((ByteArrayWritableBuffer) frame).bytes, 0, frame.readableBytes());
 
                     websocketSession.getBasicRemote().sendBinary(payload);
+                    transportState.runOnTransportThread(() -> transportState.onSentBytes(numBytes));
                 }
 
             } catch (IOException e) {

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebsocketStreamImpl.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebsocketStreamImpl.java
@@ -127,10 +127,6 @@ public class WebsocketStreamImpl extends AbstractServerStream {
         transportState().transportReportStatus(status);
     }
 
-    public void complete() {
-        transportState().complete();
-    }
-
     @Override
     public TransportState transportState() {
         return transportState;
@@ -253,6 +249,9 @@ public class WebsocketStreamImpl extends AbstractServerStream {
             } catch (IOException e) {
                 throw Status.fromThrowable(e).asRuntimeException();
             }
+            transportState().runOnTransportThread(() -> {
+                transportState().complete();
+            });
         }
 
         @Override

--- a/java-client/barrage-examples/src/main/resources/logback.xml
+++ b/java-client/barrage-examples/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>

--- a/java-client/flight-examples/src/main/resources/logback.xml
+++ b/java-client/flight-examples/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>

--- a/java-client/session-examples/src/main/resources/logback.xml
+++ b/java-client/session-examples/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>

--- a/log-factory/examples/example-logback/src/main/resources/logback.xml
+++ b/log-factory/examples/example-logback/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration debug="true">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>

--- a/qst/graphviz/src/main/resources/logback.xml
+++ b/qst/graphviz/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':proto:proto-backplane-grpc-flight')
     implementation project(':open-api-lang-tools')
     implementation project(':log-factory')
+    Classpaths.inheritSlf4j(project, 'jul-to-slf4j', 'implementation')
     implementation project(':application-mode')
     implementation 'com.github.f4b6a3:uuid-creator:3.6.0'
 

--- a/server/jetty/build.gradle
+++ b/server/jetty/build.gradle
@@ -69,3 +69,7 @@ applicationDefaultJvmArgs = [
 ] + extraJvmArgs
 
 apply plugin: 'io.deephaven.java-open-nio'
+
+tasks.withType(JavaExec) {
+    jvmArgs applicationDefaultJvmArgs
+}

--- a/server/jetty/build.gradle
+++ b/server/jetty/build.gradle
@@ -41,14 +41,7 @@ distributions {
     }
 }
 
-def extraJvmArgs = []
-if (hasProperty('groovy')) {
-    extraJvmArgs = ['-Ddeephaven.console.type=groovy']
-}
-
-applicationName = 'start'
-mainClassName = 'io.deephaven.server.jetty.JettyMain'
-applicationDefaultJvmArgs = [
+def extraJvmArgs = [
         '-server',
         '-XX:+UseG1GC',
         '-XX:MaxGCPauseMillis=100',
@@ -66,10 +59,19 @@ applicationDefaultJvmArgs = [
         '-XX:MinRAMPercentage=70.0',
         // the percentage of system memory that the JVM will use as maximum
         '-XX:MaxRAMPercentage=80.0',
-] + extraJvmArgs
+]
+if (hasProperty('groovy')) {
+    extraJvmArgs += ['-Ddeephaven.console.type=groovy']
+}
+tasks.withType(JavaExec) {
+    // This appends to the existing jvm args, so that java-open-nio still takes effect
+    jvmArgs extraJvmArgs
+}
+tasks.withType(CreateStartScripts) {
+    defaultJvmOpts += extraJvmArgs
+}
+
+applicationName = 'start'
+mainClassName = 'io.deephaven.server.jetty.JettyMain'
 
 apply plugin: 'io.deephaven.java-open-nio'
-
-tasks.withType(JavaExec) {
-    jvmArgs applicationDefaultJvmArgs
-}

--- a/server/jetty/src/main/resources/logback-debug.xml
+++ b/server/jetty/src/main/resources/logback-debug.xml
@@ -1,4 +1,5 @@
 <configuration debug="true">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
   <!-- System.out / System.err may be redirected (and sent to LogBuffer).
       By referencing PrintStreamGlobalsConsole, we can be sure to avoid that potential redirection

--- a/server/jetty/src/main/resources/logback-minimal.xml
+++ b/server/jetty/src/main/resources/logback-minimal.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
   <!-- LogBuffer is a ring-buffer of recent log messages. It allows clients (such as the web console)
     to subscribe and display information. -->

--- a/server/jetty/src/main/resources/logback.xml
+++ b/server/jetty/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
   <!-- System.out / System.err may be redirected (and captured by LogBuffer).
        By referencing PrintStreamGlobalsConsole, we can be sure that we avoid that redirection so

--- a/server/netty/build.gradle
+++ b/server/netty/build.gradle
@@ -65,3 +65,7 @@ artifacts {
 }
 
 apply plugin: 'io.deephaven.java-open-nio'
+
+tasks.withType(JavaExec) {
+    jvmArgs applicationDefaultJvmArgs
+}

--- a/server/netty/build.gradle
+++ b/server/netty/build.gradle
@@ -33,14 +33,7 @@ distributions {
     }
 }
 
-def extraJvmArgs = []
-if (hasProperty('groovy')) {
-    extraJvmArgs = ['-Ddeephaven.console.type=groovy']
-}
-
-applicationName = 'start'
-mainClassName = 'io.deephaven.server.netty.NettyMain'
-applicationDefaultJvmArgs = [
+def extraJvmArgs = [
         '-server',
         '-XX:+UseG1GC',
         '-XX:MaxGCPauseMillis=100',
@@ -58,14 +51,23 @@ applicationDefaultJvmArgs = [
         '-XX:MinRAMPercentage=70.0',
         // the percentage of system memory that the JVM will use as maximum
         '-XX:MaxRAMPercentage=80.0',
-] + extraJvmArgs
+]
+if (hasProperty('groovy')) {
+    extraJvmArgs += ['-Ddeephaven.console.type=groovy']
+}
+tasks.withType(JavaExec) {
+    // This appends to the existing jvm args, so that java-open-nio still takes effect
+    jvmArgs extraJvmArgs
+}
+tasks.withType(CreateStartScripts) {
+    defaultJvmOpts += extraJvmArgs
+}
+
+applicationName = 'start'
+mainClassName = 'io.deephaven.server.netty.NettyMain'
 
 artifacts {
     applicationDist project.tasks.findByName('distTar')
 }
 
 apply plugin: 'io.deephaven.java-open-nio'
-
-tasks.withType(JavaExec) {
-    jvmArgs applicationDefaultJvmArgs
-}

--- a/server/netty/src/main/resources/logback-debug.xml
+++ b/server/netty/src/main/resources/logback-debug.xml
@@ -1,4 +1,5 @@
 <configuration debug="true">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
   <!-- System.out / System.err may be redirected (and sent to LogBuffer).
       By referencing PrintStreamGlobalsConsole, we can be sure to avoid that potential redirection

--- a/server/netty/src/main/resources/logback-minimal.xml
+++ b/server/netty/src/main/resources/logback-minimal.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
   <!-- LogBuffer is a ring-buffer of recent log messages. It allows clients (such as the web console)
     to subscribe and display information. -->

--- a/server/netty/src/main/resources/logback.xml
+++ b/server/netty/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration debug="false">
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
 
   <!-- System.out / System.err may be redirected (and captured by LogBuffer).
        By referencing PrintStreamGlobalsConsole, we can be sure that we avoid that redirection so

--- a/server/src/main/java/io/deephaven/server/runner/Main.java
+++ b/server/src/main/java/io/deephaven/server/runner/Main.java
@@ -8,6 +8,7 @@ import io.deephaven.io.logger.LogBufferInterceptor;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.util.process.ProcessEnvironment;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -61,6 +62,10 @@ public class Main {
         log.info().append("Starting up ").append(mainClass.getName()).append("...").endl();
 
         final Configuration config = Configuration.getInstance();
+
+        // After logging and config are working, redirect any future JUL logging to SLF4J
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
 
         // Push our log to ProcessEnvironment, so that any parts of the system relying on ProcessEnvironment
         // instead of LoggerFactory can get the correct logger.


### PR DESCRIPTION
Websocket-based gRPC-web streams were not correctly notifying gRPC internals when the stream was finished, this patch removes a poor attempt at that and correctly ends the stream.

This diff also adds java.util.logging support, forwarding it to slf4j, and sending slf4j's log level configuration back into java.util.logging.

Finally, this patch simplifies directly running main()s in the server project, so that they share configuration with the actual declare application.

Fixes #1745