### PR TITLE
Create a new array rather than slicing a typedarray to support nulls

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/ViewportData.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/ViewportData.java
@@ -8,6 +8,7 @@ import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsProperty;
 import jsinterop.base.Any;
 import jsinterop.base.Js;
+import jsinterop.base.JsArrayLike;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -253,7 +254,7 @@ public class ViewportData implements TableData {
                 DataCleaner dataCleaner = getDataCleanerForColumnType(column.getType());
                 if (dataCleaner != null) {
                     JsArray<Any> values = Js.uncheckedCast(dataColumn);
-                    JsArray<Any> cleanData = Js.uncheckedCast(values.slice());
+                    JsArray<Any> cleanData = Js.uncheckedCast(JsArray.from((JsArrayLike<Any>) values));
 
                     for (int i = 0; i < values.length; i++) {
                         dataCleaner.clean(cleanData, i);


### PR DESCRIPTION
A typed array cannot hold nulls, and our uncheckedCast makes it appear
that this is sane while it isn't.

Fixes #1224