### PR TITLE
Backport bench tweaks for RowSetGetFindBench and gradle setup for Benchmarks.

### DIFF
--- a/BenchmarkSupport/src/main/java/io/deephaven/benchmarking/runner/EnvUtils.java
+++ b/BenchmarkSupport/src/main/java/io/deephaven/benchmarking/runner/EnvUtils.java
@@ -1,2 +1,83 @@
-package io.deephaven.benchmarking.runner;public class EnvUtils {
+package io.deephaven.benchmarking.runner;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+public class EnvUtils {
+    private static List<GarbageCollectorMXBean> gcBeans = null;
+
+    public static class GcTimeCollector {
+        private enum State {
+            STARTED,
+            STOPPED,
+        }
+        /**
+         *  In STARTED state, absolute count of collections since program start.
+         *  In STOPPED state, number of collections between
+         *  last call to {@code resetAndStart} and last call to {@code stopAndSample}.
+         */
+        private long collectionCount;
+        /**
+         *  In STARTED state, absolute time in millis in collections since program start.
+         *  In STOPPED state, time in millis for collections between
+         *  last call to {@code resetAndStart} and last call to {@code stopAndSample}.
+         */
+        private long collectionTimeMs;
+        private State state;
+
+        public GcTimeCollector() {
+            state = State.STOPPED;
+        }
+
+        public void resetAndStart() {
+            if (state != State.STOPPED) {
+                throw new IllegalStateException("Already started");
+            }
+            synchronized (EnvUtils.class) {
+                if (gcBeans == null) {
+                    gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+                }
+            }
+            long countAccum = 0;
+            long timeAccumMs = 0;
+            for (final GarbageCollectorMXBean gcBean : gcBeans) {
+                countAccum += gcBean.getCollectionCount();
+                timeAccumMs += gcBean.getCollectionTime();
+            }
+            collectionCount = countAccum;
+            collectionTimeMs = timeAccumMs;
+            state = State.STARTED;
+        }
+
+        public void stopAndSample() {
+            if (state != State.STARTED) {
+                throw new IllegalStateException("Not started");
+            }
+            long countAccum = 0;
+            long timeAccumMs = 0;
+            for (final GarbageCollectorMXBean gcBean : gcBeans) {
+                countAccum += gcBean.getCollectionCount();
+                timeAccumMs += gcBean.getCollectionTime();
+            }
+            collectionCount = countAccum - collectionCount;
+            collectionTimeMs = timeAccumMs - collectionTimeMs;
+            state = State.STOPPED;
+        }
+
+        public long getCollectionCount() {
+            if (state != State.STOPPED) {
+                throw new IllegalStateException("Still running");
+            }
+            return collectionCount;
+        }
+
+        public long getCollectionTimeMs() {
+            if (state != State.STOPPED) {
+                throw new IllegalStateException("Still running");
+            }
+            return collectionTimeMs;
+        }
+    }
 }
+

--- a/BenchmarkSupport/src/main/java/io/deephaven/benchmarking/runner/EnvUtils.java
+++ b/BenchmarkSupport/src/main/java/io/deephaven/benchmarking/runner/EnvUtils.java
@@ -9,19 +9,17 @@ public class EnvUtils {
 
     public static class GcTimeCollector {
         private enum State {
-            STARTED,
-            STOPPED,
+            STARTED, STOPPED,
         }
+
         /**
-         *  In STARTED state, absolute count of collections since program start.
-         *  In STOPPED state, number of collections between
-         *  last call to {@code resetAndStart} and last call to {@code stopAndSample}.
+         * In STARTED state, absolute count of collections since program start. In STOPPED state, number of collections
+         * between last call to {@code resetAndStart} and last call to {@code stopAndSample}.
          */
         private long collectionCount;
         /**
-         *  In STARTED state, absolute time in millis in collections since program start.
-         *  In STOPPED state, time in millis for collections between
-         *  last call to {@code resetAndStart} and last call to {@code stopAndSample}.
+         * In STARTED state, absolute time in millis in collections since program start. In STOPPED state, time in
+         * millis for collections between last call to {@code resetAndStart} and last call to {@code stopAndSample}.
          */
         private long collectionTimeMs;
         private State state;

--- a/BenchmarkSupport/src/main/java/io/deephaven/benchmarking/runner/EnvUtils.java
+++ b/BenchmarkSupport/src/main/java/io/deephaven/benchmarking/runner/EnvUtils.java
@@ -1,0 +1,2 @@
+package io.deephaven.benchmarking.runner;public class EnvUtils {
+}

--- a/engine/benchmark/build.gradle
+++ b/engine/benchmark/build.gradle
@@ -63,7 +63,7 @@ task jmhRun(type: JavaExec)  {
 }
 
 def createJmhTask = {
-    taskName, cliArgs, heapSize='8g' -> tasks.create(taskName, JavaExec, { JavaExec task ->
+    taskName, cliArgs, jvmAddArgs=[], heapSize='8g' -> tasks.create(taskName, JavaExec, { JavaExec task ->
         new File("$rootDir/tmp/workspace").mkdirs()
         new File("$rootDir/tmp/logs").mkdirs()
 
@@ -72,7 +72,7 @@ def createJmhTask = {
         task.main = 'io.deephaven.benchmarking.runner.BenchmarkRunner'
 
         // arguments to pass to the application
-        task.jvmArgs '-DConfiguration.rootFile=dh-tests.prop',
+        def jvmArgs = [ '-DConfiguration.rootFile=dh-tests.prop',
                 "-Ddevroot=$rootDir",
                 "-Dworkspace=$rootDir/tmp/workspace",
                 '-Dconfiguration.quiet=true',
@@ -81,7 +81,9 @@ def createJmhTask = {
                 '-DUpdateGraphProcessor.checkTableOperations=false',
                 "-Xmx$heapSize"
                 //'-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9501'
-
+        ]
+        jvmArgs.addAll(jvmAddArgs)
+        task.jvmArgs jvmArgs
         task.args cliArgs
 
         return
@@ -94,7 +96,8 @@ createJmhTask('jmhRunRangeFilter', 'RangeFilterBenchmark')
 createJmhTask('jmhRunNaturalJoin', 'NaturalJoinBenchmark')
 createJmhTask('jmhRunSparseSelect', 'SparseSelectBenchmark')
 createJmhTask('jmhRunRCS', 'RegionedColumnSourceBenchmark')
-createJmhTask('jmhRunBy', 'ByBenchmark', '8g')
+createJmhTask('jmhRunBy', 'ByBenchmark')
+createJmhTask('jmhRunRowSetGetFind', 'RowSetGetFindBench', ['-DMetricsManager.enabled=true'])
 
 def createDeephavenTestExecTask = {
     taskName, mainClass -> tasks.create(taskName, JavaExec, { JavaExec task ->

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/util/RowSetGetFindBench.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/util/RowSetGetFindBench.java
@@ -2,6 +2,7 @@ package io.deephaven.benchmark.engine.util;
 
 import io.deephaven.benchmarking.BenchUtil;
 import io.deephaven.benchmarking.runner.EnvUtils;
+import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetBuilderSequential;
 import io.deephaven.engine.rowset.RowSetFactory;
@@ -55,12 +56,7 @@ public class RowSetGetFindBench {
         final long ops = millionOps * 1000 * 1000;
         final RowSet opRowSet = rowSet.subSetByPositionRange(0, ops);
         opsValues = new long[(int) opRowSet.size()];
-        int i = 0;
-        try (final RowSet.Iterator it = opRowSet.iterator()) {
-            while (it.hasNext()) {
-                opsValues[i++] = it.nextLong();
-            }
-        }
+        opRowSet.fillRowKeyChunk(WritableLongChunk.writableChunkWrap(opsValues));
     }
 
     EnvUtils.GcTimeCollector gcTimeCollector = new EnvUtils.GcTimeCollector();


### PR DESCRIPTION
The additional GC time sampling helps ensure individual iterations don't have GC noise.  It shows in the JMH output like this:

```
[...]
Iteration   4: Gc during iteration: count=0, timeMs=0
2770.689 ms/op
                 Max CPU:       3.800 percent
                 Max free heap: 2090860544.000 bytes
                 Max heap:      2109734912.000 bytes
                 Max threads:   2.000 threads
                 Max used heap: 403989504.000 bytes
[...]
```