### PR TITLE
Do not use the "week year" when year is expected

### DIFF
--- a/Util/src/main/java/io/deephaven/util/HeapDump.java
+++ b/Util/src/main/java/io/deephaven/util/HeapDump.java
@@ -30,7 +30,7 @@ public class HeapDump {
         final Configuration configuration = Configuration.getInstance();
         final String processName = configuration.getProcessName();
         return configuration.getLogPath(processName + "_"
-                + new SimpleDateFormat("YYYYMMddHHmmss").format(new Date(System.currentTimeMillis())) + ".hprof");
+                + new SimpleDateFormat("yyyyMMddHHmmss").format(new Date(System.currentTimeMillis())) + ".hprof");
     }
 
     @SuppressWarnings("WeakerAccess")


### PR DESCRIPTION
No other java date format strings were found with this bug, and various
javadocs were left alone, as they use DD (day-in-year), and use MM to
mean both month and minute.