### PR TITLE
Use the same version of barrage in all parts of the project

### DIFF
--- a/proto/proto-backplane-grpc/build.gradle
+++ b/proto/proto-backplane-grpc/build.gradle
@@ -40,8 +40,8 @@ dependencies {
 
   // technically we should have a runtime dependency on barrage-core, but instead we are regenerating
   // the same output that it contains, and we have declared the correct dependencies as necessary
-  //  compile 'io.deephaven.barrage:barrage-core:0.2.0'
-  download 'io.deephaven.barrage:barrage-core:0.2.0'
+  //  compile 'io.deephaven.barrage:barrage-core:0.3.0'
+  download 'io.deephaven.barrage:barrage-core:0.3.0'
   Classpaths.inheritArrow(project, 'flight-core', 'download')
 }
 


### PR DESCRIPTION
This only affects the JS API - I manually tested to confirm that subscriptions still work correctly.

https://github.com/deephaven/deephaven-core/issues/1162 should make this mistake harder to happen in the future.