### PR TITLE
Fix redpanda docker-compose.yml related files

### DIFF
--- a/redpanda-apicurio/.env
+++ b/redpanda-apicurio/.env
@@ -4,3 +4,4 @@ TAG=main
 PORT=10000
 DEEPHAVEN_CONSOLE_TYPE=python
 DEEPHAVEN_APPLICATION_DIR=/data/app.d
+DEEPHAVEN_SERVER_IMAGE=deephaven/server:local-build

--- a/redpanda-apicurio/docker-compose.yml
+++ b/redpanda-apicurio/docker-compose.yml
@@ -20,7 +20,9 @@ services:
       file: ../docker-compose-common.yml
       service: grpc-proxy
     depends_on:
-      - grpc-api
+      server:
+        condition: service_healthy
+
 
   envoy:
     # A reverse proxy configured for no SSL on localhost. It fronts the requests
@@ -29,9 +31,12 @@ services:
       file: ../docker-compose-common.yml
       service: envoy
     depends_on:
-      - web
-      - grpc-proxy
-      - grpc-api
+      server:
+        condition: service_healthy
+      grpc-proxy:
+        condition: service_started
+      web:
+        condition: service_started
 
   redpanda:
     extends:
@@ -43,10 +48,9 @@ services:
     expose:
       - 8080
     ports:
-      - "8081:8080"
+      - "8083:8080"
     environment:
       QUARKUS_PROFILE: prod
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       APPLICATION_ID: registry_id
       APPLICATION_SERVER: localhost:9000
- 

--- a/redpanda-apicurio/examples/post-share-price-schema.sh
+++ b/redpanda-apicurio/examples/post-share-price-schema.sh
@@ -1,4 +1,4 @@
 #
 # Simple sh command line to load an example avro schema into our test compose including redpanda and apicurio.
 #
-curl -X POST -H "Content-type: application/json; artifactType=AVRO" -H "X-Registry-ArtifactId: share_price_record" -H "X-Registry-Version: 1" --data-binary "@avro/share_price.json" http://localhost:8081/api/artifacts
+curl -X POST -H "Content-type: application/json; artifactType=AVRO" -H "X-Registry-ArtifactId: share_price_record" -H "X-Registry-Version: 1" --data-binary "@avro/share_price.json" http://localhost:8083/api/artifacts

--- a/redpanda-apicurio/examples/python/kafka-produce-avro.py
+++ b/redpanda-apicurio/examples/python/kafka-produce-avro.py
@@ -33,7 +33,7 @@
 #
 # The last command above should have loaded the avro schema in the file avro/share_price.json
 # to the apicurio registry. You can check it was loaded visiting on the host the URL:
-#   http://localhost:8081/ui/artifacts
+#   http://localhost:8083/ui/artifacts
 # That page should now list 'share_price_record' as an available schema.
 #
 # From the web IDE, run:
@@ -79,7 +79,7 @@ def delivery_report(err, msg):
 avroProducer = AvroProducer({
     'bootstrap.servers': 'localhost:9092',
     'on_delivery': delivery_report,
-    'schema.registry.url': 'http://localhost:8081/api/ccompat'
+    'schema.registry.url': 'http://localhost:8083/api/ccompat'
 }, default_value_schema=value_schema)
 
 def wrong_form(value_arg):

--- a/redpanda/.env
+++ b/redpanda/.env
@@ -4,3 +4,4 @@ TAG=main
 PORT=10000
 DEEPHAVEN_CONSOLE_TYPE=python
 DEEPHAVEN_APPLICATION_DIR=/data/app.d
+DEEPHAVEN_SERVER_IMAGE=deephaven/server:local-build

--- a/redpanda/docker-compose.yml
+++ b/redpanda/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       file: ../docker-compose-common.yml
       service: grpc-proxy
     depends_on:
-      - grpc-api
+      server:
+        condition: service_healthy  
 
   envoy:
     # A reverse proxy configured for no SSL on localhost. It fronts the requests
@@ -29,9 +30,12 @@ services:
       file: ../docker-compose-common.yml
       service: envoy
     depends_on:
-      - web
-      - grpc-proxy
-      - grpc-api
+      server:
+        condition: service_healthy
+      grpc-proxy:
+        condition: service_started
+      web:
+        condition: service_started
 
   redpanda:
     extends:


### PR DESCRIPTION
Broken after grp-api to server change.  Also fix redpanda-apicurio ports (noticed overlapping ports on new redpanda docker image when trying to test fix).