### PR TITLE
Add meta tags to deephaven demo loading page

### DIFF
--- a/demo/src/main/java/io/deephaven/demo/index.html
+++ b/demo/src/main/java/io/deephaven/demo/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title>Deephaven Demo</title>
+    <meta property="og:image" content="https://deephaven.io/img/demo-og-image.png" />
+    <meta name="twitter:image" content="https://deephaven.io/img/demo-og-image.png" />
     <style>
       :root {
         --background: #1a171a;


### PR DESCRIPTION
The image is hosted in the deephaven.io repo, and depends on deephaven/deephaven.io#1126 merging for the image.

This adds an og:image for the loading page, so that when linking to demo.deephaven.app a preview image is provided for social media.