### PR TITLE
Tag protoc-base as part of the release.

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -233,6 +233,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         run: |
           ./docker/registry/python-dev-base/build/crane/retag.sh
+          ./docker/registry/protoc-base/build/crane/retag.sh
           ./docker/registry/slim-base/build/crane/retag.sh
           ./docker/registry/server-base/build/crane/retag.sh
           ./docker/registry/nltk-base/build/crane/retag.sh


### PR DESCRIPTION
On further examination, it probably doesn't make sense to add an explicit dependency on the java image to just tag it. We don't have a direct dependency on it.

Fixes #1792