### PR TITLE
A workaround to a JPY issue with long values, fixes #1461

### DIFF
--- a/Integrations/python/functional-tests/pylong_conv_test.py
+++ b/Integrations/python/functional-tests/pylong_conv_test.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+#
+import unittest
+from deephaven import TableTools
+import bootstrap
+
+long_value = 2 ** 32 + 5
+
+
+class TestClass(unittest.TestCase):
+
+    def test_long_number_conversion(self):
+        t = TableTools.emptyTable(1)
+        result = TableTools.string(t.update("X = long_value"), 1)
+        self.assertEqual(long_value, int(result.split()[2]))
+
+
+if __name__ == "__main__":
+    bootstrap.build_py_session()
+
+    unittest.main(verbosity=2)

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -192,7 +192,7 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
             Object objValue = pyObject.getObjectValue();
             // workaround a JPY issue with determining the correct Java type a Python 'int' should be
             // mapped to (int or long) without causing an implicit overflow
-            if (objValue instanceof Integer || objValue.getClass() == int.class) {
+            if (objValue instanceof Integer) {
                 long longValue;
                 if ((longValue = pyObject.getLongValue()) != (int) objValue) {
                     return longValue;

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -194,7 +194,7 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
             // mapped to (int or long) without causing an implicit overflow
             if (objValue instanceof  Integer || objValue.getClass() == int.class) {
                 long longValue;
-                if ((longValue = pyObject.getLongValue()) > (int) objValue) {
+                if ((longValue = pyObject.getLongValue()) !=  (int) objValue) {
                     return longValue;
                 }
             }

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -189,7 +189,16 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
         } else if (pyObject.isCallable()) {
             return wrapCallable(pyObject);
         } else if (pyObject.isConvertible()) {
-            return pyObject.getObjectValue();
+            Object objValue = pyObject.getObjectValue();
+            // workaround a JPY issue with determining the correct Java type a Python 'int' should be
+            // mapped to (int or long) without causing an implicit overflow
+            if (objValue instanceof  Integer || objValue.getClass() == int.class) {
+                long longValue;
+                if ((longValue = pyObject.getLongValue()) > (int) objValue) {
+                    return longValue;
+                }
+            }
+            return objValue;
         } else {
             return pyObject;
         }

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -192,9 +192,9 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
             Object objValue = pyObject.getObjectValue();
             // workaround a JPY issue with determining the correct Java type a Python 'int' should be
             // mapped to (int or long) without causing an implicit overflow
-            if (objValue instanceof  Integer || objValue.getClass() == int.class) {
+            if (objValue instanceof Integer || objValue.getClass() == int.class) {
                 long longValue;
-                if ((longValue = pyObject.getLongValue()) !=  (int) objValue) {
+                if ((longValue = pyObject.getLongValue()) != (int) objValue) {
                     return longValue;
                 }
             }


### PR DESCRIPTION
In JPY, PyObject.getObjectValue() seems always to select Java Integer
for a Python int object  which is not restricted by the number
of bits in Python 3