### PR TITLE
Jpy's mvn build should be in batch mode to reduce log noise

### DIFF
--- a/py/jpy/setup.py
+++ b/py/jpy/setup.py
@@ -170,7 +170,7 @@ def package_maven():
 
     mvn_goal = 'package'
     log.info("Executing Maven goal '" + mvn_goal + "'")
-    code = subprocess.call(['mvn', 'clean', mvn_goal, '-DskipTests'],
+    code = subprocess.call(['mvn', 'clean', mvn_goal, '-DskipTests', '-B'],
                            shell=platform.system() == 'Windows')
     if code:
         exit(code)


### PR DESCRIPTION
~600 lines of logs for the jpy maven build, down from 3012, and we're only losing the "progress of downloading jar files".