### PR TITLE
Avoid exceptions on autocomplete

### DIFF
--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
@@ -636,6 +636,10 @@ public class ChunkerCompleter implements CompletionHandler {
             // user wants completion on the ident itself...
             String src = node.toSource();
             final Token tok = node.jjtGetFirstToken();
+            if (tok.startIndex > request.getCandidate()) {
+                // would result in a negative substring, abort
+                return;
+            }
             src = src.substring(0, request.getCandidate() - tok.startIndex);
             addMethodsAndVariables(results, node.jjtGetFirstToken(), request, Collections.singletonList(node), src);
         }

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CompletionRequest.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CompletionRequest.java
@@ -53,7 +53,7 @@ public class CompletionRequest {
         this.offset = this.candidate = offset;
         this.completer = completer;
         this.localDefs = localDefs;
-        Require.gtZero(offset, "offset");
+        Require.geqZero(offset, "offset");
         Require.leq(offset, "offset", command.length(), "command.length()");
     }
 

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CompletionRequest.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CompletionRequest.java
@@ -53,8 +53,8 @@ public class CompletionRequest {
         this.offset = this.candidate = offset;
         this.completer = completer;
         this.localDefs = localDefs;
-        Require.requirement(offset >= 0, "offset >= 0");
-        Require.requirement(offset <= command.length(), "offset <= command.length()");
+        Require.gtZero(offset, "offset");
+        Require.leq(offset, "offset", command.length(), "command.length()");
     }
 
     public String getSource() {

--- a/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerCompletionHandlerTest.groovy
+++ b/open-api/lang-tools/src/test/groovy/io/deephaven/lang/completion/ChunkerCompletionHandlerTest.groovy
@@ -168,6 +168,31 @@ b = 2
 c = 3
 t = emptyTable."""
     }
+
+    def "Completion should not error out in a comment between two lines"() {
+        given:
+        CompletionParser p = new CompletionParser()
+        String beforeCursor = """
+a = 1
+# hello world a."""
+        String afterCursor = """
+b = 2
+"""
+        String src = beforeCursor + afterCursor;
+
+        doc = p.parse(src)
+
+        LoggerFactory.getLogger(CompletionHandler)
+        VariableProvider variables = Mock(VariableProvider) {
+            _ * getVariableNames() >> ['emptyTable']
+            0 * _
+        }
+
+        when: "Cursor is in the comment after the variablename+dot and completion is requested"
+        Set<CompletionItem> result = performSearch(doc, beforeCursor.length(), variables)
+        then: "Expect the completion result to suggest nothing"
+        result.size() == 0
+    }
     @Override
     VariableProvider getVariables() {
         return Mock(VariableProvider) {


### PR DESCRIPTION
This patch fixes a case where the autocomplete would fail to get the
correct indent to suggest, and also reduces the log level for any
messages that can result from autocomplete errors.

Fixes #1196