### PR TITLE
Renamed `Index` to `RowSet` in source

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageProtoUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageProtoUtil.java
@@ -56,7 +56,7 @@ public class BarrageProtoUtil {
         }
     }
 
-    public static RowSet toIndex(final ByteBuffer string) {
+    public static RowSet toRowSet(final ByteBuffer string) {
         // noinspection UnstableApiUsage
         try (final InputStream bais = new ByteBufferInputStream(string);
                 final LittleEndianDataInputStream ois = new LittleEndianDataInputStream(bais)) {

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -411,7 +411,7 @@ public class ArrowFlightUtil {
 
             isViewport = subscriptionRequest.viewportVector() != null;
             final RowSet viewport =
-                    isViewport ? BarrageProtoUtil.toIndex(subscriptionRequest.viewportAsByteBuffer()) : null;
+                    isViewport ? BarrageProtoUtil.toRowSet(subscriptionRequest.viewportAsByteBuffer()) : null;
 
             bmp.addSubscription(listener, optionsAdapter.adapt(subscriptionRequest), columns, viewport);
 
@@ -435,7 +435,7 @@ public class ArrowFlightUtil {
 
             final boolean hasViewport = subscriptionRequest.viewportVector() != null;
             final RowSet viewport =
-                    isViewport ? BarrageProtoUtil.toIndex(subscriptionRequest.viewportAsByteBuffer()) : null;
+                    isViewport ? BarrageProtoUtil.toRowSet(subscriptionRequest.viewportAsByteBuffer()) : null;
 
             final boolean subscriptionFound;
             if (isViewport && hasColumns && hasViewport) {


### PR DESCRIPTION
Updates a few additional places where `Index` was still being used instead of `RowSet`

Resolves #1849