### PR TITLE
Fix variable order in console sessions

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -60,9 +61,9 @@ public interface ScriptSession extends ReleasableLivenessManager, LivenessNode {
 
         // TODO(deephaven-core#1781): Close gaps between proto "CustomType" fields
 
-        public Map<String, String> created = new HashMap<>();
-        public Map<String, String> updated = new HashMap<>();
-        public Map<String, String> removed = new HashMap<>();
+        public Map<String, String> created = new LinkedHashMap<>();
+        public Map<String, String> updated = new LinkedHashMap<>();
+        public Map<String, String> removed = new LinkedHashMap<>();
 
         public boolean isEmpty() {
             return error == null && created.isEmpty() && updated.isEmpty() && removed.isEmpty();

--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
@@ -27,12 +27,7 @@ import io.grpc.stub.StreamObserver;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.Closeable;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 @Singleton
 public class ApplicationServiceGrpcImpl extends ApplicationServiceGrpc.ApplicationServiceImplBase
@@ -53,13 +48,13 @@ public class ApplicationServiceGrpcImpl extends ApplicationServiceGrpc.Applicati
     private final FieldUpdatePropagationJob propagationJob = new FieldUpdatePropagationJob();
 
     /** Which fields have been updated since we last propagated? */
-    private final Map<AppFieldId, Field<?>> addedFields = new HashMap<>();
+    private final Map<AppFieldId, Field<?>> addedFields = new LinkedHashMap<>();
     /** Which fields have been removed since we last propagated? */
-    private final Set<AppFieldId> removedFields = new HashSet<>();
+    private final Set<AppFieldId> removedFields = new LinkedHashSet<>();
     /** Which fields have been updated since we last propagated? */
-    private final Set<AppFieldId> updatedFields = new HashSet<>();
+    private final Set<AppFieldId> updatedFields = new LinkedHashSet<>();
     /** Which [remaining] fields have we seen? */
-    private final Map<AppFieldId, Field<?>> knownFieldMap = new HashMap<>();
+    private final Map<AppFieldId, Field<?>> knownFieldMap = new LinkedHashMap<>();
 
     @Inject
     public ApplicationServiceGrpcImpl(final AppMode mode,


### PR DESCRIPTION
Note this only fixes the intra ordering of the changes, such as within the created, updated, or removed lists. This does not fix inter Changes created/updated/removed ordering, which would require a structural change.

Tested by running the following, ensuring the tables appeared in order:
```
from deephaven.TableTools import emptyTable

t1 = emptyTable(1000).update("C=i*2")
t2 = emptyTable(1000).update("A=i")
t3 = emptyTable(100).update("A=i", "B=i*i")

t4 = emptyTable(1000).update("C=i*2")
t5 = emptyTable(1000).update("A=i")
t6 = emptyTable(100).update("A=i", "B=i*i")

t7 = emptyTable(1000).update("C=i*2")
t8 = emptyTable(1000).update("A=i")
t9 = emptyTable(100).update("A=i", "B=i*i")
```