### PR TITLE
Send enough bits to represent the column set to subscribe to

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/BarrageUtils.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/BarrageUtils.java
@@ -85,7 +85,7 @@ public class BarrageUtils {
     }
 
     public static Uint8Array makeUint8ArrayFromBitset(BitSet bitset) {
-        int length = (bitset.cardinality() + 7) / 8;
+        int length = (bitset.previousSetBit(Integer.MAX_VALUE - 1) + 8) / 8;
         Uint8Array array = new Uint8Array(length);
         byte[] bytes = bitset.toByteArray();
         for (int i = 0; i < bytes.length; i++) {


### PR DESCRIPTION
Fixes #1815

Logic is taken from BarrageStreamGenerator.BitSetGenerator's constructor.