### PR TITLE
JSAPI for fetching custom object

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -830,7 +830,10 @@ public class WorkerConnection {
         return whenServerReady("get a widget")
                 .then(server -> Callbacks.<FetchObjectResponse, Object>grpcUnaryPromise(c -> {
                     FetchObjectRequest request = new FetchObjectRequest();
-                    request.setSourceId(TableTicket.createTicket(varDef));
+                    TypedTicket typedTicket = new TypedTicket();
+                    typedTicket.setTicket(TableTicket.createTicket(varDef));
+                    typedTicket.setType(varDef.getType());
+                    request.setSourceId(typedTicket);
                     objectServiceClient().fetchObject(request, metadata(), c::apply);
                 })).then(response -> Promise.resolve(new JsWidget(this, response)));
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -83,7 +83,6 @@ import io.deephaven.web.client.state.TableReviver;
 import io.deephaven.web.shared.data.*;
 import io.deephaven.web.shared.fu.JsConsumer;
 import io.deephaven.web.shared.fu.JsRunnable;
-import io.deephaven.web.shared.ide.VariableType;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOptional;
 import jsinterop.base.Js;
@@ -700,9 +699,9 @@ public class WorkerConnection {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Promise<Object> getObject(JsVariableDefinition definition) {
-        if (definition.getType().equals(VariableType.Table.toString())) {
+        if (definition.getType().equals(JsVariableChanges.TABLE)) {
             return (Promise) getTable(definition, null);
-        } else if (definition.getType().equals(VariableType.Figure.toString())) {
+        } else if (definition.getType().equals(JsVariableChanges.FIGURE)) {
             return (Promise) getFigure(definition);
         } else {
             return (Promise) getWidget(definition);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -83,6 +83,7 @@ import io.deephaven.web.client.state.TableReviver;
 import io.deephaven.web.shared.data.*;
 import io.deephaven.web.shared.fu.JsConsumer;
 import io.deephaven.web.shared.fu.JsRunnable;
+import io.deephaven.web.shared.ide.VariableType;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOptional;
 import jsinterop.base.Js;
@@ -699,9 +700,9 @@ public class WorkerConnection {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Promise<Object> getObject(JsVariableDefinition definition) {
-        if ("Table".equals(definition.getType())) {
+        if (definition.getType().equals(VariableType.Table.toString())) {
             return (Promise) getTable(definition, null);
-        } else if ("Figure".equals(definition.getType())) {
+        } else if (definition.getType().equals(VariableType.Figure.toString())) {
             return (Promise) getFigure(definition);
         } else {
             return (Promise) getWidget(definition);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -1,23 +1,17 @@
 package io.deephaven.web.client.api.widget;
 
-import elemental2.core.JsArray;
 import elemental2.core.Uint8Array;
-import elemental2.promise.Promise;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.object_pb.FetchObjectResponse;
-import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.ExportedTableCreationResponse;
-import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.TypedTicket;
-import io.deephaven.web.client.api.Callbacks;
-import io.deephaven.web.client.api.JsTable;
 import io.deephaven.web.client.api.WorkerConnection;
-import io.deephaven.web.client.state.ClientTableState;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
 
 public class JsWidget {
-
     private final WorkerConnection connection;
 
     private final FetchObjectResponse response;
+
+    private JsWidgetExportedObject[] exportedObjects;
 
     public JsWidget(WorkerConnection connection, FetchObjectResponse response) {
         this.connection = connection;
@@ -29,39 +23,24 @@ public class JsWidget {
         return response.getType();
     }
 
-    @JsProperty
-    public String getData() {
+    @JsMethod
+    public String getDataAsBase64() {
         return response.getData_asB64();
     }
 
-    @JsProperty
+    @JsMethod
     public Uint8Array getDataAsU8() {
         return response.getData_asU8();
     }
 
     @JsProperty
-    public String[] getExportedObjectTypes() {
-        return response.getTypedExportIdList().asList().stream().map(TypedTicket::getType).toArray(String[]::new);
-    }
-
-    @JsMethod
-    public Promise<JsTable> getTable(int index) {
-        TypedTicket ticket = this.response.getTypedExportIdList().getAt(index);
-        if (!ticket.getType().equals("Table")) {
-            // TODO (deephaven-core#62) implement fetch for tablemaps
-            assert false : ticket.getType() + " found in widget, not yet supported";
-            return null;
+    public JsWidgetExportedObject[] getExportedObjects() {
+        if (this.exportedObjects == null) {
+            this.exportedObjects = response.getTypedExportIdList().asList().stream()
+                    .map(ticket -> new JsWidgetExportedObject(connection, ticket))
+                    .toArray(JsWidgetExportedObject[]::new);
         }
 
-        return Callbacks.<ExportedTableCreationResponse, Object>grpcUnaryPromise(c -> {
-            connection.tableServiceClient().getExportedTableCreationResponse(ticket.getTicket(), connection.metadata(),
-                    c::apply);
-        }).then(etcr -> {
-            ClientTableState cts = connection.newStateFromUnsolicitedTable(etcr, "table for widget");
-            JsTable table = new JsTable(connection, cts);
-            // never attempt a reconnect, since we might have a different widget schema entirely
-            table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
-            return Promise.resolve(table);
-        });
+        return this.exportedObjects;
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -1,0 +1,67 @@
+package io.deephaven.web.client.api.widget;
+
+import elemental2.core.JsArray;
+import elemental2.core.Uint8Array;
+import elemental2.promise.Promise;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.object_pb.FetchObjectResponse;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.ExportedTableCreationResponse;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.TypedTicket;
+import io.deephaven.web.client.api.Callbacks;
+import io.deephaven.web.client.api.JsTable;
+import io.deephaven.web.client.api.WorkerConnection;
+import io.deephaven.web.client.state.ClientTableState;
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsProperty;
+
+public class JsWidget {
+
+    private final WorkerConnection connection;
+
+    private final FetchObjectResponse response;
+
+    public JsWidget(WorkerConnection connection, FetchObjectResponse response) {
+        this.connection = connection;
+        this.response = response;
+    }
+
+    @JsProperty
+    public String getType() {
+        return response.getType();
+    }
+
+    @JsProperty
+    public String getData() {
+        return response.getData_asB64();
+    }
+
+    @JsProperty
+    public Uint8Array getDataAsU8() {
+        return response.getData_asU8();
+    }
+
+    @JsProperty
+    public String[] getExportedObjectTypes() {
+        return response.getTypedExportIdList().asList().stream().map(TypedTicket::getType).toArray(String[]::new);
+    }
+
+    @JsMethod
+    public Promise<JsTable> getTable(int index) {
+        TypedTicket ticket = this.response.getTypedExportIdList().getAt(index);
+        if (!ticket.getType().equals("Table")) {
+            // TODO (deephaven-core#62) implement fetch for tablemaps
+            assert false : ticket.getType() + " found in widget, not yet supported";
+            return null;
+        }
+
+        return Callbacks.<ExportedTableCreationResponse, Object>grpcUnaryPromise(c -> {
+            connection.tableServiceClient().getExportedTableCreationResponse(ticket.getTicket(), connection.metadata(),
+                    c::apply);
+        }).then(etcr -> {
+            ClientTableState cts = connection.newStateFromUnsolicitedTable(etcr, "table for widget");
+            JsTable table = new JsTable(connection, cts);
+            // never attempt a reconnect, since we might have a different widget schema entirely
+            table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
+            return Promise.resolve(table);
+        });
+    }
+}

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -1,0 +1,47 @@
+package io.deephaven.web.client.api.widget;
+
+import elemental2.promise.Promise;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.ExportedTableCreationResponse;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.TypedTicket;
+import io.deephaven.web.client.api.Callbacks;
+import io.deephaven.web.client.api.JsTable;
+import io.deephaven.web.client.api.WorkerConnection;
+import io.deephaven.web.client.state.ClientTableState;
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsProperty;
+
+public class JsWidgetExportedObject {
+    private final WorkerConnection connection;
+
+    private final TypedTicket ticket;
+
+    public JsWidgetExportedObject(WorkerConnection connection, TypedTicket ticket) {
+        this.connection = connection;
+        this.ticket = ticket;
+    }
+
+    @JsProperty
+    String getType() {
+        return ticket.getType();
+    }
+
+    @JsMethod
+    Promise<Object> fetch() {
+        if (!getType().equals("Table")) {
+            // TODO (deephaven-core#62) implement fetch for tablemaps
+            assert false : getType() + " found in widget, not yet supported";
+            return null;
+        }
+
+        return Callbacks.<ExportedTableCreationResponse, Object>grpcUnaryPromise(c -> {
+            connection.tableServiceClient().getExportedTableCreationResponse(ticket.getTicket(), connection.metadata(),
+                    c::apply);
+        }).then(etcr -> {
+            ClientTableState cts = connection.newStateFromUnsolicitedTable(etcr, "table for widget");
+            JsTable table = new JsTable(connection, cts);
+            // never attempt a reconnect, since we might have a different widget schema entirely
+            table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
+            return Promise.resolve(table);
+        });
+    }
+}

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -6,8 +6,8 @@ import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.Typ
 import io.deephaven.web.client.api.Callbacks;
 import io.deephaven.web.client.api.JsTable;
 import io.deephaven.web.client.api.WorkerConnection;
+import io.deephaven.web.client.api.console.JsVariableChanges;
 import io.deephaven.web.client.state.ClientTableState;
-import io.deephaven.web.shared.ide.VariableType;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
 
@@ -28,7 +28,7 @@ public class JsWidgetExportedObject {
 
     @JsMethod
     public Promise<Object> fetch() {
-        if (!getType().equals(VariableType.Table.toString())) {
+        if (!getType().equals(JsVariableChanges.TABLE)) {
             // TODO (deephaven-core#62) implement fetch for tablemaps
             assert false : getType() + " found in widget, not yet supported";
             return null;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -22,12 +22,12 @@ public class JsWidgetExportedObject {
     }
 
     @JsProperty
-    String getType() {
+    public String getType() {
         return ticket.getType();
     }
 
     @JsMethod
-    Promise<Object> fetch() {
+    public Promise<Object> fetch() {
         if (!getType().equals(VariableType.Table.toString())) {
             // TODO (deephaven-core#62) implement fetch for tablemaps
             assert false : getType() + " found in widget, not yet supported";

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -7,6 +7,7 @@ import io.deephaven.web.client.api.Callbacks;
 import io.deephaven.web.client.api.JsTable;
 import io.deephaven.web.client.api.WorkerConnection;
 import io.deephaven.web.client.state.ClientTableState;
+import io.deephaven.web.shared.ide.VariableType;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
 
@@ -27,7 +28,7 @@ public class JsWidgetExportedObject {
 
     @JsMethod
     Promise<Object> fetch() {
-        if (!getType().equals("Table")) {
+        if (!getType().equals(VariableType.Table.toString())) {
             // TODO (deephaven-core#62) implement fetch for tablemaps
             assert false : getType() + " found in widget, not yet supported";
             return null;


### PR DESCRIPTION
Methods for fetching the JsWidget for custom types. Tested by installing deephaven-plugin and deephaven-plugin-matplotlib, using web-client-ui server-widgets branch that I've created, and running the following code snippets:

```
import matplotlib.pyplot as plt

x = [0, 2, 4, 6]
y = [1, 3, 4, 8]
plt.plot(x, y)
plt.xlabel('x values')
plt.ylabel('y values')
plt.title('plotted x and y values')
plt.legend(['line 1'])

m_figure=plt.gcf()
```

```
from deephaven.TableTools import emptyTable
from deephaven.plugin.json import Node

t1 = emptyTable(10).update("A=i")
t2 = emptyTable(100).update("B=2*i")
t3 = emptyTable(1000).update("C=i*i")

z = Node({'x': 1, 't1': t1, 't2': t2, 't3': t3})
```

Fixes #1874 