### PR TITLE
Make the quick check fail fast

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -44,8 +44,8 @@ jobs:
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: checks
-          # todo: eventually expand to more
-          arguments: --scan --continue quick
+          # Even though quick includes spotlessCheck, we want to make sure it runs first and fails ASAP for quick feedback
+          arguments: --scan spotlessCheck quick
           gradle-version: wrapper
 
       - name: Upload Test Results

--- a/build.gradle
+++ b/build.gradle
@@ -475,7 +475,6 @@ tasks.register('quick') {
         allprojects.collect { it.tasks.matching { it.name == 'compileTestJava' } } +\
         allprojects.collect { it.tasks.matching { it.name == 'spotlessCheck' } }
     }
-    it.dependsOn project(':server').tasks.findByName(LifecycleBasePlugin.CHECK_TASK_NAME)
     it.dependsOn project(':Generators').tasks.findByName(LifecycleBasePlugin.CHECK_TASK_NAME)
 }
 


### PR DESCRIPTION
Removes server:check from the quick check (was taking 20 minutes), and the quick ci task will error out immediately instead of `--continue`.