### PR TITLE
Web version bump v0.9.1

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
-ARG WEB_VERSION=0.9.0
+ARG WEB_VERSION=0.9.1
 
 # Pull in the published package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Release Notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.9.1
