### PR TITLE
Set load generation parameters the same as original demo

### DIFF
--- a/debezium-demo/loadgen/generate_load.py
+++ b/debezium-demo/loadgen/generate_load.py
@@ -5,8 +5,8 @@ from kafka import KafkaProducer
 # CONFIG
 userSeedCount      = 10000
 itemSeedCount      = 1000
-purchaseGenCount   = 1000
-purchaseGenEveryMS = 2000
+purchaseGenCount   = 500000
+purchaseGenEveryMS = 100
 pageviewMultiplier = 75       # Translates to 75x purchases, currently 750/sec or 65M/day
 itemInventoryMin   = 1000
 itemInventoryMax   = 5000


### PR DESCRIPTION
I was using testing/debugging params before.

Reference:
https://github.com/MaterializeInc/ecommerce-demo/blob/c5a221d1a78b61913dfd636038b4a9845e0d383b/loadgen/generate_load.py#L8