### PR TITLE
Fix column name remapping in Parquet writing, and add unit tests

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTableWriter.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTableWriter.java
@@ -187,9 +187,11 @@ public class ParquetTableWriter {
                         .map(columnName -> groupingAsTable(t, columnName)).toArray(Table[]::new);
                 final Path destDirPath = Paths.get(destPathName).getParent();
                 for (int gci = 0; gci < auxiliaryTables.length; ++gci) {
-                    final String groupingPath = groupingPathFactory.apply(groupingColumns[gci]);
+                    final String parquetColumnName =
+                            writeInstructions.getParquetColumnNameFromColumnNameOrDefault(groupingColumns[gci]);
+                    final String groupingPath = groupingPathFactory.apply(parquetColumnName);
                     cleanupPaths.add(groupingPath);
-                    tableInfoBuilder.addGroupingColumns(GroupingColumnInfo.of(groupingColumns[gci],
+                    tableInfoBuilder.addGroupingColumns(GroupingColumnInfo.of(parquetColumnName,
                             destDirPath.relativize(Paths.get(groupingPath)).toString()));
                     write(auxiliaryTables[gci], auxiliaryTables[gci].getDefinition(), writeInstructions, groupingPath,
                             Collections.emptyMap());
@@ -448,7 +450,8 @@ public class ParquetTableWriter {
             columnSource = (ColumnSource<DATA_TYPE>) ReinterpretUtils.booleanToByteSource(columnSource);
         }
 
-        ColumnWriter columnWriter = rowGroupWriter.addColumn(name);
+        ColumnWriter columnWriter = rowGroupWriter.addColumn(
+                writeInstructions.getParquetColumnNameFromColumnNameOrDefault(name));
 
         boolean usedDictionary = false;
         if (supportsDictionary(columnSource.getType())) {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
@@ -375,6 +375,8 @@ class TypeInfos {
                 @NotNull final ParquetInstructions instructions) {
             final Class<?> dataType = columnDefinition.getDataType();
             final Class<?> componentType = columnDefinition.getComponentType();
+            final String parquetColumnName =
+                    instructions.getParquetColumnNameFromColumnNameOrDefault(columnDefinition.getName());
 
             final PrimitiveBuilder<PrimitiveType> builder;
             final boolean isRepeating;
@@ -393,12 +395,12 @@ class TypeInfos {
                 isRepeating = false;
             }
             if (!isRepeating) {
-                return builder.named(columnDefinition.getName());
+                return builder.named(parquetColumnName);
             }
             return Types.buildGroup(Type.Repetition.OPTIONAL).addField(
                     Types.buildGroup(Type.Repetition.REPEATED).addField(
-                            builder.named("item")).named(columnDefinition.getName()))
-                    .as(LogicalTypeAnnotation.listType()).named(columnDefinition.getName());
+                            builder.named("item")).named(parquetColumnName))
+                    .as(LogicalTypeAnnotation.listType()).named(parquetColumnName);
         }
 
         PrimitiveBuilder<PrimitiveType> getBuilder(boolean required, boolean repeating, Class dataType);

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetGrouping.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetGrouping.java
@@ -33,19 +33,22 @@ public class TestParquetGrouping extends TestCase {
             }
 
             final TableDefinition tableDefinition = TableDefinition.of(ColumnDefinition.ofInt("v").withGrouping());
-            Table table = TableTools.newTable(tableDefinition, TableTools.col("v", data));
-            File dest = new File(directory, "testOverflow.parquet");
-            ParquetTools.writeTable(table, dest, tableDefinition);
+            final Table table = TableTools.newTable(tableDefinition, TableTools.col("v", data));
+            final ParquetInstructions instructions = ParquetInstructions.builder()
+                    .addColumnNameMapping("V", "v")
+                    .build();
+            final File dest = new File(directory, "testOverflow.parquet");
+            ParquetTools.writeTable(table, dest, tableDefinition, instructions);
 
-            Table tableR = ParquetTools.readTable(dest);
+            final Table tableR = ParquetTools.readTable(dest);
             assertEquals(data.length, tableR.size());
-            assertNotNull(tableR.getColumnSource("v").getGroupToRange());
+            assertNotNull(tableR.getColumnSource("V").getGroupToRange());
             assertEquals(80_000 * 4, tableR.getRowSet().size());
-            assertEquals(80_000, tableR.getColumnSource("v").getGroupToRange().size());
-            assertEquals(80_000, tableR.getColumnSource("v").getValuesMapping(tableR.getRowSet()).size());
-            assertEquals(80_000, tableR.getColumnSource("v")
+            assertEquals(80_000, tableR.getColumnSource("V").getGroupToRange().size());
+            assertEquals(80_000, tableR.getColumnSource("V").getValuesMapping(tableR.getRowSet()).size());
+            assertEquals(80_000, tableR.getColumnSource("V")
                     .getValuesMapping(tableR.getRowSet().subSetByPositionRange(0, tableR.size())).size());
-            final Map mapper = tableR.getColumnSource("v").getGroupToRange();
+            final Map mapper = tableR.getColumnSource("V").getGroupToRange();
             for (int i = 0; i < data.length / 4; i++) {
                 assertEquals(mapper.get(i), RowSetFactory.fromRange(i * 4, i * 4 + 3));
             }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -182,6 +182,29 @@ public class TestParquetTools {
     }
 
     @Test
+    public void testWriteTableRenames() {
+        final String path = testRoot + File.separator + "Table_W_Renames.parquet";
+        final File pathFile = new File(path);
+        final ParquetInstructions instructions = ParquetInstructions.builder()
+                .addColumnNameMapping("X", "StringKeys")
+                .addColumnNameMapping("Y", "GroupedInts")
+                .build();
+        ParquetTools.writeTable(table1, pathFile, instructions);
+
+        final Table resultDefault = ParquetTools.readTable(pathFile);
+        TableTools.show(table1);
+        TableTools.show(resultDefault);
+        TstUtils.assertTableEquals(table1.view("X=StringKeys", "Y=GroupedInts"), resultDefault);
+        resultDefault.close();
+
+        final Table resultRenamed = ParquetTools.readTable(pathFile, instructions);
+        TableTools.show(table1);
+        TableTools.show(resultRenamed);
+        TstUtils.assertTableEquals(table1, resultRenamed);
+        resultRenamed.close();
+    }
+
+    @Test
     public void testWriteTableEmpty() {
         final File dest = new File(testRoot + File.separator + "Empty.parquet");
         ParquetTools.writeTable(emptyTable, dest);


### PR DESCRIPTION
Fixes #1926 