### PR TITLE
Handle 'x == null' differently to avoid ambiguous eq overloads.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -1028,32 +1028,20 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
         Class<?> rhType = getTypeWithCaching(rightExpr);
 
         if ((lhType == String.class || rhType == String.class) && op == BinaryExpr.Operator.PLUS) {
-
             if (printer.hasStringBuilder()) {
                 leftExpr.accept(this, printer);
-            }
-
-            printer.append(getOperatorSymbol(op));
-
-            if (printer.hasStringBuilder()) {
+                printer.append(getOperatorSymbol(op));
                 rightExpr.accept(this, printer);
             }
-
             return String.class;
         }
 
         if (op == BinaryExpr.Operator.OR || op == BinaryExpr.Operator.AND) {
-
             if (printer.hasStringBuilder()) {
                 leftExpr.accept(this, printer);
-            }
-
-            printer.append(getOperatorSymbol(op));
-
-            if (printer.hasStringBuilder()) {
+                printer.append(getOperatorSymbol(op));
                 rightExpr.accept(this, printer);
             }
-
             return boolean.class;
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -1021,20 +1021,22 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
     @Override
     public Class<?> visit(BinaryExpr n, VisitArgs printer) {
         BinaryExpr.Operator op = n.getOperator();
+        final Expression leftExpr = n.getLeft();
+        final Expression rightExpr = n.getRight();
 
-        Class<?> lhType = getTypeWithCaching(n.getLeft());
-        Class<?> rhType = getTypeWithCaching(n.getRight());
+        Class<?> lhType = getTypeWithCaching(leftExpr);
+        Class<?> rhType = getTypeWithCaching(rightExpr);
 
         if ((lhType == String.class || rhType == String.class) && op == BinaryExpr.Operator.PLUS) {
 
             if (printer.hasStringBuilder()) {
-                n.getLeft().accept(this, printer);
+                leftExpr.accept(this, printer);
             }
 
             printer.append(getOperatorSymbol(op));
 
             if (printer.hasStringBuilder()) {
-                n.getRight().accept(this, printer);
+                rightExpr.accept(this, printer);
             }
 
             return String.class;
@@ -1043,13 +1045,13 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
         if (op == BinaryExpr.Operator.OR || op == BinaryExpr.Operator.AND) {
 
             if (printer.hasStringBuilder()) {
-                n.getLeft().accept(this, printer);
+                leftExpr.accept(this, printer);
             }
 
             printer.append(getOperatorSymbol(op));
 
             if (printer.hasStringBuilder()) {
-                n.getRight().accept(this, printer);
+                rightExpr.accept(this, printer);
             }
 
             return boolean.class;
@@ -1061,6 +1063,25 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
         }
 
         boolean isArray = lhType.isArray() || rhType.isArray() || isTypedVector(lhType) || isTypedVector(rhType);
+
+        if (op == BinaryExpr.Operator.EQUALS) {
+            if (leftExpr.isNullLiteralExpr()) {
+                if (printer.hasStringBuilder()) {
+                    printer.append("isNull(");
+                    rightExpr.accept(this, printer);
+                    printer.append(")");
+                }
+                return boolean.class;
+            }
+            if (rightExpr.isNullLiteralExpr()) {
+                if (printer.hasStringBuilder()) {
+                    printer.append("isNull(");
+                    leftExpr.accept(this, printer);
+                    printer.append(")");
+                }
+                return boolean.class;
+            }
+        }
 
         String methodName = getOperatorName(op) + (isArray ? "Array" : "");
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
@@ -930,7 +930,7 @@ public class TestQueryLanguageParser extends BaseArrayTestCase {
         check(expression, resultExpression, Boolean.class, new String[] {"myBoolean"});
 
         expression = "(String)myString==null";
-        resultExpression = "eq((String)myString, null)";
+        resultExpression = "isNull((String)myString)";
         check(expression, resultExpression, boolean.class, new String[] {"myString"});
 
         expression = "1==1 ? myString : null";
@@ -1855,7 +1855,7 @@ public class TestQueryLanguageParser extends BaseArrayTestCase {
                 new QueryLanguageParser(
                         "io.deephaven.engine.table.impl.lang.TestQueryLanguageParser.InnerEnum.YEAH!=null", null,
                         null, staticImports, null, null).getResult();
-        assertEquals("!eq(io.deephaven.engine.table.impl.lang.TestQueryLanguageParser.InnerEnum.YEAH, null)",
+        assertEquals("!isNull(io.deephaven.engine.table.impl.lang.TestQueryLanguageParser.InnerEnum.YEAH)",
                 result.getConvertedExpression());
     }
 


### PR DESCRIPTION
Fixes #1925.