### PR TITLE
Followup to Paul's comments about debezium-demo over slack.

### DIFF
--- a/debezium-demo/demo.py
+++ b/debezium-demo/demo.py
@@ -76,6 +76,7 @@ item_summary = items \
     .naturalJoin(purchases_by_item, 'item_id') \
     .naturalJoin(pageviews_by_item, 'item_id') \
     .dropColumns('item_id') \
+    .moveColumnsDown('revenue', 'pageviews') \
     .updateView('conversion_rate = orders / (double) pageviews')
 
 # These two 'top_*' tables match the 'Business Intelligence: Metabase' / dashboard
@@ -99,10 +100,7 @@ profile_views_per_minute_last_10 = \
     ).where(
         'in_last_10min = true'
     ).updateView(
-        'received_at_nanos = nanos(received_at)',
-        'received_at_minutes = received_at_nanos - received_at_nanos % minute_in_nanos'
-    ).updateView(
-        'received_at_minute = new DateTime(received_at_minutes)'
+        'received_at_minute = lowerBin(received_at, minute_in_nanos)'
     ).view(
         'user_id = target_id',
         'received_at_minute'
@@ -120,18 +118,32 @@ profile_views = pageviews_stg \
         'owner_id = target_id',
         'viewer_id = user_id',
         'received_at'
-    ).partitionBy(
-        'owner_id'
-    ).transformTables(
-        tmapfun(lambda t : t
-            .sortDescending('received_at')
-            .head(10)
-        )
-    ).merge()
+    ).sort(
+        'owner_id',
+        'received_at'
+    ).tailBy(10, 'owner_id')
+
+# This is an alternative definition for profile_views;
+# is a lot more complicated, but should be more efficient in that
+# it sorts smaller tables.
+#profile_views = pageviews_stg \
+#    .view(
+#        'owner_id = target_id',
+#        'viewer_id = user_id',
+#        'received_at'
+#    ).partitionBy(
+#        'owner_id'
+#    ).transformTables(
+#        tmapfun(lambda t : t
+#            .sortDescending('received_at')
+#            .head(10)
+#        )
+#    ).merge()
     
 profile_views_enriched = profile_views \
     .naturalJoin(users, 'owner_id = id', 'owner_email = email') \
-    .naturalJoin(users, 'viewer_id = id', 'viewer_email = email')
+    .naturalJoin(users, 'viewer_id = id', 'viewer_email = email') \
+    .moveColumnsDown('received_at')
 
 dd_flagged_profiles = ck.consumeToTable(
     consume_properties,
@@ -143,7 +155,7 @@ dd_flagged_profiles = ck.consumeToTable(
 ).view('user_id = Long.parseLong(user_id_str.substring(1, user_id_str.length() - 1))')  # strip quotes
 
 dd_flagged_profile_view = dd_flagged_profiles \
-    .naturalJoin(pageviews_stg, 'user_id')
+    .join(pageviews_stg, 'user_id')
 
 high_value_users = purchases \
     .updateView(
@@ -156,7 +168,8 @@ high_value_users = purchases \
         'user_id'
     ) \
     .where('lifetime_value > 10000') \
-    .naturalJoin(users, 'user_id = id', 'email')
+    .naturalJoin(users, 'user_id = id', 'email') \
+    .view('id = user_id', 'email', 'lifetime_value', 'purchases')  # column rename and reorder
 
 schema_namespace = 'io.deephaven.examples'
 

--- a/debezium-demo/demo.py
+++ b/debezium-demo/demo.py
@@ -119,27 +119,9 @@ profile_views = pageviews_stg \
         'viewer_id = user_id',
         'received_at'
     ).sort(
-        'owner_id',
         'received_at'
     ).tailBy(10, 'owner_id')
 
-# This is an alternative definition for profile_views;
-# is a lot more complicated, but should be more efficient in that
-# it sorts smaller tables.
-#profile_views = pageviews_stg \
-#    .view(
-#        'owner_id = target_id',
-#        'viewer_id = user_id',
-#        'received_at'
-#    ).partitionBy(
-#        'owner_id'
-#    ).transformTables(
-#        tmapfun(lambda t : t
-#            .sortDescending('received_at')
-#            .head(10)
-#        )
-#    ).merge()
-    
 profile_views_enriched = profile_views \
     .naturalJoin(users, 'owner_id = id', 'owner_email = email') \
     .naturalJoin(users, 'viewer_id = id', 'viewer_email = email') \


### PR DESCRIPTION
The comments were:

===

Vs README_RPM.md
* pageview_stg - looks good. Only difference is they use double for received_at and we use datetime, which is better.
* purchases_by_item - looks good
* pageviews_by_item - looks good
* item_summary - different column order, but logic looks good
* profile_views_per_minute_last_10 could be simpler IMO with:
received_at_minute = lowerBin(received_at, minute_in_nanos)
profile_views
looks wrong from their perspective (they say last 5 users per profile, but are selecting 10). 
* We could use tailBy() to make this a lot simpler. 
pf2 = pageviews_stg.sort("target_id","received_at").tailBy(5, "target_id")
* profile_views_enriched - column order and some column names are different, but otherwise looks good
* I don't see any data for dd_flagged tables.
* high_value_users
Column order is different
Some column names are different
Data type of lifetime_value is different (our BigDecimal vs. their int)
Otherwise, looks good

===

We discussed about data for dd_flagged_tables having to come from a curl invocation scripted in the README_RPM.md original.   When Paul did that he found another issue related to the natural join in the definition for dd_flagged_profiles_view throwing an exception due to finding more than one right hand match; the solution is to change the operation from `naturalJoin` to `join`.

I addressed column order and simplifications suggested by Paul.