### PR TITLE
Update the web UI to v0.9.3

### DIFF
--- a/demo/push.sh
+++ b/demo/push.sh
@@ -10,7 +10,7 @@ while [ -n "$dir" ]; do
     docker rmi us-central1-docker.pkg.dev/deephaven-oss/deephaven/grpc-api:0.5.0 &>/dev/null
     docker rmi us-central1-docker.pkg.dev/deephaven-oss/deephaven/web:0.5.0 &>/dev/null
 
-    export WEB_VERSION=${WEB_VERSION:-0.6.1-markdownnotebooks.7}
+    export WEB_VERSION=${WEB_VERSION:-0.9.3}
     "$dir/gradlew" quarkusBuild pushAll \
         -i \
         -PdockerPath=deephaven-oss/deephaven \

--- a/web/client-ui/gradle.properties
+++ b/web/client-ui/gradle.properties
@@ -1,2 +1,2 @@
 # TODO(deephaven-core#1406): Demo merge blockers
-webVersion=0.6.1-markdownnotebooks.7
+webVersion=0.9.3


### PR DESCRIPTION
No longer need the separate (out of date) markdownnotebooks branch.