### PR TITLE
git ignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ irisDb.history
 .illumon.launcher.properties
 Containers/dockers/packages*
 Containers/dockers/third-party/*
+docker-compose.override.yml
 **/.DS_Store
 /data/
 /test.*


### PR DESCRIPTION
Now we can have a local docker-compose.override.yml file for local development that we can change for debugging without having to worry about accidentally committing something. An example override for debugging:

```
# Add some overrides to allow remote debugging
services:
  server:
    environment:
      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}

    ports:
      - '5005:5005'
```

See https://docs.docker.com/compose/extends/ for details on overrides.
