### PR TITLE
Encode Vectors similar to Arrays over Barrage

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
@@ -254,28 +254,38 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
             final FieldNodeInfo nodeInfo,
             final WritableByteChunk<Values> chunk,
             final WritableLongChunk<Values> isValid) throws IOException {
-        long nextValid = 0;
-        for (int ii = 0; ii < nodeInfo.numElements; ) {
-            if ((ii % 64) == 0) {
-                nextValid = isValid.get(ii / 64);
-            }
-            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
-            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
+        final int numElements = nodeInfo.numElements;
+        final int numValidityWords = (numElements + 63) / 64;
 
-            if (numToSkip > 0) {
-                is.skipBytes(numToSkip * elementSize);
-                nextValid >>= numToSkip;
-                for (int jj = 0; jj < numToSkip; ++jj) {
-                    chunk.set(ii + jj, NULL_BYTE);
+        int ei = 0;
+        int pendingSkips = 0;
+
+        for (int vi = 0; vi < numValidityWords; ++vi) {
+            int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
+            long validityWord = isValid.get(vi);
+            do {
+                if ((validityWord & 1) == 1) {
+                    if (pendingSkips > 0) {
+                        is.skipBytes(pendingSkips * elementSize);
+                        chunk.fillWithNullValue(ei, pendingSkips);
+                        ei += pendingSkips;
+                        pendingSkips = 0;
+                    }
+                    chunk.set(ei++, conversion.apply(is.readByte()));
+                    validityWord >>= 1;
+                    bitsLeftInThisWord--;
+                } else {
+                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    pendingSkips += skips;
+                    validityWord >>= skips;
+                    bitsLeftInThisWord -= skips;
                 }
-                ii += numToSkip;
-            }
-            if (maxToSkip > numToSkip) {
-                final byte value = conversion.apply(is.readByte());
-                nextValid >>= 1;
-                chunk.set(ii, value);
-                ++ii;
-            }
+            } while (bitsLeftInThisWord > 0);
+        }
+
+        if (pendingSkips > 0) {
+            is.skipBytes(pendingSkips * elementSize);
+            chunk.fillWithNullValue(ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
@@ -10,11 +10,15 @@
 package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.ByteChunk;
 import io.deephaven.chunk.Chunk;
@@ -31,6 +35,19 @@ import static io.deephaven.util.QueryConstants.*;
 
 public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<ByteChunk<Values>> {
     private static final String DEBUG_NAME = "ByteChunkInputStreamGenerator";
+
+    public static ByteChunkInputStreamGenerator convertBoxed(final ObjectChunk<Byte, Values> inChunk) {
+        // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
+        WritableByteChunk<Values> outChunk = WritableByteChunk.makeWritableChunk(inChunk.size());
+        for (int i = 0; i < inChunk.size(); ++i) {
+            final Byte value = inChunk.get(i);
+            outChunk.set(i, value == null ? QueryConstants.NULL_BYTE : value);
+        }
+        if (inChunk instanceof PoolableChunk) {
+            ((PoolableChunk) inChunk).close();
+        }
+        return new ByteChunkInputStreamGenerator(outChunk, Byte.BYTES);
+    }
 
     ByteChunkInputStreamGenerator(final ByteChunk<Values> chunk, final int elementSize) {
         super(chunk, elementSize);
@@ -118,22 +135,23 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 bytesWritten += getValidityMapSerializationSizeFor(subset.intSize());
             }
 
-                // write the included values
-                subset.forAllRowKeys(row -> {
-                    try {
-                        final byte val = chunk.get((int) row);
-                        dos.writeByte(val);
-                    } catch (final IOException e) {
-                        throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
-                    }
-                });
-
-                bytesWritten += elementSize * subset.size();
-                final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
-                if (bytesExtended > 0) {
-                    bytesWritten += 8 - bytesExtended;
-                    dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            // write the included values
+            subset.forAllRowKeys(row -> {
+                try {
+                    final byte val = chunk.get((int) row);
+                    dos.writeByte(val);
+                } catch (final IOException e) {
+                    throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
                 }
+            });
+
+            bytesWritten += elementSize * subset.size();
+            final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
+            if (bytesExtended > 0) {
+                bytesWritten += 8 - bytesExtended;
+                dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            }
+
             return LongSizedDataStructure.intSize("ByteChunkInputStreamGenerator", bytesWritten);
         }
     }
@@ -142,6 +160,12 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
     public interface ByteConversion {
         byte apply(byte in);
         ByteConversion IDENTITY = (byte a) -> a;
+    }
+
+    @FunctionalInterface
+    public interface ByteToTypeConversion<T> {
+        T apply(byte in);
+        ByteToTypeConversion<Byte> BOXED = (byte a) -> a == NULL_BYTE ? null : (Byte) a;
     }
 
     static Chunk<Values> extractChunkFromInputStream(
@@ -222,6 +246,81 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                     final byte value;
                     if ((nextValid & 0x1) == 0x0) {
                         value = NULL_BYTE;
+                        is.skipBytes(elementSize);
+                    } else {
+                        value = conversion.apply(is.readByte());
+                    }
+                    nextValid >>= 1;
+                    chunk.set(ii, value);
+                }
+            }
+
+            final long overhangPayload = payloadBuffer - payloadRead;
+            if (overhangPayload > 0) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            }
+        }
+
+        chunk.setSize(nodeInfo.numElements);
+        return chunk;
+    }
+
+    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+            final int elementSize,
+            final StreamReaderOptions options,
+            final ByteToTypeConversion<T> conversion,
+            final Iterator<FieldNodeInfo> fieldNodeIter,
+            final TLongIterator bufferInfoIter,
+            final DataInput is) throws IOException {
+
+        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
+        final long validityBuffer = bufferInfoIter.next();
+        final long payloadBuffer = bufferInfoIter.next();
+
+        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
+
+        if (nodeInfo.numElements == 0) {
+            return chunk;
+        }
+
+        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
+        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
+            if (options.useDeephavenNulls() && validityBuffer != 0) {
+                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            }
+            int jj = 0;
+            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
+                isValid.set(jj, is.readLong());
+            }
+            final long valBufRead = jj * 8L;
+            if (valBufRead < validityBuffer) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
+            }
+            // we support short validity buffers
+            for (; jj < numValidityLongs; ++jj) {
+                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
+            }
+            // consumed entire validity buffer by here
+
+            final long payloadRead = (long) nodeInfo.numElements * elementSize;
+            if (payloadBuffer < payloadRead) {
+                throw new IllegalStateException("payload buffer is too short for expected number of elements");
+            }
+
+            if (options.useDeephavenNulls()) {
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    final byte in = is.readByte();
+                    chunk.set(ii, in == NULL_BYTE ? null : conversion.apply(in));
+                }
+            } else {
+                long nextValid = 0;
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    if ((ii % 64) == 0) {
+                        nextValid = isValid.get(ii / 64);
+                    }
+                    final T value;
+                    if ((nextValid & 0x1) == 0x0) {
+                        value = null;
                         is.skipBytes(elementSize);
                     } else {
                         value = conversion.apply(is.readByte());

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
@@ -11,19 +11,18 @@ package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
 import io.deephaven.chunk.ObjectChunk;
-import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
-import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.ByteChunk;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.util.type.TypeUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.DataInput;
@@ -41,7 +40,7 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         WritableByteChunk<Values> outChunk = WritableByteChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
             final Byte value = inChunk.get(i);
-            outChunk.set(i, value == null ? QueryConstants.NULL_BYTE : value);
+            outChunk.set(i, TypeUtils.unbox(value));
         }
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
@@ -162,12 +161,6 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         ByteConversion IDENTITY = (byte a) -> a;
     }
 
-    @FunctionalInterface
-    public interface ByteToTypeConversion<T> {
-        T apply(byte in);
-        ByteToTypeConversion<Byte> BOXED = (byte a) -> a == NULL_BYTE ? null : (Byte) a;
-    }
-
     static Chunk<Values> extractChunkFromInputStream(
             final int elementSize,
             final StreamReaderOptions options,
@@ -221,38 +214,9 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
             }
 
             if (options.useDeephavenNulls()) {
-                if (conversion == ByteChunkInputStreamGenerator.ByteConversion.IDENTITY) {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        chunk.set(ii, is.readByte());
-                    }
-                } else {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        final byte in = is.readByte();
-                        final byte out;
-                        if (in == NULL_BYTE) {
-                            out = in;
-                        } else {
-                            out = conversion.apply(in);
-                        }
-                        chunk.set(ii, out);
-                    }
-                }
+                useDeephavenNulls(conversion, is, nodeInfo, chunk);
             } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final byte value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = NULL_BYTE;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readByte());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;
@@ -265,78 +229,53 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         return chunk;
     }
 
-    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+    private static void useDeephavenNulls(
+            final ByteConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableByteChunk<Values> chunk) throws IOException {
+        if (conversion == ByteConversion.IDENTITY) {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                chunk.set(ii, is.readByte());
+            }
+        } else {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                final byte in = is.readByte();
+                final byte out = in == NULL_BYTE ? in : conversion.apply(in);
+                chunk.set(ii, out);
+            }
+        }
+    }
+
+    private static void useValidityBuffer(
             final int elementSize,
-            final StreamReaderOptions options,
-            final ByteToTypeConversion<T> conversion,
-            final Iterator<FieldNodeInfo> fieldNodeIter,
-            final TLongIterator bufferInfoIter,
-            final DataInput is) throws IOException {
-
-        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
-        final long validityBuffer = bufferInfoIter.next();
-        final long payloadBuffer = bufferInfoIter.next();
-
-        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
-
-        if (nodeInfo.numElements == 0) {
-            return chunk;
-        }
-
-        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
-        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
-            if (options.useDeephavenNulls() && validityBuffer != 0) {
-                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            final ByteConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableByteChunk<Values> chunk,
+            final WritableLongChunk<Values> isValid) throws IOException {
+        long nextValid = 0;
+        for (int ii = 0; ii < nodeInfo.numElements; ) {
+            if ((ii % 64) == 0) {
+                nextValid = isValid.get(ii / 64);
             }
-            int jj = 0;
-            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
-                isValid.set(jj, is.readLong());
-            }
-            final long valBufRead = jj * 8L;
-            if (valBufRead < validityBuffer) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
-            }
-            // we support short validity buffers
-            for (; jj < numValidityLongs; ++jj) {
-                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
-            }
-            // consumed entire validity buffer by here
+            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
+            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
 
-            final long payloadRead = (long) nodeInfo.numElements * elementSize;
-            if (payloadBuffer < payloadRead) {
-                throw new IllegalStateException("payload buffer is too short for expected number of elements");
-            }
-
-            if (options.useDeephavenNulls()) {
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    final byte in = is.readByte();
-                    chunk.set(ii, in == NULL_BYTE ? null : conversion.apply(in));
+            if (numToSkip > 0) {
+                is.skipBytes(numToSkip * elementSize);
+                nextValid >>= numToSkip;
+                for (int jj = 0; jj < numToSkip; ++jj) {
+                    chunk.set(ii + jj, NULL_BYTE);
                 }
-            } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final T value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = null;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readByte());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                ii += numToSkip;
             }
-
-            final long overhangPayload = payloadBuffer - payloadRead;
-            if (overhangPayload > 0) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            if (maxToSkip > numToSkip) {
+                final byte value = conversion.apply(is.readByte());
+                nextValid >>= 1;
+                chunk.set(ii, value);
+                ++ii;
             }
         }
-
-        chunk.setSize(nodeInfo.numElements);
-        return chunk;
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
@@ -249,28 +249,38 @@ public class CharChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
             final FieldNodeInfo nodeInfo,
             final WritableCharChunk<Values> chunk,
             final WritableLongChunk<Values> isValid) throws IOException {
-        long nextValid = 0;
-        for (int ii = 0; ii < nodeInfo.numElements; ) {
-            if ((ii % 64) == 0) {
-                nextValid = isValid.get(ii / 64);
-            }
-            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
-            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
+        final int numElements = nodeInfo.numElements;
+        final int numValidityWords = (numElements + 63) / 64;
 
-            if (numToSkip > 0) {
-                is.skipBytes(numToSkip * elementSize);
-                nextValid >>= numToSkip;
-                for (int jj = 0; jj < numToSkip; ++jj) {
-                    chunk.set(ii + jj, NULL_CHAR);
+        int ei = 0;
+        int pendingSkips = 0;
+
+        for (int vi = 0; vi < numValidityWords; ++vi) {
+            int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
+            long validityWord = isValid.get(vi);
+            do {
+                if ((validityWord & 1) == 1) {
+                    if (pendingSkips > 0) {
+                        is.skipBytes(pendingSkips * elementSize);
+                        chunk.fillWithNullValue(ei, pendingSkips);
+                        ei += pendingSkips;
+                        pendingSkips = 0;
+                    }
+                    chunk.set(ei++, conversion.apply(is.readChar()));
+                    validityWord >>= 1;
+                    bitsLeftInThisWord--;
+                } else {
+                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    pendingSkips += skips;
+                    validityWord >>= skips;
+                    bitsLeftInThisWord -= skips;
                 }
-                ii += numToSkip;
-            }
-            if (maxToSkip > numToSkip) {
-                final char value = conversion.apply(is.readChar());
-                nextValid >>= 1;
-                chunk.set(ii, value);
-                ++ii;
-            }
+            } while (bitsLeftInThisWord > 0);
+        }
+
+        if (pendingSkips > 0) {
+            is.skipBytes(pendingSkips * elementSize);
+            chunk.fillWithNullValue(ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
@@ -16,11 +16,11 @@ import io.deephaven.extensions.barrage.util.DefensiveDrainable;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
 import io.deephaven.time.DateTime;
 import io.deephaven.time.DateTimeUtils;
-import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.util.SafeCloseable;
+import io.deephaven.util.type.TypeUtils;
 import io.deephaven.vector.Vector;
 import org.jetbrains.annotations.Nullable;
 
@@ -206,49 +206,50 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
                     );
                 }
                 if (type == DateTime.class) {
-                    return LongChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Long.BYTES, options, DateTime::new, fieldNodeIter, bufferInfoIter, is
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Long.BYTES, options, io -> DateTimeUtils.nanosToTime(io.readLong()),
+                            fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == Byte.class) {
-                    return ByteChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Byte.BYTES, options, ByteChunkInputStreamGenerator.ByteToTypeConversion.BOXED,
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Byte.BYTES, options, io -> TypeUtils.box(io.readByte()),
                             fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == Character.class) {
-                    return CharChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Character.BYTES, options, CharChunkInputStreamGenerator.CharToTypeConversion.BOXED,
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Character.BYTES, options, io -> TypeUtils.box(io.readChar()),
                             fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == Double.class) {
-                    return DoubleChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Double.BYTES, options, DoubleChunkInputStreamGenerator.DoubleToTypeConversion.BOXED,
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Double.BYTES, options, io -> TypeUtils.box(io.readDouble()),
                             fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == Float.class) {
-                    return FloatChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Float.BYTES, options, FloatChunkInputStreamGenerator.FloatToTypeConversion.BOXED,
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Float.BYTES, options, io -> TypeUtils.box(io.readFloat()),
                             fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == Integer.class) {
-                    return IntChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Integer.BYTES, options, IntChunkInputStreamGenerator.IntToTypeConversion.BOXED,
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Integer.BYTES, options, io -> TypeUtils.box(io.readInt()),
                             fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == Long.class) {
-                    return LongChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Long.BYTES, options, LongChunkInputStreamGenerator.LongToTypeConversion.BOXED,
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Long.BYTES, options, io -> TypeUtils.box(io.readLong()),
                             fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == Short.class) {
-                    return ShortChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
-                            Short.BYTES, options, ShortChunkInputStreamGenerator.ShortToTypeConversion.BOXED,
+                    return FixedWidthChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Short.BYTES, options, io -> TypeUtils.box(io.readShort()),
                             fieldNodeIter, bufferInfoIter, is
                     );
                 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
@@ -6,15 +6,22 @@ package io.deephaven.extensions.barrage.chunk;
 
 import com.google.common.base.Charsets;
 import gnu.trove.iterator.TLongIterator;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.extensions.barrage.ColumnConversionMode;
 import io.deephaven.extensions.barrage.util.DefensiveDrainable;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
+import io.deephaven.time.DateTime;
+import io.deephaven.time.DateTimeUtils;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.util.SafeCloseable;
+import io.deephaven.vector.Vector;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.DataInput;
@@ -26,7 +33,7 @@ import java.util.Iterator;
 public interface ChunkInputStreamGenerator extends SafeCloseable {
 
     static <T> ChunkInputStreamGenerator makeInputStreamGenerator(
-            final ChunkType chunkType, final Class<T> type, final Chunk<Values> chunk) {
+            final ChunkType chunkType, final Class<T> type, final Class<?> componentType, final Chunk<Values> chunk) {
         switch (chunkType) {
             case Boolean:
                 throw new UnsupportedOperationException("Booleans are reinterpreted as bytes");
@@ -47,6 +54,10 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
             case Object:
                 if (type.isArray()) {
                     return new VarListChunkInputStreamGenerator<>(type, chunk.asObjectChunk());
+                }
+                if (Vector.class.isAssignableFrom(type)) {
+                    //noinspection unchecked
+                    return new VectorChunkInputStreamGenerator((Class<Vector<?>>) type, componentType, chunk.asObjectChunk());
                 }
                 if (type == String.class) {
                     return new VarBinaryChunkInputStreamGenerator<>(String.class, chunk.asObjectChunk(), (out, str) -> {
@@ -70,6 +81,39 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
                         out.write(normal.unscaledValue().toByteArray());
                     });
                 }
+                if (type == DateTime.class) {
+                    // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
+                    ObjectChunk<DateTime, Values> objChunk = chunk.asObjectChunk();
+                    WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(objChunk.size());
+                    for (int i = 0; i < objChunk.size(); ++i) {
+                        outChunk.set(i, DateTimeUtils.nanos(objChunk.get(i)));
+                    }
+                    if (chunk instanceof PoolableChunk) {
+                        ((PoolableChunk) chunk).close();
+                    }
+                    return new LongChunkInputStreamGenerator(outChunk, Long.BYTES);
+                }
+                if (type == Byte.class) {
+                    return ByteChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk());
+                }
+                if (type == Character.class) {
+                    return CharChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk());
+                }
+                if (type == Double.class) {
+                    return DoubleChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk());
+                }
+                if (type == Float.class) {
+                    return FloatChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk());
+                }
+                if (type == Integer.class) {
+                    return IntChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk());
+                }
+                if (type == Long.class) {
+                    return LongChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk());
+                }
+                if (type == Short.class) {
+                    return ShortChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk());
+                }
                 // TODO (core#936): support column conversion modes
 
                 return new VarBinaryChunkInputStreamGenerator<>(type, chunk.asObjectChunk(), (out, item) -> {
@@ -80,19 +124,19 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
         }
     }
 
-    static <T> Chunk<Values> extractChunkFromInputStream(
+    static Chunk<Values> extractChunkFromInputStream(
             final StreamReaderOptions options,
-            final ChunkType chunkType, final Class<T> type,
+            final ChunkType chunkType, final Class<?> type, final Class<?> componentType,
             final Iterator<FieldNodeInfo> fieldNodeIter,
             final TLongIterator bufferInfoIter,
             final DataInput is) throws IOException {
-        return extractChunkFromInputStream(options, 1, chunkType, type, fieldNodeIter, bufferInfoIter, is);
+        return extractChunkFromInputStream(options, 1, chunkType, type, componentType, fieldNodeIter, bufferInfoIter, is);
     }
 
-    static <T> Chunk<Values> extractChunkFromInputStream(
+    static Chunk<Values> extractChunkFromInputStream(
             final StreamReaderOptions options,
             final int factor,
-            final ChunkType chunkType, final Class<T> type,
+            final ChunkType chunkType, final Class<?> type, final Class<?> componentType,
             final Iterator<FieldNodeInfo> fieldNodeIter,
             final TLongIterator bufferInfoIter,
             final DataInput is) throws IOException {
@@ -132,6 +176,11 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
                    return VarListChunkInputStreamGenerator.extractChunkFromInputStream(
                            options, type, fieldNodeIter, bufferInfoIter, is);
                 }
+                if (Vector.class.isAssignableFrom(type)) {
+                    //noinspection unchecked
+                    return VectorChunkInputStreamGenerator.extractChunkFromInputStream(
+                            options, (Class<Vector<?>>)type, componentType, fieldNodeIter, bufferInfoIter, is);
+                }
                 if (type == BigInteger.class) {
                     return VarBinaryChunkInputStreamGenerator.extractChunkFromInputStream(
                             is,
@@ -154,6 +203,53 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
                                 final int scale = b4 << 24 | (b3 & 0xFF) << 16 | (b2 & 0xFF) << 8 | (b1 & 0xFF);
                                 return new BigDecimal(new BigInteger(buf, offset + 4, length - 4), scale);
                             }
+                    );
+                }
+                if (type == DateTime.class) {
+                    return LongChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Long.BYTES, options, DateTime::new, fieldNodeIter, bufferInfoIter, is
+                    );
+                }
+                if (type == Byte.class) {
+                    return ByteChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Byte.BYTES, options, ByteChunkInputStreamGenerator.ByteToTypeConversion.BOXED,
+                            fieldNodeIter, bufferInfoIter, is
+                    );
+                }
+                if (type == Character.class) {
+                    return CharChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Character.BYTES, options, CharChunkInputStreamGenerator.CharToTypeConversion.BOXED,
+                            fieldNodeIter, bufferInfoIter, is
+                    );
+                }
+                if (type == Double.class) {
+                    return DoubleChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Double.BYTES, options, DoubleChunkInputStreamGenerator.DoubleToTypeConversion.BOXED,
+                            fieldNodeIter, bufferInfoIter, is
+                    );
+                }
+                if (type == Float.class) {
+                    return FloatChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Float.BYTES, options, FloatChunkInputStreamGenerator.FloatToTypeConversion.BOXED,
+                            fieldNodeIter, bufferInfoIter, is
+                    );
+                }
+                if (type == Integer.class) {
+                    return IntChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Integer.BYTES, options, IntChunkInputStreamGenerator.IntToTypeConversion.BOXED,
+                            fieldNodeIter, bufferInfoIter, is
+                    );
+                }
+                if (type == Long.class) {
+                    return LongChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Long.BYTES, options, LongChunkInputStreamGenerator.LongToTypeConversion.BOXED,
+                            fieldNodeIter, bufferInfoIter, is
+                    );
+                }
+                if (type == Short.class) {
+                    return ShortChunkInputStreamGenerator.extractChunkFromInputStreamWithTypeConversion(
+                            Short.BYTES, options, ShortChunkInputStreamGenerator.ShortToTypeConversion.BOXED,
+                            fieldNodeIter, bufferInfoIter, is
                     );
                 }
                 if (type == String.class ||

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
@@ -254,28 +254,38 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
             final FieldNodeInfo nodeInfo,
             final WritableDoubleChunk<Values> chunk,
             final WritableLongChunk<Values> isValid) throws IOException {
-        long nextValid = 0;
-        for (int ii = 0; ii < nodeInfo.numElements; ) {
-            if ((ii % 64) == 0) {
-                nextValid = isValid.get(ii / 64);
-            }
-            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
-            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
+        final int numElements = nodeInfo.numElements;
+        final int numValidityWords = (numElements + 63) / 64;
 
-            if (numToSkip > 0) {
-                is.skipBytes(numToSkip * elementSize);
-                nextValid >>= numToSkip;
-                for (int jj = 0; jj < numToSkip; ++jj) {
-                    chunk.set(ii + jj, NULL_DOUBLE);
+        int ei = 0;
+        int pendingSkips = 0;
+
+        for (int vi = 0; vi < numValidityWords; ++vi) {
+            int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
+            long validityWord = isValid.get(vi);
+            do {
+                if ((validityWord & 1) == 1) {
+                    if (pendingSkips > 0) {
+                        is.skipBytes(pendingSkips * elementSize);
+                        chunk.fillWithNullValue(ei, pendingSkips);
+                        ei += pendingSkips;
+                        pendingSkips = 0;
+                    }
+                    chunk.set(ei++, conversion.apply(is.readDouble()));
+                    validityWord >>= 1;
+                    bitsLeftInThisWord--;
+                } else {
+                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    pendingSkips += skips;
+                    validityWord >>= skips;
+                    bitsLeftInThisWord -= skips;
                 }
-                ii += numToSkip;
-            }
-            if (maxToSkip > numToSkip) {
-                final double value = conversion.apply(is.readDouble());
-                nextValid >>= 1;
-                chunk.set(ii, value);
-                ++ii;
-            }
+            } while (bitsLeftInThisWord > 0);
+        }
+
+        if (pendingSkips > 0) {
+            is.skipBytes(pendingSkips * elementSize);
+            chunk.fillWithNullValue(ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
@@ -10,11 +10,15 @@
 package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.DoubleChunk;
 import io.deephaven.chunk.Chunk;
@@ -31,6 +35,19 @@ import static io.deephaven.util.QueryConstants.*;
 
 public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<DoubleChunk<Values>> {
     private static final String DEBUG_NAME = "DoubleChunkInputStreamGenerator";
+
+    public static DoubleChunkInputStreamGenerator convertBoxed(final ObjectChunk<Double, Values> inChunk) {
+        // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
+        WritableDoubleChunk<Values> outChunk = WritableDoubleChunk.makeWritableChunk(inChunk.size());
+        for (int i = 0; i < inChunk.size(); ++i) {
+            final Double value = inChunk.get(i);
+            outChunk.set(i, value == null ? QueryConstants.NULL_DOUBLE : value);
+        }
+        if (inChunk instanceof PoolableChunk) {
+            ((PoolableChunk) inChunk).close();
+        }
+        return new DoubleChunkInputStreamGenerator(outChunk, Double.BYTES);
+    }
 
     DoubleChunkInputStreamGenerator(final DoubleChunk<Values> chunk, final int elementSize) {
         super(chunk, elementSize);
@@ -118,22 +135,23 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
                 bytesWritten += getValidityMapSerializationSizeFor(subset.intSize());
             }
 
-                // write the included values
-                subset.forAllRowKeys(row -> {
-                    try {
-                        final double val = chunk.get((int) row);
-                        dos.writeDouble(val);
-                    } catch (final IOException e) {
-                        throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
-                    }
-                });
-
-                bytesWritten += elementSize * subset.size();
-                final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
-                if (bytesExtended > 0) {
-                    bytesWritten += 8 - bytesExtended;
-                    dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            // write the included values
+            subset.forAllRowKeys(row -> {
+                try {
+                    final double val = chunk.get((int) row);
+                    dos.writeDouble(val);
+                } catch (final IOException e) {
+                    throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
                 }
+            });
+
+            bytesWritten += elementSize * subset.size();
+            final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
+            if (bytesExtended > 0) {
+                bytesWritten += 8 - bytesExtended;
+                dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            }
+
             return LongSizedDataStructure.intSize("DoubleChunkInputStreamGenerator", bytesWritten);
         }
     }
@@ -142,6 +160,12 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
     public interface DoubleConversion {
         double apply(double in);
         DoubleConversion IDENTITY = (double a) -> a;
+    }
+
+    @FunctionalInterface
+    public interface DoubleToTypeConversion<T> {
+        T apply(double in);
+        DoubleToTypeConversion<Double> BOXED = (double a) -> a == NULL_DOUBLE ? null : (Double) a;
     }
 
     static Chunk<Values> extractChunkFromInputStream(
@@ -222,6 +246,81 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
                     final double value;
                     if ((nextValid & 0x1) == 0x0) {
                         value = NULL_DOUBLE;
+                        is.skipBytes(elementSize);
+                    } else {
+                        value = conversion.apply(is.readDouble());
+                    }
+                    nextValid >>= 1;
+                    chunk.set(ii, value);
+                }
+            }
+
+            final long overhangPayload = payloadBuffer - payloadRead;
+            if (overhangPayload > 0) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            }
+        }
+
+        chunk.setSize(nodeInfo.numElements);
+        return chunk;
+    }
+
+    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+            final int elementSize,
+            final StreamReaderOptions options,
+            final DoubleToTypeConversion<T> conversion,
+            final Iterator<FieldNodeInfo> fieldNodeIter,
+            final TLongIterator bufferInfoIter,
+            final DataInput is) throws IOException {
+
+        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
+        final long validityBuffer = bufferInfoIter.next();
+        final long payloadBuffer = bufferInfoIter.next();
+
+        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
+
+        if (nodeInfo.numElements == 0) {
+            return chunk;
+        }
+
+        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
+        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
+            if (options.useDeephavenNulls() && validityBuffer != 0) {
+                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            }
+            int jj = 0;
+            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
+                isValid.set(jj, is.readLong());
+            }
+            final long valBufRead = jj * 8L;
+            if (valBufRead < validityBuffer) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
+            }
+            // we support short validity buffers
+            for (; jj < numValidityLongs; ++jj) {
+                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
+            }
+            // consumed entire validity buffer by here
+
+            final long payloadRead = (long) nodeInfo.numElements * elementSize;
+            if (payloadBuffer < payloadRead) {
+                throw new IllegalStateException("payload buffer is too short for expected number of elements");
+            }
+
+            if (options.useDeephavenNulls()) {
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    final double in = is.readDouble();
+                    chunk.set(ii, in == NULL_DOUBLE ? null : conversion.apply(in));
+                }
+            } else {
+                long nextValid = 0;
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    if ((ii % 64) == 0) {
+                        nextValid = isValid.get(ii / 64);
+                    }
+                    final T value;
+                    if ((nextValid & 0x1) == 0x0) {
+                        value = null;
                         is.skipBytes(elementSize);
                     } else {
                         value = conversion.apply(is.readDouble());

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
@@ -11,19 +11,18 @@ package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
 import io.deephaven.chunk.ObjectChunk;
-import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
-import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.DoubleChunk;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.util.type.TypeUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.DataInput;
@@ -41,7 +40,7 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
         WritableDoubleChunk<Values> outChunk = WritableDoubleChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
             final Double value = inChunk.get(i);
-            outChunk.set(i, value == null ? QueryConstants.NULL_DOUBLE : value);
+            outChunk.set(i, TypeUtils.unbox(value));
         }
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
@@ -162,12 +161,6 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
         DoubleConversion IDENTITY = (double a) -> a;
     }
 
-    @FunctionalInterface
-    public interface DoubleToTypeConversion<T> {
-        T apply(double in);
-        DoubleToTypeConversion<Double> BOXED = (double a) -> a == NULL_DOUBLE ? null : (Double) a;
-    }
-
     static Chunk<Values> extractChunkFromInputStream(
             final int elementSize,
             final StreamReaderOptions options,
@@ -221,38 +214,9 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
             }
 
             if (options.useDeephavenNulls()) {
-                if (conversion == DoubleChunkInputStreamGenerator.DoubleConversion.IDENTITY) {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        chunk.set(ii, is.readDouble());
-                    }
-                } else {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        final double in = is.readDouble();
-                        final double out;
-                        if (in == NULL_DOUBLE) {
-                            out = in;
-                        } else {
-                            out = conversion.apply(in);
-                        }
-                        chunk.set(ii, out);
-                    }
-                }
+                useDeephavenNulls(conversion, is, nodeInfo, chunk);
             } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final double value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = NULL_DOUBLE;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readDouble());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;
@@ -265,78 +229,53 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
         return chunk;
     }
 
-    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+    private static void useDeephavenNulls(
+            final DoubleConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableDoubleChunk<Values> chunk) throws IOException {
+        if (conversion == DoubleConversion.IDENTITY) {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                chunk.set(ii, is.readDouble());
+            }
+        } else {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                final double in = is.readDouble();
+                final double out = in == NULL_DOUBLE ? in : conversion.apply(in);
+                chunk.set(ii, out);
+            }
+        }
+    }
+
+    private static void useValidityBuffer(
             final int elementSize,
-            final StreamReaderOptions options,
-            final DoubleToTypeConversion<T> conversion,
-            final Iterator<FieldNodeInfo> fieldNodeIter,
-            final TLongIterator bufferInfoIter,
-            final DataInput is) throws IOException {
-
-        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
-        final long validityBuffer = bufferInfoIter.next();
-        final long payloadBuffer = bufferInfoIter.next();
-
-        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
-
-        if (nodeInfo.numElements == 0) {
-            return chunk;
-        }
-
-        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
-        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
-            if (options.useDeephavenNulls() && validityBuffer != 0) {
-                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            final DoubleConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableDoubleChunk<Values> chunk,
+            final WritableLongChunk<Values> isValid) throws IOException {
+        long nextValid = 0;
+        for (int ii = 0; ii < nodeInfo.numElements; ) {
+            if ((ii % 64) == 0) {
+                nextValid = isValid.get(ii / 64);
             }
-            int jj = 0;
-            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
-                isValid.set(jj, is.readLong());
-            }
-            final long valBufRead = jj * 8L;
-            if (valBufRead < validityBuffer) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
-            }
-            // we support short validity buffers
-            for (; jj < numValidityLongs; ++jj) {
-                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
-            }
-            // consumed entire validity buffer by here
+            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
+            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
 
-            final long payloadRead = (long) nodeInfo.numElements * elementSize;
-            if (payloadBuffer < payloadRead) {
-                throw new IllegalStateException("payload buffer is too short for expected number of elements");
-            }
-
-            if (options.useDeephavenNulls()) {
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    final double in = is.readDouble();
-                    chunk.set(ii, in == NULL_DOUBLE ? null : conversion.apply(in));
+            if (numToSkip > 0) {
+                is.skipBytes(numToSkip * elementSize);
+                nextValid >>= numToSkip;
+                for (int jj = 0; jj < numToSkip; ++jj) {
+                    chunk.set(ii + jj, NULL_DOUBLE);
                 }
-            } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final T value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = null;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readDouble());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                ii += numToSkip;
             }
-
-            final long overhangPayload = payloadBuffer - payloadRead;
-            if (overhangPayload > 0) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            if (maxToSkip > numToSkip) {
+                final double value = conversion.apply(is.readDouble());
+                nextValid >>= 1;
+                chunk.set(ii, value);
+                ++ii;
             }
         }
-
-        chunk.setSize(nodeInfo.numElements);
-        return chunk;
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FixedWidthChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FixedWidthChunkInputStreamGenerator.java
@@ -1,0 +1,130 @@
+package io.deephaven.extensions.barrage.chunk;
+
+import gnu.trove.iterator.TLongIterator;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.extensions.barrage.util.StreamReaderOptions;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.Iterator;
+
+import static io.deephaven.util.QueryConstants.NULL_CHAR;
+
+public class FixedWidthChunkInputStreamGenerator {
+    private static final String DEBUG_NAME = "FixedWidthChunkInputStreamGenerator";
+
+    @FunctionalInterface
+    public interface TypeConversion<T> {
+        T apply(DataInput in) throws IOException;
+    }
+
+    /**
+     * Generic input stream reading from arrow's buffer and convert directly to java type.
+     *
+     * If useDeephavenNulls is enabled, then the conversion method must properly return a null value.
+     *
+     * @param elementSize    the number of bytes per element (element size is fixed)
+     * @param options        the stream reader options
+     * @param conversion     the conversion method from input stream to the result type
+     * @param fieldNodeIter  arrow field node iterator
+     * @param bufferInfoIter arrow buffer info iterator
+     * @param is             data input stream
+     * @param <T>            the result type
+     * @return               the resulting chunk of the buffer that is read
+     */
+    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+            final int elementSize,
+            final StreamReaderOptions options,
+            final TypeConversion<T> conversion,
+            final Iterator<ChunkInputStreamGenerator.FieldNodeInfo> fieldNodeIter,
+            final TLongIterator bufferInfoIter,
+            final DataInput is) throws IOException {
+
+        final ChunkInputStreamGenerator.FieldNodeInfo nodeInfo = fieldNodeIter.next();
+        final long validityBuffer = bufferInfoIter.next();
+        final long payloadBuffer = bufferInfoIter.next();
+
+        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
+
+        if (nodeInfo.numElements == 0) {
+            return chunk;
+        }
+
+        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
+        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
+            if (options.useDeephavenNulls() && validityBuffer != 0) {
+                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            }
+            int jj = 0;
+            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
+                isValid.set(jj, is.readLong());
+            }
+            final long valBufRead = jj * 8L;
+            if (valBufRead < validityBuffer) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
+            }
+            // we support short validity buffers
+            for (; jj < numValidityLongs; ++jj) {
+                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
+            }
+            // consumed entire validity buffer by here
+
+            final long payloadRead = (long) nodeInfo.numElements * elementSize;
+            if (payloadBuffer < payloadRead) {
+                throw new IllegalStateException("payload buffer is too short for expected number of elements");
+            }
+
+            if (options.useDeephavenNulls()) {
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    chunk.set(ii, conversion.apply(is));
+                }
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, isValid);
+            }
+
+            final long overhangPayload = payloadBuffer - payloadRead;
+            if (overhangPayload > 0) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            }
+        }
+
+        chunk.setSize(nodeInfo.numElements);
+        return chunk;
+    }
+
+    private static <T> void useValidityBuffer(
+            final int elementSize,
+            final TypeConversion<T> conversion,
+            final DataInput is,
+            final ChunkInputStreamGenerator.FieldNodeInfo nodeInfo,
+            final WritableObjectChunk<T, Values> chunk,
+            final WritableLongChunk<Values> isValid) throws IOException {
+        long nextValid = 0;
+        for (int ii = 0; ii < nodeInfo.numElements; ) {
+            if ((ii % 64) == 0) {
+                nextValid = isValid.get(ii / 64);
+            }
+            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
+            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
+
+            if (numToSkip > 0) {
+                is.skipBytes(numToSkip * elementSize);
+                nextValid >>= numToSkip;
+                for (int jj = 0; jj < numToSkip; ++jj) {
+                    chunk.set(ii + jj, null);
+                }
+                ii += numToSkip;
+            }
+            if (maxToSkip > numToSkip) {
+                final T value = conversion.apply(is);
+                nextValid >>= 1;
+                chunk.set(ii, value);
+                ++ii;
+            }
+        }
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
@@ -254,28 +254,38 @@ public class FloatChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
             final FieldNodeInfo nodeInfo,
             final WritableFloatChunk<Values> chunk,
             final WritableLongChunk<Values> isValid) throws IOException {
-        long nextValid = 0;
-        for (int ii = 0; ii < nodeInfo.numElements; ) {
-            if ((ii % 64) == 0) {
-                nextValid = isValid.get(ii / 64);
-            }
-            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
-            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
+        final int numElements = nodeInfo.numElements;
+        final int numValidityWords = (numElements + 63) / 64;
 
-            if (numToSkip > 0) {
-                is.skipBytes(numToSkip * elementSize);
-                nextValid >>= numToSkip;
-                for (int jj = 0; jj < numToSkip; ++jj) {
-                    chunk.set(ii + jj, NULL_FLOAT);
+        int ei = 0;
+        int pendingSkips = 0;
+
+        for (int vi = 0; vi < numValidityWords; ++vi) {
+            int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
+            long validityWord = isValid.get(vi);
+            do {
+                if ((validityWord & 1) == 1) {
+                    if (pendingSkips > 0) {
+                        is.skipBytes(pendingSkips * elementSize);
+                        chunk.fillWithNullValue(ei, pendingSkips);
+                        ei += pendingSkips;
+                        pendingSkips = 0;
+                    }
+                    chunk.set(ei++, conversion.apply(is.readFloat()));
+                    validityWord >>= 1;
+                    bitsLeftInThisWord--;
+                } else {
+                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    pendingSkips += skips;
+                    validityWord >>= skips;
+                    bitsLeftInThisWord -= skips;
                 }
-                ii += numToSkip;
-            }
-            if (maxToSkip > numToSkip) {
-                final float value = conversion.apply(is.readFloat());
-                nextValid >>= 1;
-                chunk.set(ii, value);
-                ++ii;
-            }
+            } while (bitsLeftInThisWord > 0);
+        }
+
+        if (pendingSkips > 0) {
+            is.skipBytes(pendingSkips * elementSize);
+            chunk.fillWithNullValue(ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
@@ -10,11 +10,15 @@
 package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.Chunk;
@@ -31,6 +35,19 @@ import static io.deephaven.util.QueryConstants.*;
 
 public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<IntChunk<Values>> {
     private static final String DEBUG_NAME = "IntChunkInputStreamGenerator";
+
+    public static IntChunkInputStreamGenerator convertBoxed(final ObjectChunk<Integer, Values> inChunk) {
+        // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
+        WritableIntChunk<Values> outChunk = WritableIntChunk.makeWritableChunk(inChunk.size());
+        for (int i = 0; i < inChunk.size(); ++i) {
+            final Integer value = inChunk.get(i);
+            outChunk.set(i, value == null ? QueryConstants.NULL_INT : value);
+        }
+        if (inChunk instanceof PoolableChunk) {
+            ((PoolableChunk) inChunk).close();
+        }
+        return new IntChunkInputStreamGenerator(outChunk, Integer.BYTES);
+    }
 
     IntChunkInputStreamGenerator(final IntChunk<Values> chunk, final int elementSize) {
         super(chunk, elementSize);
@@ -118,22 +135,23 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
                 bytesWritten += getValidityMapSerializationSizeFor(subset.intSize());
             }
 
-                // write the included values
-                subset.forAllRowKeys(row -> {
-                    try {
-                        final int val = chunk.get((int) row);
-                        dos.writeInt(val);
-                    } catch (final IOException e) {
-                        throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
-                    }
-                });
-
-                bytesWritten += elementSize * subset.size();
-                final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
-                if (bytesExtended > 0) {
-                    bytesWritten += 8 - bytesExtended;
-                    dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            // write the included values
+            subset.forAllRowKeys(row -> {
+                try {
+                    final int val = chunk.get((int) row);
+                    dos.writeInt(val);
+                } catch (final IOException e) {
+                    throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
                 }
+            });
+
+            bytesWritten += elementSize * subset.size();
+            final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
+            if (bytesExtended > 0) {
+                bytesWritten += 8 - bytesExtended;
+                dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            }
+
             return LongSizedDataStructure.intSize("IntChunkInputStreamGenerator", bytesWritten);
         }
     }
@@ -142,6 +160,12 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
     public interface IntConversion {
         int apply(int in);
         IntConversion IDENTITY = (int a) -> a;
+    }
+
+    @FunctionalInterface
+    public interface IntToTypeConversion<T> {
+        T apply(int in);
+        IntToTypeConversion<Integer> BOXED = (int a) -> a == NULL_INT ? null : (Integer) a;
     }
 
     static Chunk<Values> extractChunkFromInputStream(
@@ -222,6 +246,81 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
                     final int value;
                     if ((nextValid & 0x1) == 0x0) {
                         value = NULL_INT;
+                        is.skipBytes(elementSize);
+                    } else {
+                        value = conversion.apply(is.readInt());
+                    }
+                    nextValid >>= 1;
+                    chunk.set(ii, value);
+                }
+            }
+
+            final long overhangPayload = payloadBuffer - payloadRead;
+            if (overhangPayload > 0) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            }
+        }
+
+        chunk.setSize(nodeInfo.numElements);
+        return chunk;
+    }
+
+    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+            final int elementSize,
+            final StreamReaderOptions options,
+            final IntToTypeConversion<T> conversion,
+            final Iterator<FieldNodeInfo> fieldNodeIter,
+            final TLongIterator bufferInfoIter,
+            final DataInput is) throws IOException {
+
+        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
+        final long validityBuffer = bufferInfoIter.next();
+        final long payloadBuffer = bufferInfoIter.next();
+
+        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
+
+        if (nodeInfo.numElements == 0) {
+            return chunk;
+        }
+
+        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
+        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
+            if (options.useDeephavenNulls() && validityBuffer != 0) {
+                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            }
+            int jj = 0;
+            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
+                isValid.set(jj, is.readLong());
+            }
+            final long valBufRead = jj * 8L;
+            if (valBufRead < validityBuffer) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
+            }
+            // we support short validity buffers
+            for (; jj < numValidityLongs; ++jj) {
+                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
+            }
+            // consumed entire validity buffer by here
+
+            final long payloadRead = (long) nodeInfo.numElements * elementSize;
+            if (payloadBuffer < payloadRead) {
+                throw new IllegalStateException("payload buffer is too short for expected number of elements");
+            }
+
+            if (options.useDeephavenNulls()) {
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    final int in = is.readInt();
+                    chunk.set(ii, in == NULL_INT ? null : conversion.apply(in));
+                }
+            } else {
+                long nextValid = 0;
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    if ((ii % 64) == 0) {
+                        nextValid = isValid.get(ii / 64);
+                    }
+                    final T value;
+                    if ((nextValid & 0x1) == 0x0) {
+                        value = null;
                         is.skipBytes(elementSize);
                     } else {
                         value = conversion.apply(is.readInt());

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
@@ -11,19 +11,18 @@ package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
 import io.deephaven.chunk.ObjectChunk;
-import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
-import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.util.type.TypeUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.DataInput;
@@ -41,7 +40,7 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
         WritableIntChunk<Values> outChunk = WritableIntChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
             final Integer value = inChunk.get(i);
-            outChunk.set(i, value == null ? QueryConstants.NULL_INT : value);
+            outChunk.set(i, TypeUtils.unbox(value));
         }
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
@@ -162,12 +161,6 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
         IntConversion IDENTITY = (int a) -> a;
     }
 
-    @FunctionalInterface
-    public interface IntToTypeConversion<T> {
-        T apply(int in);
-        IntToTypeConversion<Integer> BOXED = (int a) -> a == NULL_INT ? null : (Integer) a;
-    }
-
     static Chunk<Values> extractChunkFromInputStream(
             final int elementSize,
             final StreamReaderOptions options,
@@ -221,38 +214,9 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
             }
 
             if (options.useDeephavenNulls()) {
-                if (conversion == IntChunkInputStreamGenerator.IntConversion.IDENTITY) {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        chunk.set(ii, is.readInt());
-                    }
-                } else {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        final int in = is.readInt();
-                        final int out;
-                        if (in == NULL_INT) {
-                            out = in;
-                        } else {
-                            out = conversion.apply(in);
-                        }
-                        chunk.set(ii, out);
-                    }
-                }
+                useDeephavenNulls(conversion, is, nodeInfo, chunk);
             } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final int value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = NULL_INT;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readInt());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;
@@ -265,78 +229,53 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
         return chunk;
     }
 
-    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+    private static void useDeephavenNulls(
+            final IntConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableIntChunk<Values> chunk) throws IOException {
+        if (conversion == IntConversion.IDENTITY) {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                chunk.set(ii, is.readInt());
+            }
+        } else {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                final int in = is.readInt();
+                final int out = in == NULL_INT ? in : conversion.apply(in);
+                chunk.set(ii, out);
+            }
+        }
+    }
+
+    private static void useValidityBuffer(
             final int elementSize,
-            final StreamReaderOptions options,
-            final IntToTypeConversion<T> conversion,
-            final Iterator<FieldNodeInfo> fieldNodeIter,
-            final TLongIterator bufferInfoIter,
-            final DataInput is) throws IOException {
-
-        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
-        final long validityBuffer = bufferInfoIter.next();
-        final long payloadBuffer = bufferInfoIter.next();
-
-        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
-
-        if (nodeInfo.numElements == 0) {
-            return chunk;
-        }
-
-        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
-        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
-            if (options.useDeephavenNulls() && validityBuffer != 0) {
-                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            final IntConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableIntChunk<Values> chunk,
+            final WritableLongChunk<Values> isValid) throws IOException {
+        long nextValid = 0;
+        for (int ii = 0; ii < nodeInfo.numElements; ) {
+            if ((ii % 64) == 0) {
+                nextValid = isValid.get(ii / 64);
             }
-            int jj = 0;
-            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
-                isValid.set(jj, is.readLong());
-            }
-            final long valBufRead = jj * 8L;
-            if (valBufRead < validityBuffer) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
-            }
-            // we support short validity buffers
-            for (; jj < numValidityLongs; ++jj) {
-                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
-            }
-            // consumed entire validity buffer by here
+            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
+            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
 
-            final long payloadRead = (long) nodeInfo.numElements * elementSize;
-            if (payloadBuffer < payloadRead) {
-                throw new IllegalStateException("payload buffer is too short for expected number of elements");
-            }
-
-            if (options.useDeephavenNulls()) {
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    final int in = is.readInt();
-                    chunk.set(ii, in == NULL_INT ? null : conversion.apply(in));
+            if (numToSkip > 0) {
+                is.skipBytes(numToSkip * elementSize);
+                nextValid >>= numToSkip;
+                for (int jj = 0; jj < numToSkip; ++jj) {
+                    chunk.set(ii + jj, NULL_INT);
                 }
-            } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final T value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = null;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readInt());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                ii += numToSkip;
             }
-
-            final long overhangPayload = payloadBuffer - payloadRead;
-            if (overhangPayload > 0) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            if (maxToSkip > numToSkip) {
+                final int value = conversion.apply(is.readInt());
+                nextValid >>= 1;
+                chunk.set(ii, value);
+                ++ii;
             }
         }
-
-        chunk.setSize(nodeInfo.numElements);
-        return chunk;
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
@@ -254,28 +254,38 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
             final FieldNodeInfo nodeInfo,
             final WritableIntChunk<Values> chunk,
             final WritableLongChunk<Values> isValid) throws IOException {
-        long nextValid = 0;
-        for (int ii = 0; ii < nodeInfo.numElements; ) {
-            if ((ii % 64) == 0) {
-                nextValid = isValid.get(ii / 64);
-            }
-            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
-            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
+        final int numElements = nodeInfo.numElements;
+        final int numValidityWords = (numElements + 63) / 64;
 
-            if (numToSkip > 0) {
-                is.skipBytes(numToSkip * elementSize);
-                nextValid >>= numToSkip;
-                for (int jj = 0; jj < numToSkip; ++jj) {
-                    chunk.set(ii + jj, NULL_INT);
+        int ei = 0;
+        int pendingSkips = 0;
+
+        for (int vi = 0; vi < numValidityWords; ++vi) {
+            int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
+            long validityWord = isValid.get(vi);
+            do {
+                if ((validityWord & 1) == 1) {
+                    if (pendingSkips > 0) {
+                        is.skipBytes(pendingSkips * elementSize);
+                        chunk.fillWithNullValue(ei, pendingSkips);
+                        ei += pendingSkips;
+                        pendingSkips = 0;
+                    }
+                    chunk.set(ei++, conversion.apply(is.readInt()));
+                    validityWord >>= 1;
+                    bitsLeftInThisWord--;
+                } else {
+                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    pendingSkips += skips;
+                    validityWord >>= skips;
+                    bitsLeftInThisWord -= skips;
                 }
-                ii += numToSkip;
-            }
-            if (maxToSkip > numToSkip) {
-                final int value = conversion.apply(is.readInt());
-                nextValid >>= 1;
-                chunk.set(ii, value);
-                ++ii;
-            }
+            } while (bitsLeftInThisWord > 0);
+        }
+
+        if (pendingSkips > 0) {
+            is.skipBytes(pendingSkips * elementSize);
+            chunk.fillWithNullValue(ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
@@ -11,19 +11,18 @@ package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
 import io.deephaven.chunk.ObjectChunk;
-import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
-import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.util.type.TypeUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.DataInput;
@@ -41,7 +40,7 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
             final Long value = inChunk.get(i);
-            outChunk.set(i, value == null ? QueryConstants.NULL_LONG : value);
+            outChunk.set(i, TypeUtils.unbox(value));
         }
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
@@ -162,12 +161,6 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         LongConversion IDENTITY = (long a) -> a;
     }
 
-    @FunctionalInterface
-    public interface LongToTypeConversion<T> {
-        T apply(long in);
-        LongToTypeConversion<Long> BOXED = (long a) -> a == NULL_LONG ? null : (Long) a;
-    }
-
     static Chunk<Values> extractChunkFromInputStream(
             final int elementSize,
             final StreamReaderOptions options,
@@ -221,38 +214,9 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
             }
 
             if (options.useDeephavenNulls()) {
-                if (conversion == LongChunkInputStreamGenerator.LongConversion.IDENTITY) {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        chunk.set(ii, is.readLong());
-                    }
-                } else {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        final long in = is.readLong();
-                        final long out;
-                        if (in == NULL_LONG) {
-                            out = in;
-                        } else {
-                            out = conversion.apply(in);
-                        }
-                        chunk.set(ii, out);
-                    }
-                }
+                useDeephavenNulls(conversion, is, nodeInfo, chunk);
             } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final long value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = NULL_LONG;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readLong());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;
@@ -265,78 +229,53 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         return chunk;
     }
 
-    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+    private static void useDeephavenNulls(
+            final LongConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableLongChunk<Values> chunk) throws IOException {
+        if (conversion == LongConversion.IDENTITY) {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                chunk.set(ii, is.readLong());
+            }
+        } else {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                final long in = is.readLong();
+                final long out = in == NULL_LONG ? in : conversion.apply(in);
+                chunk.set(ii, out);
+            }
+        }
+    }
+
+    private static void useValidityBuffer(
             final int elementSize,
-            final StreamReaderOptions options,
-            final LongToTypeConversion<T> conversion,
-            final Iterator<FieldNodeInfo> fieldNodeIter,
-            final TLongIterator bufferInfoIter,
-            final DataInput is) throws IOException {
-
-        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
-        final long validityBuffer = bufferInfoIter.next();
-        final long payloadBuffer = bufferInfoIter.next();
-
-        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
-
-        if (nodeInfo.numElements == 0) {
-            return chunk;
-        }
-
-        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
-        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
-            if (options.useDeephavenNulls() && validityBuffer != 0) {
-                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            final LongConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableLongChunk<Values> chunk,
+            final WritableLongChunk<Values> isValid) throws IOException {
+        long nextValid = 0;
+        for (int ii = 0; ii < nodeInfo.numElements; ) {
+            if ((ii % 64) == 0) {
+                nextValid = isValid.get(ii / 64);
             }
-            int jj = 0;
-            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
-                isValid.set(jj, is.readLong());
-            }
-            final long valBufRead = jj * 8L;
-            if (valBufRead < validityBuffer) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
-            }
-            // we support short validity buffers
-            for (; jj < numValidityLongs; ++jj) {
-                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
-            }
-            // consumed entire validity buffer by here
+            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
+            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
 
-            final long payloadRead = (long) nodeInfo.numElements * elementSize;
-            if (payloadBuffer < payloadRead) {
-                throw new IllegalStateException("payload buffer is too short for expected number of elements");
-            }
-
-            if (options.useDeephavenNulls()) {
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    final long in = is.readLong();
-                    chunk.set(ii, in == NULL_LONG ? null : conversion.apply(in));
+            if (numToSkip > 0) {
+                is.skipBytes(numToSkip * elementSize);
+                nextValid >>= numToSkip;
+                for (int jj = 0; jj < numToSkip; ++jj) {
+                    chunk.set(ii + jj, NULL_LONG);
                 }
-            } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final T value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = null;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readLong());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                ii += numToSkip;
             }
-
-            final long overhangPayload = payloadBuffer - payloadRead;
-            if (overhangPayload > 0) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            if (maxToSkip > numToSkip) {
+                final long value = conversion.apply(is.readLong());
+                nextValid >>= 1;
+                chunk.set(ii, value);
+                ++ii;
             }
         }
-
-        chunk.setSize(nodeInfo.numElements);
-        return chunk;
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
@@ -254,28 +254,38 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
             final FieldNodeInfo nodeInfo,
             final WritableLongChunk<Values> chunk,
             final WritableLongChunk<Values> isValid) throws IOException {
-        long nextValid = 0;
-        for (int ii = 0; ii < nodeInfo.numElements; ) {
-            if ((ii % 64) == 0) {
-                nextValid = isValid.get(ii / 64);
-            }
-            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
-            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
+        final int numElements = nodeInfo.numElements;
+        final int numValidityWords = (numElements + 63) / 64;
 
-            if (numToSkip > 0) {
-                is.skipBytes(numToSkip * elementSize);
-                nextValid >>= numToSkip;
-                for (int jj = 0; jj < numToSkip; ++jj) {
-                    chunk.set(ii + jj, NULL_LONG);
+        int ei = 0;
+        int pendingSkips = 0;
+
+        for (int vi = 0; vi < numValidityWords; ++vi) {
+            int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
+            long validityWord = isValid.get(vi);
+            do {
+                if ((validityWord & 1) == 1) {
+                    if (pendingSkips > 0) {
+                        is.skipBytes(pendingSkips * elementSize);
+                        chunk.fillWithNullValue(ei, pendingSkips);
+                        ei += pendingSkips;
+                        pendingSkips = 0;
+                    }
+                    chunk.set(ei++, conversion.apply(is.readLong()));
+                    validityWord >>= 1;
+                    bitsLeftInThisWord--;
+                } else {
+                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    pendingSkips += skips;
+                    validityWord >>= skips;
+                    bitsLeftInThisWord -= skips;
                 }
-                ii += numToSkip;
-            }
-            if (maxToSkip > numToSkip) {
-                final long value = conversion.apply(is.readLong());
-                nextValid >>= 1;
-                chunk.set(ii, value);
-                ++ii;
-            }
+            } while (bitsLeftInThisWord > 0);
+        }
+
+        if (pendingSkips > 0) {
+            is.skipBytes(pendingSkips * elementSize);
+            chunk.fillWithNullValue(ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
@@ -10,11 +10,15 @@
 package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.Chunk;
@@ -31,6 +35,19 @@ import static io.deephaven.util.QueryConstants.*;
 
 public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<LongChunk<Values>> {
     private static final String DEBUG_NAME = "LongChunkInputStreamGenerator";
+
+    public static LongChunkInputStreamGenerator convertBoxed(final ObjectChunk<Long, Values> inChunk) {
+        // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
+        WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(inChunk.size());
+        for (int i = 0; i < inChunk.size(); ++i) {
+            final Long value = inChunk.get(i);
+            outChunk.set(i, value == null ? QueryConstants.NULL_LONG : value);
+        }
+        if (inChunk instanceof PoolableChunk) {
+            ((PoolableChunk) inChunk).close();
+        }
+        return new LongChunkInputStreamGenerator(outChunk, Long.BYTES);
+    }
 
     LongChunkInputStreamGenerator(final LongChunk<Values> chunk, final int elementSize) {
         super(chunk, elementSize);
@@ -118,22 +135,23 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 bytesWritten += getValidityMapSerializationSizeFor(subset.intSize());
             }
 
-                // write the included values
-                subset.forAllRowKeys(row -> {
-                    try {
-                        final long val = chunk.get((int) row);
-                        dos.writeLong(val);
-                    } catch (final IOException e) {
-                        throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
-                    }
-                });
-
-                bytesWritten += elementSize * subset.size();
-                final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
-                if (bytesExtended > 0) {
-                    bytesWritten += 8 - bytesExtended;
-                    dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            // write the included values
+            subset.forAllRowKeys(row -> {
+                try {
+                    final long val = chunk.get((int) row);
+                    dos.writeLong(val);
+                } catch (final IOException e) {
+                    throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
                 }
+            });
+
+            bytesWritten += elementSize * subset.size();
+            final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
+            if (bytesExtended > 0) {
+                bytesWritten += 8 - bytesExtended;
+                dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            }
+
             return LongSizedDataStructure.intSize("LongChunkInputStreamGenerator", bytesWritten);
         }
     }
@@ -142,6 +160,12 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
     public interface LongConversion {
         long apply(long in);
         LongConversion IDENTITY = (long a) -> a;
+    }
+
+    @FunctionalInterface
+    public interface LongToTypeConversion<T> {
+        T apply(long in);
+        LongToTypeConversion<Long> BOXED = (long a) -> a == NULL_LONG ? null : (Long) a;
     }
 
     static Chunk<Values> extractChunkFromInputStream(
@@ -222,6 +246,81 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                     final long value;
                     if ((nextValid & 0x1) == 0x0) {
                         value = NULL_LONG;
+                        is.skipBytes(elementSize);
+                    } else {
+                        value = conversion.apply(is.readLong());
+                    }
+                    nextValid >>= 1;
+                    chunk.set(ii, value);
+                }
+            }
+
+            final long overhangPayload = payloadBuffer - payloadRead;
+            if (overhangPayload > 0) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            }
+        }
+
+        chunk.setSize(nodeInfo.numElements);
+        return chunk;
+    }
+
+    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+            final int elementSize,
+            final StreamReaderOptions options,
+            final LongToTypeConversion<T> conversion,
+            final Iterator<FieldNodeInfo> fieldNodeIter,
+            final TLongIterator bufferInfoIter,
+            final DataInput is) throws IOException {
+
+        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
+        final long validityBuffer = bufferInfoIter.next();
+        final long payloadBuffer = bufferInfoIter.next();
+
+        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
+
+        if (nodeInfo.numElements == 0) {
+            return chunk;
+        }
+
+        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
+        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
+            if (options.useDeephavenNulls() && validityBuffer != 0) {
+                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            }
+            int jj = 0;
+            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
+                isValid.set(jj, is.readLong());
+            }
+            final long valBufRead = jj * 8L;
+            if (valBufRead < validityBuffer) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
+            }
+            // we support short validity buffers
+            for (; jj < numValidityLongs; ++jj) {
+                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
+            }
+            // consumed entire validity buffer by here
+
+            final long payloadRead = (long) nodeInfo.numElements * elementSize;
+            if (payloadBuffer < payloadRead) {
+                throw new IllegalStateException("payload buffer is too short for expected number of elements");
+            }
+
+            if (options.useDeephavenNulls()) {
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    final long in = is.readLong();
+                    chunk.set(ii, in == NULL_LONG ? null : conversion.apply(in));
+                }
+            } else {
+                long nextValid = 0;
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    if ((ii % 64) == 0) {
+                        nextValid = isValid.get(ii / 64);
+                    }
+                    final T value;
+                    if ((nextValid & 0x1) == 0x0) {
+                        value = null;
                         is.skipBytes(elementSize);
                     } else {
                         value = conversion.apply(is.readLong());

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
@@ -10,11 +10,15 @@
 package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.ShortChunk;
 import io.deephaven.chunk.Chunk;
@@ -31,6 +35,19 @@ import static io.deephaven.util.QueryConstants.*;
 
 public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<ShortChunk<Values>> {
     private static final String DEBUG_NAME = "ShortChunkInputStreamGenerator";
+
+    public static ShortChunkInputStreamGenerator convertBoxed(final ObjectChunk<Short, Values> inChunk) {
+        // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
+        WritableShortChunk<Values> outChunk = WritableShortChunk.makeWritableChunk(inChunk.size());
+        for (int i = 0; i < inChunk.size(); ++i) {
+            final Short value = inChunk.get(i);
+            outChunk.set(i, value == null ? QueryConstants.NULL_SHORT : value);
+        }
+        if (inChunk instanceof PoolableChunk) {
+            ((PoolableChunk) inChunk).close();
+        }
+        return new ShortChunkInputStreamGenerator(outChunk, Short.BYTES);
+    }
 
     ShortChunkInputStreamGenerator(final ShortChunk<Values> chunk, final int elementSize) {
         super(chunk, elementSize);
@@ -118,22 +135,23 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
                 bytesWritten += getValidityMapSerializationSizeFor(subset.intSize());
             }
 
-                // write the included values
-                subset.forAllRowKeys(row -> {
-                    try {
-                        final short val = chunk.get((int) row);
-                        dos.writeShort(val);
-                    } catch (final IOException e) {
-                        throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
-                    }
-                });
-
-                bytesWritten += elementSize * subset.size();
-                final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
-                if (bytesExtended > 0) {
-                    bytesWritten += 8 - bytesExtended;
-                    dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            // write the included values
+            subset.forAllRowKeys(row -> {
+                try {
+                    final short val = chunk.get((int) row);
+                    dos.writeShort(val);
+                } catch (final IOException e) {
+                    throw new UncheckedDeephavenException("Unexpected exception while draining data to OutputStream: ", e);
                 }
+            });
+
+            bytesWritten += elementSize * subset.size();
+            final long bytesExtended = bytesWritten & REMAINDER_MOD_8_MASK;
+            if (bytesExtended > 0) {
+                bytesWritten += 8 - bytesExtended;
+                dos.write(PADDING_BUFFER, 0, (int) (8 - bytesExtended));
+            }
+
             return LongSizedDataStructure.intSize("ShortChunkInputStreamGenerator", bytesWritten);
         }
     }
@@ -142,6 +160,12 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
     public interface ShortConversion {
         short apply(short in);
         ShortConversion IDENTITY = (short a) -> a;
+    }
+
+    @FunctionalInterface
+    public interface ShortToTypeConversion<T> {
+        T apply(short in);
+        ShortToTypeConversion<Short> BOXED = (short a) -> a == NULL_SHORT ? null : (Short) a;
     }
 
     static Chunk<Values> extractChunkFromInputStream(
@@ -222,6 +246,81 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
                     final short value;
                     if ((nextValid & 0x1) == 0x0) {
                         value = NULL_SHORT;
+                        is.skipBytes(elementSize);
+                    } else {
+                        value = conversion.apply(is.readShort());
+                    }
+                    nextValid >>= 1;
+                    chunk.set(ii, value);
+                }
+            }
+
+            final long overhangPayload = payloadBuffer - payloadRead;
+            if (overhangPayload > 0) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            }
+        }
+
+        chunk.setSize(nodeInfo.numElements);
+        return chunk;
+    }
+
+    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+            final int elementSize,
+            final StreamReaderOptions options,
+            final ShortToTypeConversion<T> conversion,
+            final Iterator<FieldNodeInfo> fieldNodeIter,
+            final TLongIterator bufferInfoIter,
+            final DataInput is) throws IOException {
+
+        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
+        final long validityBuffer = bufferInfoIter.next();
+        final long payloadBuffer = bufferInfoIter.next();
+
+        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
+
+        if (nodeInfo.numElements == 0) {
+            return chunk;
+        }
+
+        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
+        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
+            if (options.useDeephavenNulls() && validityBuffer != 0) {
+                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            }
+            int jj = 0;
+            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
+                isValid.set(jj, is.readLong());
+            }
+            final long valBufRead = jj * 8L;
+            if (valBufRead < validityBuffer) {
+                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
+            }
+            // we support short validity buffers
+            for (; jj < numValidityLongs; ++jj) {
+                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
+            }
+            // consumed entire validity buffer by here
+
+            final long payloadRead = (long) nodeInfo.numElements * elementSize;
+            if (payloadBuffer < payloadRead) {
+                throw new IllegalStateException("payload buffer is too short for expected number of elements");
+            }
+
+            if (options.useDeephavenNulls()) {
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    final short in = is.readShort();
+                    chunk.set(ii, in == NULL_SHORT ? null : conversion.apply(in));
+                }
+            } else {
+                long nextValid = 0;
+                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                    if ((ii % 64) == 0) {
+                        nextValid = isValid.get(ii / 64);
+                    }
+                    final T value;
+                    if ((nextValid & 0x1) == 0x0) {
+                        value = null;
                         is.skipBytes(elementSize);
                     } else {
                         value = conversion.apply(is.readShort());

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
@@ -11,19 +11,18 @@ package io.deephaven.extensions.barrage.chunk;
 
 import gnu.trove.iterator.TLongIterator;
 import io.deephaven.chunk.ObjectChunk;
-import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import com.google.common.io.LittleEndianDataOutputStream;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
-import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.ShortChunk;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.util.type.TypeUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.DataInput;
@@ -41,7 +40,7 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
         WritableShortChunk<Values> outChunk = WritableShortChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
             final Short value = inChunk.get(i);
-            outChunk.set(i, value == null ? QueryConstants.NULL_SHORT : value);
+            outChunk.set(i, TypeUtils.unbox(value));
         }
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
@@ -162,12 +161,6 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
         ShortConversion IDENTITY = (short a) -> a;
     }
 
-    @FunctionalInterface
-    public interface ShortToTypeConversion<T> {
-        T apply(short in);
-        ShortToTypeConversion<Short> BOXED = (short a) -> a == NULL_SHORT ? null : (Short) a;
-    }
-
     static Chunk<Values> extractChunkFromInputStream(
             final int elementSize,
             final StreamReaderOptions options,
@@ -221,38 +214,9 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
             }
 
             if (options.useDeephavenNulls()) {
-                if (conversion == ShortChunkInputStreamGenerator.ShortConversion.IDENTITY) {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        chunk.set(ii, is.readShort());
-                    }
-                } else {
-                    for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                        final short in = is.readShort();
-                        final short out;
-                        if (in == NULL_SHORT) {
-                            out = in;
-                        } else {
-                            out = conversion.apply(in);
-                        }
-                        chunk.set(ii, out);
-                    }
-                }
+                useDeephavenNulls(conversion, is, nodeInfo, chunk);
             } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final short value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = NULL_SHORT;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readShort());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;
@@ -265,78 +229,53 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
         return chunk;
     }
 
-    static <T> ObjectChunk<T, Values> extractChunkFromInputStreamWithTypeConversion(
+    private static void useDeephavenNulls(
+            final ShortConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableShortChunk<Values> chunk) throws IOException {
+        if (conversion == ShortConversion.IDENTITY) {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                chunk.set(ii, is.readShort());
+            }
+        } else {
+            for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
+                final short in = is.readShort();
+                final short out = in == NULL_SHORT ? in : conversion.apply(in);
+                chunk.set(ii, out);
+            }
+        }
+    }
+
+    private static void useValidityBuffer(
             final int elementSize,
-            final StreamReaderOptions options,
-            final ShortToTypeConversion<T> conversion,
-            final Iterator<FieldNodeInfo> fieldNodeIter,
-            final TLongIterator bufferInfoIter,
-            final DataInput is) throws IOException {
-
-        final FieldNodeInfo nodeInfo = fieldNodeIter.next();
-        final long validityBuffer = bufferInfoIter.next();
-        final long payloadBuffer = bufferInfoIter.next();
-
-        final WritableObjectChunk<T, Values> chunk = WritableObjectChunk.makeWritableChunk(nodeInfo.numElements);
-
-        if (nodeInfo.numElements == 0) {
-            return chunk;
-        }
-
-        final int numValidityLongs = options.useDeephavenNulls() ? 0 : (nodeInfo.numElements + 63) / 64;
-        try (final WritableLongChunk<Values> isValid = WritableLongChunk.makeWritableChunk(numValidityLongs)) {
-            if (options.useDeephavenNulls() && validityBuffer != 0) {
-                throw new IllegalStateException("validity buffer is non-empty, but is unnecessary");
+            final ShortConversion conversion,
+            final DataInput is,
+            final FieldNodeInfo nodeInfo,
+            final WritableShortChunk<Values> chunk,
+            final WritableLongChunk<Values> isValid) throws IOException {
+        long nextValid = 0;
+        for (int ii = 0; ii < nodeInfo.numElements; ) {
+            if ((ii % 64) == 0) {
+                nextValid = isValid.get(ii / 64);
             }
-            int jj = 0;
-            for (; jj < Math.min(numValidityLongs, validityBuffer / 8); ++jj) {
-                isValid.set(jj, is.readLong());
-            }
-            final long valBufRead = jj * 8L;
-            if (valBufRead < validityBuffer) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, validityBuffer - valBufRead));
-            }
-            // we support short validity buffers
-            for (; jj < numValidityLongs; ++jj) {
-                isValid.set(jj, -1); // -1 is bit-wise representation of all ones
-            }
-            // consumed entire validity buffer by here
+            int maxToSkip = Math.min(nodeInfo.numElements - ii, 64 - (ii % 64));
+            int numToSkip = Math.min(maxToSkip, Long.numberOfTrailingZeros(nextValid));
 
-            final long payloadRead = (long) nodeInfo.numElements * elementSize;
-            if (payloadBuffer < payloadRead) {
-                throw new IllegalStateException("payload buffer is too short for expected number of elements");
-            }
-
-            if (options.useDeephavenNulls()) {
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    final short in = is.readShort();
-                    chunk.set(ii, in == NULL_SHORT ? null : conversion.apply(in));
+            if (numToSkip > 0) {
+                is.skipBytes(numToSkip * elementSize);
+                nextValid >>= numToSkip;
+                for (int jj = 0; jj < numToSkip; ++jj) {
+                    chunk.set(ii + jj, NULL_SHORT);
                 }
-            } else {
-                long nextValid = 0;
-                for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-                    if ((ii % 64) == 0) {
-                        nextValid = isValid.get(ii / 64);
-                    }
-                    final T value;
-                    if ((nextValid & 0x1) == 0x0) {
-                        value = null;
-                        is.skipBytes(elementSize);
-                    } else {
-                        value = conversion.apply(is.readShort());
-                    }
-                    nextValid >>= 1;
-                    chunk.set(ii, value);
-                }
+                ii += numToSkip;
             }
-
-            final long overhangPayload = payloadBuffer - payloadRead;
-            if (overhangPayload > 0) {
-                is.skipBytes(LongSizedDataStructure.intSize(DEBUG_NAME, overhangPayload));
+            if (maxToSkip > numToSkip) {
+                final short value = conversion.apply(is.readShort());
+                nextValid >>= 1;
+                chunk.set(ii, value);
+                ++ii;
             }
         }
-
-        chunk.setSize(nodeInfo.numElements);
-        return chunk;
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VectorChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VectorChunkInputStreamGenerator.java
@@ -34,7 +34,6 @@ import java.util.Iterator;
 public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<ObjectChunk<Vector<?>, Values>> {
     private static final String DEBUG_NAME = "VarListChunkInputStreamGenerator";
 
-    private final Class<Vector<?>> type;
     private final Class<?> componentType;
 
     private WritableIntChunk<ChunkPositions> offsets;
@@ -43,7 +42,6 @@ public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
     VectorChunkInputStreamGenerator(final Class<Vector<?>> type, final Class<?> componentType,
                                     final ObjectChunk<Vector<?>, Values> chunk) {
         super(chunk, 0);
-        this.type = type;
         this.componentType = VectorExpansionKernel.getComponentType(type, componentType);
     }
 
@@ -52,13 +50,14 @@ public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
             return;
         }
 
+        final Class<?> innerComponentType = componentType != null ? componentType.getComponentType() : null;
         final ChunkType chunkType = ChunkType.fromElementType(componentType);
         final VectorExpansionKernel kernel = VectorExpansionKernel.makeExpansionKernel(chunkType, componentType);
         offsets = WritableIntChunk.makeWritableChunk(chunk.size() + 1);
 
         final WritableChunk<Values> innerChunk = kernel.expand(chunk, offsets);
         innerGenerator = ChunkInputStreamGenerator.makeInputStreamGenerator(
-                chunkType, componentType, null, innerChunk);
+                chunkType, componentType, innerComponentType, innerChunk);
     }
 
     @Override
@@ -307,4 +306,3 @@ public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
         return chunk;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ArrayExpansionKernel.java
@@ -16,7 +16,7 @@ import io.deephaven.chunk.attributes.ChunkPositions;
 
 public interface ArrayExpansionKernel {
     /**
-     * @return a kernel that expands a `Chunk<T[]>` to pair of `LongChunk, Chunk<T>`
+     * @return a kernel that expands a {@code Chunk<T[]>} to pair of {@code LongChunk, Chunk<T>}
      */
     static ArrayExpansionKernel makeExpansionKernel(final ChunkType chunkType, final Class<?> componentType) {
         switch (chunkType) {
@@ -40,21 +40,21 @@ public interface ArrayExpansionKernel {
     }
 
     /**
-     * This expands the source from a `T[]` per element to a flat `T` per element. The kernel records the number of
-     * consecutive elements that belong to a row in `perElementLengthDest`. The returned chunk is owned by the caller.
+     * This expands the source from a {@code T[]} per element to a flat {@code T} per element. The kernel records the number of
+     * consecutive elements that belong to a row in {@code perElementLengthDest}. The returned chunk is owned by the caller.
      *
      * @param source the source chunk of T[] to expand
-     * @param perElementLengthDest the destination IntChunk for which `dest.get(i + 1) - dest.get(i)` is equivalent to `source.get(i).length`
+     * @param perElementLengthDest the destination IntChunk for which {@code dest.get(i + 1) - dest.get(i)} is equivalent to {@code source.get(i).length}
      * @return an unrolled/flattened chunk of T
      */
     <T, A extends Any> WritableChunk<A> expand(ObjectChunk<T, A> source, WritableIntChunk<ChunkPositions> perElementLengthDest);
 
     /**
-     * This contracts the source from a pair of `LongChunk` and `Chunk<T>` and produces a `Chunk<T[]>`. The returned
+     * This contracts the source from a pair of {@code LongChunk} and {@code Chunk<T>} and produces a {@code Chunk<T[]>}. The returned
      * chunk is owned by the caller.
      *
      * @param source the source chunk of T to contract
-     * @param perElementLengthDest the source IntChunk for which `dest.get(i + 1) - dest.get(i)` is equivalent to `source.get(i).length`
+     * @param perElementLengthDest the source IntChunk for which {@code dest.get(i + 1) - dest.get(i)} is equivalent to {@code source.get(i).length}
      * @return a result chunk of T[]
      */
     <T, A extends Any> WritableObjectChunk<T, A> contract(Chunk<A> source, IntChunk<ChunkPositions> perElementLengthDest);

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ArrayExpansionKernel.java
@@ -18,7 +18,7 @@ public interface ArrayExpansionKernel {
     /**
      * @return a kernel that expands a `Chunk<T[]>` to pair of `LongChunk, Chunk<T>`
      */
-    static ArrayExpansionKernel makeExpansionKernel(final ChunkType chunkType) {
+    static ArrayExpansionKernel makeExpansionKernel(final ChunkType chunkType, final Class<?> componentType) {
         switch (chunkType) {
             case Char:
                 return CharArrayExpansionKernel.INSTANCE;
@@ -35,7 +35,7 @@ public interface ArrayExpansionKernel {
             case Double:
                 return DoubleArrayExpansionKernel.INSTANCE;
             default:
-                return ObjectArrayExpansionKernel.INSTANCE;
+                return new ObjectArrayExpansionKernel(componentType);
         }
     }
 

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/BooleanVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/BooleanVectorExpansionKernel.java
@@ -1,0 +1,89 @@
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharVectorExpansionKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.BooleanChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedBooleanChunk;
+import io.deephaven.vector.BooleanVector;
+import io.deephaven.vector.BooleanVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class BooleanVectorExpansionKernel implements VectorExpansionKernel {
+    private final static BooleanVector ZERO_LEN_VECTOR = new BooleanVectorDirect();
+    public final static BooleanVectorExpansionKernel INSTANCE = new BooleanVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableBooleanChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<BooleanVector, A> typedSource = source.asObjectChunk();
+        final SizedBooleanChunk<A> resultWrapper = new SizedBooleanChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final BooleanVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableBooleanChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final BooleanChunk<A> typedSource = source.asBooleanChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final Boolean[] row = new Boolean[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new BooleanVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ByteVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ByteVectorExpansionKernel.java
@@ -43,7 +43,7 @@ public class ByteVectorExpansionKernel implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final ByteVector row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("ByteVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableByteChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
             for (int j = 0; j < len; ++j) {
@@ -86,4 +86,3 @@ public class ByteVectorExpansionKernel implements VectorExpansionKernel {
         return result;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ByteVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ByteVectorExpansionKernel.java
@@ -1,0 +1,89 @@
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharVectorExpansionKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.ByteChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableByteChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedByteChunk;
+import io.deephaven.vector.ByteVector;
+import io.deephaven.vector.ByteVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class ByteVectorExpansionKernel implements VectorExpansionKernel {
+    private final static ByteVector ZERO_LEN_VECTOR = new ByteVectorDirect();
+    public final static ByteVectorExpansionKernel INSTANCE = new ByteVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableByteChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<ByteVector, A> typedSource = source.asObjectChunk();
+        final SizedByteChunk<A> resultWrapper = new SizedByteChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final ByteVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableByteChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final ByteChunk<A> typedSource = source.asByteChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final byte[] row = new byte[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new ByteVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/CharVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/CharVectorExpansionKernel.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.CharChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableCharChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedCharChunk;
+import io.deephaven.vector.CharVector;
+import io.deephaven.vector.CharVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class CharVectorExpansionKernel implements VectorExpansionKernel {
+    private final static CharVector ZERO_LEN_VECTOR = new CharVectorDirect();
+    public final static CharVectorExpansionKernel INSTANCE = new CharVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableCharChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<CharVector, A> typedSource = source.asObjectChunk();
+        final SizedCharChunk<A> resultWrapper = new SizedCharChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final CharVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableCharChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final CharChunk<A> typedSource = source.asCharChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final char[] row = new char[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new CharVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/CharVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/CharVectorExpansionKernel.java
@@ -81,4 +81,3 @@ public class CharVectorExpansionKernel implements VectorExpansionKernel {
         return result;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/CharVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/CharVectorExpansionKernel.java
@@ -38,7 +38,7 @@ public class CharVectorExpansionKernel implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final CharVector row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("CharVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableCharChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
             for (int j = 0; j < len; ++j) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/DoubleVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/DoubleVectorExpansionKernel.java
@@ -1,0 +1,89 @@
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharVectorExpansionKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.DoubleChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableDoubleChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedDoubleChunk;
+import io.deephaven.vector.DoubleVector;
+import io.deephaven.vector.DoubleVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class DoubleVectorExpansionKernel implements VectorExpansionKernel {
+    private final static DoubleVector ZERO_LEN_VECTOR = new DoubleVectorDirect();
+    public final static DoubleVectorExpansionKernel INSTANCE = new DoubleVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableDoubleChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<DoubleVector, A> typedSource = source.asObjectChunk();
+        final SizedDoubleChunk<A> resultWrapper = new SizedDoubleChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final DoubleVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableDoubleChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final DoubleChunk<A> typedSource = source.asDoubleChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final double[] row = new double[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new DoubleVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/DoubleVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/DoubleVectorExpansionKernel.java
@@ -43,7 +43,7 @@ public class DoubleVectorExpansionKernel implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final DoubleVector row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("DoubleVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableDoubleChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
             for (int j = 0; j < len; ++j) {
@@ -86,4 +86,3 @@ public class DoubleVectorExpansionKernel implements VectorExpansionKernel {
         return result;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/FloatVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/FloatVectorExpansionKernel.java
@@ -43,7 +43,7 @@ public class FloatVectorExpansionKernel implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final FloatVector row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("FloatVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableFloatChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
             for (int j = 0; j < len; ++j) {
@@ -86,4 +86,3 @@ public class FloatVectorExpansionKernel implements VectorExpansionKernel {
         return result;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/FloatVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/FloatVectorExpansionKernel.java
@@ -1,0 +1,89 @@
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharVectorExpansionKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.FloatChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableFloatChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedFloatChunk;
+import io.deephaven.vector.FloatVector;
+import io.deephaven.vector.FloatVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class FloatVectorExpansionKernel implements VectorExpansionKernel {
+    private final static FloatVector ZERO_LEN_VECTOR = new FloatVectorDirect();
+    public final static FloatVectorExpansionKernel INSTANCE = new FloatVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableFloatChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<FloatVector, A> typedSource = source.asObjectChunk();
+        final SizedFloatChunk<A> resultWrapper = new SizedFloatChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final FloatVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableFloatChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final FloatChunk<A> typedSource = source.asFloatChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final float[] row = new float[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new FloatVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/IntVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/IntVectorExpansionKernel.java
@@ -43,7 +43,7 @@ public class IntVectorExpansionKernel implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final IntVector row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("IntVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableIntChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
             for (int j = 0; j < len; ++j) {
@@ -86,4 +86,3 @@ public class IntVectorExpansionKernel implements VectorExpansionKernel {
         return result;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/IntVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/IntVectorExpansionKernel.java
@@ -1,0 +1,89 @@
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharVectorExpansionKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedIntChunk;
+import io.deephaven.vector.IntVector;
+import io.deephaven.vector.IntVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class IntVectorExpansionKernel implements VectorExpansionKernel {
+    private final static IntVector ZERO_LEN_VECTOR = new IntVectorDirect();
+    public final static IntVectorExpansionKernel INSTANCE = new IntVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableIntChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<IntVector, A> typedSource = source.asObjectChunk();
+        final SizedIntChunk<A> resultWrapper = new SizedIntChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final IntVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableIntChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final IntChunk<A> typedSource = source.asIntChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final int[] row = new int[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new IntVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/LongVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/LongVectorExpansionKernel.java
@@ -1,0 +1,89 @@
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharVectorExpansionKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.LongChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedLongChunk;
+import io.deephaven.vector.LongVector;
+import io.deephaven.vector.LongVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class LongVectorExpansionKernel implements VectorExpansionKernel {
+    private final static LongVector ZERO_LEN_VECTOR = new LongVectorDirect();
+    public final static LongVectorExpansionKernel INSTANCE = new LongVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableLongChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<LongVector, A> typedSource = source.asObjectChunk();
+        final SizedLongChunk<A> resultWrapper = new SizedLongChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final LongVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableLongChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final LongChunk<A> typedSource = source.asLongChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final long[] row = new long[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new LongVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/LongVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/LongVectorExpansionKernel.java
@@ -43,7 +43,7 @@ public class LongVectorExpansionKernel implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final LongVector row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("LongVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableLongChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
             for (int j = 0; j < len; ++j) {
@@ -86,4 +86,3 @@ public class LongVectorExpansionKernel implements VectorExpansionKernel {
         return result;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ObjectVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ObjectVectorExpansionKernel.java
@@ -2,11 +2,8 @@
  * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
  */
 
-package io.deephaven.extensions.barrage.chunk.array;
+package io.deephaven.extensions.barrage.chunk.vector;
 
-import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.datastructures.util.CollectionUtil;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.chunk.IntChunk;
@@ -14,37 +11,43 @@ import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
 import io.deephaven.chunk.sized.SizedChunk;
+import io.deephaven.vector.ObjectVector;
+import io.deephaven.vector.ObjectVectorDirect;
+import io.deephaven.vector.Vector;
 
 import java.lang.reflect.Array;
 
-public class ObjectArrayExpansionKernel implements ArrayExpansionKernel {
+public class ObjectVectorExpansionKernel<T> implements VectorExpansionKernel {
+    private final Class<T> componentType;
 
-    private final Class<?> componentType;
-
-    public ObjectArrayExpansionKernel(final Class<?> componentType) {
+    public ObjectVectorExpansionKernel(final Class<T> componentType) {
         this.componentType = componentType;
     }
 
     @Override
-    public <T, A extends Any> WritableChunk<A> expand(final ObjectChunk<T, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
         if (source.size() == 0) {
             perElementLengthDest.setSize(0);
             return WritableObjectChunk.makeWritableChunk(0);
         }
 
-        final ObjectChunk<T[], A> typedSource = source.asObjectChunk();
+        final ObjectChunk<ObjectVector<?>, A> typedSource = source.asObjectChunk();
         final SizedChunk<A> resultWrapper = new SizedChunk<>(ChunkType.Object);
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
-            final T[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
+            final ObjectVector<?> row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
             perElementLengthDest.set(i, lenWritten);
-            final WritableObjectChunk<T, A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len).asWritableObjectChunk();
+            final WritableObjectChunk<Object, A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len)
+                    .asWritableObjectChunk();
             for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+                result.set(lenWritten + j, row.get(j));
             }
             lenWritten += len;
             result.setSize(lenWritten);
@@ -55,31 +58,37 @@ public class ObjectArrayExpansionKernel implements ArrayExpansionKernel {
     }
 
     @Override
-    public <T, A extends Any> WritableObjectChunk<T, A> contract(final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
         if (perElementLengthDest.size() == 0) {
             return WritableObjectChunk.makeWritableChunk(0);
         }
 
         final ObjectChunk<T, A> typedSource = source.asObjectChunk();
-        final WritableObjectChunk<Object, A> result = WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
 
         int lenRead = 0;
+        ObjectVector<?> ZERO_LEN_VECTOR = null;
+
         for (int i = 0; i < result.size(); ++i) {
             final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
             if (ROW_LEN == 0) {
-                result.set(i, CollectionUtil.ZERO_LENGTH_OBJECT_ARRAY);
+                if (ZERO_LEN_VECTOR == null) {
+                    ZERO_LEN_VECTOR = new ObjectVectorDirect<>();
+                }
+                result.set(i, ZERO_LEN_VECTOR);
             } else {
-                //noinspection unchecked
-                final T[] row = (T[])Array.newInstance(componentType, ROW_LEN);
+                // noinspection unchecked
+                final T[] row = (T[]) Array.newInstance(componentType, ROW_LEN);
                 for (int j = 0; j < ROW_LEN; ++j) {
                     row[j] = typedSource.get(lenRead + j);
                 }
                 lenRead += ROW_LEN;
-                result.set(i, row);
+                result.set(i, new ObjectVectorDirect<>(row));
             }
         }
 
-        //noinspection unchecked
-        return (WritableObjectChunk<T, A>)result;
+        return result;
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ObjectVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ObjectVectorExpansionKernel.java
@@ -43,7 +43,7 @@ public class ObjectVectorExpansionKernel<T> implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final ObjectVector<?> row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("ObjectVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableObjectChunk<Object, A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len)
                     .asWritableObjectChunk();
@@ -70,7 +70,6 @@ public class ObjectVectorExpansionKernel<T> implements VectorExpansionKernel {
                 WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
 
         int lenRead = 0;
-
         for (int i = 0; i < result.size(); ++i) {
             final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
             if (ROW_LEN == 0) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ObjectVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ObjectVectorExpansionKernel.java
@@ -21,6 +21,7 @@ import io.deephaven.vector.Vector;
 import java.lang.reflect.Array;
 
 public class ObjectVectorExpansionKernel<T> implements VectorExpansionKernel {
+    private final static ObjectVector<?> ZERO_LEN_VECTOR = new ObjectVectorDirect<>();
     private final Class<T> componentType;
 
     public ObjectVectorExpansionKernel(final Class<T> componentType) {
@@ -69,14 +70,10 @@ public class ObjectVectorExpansionKernel<T> implements VectorExpansionKernel {
                 WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
 
         int lenRead = 0;
-        ObjectVector<?> ZERO_LEN_VECTOR = null;
 
         for (int i = 0; i < result.size(); ++i) {
             final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
             if (ROW_LEN == 0) {
-                if (ZERO_LEN_VECTOR == null) {
-                    ZERO_LEN_VECTOR = new ObjectVectorDirect<>();
-                }
                 result.set(i, ZERO_LEN_VECTOR);
             } else {
                 // noinspection unchecked

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ShortVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ShortVectorExpansionKernel.java
@@ -1,0 +1,89 @@
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharVectorExpansionKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.ShortChunk;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableShortChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.chunk.sized.SizedShortChunk;
+import io.deephaven.vector.ShortVector;
+import io.deephaven.vector.ShortVectorDirect;
+import io.deephaven.vector.Vector;
+
+public class ShortVectorExpansionKernel implements VectorExpansionKernel {
+    private final static ShortVector ZERO_LEN_VECTOR = new ShortVectorDirect();
+    public final static ShortVectorExpansionKernel INSTANCE = new ShortVectorExpansionKernel();
+
+    @Override
+    public <A extends Any> WritableChunk<A> expand(
+            final ObjectChunk<Vector<?>, A> source, final WritableIntChunk<ChunkPositions> perElementLengthDest) {
+        if (source.size() == 0) {
+            perElementLengthDest.setSize(0);
+            return WritableShortChunk.makeWritableChunk(0);
+        }
+
+        final ObjectChunk<ShortVector, A> typedSource = source.asObjectChunk();
+        final SizedShortChunk<A> resultWrapper = new SizedShortChunk<>();
+
+        int lenWritten = 0;
+        perElementLengthDest.setSize(source.size() + 1);
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final ShortVector row = typedSource.get(i);
+            final int len = row == null ? 0 : row.intSize();
+            perElementLengthDest.set(i, lenWritten);
+            final WritableShortChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
+            for (int j = 0; j < len; ++j) {
+                result.set(lenWritten + j, row.get(j));
+            }
+            lenWritten += len;
+            result.setSize(lenWritten);
+        }
+        perElementLengthDest.set(typedSource.size(), lenWritten);
+
+        return resultWrapper.get();
+    }
+
+    @Override
+    public <A extends Any> WritableObjectChunk<Vector<?>, A> contract(
+            final Chunk<A> source, final IntChunk<ChunkPositions> perElementLengthDest) {
+        if (perElementLengthDest.size() == 0) {
+            return WritableObjectChunk.makeWritableChunk(0);
+        }
+
+        final ShortChunk<A> typedSource = source.asShortChunk();
+        final WritableObjectChunk<Vector<?>, A> result =
+                WritableObjectChunk.makeWritableChunk(perElementLengthDest.size() - 1);
+
+        int lenRead = 0;
+        for (int i = 0; i < result.size(); ++i) {
+            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (ROW_LEN == 0) {
+                result.set(i, ZERO_LEN_VECTOR);
+            } else {
+                final short[] row = new short[ROW_LEN];
+                for (int j = 0; j < ROW_LEN; ++j) {
+                    row[j] = typedSource.get(lenRead + j);
+                }
+                lenRead += ROW_LEN;
+                result.set(i, new ShortVectorDirect(row));
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ShortVectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/ShortVectorExpansionKernel.java
@@ -43,7 +43,7 @@ public class ShortVectorExpansionKernel implements VectorExpansionKernel {
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final ShortVector row = typedSource.get(i);
-            final int len = row == null ? 0 : row.intSize();
+            final int len = row == null ? 0 : row.intSize("ShortVectorExpansionKernel");
             perElementLengthDest.set(i, lenWritten);
             final WritableShortChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
             for (int j = 0; j < len; ++j) {
@@ -86,4 +86,3 @@ public class ShortVectorExpansionKernel implements VectorExpansionKernel {
         return result;
     }
 }
-

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/VectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/VectorExpansionKernel.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage.chunk.vector;
+
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.attributes.ChunkPositions;
+import io.deephaven.vector.BooleanVector;
+import io.deephaven.vector.CharVector;
+import io.deephaven.vector.DoubleVector;
+import io.deephaven.vector.FloatVector;
+import io.deephaven.vector.IntVector;
+import io.deephaven.vector.LongVector;
+import io.deephaven.vector.ObjectVector;
+import io.deephaven.vector.ShortVector;
+import io.deephaven.vector.Vector;
+
+public interface VectorExpansionKernel {
+
+    static Class<?> getComponentType(final Class<?> type, final Class<?> componentType) {
+        if (BooleanVector.class.isAssignableFrom(type)) {
+            return Boolean.class;
+        }
+        if (CharVector.class.isAssignableFrom(type)) {
+            return char.class;
+        }
+        if (DoubleVector.class.isAssignableFrom(type)) {
+            return double.class;
+        }
+        if (FloatVector.class.isAssignableFrom(type)) {
+            return float.class;
+        }
+        if (IntVector.class.isAssignableFrom(type)) {
+            return int.class;
+        }
+        if (LongVector.class.isAssignableFrom(type)) {
+            return long.class;
+        }
+        if (ObjectVector.class.isAssignableFrom(type)) {
+            return componentType != null ? componentType : Object.class;
+        }
+        if (ShortVector.class.isAssignableFrom(type)) {
+            return short.class;
+        }
+        throw new IllegalStateException("Unexpected vector type: " + type.getCanonicalName());
+    }
+
+    /**
+     * @return a kernel that expands a `Chunk<VectorT>` to pair of `LongChunk, Chunk<T>`
+     */
+    static <T> VectorExpansionKernel makeExpansionKernel(final ChunkType chunkType, final Class<T> componentType) {
+        switch (chunkType) {
+            case Char:
+                return CharVectorExpansionKernel.INSTANCE;
+            case Byte:
+                return ByteVectorExpansionKernel.INSTANCE;
+            case Short:
+                return ShortVectorExpansionKernel.INSTANCE;
+            case Int:
+                return IntVectorExpansionKernel.INSTANCE;
+            case Long:
+                return LongVectorExpansionKernel.INSTANCE;
+            case Float:
+                return FloatVectorExpansionKernel.INSTANCE;
+            case Double:
+                return DoubleVectorExpansionKernel.INSTANCE;
+            case Boolean:
+                return BooleanVectorExpansionKernel.INSTANCE;
+            default:
+                return new ObjectVectorExpansionKernel<>(componentType);
+        }
+    }
+
+    /**
+     * This expands the source from a `TVector` per element to a flat `T` per element. The kernel records the number of
+     * consecutive elements that belong to a row in `perElementLengthDest`. The returned chunk is owned by the caller.
+     *
+     * @param source the source chunk of TVector to expand
+     * @param perElementLengthDest the destination IntChunk for which `dest.get(i + 1) - dest.get(i)` is equivalent to
+     *        `source.get(i).length`
+     * @return an unrolled/flattened chunk of T
+     */
+    <A extends Any> WritableChunk<A> expand(ObjectChunk<Vector<?>, A> source,
+            WritableIntChunk<ChunkPositions> perElementLengthDest);
+
+    /**
+     * This contracts the source from a pair of `LongChunk` and `Chunk<T>` and produces a `Chunk<T[]>`. The returned
+     * chunk is owned by the caller.
+     *
+     * @param source the source chunk of T to contract
+     * @param perElementLengthDest the source IntChunk for which `dest.get(i + 1) - dest.get(i)` is equivalent to
+     *        `source.get(i).length`
+     * @return a result chunk of T[]
+     */
+    <A extends Any> WritableObjectChunk<Vector<?>, A> contract(Chunk<A> source,
+            IntChunk<ChunkPositions> perElementLengthDest);
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/VectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/VectorExpansionKernel.java
@@ -80,20 +80,21 @@ public interface VectorExpansionKernel {
     }
 
     /**
-     * This expands the source from a {@code TVector} per element to a flat {@code T} per element. The kernel records the number of
-     * consecutive elements that belong to a row in {@code perElementLengthDest}. The returned chunk is owned by the caller.
+     * This expands the source from a {@code TVector} per element to a flat {@code T} per element. The kernel records
+     * the number of consecutive elements that belong to a row in {@code perElementLengthDest}. The returned chunk is
+     * owned by the caller.
      *
      * @param source the source chunk of TVector to expand
-     * @param perElementLengthDest the destination IntChunk for which {@code dest.get(i + 1) - dest.get(i)} is equivalent to
-     *        {@code source.get(i).length}
+     * @param perElementLengthDest the destination IntChunk for which {@code dest.get(i + 1) - dest.get(i)} is
+     *        equivalent to {@code source.get(i).length}
      * @return an unrolled/flattened chunk of T
      */
     <A extends Any> WritableChunk<A> expand(ObjectChunk<Vector<?>, A> source,
             WritableIntChunk<ChunkPositions> perElementLengthDest);
 
     /**
-     * This contracts the source from a pair of {@code LongChunk} and {@code Chunk<T>} and produces a {@code Chunk<T[]>}. The returned
-     * chunk is owned by the caller.
+     * This contracts the source from a pair of {@code LongChunk} and {@code Chunk<T>} and produces a
+     * {@code Chunk<T[]>}. The returned chunk is owned by the caller.
      *
      * @param source the source chunk of T to contract
      * @param perElementLengthDest the source IntChunk for which {@code dest.get(i + 1) - dest.get(i)} is equivalent to

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/VectorExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/VectorExpansionKernel.java
@@ -27,7 +27,7 @@ public interface VectorExpansionKernel {
 
     static Class<?> getComponentType(final Class<?> type, final Class<?> componentType) {
         if (BooleanVector.class.isAssignableFrom(type)) {
-            return Boolean.class;
+            return boolean.class;
         }
         if (CharVector.class.isAssignableFrom(type)) {
             return char.class;
@@ -44,17 +44,17 @@ public interface VectorExpansionKernel {
         if (LongVector.class.isAssignableFrom(type)) {
             return long.class;
         }
-        if (ObjectVector.class.isAssignableFrom(type)) {
-            return componentType != null ? componentType : Object.class;
-        }
         if (ShortVector.class.isAssignableFrom(type)) {
             return short.class;
+        }
+        if (ObjectVector.class.isAssignableFrom(type)) {
+            return componentType != null ? componentType : Object.class;
         }
         throw new IllegalStateException("Unexpected vector type: " + type.getCanonicalName());
     }
 
     /**
-     * @return a kernel that expands a `Chunk<VectorT>` to pair of `LongChunk, Chunk<T>`
+     * @return a kernel that expands a {@code Chunk<VectorT>} to pair of {@code LongChunk, Chunk<T>}
      */
     static <T> VectorExpansionKernel makeExpansionKernel(final ChunkType chunkType, final Class<T> componentType) {
         switch (chunkType) {
@@ -80,24 +80,24 @@ public interface VectorExpansionKernel {
     }
 
     /**
-     * This expands the source from a `TVector` per element to a flat `T` per element. The kernel records the number of
-     * consecutive elements that belong to a row in `perElementLengthDest`. The returned chunk is owned by the caller.
+     * This expands the source from a {@code TVector} per element to a flat {@code T} per element. The kernel records the number of
+     * consecutive elements that belong to a row in {@code perElementLengthDest}. The returned chunk is owned by the caller.
      *
      * @param source the source chunk of TVector to expand
-     * @param perElementLengthDest the destination IntChunk for which `dest.get(i + 1) - dest.get(i)` is equivalent to
-     *        `source.get(i).length`
+     * @param perElementLengthDest the destination IntChunk for which {@code dest.get(i + 1) - dest.get(i)} is equivalent to
+     *        {@code source.get(i).length}
      * @return an unrolled/flattened chunk of T
      */
     <A extends Any> WritableChunk<A> expand(ObjectChunk<Vector<?>, A> source,
             WritableIntChunk<ChunkPositions> perElementLengthDest);
 
     /**
-     * This contracts the source from a pair of `LongChunk` and `Chunk<T>` and produces a `Chunk<T[]>`. The returned
+     * This contracts the source from a pair of {@code LongChunk} and {@code Chunk<T>} and produces a {@code Chunk<T[]>}. The returned
      * chunk is owned by the caller.
      *
      * @param source the source chunk of T to contract
-     * @param perElementLengthDest the source IntChunk for which `dest.get(i + 1) - dest.get(i)` is equivalent to
-     *        `source.get(i).length`
+     * @param perElementLengthDest the source IntChunk for which {@code dest.get(i + 1) - dest.get(i)} is equivalent to
+     *        {@code source.get(i).length}
      * @return a result chunk of T[]
      */
     <A extends Any> WritableObjectChunk<Vector<?>, A> contract(Chunk<A> source,

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
@@ -219,14 +219,16 @@ public class BarrageStreamReader implements StreamReader {
                     if (isAddBatch) {
                         for (int ci = 0; ci < msg.addColumnData.length; ++ci) {
                             msg.addColumnData[ci].data = ChunkInputStreamGenerator.extractChunkFromInputStream(options,
-                                    columnChunkTypes[ci], columnTypes[ci], fieldNodeIter, bufferInfoIter, ois);
+                                    columnChunkTypes[ci], columnTypes[ci], componentTypes[ci], fieldNodeIter,
+                                    bufferInfoIter, ois);
                         }
                     } else {
                         for (int ci = 0; ci < msg.modColumnData.length; ++ci) {
                             final BarrageMessage.ModColumnData mcd = msg.modColumnData[ci];
                             final int numModded = mcd.rowsModified.intSize();
                             mcd.data = ChunkInputStreamGenerator.extractChunkFromInputStream(options,
-                                    columnChunkTypes[ci], columnTypes[ci], fieldNodeIter, bufferInfoIter, ois);
+                                    columnChunkTypes[ci], columnTypes[ci], componentTypes[ci], fieldNodeIter,
+                                    bufferInfoIter, ois);
                             if (mcd.data.size() != numModded) {
                                 throw new IllegalStateException(
                                         "Mod column data does not have the expected number of rows.");

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -434,7 +434,7 @@ public class BarrageUtil {
             final String name, final Class<?> type, final Class<?> componentType, final Map<String, String> metadata) {
         List<Field> children = Collections.emptyList();
 
-        final FieldType fieldType = arrowFieldTypeFor(type, componentType, metadata);
+        final FieldType fieldType = arrowFieldTypeFor(type, metadata);
         if (fieldType.getType().isComplex()) {
             if (type.isArray()) {
                 children = Collections.singletonList(arrowFieldFor(
@@ -447,12 +447,14 @@ public class BarrageUtil {
         return new Field(name, fieldType, children);
     }
 
-    private static FieldType arrowFieldTypeFor(final Class<?> type, final Class<?> componentType,
-            final Map<String, String> metadata) {
-        return new FieldType(true, arrowTypeFor(type, componentType), null, metadata);
+    private static FieldType arrowFieldTypeFor(final Class<?> type, final Map<String, String> metadata) {
+        return new FieldType(true, arrowTypeFor(type), null, metadata);
     }
 
-    private static ArrowType arrowTypeFor(final Class<?> type, final Class<?> componentType) {
+    private static ArrowType arrowTypeFor(Class<?> type) {
+        if (TypeUtils.isBoxedType(type)) {
+            type = TypeUtils.getUnboxedType(type);
+        }
         final ChunkType chunkType = ChunkType.fromElementType(type);
         switch (chunkType) {
             case Boolean:

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateBarrageUtils.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateBarrageUtils.java
@@ -14,5 +14,7 @@ public class ReplicateBarrageUtils {
                 "extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java");
         ReplicatePrimitiveCode.charToAll(
                 "extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/CharArrayExpansionKernel.java");
+        ReplicatePrimitiveCode.charToAllButBoolean(
+                "extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/vector/CharVectorExpansionKernel.java");
     }
 }

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -172,7 +172,8 @@ public class ArrowFlightUtil {
                     final int factor = (columnConversionFactors == null) ? 1 : columnConversionFactors[ci];
                     try {
                         acd.data = ChunkInputStreamGenerator.extractChunkFromInputStream(options, factor,
-                                columnChunkTypes[ci], columnTypes[ci], fieldNodeIter, bufferInfoIter, mi.inputStream);
+                                columnChunkTypes[ci], columnTypes[ci], componentTypes[ci], fieldNodeIter,
+                                bufferInfoIter, mi.inputStream);
                     } catch (final IOException unexpected) {
                         throw new UncheckedDeephavenException(unexpected);
                     }

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -1610,7 +1610,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
                 }
 
                 modifications.type = sourceColumn.getType();
-                modifications.componentType = sourceColumns.getClass();
+                modifications.componentType = sourceColumn.getComponentType();
             }
         }
 

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -370,7 +370,8 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
             // If the source column is a DBDate time we'll just always use longs to avoid silly reinterpretations during
             // serialization/deserialization
             sourceColumns[i] = ReinterpretUtils.maybeConvertToPrimitive(sourceColumns[i]);
-            deltaColumns[i] = ArrayBackedColumnSource.getMemoryColumnSource(capacity, sourceColumns[i].getType());
+            deltaColumns[i] = ArrayBackedColumnSource.getMemoryColumnSource(
+                    capacity, sourceColumns[i].getType(), sourceColumns[i].getComponentType());
 
             if (deltaColumns[i] instanceof ObjectArraySource) {
                 objectColumns.set(i);

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -12,6 +12,8 @@ import gnu.trove.list.array.TIntArrayList;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.barrage.flatbuf.*;
 import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.sized.SizedChunk;
 import io.deephaven.chunk.sized.SizedLongChunk;
@@ -454,18 +456,20 @@ public class BarrageStreamGenerator implements
             };
             numRows = columnVisitor.visit(view, addStream, fieldNodeListener, bufferListener);
 
-            RecordBatch.startNodesVector(header, nodeOffsets.get().size());
-            for (int i = nodeOffsets.get().size() - 1; i >= 0; --i) {
+            final WritableChunk<Values> noChunk = nodeOffsets.get();
+            RecordBatch.startNodesVector(header, noChunk.size());
+            for (int i = noChunk.size() - 1; i >= 0; --i) {
                 final ChunkInputStreamGenerator.FieldNodeInfo node =
-                        (ChunkInputStreamGenerator.FieldNodeInfo) nodeOffsets.get().asObjectChunk().get(i);
+                        (ChunkInputStreamGenerator.FieldNodeInfo) noChunk.asObjectChunk().get(i);
                 FieldNode.createFieldNode(header, node.numElements, node.nullCount);
             }
             nodesOffset = header.endVector();
 
-            RecordBatch.startBuffersVector(header, bufferInfos.get().size());
-            for (int i = bufferInfos.get().size() - 1; i >= 0; --i) {
-                totalBufferLength.subtract(bufferInfos.get().get(i));
-                Buffer.createBuffer(header, totalBufferLength.longValue(), bufferInfos.get().get(i));
+            final WritableLongChunk<Values> biChunk = bufferInfos.get();
+            RecordBatch.startBuffersVector(header, biChunk.size());
+            for (int i = biChunk.size() - 1; i >= 0; --i) {
+                totalBufferLength.subtract(biChunk.get(i));
+                Buffer.createBuffer(header, totalBufferLength.longValue(), biChunk.get(i));
             }
             buffersOffset = header.endVector();
         }

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -100,7 +100,8 @@ public class BarrageStreamGenerator implements
 
         ModColumnData(final BarrageMessage.ModColumnData col) throws IOException {
             rowsModified = new RowSetGenerator(col.rowsModified);
-            data = ChunkInputStreamGenerator.makeInputStreamGenerator(col.data.getChunkType(), col.type, col.data);
+            data = ChunkInputStreamGenerator.makeInputStreamGenerator(
+                    col.data.getChunkType(), col.type, col.componentType, col.data);
         }
     }
 
@@ -141,8 +142,8 @@ public class BarrageStreamGenerator implements
             addColumnData = new ChunkInputStreamGenerator[message.addColumnData.length];
             for (int i = 0; i < message.addColumnData.length; ++i) {
                 final BarrageMessage.AddColumnData acd = message.addColumnData[i];
-                addColumnData[i] =
-                        ChunkInputStreamGenerator.makeInputStreamGenerator(acd.data.getChunkType(), acd.type, acd.data);
+                addColumnData[i] = ChunkInputStreamGenerator.makeInputStreamGenerator(
+                        acd.data.getChunkType(), acd.type, acd.componentType, acd.data);
             }
             modColumnData = new ModColumnData[message.modColumnData.length];
             for (int i = 0; i < modColumnData.length; ++i) {

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -314,7 +314,6 @@ public class BarrageStreamGenerator implements
         public final RowSet keyspaceViewport;
         public final BitSet subscribedColumns;
         public final boolean hasAddBatch;
-        public final boolean hasModBatch;
 
         public SnapshotView(final BarrageStreamGenerator generator,
                 final BarrageSnapshotOptions options,
@@ -329,7 +328,6 @@ public class BarrageStreamGenerator implements
 
             this.keyspaceViewport = keyspaceViewport;
             this.subscribedColumns = subscribedColumns;
-            this.hasModBatch = false;
             this.hasAddBatch = generator.rowsIncluded.original.isNonempty();
         }
 


### PR DESCRIPTION
- Fixes #755.
- Also fixes ungroup() on an object array column that was received via barrage; such as a `long []`.
- Also adds support for `DateTime[]` and `ObjectVector` of `DateTime` (such as one created via a `groupBy`).
- Also fixes columns of Boxed arrays.