### PR TITLE
Update web to v0.11.0

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
-ARG WEB_VERSION=0.9.1
+ARG WEB_VERSION=0.11.0
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Adds JS plugin support. See release notes for more details: https://github.com/deephaven/web-client-ui/releases