### PR TITLE
Drop requirement for Java 8 in buildSrc

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 


### PR DESCRIPTION
This brings us to requiring only a Java 11 JDK to build.