### PR TITLE
Discard listener for incremental release filters to avoid python holding it forever.

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -10,7 +10,7 @@ services:
       # with max memory.
       #
       # To turn on debug logging, add: -Dlogback.configurationFile=logback-debug.xml
-      - JAVA_TOOL_OPTIONS=-Xmx16g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       # For remote debugging switch the line above for the one below (and also change the ports below)
       # - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
 
@@ -28,10 +28,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '8.0'
-          memory: 16500M
-        reservations:
-          memory: 16000M
+          cpus: '4.0'
 
     # Allows the querying of this process jinfo/jmap
     # docker-compose exec server jmap -heap 1

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -12,13 +12,14 @@ services:
       # To turn on debug logging, add: -Dlogback.configurationFile=logback-debug.xml
       - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       # For remote debugging switch the line above for the one below (and also change the ports below)
-      # - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+      #- JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx16g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+# -XX:Tier4CompileThreshold=1000 -XX:+PrintCompilation
 
 
     expose:
       - '8080'
-#    ports:
-#      - '5005:5005'        # For remote debugging (change if using different port)
+    ports:
+      - '5005:5005'        # For remote debugging (change if using different port)
 
     # Note: using old-style volume mounts, so that the directories get created if they don't exist
     # See https://docs.docker.com/storage/bind-mounts/#differences-between--v-and---mount-behavior
@@ -28,7 +29,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4.0'
+          cpus: '8.0'
+          memory: 16500M
+        reservations:
+          memory: 16000M
 
     # Allows the querying of this process jinfo/jmap
     # docker-compose exec server jmap -heap 1

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -12,14 +12,13 @@ services:
       # To turn on debug logging, add: -Dlogback.configurationFile=logback-debug.xml
       - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       # For remote debugging switch the line above for the one below (and also change the ports below)
-      #- JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx16g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
-# -XX:Tier4CompileThreshold=1000 -XX:+PrintCompilation
+      # - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
 
 
     expose:
       - '8080'
-    ports:
-      - '5005:5005'        # For remote debugging (change if using different port)
+#    ports:
+#      - '5005:5005'        # For remote debugging (change if using different port)
 
     # Note: using old-style volume mounts, so that the directories get created if they don't exist
     # See https://docs.docker.com/storage/bind-mounts/#differences-between--v-and---mount-behavior
@@ -29,10 +28,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '8.0'
-          memory: 16500M
-        reservations:
-          memory: 16000M
+          cpus: '4.0'
 
     # Allows the querying of this process jinfo/jmap
     # docker-compose exec server jmap -heap 1

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -10,7 +10,7 @@ services:
       # with max memory.
       #
       # To turn on debug logging, add: -Dlogback.configurationFile=logback-debug.xml
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+      - JAVA_TOOL_OPTIONS=-Xmx16g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       # For remote debugging switch the line above for the one below (and also change the ports below)
       # - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
 
@@ -28,7 +28,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4.0'
+          cpus: '8.0'
+          memory: 16500M
+        reservations:
+          memory: 16000M
 
     # Allows the querying of this process jinfo/jmap
     # docker-compose exec server jmap -heap 1

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AutoTuningIncrementalReleaseFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AutoTuningIncrementalReleaseFilter.java
@@ -271,6 +271,7 @@ public class AutoTuningIncrementalReleaseFilter extends BaseIncrementalReleaseFi
             @Override
             public void run() {
                 cycleEnd = timeProvider.currentTime();
+                UpdateGraphProcessor.DEFAULT.requestRefresh();
                 if (!captureReleasedAll && releasedAll) {
                     final DecimalFormat decimalFormat = new DecimalFormat("###,###.##");
                     final long durationNanos = cycleEnd.getNanos() - firstCycle.getNanos();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/BaseIncrementalReleaseFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/BaseIncrementalReleaseFilter.java
@@ -97,6 +97,7 @@ public abstract class BaseIncrementalReleaseFilter extends WhereFilterLivenessAr
             onReleaseAll();
             releasedSize = fullSet.size();
             UpdateGraphProcessor.DEFAULT.removeSource(this);
+	    listener = null;
         }
 
         return fullSet.subSetByPositionRange(0, releasedSize).intersect(selection);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/BaseIncrementalReleaseFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/BaseIncrementalReleaseFilter.java
@@ -97,7 +97,7 @@ public abstract class BaseIncrementalReleaseFilter extends WhereFilterLivenessAr
             onReleaseAll();
             releasedSize = fullSet.size();
             UpdateGraphProcessor.DEFAULT.removeSource(this);
-	    listener = null;
+            listener = null;
         }
 
         return fullSet.subSetByPositionRange(0, releasedSize).intersect(selection);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestIncrementalReleaseFilter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestIncrementalReleaseFilter.java
@@ -36,7 +36,11 @@ public class TestIncrementalReleaseFilter extends RefreshingTableTestCase {
 
             TableTools.show(filtered);
             assertEquals(Math.min(3 + ii, 10), filtered.size());
+            if (filtered.size() == source.size()) {
+                break;
+            }
         }
+        assertEquals(source.size(), filtered.size());
     }
 
     public void testBigTable() {


### PR DESCRIPTION
After we are done releasing rows incrementally, we should drop the reference from the filter to the listener.  A heap dump showed a global JNI reference to the filter, which then held onto the listener, which in turn held onto the filtered table, which held onto its parent that contained gigabytes of selected data.  With this change I can run more incremental tests in a single container without restarting it.

Additionally, by requesting a refresh from our terminal notifications we can eliminate the inter cycle gap, which can distort tests that are fairly quick by doing nothing between cycles (e.g., a "2 second" test may end up with almost a second of wait time after the initial release.