### PR TITLE
Nightly builds to run on both Java11 and 17

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -52,22 +52,19 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: nightly-check-ci-results
-          path: '**/build/test-results/*/TEST-*.xml'
-
-      - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: nightly-check-ci-reports
-          path: '**/build/reports/tests/**'
+          name: nightly-check-ci-test-results
+          path: |
+            **/build/test-results/*/TEST-*.xml
+            **/build/reports/tests/**
 
       - name: Upload JVM Error Logs
         uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: nightly-check-ci-jvm-err
-          path: '**/*_pid*.log'
+          path: |
+            **/*_pid*.log
+            **/core.*
           if-no-files-found: ignore
 
       - name: Publish Test Results

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -13,7 +13,8 @@ jobs:
   check:
     strategy:
       matrix:
-        gradle-check: [check, testSerial, testParallel, testOutOfBand]
+        gradle-check: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
+        test-jvm-version: ['-PtestRuntimeVersion=11', '-PtestRuntimeVersion=17']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: check
-          arguments: --scan --continue --rerun-tasks check
+          arguments: --rerun-tasks check testOutOfBand testParallel testSerial
           gradle-version: wrapper
 
       - name: Upload Test Results

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -80,13 +80,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
-      - name: Slack Nightly Failure
-        uses: slackapi/slack-github-action@v1.15.0
-        id: slack-nightly-failure
-        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+#      - name: Slack Nightly Failure
+#        uses: slackapi/slack-github-action@v1.15.0
+#        id: slack-nightly-failure
+#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
 
   testSerial:
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -155,13 +155,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
-      - name: Slack Nightly Failure
-        uses: slackapi/slack-github-action@v1.15.0
-        id: slack-nightly-failure
-        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+#      - name: Slack Nightly Failure
+#        uses: slackapi/slack-github-action@v1.15.0
+#        id: slack-nightly-failure
+#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
 
   testParallel:
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
@@ -233,13 +233,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
-      - name: Slack Nightly Failure
-        uses: slackapi/slack-github-action@v1.15.0
-        id: slack-nightly-failure
-        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+#      - name: Slack Nightly Failure
+#        uses: slackapi/slack-github-action@v1.15.0
+#        id: slack-nightly-failure
+#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
 
   testOutOfBand:
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
@@ -311,10 +311,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
-      - name: Slack Nightly Failure
-        uses: slackapi/slack-github-action@v1.15.0
-        id: slack-nightly-failure
-        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+#      - name: Slack Nightly Failure
+#        uses: slackapi/slack-github-action@v1.15.0
+#        id: slack-nightly-failure
+#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -87,7 +87,9 @@ jobs:
         id: slack-nightly-failure
         if: ${{ failure() && github.repository_owner == 'deephaven' }}
         with:
-          slack-message:
-            Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}
+          payload: |
+            {
+              "slack-message": "Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}"
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -81,12 +81,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
-      - name: Slack Nightly Failure
-        uses: slackapi/slack-github-action@v1.18.0
-        id: slack-nightly-failure
-        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-        with:
-          slack-message:
-            Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+#      - name: Slack Nightly Failure
+#        uses: slackapi/slack-github-action@v1.18.0
+#        id: slack-nightly-failure
+#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+#        with:
+#          slack-message:
+#            Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -77,6 +77,7 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
         with:
+          # We have to make a unique report per run https://github.com/ScaCap/action-surefire-report/issues/70
           check_name: check report ${{ matrix.gradle-check }} java${{ matrix.test-jvm-version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -10,10 +10,10 @@ on:
     branches: [ 'nightly/**', 'release/v*' ]
 
 jobs:
-  check:
+  nightly:
     strategy:
       matrix:
-        gradle-check: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
+        gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
         test-jvm-version: ['11', '17']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-20.04
@@ -45,18 +45,18 @@ jobs:
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 
-      - name: Run gradle ${{ matrix.gradle-check }} on java ${{ matrix.test-jvm-version }}
+      - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}
         uses: burrunan/gradle-cache-action@v1
         with:
-          job-id: check
-          arguments: --scan --continue --rerun-tasks ${{ matrix.gradle-check }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
+          job-id: gradle-run
+          arguments: --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
           gradle-version: wrapper
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: nightly-${{ matrix.gradle-check }}-java${{ matrix.test-jvm-version }}-ci-results
+          name: nightly-${{ matrix.gradle-task }}-java${{ matrix.test-jvm-version }}-ci-results
           path: |
             **/build/test-results/*/TEST-*.xml
             **/build/reports/tests/**
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: nightly-${{ matrix.gradle-check }}-java${{ matrix.test-jvm-version }}-ci-jvm-err
+          name: nightly-${{ matrix.gradle-task }}-java${{ matrix.test-jvm-version }}-ci-jvm-err
           path: |
             **/*_pid*.log
             **/core.*
@@ -78,7 +78,7 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
         with:
           # We have to make a unique report per run https://github.com/ScaCap/action-surefire-report/issues/70
-          check_name: check report ${{ matrix.gradle-check }} java${{ matrix.test-jvm-version }}
+          check_name: check report ${{ matrix.gradle-task }} java${{ matrix.test-jvm-version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
@@ -89,7 +89,7 @@ jobs:
         with:
           payload: |
             {
-              "slack-message": "Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}"
+              "slack-message": "Nightly build failure in ${{ matrix.gradle-task }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   nightly:
     strategy:
+      fast-fail: false
       matrix:
         gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
         test-jvm-version: ['11', '17']

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   check:
+    strategy:
+      matrix:
+        gradle-check: [check, testSerial, testParallel, testOutOfBand]
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-20.04
     steps:
@@ -41,11 +44,11 @@ jobs:
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 
-      - name: Run gradle
+      - name: Run gradle {{ matrix.gradle-check }}
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: check
-          arguments: --rerun-tasks check testOutOfBand testParallel testSerial
+          arguments: --scan --continue --rerun-tasks {{ matrix.gradle-check }}
           gradle-version: wrapper
 
       - name: Upload Test Results
@@ -73,248 +76,15 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
         with:
-          check_name: check report
+          check_name: {{ matrix.gradle-check }} report
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
-#      - name: Slack Nightly Failure
-#        uses: slackapi/slack-github-action@v1.15.0
-#        id: slack-nightly-failure
-#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
-
-  testSerial:
-    if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup JDK 11
-        id: setup-java-11
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-
-      - name: Setup JDK 17
-        id: setup-java-17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Set JAVA_HOME
-        run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
-
-      - name: Setup gradle properties
-        run: |
-          cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
-          echo >> gradle.properties
-          echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
-          cat gradle.properties
-
-      - name: Run gradle
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: testSerial
-          arguments: --scan --continue --rerun-tasks testSerial
-          gradle-version: wrapper
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: nightly-testSerial-ci-results
-          path: '**/build/test-results/*/TEST-*.xml'
-
-      - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: nightly-testSerial-ci-reports
-          path: '**/build/reports/tests/**'
-
-      - name: Upload JVM Error Logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: nightly-testSerial-ci-jvm-err
-          path: '**/*_pid*.log'
-          if-no-files-found: ignore
-
-      - name: Publish Test Results
-        uses: scacap/action-surefire-report@v1
-        if: ${{ github.repository_owner == 'deephaven' }}
+      - name: Slack Nightly Failure
+        uses: slackapi/slack-github-action@v1.18.0
+        id: slack-nightly-failure
+        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+        slack-message:
+          Nightly build failure in {{ matrix.gradle-check }} {{ github.event.head_commit.url }}
         env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        with:
-          check_name: testSerial report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/*/TEST-*.xml'
-
-#      - name: Slack Nightly Failure
-#        uses: slackapi/slack-github-action@v1.15.0
-#        id: slack-nightly-failure
-#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
-
-  testParallel:
-    if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup JDK 11
-        id: setup-java-11
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-
-      - name: Setup JDK 17
-        id: setup-java-17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Set JAVA_HOME
-        run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
-
-      - name: Setup gradle properties
-        run: |
-          cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
-          echo >> gradle.properties
-          echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
-          cat gradle.properties
-
-      - name: Run gradle
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: testParallel
-          arguments: --scan --continue --rerun-tasks testParallel
-          gradle-version: wrapper
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: nightly-testParallel-ci-results
-          path: '**/build/test-results/*/TEST-*.xml'
-
-      - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: nightly-testParallel-ci-reports
-          path: '**/build/reports/tests/**'
-
-      - name: Upload JVM Error Logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: nightly-testParallel-ci-jvm-err
-          path: '**/*_pid*.log'
-          if-no-files-found: ignore
-
-      - name: Publish Test Results
-        uses: scacap/action-surefire-report@v1
-        if: ${{ github.repository_owner == 'deephaven' }}
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        with:
-          check_name: testParallel report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/*/TEST-*.xml'
-
-#      - name: Slack Nightly Failure
-#        uses: slackapi/slack-github-action@v1.15.0
-#        id: slack-nightly-failure
-#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
-
-  testOutOfBand:
-    if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup JDK 11
-        id: setup-java-11
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-
-      - name: Setup JDK 17
-        id: setup-java-17
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Set JAVA_HOME
-        run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
-
-      - name: Setup gradle properties
-        run: |
-          cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
-          echo >> gradle.properties
-          echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
-          cat gradle.properties
-
-      - name: Run gradle
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: testOutOfBand
-          arguments: --scan --continue --rerun-tasks testOutOfBand
-          gradle-version: wrapper
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: nightly-testOutOfBand-ci-results
-          path: '**/build/test-results/*/TEST-*.xml'
-
-      - name: Upload Test Reports
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: nightly-testOutOfBand-ci-reports
-          path: '**/build/reports/tests/**'
-
-      - name: Upload JVM Error Logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: nightly-testOutOfBand-ci-jvm-err
-          path: '**/*_pid*.log'
-          if-no-files-found: ignore
-
-      - name: Publish Test Results
-        uses: scacap/action-surefire-report@v1
-        if: ${{ github.repository_owner == 'deephaven' }}
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        with:
-          check_name: testOutOfBand report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/*/TEST-*.xml'
-
-#      - name: Slack Nightly Failure
-#        uses: slackapi/slack-github-action@v1.15.0
-#        id: slack-nightly-failure
-#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-#        # TODO(deephaven-core#947): Parameterize nightly ci failure workflow and trigger
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         gradle-check: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
-        test-jvm-version: ['-PtestRuntimeVersion=11', '-PtestRuntimeVersion=17']
+        test-jvm-version: ['11', '17']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-20.04
     steps:
@@ -45,18 +45,18 @@ jobs:
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 
-      - name: Run gradle {{ matrix.gradle-check }}
+      - name: Run gradle {{ matrix.gradle-check }} on java {{ matrix.test-jvm-version }}
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: check
-          arguments: --scan --continue --rerun-tasks {{ matrix.gradle-check }}
+          arguments: --scan --continue --rerun-tasks {{ matrix.gradle-check }} -PtestRuntimeVersion={{ matrix.test-jvm-version }}
           gradle-version: wrapper
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: nightly-check-ci-test-results
+          name: nightly-{{ matrix.gradle-check }}-java{{ matrix.test-jvm-version }}-ci-results
           path: |
             **/build/test-results/*/TEST-*.xml
             **/build/reports/tests/**
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: nightly-check-ci-jvm-err
+          name: nightly-{{ matrix.gradle-check }}-java{{ matrix.test-jvm-version }}-ci-jvm-err
           path: |
             **/*_pid*.log
             **/core.*
@@ -77,7 +77,7 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
         with:
-          check_name: {{ matrix.gradle-check }} report
+          check_name: check report {{ matrix.gradle-check }} java{{ matrix.test-jvm-version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
@@ -85,7 +85,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.18.0
         id: slack-nightly-failure
         if: ${{ failure() && github.repository_owner == 'deephaven' }}
-        slack-message:
-          Nightly build failure in {{ matrix.gradle-check }} {{ github.event.head_commit.url }}
+        with:
+          slack-message:
+            Nightly build failure in {{ matrix.gradle-check }} on Java {{ matrix.test-jvm-version }} @ {{ github.event.head_commit.url }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -81,12 +81,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
-#      - name: Slack Nightly Failure
-#        uses: slackapi/slack-github-action@v1.18.0
-#        id: slack-nightly-failure
-#        if: ${{ failure() && github.repository_owner == 'deephaven' }}
-#        with:
-#          slack-message:
-#            Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+      - name: Slack Nightly Failure
+        uses: slackapi/slack-github-action@v1.18.0
+        id: slack-nightly-failure
+        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+        with:
+          slack-message:
+            Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -45,18 +45,18 @@ jobs:
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 
-      - name: Run gradle {{ matrix.gradle-check }} on java {{ matrix.test-jvm-version }}
+      - name: Run gradle ${{ matrix.gradle-check }} on java ${{ matrix.test-jvm-version }}
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: check
-          arguments: --scan --continue --rerun-tasks {{ matrix.gradle-check }} -PtestRuntimeVersion={{ matrix.test-jvm-version }}
+          arguments: --scan --continue --rerun-tasks ${{ matrix.gradle-check }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
           gradle-version: wrapper
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: nightly-{{ matrix.gradle-check }}-java{{ matrix.test-jvm-version }}-ci-results
+          name: nightly-${{ matrix.gradle-check }}-java${{ matrix.test-jvm-version }}-ci-results
           path: |
             **/build/test-results/*/TEST-*.xml
             **/build/reports/tests/**
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: nightly-{{ matrix.gradle-check }}-java{{ matrix.test-jvm-version }}-ci-jvm-err
+          name: nightly-${{ matrix.gradle-check }}-java${{ matrix.test-jvm-version }}-ci-jvm-err
           path: |
             **/*_pid*.log
             **/core.*
@@ -77,7 +77,7 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
         with:
-          check_name: check report {{ matrix.gradle-check }} java{{ matrix.test-jvm-version }}
+          check_name: check report ${{ matrix.gradle-check }} java${{ matrix.test-jvm-version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/*/TEST-*.xml'
 
@@ -87,6 +87,6 @@ jobs:
         if: ${{ failure() && github.repository_owner == 'deephaven' }}
         with:
           slack-message:
-            Nightly build failure in {{ matrix.gradle-check }} on Java {{ matrix.test-jvm-version }} @ {{ github.event.head_commit.url }}
+            Nightly build failure in ${{ matrix.gradle-check }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -2439,9 +2439,8 @@ public class QueryTableAggregationTest {
         final Random random = new Random(0);
         final ColumnInfo[] columnInfo;
         final QueryTable queryTable = getTable(size, random,
-                columnInfo = initColumnInfos(new String[] {"Sym", "intCol", "doubleCol", "floatCol"},
+                columnInfo = initColumnInfos(new String[] {"Sym", "doubleCol", "floatCol"},
                         new SetGenerator<>("a", "b", "c", "d"),
-                        new IntGenerator(10, 100),
                         new SetGenerator<>(10.1, 20.1, 30.1),
                         new FloatGenerator(0, 100.0f)));
         final Table withoutFloats = queryTable.dropColumns("floatCol");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -2439,8 +2439,9 @@ public class QueryTableAggregationTest {
         final Random random = new Random(0);
         final ColumnInfo[] columnInfo;
         final QueryTable queryTable = getTable(size, random,
-                columnInfo = initColumnInfos(new String[] {"Sym", "doubleCol", "floatCol"},
+                columnInfo = initColumnInfos(new String[] {"Sym", "intCol", "doubleCol", "floatCol"},
                         new SetGenerator<>("a", "b", "c", "d"),
+                        new IntGenerator(10, 100),
                         new SetGenerator<>(10.1, 20.1, 30.1),
                         new FloatGenerator(0, 100.0f)));
         final Table withoutFloats = queryTable.dropColumns("floatCol");


### PR DESCRIPTION
This patch is the result of the bug hunt around c2 compilation issues, and while it adds support for building each night on each Java 11 and 17, it also simplifies the nightly build yml to run each expected task using the matrix strategy instead of repeating sections of the build over and over.

Build output such as test reports are also somewhat consolidated, to reduce the number of zips available for download, and contain related material in the same file.

One potential downside is that the "Publish Test Results" is now once per matrix run rather than collecting results across all runs.

Another potential downside (or upside) is that when one task fails, the others don't continue. This could also be an upside, save some build minutes, as these are not short tasks. This is configurable, I just set the default for now.