### PR TITLE
Remove unnecessary `update()` functions from `BarrageMessageProducer`

### DIFF
--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -532,52 +532,20 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
     }
 
     public boolean updateSubscription(final StreamObserver<MessageView> listener,
-            final BitSet newSubscribedColumns) {
-        return findAndUpdateSubscription(listener, sub -> {
-            sub.pendingColumns = (BitSet) newSubscribedColumns.clone();
-            if (sub.isViewport() && sub.pendingViewport == null) {
-                sub.pendingViewport = sub.viewport.copy();
-            }
-            log.info().append(logPrefix).append(sub.logPrefix)
-                    .append("scheduling update immediately, for column updates.").endl();
-        });
+              final RowSet newViewport, final BitSet columnsToSubscribe) {
+        // assume forward viewport when not specified
+        return updateSubscription(listener, newViewport, columnsToSubscribe, false);
     }
 
-    public boolean updateViewport(final StreamObserver<MessageView> listener,
-            final RowSet newViewport) {
-        return updateViewport(listener, newViewport, false);
-    }
-
-    public boolean updateViewport(final StreamObserver<MessageView> listener, final RowSet newViewport,
-            final boolean newReverseViewport) {
+    public boolean updateSubscription(final StreamObserver<MessageView> listener, final RowSet newViewport,
+              final BitSet columnsToSubscribe, final boolean newReverseViewport) {
         return findAndUpdateSubscription(listener, sub -> {
             if (sub.pendingViewport != null) {
                 sub.pendingViewport.close();
             }
             sub.pendingViewport = newViewport.copy();
             sub.pendingReverseViewport = newReverseViewport;
-            if (sub.pendingColumns == null) {
-                sub.pendingColumns = (BitSet) sub.subscribedColumns.clone();
-            }
-            log.info().append(logPrefix).append(sub.logPrefix)
-                    .append("scheduling update immediately, for viewport updates.").endl();
-        });
-    }
-
-    public boolean updateViewportAndColumns(final StreamObserver<MessageView> listener,
-            final RowSet newViewport, final BitSet columnsToSubscribe) {
-        return updateViewportAndColumns(listener, newViewport, columnsToSubscribe);
-    }
-
-    public boolean updateViewportAndColumns(final StreamObserver<MessageView> listener, final RowSet newViewport,
-            final BitSet columnsToSubscribe, final boolean newReverseViewport) {
-        return findAndUpdateSubscription(listener, sub -> {
-            if (sub.pendingViewport != null) {
-                sub.pendingViewport.close();
-            }
-            sub.pendingViewport = newViewport.copy();
-            sub.pendingReverseViewport = newReverseViewport;
-            sub.pendingColumns = (BitSet) columnsToSubscribe.clone();
+            sub.pendingColumns = columnsToSubscribe != null ? (BitSet) columnsToSubscribe.clone() : null;
             log.info().append(logPrefix).append(sub.logPrefix)
                     .append("scheduling update immediately, for viewport and column updates.").endl();
         });

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -532,13 +532,13 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
     }
 
     public boolean updateSubscription(final StreamObserver<MessageView> listener,
-              final RowSet newViewport, final BitSet columnsToSubscribe) {
+            final RowSet newViewport, final BitSet columnsToSubscribe) {
         // assume forward viewport when not specified
         return updateSubscription(listener, newViewport, columnsToSubscribe, false);
     }
 
     public boolean updateSubscription(final StreamObserver<MessageView> listener, final RowSet newViewport,
-              final BitSet columnsToSubscribe, final boolean newReverseViewport) {
+            final BitSet columnsToSubscribe, final boolean newReverseViewport) {
         return findAndUpdateSubscription(listener, sub -> {
             if (sub.pendingViewport != null) {
                 sub.pendingViewport.close();

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -315,12 +315,15 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
             viewport = newViewport;
             reverseViewport = newReverseViewport;
 
-            barrageMessageProducer.updateViewport(dummyObserver, viewport, reverseViewport);
+            // maintain the existing subscribedColumns set
+            barrageMessageProducer.updateSubscription(dummyObserver, viewport, subscribedColumns, reverseViewport);
         }
 
         public void setSubscribedColumns(final BitSet newColumns) {
             subscribedColumns = newColumns;
-            barrageMessageProducer.updateSubscription(dummyObserver, newColumns);
+
+            // maintain the existing viewport and viewport direction
+            barrageMessageProducer.updateSubscription(dummyObserver, viewport, subscribedColumns, reverseViewport);
         }
 
         public void setViewportAndColumns(final RowSet newViewport, final BitSet newColumns) {
@@ -333,7 +336,7 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
             viewport = newViewport;
             reverseViewport = newReverseViewport;
             subscribedColumns = newColumns;
-            barrageMessageProducer.updateViewportAndColumns(dummyObserver, viewport, subscribedColumns);
+            barrageMessageProducer.updateSubscription(dummyObserver, viewport, subscribedColumns, newReverseViewport);
         }
     }
 


### PR DESCRIPTION
`BarrageMessageProducer` has  multiple update subscription functions (`updateSubscription()`, `updateViewport()` and `updateViewportAndColumns()`) which are unnecessary and incorrect.  This change combines these into single `updateSubscription()` function with the needed functionality.

Closes #2089