### PR TITLE
Update envoy to 1.21.1, and modernize envoy.yaml

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -94,5 +94,5 @@ human-friendly names. Most docker library images follow the pattern where they p
 `<name>:<major>.<minor>`, and `<name>:<major>.<minor>.<patch>`; or some variant on `<name>:latest`. When specifying the
 full semver for example, the automatically checks may never trigger if the publisher treats them as "immutable". An
 example of this is envoy - they publish "immutable", full semver tags without providing partial semver tags. Ie, they
-publish `envoyproxy/envoy:v1.17.1` but not `envoyproxy/envoy:v1.17`, meaning it's on the developers to manually update
+publish `envoyproxy/envoy:v1.21.1` but not `envoyproxy/envoy:v1.21`, meaning it's on the developers to manually update
 the mapping details when necessary.

--- a/docker/registry/envoyproxy/gradle.properties
+++ b/docker/registry/envoyproxy/gradle.properties
@@ -1,4 +1,4 @@
 # Note: using the registry name "envoyproxy" instead of "envoy" since the ":envoy" project produces deephaven/envoy:local-build.
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
-deephaven.registry.imageName=envoyproxy/envoy:v1.17.1
-deephaven.registry.imageId=envoyproxy/envoy@sha256:1e4de079793a62a1ed7023bc44228b80d753773dbf24dcf7b318f360ca595b31
+deephaven.registry.imageName=envoyproxy/envoy:v1.21.1
+deephaven.registry.imageId=envoyproxy/envoy@sha256:e9ad4cde73ffb01402c4e3fb6ce1a764d9e84650230135b88495f30904a378fc

--- a/envoy/contents/envoy.yaml
+++ b/envoy/contents/envoy.yaml
@@ -1,5 +1,10 @@
 admin:
-  access_log_path: /tmp/admin_access.log
+  access_log:
+    - name: envoy.access_loggers.file
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+        path: /tmp/admin_access.log
+
   address:
     socket_address: { address: 0.0.0.0, port_value: 9090 }
 
@@ -84,7 +89,11 @@ static_resources:
       connect_timeout: 10s
       type: LOGICAL_DNS
       lb_policy: ROUND_ROBIN
-      http2_protocol_options: {}
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
       load_assignment:
         cluster_name: server
         endpoints:
@@ -98,7 +107,11 @@ static_resources:
       connect_timeout: 10s
       type: LOGICAL_DNS
       lb_policy: ROUND_ROBIN
-      http_protocol_options: {}
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http_protocol_options: {}
       load_assignment:
         cluster_name: web
         endpoints:


### PR DESCRIPTION
Tested from the web browser and from FlightClient to confirm that the proxy still handles grpc correctly, as well as static http content via nginx.

Fixes #1974