### PR TITLE
Correctly close http2-based emulated bidi streams from JS

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/ide/shared/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/ide/shared/IdeSession.java
@@ -81,14 +81,11 @@ public class IdeSession extends HasEventHandling {
         this.closer = closer;
 
         BiDiStream.Factory<AutoCompleteRequest, AutoCompleteResponse> factory = connection.streamFactory();
-        streamFactory = () -> {
-            return factory.create(
-                    connection.consoleServiceClient()::autoCompleteStream,
-                    (firstPayload, headers) -> connection.consoleServiceClient().openAutoCompleteStream(firstPayload,
-                            headers),
-                    (nextPayload, headers, c) -> connection.consoleServiceClient().nextAutoCompleteStream(nextPayload,
-                            headers, c::apply));
-        };
+        streamFactory = () -> factory.create(
+                connection.consoleServiceClient()::autoCompleteStream,
+                (first, headers) -> connection.consoleServiceClient().openAutoCompleteStream(first, headers),
+                (next, headers, c) -> connection.consoleServiceClient().nextAutoCompleteStream(next, headers, c::apply),
+                new AutoCompleteRequest());
     }
 
     // TODO (deephaven-core#188): improve usage of subscriptions (w.r.t. this optional param)

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -945,9 +945,9 @@ public class WorkerConnection {
             // table's creation, which can race this
             BiDiStream<FlightData, FlightData> stream = this.<FlightData, FlightData>streamFactory().create(
                     headers -> flightServiceClient.doPut(headers),
-                    (firstPayload, headers) -> browserFlightServiceClient.openDoPut(firstPayload, headers),
-                    (nextPayload, headers, callback) -> browserFlightServiceClient.nextDoPut(nextPayload, headers,
-                            callback::apply));
+                    (first, headers) -> browserFlightServiceClient.openDoPut(first, headers),
+                    (next, headers, callback) -> browserFlightServiceClient.nextDoPut(next, headers, callback::apply),
+                    new FlightData());
             stream.send(schemaMessage);
 
             stream.onEnd(status -> {
@@ -1300,9 +1300,9 @@ public class WorkerConnection {
 
                 BiDiStream<FlightData, FlightData> stream = this.<FlightData, FlightData>streamFactory().create(
                         headers -> flightServiceClient.doExchange(headers),
-                        (firstPayload, headers) -> browserFlightServiceClient.openDoExchange(firstPayload, headers),
-                        (nextPayload, headers, c) -> browserFlightServiceClient.nextDoExchange(nextPayload, headers,
-                                c::apply));
+                        (first, headers) -> browserFlightServiceClient.openDoExchange(first, headers),
+                        (next, headers, c) -> browserFlightServiceClient.nextDoExchange(next, headers, c::apply),
+                        new FlightData());
 
                 stream.send(request);
                 stream.onData(new JsConsumer<FlightData>() {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/stream/BiDiStream.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/stream/BiDiStream.java
@@ -47,13 +47,15 @@ public abstract class BiDiStream<Req, Resp> {
         public BiDiStream<ReqT, RespT> create(
                 BiDiStreamFactory bidirectionalStream,
                 OpenStreamFactory<ReqT> openEmulatedStream,
-                NextStreamMessageFactory<ReqT> nextEmulatedStream) {
+                NextStreamMessageFactory<ReqT> nextEmulatedStream,
+                ReqT emptyReq) {
             if (useWebsocket) {
                 return websocket(bidirectionalStream.openBiDiStream(headers.get()));
             } else {
                 return new EmulatedBiDiStream<>(
                         openEmulatedStream,
                         nextEmulatedStream,
+                        emptyReq,
                         nextIntTicket.getAsInt(),
                         headers);
             }
@@ -64,6 +66,7 @@ public abstract class BiDiStream<Req, Resp> {
             BiDiStreamFactory bidirectionalStream,
             OpenStreamFactory<Req> openEmulatedStream,
             NextStreamMessageFactory<Req> nextEmulatedStream,
+            Req emptyReq,
             Supplier<BrowserHeaders> headers,
             IntSupplier nextIntTicket,
             boolean useWebsocket) {
@@ -73,6 +76,7 @@ public abstract class BiDiStream<Req, Resp> {
             return new EmulatedBiDiStream<>(
                     openEmulatedStream,
                     nextEmulatedStream,
+                    emptyReq,
                     nextIntTicket.getAsInt(),
                     headers);
         }
@@ -146,6 +150,7 @@ public abstract class BiDiStream<Req, Resp> {
     static class EmulatedBiDiStream<T, U> extends BiDiStream<T, U> {
         private final JsFunction<T, ResponseStreamWrapper<U>> responseStreamFactory;
         private final JsArray<JsConsumer<ResponseStreamWrapper<U>>> pending = new JsArray<>();
+        private final T emptyReq;
         private final int intTicket;
 
         private ResponseStreamWrapper<U> responseStream;
@@ -155,10 +160,12 @@ public abstract class BiDiStream<Req, Resp> {
         private int nextSeq = 0;
 
         EmulatedBiDiStream(OpenStreamFactory<T> responseStreamFactory, NextStreamMessageFactory<T> nextWrapper,
+                T emptyReq,
                 int intTicket, Supplier<BrowserHeaders> headers) {
             this.responseStreamFactory =
                     firstReq -> ResponseStreamWrapper.of(responseStreamFactory.openStream(firstReq, makeHeaders()));
             this.nextWrapper = nextWrapper;
+            this.emptyReq = emptyReq;
             this.intTicket = intTicket;
             this.headers = headers;
         }
@@ -203,7 +210,7 @@ public abstract class BiDiStream<Req, Resp> {
             BrowserHeaders nextHeaders = makeHeaders();
             nextHeaders.set("x-deephaven-stream-halfclose", "1");
             // TODO #730 handle failure of this call
-            nextWrapper.nextStreamMessage(Js.uncheckedCast(new Ticket()), nextHeaders, (failure, success) -> {
+            nextWrapper.nextStreamMessage(emptyReq, nextHeaders, (failure, success) -> {
             });
         }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -279,11 +279,10 @@ public class TableViewportSubscription extends HasEventHandling {
                 WorkerConnection connection = table.getConnection();
                 BiDiStream<FlightData, FlightData> stream = connection.<FlightData, FlightData>streamFactory().create(
                         headers -> connection.flightServiceClient().doExchange(headers),
-                        (firstPayload, headers) -> connection.browserFlightServiceClient().openDoExchange(firstPayload,
-                                headers),
-                        (nextPayload, headers, c) -> connection.browserFlightServiceClient().nextDoExchange(nextPayload,
-                                headers,
-                                c::apply));
+                        (first, headers) -> connection.browserFlightServiceClient().openDoExchange(first, headers),
+                        (next, headers, c) -> connection.browserFlightServiceClient().nextDoExchange(next, headers,
+                                c::apply),
+                        new FlightData());
 
                 Builder doGetRequest = new Builder(1024);
                 double columnsOffset = BarrageSubscriptionRequest.createColumnsVector(doGetRequest,


### PR DESCRIPTION
The earlier iteration of this assumed that just because one empty JS PB object was the same as another from JS's perspective, that GWT/Java wouldn't mind, and this isn't the case. It isn't possible to send null, as the TS gRPC library will not accept a null value, though from a regular Java gRPC library, that is probably what we would do here.

Tested by Devin on his demo server.

Fixes #2095