### PR TITLE
Revert "jpy vararg leak"

### DIFF
--- a/py/jpy/src/main/c/jni/org_jpy_PyLib.c
+++ b/py/jpy/src/main/c/jni/org_jpy_PyLib.c
@@ -1856,11 +1856,13 @@ JNIEXPORT jobjectArray JNICALL Java_org_jpy_PyLib_getObjectArrayValue
         for (i = 0; i < length; i++) {
             pyItem = PySequence_GetItem(pyObject, i);
             if (pyItem == NULL) {
-                JPy_DELETE_LOCAL_REF(jObject);
+                (*jenv)->DeleteLocalRef(jenv, jObject);
+                jObject = NULL;
                 goto error;
             }
             if (JPy_AsJObject(jenv, pyItem, &jItem, JNI_FALSE) < 0) {
-                JPy_DELETE_LOCAL_REF(jObject);
+                (*jenv)->DeleteLocalRef(jenv, jObject);
+                jObject = NULL;
                 JPy_DIAG_PRINT(JPy_DIAG_F_ALL, "Java_org_jpy_PyLib_getObjectArrayValue: error: failed to convert Python item to Java Object\n");
                 PyLib_HandlePythonException(jenv);
                 goto error;
@@ -1868,7 +1870,8 @@ JNIEXPORT jobjectArray JNICALL Java_org_jpy_PyLib_getObjectArrayValue
             Py_XDECREF(pyItem);
             (*jenv)->SetObjectArrayElement(jenv, jObject, i, jItem);
             if ((*jenv)->ExceptionCheck(jenv)) {
-                JPy_DELETE_LOCAL_REF(jObject);
+                (*jenv)->DeleteLocalRef(jenv, jObject);
+                jObject = NULL;
                 goto error;
             }
         }
@@ -2347,9 +2350,9 @@ PyObject* PyLib_CallAndReturnObject(JNIEnv *jenv, PyObject* pyObject, jboolean i
         }
         pyArg = PyLib_FromJObjectForTuple(jenv, jArg, jParamClass, nameChars, i);
         if (jParamClass != NULL) {
-            JPy_DELETE_LOCAL_REF(jParamClass);
+            (*jenv)->DeleteLocalRef(jenv, jParamClass);
+            jParamClass = NULL;
         }
-        JPy_DELETE_LOCAL_REF(jArg);
         if (pyArg == NULL) {
             JPy_DIAG_PRINT(JPy_DIAG_F_ALL, "PyLib_CallAndReturnObject: error: callable '%s': argument %d: failed to convert Java into Python object\n", nameChars, i);
             PyLib_HandlePythonException(jenv);

--- a/py/jpy/src/main/c/jpy_conv.c
+++ b/py/jpy/src/main/c/jpy_conv.c
@@ -163,7 +163,7 @@ char* JPy_GetTypeName(JNIEnv* jenv, jclass classRef)
         typeNameCopy = JPy_CopyUTFString(jTypeNameChars);
         (*jenv)->ReleaseStringUTFChars(jenv, jTypeName, jTypeNameChars);
     }
-    JPy_DELETE_LOCAL_REF(jTypeName);
+    (*jenv)->DeleteLocalRef(jenv, jTypeName);
     return typeNameCopy;
 }
 
@@ -190,7 +190,7 @@ PyObject* JPy_FromTypeName(JNIEnv* jenv, jclass classRef)
         pyTypeName = Py_BuildValue("s", jTypeNameChars);
         (*jenv)->ReleaseStringUTFChars(jenv, jTypeName, jTypeNameChars);
     }
-    JPy_DELETE_LOCAL_REF(jTypeName);
+    (*jenv)->DeleteLocalRef(jenv, jTypeName);
     return pyTypeName;
 }
 

--- a/py/jpy/src/main/c/jpy_jmethod.c
+++ b/py/jpy/src/main/c/jpy_jmethod.c
@@ -307,12 +307,12 @@ PyObject* JMethod_InvokeMethod(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyAr
             jstring v = (*jenv)->CallStaticObjectMethodA(jenv, classRef, method->mid, jArgs);
             JPy_ON_JAVA_EXCEPTION_GOTO(error);
             returnValue = JPy_FromJString(jenv, v);
-            JPy_DELETE_LOCAL_REF(v);
+            (*jenv)->DeleteLocalRef(jenv, v);
         } else {
             jobject v = (*jenv)->CallStaticObjectMethodA(jenv, classRef, method->mid, jArgs);
             JPy_ON_JAVA_EXCEPTION_GOTO(error);
             returnValue = JMethod_FromJObject(jenv, method, pyArgs, jArgs, 0, returnType, v);
-            JPy_DELETE_LOCAL_REF(v);
+            (*jenv)->DeleteLocalRef(jenv, v);
         }
 
     } else {
@@ -365,12 +365,12 @@ PyObject* JMethod_InvokeMethod(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyAr
             jstring v = (*jenv)->CallObjectMethodA(jenv, objectRef, method->mid, jArgs);
             JPy_ON_JAVA_EXCEPTION_GOTO(error);
             returnValue = JPy_FromJString(jenv, v);
-            JPy_DELETE_LOCAL_REF(v);
+            (*jenv)->DeleteLocalRef(jenv, v);
         } else {
             jobject v = (*jenv)->CallObjectMethodA(jenv, objectRef, method->mid, jArgs);
             JPy_ON_JAVA_EXCEPTION_GOTO(error);
             returnValue = JMethod_FromJObject(jenv, method, pyArgs, jArgs, 1, returnType, v);
-            JPy_DELETE_LOCAL_REF(v);
+            (*jenv)->DeleteLocalRef(jenv, v);
         }
     }
 

--- a/py/jpy/src/main/c/jpy_jobj.c
+++ b/py/jpy/src/main/c/jpy_jobj.c
@@ -88,8 +88,7 @@ int JObj_init_internal(JNIEnv* jenv, JPy_JObj* self, PyObject* args, PyObject* k
     JPy_JType* jType;
     PyObject* constructor;
     JPy_JMethod* jMethod;
-    jobject localObjectRef;
-    jobject globalObjectRef;
+    jobject objectRef;
     jvalue* jArgs;
     JPy_ArgDisposer* jDisposers;
     int isVarArgsArray;
@@ -124,10 +123,10 @@ int JObj_init_internal(JNIEnv* jenv, JPy_JObj* self, PyObject* args, PyObject* k
 
     JPy_DIAG_PRINT(JPy_DIAG_F_MEM, "JObj_init: calling Java constructor %s\n", jType->javaName);
 
-    localObjectRef = (*jenv)->NewObjectA(jenv, jType->classRef, jMethod->mid, jArgs);
+    objectRef = (*jenv)->NewObjectA(jenv, jType->classRef, jMethod->mid, jArgs);
     JPy_ON_JAVA_EXCEPTION_RETURN(-1);
 
-    if (localObjectRef == NULL) {
+    if (objectRef == NULL) {
         PyErr_NoMemory();
         return -1;
     }
@@ -136,19 +135,18 @@ int JObj_init_internal(JNIEnv* jenv, JPy_JObj* self, PyObject* args, PyObject* k
         JMethod_DisposeJArgs(jenv, jMethod->paramCount, jArgs, jDisposers);
     }
 
-    globalObjectRef = (*jenv)->NewGlobalRef(jenv, localObjectRef);
-    if (globalObjectRef == NULL) {
+    objectRef = (*jenv)->NewGlobalRef(jenv, objectRef);
+    if (objectRef == NULL) {
         PyErr_NoMemory();
         return -1;
     }
-    JPy_DELETE_LOCAL_REF(localObjectRef);
 
     // Note:  __init__ may be called multiple times, so we have to release the old objectRef
     if (self->objectRef != NULL) {
         (*jenv)->DeleteGlobalRef(jenv, self->objectRef);
     }
 
-    self->objectRef = globalObjectRef;
+    self->objectRef = objectRef;
 
     JPy_DIAG_PRINT(JPy_DIAG_F_MEM, "JObj_init: self->objectRef=%p\n", self->objectRef);
 
@@ -351,7 +349,7 @@ PyObject* JObj_str(JPy_JObj* self)
     returnValue = JPy_FromJString(jenv, stringRef);
 
 error:
-    JPy_DELETE_LOCAL_REF(stringRef);
+    (*jenv)->DeleteLocalRef(jenv, stringRef);
 
     return returnValue;
 }
@@ -511,7 +509,7 @@ PyObject* JObj_getattro(JPy_JObj* self, PyObject* name)
             jobject item = (*jenv)->GetObjectField(jenv, self->objectRef, field->fid);
             JPy_ON_JAVA_EXCEPTION_RETURN(NULL);
             returnValue = JPy_FromJObjectWithType(jenv, item, field->type);
-            JPy_DELETE_LOCAL_REF(item);
+            (*jenv)->DeleteLocalRef(jenv, item);
             return returnValue;
         }
     } else {
@@ -610,7 +608,7 @@ PyObject* JObj_sq_item(JPy_JObj* self, Py_ssize_t index)
         jobject item = (*jenv)->GetObjectArrayElement(jenv, self->objectRef, (jsize) index);
         JPy_ON_JAVA_EXCEPTION_RETURN(NULL);
         returnValue = JPy_FromJObjectWithType(jenv, item, type->componentType);
-        JPy_DELETE_LOCAL_REF(item);
+        (*jenv)->DeleteLocalRef(jenv, item);
         return returnValue;
     }
 }

--- a/py/jpy/src/main/c/jpy_jtype.c
+++ b/py/jpy/src/main/c/jpy_jtype.c
@@ -57,7 +57,7 @@ JPy_JType* JType_GetTypeForObject(JNIEnv* jenv, jobject objectRef, jboolean reso
     jclass classRef;
     classRef = (*jenv)->GetObjectClass(jenv, objectRef);
     type = JType_GetType(jenv, classRef, resolve);
-    JPy_DELETE_LOCAL_REF(classRef);
+    (*jenv)->DeleteLocalRef(jenv, classRef);
     return type;
 }
 
@@ -66,7 +66,6 @@ JPy_JType* JType_GetTypeForName(JNIEnv* jenv, const char* typeName, jboolean res
 {
     const char* resourceName;
     jclass classRef;
-    JPy_JType *result;
 
     JPy_JType* javaType = NULL;
     if (strcmp(typeName, "boolean") == 0) {
@@ -125,9 +124,7 @@ JPy_JType* JType_GetTypeForName(JNIEnv* jenv, const char* typeName, jboolean res
         return NULL;
     }
 
-    result = JType_GetType(jenv, classRef, resolve);
-    JPy_DELETE_LOCAL_REF(classRef);
-    return result;
+    return JType_GetType(jenv, classRef, resolve);
 }
 
 /**
@@ -272,21 +269,7 @@ JPy_JType* JType_New(JNIEnv* jenv, jclass classRef, jboolean resolve)
     }
 
     type->isPrimitive = (*jenv)->CallBooleanMethod(jenv, type->classRef, JPy_Class_IsPrimitive_MID);
-    if ((*jenv)->ExceptionCheck(jenv)) {
-        (*jenv)->ExceptionClear(jenv);
-        PyMem_Del(type->javaName);
-        type->javaName = NULL;
-        metaType->tp_free(type);
-        return NULL;
-    }
     type->isInterface = (*jenv)->CallBooleanMethod(jenv, type->classRef, JPy_Class_IsInterface_MID);
-    if ((*jenv)->ExceptionCheck(jenv)) {
-        (*jenv)->ExceptionClear(jenv);
-        PyMem_Del(type->javaName);
-        type->javaName = NULL;
-        metaType->tp_free(type);
-        return NULL;
-    }
 
     JPy_DIAG_PRINT(JPy_DIAG_F_TYPE, "JType_New: javaName=\"%s\", resolve=%d, type=%p\n", type->javaName, resolve, type);
 
@@ -560,7 +543,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jboolean* items = (*jenv)->GetBooleanArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -568,14 +551,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseBooleanArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JBOOLEAN(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseBooleanArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -590,7 +573,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jbyte* items = (*jenv)->GetByteArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -598,14 +581,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseByteArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JBYTE(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseByteArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -620,7 +603,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jchar* items = (*jenv)->GetCharArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -628,14 +611,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseCharArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JCHAR(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseCharArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -650,7 +633,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jshort* items = (*jenv)->GetShortArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -658,14 +641,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseShortArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JSHORT(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseShortArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -680,7 +663,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jint* items = (*jenv)->GetIntArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -688,14 +671,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseIntArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JINT(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseIntArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -710,7 +693,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jlong* items = (*jenv)->GetLongArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -718,14 +701,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseLongArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JLONG(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseLongArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -740,7 +723,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jfloat* items = (*jenv)->GetFloatArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -748,14 +731,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseFloatArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JFLOAT(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseFloatArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -770,7 +753,7 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         if (itemCount > 0) {
             jdouble* items = (*jenv)->GetDoubleArrayElements(jenv, arrayRef, NULL);
             if (items == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 PyErr_NoMemory();
                 return -1;
             }
@@ -778,14 +761,14 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
                 pyItem = PySequence_GetItem(pyArg, index);
                 if (pyItem == NULL) {
                     (*jenv)->ReleaseDoubleArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
                 items[index] = JPy_AS_JDOUBLE(pyItem);
                 Py_DECREF(pyItem);
                 if (PyErr_Occurred()) {
                     (*jenv)->ReleaseDoubleArrayElements(jenv, arrayRef, items, 0);
-                    JPy_DELETE_LOCAL_REF(arrayRef);
+                    (*jenv)->DeleteLocalRef(jenv, arrayRef);
                     return -1;
                 }
             }
@@ -801,19 +784,19 @@ int JType_CreateJavaArray(JNIEnv* jenv, JPy_JType* componentType, PyObject* pyAr
         for (index = 0; index < itemCount; index++) {
             pyItem = PySequence_GetItem(pyArg, index);
             if (pyItem == NULL) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 return -1;
             }
             if (JType_ConvertPythonToJavaObject(jenv, componentType, pyItem, &jItem, allowObjectWrapping) < 0) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
                 Py_DECREF(pyItem);
                 return -1;
             }
             Py_DECREF(pyItem);
             (*jenv)->SetObjectArrayElement(jenv, arrayRef, index, jItem);
             if ((*jenv)->ExceptionCheck(jenv)) {
-                JPy_DELETE_LOCAL_REF(arrayRef);
-                JPy_DELETE_LOCAL_REF(jItem);
+                (*jenv)->DeleteLocalRef(jenv, arrayRef);
+                (*jenv)->DeleteLocalRef(jenv, jItem);
                 JPy_HandleJavaException(jenv);
                 return -1;
             }
@@ -1057,10 +1040,8 @@ int JType_InitComponentType(JNIEnv* jenv, JPy_JType* type, jboolean resolve)
     jclass componentTypeRef;
 
     componentTypeRef = (jclass) (*jenv)->CallObjectMethod(jenv, type->classRef, JPy_Class_GetComponentType_MID);
-    JPy_ON_JAVA_EXCEPTION_RETURN(-1);
     if (componentTypeRef != NULL) {
         type->componentType = JType_GetType(jenv, componentTypeRef, resolve);
-        JPy_DELETE_LOCAL_REF(componentTypeRef);
         if (type->componentType == NULL) {
             return -1;
         }
@@ -1083,7 +1064,7 @@ int JType_InitSuperType(JNIEnv* jenv, JPy_JType* type, jboolean resolve)
             return -1;
         }
         Py_INCREF(type->superType);
-        JPy_DELETE_LOCAL_REF(superClassRef);
+        (*jenv)->DeleteLocalRef(jenv, superClassRef);
     } else if (type->isInterface && JPy_JObject != NULL) {
         // This solves the problems that java.lang.Object methods can not be called on interfaces (https://github.com/bcdev/jpy/issues/57)
         type->superType = JPy_JObject;
@@ -1113,7 +1094,6 @@ int JType_ProcessClassConstructors(JNIEnv* jenv, JPy_JType* type)
     classRef = type->classRef;
     methodKey = Py_BuildValue("s", JPy_JTYPE_ATTR_NAME_JINIT);
     constructors = (*jenv)->CallObjectMethod(jenv, classRef, JPy_Class_GetDeclaredConstructors_MID);
-    JPy_ON_JAVA_EXCEPTION_RETURN(-1);
     constrCount = (*jenv)->GetArrayLength(jenv, constructors);
 
     JPy_DIAG_PRINT(JPy_DIAG_F_TYPE, "JType_ProcessClassConstructors: constrCount=%d\n", constrCount);
@@ -1121,20 +1101,18 @@ int JType_ProcessClassConstructors(JNIEnv* jenv, JPy_JType* type)
     for (i = 0; i < constrCount; i++) {
         constructor = (*jenv)->GetObjectArrayElement(jenv, constructors, i);
         modifiers = (*jenv)->CallIntMethod(jenv, constructor, JPy_Constructor_GetModifiers_MID);
-        JPy_ON_JAVA_EXCEPTION_RETURN(-1);
         isPublic = (modifiers & 0x0001) != 0;
         isVarArg = (modifiers & 0x0080) != 0;
         if (isPublic) {
             parameterTypes = (*jenv)->CallObjectMethod(jenv, constructor, JPy_Constructor_GetParameterTypes_MID);
-            JPy_ON_JAVA_EXCEPTION_RETURN(-1);
             mid = (*jenv)->FromReflectedMethod(jenv, constructor);
             JType_ProcessMethod(jenv, type, methodKey, JPy_JTYPE_ATTR_NAME_JINIT, NULL, parameterTypes, 1, isVarArg, mid);
-            JPy_DELETE_LOCAL_REF(parameterTypes);
+            (*jenv)->DeleteLocalRef(jenv, parameterTypes);
         }
-        JPy_DELETE_LOCAL_REF(constructor);
+        (*jenv)->DeleteLocalRef(jenv, constructor);
     }
 
-    JPy_DELETE_LOCAL_REF(constructors);
+    (*jenv)->DeleteLocalRef(jenv, constructors);
 
     return 0;
 }
@@ -1163,7 +1141,6 @@ int JType_ProcessClassFields(JNIEnv* jenv, JPy_JType* type)
     } else {
         fields = (*jenv)->CallObjectMethod(jenv, classRef, JPy_Class_GetDeclaredFields_MID);
     }
-    JPy_ON_JAVA_EXCEPTION_RETURN(-1);
     fieldCount = (*jenv)->GetArrayLength(jenv, fields);
 
     JPy_DIAG_PRINT(JPy_DIAG_F_TYPE, "JType_ProcessClassFields: fieldCount=%d\n", fieldCount);
@@ -1171,16 +1148,13 @@ int JType_ProcessClassFields(JNIEnv* jenv, JPy_JType* type)
     for (i = 0; i < fieldCount; i++) {
         field = (*jenv)->GetObjectArrayElement(jenv, fields, i);
         modifiers = (*jenv)->CallIntMethod(jenv, field, JPy_Field_GetModifiers_MID);
-        JPy_ON_JAVA_EXCEPTION_RETURN(-1);
         // see http://docs.oracle.com/javase/6/docs/api/constant-values.html#java.lang.reflect.Modifier.PUBLIC
         isPublic = (modifiers & 0x0001) != 0;
         isStatic = (modifiers & 0x0008) != 0;
         isFinal  = (modifiers & 0x0010) != 0;
         if (isPublic) {
             fieldNameStr = (*jenv)->CallObjectMethod(jenv, field, JPy_Field_GetName_MID);
-            JPy_ON_JAVA_EXCEPTION_RETURN(-1);
             fieldTypeObj = (*jenv)->CallObjectMethod(jenv, field, JPy_Field_GetType_MID);
-            JPy_ON_JAVA_EXCEPTION_RETURN(-1);
             fid = (*jenv)->FromReflectedField(jenv, field);
 
             fieldName = (*jenv)->GetStringUTFChars(jenv, fieldNameStr, NULL);
@@ -1188,16 +1162,17 @@ int JType_ProcessClassFields(JNIEnv* jenv, JPy_JType* type)
             JType_ProcessField(jenv, type, fieldKey, fieldName, fieldTypeObj, isStatic, isFinal, fid);
             (*jenv)->ReleaseStringUTFChars(jenv, fieldNameStr, fieldName);
 
-            JPy_DELETE_LOCAL_REF(fieldTypeObj);
-            JPy_DELETE_LOCAL_REF(fieldNameStr);
+            (*jenv)->DeleteLocalRef(jenv, fieldTypeObj);
+            (*jenv)->DeleteLocalRef(jenv, fieldNameStr);
         }
-        JPy_DELETE_LOCAL_REF(field);
+        (*jenv)->DeleteLocalRef(jenv, field);
     }
-    JPy_DELETE_LOCAL_REF(fields);
+    (*jenv)->DeleteLocalRef(jenv, fields);
     return 0;
 }
 
-int JType_ProcessClassMethods(JNIEnv* jenv, JPy_JType* type) {
+int JType_ProcessClassMethods(JNIEnv* jenv, JPy_JType* type)
+{
     jclass classRef;
     jobject methods;
     jobject method;
@@ -1211,24 +1186,20 @@ int JType_ProcessClassMethods(JNIEnv* jenv, JPy_JType* type) {
     jboolean isVarArg;
     jboolean isPublic;
     jboolean isBridge;
-    const char *methodName;
+    const char* methodName;
     jmethodID mid;
-    PyObject *methodKey;
+    PyObject* methodKey;
 
     classRef = type->classRef;
 
     methods = (*jenv)->CallObjectMethod(jenv, classRef, JPy_Class_GetMethods_MID);
-    JPy_ON_JAVA_EXCEPTION_RETURN(-1);
     methodCount = (*jenv)->GetArrayLength(jenv, methods);
-    JPy_ON_JAVA_EXCEPTION_RETURN(-1);
 
     JPy_DIAG_PRINT(JPy_DIAG_F_TYPE, "JType_ProcessClassMethods: methodCount=%d\n", methodCount);
 
     for (i = 0; i < methodCount; i++) {
         method = (*jenv)->GetObjectArrayElement(jenv, methods, i);
         modifiers = (*jenv)->CallIntMethod(jenv, method, JPy_Method_GetModifiers_MID);
-        JPy_ON_JAVA_EXCEPTION_RETURN(-1);
-
         // see http://docs.oracle.com/javase/6/docs/api/constant-values.html#java.lang.reflect.Modifier.PUBLIC
         isPublic   = (modifiers & 0x0001) != 0;
         isStatic   = (modifiers & 0x0008) != 0;
@@ -1237,11 +1208,8 @@ int JType_ProcessClassMethods(JNIEnv* jenv, JPy_JType* type) {
         // we exclude bridge methods; as covariant return types will result in bridge methods that cause ambiguity
         if (isPublic && !isBridge) {
             methodNameStr = (*jenv)->CallObjectMethod(jenv, method, JPy_Method_GetName_MID);
-            JPy_ON_JAVA_EXCEPTION_RETURN(-1);
             returnType = (*jenv)->CallObjectMethod(jenv, method, JPy_Method_GetReturnType_MID);
-            JPy_ON_JAVA_EXCEPTION_RETURN(-1);
             parameterTypes = (*jenv)->CallObjectMethod(jenv, method, JPy_Method_GetParameterTypes_MID);
-            JPy_ON_JAVA_EXCEPTION_RETURN(-1);
             mid = (*jenv)->FromReflectedMethod(jenv, method);
 
             methodName = (*jenv)->GetStringUTFChars(jenv, methodNameStr, NULL);
@@ -1249,13 +1217,13 @@ int JType_ProcessClassMethods(JNIEnv* jenv, JPy_JType* type) {
             JType_ProcessMethod(jenv, type, methodKey, methodName, returnType, parameterTypes, isStatic, isVarArg, mid);
             (*jenv)->ReleaseStringUTFChars(jenv, methodNameStr, methodName);
 
-            JPy_DELETE_LOCAL_REF(parameterTypes);
-            JPy_DELETE_LOCAL_REF(returnType);
-            JPy_DELETE_LOCAL_REF(methodNameStr);
+            (*jenv)->DeleteLocalRef(jenv, parameterTypes);
+            (*jenv)->DeleteLocalRef(jenv, returnType);
+            (*jenv)->DeleteLocalRef(jenv, methodNameStr);
         }
-        JPy_DELETE_LOCAL_REF(method);
+        (*jenv)->DeleteLocalRef(jenv, method);
     }
-    JPy_DELETE_LOCAL_REF(methods);
+    (*jenv)->DeleteLocalRef(jenv, methods);
     return 0;
 }
 
@@ -1330,11 +1298,11 @@ int JType_AddFieldAttribute(JNIEnv* jenv, JPy_JType* declaringClass, PyObject* f
     } else if (fieldType == JPy_JString) {
         jstring objectRef = (*jenv)->GetStaticObjectField(jenv, declaringClass->classRef, fid);
         fieldValue = JPy_FromJString(jenv, objectRef);
-        JPy_DELETE_LOCAL_REF(objectRef);
+        (*jenv)->DeleteLocalRef(jenv, objectRef);
     } else {
         jobject objectRef = (*jenv)->GetStaticObjectField(jenv, declaringClass->classRef, fid);
         fieldValue = JPy_FromJObjectWithType(jenv, objectRef, (JPy_JType*) fieldType);
-        JPy_DELETE_LOCAL_REF(objectRef);
+        (*jenv)->DeleteLocalRef(jenv, objectRef);
     }
     PyDict_SetItem(typeDict, fieldName, fieldValue);
     return 0;
@@ -1496,7 +1464,6 @@ JPy_ParamDescriptor* JType_CreateParamDescriptors(JNIEnv* jenv, int paramCount, 
         paramDescriptor = paramDescriptors + i;
 
         type = JType_GetType(jenv, paramClass, JNI_FALSE);
-        JPy_DELETE_LOCAL_REF(paramClass);
         if (type == NULL) {
             return NULL;
         }
@@ -1674,6 +1641,7 @@ int JType_MatchVarArgPyArgAsJObjectParam(JNIEnv* jenv, JPy_ParamDescriptor* para
     Py_ssize_t remaining = (argCount - idx);
 
     JPy_JType *componentType = paramDescriptor->type->componentType;
+    PyObject *varArgs;
     int minMatch = 100;
     int ii;
 
@@ -1685,15 +1653,15 @@ int JType_MatchVarArgPyArgAsJObjectParam(JNIEnv* jenv, JPy_ParamDescriptor* para
         return 10;
     }
 
+    varArgs = PyTuple_GetSlice(pyArg, idx, argCount);
     for (ii = 0; ii < remaining; ii++) {
-        PyObject *unpack = PyTuple_GetItem(pyArg, idx + ii);
+        PyObject *unpack = PyTuple_GetItem(varArgs, ii);
         int matchValue = JType_MatchPyArgAsJObject(jenv, componentType, unpack);
         if (matchValue == 0) {
             return 0;
         }
         minMatch = matchValue < minMatch ? matchValue : minMatch;
     }
-
     return minMatch;
 }
 
@@ -1703,6 +1671,7 @@ int JType_MatchVarArgPyArgAsJStringParam(JNIEnv* jenv, JPy_ParamDescriptor* para
     Py_ssize_t remaining = (argCount - idx);
 
     JPy_JType *componentType = paramDescriptor->type->componentType;
+    PyObject *varArgs;
     int minMatch = 100;
     int ii;
 
@@ -1714,15 +1683,15 @@ int JType_MatchVarArgPyArgAsJStringParam(JNIEnv* jenv, JPy_ParamDescriptor* para
         return 10;
     }
 
+    varArgs = PyTuple_GetSlice(pyArg, idx, argCount);
     for (ii = 0; ii < remaining; ii++) {
-        PyObject *unpack = PyTuple_GetItem(pyArg, idx + ii);
+        PyObject *unpack = PyTuple_GetItem(varArgs, ii);
         int matchValue = JType_MatchPyArgAsJStringParam(jenv, paramDescriptor, unpack);
         if (matchValue == 0) {
             return 0;
         }
         minMatch = matchValue < minMatch ? matchValue : minMatch;
     }
-
     return minMatch;
 }
 
@@ -1732,6 +1701,7 @@ int JType_MatchVarArgPyArgAsJPyObjectParam(JNIEnv* jenv, JPy_ParamDescriptor* pa
     Py_ssize_t remaining = (argCount - idx);
 
     JPy_JType *componentType = paramDescriptor->type->componentType;
+    PyObject *varArgs;
     int minMatch = 100;
     int ii;
 
@@ -1743,8 +1713,9 @@ int JType_MatchVarArgPyArgAsJPyObjectParam(JNIEnv* jenv, JPy_ParamDescriptor* pa
         return 10;
     }
 
+    varArgs = PyTuple_GetSlice(pyArg, idx, argCount);
     for (ii = 0; ii < remaining; ii++) {
-        PyObject *unpack = PyTuple_GetItem(pyArg, idx + ii);
+        PyObject *unpack = PyTuple_GetItem(varArgs, ii);
         int matchValue = JType_MatchPyArgAsJPyObjectParam(jenv, paramDescriptor, unpack);
         if (matchValue == 0) {
             return 0;
@@ -1760,6 +1731,7 @@ int JType_MatchVarArgPyArgAsJBooleanParam(JNIEnv *jenv, JPy_ParamDescriptor *par
     Py_ssize_t remaining = (argCount - idx);
 
     JPy_JType *componentType = paramDescriptor->type->componentType;
+    PyObject *varArgs;
     int minMatch = 100;
     int ii;
 
@@ -1772,8 +1744,9 @@ int JType_MatchVarArgPyArgAsJBooleanParam(JNIEnv *jenv, JPy_ParamDescriptor *par
         return 10;
     }
 
+    varArgs = PyTuple_GetSlice(pyArg, idx, argCount);
     for (ii = 0; ii < remaining; ii++) {
-        PyObject *unpack = PyTuple_GetItem(pyArg, idx + ii);
+        PyObject *unpack = PyTuple_GetItem(varArgs, ii);
 
         int matchValue;
         if (PyBool_Check(unpack)) matchValue = 100;
@@ -1816,6 +1789,7 @@ int JType_MatchVarArgPyArgIntType(const JPy_ParamDescriptor *paramDescriptor, Py
     Py_ssize_t remaining = (argCount - idx);
 
     JPy_JType *componentType = paramDescriptor->type->componentType;
+    PyObject *varArgs;
     int minMatch = 100;
     int ii;
 
@@ -1828,8 +1802,9 @@ int JType_MatchVarArgPyArgIntType(const JPy_ParamDescriptor *paramDescriptor, Py
         return 10;
     }
 
+    varArgs = PyTuple_GetSlice(pyArg, idx, argCount);
     for (ii = 0; ii < remaining; ii++) {
-        PyObject *unpack = PyTuple_GetItem(pyArg, idx + ii);
+        PyObject *unpack = PyTuple_GetItem(varArgs, ii);
 
         int matchValue;
         if (JPy_IS_CLONG(unpack)) matchValue = 100;
@@ -1860,6 +1835,7 @@ int JType_MatchVarArgPyArgAsFPType(const JPy_ParamDescriptor *paramDescriptor, P
     Py_ssize_t remaining = (argCount - idx);
 
     JPy_JType *componentType = paramDescriptor->type->componentType;
+    PyObject *varArgs;
     int minMatch = 100;
     int ii;
 
@@ -1872,8 +1848,9 @@ int JType_MatchVarArgPyArgAsFPType(const JPy_ParamDescriptor *paramDescriptor, P
         return 10;
     }
 
+    varArgs = PyTuple_GetSlice(pyArg, idx, argCount);
     for (ii = 0; ii < remaining; ii++) {
-        PyObject *unpack = PyTuple_GetItem(pyArg, idx + ii);
+        PyObject *unpack = PyTuple_GetItem(varArgs, ii);
 
         int matchValue;
         if (PyFloat_Check(unpack)) matchValue = floatMatch;
@@ -1921,14 +1898,12 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
             pyBuffer = PyMem_New(Py_buffer, 1);
             if (pyBuffer == NULL) {
                 PyErr_NoMemory();
-                Py_DECREF(pyArg);
                 return -1;
             }
 
             flags = paramDescriptor->isMutable ? PyBUF_WRITABLE : PyBUF_SIMPLE;
             if (PyObject_GetBuffer(pyArg, pyBuffer, flags) < 0) {
                 PyMem_Del(pyBuffer);
-                Py_DECREF(pyArg);
                 return -1;
             }
 
@@ -1936,7 +1911,6 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
             if (itemCount <= 0) {
                 PyBuffer_Release(pyBuffer);
                 PyMem_Del(pyBuffer);
-                Py_DECREF(pyArg);
                 PyErr_Format(PyExc_ValueError, "illegal buffer argument: not a positive item count: %ld", itemCount);
                 return -1;
             }
@@ -1966,7 +1940,6 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
                 jArray = (*jenv)->NewDoubleArray(jenv, itemCount);
                 itemSize = sizeof(jdouble);
             } else {
-                Py_DECREF(pyArg);
                 PyBuffer_Release(pyBuffer);
                 PyMem_Del(pyBuffer);
                 PyErr_SetString(PyExc_RuntimeError, "internal error: illegal primitive Java type");
@@ -1977,7 +1950,6 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
                 Py_ssize_t bufferLen = pyBuffer->len;
                 Py_ssize_t bufferItemSize = pyBuffer->itemsize;
                 //printf("%ld, %ld, %ld, %ld\n", pyBuffer->len , pyBuffer->itemsize, itemCount, itemSize);
-                Py_DECREF(pyArg);
                 PyBuffer_Release(pyBuffer);
                 PyMem_Del(pyBuffer);
                 PyErr_Format(PyExc_ValueError,
@@ -1987,7 +1959,6 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
             }
 
             if (jArray == NULL) {
-                Py_DECREF(pyArg);
                 PyBuffer_Release(pyBuffer);
                 PyMem_Del(pyBuffer);
                 PyErr_NoMemory();
@@ -1997,7 +1968,6 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
             if (!paramDescriptor->isOutput) {
                 arrayItems = (*jenv)->GetPrimitiveArrayCritical(jenv, jArray, NULL);
                 if (arrayItems == NULL) {
-                    Py_DECREF(pyArg);
                     PyBuffer_Release(pyBuffer);
                     PyMem_Del(pyBuffer);
                     PyErr_NoMemory();
@@ -2014,7 +1984,6 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
         } else {
             jobject objectRef;
             if (JType_ConvertPythonToJavaObject(jenv, paramType, pyArg, &objectRef, JNI_FALSE) < 0) {
-                Py_DECREF(pyArg);
                 return -1;
             }
             value->l = objectRef;
@@ -2022,8 +1991,6 @@ int JType_ConvertVarArgPyArgToJObjectArg(JNIEnv* jenv, JPy_ParamDescriptor* para
             disposer->DisposeArg = JType_DisposeLocalObjectRefArg;
         }
     }
-
-    Py_DECREF(pyArg);
 
     return 0;
 }
@@ -2368,7 +2335,7 @@ void JType_DisposeLocalObjectRefArg(JNIEnv* jenv, jvalue* value, void* data)
     jobject objectRef = value->l;
     if (objectRef != NULL) {
         JPy_DIAG_PRINT(JPy_DIAG_F_MEM, "JType_DisposeLocalObjectRefArg: objectRef=%p\n", objectRef);
-        JPy_DELETE_LOCAL_REF(objectRef);
+        (*jenv)->DeleteLocalRef(jenv, objectRef);
     }
 }
 
@@ -2387,7 +2354,7 @@ void JType_DisposeReadOnlyBufferArg(JNIEnv* jenv, jvalue* value, void* data)
         PyMem_Del(pyBuffer);
     }
     if (jArray != NULL) {
-        JPy_DELETE_LOCAL_REF(jArray);
+        (*jenv)->DeleteLocalRef(jenv, jArray);
     }
 }
 
@@ -2410,14 +2377,14 @@ void JType_DisposeWritableBufferArg(JNIEnv* jenv, jvalue* value, void* data)
             memcpy(pyBuffer->buf, arrayItems, pyBuffer->len);
             (*jenv)->ReleasePrimitiveArrayCritical(jenv, jArray, arrayItems, 0);
         }
-        JPy_DELETE_LOCAL_REF(jArray);
+        (*jenv)->DeleteLocalRef(jenv, jArray);
         PyBuffer_Release(pyBuffer);
         PyMem_Del(pyBuffer);
     } else if (pyBuffer != NULL) {
         PyBuffer_Release(pyBuffer);
         PyMem_Del(pyBuffer);
     } else if (jArray != NULL) {
-        JPy_DELETE_LOCAL_REF(jArray);
+        (*jenv)->DeleteLocalRef(jenv, jArray);
     }
 }
 
@@ -2524,7 +2491,7 @@ PyObject* JType_str(JPy_JType* self)
     utfChars = (*jenv)->GetStringUTFChars(jenv, strJObj, &isCopy);
     strPyObj = JPy_FROM_FORMAT("%s", utfChars);
     (*jenv)->ReleaseStringUTFChars(jenv, strJObj, utfChars);
-    JPy_DELETE_LOCAL_REF(strJObj);
+    (*jenv)->DeleteLocalRef(jenv, strJObj);
 
     return strPyObj;
 }

--- a/py/jpy/src/main/c/jpy_module.c
+++ b/py/jpy/src/main/c/jpy_module.c
@@ -679,7 +679,6 @@ JPy_JType* JPy_GetNonObjectJType(JNIEnv* jenv, jclass classRef)
     }
 
     type = JType_GetType(jenv, primClassRef, JNI_FALSE);
-    JPy_DELETE_LOCAL_REF(primClassRef);
     if (type == NULL) {
         return NULL;
     }
@@ -702,7 +701,7 @@ jclass JPy_GetClass(JNIEnv* jenv, const char* name)
     }
 
     globalClassRef = (*jenv)->NewGlobalRef(jenv, localClassRef);
-    JPy_DELETE_LOCAL_REF(localClassRef);
+    //(*jenv)->DeleteLocalRef(jenv, localClassRef);
     if (globalClassRef == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -1161,7 +1160,7 @@ void JPy_HandleJavaException(JNIEnv* jenv)
                         allocError = 1;
                         break;
                     }
-                    JPy_DELETE_LOCAL_REF(message);
+                    (*jenv)->DeleteLocalRef(jenv, message);
                 }
 
                 /* We should assemble a string based on the stack trace. */
@@ -1266,13 +1265,13 @@ void JPy_HandleJavaException(JNIEnv* jenv)
                     PyErr_SetString(PyExc_RuntimeError,
                                     "Java VM exception occurred, but failed to allocate message text");
                 }
-                JPy_DELETE_LOCAL_REF(message);
+                (*jenv)->DeleteLocalRef(jenv, message);
             } else {
                 PyErr_SetString(PyExc_RuntimeError, "Java VM exception occurred, no message");
             }
         }
 
-        JPy_DELETE_LOCAL_REF(error);
+        (*jenv)->DeleteLocalRef(jenv, error);
         (*jenv)->ExceptionClear(jenv);
     }
 }

--- a/py/jpy/src/main/c/jpy_module.h
+++ b/py/jpy/src/main/c/jpy_module.h
@@ -80,9 +80,6 @@ void JPy_ClearGlobalVars(JNIEnv* jenv);
  */
 void JPy_HandleJavaException(JNIEnv* jenv);
 
-#define JPy_DELETE_LOCAL_REF(VALUE) \
-    (*jenv)->DeleteLocalRef(jenv, VALUE); \
-    VALUE = NULL;
 
 #define JPy_ON_JAVA_EXCEPTION_GOTO(LABEL) \
     if ((*jenv)->ExceptionCheck(jenv)) { \

--- a/py/jpy/src/test/python/jpy_exception_test.py
+++ b/py/jpy/src/test/python/jpy_exception_test.py
@@ -27,18 +27,13 @@ class TestExceptions(unittest.TestCase):
         fixture = self.Fixture()
         self.assertEqual(fixture.throwAioobeIfIndexIsNotZero(0), 101)
 
-        with self.assertRaises(RuntimeError, msg='Java ArrayIndexOutOfBoundsException expected') as e:
+        with  self.assertRaises(RuntimeError, msg='Java ArrayIndexOutOfBoundsException expected') as e:
             fixture.throwAioobeIfIndexIsNotZero(1)
-        exceptText = str(e.exception)
-        if not exceptText == "java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1":
-            print("Except Text", exceptText)
-            self.assertEqual(str(e.exception), 'java.lang.ArrayIndexOutOfBoundsException: 1')
+        self.assertEqual(str(e.exception), 'java.lang.ArrayIndexOutOfBoundsException: 1')
 
-        with self.assertRaises(RuntimeError, msg='Java ArrayIndexOutOfBoundsException expected') as e:
+        with  self.assertRaises(RuntimeError, msg='Java ArrayIndexOutOfBoundsException expected') as e:
             fixture.throwAioobeIfIndexIsNotZero(-1)
-        exceptText = str(e.exception)
-        if not exceptText == "java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 1":
-            self.assertEqual(str(e.exception), 'java.lang.ArrayIndexOutOfBoundsException: -1')
+        self.assertEqual(str(e.exception), 'java.lang.ArrayIndexOutOfBoundsException: -1')
 
 
     def test_RuntimeException(self):


### PR DESCRIPTION
This fix seems to be causing JVM crashes in at least one deephaven2 test.
Reverts deephaven/deephaven-core#2105