### PR TITLE
Avoid clock checks for snapshots of static tables

### DIFF
--- a/ClientSupport/src/main/java/io/deephaven/treetable/AbstractTreeSnapshotImpl.java
+++ b/ClientSupport/src/main/java/io/deephaven/treetable/AbstractTreeSnapshotImpl.java
@@ -326,7 +326,8 @@ public abstract class AbstractTreeSnapshotImpl<INFO_TYPE extends HierarchicalTab
         // NB: Our snapshot control must be notification-aware, because if source ticks we cannot guarantee that we
         // won't observe some newly created components on their instantiation step.
         final ConstructSnapshot.SnapshotControl control =
-                ConstructSnapshot.makeSnapshotControl(true, baseTable.isRefreshing(), ((NotificationStepSource) baseTable.getSourceTable()));
+                ConstructSnapshot.makeSnapshotControl(true, baseTable.isRefreshing(),
+                        ((NotificationStepSource) baseTable.getSourceTable()));
         final MutableObject<SnapshotState> finalState = new MutableObject<>();
         ConstructSnapshot.callDataSnapshotFunction(getClass().getSimpleName(), control,
                 (final boolean usePrev, final long beforeClockValue) -> {

--- a/ClientSupport/src/main/java/io/deephaven/treetable/AbstractTreeSnapshotImpl.java
+++ b/ClientSupport/src/main/java/io/deephaven/treetable/AbstractTreeSnapshotImpl.java
@@ -326,7 +326,7 @@ public abstract class AbstractTreeSnapshotImpl<INFO_TYPE extends HierarchicalTab
         // NB: Our snapshot control must be notification-aware, because if source ticks we cannot guarantee that we
         // won't observe some newly created components on their instantiation step.
         final ConstructSnapshot.SnapshotControl control =
-                ConstructSnapshot.makeSnapshotControl(true, ((NotificationStepSource) baseTable.getSourceTable()));
+                ConstructSnapshot.makeSnapshotControl(true, baseTable.isRefreshing(), ((NotificationStepSource) baseTable.getSourceTable()));
         final MutableObject<SnapshotState> finalState = new MutableObject<>();
         ConstructSnapshot.callDataSnapshotFunction(getClass().getSimpleName(), control,
                 (final boolean usePrev, final long beforeClockValue) -> {

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
@@ -207,7 +207,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
      * @return A function that runs a {@link }
      */
     @SuppressWarnings("WeakerAccess")
-    protected static FunctionalInterfaces.ThrowingBiConsumer<QueryDataRetrievalOperation, NotificationStepSource, RuntimeException> getDoLockedConsumer(
+    protected static FunctionalInterfaces.ThrowingBiConsumer<QueryDataRetrievalOperation, Table, RuntimeException> getDoLockedConsumer(
             final GetDataLockType lockType) {
         switch (lockType) {
             case UGP_LOCK_ALREADY_HELD:
@@ -222,7 +222,8 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
                 return (queryDataRetrievalOperation, source) -> {
                     try {
                         ConstructSnapshot.callDataSnapshotFunction("ModelFarmBase.getData(SNAPSHOT)",
-                                ConstructSnapshot.makeSnapshotControl(false, true, source),
+                                ConstructSnapshot.makeSnapshotControl(false, source.isRefreshing(),
+                                        (NotificationStepSource) source),
                                 (usePrev, beforeClockValue) -> {
                                     queryDataRetrievalOperation.retrieveData(usePrev);
                                     return true; // This indicates that the snapshot ran OK, not that the data is OK.

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmBase.java
@@ -222,7 +222,7 @@ public abstract class ModelFarmBase<DATATYPE> implements ModelFarm {
                 return (queryDataRetrievalOperation, source) -> {
                     try {
                         ConstructSnapshot.callDataSnapshotFunction("ModelFarmBase.getData(SNAPSHOT)",
-                                ConstructSnapshot.makeSnapshotControl(false, source),
+                                ConstructSnapshot.makeSnapshotControl(false, true, source),
                                 (usePrev, beforeClockValue) -> {
                                     queryDataRetrievalOperation.retrieveData(usePrev);
                                     return true; // This indicates that the snapshot ran OK, not that the data is OK.

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmOnDemand.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmOnDemand.java
@@ -34,7 +34,7 @@ public class ModelFarmOnDemand<KEYTYPE, DATATYPE, ROWDATAMANAGERTYPE extends Row
     private static final boolean LOG_PERF =
             Configuration.getInstance().getBooleanWithDefault("ModelFarm.logModelFarmOnDemandPerformance", false);
     private static final Logger log = LoggerFactory.getLogger(ModelFarmOnDemand.class);
-    private static final FunctionalInterfaces.ThrowingBiConsumer<QueryDataRetrievalOperation, NotificationStepSource, RuntimeException> DO_LOCKED_FUNCTION =
+    private static final FunctionalInterfaces.ThrowingBiConsumer<QueryDataRetrievalOperation, Table, RuntimeException> DO_LOCKED_FUNCTION =
             getDoLockedConsumer(GetDataLockType.UGP_READ_LOCK);
 
     private static class QueueAndCallback<DATATYPE> {

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmOnDemand.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/ModelFarmOnDemand.java
@@ -131,7 +131,7 @@ public class ModelFarmOnDemand<KEYTYPE, DATATYPE, ROWDATAMANAGERTYPE extends Row
                     dataToEval.add(data);
                 }
             }
-        }, (NotificationStepSource) dataManagerTable);
+        }, dataManagerTable);
 
         if (dataToEval.isEmpty()) {
             log.warn().append("ModelFarmOnDemand: dataToEval is empty!").endl();

--- a/ModelFarm/src/main/java/io/deephaven/modelfarm/RDMModelFarm.java
+++ b/ModelFarm/src/main/java/io/deephaven/modelfarm/RDMModelFarm.java
@@ -6,6 +6,7 @@ package io.deephaven.modelfarm;
 
 import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.Require;
+import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.ShiftObliviousInstrumentedListenerAdapter;
 import io.deephaven.engine.table.impl.NotificationStepSource;
 import io.deephaven.engine.rowset.RowSet;
@@ -178,7 +179,7 @@ public abstract class RDMModelFarm<KEYTYPE, DATATYPE, ROWDATAMANAGERTYPE extends
             final ModelFarmBase.GetDataLockType lockType) {
         // Get the "doLockedConsumer", which will call the FitDataPopulator (i.e. the lambda below) using the configured
         // lock type and the appropriate value for 'usePrev'.
-        final FunctionalInterfaces.ThrowingBiConsumer<ModelFarmBase.QueryDataRetrievalOperation, NotificationStepSource, RuntimeException> doLockedConsumer =
+        final FunctionalInterfaces.ThrowingBiConsumer<ModelFarmBase.QueryDataRetrievalOperation, Table, RuntimeException> doLockedConsumer =
                 getDoLockedConsumer(lockType);
         return (key) -> {
             final DATATYPE data = dataManager.newData();
@@ -186,7 +187,7 @@ public abstract class RDMModelFarm<KEYTYPE, DATATYPE, ROWDATAMANAGERTYPE extends
 
             // (This lambda is a FitDataPopulator.)
             doLockedConsumer.accept(usePrev -> isOk[0] = loadData(data, key, usePrev),
-                    (NotificationStepSource) dataManager.table());
+                    dataManager.table());
 
             if (isOk[0]) {
                 return data;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -1372,7 +1372,6 @@ public abstract class BaseTable extends LivenessArtifact
     public <SL extends SwapListenerBase<?>> void initializeWithSnapshot(
             String logPrefix, SL swapListener, ConstructSnapshot.SnapshotFunction snapshotFunction) {
         if (swapListener == null) {
-            Assert.eqFalse(isRefreshing(), "isRefreshing");
             snapshotFunction.call(false, LogicalClock.DEFAULT.currentValue());
             return;
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -2057,7 +2057,8 @@ public class QueryTable extends BaseTable {
             if (!isRefreshing() && tableToSnapshot.isRefreshing() && !lazySnapshot) {
                 // if we are making a static copy of the table, we must ensure that it does not change out from under us
                 ConstructSnapshot.callDataSnapshotFunction("snapshotInternal",
-                        ConstructSnapshot.makeSnapshotControl(false, tableToSnapshot.isRefreshing(),(NotificationStepSource) tableToSnapshot),
+                        ConstructSnapshot.makeSnapshotControl(false, tableToSnapshot.isRefreshing(),
+                                (NotificationStepSource) tableToSnapshot),
                         (usePrev, beforeClockUnused) -> {
                             listener.doSnapshot(false, usePrev);
                             result.getRowSet().writableCast().initializePreviousValue();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -87,6 +87,11 @@ import static io.deephaven.engine.table.impl.by.RollupConstants.ROLLUP_COLUMN_SU
 public class QueryTable extends BaseTable {
 
     public interface Operation<T extends DynamicNode & NotificationStepReceiver> {
+
+        default boolean snapshotNeeded() {
+            return true;
+        }
+
         /**
          * The resulting table and listener of the operation.
          */
@@ -2052,7 +2057,7 @@ public class QueryTable extends BaseTable {
             if (!isRefreshing() && tableToSnapshot.isRefreshing() && !lazySnapshot) {
                 // if we are making a static copy of the table, we must ensure that it does not change out from under us
                 ConstructSnapshot.callDataSnapshotFunction("snapshotInternal",
-                        ConstructSnapshot.makeSnapshotControl(false, (NotificationStepSource) tableToSnapshot),
+                        ConstructSnapshot.makeSnapshotControl(false, tableToSnapshot.isRefreshing(),(NotificationStepSource) tableToSnapshot),
                         (usePrev, beforeClockUnused) -> {
                             listener.doSnapshot(false, usePrev);
                             result.getRowSet().writableCast().initializePreviousValue();
@@ -3102,7 +3107,7 @@ public class QueryTable extends BaseTable {
             final Mutable<T> resultTable = new MutableObject<>();
 
             final SwapListener swapListener;
-            if (isRefreshing()) {
+            if (isRefreshing() && operation.snapshotNeeded()) {
                 swapListener = operation.newSwapListener(this);
                 swapListener.subscribeForUpdates();
             } else {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
@@ -540,7 +540,8 @@ public class ConstructSnapshot {
             @Nullable final RowSet positionsToSnapshot,
             @Nullable final RowSet reversePositionsToSnapshot) {
         return constructBackplaneSnapshotInPositionSpace(logIdentityObject, table, columnsToSerialize,
-                positionsToSnapshot, reversePositionsToSnapshot, makeSnapshotControl(false, table.isRefreshing(), table));
+                positionsToSnapshot, reversePositionsToSnapshot,
+                makeSnapshotControl(false, table.isRefreshing(), table));
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
@@ -821,7 +821,7 @@ public class ConstructSnapshot {
      * Make a default {@link SnapshotControl} for a single source.
      *
      * @param notificationAware Whether the result should be concerned with not missing notifications
-     * @param refreshing Whether the parent table is refreshing (vs static)
+     * @param refreshing Whether the data source (usually a {@link Table} table) is refreshing (vs static)
      * @param source The source
      * @return An appropriate {@link SnapshotControl}
      */
@@ -838,7 +838,7 @@ public class ConstructSnapshot {
      * Make a default {@link SnapshotControl} for one or more sources.
      *
      * @param notificationAware Whether the result should be concerned with not missing notifications
-     * @param refreshing Whether the parent table is refreshing (vs static)
+     * @param refreshing Whether any of the data sources (usually {@link Table tables}) are refreshing (vs static)
      * @param sources The sources
      * @return An appropriate {@link SnapshotControl}
      */

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
@@ -448,7 +448,7 @@ public class ConstructSnapshot {
             @Nullable final BitSet columnsToSerialize,
             @Nullable final RowSet keysToSnapshot) {
         return constructInitialSnapshot(logIdentityObject, table, columnsToSerialize, keysToSnapshot,
-                makeSnapshotControl(false, table));
+                makeSnapshotControl(false, table.isRefreshing(), table));
     }
 
     static InitialSnapshot constructInitialSnapshot(final Object logIdentityObject,
@@ -482,7 +482,7 @@ public class ConstructSnapshot {
             @Nullable final BitSet columnsToSerialize,
             @Nullable final RowSet positionsToSnapshot) {
         return constructInitialSnapshotInPositionSpace(logIdentityObject, table, columnsToSerialize,
-                positionsToSnapshot, makeSnapshotControl(false, table));
+                positionsToSnapshot, makeSnapshotControl(false, table.isRefreshing(), table));
     }
 
     static InitialSnapshot constructInitialSnapshotInPositionSpace(final Object logIdentityObject,
@@ -540,7 +540,7 @@ public class ConstructSnapshot {
             @Nullable final RowSet positionsToSnapshot,
             @Nullable final RowSet reversePositionsToSnapshot) {
         return constructBackplaneSnapshotInPositionSpace(logIdentityObject, table, columnsToSerialize,
-                positionsToSnapshot, reversePositionsToSnapshot, makeSnapshotControl(false, table));
+                positionsToSnapshot, reversePositionsToSnapshot, makeSnapshotControl(false, table.isRefreshing(), table));
     }
 
     /**
@@ -820,31 +820,37 @@ public class ConstructSnapshot {
      * Make a default {@link SnapshotControl} for a single source.
      *
      * @param notificationAware Whether the result should be concerned with not missing notifications
+     * @param refreshing Whether the parent table is refreshing (vs static)
      * @param source The source
      * @return An appropriate {@link SnapshotControl}
      */
-    public static SnapshotControl makeSnapshotControl(final boolean notificationAware,
+    public static SnapshotControl makeSnapshotControl(final boolean notificationAware, final boolean refreshing,
             @NotNull final NotificationStepSource source) {
-        return notificationAware
-                ? new NotificationAwareSingleSourceSnapshotControl(source)
-                : new NotificationObliviousSingleSourceSnapshotControl(source);
+        return refreshing
+                ? notificationAware
+                        ? new NotificationAwareSingleSourceSnapshotControl(source)
+                        : new NotificationObliviousSingleSourceSnapshotControl(source)
+                : StaticSnapshotControl.INSTANCE;
     }
 
     /**
      * Make a default {@link SnapshotControl} for one or more sources.
      *
      * @param notificationAware Whether the result should be concerned with not missing notifications
+     * @param refreshing Whether the parent table is refreshing (vs static)
      * @param sources The sources
      * @return An appropriate {@link SnapshotControl}
      */
-    public static SnapshotControl makeSnapshotControl(final boolean notificationAware,
+    public static SnapshotControl makeSnapshotControl(final boolean notificationAware, final boolean refreshing,
             @NotNull final NotificationStepSource... sources) {
         if (sources.length == 1) {
-            return makeSnapshotControl(notificationAware, sources[0]);
+            return makeSnapshotControl(notificationAware, refreshing, sources[0]);
         }
-        return notificationAware
-                ? new NotificationAwareMultipleSourceSnapshotControl(sources)
-                : new NotificationObliviousMultipleSourceSnapshotControl(sources);
+        return refreshing
+                ? notificationAware
+                        ? new NotificationAwareMultipleSourceSnapshotControl(sources)
+                        : new NotificationObliviousMultipleSourceSnapshotControl(sources)
+                : StaticSnapshotControl.INSTANCE;
     }
 
     /**

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestConcurrentInstantiation.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestConcurrentInstantiation.java
@@ -1507,7 +1507,7 @@ public class TestConcurrentInstantiation extends QueryTableTestBase {
         final Future<String[]> future = pool.submit(() -> {
             final MutableObject<String[]> result = new MutableObject<>();
             ConstructSnapshot.callDataSnapshotFunction("testConstructSnapshotException",
-                    ConstructSnapshot.makeSnapshotControl(false, table), (usePrev, clock) -> {
+                    ConstructSnapshot.makeSnapshotControl(false, table.isRefreshing(), table), (usePrev, clock) -> {
                         Assert.eqFalse(usePrev, "usePrev");
                         final int size = table.intSize();
                         final String[] result1 = new String[size];

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -582,14 +582,14 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
     //////////////////////////////////////////////////
 
     private DeltaListener constructListener() {
-        return parent.isRefreshing() ? new DeltaListener() : null;
+        return parentIsRefreshing ? new DeltaListener() : null;
     }
 
     private class DeltaListener extends InstrumentedTableUpdateListener {
 
         DeltaListener() {
             super("BarrageMessageProducer");
-            Assert.assertion(parent.isRefreshing(), "parent.isRefreshing()");
+            Assert.assertion(parentIsRefreshing, "parent.isRefreshing()");
             manage(parent);
             addParentReference(this);
             parent.listenForUpdates(this);
@@ -1722,7 +1722,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         public boolean snapshotCompletedConsistently(final long afterClockValue, final boolean usedPreviousValues) {
             final boolean success;
             synchronized (BarrageMessageProducer.this) {
-                success = parentIsRefreshing ? capturedLastIndexClockStep == getLastIndexClockStep() : true;
+                success = snapshotConsistent(afterClockValue, usedPreviousValues);
 
                 if (!success) {
                     step = -1;

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -226,6 +226,11 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
                     scheduler, streamGeneratorFactory, parent, updateIntervalMs, onGetSnapshot);
             return new Result<>(result, result.constructListener());
         }
+
+        @Override
+        public boolean snapshotNeeded() {
+            return false;
+        }
     }
 
     private static class MyMemoKey extends MemoizedOperationKey {
@@ -338,6 +343,8 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
 
     private final Runnable onGetSnapshot;
 
+    private final boolean parentIsRefreshing;
+
     public BarrageMessageProducer(final Scheduler scheduler,
             final StreamGenerator.Factory<MessageView> streamGeneratorFactory,
             final BaseTable parent,
@@ -353,6 +360,8 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         this.parent = parent;
         this.updateIntervalMs = updateIntervalMs;
         this.onGetSnapshot = onGetSnapshot;
+
+        this.parentIsRefreshing = parent.isRefreshing();
 
         if (DEBUG) {
             log.info().append(logPrefix).append("Creating new BarrageMessageProducer for ")
@@ -573,17 +582,17 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
     //////////////////////////////////////////////////
 
     private DeltaListener constructListener() {
-        return new DeltaListener();
+        return parent.isRefreshing() ? new DeltaListener() : null;
     }
 
     private class DeltaListener extends InstrumentedTableUpdateListener {
 
         DeltaListener() {
             super("BarrageMessageProducer");
-            if (parent.isRefreshing()) {
-                manage(parent);
-                addParentReference(this);
-            }
+            Assert.assertion(parent.isRefreshing(), "parent.isRefreshing()");
+            manage(parent);
+            addParentReference(this);
+            parent.listenForUpdates(this);
         }
 
         @Override
@@ -1674,6 +1683,10 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         @SuppressWarnings("AutoBoxing")
         @Override
         public Boolean usePreviousValues(final long beforeClockValue) {
+            if (!parentIsRefreshing) {
+                return false;
+            }
+
             capturedLastIndexClockStep = getLastIndexClockStep();
 
             final LogicalClock.State state = LogicalClock.getState(beforeClockValue);
@@ -1699,6 +1712,9 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
 
         @Override
         public boolean snapshotConsistent(final long currentClockValue, final boolean usingPreviousValues) {
+            if (!parentIsRefreshing) {
+                return true;
+            }
             return capturedLastIndexClockStep == getLastIndexClockStep();
         }
 
@@ -1706,7 +1722,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         public boolean snapshotCompletedConsistently(final long afterClockValue, final boolean usedPreviousValues) {
             final boolean success;
             synchronized (BarrageMessageProducer.this) {
-                success = capturedLastIndexClockStep == getLastIndexClockStep();
+                success = parentIsRefreshing ? capturedLastIndexClockStep == getLastIndexClockStep() : true;
 
                 if (!success) {
                     step = -1;


### PR DESCRIPTION
Modify `makeSnapshotControl()` definition to allow specifying if the underlying table is `refreshing` or `static`. 

Also add `boolean snapshotNeeded()` to `QueryTable#Operation` interface with a default of returning `true`.

Closes #1093