### PR TITLE
Add nested JSON support to KafkaTools.consumeToTable.

### DIFF
--- a/Integrations/python/deephaven/ConsumeKafka.py
+++ b/Integrations/python/deephaven/ConsumeKafka.py
@@ -281,8 +281,8 @@ def json(col_defs, mapping:dict = None):
        string for column name and a Deephaven type for column data type.
     :param mapping:   A dict mapping JSON fields to column names defined in the col_defs
        argument.
-       Fields starting with a '/' character are interpreted as a JSON Pointer (see RFC 6901,
-         * ISSN: 2070-1721 for details, essentially nested fields are represented like "/parent/nested").
+       Fields starting with a '/' character are interpreted as a JSON Pointer (see RFC 6901, 
+       ISSN: 2070-1721 for details, essentially nested fields are represented like "/parent/nested").
        Fields not starting with a '/' character are interpreted as toplevel field names.
        If the mapping argument is not present or None, a 1:1 mapping between JSON fields and Deephaven
        table column names is assumed.

--- a/Integrations/python/deephaven/ConsumeKafka.py
+++ b/Integrations/python/deephaven/ConsumeKafka.py
@@ -279,8 +279,12 @@ def json(col_defs, mapping:dict = None):
     :param col_defs:  A sequence of tuples specifying names and types for columns to be
        created on the resulting Deephaven table.  Tuples contain two elements, a
        string for column name and a Deephaven type for column data type.
-    :param mapping:   A dict mapping JSON field names to column names defined in the col_defs
-       argument.  If not present or None, a 1:1 mapping between JSON fields and Deephaven
+    :param mapping:   A dict mapping JSON fields to column names defined in the col_defs
+       argument.
+       Fields starting with a '/' character are interpreted as a JSON Pointer (see RFC 6901,
+         * ISSN: 2070-1721 for details, essentially nested fields are represented like "/parent/nested").
+       Fields not starting with a '/' character are interpreted as toplevel field names.
+       If the mapping argument is not present or None, a 1:1 mapping between JSON fields and Deephaven
        table column names is assumed.
     :return:  A Kafka Key or Value spec object to use in a call to consumeToTable.
     :raises:  ValueError, TypeError or Exception if arguments provided can't be processed.

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -101,9 +101,10 @@ public class KafkaTools {
     public static final String BYTE_BUFFER_SERIALIZER = ByteBufferSerializer.class.getName();
     public static final String AVRO_SERIALIZER = KafkaAvroSerializer.class.getName();
     public static final String SERIALIZER_FOR_IGNORE = BYTE_BUFFER_SERIALIZER;
-    public static final String NESTED_FIELD_NAME_SEPARATOR = "__";
+    public static final String NESTED_FIELD_NAME_SEPARATOR = ".";
     private static final Pattern NESTED_FIELD_NAME_SEPARATOR_PATTERN =
             Pattern.compile(Pattern.quote(NESTED_FIELD_NAME_SEPARATOR));
+    public static final String NESTED_FIELD_COLUMN_NAME_SEPARATOR = "__";
     public static final String AVRO_LATEST_VERSION = "latest";
 
     private static final Logger log = LoggerFactory.getLogger(KafkaTools.class);
@@ -575,18 +576,49 @@ public class KafkaTools {
              */
             static final class Json extends KeyOrValueSpec {
                 final ColumnDefinition<?>[] columnDefinitions;
-                final Map<String, String> fieldNameToColumnName;
+                final Map<String, String> fieldToColumnName;
 
                 private Json(
                         final ColumnDefinition<?>[] columnDefinitions,
                         final Map<String, String> fieldNameToColumnName) {
                     this.columnDefinitions = columnDefinitions;
-                    this.fieldNameToColumnName = fieldNameToColumnName;
+                    this.fieldToColumnName = mapNonPointers(fieldNameToColumnName);
                 }
 
                 @Override
                 DataFormat dataFormat() {
                     return DataFormat.JSON;
+                }
+
+                private static Map<String, String> mapNonPointers(final Map<String, String> fieldNameToColumnName) {
+                    if (fieldNameToColumnName == null) {
+                        return null;
+                    }
+                    boolean needsMapping = false;
+                    for (Map.Entry<String, String> entry : fieldNameToColumnName.entrySet()) {
+                        final String key = entry.getKey();
+                        if (!key.startsWith("/")) {
+                            needsMapping = true;
+                            break;
+                        }
+                    }
+                    if (!needsMapping) {
+                        return fieldNameToColumnName;
+                    }
+                    final Map<String, String> ans = new HashMap<>(fieldNameToColumnName.size());
+                    for (Map.Entry<String, String> entry : fieldNameToColumnName.entrySet()) {
+                        final String key = entry.getKey();
+                        if (key.startsWith("/")) {
+                            ans.put(key, entry.getValue());
+                        } else {
+                            ans.put(mapTopLevelFieldNameToJsonPointerStr(key), entry.getValue());
+                        }
+                    }
+                    return ans;
+                }
+
+                public static String mapTopLevelFieldNameToJsonPointerStr(final String key) {
+                    return "/" + key.replace("~", "~0").replace("/", "~1");
                 }
             }
         }
@@ -604,18 +636,21 @@ public class KafkaTools {
         }
 
         /**
-         * A JSON spec from a set of column definitions.
+         * A JSON spec from a set of column definitions, with an specific mapping of JSON nodes to columns.
+         * JSON nodes can be specified as a string field name, or as a JSON Pointer string (see RFC 6901,
+         * ISSN: 2070-1721).
          *
          * @param columnDefinitions An array of column definitions for specifying the table to be created.
-         * @param fieldNameToColumnName A mapping from JSON field names to column names provided in the definition.
+         * @param fieldToColumnName A mapping from JSON field names or JSON Pointer strings to column names provided in the definition.
+         *        For each field key, if it starts with '/' it is assumed to be a JSON Pointer.
          *        Fields not included will be ignored.
          * @return A JSON spec for the given inputs.
          */
         @SuppressWarnings("unused")
         public static KeyOrValueSpec jsonSpec(
                 final ColumnDefinition<?>[] columnDefinitions,
-                final Map<String, String> fieldNameToColumnName) {
-            return new KeyOrValueSpec.Json(columnDefinitions, fieldNameToColumnName);
+                final Map<String, String> fieldToColumnName) {
+            return new KeyOrValueSpec.Json(columnDefinitions, fieldToColumnName);
         }
 
         /**
@@ -1628,8 +1663,8 @@ public class KafkaTools {
                 // Populate out field to column name mapping from two potential sources.
                 data.fieldPathToColumnName = new HashMap<>(jsonSpec.columnDefinitions.length);
                 final Set<String> coveredColumns = new HashSet<>(jsonSpec.columnDefinitions.length);
-                if (jsonSpec.fieldNameToColumnName != null) {
-                    for (final Map.Entry<String, String> entry : jsonSpec.fieldNameToColumnName.entrySet()) {
+                if (jsonSpec.fieldToColumnName != null) {
+                    for (final Map.Entry<String, String> entry : jsonSpec.fieldToColumnName.entrySet()) {
                         final String colName = entry.getValue();
                         data.fieldPathToColumnName.put(entry.getKey(), colName);
                         coveredColumns.add(colName);
@@ -1638,7 +1673,8 @@ public class KafkaTools {
                 for (final ColumnDefinition<?> colDef : jsonSpec.columnDefinitions) {
                     final String colName = colDef.getName();
                     if (!coveredColumns.contains(colName)) {
-                        data.fieldPathToColumnName.put(colName, colName);
+                        final String jsonPtrStr = Consume.KeyOrValueSpec.Json.mapTopLevelFieldNameToJsonPointerStr(colName);
+                        data.fieldPathToColumnName.put(jsonPtrStr, colName);
                     }
                 }
                 break;
@@ -1860,7 +1896,8 @@ public class KafkaTools {
     @SuppressWarnings("unused")
     public static final IntToLongFunction ALL_PARTITIONS_SEEK_TO_END = KafkaIngester.ALL_PARTITIONS_SEEK_TO_END;
     @SuppressWarnings("unused")
-    public static final Function<String, String> DIRECT_MAPPING = Function.identity();
+    public static final Function<String, String> DIRECT_MAPPING =
+            fieldName -> fieldName.replace(NESTED_FIELD_NAME_SEPARATOR, NESTED_FIELD_COLUMN_NAME_SEPARATOR);
     @SuppressWarnings("unused")
     public static final Consume.KeyOrValueSpec FROM_PROPERTIES = Consume.KeyOrValueSpec.FROM_PROPERTIES;
 

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -636,15 +636,15 @@ public class KafkaTools {
         }
 
         /**
-         * A JSON spec from a set of column definitions, with an specific mapping of JSON nodes to columns.
-         * JSON nodes can be specified as a string field name, or as a JSON Pointer string (see RFC 6901,
-         * ISSN: 2070-1721).
+         * A JSON spec from a set of column definitions, with an specific mapping of JSON nodes to columns. JSON nodes
+         * can be specified as a string field name, or as a JSON Pointer string (see RFC 6901, ISSN: 2070-1721).
          *
-         * @param columnDefinitions An array of column definitions for specifying the table to be created.
-         * @param fieldToColumnName A mapping from JSON field names or JSON Pointer strings to column names provided in the definition.
-         *        For each field key, if it starts with '/' it is assumed to be a JSON Pointer.
-         *        Fields not included will be ignored.
-         * @return A JSON spec for the given inputs.
+         * @param columnDefinitions An array of column definitions for specifying the table to be created
+         * @param fieldToColumnName A mapping from JSON field names or JSON Pointer strings to column names provided in
+         *        the definition. For each field key, if it starts with '/' it is assumed to be a JSON Pointer (e.g.,
+         *        {@code "/parent/nested"} represents a pointer to the nested field {@code "nested"} inside the toplevel
+         *        field {@code "parent"}). Fields not included will be ignored
+         * @return A JSON spec for the given inputs
          */
         @SuppressWarnings("unused")
         public static KeyOrValueSpec jsonSpec(
@@ -1673,7 +1673,8 @@ public class KafkaTools {
                 for (final ColumnDefinition<?> colDef : jsonSpec.columnDefinitions) {
                     final String colName = colDef.getName();
                     if (!coveredColumns.contains(colName)) {
-                        final String jsonPtrStr = Consume.KeyOrValueSpec.Json.mapTopLevelFieldNameToJsonPointerStr(colName);
+                        final String jsonPtrStr =
+                                Consume.KeyOrValueSpec.Json.mapTopLevelFieldNameToJsonPointerStr(colName);
                         data.fieldPathToColumnName.put(jsonPtrStr, colName);
                     }
                 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -595,7 +595,7 @@ public class KafkaTools {
                         return null;
                     }
                     final boolean needsMapping =
-                            fieldNameToColumnName.keySet().stream().anyMatch(key -> key.startsWith("/"));
+                            fieldNameToColumnName.keySet().stream().anyMatch(key -> !key.startsWith("/"));
                     if (!needsMapping) {
                         return fieldNameToColumnName;
                     }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeByteFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeByteFieldCopier.java
@@ -5,6 +5,7 @@
  */
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
@@ -12,10 +13,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeByteFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeByteFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeByteFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -26,7 +27,7 @@ public class JsonNodeByteFieldCopier implements FieldCopier {
         final WritableByteChunk<Values> output = publisherChunk.asWritableByteChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getByte(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getByte(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeCharFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeCharFieldCopier.java
@@ -1,5 +1,6 @@
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
@@ -7,10 +8,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeCharFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeCharFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeCharFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -21,7 +22,7 @@ public class JsonNodeCharFieldCopier implements FieldCopier {
         final WritableCharChunk<Values> output = publisherChunk.asWritableCharChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getChar(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getChar(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
@@ -16,9 +16,9 @@ public class JsonNodeChunkAdapter extends MultiFieldChunkAdapter {
     private JsonNodeChunkAdapter(
             final TableDefinition definition,
             final IntFunction<ChunkType> chunkTypeForIndex,
-            final Map<String, String> fieldNamesToColumnNames,
+            final Map<String, String> jsonPointerStrToColumnNames,
             final boolean allowNulls) {
-        super(definition, chunkTypeForIndex, fieldNamesToColumnNames, allowNulls,
+        super(definition, chunkTypeForIndex, jsonPointerStrToColumnNames, allowNulls,
                 JsonNodeChunkAdapter::makeFieldCopier);
     }
 
@@ -27,17 +27,17 @@ public class JsonNodeChunkAdapter extends MultiFieldChunkAdapter {
      *
      * @param definition the definition of the output table
      * @param chunkTypeForIndex a function from column index to chunk type
-     * @param fieldNamesToColumnNames a map from JSON field names to Deephaven column names
+     * @param jsonPointerStrToColumnNames a map from JSON pointer strings to Deephaven column names
      * @param allowNulls true if null records should be allowed, if false then an ISE is thrown
      * @return a JsonRecordChunkAdapter for the given definition and column mapping
      */
     public static JsonNodeChunkAdapter make(
             final TableDefinition definition,
             final IntFunction<ChunkType> chunkTypeForIndex,
-            final Map<String, String> fieldNamesToColumnNames,
+            final Map<String, String> jsonPointerStrToColumnNames,
             final boolean allowNulls) {
         return new JsonNodeChunkAdapter(
-                definition, chunkTypeForIndex, fieldNamesToColumnNames, allowNulls);
+                definition, chunkTypeForIndex, jsonPointerStrToColumnNames, allowNulls);
     }
 
     private static FieldCopier makeFieldCopier(

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeDateTimeFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeDateTimeFieldCopier.java
@@ -1,15 +1,16 @@
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.time.DateTimeUtils;
 
 public class JsonNodeDateTimeFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeDateTimeFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeDateTimeFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -22,7 +23,7 @@ public class JsonNodeDateTimeFieldCopier implements FieldCopier {
         final WritableLongChunk<Values> output = publisherChunk.asWritableLongChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            final long valueAsLong = JsonNodeUtil.getLong(node, fieldName, true, true);
+            final long valueAsLong = JsonNodeUtil.getLong(node, fieldPointer, true, true);
             output.set(ii + destOffset, DateTimeUtils.autoEpochToNanos(valueAsLong));
         }
     }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeDoubleFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeDoubleFieldCopier.java
@@ -5,6 +5,7 @@
  */
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableChunk;
@@ -12,10 +13,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeDoubleFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeDoubleFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeDoubleFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -26,7 +27,7 @@ public class JsonNodeDoubleFieldCopier implements FieldCopier {
         final WritableDoubleChunk<Values> output = publisherChunk.asWritableDoubleChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getDouble(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getDouble(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeFloatFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeFloatFieldCopier.java
@@ -5,6 +5,7 @@
  */
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableFloatChunk;
 import io.deephaven.chunk.WritableChunk;
@@ -12,10 +13,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeFloatFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeFloatFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeFloatFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -26,7 +27,7 @@ public class JsonNodeFloatFieldCopier implements FieldCopier {
         final WritableFloatChunk<Values> output = publisherChunk.asWritableFloatChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getFloat(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getFloat(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeIntFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeIntFieldCopier.java
@@ -5,6 +5,7 @@
  */
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableChunk;
@@ -12,10 +13,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeIntFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeIntFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeIntFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -26,7 +27,7 @@ public class JsonNodeIntFieldCopier implements FieldCopier {
         final WritableIntChunk<Values> output = publisherChunk.asWritableIntChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getInt(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getInt(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeLongFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeLongFieldCopier.java
@@ -5,6 +5,7 @@
  */
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableChunk;
@@ -12,10 +13,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeLongFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeLongFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeLongFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -26,7 +27,7 @@ public class JsonNodeLongFieldCopier implements FieldCopier {
         final WritableLongChunk<Values> output = publisherChunk.asWritableLongChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getLong(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getLong(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeShortFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeShortFieldCopier.java
@@ -5,6 +5,7 @@
  */
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableChunk;
@@ -12,10 +13,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeShortFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeShortFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeShortFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
@@ -26,7 +27,7 @@ public class JsonNodeShortFieldCopier implements FieldCopier {
         final WritableShortChunk<Values> output = publisherChunk.asWritableShortChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getShort(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getShort(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeStringFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeStringFieldCopier.java
@@ -1,5 +1,6 @@
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableObjectChunk;
@@ -7,18 +8,23 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
 public class JsonNodeStringFieldCopier implements FieldCopier {
-    private final String fieldName;
+    private final JsonPointer fieldPointer;
 
-    public JsonNodeStringFieldCopier(String fieldName) {
-        this.fieldName = fieldName;
+    public JsonNodeStringFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 
     @Override
-    public void copyField(ObjectChunk<Object, Values> inputChunk, WritableChunk<Values> publisherChunk, int sourceOffset, int destOffset, int length) {
+    public void copyField(
+            final ObjectChunk<Object, Values> inputChunk,
+            final WritableChunk<Values> publisherChunk,
+            final int sourceOffset,
+            final int destOffset,
+            final int length) {
         final WritableObjectChunk<Object, Values> output = publisherChunk.asWritableObjectChunk();
         for (int ii = 0; ii < length; ++ii) {
             final JsonNode node = (JsonNode) inputChunk.get(ii + sourceOffset);
-            output.set(ii + destOffset, JsonNodeUtil.getString(node, fieldName, true, true));
+            output.set(ii + destOffset, JsonNodeUtil.getString(node, fieldPointer, true, true));
         }
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
@@ -1,5 +1,6 @@
 package io.deephaven.kafka.ingest;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -21,7 +22,6 @@ public class JsonNodeUtil {
             .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
 
     public static JsonNode makeJsonNode(final String json) {
-        final JsonNode node;
         try {
             return objectMapper.readTree(json);
         } catch (JsonProcessingException ex) {
@@ -44,6 +44,22 @@ public class JsonNodeUtil {
         return tmpNode;
     }
 
+
+    private static JsonNode checkAllowMissingOrNull(
+            final JsonNode node, @NotNull final JsonPointer ptr,
+            final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = node == null ? null : node.at(ptr);
+        if (!allowMissingKeys && isNullField(tmpNode)) {
+            throw new IllegalArgumentException(
+                    "JsonPointer " + ptr + " not found in the record, and allowMissingKeys is false.");
+        }
+        if (!isNullField(tmpNode) && !allowNullValues && tmpNode.isNull()) {
+            throw new IllegalArgumentException(
+                    "Value for JsonPointer " + ptr + " is null in the record, and allowNullValues is false.");
+        }
+        return tmpNode;
+    }
+
     /**
      * @return true if node is null object or is a "Json" null
      */
@@ -61,6 +77,19 @@ public class JsonNodeUtil {
     public static int getInt(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
+        return getInt(tmpNode);
+    }
+
+    /**
+     * Returns a Deephaven int (primitive int with reserved values for null) from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Deephaven int (primitive int with reserved values for null)
+     */
+    public static int getInt(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
+                             final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getInt(tmpNode);
     }
 
@@ -114,6 +143,19 @@ public class JsonNodeUtil {
 
     /**
      * Returns a Deephaven short (primitive short with reserved values for Null) from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Deephaven short (primitive short with reserved values for Null)
+     */
+    public static short getShort(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
+                                 final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
+        return getShort(tmpNode);
+    }
+
+    /**
+     * Returns a Deephaven short (primitive short with reserved values for Null) from a {@link JsonNode}.
      * 
      * @param node The {@link JsonNode} from which to retrieve the value.
      * @return A Deephaven short (primitive short with reserved values for Null)
@@ -151,6 +193,19 @@ public class JsonNodeUtil {
     public static long getLong(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
+        return getLong(tmpNode);
+    }
+
+    /**
+     * Returns a Deephaven long (primitive long with reserved values for Null) from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Deephaven long (primitive long with reserved values for Null)
+     */
+    public static long getLong(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
+                               final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getLong(tmpNode);
     }
 
@@ -204,6 +259,19 @@ public class JsonNodeUtil {
 
     /**
      * Returns a Deephaven double (primitive double with reserved values for null) from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Deephaven double (primitive double with reserved values for null)
+     */
+    public static double getDouble(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
+                                   final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
+        return getDouble(tmpNode);
+    }
+
+    /**
+     * Returns a Deephaven double (primitive double with reserved values for null) from a {@link JsonNode}.
      * 
      * @param node The {@link JsonNode} from which to retrieve the value.
      * @return A Deephaven double (primitive double with reserved values for null)
@@ -252,6 +320,19 @@ public class JsonNodeUtil {
 
     /**
      * Returns a Deephaven float (primitive float with reserved values for Null) from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Deephaven float (primitive float with reserved values for Null)
+     */
+    public static float getFloat(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
+                                 final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
+        return getFloat(tmpNode);
+    }
+
+    /**
+     * Returns a Deephaven float (primitive float with reserved values for Null) from a {@link JsonNode}.
      * 
      * @param node The {@link JsonNode} from which to retrieve the value.
      * @return A Deephaven float (primitive float with reserved values for Null)
@@ -295,6 +376,19 @@ public class JsonNodeUtil {
     public static byte getByte(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
+        return getByte(tmpNode);
+    }
+
+    /**
+     * Returns a Deephaven byte (primitive byte with a reserved value for Null) from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Deephaven byte (primitive byte with a reserved value for Null)
+     */
+    public static byte getByte(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
+                               final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getByte(tmpNode);
     }
 
@@ -362,6 +456,19 @@ public class JsonNodeUtil {
 
     /**
      * Returns a Deephaven char (primitive char with a reserved value for Null) from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Deephaven char (primitive char with a reserved value for Null)
+     */
+    public static char getChar(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
+                               final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
+        return getChar(tmpNode);
+    }
+
+    /**
+     * Returns a Deephaven char (primitive char with a reserved value for Null) from a {@link JsonNode}.
      * 
      * @param node The {@link JsonNode} from which to retrieve the value.
      * @return A Deephaven char (primitive char with a reserved value for Null)
@@ -419,6 +526,20 @@ public class JsonNodeUtil {
 
     /**
      * Returns a String from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A String
+     */
+    @Nullable
+    public static String getString(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
+                                   final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
+        return getString(tmpNode);
+    }
+
+    /**
+     * Returns a String from a {@link JsonNode}.
      * 
      * @param node The {@link JsonNode} from which to retrieve the value.
      * @return A String
@@ -438,6 +559,19 @@ public class JsonNodeUtil {
     public static Boolean getBoolean(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
+        return getBoolean(tmpNode);
+    }
+
+    /**
+     * Returns a Boolean from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A Boolean
+     */
+    public static Boolean getBoolean(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
+                                     final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getBoolean(tmpNode);
     }
 
@@ -467,6 +601,19 @@ public class JsonNodeUtil {
 
     /**
      * Returns a BigInteger from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A BigInteger
+     */
+    public static BigInteger getBigInteger(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
+                                           final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
+        return getBigInteger(tmpNode);
+    }
+
+    /**
+     * Returns a BigInteger from a {@link JsonNode}.
      * 
      * @param node The {@link JsonNode} from which to retrieve the value.
      * @return A BigInteger
@@ -487,6 +634,20 @@ public class JsonNodeUtil {
     public static BigDecimal getBigDecimal(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
+        return getBigDecimal(tmpNode);
+    }
+
+    /**
+     * Returns a BigDecimal from a {@link JsonNode}.
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A BigDecimal
+     */
+    @Nullable
+    public static BigDecimal getBigDecimal(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
+                                           final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getBigDecimal(tmpNode);
     }
 
@@ -539,6 +700,22 @@ public class JsonNodeUtil {
     public static DateTime getDateTime(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
+        return getDateTime(tmpNode);
+    }
+
+    /**
+     * Returns a {@link DateTime} from a {@link JsonNode}. Will try to infer precision of a long value to be parsed
+     * using {@link DateTimeUtils} autoEpochToTime. If the value in the JSON record is not numeric, this method will
+     * attempt to parse it as a Deephaven DateTime string (yyyy-MM-ddThh:mm:ss[.nnnnnnnnn] TZ).
+     *
+     * @param node The {@link JsonNode} from which to retrieve the value.
+     * @param ptr A JsonPointer to the node for the value to retrieve.
+     * @return A {@link DateTime}
+     */
+    @Nullable
+    public static DateTime getDateTime(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
+                                       final boolean allowMissingKeys, final boolean allowNullValues) {
+        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getDateTime(tmpNode);
     }
 

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
@@ -88,7 +88,7 @@ public class JsonNodeUtil {
      * @return A Deephaven int (primitive int with reserved values for null)
      */
     public static int getInt(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
-                             final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getInt(tmpNode);
     }
@@ -149,7 +149,7 @@ public class JsonNodeUtil {
      * @return A Deephaven short (primitive short with reserved values for Null)
      */
     public static short getShort(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
-                                 final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getShort(tmpNode);
     }
@@ -204,7 +204,7 @@ public class JsonNodeUtil {
      * @return A Deephaven long (primitive long with reserved values for Null)
      */
     public static long getLong(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
-                               final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getLong(tmpNode);
     }
@@ -265,7 +265,7 @@ public class JsonNodeUtil {
      * @return A Deephaven double (primitive double with reserved values for null)
      */
     public static double getDouble(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
-                                   final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getDouble(tmpNode);
     }
@@ -326,7 +326,7 @@ public class JsonNodeUtil {
      * @return A Deephaven float (primitive float with reserved values for Null)
      */
     public static float getFloat(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
-                                 final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getFloat(tmpNode);
     }
@@ -387,7 +387,7 @@ public class JsonNodeUtil {
      * @return A Deephaven byte (primitive byte with a reserved value for Null)
      */
     public static byte getByte(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
-                               final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getByte(tmpNode);
     }
@@ -462,7 +462,7 @@ public class JsonNodeUtil {
      * @return A Deephaven char (primitive char with a reserved value for Null)
      */
     public static char getChar(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
-                               final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getChar(tmpNode);
     }
@@ -533,7 +533,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static String getString(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
-                                   final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getString(tmpNode);
     }
@@ -570,7 +570,7 @@ public class JsonNodeUtil {
      * @return A Boolean
      */
     public static Boolean getBoolean(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
-                                     final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getBoolean(tmpNode);
     }
@@ -607,7 +607,7 @@ public class JsonNodeUtil {
      * @return A BigInteger
      */
     public static BigInteger getBigInteger(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
-                                           final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getBigInteger(tmpNode);
     }
@@ -646,7 +646,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static BigDecimal getBigDecimal(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
-                                           final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getBigDecimal(tmpNode);
     }
@@ -714,7 +714,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static DateTime getDateTime(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
-                                       final boolean allowMissingKeys, final boolean allowNullValues) {
+            final boolean allowMissingKeys, final boolean allowNullValues) {
         final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
         return getDateTime(tmpNode);
     }

--- a/extensions/kafka/src/test/java/io/deephaven/kafka/KafkaToolsTest.java
+++ b/extensions/kafka/src/test/java/io/deephaven/kafka/KafkaToolsTest.java
@@ -65,10 +65,10 @@ public class KafkaToolsTest {
         final List<ColumnDefinition<?>> colDefs = new ArrayList<>();
         KafkaTools.avroSchemaToColumnDefinitions(colDefs, avroSchema);
         assertEquals(2, colDefs.size());
-        assertEquals("NestedField" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR + "Symbol",
+        assertEquals("NestedField" + KafkaTools.NESTED_FIELD_COLUMN_NAME_SEPARATOR + "Symbol",
                 colDefs.get(0).getName());
         assertEquals(String.class, colDefs.get(0).getDataType());
-        assertEquals("NestedField" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR + "Price",
+        assertEquals("NestedField" + KafkaTools.NESTED_FIELD_COLUMN_NAME_SEPARATOR + "Price",
                 colDefs.get(1).getName());
         assertEquals(double.class, colDefs.get(1).getDataType());
     }
@@ -155,29 +155,32 @@ public class KafkaToolsTest {
     public void testAvroSchemaWithMoreNesting() {
         final Schema avroSchema = new Schema.Parser().parse(schemaWithMoreNesting);
         Function<String, String> mapping = (final String fieldName) -> {
-            if ("NestedFields2.NestedFields3.field4".equals(fieldName)) {
+            if (("NestedFields2" +
+                    KafkaTools.NESTED_FIELD_NAME_SEPARATOR +
+                    "NestedFields3" +
+                    KafkaTools.NESTED_FIELD_NAME_SEPARATOR +
+                    "field4").equals(fieldName)) {
                 return "field4";
             }
-            return fieldName;
+            return KafkaTools.DIRECT_MAPPING.apply(fieldName);
         };
         final List<ColumnDefinition<?>> colDefs = new ArrayList<>();
         KafkaTools.avroSchemaToColumnDefinitions(colDefs, avroSchema, mapping);
         final int nCols = 4;
         assertEquals(nCols, colDefs.size());
         int c = 0;
-        assertEquals("NestedFields1" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR + "field1",
+        assertEquals("NestedFields1" + KafkaTools.NESTED_FIELD_COLUMN_NAME_SEPARATOR + "field1",
                 colDefs.get(c).getName());
         assertEquals(int.class, colDefs.get(c++).getDataType());
-        assertEquals("NestedFields1" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR + "field2",
+        assertEquals("NestedFields1" + KafkaTools.NESTED_FIELD_COLUMN_NAME_SEPARATOR + "field2",
                 colDefs.get(c).getName());
         assertEquals(float.class, colDefs.get(c++).getDataType());
-        assertEquals("NestedFields2" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR +
-                "NestedFields3" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR +
+        assertEquals("NestedFields2" + KafkaTools.NESTED_FIELD_COLUMN_NAME_SEPARATOR +
+                "NestedFields3" + KafkaTools.NESTED_FIELD_COLUMN_NAME_SEPARATOR +
                 "field3",
                 colDefs.get(c).getName());
         assertEquals(long.class, colDefs.get(c++).getDataType());
-        assertEquals("NestedFields2" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR +
-                "NestedFields3" + KafkaTools.NESTED_FIELD_NAME_SEPARATOR +
+        assertEquals(
                 "field4",
                 colDefs.get(c).getName());
         assertEquals(double.class, colDefs.get(c++).getDataType());

--- a/pyintegration/deephaven2/stream/kafka/consumer.py
+++ b/pyintegration/deephaven2/stream/kafka/consumer.py
@@ -198,8 +198,12 @@ def json_spec(col_defs: List[Tuple[str, DType]], mapping: Dict = None) -> KeyVal
         col_defs (List[Tuple[str, DType]]):  a list of tuples specifying names and types for columns to be
             created on the resulting Deephaven table.  Tuples contain two elements, a string for column name
             and a Deephaven type for column data type.
-        mapping (Dict): a map from JSON field names to column names defined in the col_defs argument, default is None,
-            meaning a 1:1 mapping between JSON fields and Deephaven table column names
+        mapping (Dict):  a dict mapping JSON fields to column names defined in the col_defs
+            argument.  Fields starting with a '/' character are interpreted as a JSON Pointer (see RFC 6901,
+            ISSN: 2070-1721 for details, essentially nested fields are represented like "/parent/nested").
+            Fields not starting with a '/' character are interpreted as toplevel field names.
+            If the mapping argument is not present or None, a 1:1 mapping between JSON fields and Deephaven
+           table column names is assumed.
 
     Returns:
         a KeyValueSpec

--- a/redpanda/examples/python/kafka-produce.py
+++ b/redpanda/examples/python/kafka-produce.py
@@ -54,11 +54,11 @@
 # From web UI do:
 #
 #    > import deephaven.Types as dh
-#    > t3 = ck.consumeToTable({'bootstrap.servers' : 'redpanda:29092'}, 'orders', value=ck.json([ ('Symbol', dh.string), ('Side', dh.string), ('Price', dh.double), ('Qty', dh.int_) ]), table_type='append')
+#    > t3 = ck.consumeToTable({'bootstrap.servers' : 'redpanda:29092'}, 'orders', value=ck.json([ ('Symbol', dh.string), ('Side', dh.string), ('Price', dh.double), ('Qty', dh.int_), ('UserName', dh.string), ('UserId', dh.int_) ], mapping = { '/User/Name' : 'UserName', '/User/Id' : 'UserId'}), table_type='append')
 #
 # Run this script on the host (not on a docker image) to produce one row:
 #
-#    $ python3 kafka-produce.py orders 0 '' 'str:{ "Symbol" : "MSFT", "Side" : "BUY", "Price" : "278.85", "Qty" : "200" }'
+#    $ python3 kafka-produce.py orders 0 '' str:{ "Symbol" : "MSFT", "Side" : "BUY", "Price" : "278.85", "Qty" : "200", "User" : { "Name" : "Pepo", "Id" : 1234 } }'
 #
 # You should see one row of data as per above showing up in the UI.
 #


### PR DESCRIPTION
We keep the API fully backwards compatible by extending the support in the `mapping` argument to the JSON spec: before the mapping was a map from a key of JSON (toplevel) field name to a value of DH table column name.  Now the key can be either a toplevel field name or it can be a JSON Pointer to a node (the [spec](https://www.rfc-editor.org/rfc/rfc6901) has some nuance, but essentially a JSON pointer string looks like an absolute path in a filesystem, eg, `/User/FirstName`).

Example:

```
cfs@erke 17:39:22 ~/dh/oss1/deephaven-core/redpanda/examples/python
$ python3 kafka-produce.py orders 0 '' 'str:{ "Symbol" : "MSFT", "Side" : "BUY", "Price" : "278.85", "Qty" : "200", "User" : { "Name" : "Pepo", "Id" : "1234" } }'
Message key=|b''|, value=|b'{ "Symbol" : "MSFT", "Side" : "BUY", "Price" : "278.85", "Qty" : "200", "User" : { "Name" : "Pepo", "Id" : "1234" } }'| delivered to topic orders partition 0
(confluent-kafka)
```
![dh_nested_json](https://user-images.githubusercontent.com/37232625/160494813-7a5ba1a2-392f-4407-9a89-e10d065da561.png)

