### PR TITLE
Fix Groovy evaluateScript to order variables in declaration order

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -634,7 +634,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
     @Override
     protected GroovySnapshot takeSnapshot() {
         // noinspection unchecked,rawtypes
-        return new GroovySnapshot(new HashMap<>(groovyShell.getContext().getVariables()));
+        return new GroovySnapshot(new LinkedHashMap<>(groovyShell.getContext().getVariables()));
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
@@ -13,7 +13,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/engine/table/src/test/java/io/deephaven/engine/util/scripts/TestGroovyDeephavenSession.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/scripts/TestGroovyDeephavenSession.java
@@ -10,7 +10,9 @@ import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.util.GroovyDeephavenSession;
 import io.deephaven.engine.liveness.LivenessScope;
 import io.deephaven.engine.liveness.LivenessScopeStack;
+import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.plugin.type.ObjectTypeLookup.NoOp;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,6 +75,19 @@ public class TestGroovyDeephavenSession {
         Assert.neqNull(fetch("obj", Object.class), "fetchObject");
         final Table result = fetchTable("result");
         Assert.eqFalse(result.isFailed(), "result.isFailed()");
+    }
+
+    @Test
+    public void testScriptResultOrder() {
+        final ScriptSession.Changes changes = session.evaluateScript("x=emptyTable(10)\n" +
+                "z=emptyTable(10)\n" +
+                "y=emptyTable(10)\n" +
+                "u=emptyTable(10)");
+        final String[] names = new String[] {"x", "z", "y", "u"};
+        final MutableInt offset = new MutableInt();
+        changes.created.forEach((name, type) -> {
+            Assert.eq(name, "name", names[offset.getAndIncrement()], "names[offset.getAndIncrement()]");
+        });
     }
 }
 


### PR DESCRIPTION
Fixes #2136 