### PR TITLE
Fix debezium/perf/sample_top.py being tripped by leading spaces in top output.

### DIFF
--- a/debezium/perf/sample_top.py
+++ b/debezium/perf/sample_top.py
@@ -58,6 +58,7 @@ kib_2_gib = 1.0/(1024 * 1024)
 
 results={}
 for line in top_out:
+    line = line.strip()
     for name, regex in name_pidre.items():
         if re.search(regex, line) is not None:
             cols = line.split(maxsplit=12)


### PR DESCRIPTION
We were failing when parsing top output when some pids are shorter such that top output has leading spaces :facepalm:
Splitting the line to an array via `.split()` would then have an empty first field and everything pushed one position to where "it should have been" [TM] and was expected.