### PR TITLE
Update object allocation stats so it works, but disabled by default

### DIFF
--- a/Plot/Plot.gradle
+++ b/Plot/Plot.gradle
@@ -20,6 +20,8 @@ dependencies {
 
     compileOnly 'javax.inject:javax.inject:1'
 
+    implementation 'com.google.guava:guava:19.0'
+
     testCompile TestTools.projectDependency(project, 'Util'),
                 TestTools.projectDependency(project, 'engine-table')
 

--- a/Stats/build.gradle
+++ b/Stats/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 dependencies {
-    compile project(':Base'), project(':DataStructures'), project(':IO'), project(':Configuration'), project(':FishUtil'),
+    implementation project(':Base'), project(':DataStructures'), project(':IO'), project(':Configuration'), project(':FishUtil'),
             project(':Net')
-    compile depAllocation
+    compileOnly 'com.google.code.java-allocation-instrumenter:java-allocation-instrumenter:3.3.0'
 
     testCompile project(path: ':Base', configuration: 'tests')
 

--- a/Stats/src/main/java/io/deephaven/stats/ObjectAllocationCollector.java
+++ b/Stats/src/main/java/io/deephaven/stats/ObjectAllocationCollector.java
@@ -12,13 +12,14 @@ import io.deephaven.base.stats.State;
 import io.deephaven.base.stats.Stats;
 import io.deephaven.base.stats.Value;
 
+import java.util.Objects;
+
 /**
- * Use the allocation instrumenter from http://code.google.com/p/java-allocation-instrumenter/ to produce stats
+ * Use the allocation instrumenter from https://github.com/google/allocation-instrumenter to produce stats
  *
  * To use make sure you set
  *
- * -j -Dallocation.stats.enabled=true -j -Xbootclasspath/a:java_lib/allocation-2.0.jar -j
- * -javaagent:java_lib/allocation-2.0.jar (maybe even use -j -noverify)
+ * -Dallocation.stats.enabled=true -javaagent:/opt/deephaven/server/lib/java-allocation-instrumenter-3.3.0.jar
  */
 public class ObjectAllocationCollector {
 
@@ -86,7 +87,7 @@ public class ObjectAllocationCollector {
             if (null == dumpStack) {
                 if (null != CLASS_NAMES) {
                     for (String sClassName : CLASS_NAMES) {
-                        if (sClassName == clazz.getName()) {
+                        if (Objects.equals(sClassName, clazz.getName())) {
                             dumpStack = Boolean.TRUE;
                             return;
                         }

--- a/buildSrc/src/main/groovy/io.deephaven.java-classpath-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-classpath-conventions.gradle
@@ -6,7 +6,6 @@ plugins {
 // TODO(deephaven-core#1162): Adopt java-platform to manage versions
 ext {
     depAnnotations = 'com.intellij:annotations:5.1'
-    depAllocation = 'com.google.code.java-allocation-instrumenter:java-allocation-instrumenter:2.0'
     depCommonsCodec = 'commons-codec:commons-codec:1.9'
     depCommonsCompress = 'org.apache.commons:commons-compress:1.8'
     depCommonsLang3 = 'org.apache.commons:commons-lang3:3.9'
@@ -82,8 +81,7 @@ dependencies {
     fishUtil project(':FishUtil')
 
     fishStats project(':Net'),
-            project(':Stats'),
-            'com.google.code.java-allocation-instrumenter:java-allocation-instrumenter:2.0'
+            project(':Stats')
 
     fishBaseTest project(path: ':Base', configuration: 'tests')
 

--- a/engine/api/build.gradle
+++ b/engine/api/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 
     implementation 'com.github.f4b6a3:uuid-creator:3.6.0'
 
+    implementation 'com.google.guava:guava:19.0'
+
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'junit:junit:4.13.2'

--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 
     runtimeOnly project(':engine-tuplesource')
 
+    implementation 'com.google.guava:guava:19.0'
+
     testImplementation TestTools.projectDependency(project, 'Base'),
             TestTools.projectDependency(project, 'Util'),
             TestTools.projectDependency(project, 'engine-chunk'),

--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -2,7 +2,7 @@ CompilerTools.logEnabledDefault=false
 UpdatePerformanceTracker.reportingMode=LISTENER_ONLY
 UpdatePerformanceTracker.reportIntervalMillis=60000
 measurement.per_thread_cpu=false
-allocation.stats.enabled=true
+allocation.stats.enabled=false
 statsdriver.enabled=true
 UpdateGraphProcessor.checkTableOperations=true
 


### PR DESCRIPTION
Also adds guava as an explicit dependency to other modules, which
previously implicitly picked up guava from the old
java-allocation-tracker library version.

Fixes #2120