### PR TITLE
Fix JS API examples after deephaven2 -> deephaven rename

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/public/input_table.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/input_table.html
@@ -53,7 +53,7 @@
 from deephaven import empty_table
 import jpy
 KeyedArrayBackedMutableTable = jpy.get_type('io.deephaven.engine.table.impl.util.KeyedArrayBackedMutableTable')
-remoteTable = KeyedArrayBackedMutableTable.make(empty_table(0).update_view(formulas = ['id=0', 'data=""']).j_table, 'id')
+remoteTable = KeyedArrayBackedMutableTable.make(empty_table(0).update_view(['id=0', 'data=""']).j_table, 'id')
     `)
     } else if (types.indexOf("groovy") !== -1) {
       ide = await connection.startSession("groovy");

--- a/web/client-api/src/main/java/io/deephaven/web/public/input_table.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/input_table.html
@@ -50,10 +50,10 @@
       ide = await connection.startSession("python");
 
       await ide.runCode(`
-from deephaven.TableTools import emptyTable
+from deephaven import empty_table
 import jpy
 KeyedArrayBackedMutableTable = jpy.get_type('io.deephaven.engine.table.impl.util.KeyedArrayBackedMutableTable')
-remoteTable = KeyedArrayBackedMutableTable.make(emptyTable(0).updateView('id=0', 'data=""'), 'id')
+remoteTable = KeyedArrayBackedMutableTable.make(empty_table(0).update_view(formulas = ['id=0', 'data=""']).j_table, 'id')
     `)
     } else if (types.indexOf("groovy") !== -1) {
       ide = await connection.startSession("groovy");

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
@@ -35,7 +35,7 @@ var ide;
         // Run code that will create a static table with 10 rows and three columns, I, J, K
         await ide.runCode(`
 from deephaven import empty_table
-remoteTable = empty_table(10).update_view(formulas = ['I=i', 'J=I*I', 'K=i%2==0?"Hello":"World"'])
+remoteTable = empty_table(10).update_view(['I=i', 'J=I*I', 'K=i%2==0?"Hello":"World"'])
 `)
     } else if (types.indexOf("groovy") !== -1) {
         // Start a groovy session

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_basic.html
@@ -34,8 +34,8 @@ var ide;
         ide = await connection.startSession("python");
         // Run code that will create a static table with 10 rows and three columns, I, J, K
         await ide.runCode(`
-from deephaven.TableTools import emptyTable
-remoteTable = emptyTable(10).updateView('I=i', 'J=I*I', 'K=i%2==0?"Hello":"World"')
+from deephaven import empty_table
+remoteTable = empty_table(10).update_view(formulas = ['I=i', 'J=I*I', 'K=i%2==0?"Hello":"World"'])
 `)
     } else if (types.indexOf("groovy") !== -1) {
         // Start a groovy session

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
@@ -159,7 +159,7 @@
           ide = await connection.startSession("python");
           await ide.runCode(`
 from deephaven import time_table
-remoteTable = time_table("00:00:01").update_view(formulas = ["I=i", "J=I*I", "K=I%100"]).last_by("K")
+remoteTable = time_table("00:00:01").update_view(["I=i", "J=I*I", "K=I%100"]).last_by("K")
 `)
       } else if (types.indexOf("groovy") !== -1) {
           ide = await connection.startSession("groovy");

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
@@ -158,8 +158,8 @@
       if (types.indexOf("python") !== -1) {
           ide = await connection.startSession("python");
           await ide.runCode(`
-from deephaven.TableTools import timeTable
-remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")
+from deephaven import time_table
+remoteTable = time_table("00:00:01").update_view(formulas = ["I=i", "J=I*I", "K=I%100"]).last_by("K")
 `)
       } else if (types.indexOf("groovy") !== -1) {
           ide = await connection.startSession("groovy");

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_sort.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_sort.html
@@ -30,8 +30,8 @@
         if (types.indexOf("python") !== -1) {
           ide = await connection.startSession("python");
           await ide.runCode(`
-from deephaven.TableTools import timeTable
-remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")
+from deephaven import time_table
+remoteTable = time_table("00:00:01").update_view(formulas = ["I=i", "J=I*I", "K=I%100"]).last_by("K")
 `)
         } else if (types.indexOf("groovy") !== -1) {
           ide = await connection.startSession("groovy");

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_sort.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_sort.html
@@ -31,7 +31,7 @@
           ide = await connection.startSession("python");
           await ide.runCode(`
 from deephaven import time_table
-remoteTable = time_table("00:00:01").update_view(formulas = ["I=i", "J=I*I", "K=I%100"]).last_by("K")
+remoteTable = time_table("00:00:01").update_view(["I=i", "J=I*I", "K=I%100"]).last_by("K")
 `)
         } else if (types.indexOf("groovy") !== -1) {
           ide = await connection.startSession("groovy");

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_viewport.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_viewport.html
@@ -38,7 +38,7 @@ var PAGE_SIZE = 20;
         ide = await connection.startSession("python");
         await ide.runCode(`
 from deephaven import time_table
-remoteTable = time_table("00:00:01").update_view(formulas = ["I=i", "J=I*I", "K=I%100"]).last_by(by = ["K"])
+remoteTable = time_table("00:00:01").update_view(["I=i", "J=I*I", "K=I%100"]).last_by(by = ["K"])
 `)
     } else if (types.indexOf("groovy") !== -1) {
         ide = await connection.startSession("groovy");

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_viewport.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_viewport.html
@@ -37,8 +37,8 @@ var PAGE_SIZE = 20;
     if (types.indexOf("python") !== -1) {
         ide = await connection.startSession("python");
         await ide.runCode(`
-from deephaven.TableTools import timeTable
-remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")
+from deephaven import time_table
+remoteTable = time_table("00:00:01").update_view(formulas = ["I=i", "J=I*I", "K=I%100"]).last_by(by = ["K"])
 `)
     } else if (types.indexOf("groovy") !== -1) {
         ide = await connection.startSession("groovy");


### PR DESCRIPTION
- Fix all python code snippets in the JS API examples
- Tested each page accessible from http://localhost:10000/jsapi/
