### PR TITLE
Provide the compact Java exception stack by deflt

### DIFF
--- a/pyintegration/deephaven/dherror.py
+++ b/pyintegration/deephaven/dherror.py
@@ -25,6 +25,7 @@ class DHError(Exception):
         super().__init__(cause, message)
         self._message = message
         self._traceback = traceback.format_exc()
+        self._cause = cause
 
         tb_lines = self._traceback.splitlines()
         self._root_cause = ""
@@ -68,7 +69,6 @@ class DHError(Exception):
         return "\n".join(self._compact_tb)
 
     def __str__(self):
-        if self._root_cause:
-            return f"{self._message} : {self._root_cause}"
-        else:
-            return self._message
+        causes = [line for line in self._compact_tb if "caused by" in line][:-1]
+        causes = "\n       ".join(causes)
+        return f"{self._message} : {self._root_cause} \n       {causes}"

--- a/pyintegration/deephaven/dherror.py
+++ b/pyintegration/deephaven/dherror.py
@@ -69,6 +69,6 @@ class DHError(Exception):
         return "\n".join(self._compact_tb)
 
     def __str__(self):
-        causes = [line for line in self._compact_tb if "caused by" in line][:-1]
+        causes = [line.replace("caused by ", "") for line in self._compact_tb if line.startswith("caused by")]
         causes = "\n       ".join(causes)
         return f"{self._message} : {self._root_cause} \n       {causes}"


### PR DESCRIPTION
Fixes #2191 

Now the compact Java Exception info is available by default (the bolded 'caused by' line):

-Scheduler-Serial-1 | i.d.s.s.SessionState      | Internal Error 'bae18651-2657-4a17-88cd-e0ef6cb4a37d' java.lang.RuntimeException: Error in Python interpreter:
Type: <class 'deephaven.dherror.DHError'>
Value: table update operation failed. : Cannot find variable or class not_defined 
        **_caused by io.deephaven.engine.table.impl.select.FormulaCompilationException: Formula compilation error for:_**(int)get_class_number(not_defined)****
Line: 264
Namespace: update
File: /opt/deephaven-venv/lib/python3.7/site-packages/deephaven/table.py
Traceback (most recent call last):
  File "<string>", line 12, in <module>
  File "/opt/deephaven-venv/lib/python3.7/site-packages/deephaven/table.py", line 264, in update

        at org.jpy.PyLib.executeCode(PyLib.java:-2)
        at org.jpy.PyObject.executeCode(PyObject.java:138)
        at io.deephaven.engine.util.PythonEvaluatorJpy.evalScript(PythonEvaluatorJpy.java:56)
        at io.deephaven.engine.util.PythonDeephavenSession.lambda$evaluate$1(PythonDeephavenSession.java:190)
        at io.deephaven.util.locks.FunctionalLock.doLockedInterruptibly(FunctionalLock.java:46)
        at io.deephaven.engine.util.PythonDeephavenSession.evaluate(PythonDeephavenSession.java:189)
        at io.deephaven.engine.util.AbstractScriptSession.evaluateScript(AbstractScriptSession.java:147)
        at io.deephaven.engine.util.DelegatingScriptSession.evaluateScript(DelegatingScriptSession.java:71)
        at io.deephaven.engine.util.ScriptSession.evaluateScript(ScriptSession.java:84)
        at io.deephaven.server.console.ConsoleServiceGrpcImpl.lambda$executeCommand$8(ConsoleServiceGrpcImpl.java:219)
        at io.deephaven.server.session.SessionState$ExportBuilder.lambda$submit$2(SessionState.java:1299)
        at io.deephaven.server.session.SessionState$ExportObject.doExport(SessionState.java:847)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at io.deephaven.server.runner.DeephavenApiServerModule$ThreadFactory.lambda$newThread$0(DeephavenApiServerModule.java:143)
        at java.lang.Thread.run(Thread.java:829)

