### PR TITLE
Barrage needs a snapshot to sync last notification step and avoid missing first update

### DIFF
--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -226,11 +226,6 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
                     scheduler, streamGeneratorFactory, parent, updateIntervalMs, onGetSnapshot);
             return new Result<>(result, result.constructListener());
         }
-
-        @Override
-        public boolean snapshotNeeded() {
-            return false;
-        }
     }
 
     private static class MyMemoKey extends MemoizedOperationKey {
@@ -592,7 +587,6 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
             Assert.assertion(parentIsRefreshing, "parent.isRefreshing()");
             manage(parent);
             addParentReference(this);
-            parent.listenForUpdates(this);
         }
 
         @Override


### PR DESCRIPTION
In testing barrage performance metrics, I ran into an issue where the web UI did not understand the sequence of events sent by Barrage.

This was caused by a missing update between the client's snapshot and the first update. Here are the first two messages of an append-only flat table:
```
server_1      | 2022-04-05T16:47:27.123Z | heduler-Concurrent-1 |  INFO | .b.BarrageMessageProducer | BarrageMessageProducer(30089255): Snapshot: {0-23}
server_1      | 2022-04-05T16:47:28.127Z | heduler-Concurrent-4 |  INFO | .b.BarrageMessageProducer | BarrageMessageProducer(30089255): Update: {25-34}
```

Revert to using the swap listener to correctly initialize the last notification step, which fixes the missing update.