### PR TITLE
Add tests for java 18 now that it is available

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
-        test-jvm-version: ['11', '17']
+        test-jvm-version: ['11', '17', '18']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-20.04
     steps:
@@ -36,6 +36,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup JDK 18
+        id: setup-java-18
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '18'
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -43,7 +50,7 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
-          echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
+          echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }},${{ steps.setup-java-18.outputs.path }}," >> gradle.properties
           cat gradle.properties
 
       - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}

--- a/Configuration/src/test/java/io/deephaven/configuration/TestConfiguration.java
+++ b/Configuration/src/test/java/io/deephaven/configuration/TestConfiguration.java
@@ -466,6 +466,14 @@ public class TestConfiguration extends TestCase {
                             "java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
                             "java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n",
                     history.get(0).fileName);
+        } else if ("18".equals(javaVersion)) {
+            assertEquals(
+                    "<not from configuration file>: io.deephaven.configuration.TestConfiguration.testShowHistory(TestConfiguration.java:440)\n"
+                            +
+                            "java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)\n"
+                            +
+                            "java.base/java.lang.reflect.Method.invoke(Method.java:577)\n",
+                    history.get(0).fileName);
         } else {
             fail("Must add specific test for java version " + javaVersion);
         }

--- a/buildSrc/src/main/groovy/io.deephaven.java-jacoco-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-jacoco-conventions.gradle
@@ -2,22 +2,27 @@ plugins {
     id 'java'
     id 'jacoco'
 }
-
+// TODO (deephaven-core#2203) Upgrade Jacoco past 0.8.7 to support Java 18 and remove this check
 def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRuntimeVersion') ?: '11')
-if (testRuntimeVersion < 18) {
-    jacoco {
-        toolVersion = '0.8.7'
-    }
+if (testRuntimeVersion > 17) {
+    // We can't just skip configuring it, we have to actually disable it to prevent ~2GB of log output
+    // as it fails to run
+    project.tasks.forEach({ task -> task.extensions.findByType(JacocoTaskExtension)?.enabled = false })
+    return;
+}
 
-    jacocoTestReport {
-        reports {
-            xml.enabled true
-            csv.enabled true
-            html.enabled true
-        }
-    }
+jacoco {
+    toolVersion = '0.8.7'
+}
 
-    project.tasks.withType(Test).all { Test t ->
-        finalizedBy jacocoTestReport
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        csv.enabled true
+        html.enabled true
     }
+}
+
+project.tasks.withType(Test).all { Test t ->
+    finalizedBy jacocoTestReport
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-jacoco-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-jacoco-conventions.gradle
@@ -3,18 +3,21 @@ plugins {
     id 'jacoco'
 }
 
-jacoco {
-    toolVersion = '0.8.7'
-}
-
-jacocoTestReport {
-    reports {
-        xml.enabled true
-        csv.enabled true
-        html.enabled true
+def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRuntimeVersion') ?: '11')
+if (testRuntimeVersion < 18) {
+    jacoco {
+        toolVersion = '0.8.7'
     }
-}
 
-project.tasks.withType(Test).all { Test t ->
-    finalizedBy jacocoTestReport
+    jacocoTestReport {
+        reports {
+            xml.enabled true
+            csv.enabled true
+            html.enabled true
+        }
+    }
+
+    project.tasks.withType(Test).all { Test t ->
+        finalizedBy jacocoTestReport
+    }
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-jacoco-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-jacoco-conventions.gradle
@@ -2,17 +2,9 @@ plugins {
     id 'java'
     id 'jacoco'
 }
-// TODO (deephaven-core#2203) Upgrade Jacoco past 0.8.7 to support Java 18 and remove this check
-def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRuntimeVersion') ?: '11')
-if (testRuntimeVersion > 17) {
-    // We can't just skip configuring it, we have to actually disable it to prevent ~2GB of log output
-    // as it fails to run
-    project.tasks.forEach({ task -> task.extensions.findByType(JacocoTaskExtension)?.enabled = false })
-    return;
-}
 
 jacoco {
-    toolVersion = '0.8.7'
+    toolVersion = '0.8.8'
 }
 
 jacocoTestReport {


### PR DESCRIPTION
Note that Gradle does not yet officially support Java18:
https://docs.gradle.org/current/userguide/compatibility.html

Jacoco also does not support Java 18, so must be disabled for now.

See #2203 for more follow up.