### PR TITLE
Barrage Performance Metrics

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -187,6 +187,10 @@ public interface Table extends
      * Set this attribute to load a plugin for this table in the Web Client
      */
     String PLUGIN_NAME = "PluginName";
+    /**
+     * Set this attribute to enable collection of barrage performance stats.
+     */
+    String BARRAGE_PERFORMANCE_KEY_ATTRIBUTE = "BarragePerformanceTableKey";
 
     /**
      * Set the value of an attribute.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -409,6 +409,10 @@ public abstract class BaseTable extends LivenessArtifact
                 CopyAttributeOperation.Join,
                 CopyAttributeOperation.WouldMatch));
 
+        tempMap.put(BARRAGE_PERFORMANCE_KEY_ATTRIBUTE, EnumSet.of(
+                CopyAttributeOperation.Flatten, // add flatten for now because web flattens all views
+                CopyAttributeOperation.Preview));
+
         attributeToCopySet = Collections.unmodifiableMap(tempMap);
     }
 

--- a/extensions/barrage/build.gradle
+++ b/extensions/barrage/build.gradle
@@ -16,7 +16,8 @@ dependencies {
     api project(':engine-table')
     implementation project(':proto:proto-backplane-grpc-flight')
     implementation project(':log-factory')
-    api "io.deephaven.barrage:barrage-format:0.4.1"
+    api 'io.deephaven.barrage:barrage-format:0.4.1'
+    implementation 'org.hdrhistogram:HdrHistogram:2.1.12'
 
     Classpaths.inheritFlatbuffer(project, 'implementation')
 

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
@@ -12,11 +12,15 @@ import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 
 /**
- * Enable barrage performance metrics by setting the {@code BarragePerformanceLog.statsLoggingEnabled} flag, or by
- * adding the {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE} as an attribute to the table.
+ * Enable barrage performance metrics by setting the {@code BarragePerformanceLog.enableAll} flag, or by adding the
+ * {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE} as an attribute to the table.
  */
 public class BarragePerformanceLog {
-    /** If all barrage performance logging is enabled by default, then table's description is used as TableKey */
+    /**
+     * If all barrage performance logging is enabled by default, then table's description is used as TableKey unless
+     * override with {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE table key}
+     * {@link io.deephaven.engine.table.Table#setAttribute(String, Object) attribute}.
+     */
     public static final boolean ALL_PERFORMANCE_ENABLED = Configuration.getInstance().getBooleanForClassWithDefault(
             BarragePerformanceLog.class, "enableAll", true);
 
@@ -24,7 +28,7 @@ public class BarragePerformanceLog {
     public static final long CYCLE_DURATION_MILLIS = Configuration.getInstance().getLongForClassWithDefault(
             BarragePerformanceLog.class, "cycleDurationMillis", 60000);
 
-    private static BarragePerformanceLog INSTANCE;
+    private static volatile BarragePerformanceLog INSTANCE;
 
     public static BarragePerformanceLog getInstance() {
         if (INSTANCE == null) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
@@ -12,13 +12,14 @@ import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 
 /**
- * Enable barrage performance metrics by setting the {@code BarragePerformanceLog.enableAll} flag, or by adding the
- * {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE} as an attribute to the table.
+ * Enable barrage performance metrics by setting the {@code BarragePerformanceLog.enableAll} configuration property, or
+ * by adding the {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE table key} as an
+ * {@link io.deephaven.engine.table.Table#setAttribute(String, Object) attribute} to the table.
  */
 public class BarragePerformanceLog {
     /**
      * If all barrage performance logging is enabled by default, then table's description is used as TableKey unless
-     * override with {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE table key}
+     * override with the {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE table key}
      * {@link io.deephaven.engine.table.Table#setAttribute(String, Object) attribute}.
      */
     public static final boolean ALL_PERFORMANCE_ENABLED = Configuration.getInstance().getBooleanForClassWithDefault(

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
@@ -19,7 +19,7 @@ import io.deephaven.io.logger.Logger;
 public class BarragePerformanceLog {
     /**
      * If all barrage performance logging is enabled by default, then table's description is used as TableKey unless
-     * override with the {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE table key}
+     * overriden with the {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE table key}
      * {@link io.deephaven.engine.table.Table#setAttribute(String, Object) attribute}.
      */
     public static final boolean ALL_PERFORMANCE_ENABLED = Configuration.getInstance().getBooleanForClassWithDefault(

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLog.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage;
+
+import io.deephaven.configuration.Configuration;
+import io.deephaven.engine.table.impl.BaseTable;
+import io.deephaven.engine.table.impl.QueryTable;
+import io.deephaven.engine.table.impl.util.MemoryTableLogger;
+import io.deephaven.internal.log.LoggerFactory;
+import io.deephaven.io.logger.Logger;
+
+/**
+ * Enable barrage performance metrics by setting the {@code BarragePerformanceLog.statsLoggingEnabled} flag, or by
+ * adding the {@link io.deephaven.engine.table.Table#BARRAGE_PERFORMANCE_KEY_ATTRIBUTE} as an attribute to the table.
+ */
+public class BarragePerformanceLog {
+    /** If all barrage performance logging is enabled by default, then table's description is used as TableKey */
+    public static final boolean ALL_PERFORMANCE_ENABLED = Configuration.getInstance().getBooleanForClassWithDefault(
+            BarragePerformanceLog.class, "enableAll", true);
+
+    /** Explicitly set this parameter to flush performance metrics more frequently. */
+    public static final long CYCLE_DURATION_MILLIS = Configuration.getInstance().getLongForClassWithDefault(
+            BarragePerformanceLog.class, "cycleDurationMillis", 60000);
+
+    private static BarragePerformanceLog INSTANCE;
+
+    public static BarragePerformanceLog getInstance() {
+        if (INSTANCE == null) {
+            synchronized (BarragePerformanceLog.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new BarragePerformanceLog();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    private final MemoryTableLogger<BarragePerformanceLogLogger> barragePerformanceLogger;
+
+    private BarragePerformanceLog() {
+        final Logger log = LoggerFactory.getLogger(BarragePerformanceLog.class);
+        barragePerformanceLogger = new MemoryTableLogger<>(
+                log, new BarragePerformanceLogLogger(), BarragePerformanceLogLogger.getTableDefinition());
+        barragePerformanceLogger.getQueryTable().setAttribute(
+                BaseTable.BARRAGE_PERFORMANCE_KEY_ATTRIBUTE, "BarragePerformanceLog");
+    }
+
+    public QueryTable getTable() {
+        return barragePerformanceLogger.getQueryTable();
+    }
+
+    public BarragePerformanceLogLogger getLogger() {
+        return barragePerformanceLogger.getTableLogger();
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLogLogger.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/BarragePerformanceLogLogger.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+
+package io.deephaven.extensions.barrage;
+
+import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.engine.util.ColumnsSpecHelper;
+import io.deephaven.tablelogger.Row;
+import io.deephaven.tablelogger.RowSetter;
+import io.deephaven.tablelogger.TableLoggerImpl2;
+import io.deephaven.tablelogger.WritableRowContainer;
+import io.deephaven.time.DateTime;
+
+import java.io.IOException;
+
+public class BarragePerformanceLogLogger
+        extends TableLoggerImpl2<BarragePerformanceLogLogger.ISetter> {
+
+    private static final String TABLE_NAME = "BarragePerformanceLog";
+
+    public BarragePerformanceLogLogger() {
+        super(TABLE_NAME);
+    }
+
+    @SuppressWarnings("rawtypes")
+    interface ISetter extends WritableRowContainer {
+        void log(Row.Flags flags, String tableId, String tableKey, String statType, DateTime time,
+                long count, double pct50, double pct75, double pct90, double pct95, double pct99, double max)
+                throws IOException;
+    }
+
+    public static String getDefaultTableName() {
+        return TABLE_NAME;
+    }
+
+    @SuppressWarnings("rawtypes")
+    class DirectSetter extends BaseSetter implements ISetter {
+        RowSetter<String> TableId;
+        RowSetter<String> TableKey;
+        RowSetter<String> StatType;
+        RowSetter<DateTime> Time;
+        RowSetter<Long> Count;
+        RowSetter<Double> Pct50;
+        RowSetter<Double> Pct75;
+        RowSetter<Double> Pct90;
+        RowSetter<Double> Pct95;
+        RowSetter<Double> Pct99;
+        RowSetter<Double> Max;
+
+        DirectSetter() {
+            TableId = row.getSetter("TableId", String.class);
+            TableKey = row.getSetter("TableKey", String.class);
+            StatType = row.getSetter("StatType", String.class);
+            Time = row.getSetter("Time", DateTime.class);
+            Count = row.getSetter("Count", long.class);
+            Pct50 = row.getSetter("Pct50", double.class);
+            Pct75 = row.getSetter("Pct75", double.class);
+            Pct90 = row.getSetter("Pct90", double.class);
+            Pct95 = row.getSetter("Pct95", double.class);
+            Pct99 = row.getSetter("Pct99", double.class);
+            Max = row.getSetter("Max", double.class);
+        }
+
+        @Override
+        public void log(Row.Flags flags, String tableId, String tableKey, String statType, DateTime time,
+                long count, double pct50, double pct75, double pct90, double pct95, double pct99, double max)
+                throws IOException {
+            setRowFlags(flags);
+            this.TableId.set(tableId);
+            this.TableKey.set(tableKey);
+            this.StatType.set(statType);
+            this.Time.set(time);
+
+            this.Count.setLong(count);
+            this.Pct50.setDouble(pct50);
+            this.Pct75.setDouble(pct75);
+            this.Pct90.setDouble(pct90);
+            this.Pct95.setDouble(pct95);
+            this.Pct99.setDouble(pct99);
+            this.Max.setDouble(max);
+        }
+    }
+
+    @Override
+    protected String threadName() {
+        return TABLE_NAME;
+    }
+
+    private static final String[] columnNames;
+    private static final Class<?>[] columnDbTypes;
+
+    static {
+        final ColumnsSpecHelper cols = new ColumnsSpecHelper()
+                .add("TableId", String.class)
+                .add("TableKey", String.class)
+                .add("StatType", String.class)
+                .add("Time", DateTime.class)
+
+                .add("Count", long.class)
+                .add("Pct50", double.class)
+                .add("Pct75", double.class)
+                .add("Pct90", double.class)
+                .add("Pct95", double.class)
+                .add("Pct99", double.class)
+                .add("Max", double.class)
+
+        ;
+
+        columnNames = cols.getColumnNames();
+        columnDbTypes = cols.getTypes();
+    }
+
+    @Override
+    protected ISetter createSetter() {
+        outstandingSetters.getAndIncrement();
+        return new DirectSetter();
+    }
+
+    public void log(
+            String tableId, String tableKey, String statType, DateTime time,
+            long count, double pct50, double pct75, double pct90, double pct95, double pct99, double max)
+            throws IOException {
+        log(DEFAULT_INTRADAY_LOGGER_FLAGS, tableId, tableKey, statType, time,
+                count, pct50, pct75, pct90, pct95, pct99, max);
+    }
+
+    public void log(
+            Row.Flags flags, String tableId, String tableKey, String statType, DateTime time,
+            long count, double pct50, double pct75, double pct90, double pct95, double pct99, double max)
+            throws IOException {
+        verifyCondition(isInitialized(), "init() must be called before calling log()");
+        verifyCondition(!isClosed, "cannot call log() after the logger is closed");
+        verifyCondition(!isShuttingDown, "cannot call log() while the logger is shutting down");
+        final ISetter setter = setterPool.take();
+        try {
+            setter.log(flags, tableId, tableKey, statType, time, count, pct50, pct75, pct90, pct95, pct99, max);
+        } catch (Exception e) {
+            setterPool.give(setter);
+            throw e;
+        }
+        flush(setter);
+    }
+
+    private static final TableDefinition TABLE_DEFINITION = TableDefinition.tableDefinition(columnDbTypes, columnNames);
+
+    public static TableDefinition getTableDefinition() {
+        return TABLE_DEFINITION;
+    }
+
+    public static Class<?>[] getColumnDbTypes() {
+        return columnDbTypes;
+    }
+
+    public static String[] getColumnNames() {
+        return columnNames;
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkInputStreamGenerator.java
@@ -9,6 +9,7 @@ import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSequenceFactory;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.Chunk;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkInputStreamGenerator.java
@@ -9,7 +9,6 @@ import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSequenceFactory;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.Chunk;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -27,17 +27,27 @@ import io.deephaven.engine.table.impl.sources.*;
 import io.deephaven.engine.table.impl.sources.WritableRedirectedColumnSource;
 import io.deephaven.chunk.*;
 import io.deephaven.engine.table.impl.util.*;
+import io.deephaven.extensions.barrage.BarragePerformanceLog;
+import io.deephaven.extensions.barrage.BarragePerformanceLogLogger;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.log.LogEntry;
 import io.deephaven.io.log.LogLevel;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.engine.rowset.chunkattributes.RowKeys;
+import io.deephaven.time.DateTime;
 import io.deephaven.util.annotations.InternalUseOnly;
+import org.HdrHistogram.Histogram;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
 
 /**
  * A client side {@link Table} that mirrors an upstream/server side {@code Table}.
@@ -53,8 +63,11 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
 
     private final UpdateSourceRegistrar registrar;
     private final NotificationQueue notificationQueue;
+    private final ScheduledExecutorService executorService;
 
     private final PerformanceEntry refreshEntry;
+
+    private final Stats stats;
 
     /** the capacity that the destSources been set to */
     private int capacity = 0;
@@ -112,17 +125,32 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
 
     protected BarrageTable(final UpdateSourceRegistrar registrar,
             final NotificationQueue notificationQueue,
+            @Nullable final ScheduledExecutorService executorService,
             final LinkedHashMap<String, ColumnSource<?>> columns,
             final WritableColumnSource<?>[] writableSources,
             final WritableRowRedirection rowRedirection,
+            final Map<String, String> attributes,
             final boolean isViewPort) {
         super(RowSetFactory.empty().toTracking(), columns);
+        attributes.forEach(this::setAttribute);
+
         this.registrar = registrar;
         this.notificationQueue = notificationQueue;
+        this.executorService = executorService;
 
         this.rowRedirection = rowRedirection;
-        this.refreshEntry = UpdatePerformanceTracker.getInstance()
-                .getEntry("BarrageTable run " + System.identityHashCode(this));
+
+        final Object tableKey = getAttribute(Table.BARRAGE_PERFORMANCE_KEY_ATTRIBUTE);
+        if (tableKey instanceof String) {
+            stats = new Stats((String) tableKey);
+        } else if (BarragePerformanceLog.ALL_PERFORMANCE_ENABLED) {
+            stats = new Stats(getDescription());
+        } else {
+            stats = null;
+        }
+
+        this.refreshEntry = UpdatePerformanceTracker.getInstance().getEntry(
+                "BarrageTable(" + System.identityHashCode(this) + (stats != null ? ") " + stats.tableKey : ")"));
 
         if (isViewPort) {
             serverViewport = RowSetFactory.empty();
@@ -189,6 +217,9 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
      */
     public synchronized void sealTable(final Runnable onSealRunnable, final Runnable onSealFailure) {
         // TODO (core#803): sealing of static table data acquired over flight/barrage
+        if (stats != null) {
+            stats.stop();
+        }
         setRefreshing(false);
         sealed = true;
         this.onSealRunnable = onSealRunnable;
@@ -413,7 +444,9 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
     public void run() {
         refreshEntry.onUpdateStart();
         try {
+            final long startTm = System.nanoTime();
             realRefresh();
+            recordMetric(stats -> stats.refresh, System.nanoTime() - startTm);
         } catch (Exception e) {
             beginLog(LogLevel.ERROR).append(": Failure during BarrageTable run: ").append(e).endl();
             notifyListenersOnError(e, null);
@@ -454,8 +487,10 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
 
         UpdateCoalescer coalescer = null;
         for (final BarrageMessage update : localPendingUpdates) {
+            final long startTm = System.nanoTime();
             coalescer = processUpdate(update, coalescer);
             update.close();
+            recordMetric(stats -> stats.processUpdate, System.nanoTime() - startTm);
         }
         localPendingUpdates.clear();
 
@@ -524,20 +559,30 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
     /**
      * Set up a replicated table from the given proxy, id and columns. This is intended for internal use only.
      *
+     *
+     * @param executorService an executor service used to flush stats
      * @param tableDefinition the table definition
      * @param isViewPort true if the table will be a viewport.
      *
      * @return a properly initialized {@link BarrageTable}
      */
     @InternalUseOnly
-    public static BarrageTable make(final TableDefinition tableDefinition, final boolean isViewPort) {
-        return make(UpdateGraphProcessor.DEFAULT, UpdateGraphProcessor.DEFAULT, tableDefinition, isViewPort);
+    public static BarrageTable make(
+            @Nullable final ScheduledExecutorService executorService,
+            final TableDefinition tableDefinition,
+            final Map<String, String> attributes,
+            final boolean isViewPort) {
+        return make(UpdateGraphProcessor.DEFAULT, UpdateGraphProcessor.DEFAULT, executorService, tableDefinition,
+                attributes, isViewPort);
     }
 
     @VisibleForTesting
-    public static BarrageTable make(final UpdateSourceRegistrar registrar,
+    public static BarrageTable make(
+            final UpdateSourceRegistrar registrar,
             final NotificationQueue queue,
+            @Nullable final ScheduledExecutorService executor,
             final TableDefinition tableDefinition,
+            final Map<String, String> attributes,
             final boolean isViewPort) {
         final ColumnDefinition<?>[] columns = tableDefinition.getColumns();
         final WritableColumnSource<?>[] writableSources = new WritableColumnSource[columns.length];
@@ -545,8 +590,8 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
         final LinkedHashMap<String, ColumnSource<?>> finalColumns =
                 makeColumns(columns, writableSources, rowRedirection);
 
-        final BarrageTable table =
-                new BarrageTable(registrar, queue, finalColumns, writableSources, rowRedirection, isViewPort);
+        final BarrageTable table = new BarrageTable(
+                registrar, queue, executor, finalColumns, writableSources, rowRedirection, attributes, isViewPort);
 
         // Even if this source table will eventually be static, the data isn't here already. Static tables need to
         // have refreshing set to false after processing data but prior to publishing the object to consumers.
@@ -610,5 +655,90 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
      */
     private LogEntry beginLog(LogLevel level) {
         return log.getEntry(level).append(System.identityHashCode(this));
+    }
+
+    @Override
+    protected void destroy() {
+        super.destroy();
+        if (stats != null) {
+            stats.stop();
+        }
+    }
+
+    public LongConsumer getDeserializationTmConsumer() {
+        if (stats == null) {
+            return ignored -> {
+            };
+        }
+        return value -> recordMetric(stats -> stats.deserialize, value);
+    }
+
+    private void recordMetric(final Function<Stats, Histogram> hist, final long value) {
+        if (stats == null) {
+            return;
+        }
+        synchronized (stats) {
+            hist.apply(stats).recordValue(value);
+        }
+    }
+
+    private class Stats implements Runnable {
+        private final int NUM_SIG_FIGS = 3;
+
+        public final String tableId = Integer.toHexString(System.identityHashCode(BarrageTable.this));
+        public final String tableKey;
+        public final Histogram deserialize = new Histogram(NUM_SIG_FIGS);
+        public final Histogram processUpdate = new Histogram(NUM_SIG_FIGS);
+        public final Histogram refresh = new Histogram(NUM_SIG_FIGS);
+
+        private volatile boolean running = true;
+
+        public Stats(final String tableKey) {
+            this.tableKey = tableKey;
+            executorService.schedule(this, BarragePerformanceLog.CYCLE_DURATION_MILLIS, TimeUnit.MILLISECONDS);
+        }
+
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public synchronized void run() {
+            if (!running) {
+                return;
+            }
+
+            final DateTime now = DateTime.now();
+            executorService.schedule(this, BarragePerformanceLog.CYCLE_DURATION_MILLIS, TimeUnit.MILLISECONDS);
+
+            final BarragePerformanceLogLogger logger = BarragePerformanceLog.getInstance().getLogger();
+            try {
+                // noinspection SynchronizationOnLocalVariableOrMethodParameter
+                synchronized (logger) {
+                    flush(now, logger, deserialize, "DeserializationTimeMs");
+                    flush(now, logger, processUpdate, "ProcessUpdateTimeMs");
+                    flush(now, logger, refresh, "RefreshTimeMs");
+                }
+            } catch (IOException ioe) {
+                beginLog(LogLevel.ERROR).append("Unexpected exception while flushing barrage stats: ")
+                        .append(ioe).endl();
+            }
+        }
+
+        private void flush(final DateTime now, final BarragePerformanceLogLogger logger, final Histogram hist,
+                final String statType) throws IOException {
+            if (hist.getTotalCount() == 0) {
+                return;
+            }
+            logger.log(tableId, tableKey, statType, now,
+                    hist.getTotalCount(),
+                    hist.getValueAtPercentile(50) / 1e6,
+                    hist.getValueAtPercentile(75) / 1e6,
+                    hist.getValueAtPercentile(90) / 1e6,
+                    hist.getValueAtPercentile(95) / 1e6,
+                    hist.getValueAtPercentile(99) / 1e6,
+                    hist.getMaxValue() / 1e6);
+            hist.reset();
+        }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -141,7 +141,9 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
         this.rowRedirection = rowRedirection;
 
         final Object tableKey = getAttribute(Table.BARRAGE_PERFORMANCE_KEY_ATTRIBUTE);
-        if (tableKey instanceof String) {
+        if (executorService == null) {
+            stats = null;
+        } else if (tableKey instanceof String) {
             stats = new Stats((String) tableKey);
         } else if (BarragePerformanceLog.ALL_PERFORMANCE_ENABLED) {
             stats = new Stats(getDescription());

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -698,7 +698,7 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
 
         public Stats(final String tableKey) {
             this.tableKey = tableKey;
-            runFuture = executorService.scheduleAtFixedRate(this, BarragePerformanceLog.CYCLE_DURATION_MILLIS,
+            runFuture = executorService.scheduleWithFixedDelay(this, BarragePerformanceLog.CYCLE_DURATION_MILLIS,
                     BarragePerformanceLog.CYCLE_DURATION_MILLIS, TimeUnit.MILLISECONDS);
         }
 
@@ -707,9 +707,8 @@ public class BarrageTable extends QueryTable implements BarrageMessage.Listener,
         }
 
         @Override
-        public synchronized void run() {
+        public void run() {
             final DateTime now = DateTime.now();
-            executorService.schedule(this, BarragePerformanceLog.CYCLE_DURATION_MILLIS, TimeUnit.MILLISECONDS);
 
             final BarragePerformanceLogLogger logger = BarragePerformanceLog.getInstance().getLogger();
             try {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -75,6 +75,11 @@ public class BarrageUtil {
 
     private static final int ATTR_STRING_LEN_CUTOFF = 1024;
 
+    private static final String ATTR_DH_PREFIX = "deephaven:";
+    private static final String ATTR_ATTR_TAG = "attribute";
+    private static final String ATTR_TYPE_TAG = "type";
+    private static final String ATTR_COMPONENT_TYPE_TAG = "componentType";
+
     /**
      * These are the types that get special encoding but are otherwise not primitives. TODO (core#58): add custom
      * barrage serialization/deserialization support
@@ -132,7 +137,7 @@ public class BarrageUtil {
                     val instanceof Long || val instanceof Float || val instanceof Double ||
                     val instanceof Character || val instanceof Boolean ||
                     (val instanceof String && ((String) val).length() < ATTR_STRING_LEN_CUTOFF)) {
-                putMetadata(schemaMetadata, "attribute." + key, val.toString());
+                putMetadata(schemaMetadata, ATTR_ATTR_TAG + "." + key, val.toString());
             } else {
                 unsentAttributes.add(key);
             }
@@ -143,7 +148,8 @@ public class BarrageUtil {
             unsentAttributes.remove(Table.HIERARCHICAL_SOURCE_INFO_ATTRIBUTE);
             final HierarchicalTableInfo hierarchicalTableInfo =
                     (HierarchicalTableInfo) attributes.remove(Table.HIERARCHICAL_SOURCE_INFO_ATTRIBUTE);
-            final String hierarchicalSourceKeyPrefix = "attribute." + Table.HIERARCHICAL_SOURCE_INFO_ATTRIBUTE + ".";
+            final String hierarchicalSourceKeyPrefix =
+                    ATTR_ATTR_TAG + "." + Table.HIERARCHICAL_SOURCE_INFO_ATTRIBUTE + ".";
             putMetadata(schemaMetadata, hierarchicalSourceKeyPrefix + "hierarchicalColumnName",
                     hierarchicalTableInfo.getHierarchicalColumnName());
             if (hierarchicalTableInfo instanceof RollupInfo) {
@@ -162,7 +168,7 @@ public class BarrageUtil {
 
         // note which attributes have a value we couldn't send
         for (String unsentAttribute : unsentAttributes) {
-            putMetadata(schemaMetadata, "unsent.attribute." + unsentAttribute, "");
+            putMetadata(schemaMetadata, "unsent." + ATTR_ATTR_TAG + "." + unsentAttribute, "");
         }
 
         final Map<String, Field> fields = new LinkedHashMap<>();
@@ -189,7 +195,7 @@ public class BarrageUtil {
     }
 
     private static void putMetadata(final Map<String, String> metadata, final String key, final String value) {
-        metadata.put("deephaven:" + key, value);
+        metadata.put(ATTR_DH_PREFIX + key, value);
     }
 
     private static boolean maybeConvertForTimeUnit(final TimeUnit unit, final ConvertedArrowSchema result,
@@ -213,7 +219,7 @@ public class BarrageUtil {
 
     private static Class<?> getDefaultType(
             final String name, final ArrowType arrowType, final ConvertedArrowSchema result, final int i) {
-        final String exMsg = "Schema did not include `deephaven:type` metadata for field ";
+        final String exMsg = "Schema did not include `" + ATTR_DH_PREFIX + ATTR_TYPE_TAG + "` metadata for field ";
         switch (arrowType.getTypeID()) {
             case Int:
                 final ArrowType.Int intType = (ArrowType.Int) arrowType;
@@ -346,7 +352,7 @@ public class BarrageUtil {
             final IntFunction<String> getName,
             final IntFunction<ArrowType> getArrowType,
             final IntFunction<Consumer<BiConsumer<String, String>>> columnMetadataVisitor,
-            final Consumer<BiConsumer<String, String>> metadataVisitor) {
+            final Consumer<BiConsumer<String, String>> tableMetadataVisitor) {
         final ConvertedArrowSchema result = new ConvertedArrowSchema(numColumns);
         final ColumnDefinition<?>[] columns = new ColumnDefinition[numColumns];
 
@@ -357,13 +363,13 @@ public class BarrageUtil {
             final MutableObject<Class<?>> componentType = new MutableObject<>();
 
             columnMetadataVisitor.apply(i).accept((key, value) -> {
-                if (key.equals("deephaven:type")) {
+                if (key.equals(ATTR_DH_PREFIX + ATTR_TYPE_TAG)) {
                     try {
                         type.setValue(ClassUtil.lookupClass(value));
                     } catch (final ClassNotFoundException e) {
                         throw new UncheckedDeephavenException("Could not load class from schema", e);
                     }
-                } else if (key.equals("deephaven:componentType")) {
+                } else if (key.equals(ATTR_DH_PREFIX + ATTR_COMPONENT_TYPE_TAG)) {
                     try {
                         componentType.setValue(ClassUtil.lookupClass(value));
                     } catch (final ClassNotFoundException e) {
@@ -382,8 +388,8 @@ public class BarrageUtil {
         result.tableDef = new TableDefinition(columns);
 
         result.attributes = new HashMap<>();
-        metadataVisitor.accept((key, value) -> {
-            final String prefix = "deephaven:attribute.";
+        tableMetadataVisitor.accept((key, value) -> {
+            final String prefix = ATTR_DH_PREFIX + ATTR_ATTR_TAG + ".";
             if (!key.startsWith(prefix)) {
                 return;
             }
@@ -412,19 +418,19 @@ public class BarrageUtil {
         final Map<String, String> metadata = new HashMap<>(extraMetadata);
 
         if (isTypeNativelySupported(type)) {
-            putMetadata(metadata, "type", type.getCanonicalName());
+            putMetadata(metadata, ATTR_TYPE_TAG, type.getCanonicalName());
 
             if (componentType != null) {
                 if (isTypeNativelySupported(componentType)) {
-                    putMetadata(metadata, "componentType", componentType.getCanonicalName());
+                    putMetadata(metadata, ATTR_COMPONENT_TYPE_TAG, componentType.getCanonicalName());
                 } else {
                     // otherwise, it will be converted to a string
-                    putMetadata(metadata, "componentType", String.class.getCanonicalName());
+                    putMetadata(metadata, ATTR_COMPONENT_TYPE_TAG, String.class.getCanonicalName());
                 }
             }
         } else {
             // otherwise, it will be converted to a string
-            putMetadata(metadata, "type", String.class.getCanonicalName());
+            putMetadata(metadata, ATTR_TYPE_TAG, String.class.getCanonicalName());
         }
 
         // only one of these will be true, if any are true the column will not be visible

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSession.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSession.java
@@ -49,7 +49,7 @@ public class BarrageSession extends FlightSession implements BarrageSubscription
 
     @Override
     public BarrageSubscription subscribe(final TableHandle tableHandle, final BarrageSubscriptionOptions options) {
-        return new BarrageSubscriptionImpl(this, tableHandle.newRef(), options);
+        return new BarrageSubscriptionImpl(this, session.executor(), tableHandle.newRef(), options);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class BarrageSession extends FlightSession implements BarrageSubscription
 
     @Override
     public BarrageSnapshot snapshot(final TableHandle tableHandle, final BarrageSnapshotOptions options) {
-        return new BarrageSnapshotImpl(this, tableHandle.newRef(), options);
+        return new BarrageSnapshotImpl(this, session.executor(), tableHandle.newRef(), options);
     }
 
     public Channel channel() {

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.BitSet;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.Condition;
 
 public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements BarrageSnapshot {
@@ -63,24 +64,28 @@ public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements
      * Represents a BarrageSnapshot.
      *
      * @param session the Deephaven session that this export belongs to
+     * @param executorService an executor service used to flush metrics when enabled
      * @param tableHandle the tableHandle to snapshot (ownership is transferred to the snapshot)
      * @param options the transport level options for this snapshot
      */
     public BarrageSnapshotImpl(
-            final BarrageSession session, final TableHandle tableHandle, final BarrageSnapshotOptions options) {
+            final BarrageSession session, @Nullable final ScheduledExecutorService executorService,
+            final TableHandle tableHandle, final BarrageSnapshotOptions options) {
         super(false);
 
         this.logName = tableHandle.exportId().toString();
         this.options = options;
         this.tableHandle = tableHandle;
 
-        final TableDefinition tableDefinition = BarrageUtil.convertArrowSchema(tableHandle.response()).tableDef;
-        resultTable = BarrageTable.make(tableDefinition, false);
+        final BarrageUtil.ConvertedArrowSchema schema = BarrageUtil.convertArrowSchema(tableHandle.response());
+        final TableDefinition tableDefinition = schema.tableDef;
+        resultTable = BarrageTable.make(executorService, tableDefinition, schema.attributes, false);
         resultTable.addParentReference(this);
 
         final MethodDescriptor<FlightData, BarrageMessage> snapshotDescriptor =
                 getClientDoExchangeDescriptor(options, resultTable.getWireChunkTypes(), resultTable.getWireTypes(),
-                        resultTable.getWireComponentTypes(), new BarrageStreamReader());
+                        resultTable.getWireComponentTypes(),
+                        new BarrageStreamReader(resultTable.getDeserializationTmConsumer()));
 
         // We need to ensure that the DoExchange RPC does not get attached to the server RPC when this is being called
         // from a Deephaven server RPC thread. If we need to generalize this in the future, we may wrap this logic in a

--- a/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
@@ -355,6 +355,10 @@ public final class SessionImpl extends SessionBase {
         return observer;
     }
 
+    public ScheduledExecutorService executor() {
+        return executor;
+    }
+
     public long batchCount() {
         return states.batchCount();
     }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     api(project(':java-client-barrage-dagger')) {
         because 'downstream dagger compile, see deephaven-core#1722'
     }
+    implementation 'org.hdrhistogram:HdrHistogram:2.1.12'
 
     implementation project(':proto:proto-backplane-grpc-flight')
     implementation project(':open-api-lang-tools')

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -530,8 +530,9 @@ public class ArrowFlightUtil {
                                 msg.modColumnData = ZERO_MOD_COLUMNS; // no mod column data
 
                                 // translate the viewport to keyspace and make the call
-                                try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, (bits, tm) -> {
-                                });
+                                try (final BarrageStreamGenerator bsg =
+                                        new BarrageStreamGenerator(msg, (bytes, nanos) -> {
+                                        });
                                         final RowSet keySpaceViewport =
                                                 hasViewport
                                                         ? msg.rowsAdded.subSetForPositions(viewport, reverseViewport)

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -44,6 +44,7 @@ import org.apache.arrow.flatbuf.MessageHeader;
 import org.apache.arrow.flatbuf.RecordBatch;
 import org.apache.arrow.flatbuf.Schema;
 import org.apache.arrow.flight.impl.Flight;
+import org.jetbrains.annotations.Nullable;
 
 import javax.validation.constraints.NotNull;
 import java.io.Closeable;
@@ -55,6 +56,7 @@ import java.util.ArrayDeque;
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.Queue;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static io.deephaven.extensions.barrage.util.BarrageProtoUtil.DEFAULT_SER_OPTIONS;
 
@@ -72,6 +74,7 @@ public class ArrowFlightUtil {
     public static class DoPutObserver extends SingletonLivenessManager
             implements StreamObserver<InputStream>, Closeable {
 
+        private final ScheduledExecutorService executorService;
         private final SessionState session;
         private final TicketRouter ticketRouter;
         private final StreamObserver<Flight.PutResult> observer;
@@ -87,9 +90,11 @@ public class ArrowFlightUtil {
         private BarrageSubscriptionOptions options = DEFAULT_SER_OPTIONS;
 
         public DoPutObserver(
+                @Nullable final ScheduledExecutorService executorService,
                 final SessionState session,
                 final TicketRouter ticketRouter,
                 final StreamObserver<Flight.PutResult> observer) {
+            this.executorService = executorService;
             this.session = session;
             this.ticketRouter = ticketRouter;
             this.observer = observer;
@@ -264,7 +269,7 @@ public class ArrowFlightUtil {
             }
 
             final BarrageUtil.ConvertedArrowSchema result = BarrageUtil.convertArrowSchema(header);
-            resultTable = BarrageTable.make(result.tableDef, false);
+            resultTable = BarrageTable.make(executorService, result.tableDef, result.attributes, false);
             columnConversionFactors = result.conversionFactors;
             columnChunkTypes = resultTable.getWireChunkTypes();
             columnTypes = resultTable.getWireTypes();
@@ -525,7 +530,8 @@ public class ArrowFlightUtil {
                                 msg.modColumnData = ZERO_MOD_COLUMNS; // no mod column data
 
                                 // translate the viewport to keyspace and make the call
-                                try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg);
+                                try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, ignored -> {
+                                });
                                         final RowSet keySpaceViewport =
                                                 hasViewport
                                                         ? msg.rowsAdded.subSetForPositions(viewport, reverseViewport)

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -530,7 +530,7 @@ public class ArrowFlightUtil {
                                 msg.modColumnData = ZERO_MOD_COLUMNS; // no mod column data
 
                                 // translate the viewport to keyspace and make the call
-                                try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, ignored -> {
+                                try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, (bits, tm) -> {
                                 });
                                         final RowSet keySpaceViewport =
                                                 hasViewport

--- a/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
@@ -183,7 +183,7 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                         msg.modColumnData = ZERO_MOD_COLUMNS; // actually no mod column data for DoGet
 
                         // translate the viewport to keyspace and make the call
-                        try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, ignored -> {
+                        try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, (bits, tm) -> {
                         })) {
                             listener.onNext(bsg.getSnapshotView(DEFAULT_SNAPSHOT_DESER_OPTIONS));
                         }

--- a/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
@@ -23,11 +23,13 @@ import io.deephaven.server.session.TicketRouter;
 import io.grpc.stub.StreamObserver;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.FlightServiceGrpc;
+import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static io.deephaven.server.arrow.ArrowFlightUtil.ZERO_MOD_COLUMNS;
 
@@ -38,16 +40,20 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
 
     private static final Logger log = LoggerFactory.getLogger(FlightServiceGrpcImpl.class);
 
+    private final ScheduledExecutorService executorService;
     private final SessionService sessionService;
     private final TicketRouter ticketRouter;
     private final ArrowFlightUtil.DoExchangeMarshaller.Factory doExchangeFactory;
 
     @Inject
-    public FlightServiceGrpcImpl(final SessionService sessionService,
+    public FlightServiceGrpcImpl(
+            @Nullable final ScheduledExecutorService executorService,
+            final SessionService sessionService,
             final TicketRouter ticketRouter,
             final ArrowFlightUtil.DoExchangeMarshaller.Factory doExchangeFactory) {
-        this.ticketRouter = ticketRouter;
+        this.executorService = executorService;
         this.sessionService = sessionService;
+        this.ticketRouter = ticketRouter;
         this.doExchangeFactory = doExchangeFactory;
     }
 
@@ -177,7 +183,8 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                         msg.modColumnData = ZERO_MOD_COLUMNS; // actually no mod column data for DoGet
 
                         // translate the viewport to keyspace and make the call
-                        try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg)) {
+                        try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, ignored -> {
+                        })) {
                             listener.onNext(bsg.getSnapshotView(DEFAULT_SNAPSHOT_DESER_OPTIONS));
                         }
 
@@ -194,8 +201,8 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
      */
     public StreamObserver<InputStream> doPutCustom(final StreamObserver<Flight.PutResult> responseObserver) {
         return GrpcUtil.rpcWrapper(log, responseObserver,
-                () -> new ArrowFlightUtil.DoPutObserver(sessionService.getCurrentSession(), ticketRouter,
-                        responseObserver));
+                () -> new ArrowFlightUtil.DoPutObserver(executorService, sessionService.getCurrentSession(),
+                        ticketRouter, responseObserver));
     }
 
     /**

--- a/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
@@ -183,7 +183,7 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                         msg.modColumnData = ZERO_MOD_COLUMNS; // actually no mod column data for DoGet
 
                         // translate the viewport to keyspace and make the call
-                        try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, (bits, tm) -> {
+                        try (final BarrageStreamGenerator bsg = new BarrageStreamGenerator(msg, (bytes, nanos) -> {
                         })) {
                             listener.onNext(bsg.getSnapshotView(DEFAULT_SNAPSHOT_DESER_OPTIONS));
                         }

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -124,9 +124,9 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
              * Create a StreamGenerator that now owns the BarrageMessage.
              *
              * @param message the message that contains the update that we would like to propagate
-             * @param writeTmRecorder a method that can be used to record write time
+             * @param metricsConsumer a method that can be used to record write metrics
              */
-            StreamGenerator<MessageView> newGenerator(BarrageMessage message, WriteMetricsConsumer writeTmRecorder);
+            StreamGenerator<MessageView> newGenerator(BarrageMessage message, WriteMetricsConsumer metricsConsumer);
 
             /**
              * Create a MessageView of the Schema to send as the initial message to a new subscriber.
@@ -2147,8 +2147,8 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
             this.tableKey = tableKey;
 
             final DateTime now = scheduler.currentTime();
-            final DateTime nextRun = DateTimeUtils.millisToTime(
-                    now.getMillis() + BarragePerformanceLog.CYCLE_DURATION_MILLIS);
+            final DateTime nextRun = DateTimeUtils.plus(now,
+                    DateTimeUtils.millisToNanos(BarragePerformanceLog.CYCLE_DURATION_MILLIS));
             scheduler.runAtTime(nextRun, this);
         }
 

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -116,7 +116,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
      */
     public interface StreamGenerator<MessageView> extends SafeCloseable {
         interface WriteMetricsConsumer {
-            void onWrite(long bits, long cpuTime);
+            void onWrite(long bytes, long cpuNanos);
         }
 
         interface Factory<MessageView> {
@@ -2114,9 +2114,9 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         }
     }
 
-    private void recordWriteMetrics(final long bits, final long time) {
-        recordMetric(stats -> stats.writeBits, bits);
-        recordMetric(stats -> stats.writeTime, time);
+    private void recordWriteMetrics(final long bytes, final long cpuNanos) {
+        recordMetric(stats -> stats.writeBits, bytes * 8);
+        recordMetric(stats -> stats.writeTime, cpuNanos);
     }
 
     private void recordMetric(final Function<Stats, Histogram> hist, final long value) {

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -387,7 +387,10 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         this.parent = parent;
 
         final Object tableKey = parent.getAttribute(Table.BARRAGE_PERFORMANCE_KEY_ATTRIBUTE);
-        if (tableKey instanceof String) {
+        if (scheduler.inTestMode()) {
+            // When testing do not schedule statistics, as the scheduler will never empty its work queue.
+            stats = null;
+        } else if (tableKey instanceof String) {
             stats = new Stats((String) tableKey);
         } else if (BarragePerformanceLog.ALL_PERFORMANCE_ENABLED) {
             stats = new Stats(parent.getDescription());

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -1410,7 +1410,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
 
         if (snapshot != null) {
             try (final StreamGenerator<MessageView> snapshotGenerator =
-                         streamGeneratorFactory.newGenerator(snapshot, this::recordWriteMetrics)) {
+                    streamGeneratorFactory.newGenerator(snapshot, this::recordWriteMetrics)) {
                 for (final Subscription subscription : growingSubscriptions) {
                     if (subscription.pendingDelete) {
                         continue;

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -349,7 +349,6 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         }
     }
 
-    private final PerformanceEntry refreshEntry;
     private final UpdatePropagationJob updatePropagationJob = new UpdatePropagationJob();
 
     /**
@@ -394,9 +393,6 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         } else {
             stats = null;
         }
-
-        this.refreshEntry = UpdatePerformanceTracker.getInstance().getEntry(
-                "BarrageTable(" + System.identityHashCode(this) + (stats != null ? ") " + stats.tableKey : ")"));
 
         this.propagationRowSet = RowSetFactory.empty();
         this.updateIntervalMs = updateIntervalMs;
@@ -994,14 +990,9 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
 
                 try {
                     if (needsRun.compareAndSet(true, false)) {
-                        try {
-                            refreshEntry.onUpdateStart();
-                            final long startTm = System.nanoTime();
-                            updateSubscriptionsSnapshotAndPropagate();
-                            recordMetric(stats -> stats.updateJob, System.nanoTime() - startTm);
-                        } finally {
-                            refreshEntry.onUpdateEnd();
-                        }
+                        final long startTm = System.nanoTime();
+                        updateSubscriptionsSnapshotAndPropagate();
+                        recordMetric(stats -> stats.updateJob, System.nanoTime() - startTm);
                     }
                 } catch (final Exception exception) {
                     synchronized (BarrageMessageProducer.this) {

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -336,7 +336,7 @@ public class BarrageStreamGenerator implements
                     modViewport.close();
                 }
             }
-            generator.writeConsumer.onWrite(bytesWritten * 8, System.nanoTime() - startTm);
+            generator.writeConsumer.onWrite(bytesWritten, System.nanoTime() - startTm);
         }
 
         private int batchSize() {

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -58,7 +58,6 @@ import java.util.BitSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.LongConsumer;
 
 import static io.deephaven.extensions.barrage.chunk.BaseChunkInputStreamGenerator.PADDING_BUFFER;
 

--- a/server/src/main/java/io/deephaven/server/util/Scheduler.java
+++ b/server/src/main/java/io/deephaven/server/util/Scheduler.java
@@ -44,6 +44,13 @@ public interface Scheduler extends TimeProvider {
      */
     void runSerially(@NotNull Runnable command);
 
+    /**
+     * @return whether this scheduler is being run for tests.
+     */
+    default boolean inTestMode() {
+        return false;
+    }
+
     class DelegatingImpl implements Scheduler {
 
         private final ExecutorService serialDelegate;

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -61,6 +61,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Deque;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
@@ -191,14 +192,15 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
             this.barrageMessageProducer = barrageMessageProducer;
 
             this.barrageTable = BarrageTable.make(updateSourceCombiner, UpdateGraphProcessor.DEFAULT,
-                    barrageMessageProducer.getTableDefinition(), viewport != null);
+                    null, barrageMessageProducer.getTableDefinition(), new HashMap<>(), viewport != null);
 
             final BarrageSubscriptionOptions options = BarrageSubscriptionOptions.builder()
                     .useDeephavenNulls(useDeephavenNulls)
                     .build();
             final BarrageMarshaller marshaller = new BarrageMarshaller(
                     options, barrageTable.getWireChunkTypes(), barrageTable.getWireTypes(),
-                    barrageTable.getWireComponentTypes(), new BarrageStreamReader());
+                    barrageTable.getWireComponentTypes(),
+                    new BarrageStreamReader(barrageTable.getDeserializationTmConsumer()));
             this.dummyObserver = new DummyObserver(marshaller, commandQueue);
 
             if (viewport == null) {

--- a/server/src/test/java/io/deephaven/server/util/TestControlledScheduler.java
+++ b/server/src/test/java/io/deephaven/server/util/TestControlledScheduler.java
@@ -20,6 +20,11 @@ public class TestControlledScheduler implements Scheduler {
     private final TreeMultimap<DateTime, Runnable> workQueue =
             TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
 
+    @Override
+    public boolean inTestMode() {
+        return true;
+    }
+
     /**
      * Runs the first queued command if there are any.
      */

--- a/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -29,13 +29,8 @@ import io.deephaven.server.session.SessionState;
 import io.deephaven.server.session.TicketResolver;
 import io.deephaven.server.util.Scheduler;
 import io.deephaven.util.SafeCloseable;
-import io.grpc.CallOptions;
-import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.MethodDescriptor;
 import io.grpc.ServerInterceptor;
 import org.apache.arrow.flight.*;
 import org.apache.arrow.flight.impl.Flight;
@@ -46,6 +41,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,8 +54,8 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
@@ -106,6 +102,12 @@ public abstract class FlightMessageRoundTripTest {
         @Named("grpc.maxInboundMessageSize")
         int provideMaxInboundMessageSize() {
             return 1024 * 1024;
+        }
+
+        @Provides
+        @Nullable
+        ScheduledExecutorService provideExecutorService() {
+            return null;
         }
     }
 


### PR DESCRIPTION
I've added a `BarragePerformanceLog` that is an in memory table that accumulates histograms of various barrage timings. 

I've also added the propagation update log to the existing query performance log. This should help us gain insight into memory usages.

It's worth noting that the web ui cycles through BarrageMessageProducers every time it throws away a subscription and acquires a new one. 