### PR TITLE
Add dependabot to the allowlist for CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,4 +30,4 @@ jobs:
           remote-repository-name:  cla
           branch: 'main'
           path-to-signatures: 'signatures/version1/cla.json'
-          #allowlist: user1,bot*
+          allowlist: dependabot[bot]


### PR DESCRIPTION
- Bot can't sign the CLA
- Add dependabot to the list
- dependabot-preview no longer exists, just dependabot

Reference:
https://github.com/cla-assistant/cla-assistant#can-i-allow-bot-user-contributions
https://github.com/contributor-assistant/github-action#5-users-and-bots-in-allowlist
