### PR TITLE
Fix setLayoutHints not setting table attribute

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -1352,7 +1352,7 @@ public abstract class BaseTable extends LivenessArtifact
     public Table setLayoutHints(String hints) {
         final Table result = copy();
         result.setAttribute(Table.LAYOUT_HINTS_ATTRIBUTE, hints);
-        return this;
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Fixes #2260 

Tested w/ this Groovy code (also in the ticket)
```groovy
import io.deephaven.engine.util.LayoutHintBuilder

hints = LayoutHintBuilder.get().freeze("NameOfIntCol");

t = newTable(
   stringCol("NameOfStringCol", "Data String 1", 'Data String 2', "Data String 3"),
   intCol("NameOfIntCol", 4, 5, 6)
).setLayoutHints(hints.build());

println t.getAttribute("LayoutHints")
```