### PR TITLE
Allow deephaven_legacy to not be installed

### DIFF
--- a/py/server/deephaven/server/script_session/__init__.py
+++ b/py/server/deephaven/server/script_session/__init__.py
@@ -1,5 +1,8 @@
 # Implementation utilities for io.deephaven.engine.util.PythonDeephavenSession
-from deephaven_legacy.Plot import FigureWrapper
+try:
+    from deephaven_legacy.Plot import FigureWrapper
+except ImportError:
+    FigureWrapper = None
 from jpy import JType
 
 from deephaven._wrapper import JObjectWrapper
@@ -47,7 +50,7 @@ def unwrap_to_java_type(object):
         return object
     if isinstance(object, JObjectWrapper):
         return object.j_object
-    if isinstance(object, FigureWrapper):
+    if FigureWrapper is not None and isinstance(object, FigureWrapper):
         return object.figure
     # add more here when/if necessary
     return None


### PR DESCRIPTION
This will likely be removed soon, but in the meantime it would permit a user to install the deephaven and deephaven_server wheels to start the server from python without also installing deephaven_legacy.

Partial #2221