### PR TITLE
Permit null log streams, as the code is null safe

### DIFF
--- a/server/src/main/java/io/deephaven/server/log/LogModule.java
+++ b/server/src/main/java/io/deephaven/server/log/LogModule.java
@@ -15,6 +15,7 @@ import io.deephaven.io.logger.LogBuffer;
 import io.deephaven.io.logger.LogBufferGlobal;
 import io.deephaven.io.logger.StreamToLogBuffer;
 
+import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.PrintStream;
@@ -55,7 +56,8 @@ public interface LogModule {
     }
 
     @Provides
-    static StreamToPrintStreams providesStreamToReal(@Named("out") PrintStream out, @Named("err") PrintStream err) {
+    static StreamToPrintStreams providesStreamToReal(@Nullable @Named("out") PrintStream out,
+            @Nullable @Named("err") PrintStream err) {
         final boolean skipStdout = Boolean.getBoolean("stdout.skipReal");
         final boolean skipStderr = Boolean.getBoolean("stderr.skipReal");
         return new StreamToPrintStreams(skipStdout ? null : out, skipStderr ? null : err);

--- a/server/src/main/java/io/deephaven/server/runner/DeephavenApiServerComponent.java
+++ b/server/src/main/java/io/deephaven/server/runner/DeephavenApiServerComponent.java
@@ -3,6 +3,7 @@ package io.deephaven.server.runner;
 import dagger.BindsInstance;
 import dagger.Component;
 
+import javax.annotation.Nullable;
 import javax.inject.Named;
 import java.io.PrintStream;
 
@@ -24,9 +25,9 @@ public interface DeephavenApiServerComponent {
         B withMaxInboundMessageSize(@Named("grpc.maxInboundMessageSize") int maxInboundMessageSize);
 
         @BindsInstance
-        B withOut(@Named("out") PrintStream out);
+        B withOut(@Nullable @Named("out") PrintStream out);
 
         @BindsInstance
-        B withErr(@Named("err") PrintStream err);
+        B withErr(@Nullable @Named("err") PrintStream err);
     }
 }


### PR DESCRIPTION
This allows a server implementation to not provide these print streams if it doesn't want to, by explicitly binding to null.

This is clearly safe, since `providesStreamToReal` explicitly passes nulls along rather than consume the offered params, if certain system properties are set.

Partial #2221 