### PR TITLE
Defensively include Dockerfile

### DIFF
--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -249,9 +249,13 @@ class Docker {
             sync.into dockerWorkspaceContents
 
             if (cfg.dockerfileFile) {
-                sync.from cfg.dockerfileFile
+                sync.from(cfg.dockerfileFile) { CopySpec dockerfileCopy ->
+                    dockerfileCopy.include(cfg.dockerfileFile.name)
+                }
             } else if (cfg.dockerfileAction) {
-                sync.from dockerfileTask.get().outputs.files
+                sync.from(dockerfileTask.get().outputs.files) { CopySpec dockerfileCopy ->
+                    dockerfileCopy.include('Dockerfile')
+                }
             }
         }
 


### PR DESCRIPTION
This is a problem as I make the "build this wheel in docker" more customizable, as it is possible to provide "includes" and "excludes" rules for the wheel that accidentally exclude the Dockerfile itself, thus making the project unbuildable. This commit ensures that the dockerfile itself will always be included when the image is prepared.

Partial #2221