### PR TITLE
Deephaven2 Python layout hints

### DIFF
--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -26,6 +26,8 @@ _JPair = jpy.get_type("io.deephaven.api.agg.Pair")
 _JMatchPair = jpy.get_type("io.deephaven.engine.table.MatchPair")
 _JLayoutHintBuilder = jpy.get_type("io.deephaven.engine.util.LayoutHintBuilder")
 
+T = TypeVar('T')
+ValueOrArray = Union[T, List[T]]
 
 class SortDirection(Enum):
     """An enum defining the sorting orders."""
@@ -1261,16 +1263,16 @@ class Table(JObjectWrapper):
         except Exception as e:
             raise DHError(e, "failed to color format rows conditionally.") from e
 
-    def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
-                     freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None) -> Table:
+    def layout_hints(self, front: ValueOrArray[str] = None, back: ValueOrArray[str] = None,
+                     freeze: ValueOrArray[str] = None, hide: ValueOrArray[str] = None) -> Table:
         """ Sets layout hints on the Table
 
         Args:
-            front (Union[str, List[str]]): the columns to show at the front
-            back (Union[str, List[str]]): the columns to show at the back
-            freeze (Union[str, List[str]]): the columns to freeze to the front.
+            front (ValueOrArray[str]): the columns to show at the front
+            back (ValueOrArray[str]): the columns to show at the back
+            freeze (ValueOrArray[str]): the columns to freeze to the front.
                 These will not be affected by horizontal scrolling.
-            hide (Union[str, List[str]]): the columns to hide
+            hide (ValueOrArray[str]): the columns to hide
 
         Returns:
             a new table with the layout hints set
@@ -1280,34 +1282,19 @@ class Table(JObjectWrapper):
         """
         try:
             _j_layout_hint_builder = _JLayoutHintBuilder.get()
-        except Exception as e:
-            raise DHError(e, "failed to create LayoutHint") from e
 
-        try:
             if front is not None:
                 _j_layout_hint_builder.atFront(_to_sequence(front))
-        except Exception as e:
-            raise DHError(e, "invalid value for front") from e
 
-        try:
             if back is not None:
                 _j_layout_hint_builder.atEnd(_to_sequence(back))
-        except Exception as e:
-            raise DHError(e, "invalid value for back") from e
 
-        try:
             if freeze is not None:
                 _j_layout_hint_builder.freeze(_to_sequence(freeze))
-        except Exception as e:
-            raise DHError(e, "invalid value for freeze") from e
 
-        try:
             if hide is not None:
                 _j_layout_hint_builder.hide(_to_sequence(hide))
-        except Exception as e:
-            raise DHError(e, "invalid value for hide") from e
 
-        try:
             return Table(j_table=self.j_table.setLayoutHints(_j_layout_hint_builder.build()))
         except Exception as e:
             raise DHError(e, "failed to set layout hints on table") from e

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from enum import Enum, auto
-from typing import Union, TypeVar, Sequence, List, Any
+from typing import Union, TypeVar, Sequence, List
 
 import jpy
 

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -26,8 +26,6 @@ _JPair = jpy.get_type("io.deephaven.api.agg.Pair")
 _JMatchPair = jpy.get_type("io.deephaven.engine.table.MatchPair")
 _JLayoutHintBuilder = jpy.get_type("io.deephaven.engine.util.LayoutHintBuilder")
 
-T = TypeVar('T')
-ValueOrArray = Union[T, List[T]]
 
 class SortDirection(Enum):
     """An enum defining the sorting orders."""
@@ -1263,16 +1261,16 @@ class Table(JObjectWrapper):
         except Exception as e:
             raise DHError(e, "failed to color format rows conditionally.") from e
 
-    def layout_hints(self, front: ValueOrArray[str] = None, back: ValueOrArray[str] = None,
-                     freeze: ValueOrArray[str] = None, hide: ValueOrArray[str] = None) -> Table:
+    def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
+                     freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None) -> Table:
         """ Sets layout hints on the Table
 
         Args:
-            front (ValueOrArray[str]): the columns to show at the front
-            back (ValueOrArray[str]): the columns to show at the back
-            freeze (ValueOrArray[str]): the columns to freeze to the front.
+            front (Union[str, List[str]]): the columns to show at the front
+            back (Union[str, List[str]]): the columns to show at the back
+            freeze (Union[str, List[str]]): the columns to freeze to the front.
                 These will not be affected by horizontal scrolling.
-            hide (ValueOrArray[str]): the columns to hide
+            hide (Union[str, List[str]]): the columns to hide
 
         Returns:
             a new table with the layout hints set
@@ -1282,10 +1280,7 @@ class Table(JObjectWrapper):
         """
         try:
             _j_layout_hint_builder = _JLayoutHintBuilder.get()
-        except Exception as e:
-            raise DHError(e, "failed to init layout hint builder") from e
 
-        try:
             if front is not None:
                 _j_layout_hint_builder.atFront(_to_sequence(front))
 
@@ -1298,7 +1293,7 @@ class Table(JObjectWrapper):
             if hide is not None:
                 _j_layout_hint_builder.hide(_to_sequence(hide))
         except Exception as e:
-            raise DHError(e, "invalid parameter type for layout hints") from e
+            raise DHError(e, "failed to create layout hints") from e
 
         try:
             return Table(j_table=self.j_table.setLayoutHints(_j_layout_hint_builder.build()))

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1282,7 +1282,10 @@ class Table(JObjectWrapper):
         """
         try:
             _j_layout_hint_builder = _JLayoutHintBuilder.get()
+        except Exception as e:
+            raise DHError(e, "failed to init layout hint builder") from e
 
+        try:
             if front is not None:
                 _j_layout_hint_builder.atFront(_to_sequence(front))
 
@@ -1294,7 +1297,10 @@ class Table(JObjectWrapper):
 
             if hide is not None:
                 _j_layout_hint_builder.hide(_to_sequence(hide))
+        except Exception as e:
+            raise DHError(e, "invalid parameter type for layout hints") from e
 
+        try:
             return Table(j_table=self.j_table.setLayoutHints(_j_layout_hint_builder.build()))
         except Exception as e:
             raise DHError(e, "failed to set layout hints on table") from e

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -515,6 +515,11 @@ class TableTestCase(BaseTestCase):
         t = self.test_table.layout_hints()
         self.assertIsNotNone(t)
 
+        with self.assertRaises(DHError) as cm:
+            t = self.test_table.layout_hints(front=["e"], back=True)
+        self.assertTrue(cm.exception.root_cause)
+        self.assertIn("RuntimeError", cm.exception.compact_traceback)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -499,6 +499,22 @@ class TableTestCase(BaseTestCase):
         t = self.test_table.format_row_where("e % 3 = 1", "TEAL")
         self.assertIsNotNone(t)
 
+    def test_layout_hints(self):
+        t = self.test_table.layout_hints(front="d", back="b", freeze="c", hide="d")
+        self.assertIsNotNone(t)
+
+        t = self.test_table.layout_hints(front=["d", "e"], back=["a", "b"], freeze=["c"], hide=["d"])
+        self.assertIsNotNone(t)
+
+        t = self.test_table.layout_hints(front="e")
+        self.assertIsNotNone(t)
+
+        t = self.test_table.layout_hints(front=["e"])
+        self.assertIsNotNone(t)
+
+        t = self.test_table.layout_hints()
+        self.assertIsNotNone(t)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #2262. Also addresses #2273 for the Python API

Adds `table.layout_hints()` in Python. This supports 4 params which are supported by the web UI: `front`, `back`, `freeze`, and `hide`. These are arrays of column names or just a string with a single column name.

The engine does not check the column names exist. The hints are just a string applied as an attribute to the table. The web UI validates the layout hints string.

I used this Python snippet to test

```python
from deephaven import new_table
from deephaven.column import string_col, int_col

hints = {
   'front': ['D'],
   'back': ['A'],
}

base = new_table([
   string_col("A", ["A"]),
   int_col("B", [2]),
   string_col("C", ["C"]),
   int_col("D", [4]),
   string_col("E", ["E"]),
   int_col("F", [6])
])


t1 = base.layout_hints(front='D', back=['A'], freeze=["C", 'E'], hide=['F'])
t2 = base.layout_hints(**hints)
```