### PR TITLE
BarrageMessageProducer must always flip state

### DIFF
--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -1892,21 +1892,17 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
     private void flipSnapshotStateForSubscriptions(
             final List<Subscription> subscriptions) {
         for (final Subscription subscription : subscriptions) {
-            if (subscription.snapshotViewport != null) {
-                final RowSet tmp = subscription.viewport;
-                subscription.viewport = subscription.snapshotViewport;
-                subscription.snapshotViewport = (WritableRowSet) tmp;
-            }
+            final RowSet tmpViewport = subscription.viewport;
+            subscription.viewport = subscription.snapshotViewport;
+            subscription.snapshotViewport = (WritableRowSet) tmpViewport;
 
             boolean tmpDirection = subscription.reverseViewport;
             subscription.reverseViewport = subscription.snapshotReverseViewport;
             subscription.snapshotReverseViewport = tmpDirection;
 
-            if (subscription.snapshotColumns != null) {
-                final BitSet tmp = subscription.subscribedColumns;
-                subscription.subscribedColumns = subscription.snapshotColumns;
-                subscription.snapshotColumns = tmp;
-            }
+            final BitSet tmpColumns = subscription.subscribedColumns;
+            subscription.subscribedColumns = subscription.snapshotColumns;
+            subscription.snapshotColumns = tmpColumns;
         }
     }
 


### PR DESCRIPTION
Now that growing viewports initialize all subscriptions as viewports, including full subscriptions, we must unconditionally flip between snapshot and active states.

The race condition fires when the following happens:
1) full subscription is requested
2) before the snapshot is taken, we record a delta
3) snapshot is completed with at least one delta pre-snapshot

Given the above steps, the finalization of the update propagation will `flipSnapshotState` to revert to pre-snapshot state to apply the pre-snapshot delta(s). We flip back to apply any post-snapshot deltas and so that we record proper data for future ticks. However, since we represent full subscriptions with a `null` viewport the empty RowSet (or whatever the most recent growing VP state was) ends up stuck from the pre-snapshot flip. (Code, as exists, only flips if `snapshotViewport != null`).

Note that this only flips the `growingViewport` list -- which means only subscriptions with valid snapshotViewports are being flipped.