### PR TITLE
Return full traceback by default in DHError

### DIFF
--- a/py/server/deephaven/dherror.py
+++ b/py/server/deephaven/dherror.py
@@ -22,11 +22,9 @@ class DHError(Exception):
     """
 
     def __init__(self, cause=None, message=""):
-        super().__init__(cause, message)
         self._message = message
         self._traceback = traceback.format_exc()
         self._cause = cause
-
         tb_lines = self._traceback.splitlines()
         self._root_cause = ""
         self._compact_tb = []
@@ -69,6 +67,4 @@ class DHError(Exception):
         return "\n".join(self._compact_tb)
 
     def __str__(self):
-        causes = [line.replace("caused by ", "") for line in self._compact_tb if line.startswith("caused by")]
-        causes = "\n       ".join(causes)
-        return f"{self._message} : {self._root_cause} \n       {causes}"
+        return f"{self._message} : {self._root_cause}\n{self._traceback}"


### PR DESCRIPTION
A sample exception output in the console

```
r-Scheduler-Serial-1 | i.d.s.s.SessionState      | Internal Error 'd89dd256-fabe-42d6-923f-c1319a075bdf' java.lang.RuntimeException: Error in Python interpreter:
Type: <class 'deephaven.dherror.DHError'>
Value: failed to resolve the URI. : java.net.UnknownHostException: media.githubusercontent1.com
Traceback (most recent call last):
  File "/opt/deephaven-venv/lib/python3.7/site-packages/deephaven/uri.py", line 60, in resolve
    return wrap_j_object(_JResolveTools.resolve(uri))
RuntimeError: java.lang.RuntimeException: Caught exception
	at io.deephaven.server.uri.CsvTableResolver.read(CsvTableResolver.java:64)
	at io.deephaven.server.uri.CsvTableResolver.resolve(CsvTableResolver.java:54)
	at io.deephaven.server.uri.CsvTableResolver.resolve(CsvTableResolver.java:29)
	at io.deephaven.uri.resolver.UriResolvers.resolve(UriResolvers.java:62)
	at io.deephaven.uri.ResolveTools.resolve(ResolveTools.java:36)
	at io.deephaven.uri.ResolveTools.resolve(ResolveTools.java:26)
	at org.jpy.PyLib.executeCode(Native Method)
	at org.jpy.PyObject.executeCode(PyObject.java:138)
	at io.deephaven.engine.util.PythonEvaluatorJpy.evalScript(PythonEvaluatorJpy.java:56)
	at io.deephaven.engine.util.PythonDeephavenSession.lambda$evaluate$1(PythonDeephavenSession.java:190)
	at io.deephaven.util.locks.FunctionalLock.doLockedInterruptibly(FunctionalLock.java:46)
	at io.deephaven.engine.util.PythonDeephavenSession.evaluate(PythonDeephavenSession.java:189)
	at io.deephaven.engine.util.AbstractScriptSession.evaluateScript(AbstractScriptSession.java:147)
	at io.deephaven.engine.util.DelegatingScriptSession.evaluateScript(DelegatingScriptSession.java:71)
	at io.deephaven.engine.util.ScriptSession.evaluateScript(ScriptSession.java:84)
	at io.deephaven.server.console.ConsoleServiceGrpcImpl.lambda$executeCommand$8(ConsoleServiceGrpcImpl.java:219)
	at io.deephaven.server.session.SessionState$ExportBuilder.lambda$submit$2(SessionState.java:1299)
	at io.deephaven.server.session.SessionState$ExportObject.doExport(SessionState.java:847)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at io.deephaven.server.runner.DeephavenApiServerModule$ThreadFactory.lambda$newThread$0(DeephavenApiServerModule.java:143)
	at java.base/java.lang.Thread.run(Thread.java:829)
caused by io.deephaven.csv.util.CsvReaderException: Caught exception
	at io.deephaven.csv.CsvTools.readCsv(CsvTools.java:246)
	at io.deephaven.csv.CsvTools.readCsv(CsvTools.java:206)
	at io.deephaven.csv.CsvTools.readCsv(CsvTools.java:130)
	at io.deephaven.server.uri.CsvTableResolver.read(CsvTableResolver.java:62)
	... 23 more
caused by java.net.UnknownHostException: media.githubusercontent1.com
	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:229)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.base/java.net.Socket.connect(Socket.java:609)
	at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:300)
	at java.base/sun.security.ssl.BaseSSLSocketImpl.connect(BaseSSLSocketImpl.java:173)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:182)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:474)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:569)
	at java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:266)
	at java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:373)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:203)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1187)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1081)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:189)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1592)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:250)
	at java.base/java.net.URL.openStream(URL.java:1165)
	at io.deephaven.csv.CsvTools.readCsv(CsvTools.java:244)
	... 26 more


Line: 62
Namespace: resolve
File: /opt/deephaven-venv/lib/python3.7/site-packages/deephaven/uri.py
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "/opt/deephaven-venv/lib/python3.7/site-packages/deephaven/uri.py", line 62, in resolve

        at org.jpy.PyLib.executeCode(PyLib.java:-2)
        at org.jpy.PyObject.executeCode(PyObject.java:138)
        at io.deephaven.engine.util.PythonEvaluatorJpy.evalScript(PythonEvaluatorJpy.java:56)
        at io.deephaven.engine.util.PythonDeephavenSession.lambda$evaluate$1(PythonDeephavenSession.java:190)
        at io.deephaven.util.locks.FunctionalLock.doLockedInterruptibly(FunctionalLock.java:46)
        at io.deephaven.engine.util.PythonDeephavenSession.evaluate(PythonDeephavenSession.java:189)
        at io.deephaven.engine.util.AbstractScriptSession.evaluateScript(AbstractScriptSession.java:147)
        at io.deephaven.engine.util.DelegatingScriptSession.evaluateScript(DelegatingScriptSession.java:71)
        at io.deephaven.engine.util.ScriptSession.evaluateScript(ScriptSession.java:84)
        at io.deephaven.server.console.ConsoleServiceGrpcImpl.lambda$executeCommand$8(ConsoleServiceGrpcImpl.java:219)
        at io.deephaven.server.session.SessionState$ExportBuilder.lambda$submit$2(SessionState.java:1299)
        at io.deephaven.server.session.SessionState$ExportObject.doExport(SessionState.java:847)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at io.deephaven.server.runner.DeephavenApiServerModule$ThreadFactory.lambda$newThread$0(DeephavenApiServerModule.java:143)
        at java.lang.Thread.run(Thread.java:829)
```
