### PR TITLE
AppMode: log error when failed to read application config

### DIFF
--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationInjector.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationInjector.java
@@ -49,6 +49,9 @@ public class ApplicationInjector {
             configs = ApplicationConfig.find();
         } catch (final NoSuchFileException ignored) {
             configs = Collections.emptyList();
+        } catch (final RuntimeException error) {
+            log.error().append("Failed to read application config(s): ").append(error).endl();
+            throw error;
         }
 
         if (configs.isEmpty()) {


### PR DESCRIPTION
I missed `type` in my config, which resulted in a silent jvm exit.