### PR TITLE
Add LayoutHint column grouping API

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -113,24 +113,21 @@ public class LayoutHintBuilder {
 
     private static class ColumnGroup {
 
-        String name;
-        final List<String> children;
-        Color color;
+        private final String name;
+        private final List<String> children;
+        private final Color color;
 
-        ColumnGroup(String name, List<String> children, Color color) {
+        public ColumnGroup(String name, List<String> children, Color color) {
             NameValidator.validateColumnName(name);
             children.forEach(c -> NameValidator.validateColumnName(c));
 
             this.name = name;
             this.children = children;
-
-            if (color != null) {
-                this.color = color;
-            }
+            this.color = color;
         }
 
         @NotNull
-        String serialize() {
+        public String serialize() {
             StringBuilder sb = new StringBuilder("name:" + name);
 
             sb.append("::children:" + StringUtils.joinStrings(children, ","));
@@ -147,16 +144,16 @@ public class LayoutHintBuilder {
          * @return a ColumnGroup instance
          */
         @NotNull
-        static ColumnGroup fromString(String string) {
+        public static ColumnGroup fromString(String string) {
             final Map<String, String> options = Arrays.stream(string.split("::"))
                     .map(option -> option.split(":"))
-                    .collect(Collectors.toMap(parts -> parts[0], parts -> parts.length == 2 ? parts[1] : ""));
+                    .collect(Collectors.toMap(parts -> parts[0], parts -> parts.length == 2 ? parts[1] : null));
 
             final String name = options.get("name");
             final List<String> children = Arrays.asList(options.get("children").split(","));
             final String color = options.get("color");
 
-            if (color == null || color.length() == 0) {
+            if (color == null) {
                 return new ColumnGroup(name, children, null);
             }
 
@@ -376,7 +373,7 @@ public class LayoutHintBuilder {
     @ScriptApi
     public LayoutHintBuilder group(String name, List<String> children, Color color) {
         if (columnGroups == null) {
-            columnGroups = new HashMap<>();
+            columnGroups = new LinkedHashMap<>();
         }
 
         if (children.size() == 0) {
@@ -390,7 +387,7 @@ public class LayoutHintBuilder {
 
     private void addGroupData(ColumnGroup group) {
         if (columnGroups == null) {
-            columnGroups = new HashMap<>();
+            columnGroups = new LinkedHashMap<>();
         }
 
         columnGroups.put(group.name, group);

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -131,7 +131,7 @@ public class LayoutHintBuilder {
             StringBuilder sb = new StringBuilder("name:").append(name);
 
             sb.append("::children:");
-            boolean first = false;
+            boolean first = true;
             for (String child : children) {
                 if (!first) {
                     sb.append(",");

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -161,7 +161,8 @@ public class LayoutHintBuilder {
         }
     }
 
-    private LayoutHintBuilder() {}
+    private LayoutHintBuilder() {
+    }
 
     // region Builder Methods
 
@@ -365,9 +366,9 @@ public class LayoutHintBuilder {
     /**
      * Create a named group of columns in the UI
      *
-     * @param name the column group name. Must be a valid Deephaven column name
+     * @param name     the column group name. Must be a valid Deephaven column name
      * @param children the columns and other groups belonging to this group
-     * @param color the background color for the group in the UI
+     * @param color    the background color for the group in the UI
      * @return this LayoutHintBuilder
      */
     @ScriptApi
@@ -437,7 +438,7 @@ public class LayoutHintBuilder {
      * Set the default initial number of rows to fetch for columns that have been marked as
      * {@link LayoutHintBuilder#autoFilter(Collection) AutoFilter} columns.
      *
-     * @param col the column to set the fetch size for
+     * @param col  the column to set the fetch size for
      * @param size the number of rows to fetch initially
      * @return this LayoutHintBuilder
      */
@@ -576,7 +577,7 @@ public class LayoutHintBuilder {
 
         if (autoFilterCols != null && !autoFilterCols.isEmpty()) {
             sb.append("autofilter=").append(
-                    StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::serialize), ","))
+                            StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::serialize), ","))
                     .append(';');
         }
 
@@ -594,9 +595,9 @@ public class LayoutHintBuilder {
 
         if (columnGroups != null && !columnGroups.isEmpty()) {
             sb.append("columnGroups=");
-            List<String> groupStrings =
-                    columnGroups.values().stream().map(ColumnGroup::serialize).collect(Collectors.toList());
-            sb.append(String.join("|", groupStrings)).append(';');
+            String groupStrings =
+                    columnGroups.values().stream().map(ColumnGroup::serialize).collect(Collectors.joining("|"));
+            sb.append(groupStrings).append(';');
         }
 
         return sb.toString();

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -141,7 +141,7 @@ public class LayoutHintBuilder {
             }
             if (color != null) {
                 sb.append("::color:#")
-                    .append(Integer.toHexString(color.javaColor().getRGB()).substring(2));
+                        .append(Integer.toHexString(color.javaColor().getRGB()).substring(2));
             }
             return sb.toString();
         }

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -385,7 +385,7 @@ public class LayoutHintBuilder {
             columnGroups = new LinkedHashMap<>();
         }
 
-        if (children.size() == 0) {
+        if (children.isEmpty()) {
             columnGroups.remove(name);
         } else {
             columnGroups.put(name, new ColumnGroup(name, children, color));

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -135,8 +135,7 @@ public class LayoutHintBuilder {
 
     }
 
-    private LayoutHintBuilder() {
-    }
+    private LayoutHintBuilder() {}
 
     // region Builder Methods
 
@@ -321,6 +320,8 @@ public class LayoutHintBuilder {
             columnGroups = new HashMap<>();
         }
 
+        NameValidator.validateColumnName(name);
+
         if (children.size() == 0) {
             columnGroups.remove(name);
         } else {
@@ -374,7 +375,7 @@ public class LayoutHintBuilder {
      * Set the default initial number of rows to fetch for columns that have been marked as
      * {@link LayoutHintBuilder#autoFilter(Collection) AutoFilter} columns.
      *
-     * @param col  the column to set the fetch size for
+     * @param col the column to set the fetch size for
      * @param size the number of rows to fetch initially
      * @return this LayoutHintBuilder
      */
@@ -513,7 +514,7 @@ public class LayoutHintBuilder {
 
         if (autoFilterCols != null && !autoFilterCols.isEmpty()) {
             sb.append("autofilter=").append(
-                            StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::forBuilder), ","))
+                    StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::forBuilder), ","))
                     .append(';');
         }
 
@@ -530,7 +531,11 @@ public class LayoutHintBuilder {
         }
 
         if (columnGroups != null && !columnGroups.isEmpty()) {
-            columnGroups.values().forEach(g -> sb.append("group=").append(g.serialize()).append(';'));
+            sb.append("groups=");
+            List<String> groupStrings =
+                    columnGroups.values().stream().map(ColumnGroup::serialize).collect(Collectors.toList());
+            sb.append(String.join("|", groupStrings)).append(';');
+            // columnGroups.values().forEach(g -> sb.append("group=").append(g.serialize()).append(';'));
         }
 
         return sb.toString();

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -161,8 +161,7 @@ public class LayoutHintBuilder {
         }
     }
 
-    private LayoutHintBuilder() {
-    }
+    private LayoutHintBuilder() {}
 
     // region Builder Methods
 
@@ -366,9 +365,9 @@ public class LayoutHintBuilder {
     /**
      * Create a named group of columns in the UI
      *
-     * @param name     the column group name. Must be a valid Deephaven column name
+     * @param name the column group name. Must be a valid Deephaven column name
      * @param children the columns and other groups belonging to this group
-     * @param color    the background color for the group in the UI
+     * @param color the background color for the group in the UI
      * @return this LayoutHintBuilder
      */
     @ScriptApi
@@ -438,7 +437,7 @@ public class LayoutHintBuilder {
      * Set the default initial number of rows to fetch for columns that have been marked as
      * {@link LayoutHintBuilder#autoFilter(Collection) AutoFilter} columns.
      *
-     * @param col  the column to set the fetch size for
+     * @param col the column to set the fetch size for
      * @param size the number of rows to fetch initially
      * @return this LayoutHintBuilder
      */
@@ -577,7 +576,7 @@ public class LayoutHintBuilder {
 
         if (autoFilterCols != null && !autoFilterCols.isEmpty()) {
             sb.append("autofilter=").append(
-                            StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::serialize), ","))
+                    StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::serialize), ","))
                     .append(';');
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -108,9 +108,11 @@ public class LayoutHintBuilder {
         }
     }
 
-    private LayoutHintBuilder() {}
+    private LayoutHintBuilder() {
+    }
 
     // region Builder Methods
+
     /**
      * Create a LayoutHintBuilder from the specified parameter string.
      *
@@ -136,7 +138,7 @@ public class LayoutHintBuilder {
 
         final String endStr = options.get("back");
         if (endStr != null && !endStr.isEmpty()) {
-            lhb.atEnd(endStr.split(","));
+            lhb.atBack(endStr.split(","));
         }
 
         final String hideStr = options.get("hide");
@@ -218,11 +220,11 @@ public class LayoutHintBuilder {
     }
 
     /**
-     * @see LayoutHintBuilder#atEnd(Collection)
+     * @see LayoutHintBuilder#atBack(Collection)
      */
     @ScriptApi
-    public LayoutHintBuilder atEnd(String... cols) {
-        return atEnd(cols == null ? null : Arrays.asList(cols));
+    public LayoutHintBuilder atBack(String... cols) {
+        return atBack(cols == null ? null : Arrays.asList(cols));
     }
 
     /**
@@ -232,7 +234,7 @@ public class LayoutHintBuilder {
      * @return this LayoutHintBuilder
      */
     @ScriptApi
-    public LayoutHintBuilder atEnd(Collection<String> cols) {
+    public LayoutHintBuilder atBack(Collection<String> cols) {
         if (cols == null || cols.isEmpty()) {
             backCols = null;
             return this;
@@ -325,7 +327,7 @@ public class LayoutHintBuilder {
      * Set the default initial number of rows to fetch for columns that have been marked as
      * {@link LayoutHintBuilder#autoFilter(Collection) AutoFilter} columns.
      *
-     * @param col the column to set the fetch size for
+     * @param col  the column to set the fetch size for
      * @param size the number of rows to fetch initially
      * @return this LayoutHintBuilder
      */
@@ -464,7 +466,7 @@ public class LayoutHintBuilder {
 
         if (autoFilterCols != null && !autoFilterCols.isEmpty()) {
             sb.append("autofilter=").append(
-                    StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::forBuilder), ","))
+                            StringUtils.joinStrings(autoFilterCols.values().stream().map(AutoFilterData::forBuilder), ","))
                     .append(';');
         }
 
@@ -485,7 +487,7 @@ public class LayoutHintBuilder {
 
     /**
      * Helper method for building and {@link Table#setLayoutHints(String) applying} layout hints to a {@link Table}.
-     * 
+     *
      * @param table The source {@link Table}
      * @return {@code table.setLayoutHints(build())}
      */
@@ -495,6 +497,7 @@ public class LayoutHintBuilder {
     }
 
     // region Getters
+
     /**
      * Check if saved layouts should be allowed.
      *
@@ -516,7 +519,7 @@ public class LayoutHintBuilder {
     /**
      * Get the ordered set of columns that should be displayed as the last N columns.
      *
-     * @return an ordfered set of columns to display at the end.
+     * @return an ordered set of columns to display at the end.
      */
     public @NotNull Set<String> getBackCols() {
         return backCols == null ? Collections.emptySet() : Collections.unmodifiableSet(backCols);

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -128,11 +128,20 @@ public class LayoutHintBuilder {
 
         @NotNull
         public String serialize() {
-            StringBuilder sb = new StringBuilder("name:" + name);
+            StringBuilder sb = new StringBuilder("name:").append(name);
 
-            sb.append("::children:" + StringUtils.joinStrings(children, ","));
+            sb.append("::children:");
+            boolean first = false;
+            for (String child : children) {
+                if (!first) {
+                    sb.append(",");
+                }
+                first = false;
+                sb.append(child);
+            }
             if (color != null) {
-                sb.append("::color:" + "#" + Integer.toHexString(color.javaColor().getRGB()).substring(2));
+                sb.append("::color:#")
+                    .append(Integer.toHexString(color.javaColor().getRGB()).substring(2));
             }
             return sb.toString();
         }

--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -223,12 +223,12 @@ public class LayoutHintBuilder {
             lhb.groupableColumns(groupableColumns);
         }
 
-        final String groupsStr = options.get("groups");
-        if (groupsStr != null && !groupsStr.isEmpty()) {
-            Arrays.stream(groupsStr.split("\\|"))
+        final String columnGroupsStr = options.get("columnGroups");
+        if (columnGroupsStr != null && !columnGroupsStr.isEmpty()) {
+            Arrays.stream(columnGroupsStr.split("\\|"))
                     .filter(s -> s != null && !s.isEmpty())
                     .map(ColumnGroup::fromString)
-                    .forEach(lhb::addGroupData);
+                    .forEach(lhb::addColumnGroupData);
         }
 
         return lhb;
@@ -344,22 +344,22 @@ public class LayoutHintBuilder {
     }
 
     /**
-     * @see LayoutHintBuilder#group(String, List, Color)
+     * @see LayoutHintBuilder#columnGroup(String, List, Color)
      */
     @ScriptApi
-    public LayoutHintBuilder group(String name, List<String> children) {
-        return group(name, children, (Color) null);
+    public LayoutHintBuilder columnGroup(String name, List<String> children) {
+        return columnGroup(name, children, (Color) null);
     }
 
     /**
-     * @see LayoutHintBuilder#group(String, List, Color)
+     * @see LayoutHintBuilder#columnGroup(String, List, Color)
      */
     @ScriptApi
-    public LayoutHintBuilder group(String name, List<String> children, String color) {
+    public LayoutHintBuilder columnGroup(String name, List<String> children, String color) {
         if (color == null || color.length() == 0) {
-            return group(name, children, (Color) null);
+            return columnGroup(name, children, (Color) null);
         }
-        return group(name, children, new Color(color));
+        return columnGroup(name, children, new Color(color));
     }
 
     /**
@@ -371,7 +371,7 @@ public class LayoutHintBuilder {
      * @return this LayoutHintBuilder
      */
     @ScriptApi
-    public LayoutHintBuilder group(String name, List<String> children, Color color) {
+    public LayoutHintBuilder columnGroup(String name, List<String> children, Color color) {
         if (columnGroups == null) {
             columnGroups = new LinkedHashMap<>();
         }
@@ -385,7 +385,7 @@ public class LayoutHintBuilder {
         return this;
     }
 
-    private void addGroupData(ColumnGroup group) {
+    private void addColumnGroupData(ColumnGroup group) {
         if (columnGroups == null) {
             columnGroups = new LinkedHashMap<>();
         }
@@ -593,7 +593,7 @@ public class LayoutHintBuilder {
         }
 
         if (columnGroups != null && !columnGroups.isEmpty()) {
-            sb.append("groups=");
+            sb.append("columnGroups=");
             List<String> groupStrings =
                     columnGroups.values().stream().map(ColumnGroup::serialize).collect(Collectors.toList());
             sb.append(String.join("|", groupStrings)).append(';');
@@ -708,7 +708,7 @@ public class LayoutHintBuilder {
      *
      * @return the map of column groups
      */
-    public @NotNull Map<String, ColumnGroup> getGroups() {
+    public @NotNull Map<String, ColumnGroup> getColumnGroups() {
         return columnGroups == null ? Collections.emptyMap() : Collections.unmodifiableMap(columnGroups);
     }
 
@@ -718,7 +718,7 @@ public class LayoutHintBuilder {
      * @param name the name of the column group
      * @return the column group if it exists
      */
-    public @NotNull ColumnGroup getGroup(String name) {
+    public @NotNull ColumnGroup getColumnGroup(String name) {
         return columnGroups == null ? null : columnGroups.get(name);
     }
     // endregion

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1333,15 +1333,22 @@ class Table(JObjectWrapper):
             raise DHError(e, "failed to color format rows conditionally.") from e
 
     def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
-                     freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None) -> Table:
+                     freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None,
+                     groups: List[dict] = None) -> Table:
         """ Sets layout hints on the Table
 
         Args:
-            front (Union[str, List[str]]): the columns to show at the front
-            back (Union[str, List[str]]): the columns to show at the back
+            front (Union[str, List[str]]): the columns to show at the front.
+            back (Union[str, List[str]]): the columns to show at the back.
             freeze (Union[str, List[str]]): the columns to freeze to the front.
                 These will not be affected by horizontal scrolling.
-            hide (Union[str, List[str]]): the columns to hide
+            hide (Union[str, List[str]]): the columns to hide.
+            groups (List[ColumnGroup]): A list of dicts specifying which columns should be grouped in the UI
+                The dicts can specify the following:
+
+                name (str): The group name
+                children (List[str]): The
+                color (Optional[Union[str, Color]]): The color name, hex string, or color object from deephaven.plot
 
         Returns:
             a new table with the layout hints set
@@ -1356,13 +1363,18 @@ class Table(JObjectWrapper):
                 _j_layout_hint_builder.atFront(to_sequence(front))
 
             if back is not None:
-                _j_layout_hint_builder.atEnd(to_sequence(back))
+                _j_layout_hint_builder.atBack(to_sequence(back))
 
             if freeze is not None:
                 _j_layout_hint_builder.freeze(to_sequence(freeze))
 
             if hide is not None:
                 _j_layout_hint_builder.hide(to_sequence(hide))
+
+            if groups is not None:
+                for group in groups:
+                    _j_layout_hint_builder.group(group.get("name"), j_array_list(group.get("children")),
+                                                 group.get("color", ""))
         except Exception as e:
             raise DHError(e, "failed to create layout hints") from e
 

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1343,7 +1343,7 @@ class Table(JObjectWrapper):
             freeze (Union[str, List[str]]): the columns to freeze to the front.
                 These will not be affected by horizontal scrolling.
             hide (Union[str, List[str]]): the columns to hide.
-            column_groups (List[ColumnGroup]): A list of dicts specifying which columns should be grouped in the UI
+            column_groups (List[Dict]): A list of dicts specifying which columns should be grouped in the UI
                 The dicts can specify the following:
 
                 name (str): The group name

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1334,7 +1334,7 @@ class Table(JObjectWrapper):
 
     def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
                      freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None,
-                     groups: List[dict] = None) -> Table:
+                     column_groups: List[dict] = None) -> Table:
         """ Sets layout hints on the Table
 
         Args:
@@ -1343,7 +1343,7 @@ class Table(JObjectWrapper):
             freeze (Union[str, List[str]]): the columns to freeze to the front.
                 These will not be affected by horizontal scrolling.
             hide (Union[str, List[str]]): the columns to hide.
-            groups (List[ColumnGroup]): A list of dicts specifying which columns should be grouped in the UI
+            column_groups (List[ColumnGroup]): A list of dicts specifying which columns should be grouped in the UI
                 The dicts can specify the following:
 
                 name (str): The group name
@@ -1371,10 +1371,10 @@ class Table(JObjectWrapper):
             if hide is not None:
                 _j_layout_hint_builder.hide(to_sequence(hide))
 
-            if groups is not None:
-                for group in groups:
-                    _j_layout_hint_builder.group(group.get("name"), j_array_list(group.get("children")),
-                                                 group.get("color", ""))
+            if column_groups is not None:
+                for group in column_groups:
+                    _j_layout_hint_builder.columnGroup(group.get("name"), j_array_list(group.get("children")),
+                                                       group.get("color", ""))
         except Exception as e:
             raise DHError(e, "failed to create layout hints") from e
 

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1348,7 +1348,7 @@ class Table(JObjectWrapper):
 
                 name (str): The group name
                 children (List[str]): The
-                color (Optional[Union[str, Color]]): The color name, hex string, or color object from deephaven.plot
+                color (Optional[str]): The hex color string or Deephaven color name
 
         Returns:
             a new table with the layout hints set

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -525,7 +525,22 @@ class TableTestCase(BaseTestCase):
         self.assertIsNotNone(t)
 
     def test_layout_hints(self):
-        t = self.test_table.layout_hints(front="d", back="b", freeze="c", hide="d")
+        t = self.test_table.layout_hints(front="d", back="b", freeze="c", hide="d", groups=[
+            {
+                "name": "Group1",
+                "children": ["a", "b"]
+            },
+            {
+                "name": "Group2",
+                "children": ["c", "d"],
+                "color": "#123456"
+            },
+            {
+                "name": "Group3",
+                "children": ["e", "f"],
+                "color": "RED"
+            }
+        ])
         self.assertIsNotNone(t)
 
         t = self.test_table.layout_hints(front=["d", "e"], back=["a", "b"], freeze=["c"], hide=["d"])

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -525,7 +525,7 @@ class TableTestCase(BaseTestCase):
         self.assertIsNotNone(t)
 
     def test_layout_hints(self):
-        t = self.test_table.layout_hints(front="d", back="b", freeze="c", hide="d", columnGroups=[
+        t = self.test_table.layout_hints(front="d", back="b", freeze="c", hide="d", column_groups=[
             {
                 "name": "Group1",
                 "children": ["a", "b"]

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -525,7 +525,7 @@ class TableTestCase(BaseTestCase):
         self.assertIsNotNone(t)
 
     def test_layout_hints(self):
-        t = self.test_table.layout_hints(front="d", back="b", freeze="c", hide="d", groups=[
+        t = self.test_table.layout_hints(front="d", back="b", freeze="c", hide="d", columnGroups=[
             {
                 "name": "Group1",
                 "children": ["a", "b"]

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
@@ -90,11 +90,11 @@ public class JsLayoutHints {
 
         final String groupsStr = options.get("columnGroups");
         if (groupsStr != null && !groupsStr.isEmpty()) {
-            List<ColumnGroup> groups =
+            ColumnGroup[] groups =
                     Arrays.stream(groupsStr.split("\\|")).map(ColumnGroup::new).map(JsObject::freeze)
-                            .collect(Collectors.toList());
+                            .toArray(ColumnGroup[]::new);
 
-            columnGroups = JsObject.freeze(groups.toArray(new ColumnGroup[0]));
+            columnGroups = JsObject.freeze(groups);
         }
 
         return this;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
@@ -88,7 +88,7 @@ public class JsLayoutHints {
             frozenColumns = JsObject.freeze(freezeStr.split(","));
         }
 
-        final String groupsStr = options.get("groups");
+        final String groupsStr = options.get("columnGroups");
         if (groupsStr != null && !groupsStr.isEmpty()) {
             List<ColumnGroup> groups =
                     Arrays.stream(groupsStr.split("\\|")).map(ColumnGroup::new).map(JsObject::freeze)
@@ -126,7 +126,7 @@ public class JsLayoutHints {
     }
 
     @JsProperty
-    public Object[] getColumnGroups() {
+    public ColumnGroup[] getColumnGroups() {
         return columnGroups;
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
@@ -7,7 +7,6 @@ import elemental2.core.JsObject;
 import jsinterop.annotations.JsProperty;
 
 import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -62,8 +61,6 @@ public class JsLayoutHints {
 
         final Map<String, String> options = Arrays.stream(hints.split(";"))
                 .map(hint -> hint.split("="))
-                // .collect(Collectors.groupingBy((parts -> parts[0]), Collectors.mapping(parts -> parts.length == 2 ?
-                // parts[1] : "", Collectors.toList())));
                 .collect(Collectors.toMap(parts -> parts[0], parts -> parts.length == 2 ? parts[1] : ""));
 
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
@@ -52,7 +52,7 @@ public class JsLayoutHints {
     private String[] hiddenColumns;
     private String[] frozenColumns;
 
-    private Object[] columnGroups;
+    private ColumnGroup[] columnGroups;
 
     public JsLayoutHints parse(String hints) {
         if (hints == null || hints.isEmpty()) {
@@ -91,9 +91,10 @@ public class JsLayoutHints {
         final String groupsStr = options.get("groups");
         if (groupsStr != null && !groupsStr.isEmpty()) {
             List<ColumnGroup> groups =
-                    Arrays.stream(groupsStr.split("\\|")).map(ColumnGroup::new).collect(Collectors.toList());
+                    Arrays.stream(groupsStr.split("\\|")).map(ColumnGroup::new).map(JsObject::freeze)
+                            .collect(Collectors.toList());
 
-            columnGroups = JsObject.freeze(groups.toArray());
+            columnGroups = JsObject.freeze(groups.toArray(new ColumnGroup[0]));
         }
 
         return this;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
@@ -5,17 +5,55 @@ package io.deephaven.web.client.api;
 
 import elemental2.core.JsObject;
 import jsinterop.annotations.JsProperty;
+
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class JsLayoutHints {
+    private class ColumnGroup {
+        @JsProperty
+        public String name;
+        @JsProperty
+        public String[] children;
+        @JsProperty
+        public String color;
+
+        public ColumnGroup(String groupStr) {
+            if (groupStr == null || groupStr.isEmpty()) {
+                return;
+            }
+
+            final Map<String, String> options = Arrays.stream(groupStr.split("::"))
+                    .map(option -> option.split(":"))
+                    .collect(Collectors.toMap(parts -> parts[0], parts -> parts.length == 2 ? parts[1] : ""));
+
+            final String nameStr = options.get("name");
+            if (nameStr != null && !nameStr.isEmpty()) {
+                name = nameStr;
+            }
+
+            final String childrenStr = options.get("children");
+            if (childrenStr != null && !childrenStr.isEmpty()) {
+                children = JsObject.freeze(childrenStr.split(","));
+            }
+
+            final String colorStr = options.get("color");
+            if (colorStr != null && !colorStr.isEmpty()) {
+                color = colorStr;
+            }
+        }
+    }
 
     private boolean savedLayoutsAllowed = true;
     private String[] frontColumns;
     private String[] backColumns;
     private String[] hiddenColumns;
     private String[] frozenColumns;
+
+    private Object[] columnGroups;
 
     public JsLayoutHints parse(String hints) {
         if (hints == null || hints.isEmpty()) {
@@ -24,6 +62,8 @@ public class JsLayoutHints {
 
         final Map<String, String> options = Arrays.stream(hints.split(";"))
                 .map(hint -> hint.split("="))
+                // .collect(Collectors.groupingBy((parts -> parts[0]), Collectors.mapping(parts -> parts.length == 2 ?
+                // parts[1] : "", Collectors.toList())));
                 .collect(Collectors.toMap(parts -> parts[0], parts -> parts.length == 2 ? parts[1] : ""));
 
 
@@ -49,6 +89,14 @@ public class JsLayoutHints {
         final String freezeStr = options.get("freeze");
         if (freezeStr != null && !freezeStr.isEmpty()) {
             frozenColumns = JsObject.freeze(freezeStr.split(","));
+        }
+
+        final String groupsStr = options.get("groups");
+        if (groupsStr != null && !groupsStr.isEmpty()) {
+            List<ColumnGroup> groups =
+                    Arrays.stream(groupsStr.split("\\|")).map(ColumnGroup::new).collect(Collectors.toList());
+
+            columnGroups = JsObject.freeze(groups.toArray());
         }
 
         return this;
@@ -77,5 +125,10 @@ public class JsLayoutHints {
     @JsProperty
     public String[] getFrozenColumns() {
         return frozenColumns;
+    }
+
+    @JsProperty
+    public Object[] getColumnGroups() {
+        return columnGroups;
     }
 }


### PR DESCRIPTION
This API will be used to support column grouping in the UI. Users will be able to specify multiple column groups containing children. The children can be other groups or a source column.

Validation of the layout hints will occur client-side. This is how the other hints are validated currently (i.e. the frozen column name is actually in the table).

Also fixes #2273 by renaming `atEnd` to `atBack`.

Note that the UI for groups does not exist yet, but the JS API model should have values set on `model.layoutHints.columnGroups`

Python
```python
from deephaven import new_table
from deephaven.column import string_col, int_col

hints = {
   'front': ['D'],
   'back': ['A'],
   'groups': [
      { 'name': 'MyGroup', 'children': ['A', 'B'] },
      { 'name': 'MyGroup2', 'children': ['A', 'B'], 'color': '#123456' },
   ]
}

base = new_table([
   string_col("A", ["A"]),
   int_col("B", [2]),
   string_col("C", ["C"]),
   int_col("D", [4]),
   string_col("E", ["E"]),
   int_col("F", [6])
])


t1 = base.layout_hints(front='D', back=['A'], freeze=["C", 'E'], hide=['F'], groups=[{'name': 'Test', 'children': ['A', 'B']}])
t2 = base.layout_hints(**hints)

print(t1.j_table.getAttribute("LayoutHints"))
print(t2.j_table.getAttribute("LayoutHints"))
```

Groovy
```groovy
import io.deephaven.engine.util.LayoutHintBuilder

hints = LayoutHintBuilder.get()
   .freeze("NameOfIntCol")
   .group("MyGroup", ["NameOfIntCol", "NameOfStringCol"], "MEDIUMAQUAMARINE")
   .group("MyGroup2", ["COL", "OTHER_COL"]);


t = newTable(
   stringCol("NameOfStringCol", "Data String 1", 'Data String 2', "Data String 3"),
   intCol("NameOfIntCol", 4, 5, 6)
).setLayoutHints(hints.build());

println(hints.build())
println(LayoutHintBuilder.fromString(hints.build()).build()) // Test fromString
```