### PR TITLE
fix table str

### DIFF
--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -65,7 +65,7 @@ class Table(JObjectWrapper):
         repr_str = (
             f"{default_repr[:-2]}, num_rows = {self.size}, columns = {column_dict}"
         )
-        repr_str = repr_str[:115] + "...}>" if len(repr_str) > 120 else repr_str
+        repr_str = repr_str[:115] + "...}>" if len(repr_str) > 120 else repr_str + ">"
         return repr_str
 
     def __str__(self):

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -68,7 +68,7 @@ class Table(JObjectWrapper):
         repr_str = (
             f"{default_repr[:-2]}, num_rows = {self.size}, columns = {column_dict}"
         )
-        repr_str = repr_str[:115] + "...}))" if len(repr_str) > 120 else repr_str + "))"
+        repr_str = repr_str[:116] + "...}))" if len(repr_str) > 120 else repr_str + "))"
         return repr_str
 
     def __str__(self):

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -61,11 +61,14 @@ class Table(JObjectWrapper):
 
     def __repr__(self):
         default_repr = super().__repr__()
+        # default_repr is in a format like so:
+        # deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7f07e4890518))
+        # We take the last two brackets off, add a few more details about the table, then add the necessary brackets back
         column_dict = {col.name: col.data_type for col in self.columns[:10]}
         repr_str = (
             f"{default_repr[:-2]}, num_rows = {self.size}, columns = {column_dict}"
         )
-        repr_str = repr_str[:115] + "...}>" if len(repr_str) > 120 else repr_str + ">"
+        repr_str = repr_str[:115] + "...}))" if len(repr_str) > 120 else repr_str + "))"
         return repr_str
 
     def __str__(self):

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -68,7 +68,8 @@ class Table(JObjectWrapper):
         repr_str = (
             f"{default_repr[:-2]}, num_rows = {self.size}, columns = {column_dict}"
         )
-        repr_str = repr_str[:116] + "...}))" if len(repr_str) > 120 else repr_str + "))"
+        # We need to add the two brackets back, and also truncate it to be 120 char total (118 + two brackets)
+        repr_str = repr_str[:114] + "...}))" if len(repr_str) > 118 else repr_str + "))"
         return repr_str
 
     def __str__(self):

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -18,7 +18,13 @@ class TableTestCase(BaseTestCase):
         self.test_table = None
 
     def test_repr(self):
-        self.assertIn(self.test_table.__class__.__name__, repr(self.test_table))
+        regex = r"deephaven\.table\.Table\(io\.deephaven\.engine\.table\.Table\(objectRef=0x.+\{.+\}\)\)"
+        for i in range(0, 8):
+            t = empty_table(10**i).update("a=i")
+            result = repr(t)
+            self.assertRegex(result, regex)
+            self.assertLessEqual(len(result), 120)
+            self.assertIn(t.__class__.__name__, result)
 
     #
     # Table operation category: Select

--- a/server/src/test/java/io/deephaven/server/table/ops/filter/FilterPrinterTest.java
+++ b/server/src/test/java/io/deephaven/server/table/ops/filter/FilterPrinterTest.java
@@ -49,7 +49,7 @@ public class FilterPrinterTest {
 
     private static void assertSameValue(double expected) {
         Literal literal = lit(expected);
-        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
+        String str = FilterPrinter.printNoEscape(literal);
 
         // test magic values that make sense in java, but Double.parseDouble won't accept directly
         if (Double.isNaN(expected)) {
@@ -73,16 +73,9 @@ public class FilterPrinterTest {
     private static void assertSameValue(long expected) {
         assertTrue("Must be in the range that a double value can represent", Math.abs(expected) < (1L << 53));
         Literal literal = lit(expected);
-        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
+        String str = FilterPrinter.printNoEscape(literal);
 
         assertEquals(Long.toString(expected), str);
-    }
-
-    private static String removeQuotes(String quotedStr) {
-        assertTrue(quotedStr.length() >= 2);
-        assertEquals(quotedStr.charAt(0), '"');
-        assertEquals(quotedStr.charAt(quotedStr.length() - 1), '"');
-        return quotedStr.substring(1, quotedStr.length() - 1);
     }
 
     private static void rotateAndAssert(long longBits) {

--- a/server/src/test/java/io/deephaven/server/table/ops/filter/FilterPrinterTest.java
+++ b/server/src/test/java/io/deephaven/server/table/ops/filter/FilterPrinterTest.java
@@ -49,7 +49,7 @@ public class FilterPrinterTest {
 
     private static void assertSameValue(double expected) {
         Literal literal = lit(expected);
-        String str = FilterPrinter.printNoEscape(literal);
+        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
 
         // test magic values that make sense in java, but Double.parseDouble won't accept directly
         if (Double.isNaN(expected)) {
@@ -73,9 +73,16 @@ public class FilterPrinterTest {
     private static void assertSameValue(long expected) {
         assertTrue("Must be in the range that a double value can represent", Math.abs(expected) < (1L << 53));
         Literal literal = lit(expected);
-        String str = FilterPrinter.printNoEscape(literal);
+        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
 
         assertEquals(Long.toString(expected), str);
+    }
+
+    private static String removeQuotes(String quotedStr) {
+        assertTrue(quotedStr.length() >= 2);
+        assertEquals(quotedStr.charAt(0), '"');
+        assertEquals(quotedStr.charAt(quotedStr.length() - 1), '"');
+        return quotedStr.substring(1, quotedStr.length() - 1);
     }
 
     private static void rotateAndAssert(long longBits) {


### PR DESCRIPTION
- Fix up the python string repr of table
- Fix the str representation of a Table

Tested with this snippet:
```
from deephaven import empty_table
for i in range(0, 8):
    t = empty_table(10**i).update("a=i")
    print(f"t: {t}\tlen: {len(str(t))}")
```

Output:
```
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c99688, num_rows = 1, columns = {'a': byte}))	len: 117
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c996b0, num_rows = 10, columns = {'a': byte}))	len: 118
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c996a8, num_rows = 100, columns = {'a': byte}))	len: 119
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c996d0, num_rows = 1000, columns = {'a': byte}))	len: 120
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c996c8, num_rows = 10000, columns = {'a': ...}))	len: 120
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c996f8, num_rows = 100000, columns = {'a':...}))	len: 120
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c996e8, num_rows = 1000000, columns = {'a'...}))	len: 120
t: deephaven.table.Table(io.deephaven.engine.table.Table(objectRef=0x7fdca0c99610, num_rows = 10000000, columns = {'a...}))	len: 120
```