### PR TITLE
Update web to v0.11.7

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
-ARG WEB_VERSION=0.11.4
+ARG WEB_VERSION=0.11.7
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Update web from v0.11.4 to v0.11.7
Release notes:
v0.11.7: https://github.com/deephaven/web-client-ui/releases/tag/v0.11.7
v0.11.6: https://github.com/deephaven/web-client-ui/releases/tag/v0.11.6
v0.11.5: https://github.com/deephaven/web-client-ui/releases/tag/v0.11.5
