### PR TITLE
Added tests for binary RSP operations to support root-causing DHE issue DH-12544

### DIFF
--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspArray.java
@@ -3005,7 +3005,7 @@ public abstract class RspArray<T extends RspArray> extends RefCountedCow<T> {
             long[] newAcc = acc;
             final int deltaSpans = idxPairsCount / 2;
             final int newSize = size + deltaSpans;
-            boolean accWasNull = acc == null;
+            final boolean accWasNull = acc == null;
             if (newSize > spanInfos.length) {
                 inPlace = false;
                 newSpans = new Object[newSize];

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTest.java
@@ -21,10 +21,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.IntConsumer;
-import java.util.function.LongConsumer;
+import java.util.function.*;
+
 import org.junit.experimental.categories.Category;
 
 import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_LAST;

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertFalse;
 @Category(OutOfBandTest.class)
 public class RspBitmapTimeDrivenTest {
 
-    public static final int RANDOM_SEED = 2;
+    public static final int RANDOM_SEED = 3;
     public static final long DEFAULT_PER_TEST_TIME_BUDGET_MILLIS = 2 * 60 * 1000;
     public static final long LOG_PERIOD_MILLIS = 10 * 1000;
 

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertFalse;
 @Category(OutOfBandTest.class)
 public class RspBitmapTimeDrivenTest {
 
-    public static final int RANDOM_SEED = 3;
+    public static final int RANDOM_SEED = 4;
     public static final long DEFAULT_PER_TEST_TIME_BUDGET_MILLIS = 2 * 60 * 1000;
     public static final long LOG_PERIOD_MILLIS = 10 * 1000;
 
@@ -27,7 +27,7 @@ public class RspBitmapTimeDrivenTest {
     public static final int SPEC_OPTIONS = 6;
 
     // Each position in the spec array represents one block in a series of consecutive RSP blocks
-    // in the result.  Position i in the spec array represents the block starting at i*BLOCK_SIZE
+    // in the result. Position i in the spec array represents the block starting at i*BLOCK_SIZE
     private static OrderedLongSet fromBlockSpec(final int[] spec) {
         final OrderedLongSet.BuilderSequential b = new OrderedLongSetBuilderSequential();
         for (int i = 0; i < spec.length; ++i) {
@@ -130,10 +130,9 @@ public class RspBitmapTimeDrivenTest {
     }
 
     enum Operation {
-        AND_NOT_EQUALS,
-        AND_EQUALS,
-        OR_EQUALS
+        AND_NOT_EQUALS, AND_EQUALS, OR_EQUALS
     }
+
     private static final Map<Operation, BiFunction<RspBitmap, RspBitmap, RspBitmap>> rspOps = new HashMap<>();
     static {
         rspOps.put(Operation.AND_NOT_EQUALS, RspBitmap::andNotEquals);
@@ -186,7 +185,8 @@ public class RspBitmapTimeDrivenTest {
         long nextLog = start + LOG_PERIOD_MILLIS;
         long lastLogChecksDone = 0;
         final String testName = "binaryOps-" + op + "-" + mode + "-" + toTimeStr(testTimeBudgetMillis);
-        System.out.printf("%s: Starting, search space for %d blocks is %d combinations.%n", testName, nblocks, totalChecks);
+        System.out.printf("%s: Starting, search space for %d blocks is %d combinations.%n", testName, nblocks,
+                totalChecks);
         while (true) {
             final long now = System.currentTimeMillis();
             if (now > deadline) {
@@ -280,6 +280,6 @@ public class RspBitmapTimeDrivenTest {
     public void testOrEqualsRandom() {
         final Operation op = Operation.OR_EQUALS;
         binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
-                DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
+                60 * 60 * 1000);
     }
 }

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -1,0 +1,205 @@
+package io.deephaven.engine.rowset.impl.rsp;
+
+import io.deephaven.engine.rowset.impl.OrderedLongSet;
+import io.deephaven.engine.rowset.impl.OrderedLongSetBuilderSequential;
+import io.deephaven.test.types.OutOfBandTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_LAST;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+
+@Category(OutOfBandTest.class)
+public class RspBitmapTimeDrivenTest {
+
+    public static final long DEFAULT_PER_TEST_TIME_BUDGET_MILLIS = 3 * 60 * 1000;
+    public static final long LOG_PERIOD_MILLIS = 10 * 1000;
+
+    // See comment about spec value meanings in caller.
+    public static final int SPEC_OPTIONS = 6;
+    private static OrderedLongSet fromBlockSpec(final int[] spec) {
+        final OrderedLongSet.BuilderSequential b = new OrderedLongSetBuilderSequential();
+        for (int i = 0; i < spec.length; ++i) {
+            final long baseKey = 65536L * i;
+            switch (spec[i]) {
+                case 0: // Key not present.
+                    break;
+                case 1: // Singleton container with element zero.
+                    b.appendKey(baseKey);
+                    break;
+                case 2: // Singleton container with element one.
+                    b.appendKey(baseKey + 1);
+                    break;
+                case 3: // Container with elements zero and one.
+                    b.appendKey(baseKey);
+                    b.appendKey(baseKey + 1);
+                    break;
+                case 4: // Container with the range [2, BLOCK_LAST]
+                    b.appendRange(baseKey + 2, baseKey + BLOCK_LAST);
+                    break;
+                case 5: // Full block span.
+                    b.appendRange(baseKey, baseKey + BLOCK_LAST);
+                    break;
+                default:
+                    throw new IllegalStateException("Unespected spec");
+            }
+        }
+        return b.getTreeIndexImpl();
+    }
+
+    private static String toStr(final int[] spec) {
+        final StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < spec.length; ++i) {
+            final long baseKey = 65536L * i;
+            sb.append(" ").append(baseKey).append(" : ");
+            switch (spec[i]) {
+                case 0: // Key not present.
+                    sb.append("{}");
+                    break;
+                case 1: // Singleton container with element zero.
+                    sb.append("{0}");
+                    break;
+                case 2: // Singleton container with element one.
+                    sb.append("{1}");
+                    break;
+                case 3: // Container with elements zero and one.
+                    sb.append("{0,1}");
+                    break;
+                case 4: // Container with the range [2, BLOCK_LAST]
+                    sb.append("{2->}");
+                    break;
+                case 5: // Full block span.
+                    sb.append("{0->}");
+                    break;
+                default:
+                    throw new IllegalStateException("Unespected spec");
+            }
+            if (i < spec.length - 1) {
+                sb.append(", ");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static boolean increment(final int[] spec) {
+        for (int i = spec.length - 1; i >= 0; --i) {
+            final int v = ++spec[i];
+            if (v < SPEC_OPTIONS) {
+                return true;
+            }
+            spec[i] = 0;
+        }
+        return false;
+    }
+
+    private static void checkEquals(final String msg, OrderedLongSet oset0, OrderedLongSet oset1) {
+        assertEquals(msg, oset0.ixCardinality(), oset1.ixCardinality());
+        assertTrue(msg, oset0.ixSubsetOf(oset1));
+    }
+
+    private static long pow(int a, int b) {
+        long r = 1;
+        while (b > 0) {
+            r *= a;
+            --b;
+        }
+        return r;
+    }
+
+    @Test
+    public void testBinaryOpsExhaustive() {
+        final Map<String, BiFunction<RspBitmap, RspBitmap, RspBitmap>> rspOps = new HashMap<>();
+        rspOps.put("andNotEquals", RspBitmap::andNotEquals);
+        rspOps.put("andEquals", RspBitmap::andEquals);
+        rspOps.put("orEquals", RspBitmap::orEquals);
+        final Map<String, BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet>> osetOps = new HashMap<>();
+        osetOps.put("andNotEquals", (x, y) -> x.ixCowRef().ixRemove(y));
+        osetOps.put("andEquals", (x, y) -> x.ixCowRef().ixRetain(y));
+        osetOps.put("orEquals", (x, y) -> x.ixCowRef().ixInsert(y));
+        for (String opName : rspOps.keySet()) {
+            binaryOpsExhaustiveHelper(opName, rspOps.get(opName), osetOps.get(opName), 4, TestSequenceMode.EXHAUSTIVE);
+        }
+    }
+
+    enum TestSequenceMode {
+        EXHAUSTIVE,
+        RANDOM
+    }
+
+    private void binaryOpsExhaustiveHelper(
+            final String opName,
+            final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp,
+            final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp,
+            final int nblocks,
+            final TestSequenceMode mode
+            ) {
+        final long nspecs = pow(SPEC_OPTIONS, nblocks);
+        final long totalChecks = nspecs * nspecs;
+        // We will use an int value to represent a spec of whether to have for a given key:
+        // 0: Key not present
+        // 1: Singleton container with element zero.
+        // 2: Singleton container with element one.
+        // 3: Container with elements zero and one.
+        // 4: Container with elements from two to 65535.
+        // 5: Full block span.
+        final int[] spec0 = new int[nblocks];
+        final int[] spec1 = new int[nblocks];
+        // avoid testing against the fully empty case.
+        increment(spec0);
+        increment(spec1);
+        long check = 0;
+        final long start = System.currentTimeMillis();
+        long lastLog = start;
+        long nextLog = start + LOG_PERIOD_MILLIS;
+        long lastLogChecksDone = 0;
+        final String testName = "binaryOpsExhaustive-" + opName;
+        do {
+            do {
+                final long now = System.currentTimeMillis();
+                if (now >= nextLog) {
+                    final long checksDoneSinceLastLog = check - lastLogChecksDone;
+                    final long millis = now - lastLog;
+                    System.out.printf("%s: In the last %.1f seconds ran %.1f checks per second; %d checks remaining.%n",
+                            testName,
+                            millis / 1000.0,
+                            (1000.0 * checksDoneSinceLastLog) / millis,
+                            totalChecks - check);
+                    lastLog = now;
+                    nextLog = now + LOG_PERIOD_MILLIS;
+                    lastLogChecksDone = check;
+                }
+                binaryOpHelper(opName, rspOp, osetOp, spec0, spec1);
+                ++check;
+            } while (increment(spec0));
+        } while (increment(spec1));
+        System.out.printf("%s: Done in %.1f seconds.%n",
+                testName,
+                (System.currentTimeMillis() - start) / 1000.0);
+    }
+
+    private void binaryOpHelper(
+            final String opName,
+            final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp,
+            final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp,
+            final int[] spec0,
+            final int[] spec1) {
+        final String msg = opName
+                + " && spec0==" + toStr(spec0)
+                + " && spec1==" + toStr(spec1);
+        final OrderedLongSet oset0 = fromBlockSpec(spec0);
+        assertFalse(msg, oset0 instanceof RspBitmap);
+        final OrderedLongSet oset1 = fromBlockSpec(spec1);
+        assertFalse(msg, oset1 instanceof RspBitmap);
+        final RspBitmap r0 = oset0.ixToRspOnNew();
+        final RspBitmap r1 = oset1.ixToRspOnNew();
+        final RspBitmap rspResult = rspOp.apply(r0, r1);
+        final OrderedLongSet osetResult = osetOp.apply(oset0, oset1);
+        checkEquals(msg, osetResult, rspResult);
+    }
+}

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -8,24 +8,30 @@ import org.junit.experimental.categories.Category;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.function.BiFunction;
 
 import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_LAST;
+import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_SIZE;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertFalse;
 
 @Category(OutOfBandTest.class)
 public class RspBitmapTimeDrivenTest {
 
-    public static final long DEFAULT_PER_TEST_TIME_BUDGET_MILLIS = 3 * 60 * 1000;
+    public static final int RANDOM_SEED = 2;
+    public static final long DEFAULT_PER_TEST_TIME_BUDGET_MILLIS = 2 * 60 * 1000;
     public static final long LOG_PERIOD_MILLIS = 10 * 1000;
 
     // See comment about spec value meanings in caller.
     public static final int SPEC_OPTIONS = 6;
+
+    // Each position in the spec array represents one block in a series of consecutive RSP blocks
+    // in the result.  Position i in the spec array represents the block starting at i*BLOCK_SIZE
     private static OrderedLongSet fromBlockSpec(final int[] spec) {
         final OrderedLongSet.BuilderSequential b = new OrderedLongSetBuilderSequential();
         for (int i = 0; i < spec.length; ++i) {
-            final long baseKey = 65536L * i;
+            final long baseKey = BLOCK_SIZE * (long) i;
             switch (spec[i]) {
                 case 0: // Key not present.
                     break;
@@ -46,7 +52,7 @@ public class RspBitmapTimeDrivenTest {
                     b.appendRange(baseKey, baseKey + BLOCK_LAST);
                     break;
                 default:
-                    throw new IllegalStateException("Unespected spec");
+                    throw new IllegalStateException("Unexpected i=" + i + ", spec[i]=" + spec[i]);
             }
         }
         return b.getTreeIndexImpl();
@@ -55,7 +61,7 @@ public class RspBitmapTimeDrivenTest {
     private static String toStr(final int[] spec) {
         final StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < spec.length; ++i) {
-            final long baseKey = 65536L * i;
+            final long baseKey = BLOCK_SIZE * (long) i;
             sb.append(" ").append(baseKey).append(" : ");
             switch (spec[i]) {
                 case 0: // Key not present.
@@ -77,7 +83,7 @@ public class RspBitmapTimeDrivenTest {
                     sb.append("{0->}");
                     break;
                 default:
-                    throw new IllegalStateException("Unespected spec");
+                    throw new IllegalStateException("Unexpected i=" + i + ", spec[i]=" + spec[i]);
             }
             if (i < spec.length - 1) {
                 sb.append(", ");
@@ -87,6 +93,16 @@ public class RspBitmapTimeDrivenTest {
         return sb.toString();
     }
 
+    private static final Random rand = new Random(RANDOM_SEED);
+
+    private static void random(final int[] spec) {
+        for (int i = 0; i < spec.length; ++i) {
+            spec[i] = rand.nextInt(SPEC_OPTIONS);
+        }
+    }
+
+    // Do a "manual" increment of spec as if it was a number represented in base SPEC_OPTIONS
+    // with one digit per array position.
     private static boolean increment(final int[] spec) {
         for (int i = spec.length - 1; i >= 0; --i) {
             final int v = ++spec[i];
@@ -98,12 +114,13 @@ public class RspBitmapTimeDrivenTest {
         return false;
     }
 
-    private static void checkEquals(final String msg, OrderedLongSet oset0, OrderedLongSet oset1) {
+    private static void checkEquals(final String msg, final OrderedLongSet oset0, final OrderedLongSet oset1) {
         assertEquals(msg, oset0.ixCardinality(), oset1.ixCardinality());
         assertTrue(msg, oset0.ixSubsetOf(oset1));
     }
 
-    private static long pow(int a, int b) {
+    // return a^b.
+    private static long pow(final int a, int b) {
         long r = 1;
         while (b > 0) {
             r *= a;
@@ -112,33 +129,45 @@ public class RspBitmapTimeDrivenTest {
         return r;
     }
 
-    @Test
-    public void testBinaryOpsExhaustive() {
-        final Map<String, BiFunction<RspBitmap, RspBitmap, RspBitmap>> rspOps = new HashMap<>();
-        rspOps.put("andNotEquals", RspBitmap::andNotEquals);
-        rspOps.put("andEquals", RspBitmap::andEquals);
-        rspOps.put("orEquals", RspBitmap::orEquals);
-        final Map<String, BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet>> osetOps = new HashMap<>();
-        osetOps.put("andNotEquals", (x, y) -> x.ixCowRef().ixRemove(y));
-        osetOps.put("andEquals", (x, y) -> x.ixCowRef().ixRetain(y));
-        osetOps.put("orEquals", (x, y) -> x.ixCowRef().ixInsert(y));
-        for (String opName : rspOps.keySet()) {
-            binaryOpsExhaustiveHelper(opName, rspOps.get(opName), osetOps.get(opName), 4, TestSequenceMode.EXHAUSTIVE);
-        }
+    enum Operation {
+        AND_NOT_EQUALS,
+        AND_EQUALS,
+        OR_EQUALS
+    }
+    private static final Map<Operation, BiFunction<RspBitmap, RspBitmap, RspBitmap>> rspOps = new HashMap<>();
+    static {
+        rspOps.put(Operation.AND_NOT_EQUALS, RspBitmap::andNotEquals);
+        rspOps.put(Operation.AND_EQUALS, RspBitmap::andEquals);
+        rspOps.put(Operation.OR_EQUALS, RspBitmap::orEquals);
+    }
+    private static final Map<Operation, BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet>> osetOps =
+            new HashMap<>();
+    static {
+        osetOps.put(Operation.AND_NOT_EQUALS, (x, y) -> x.ixCowRef().ixRemove(y));
+        osetOps.put(Operation.AND_EQUALS, (x, y) -> x.ixCowRef().ixRetain(y));
+        osetOps.put(Operation.OR_EQUALS, (x, y) -> x.ixCowRef().ixInsert(y));
     }
 
     enum TestSequenceMode {
-        EXHAUSTIVE,
-        RANDOM
+        EXHAUSTIVE, RANDOM
     }
 
-    private void binaryOpsExhaustiveHelper(
-            final String opName,
+    private static String toTimeStr(final long millis) {
+        final long totalDeciSeconds = millis / 100;
+        final long totalSeconds = totalDeciSeconds / 10;
+        final long deciSeconds = totalDeciSeconds % 10;
+        final long minutes = totalSeconds / 60;
+        final long seconds = totalSeconds % 60;
+        return String.format("%dm%d.%ds", minutes, seconds, deciSeconds);
+    }
+
+    private static void binaryOpsExhaustiveHelper(
+            final Operation op,
             final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp,
             final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp,
             final int nblocks,
-            final TestSequenceMode mode
-            ) {
+            final TestSequenceMode mode,
+            final long testTimeBudgetMillis) {
         final long nspecs = pow(SPEC_OPTIONS, nblocks);
         final long totalChecks = nspecs * nspecs;
         // We will use an int value to represent a spec of whether to have for a given key:
@@ -146,50 +175,72 @@ public class RspBitmapTimeDrivenTest {
         // 1: Singleton container with element zero.
         // 2: Singleton container with element one.
         // 3: Container with elements zero and one.
-        // 4: Container with elements from two to 65535.
+        // 4: Container with elements from two to BLOCK_LAST.
         // 5: Full block span.
         final int[] spec0 = new int[nblocks];
         final int[] spec1 = new int[nblocks];
-        // avoid testing against the fully empty case.
-        increment(spec0);
-        increment(spec1);
         long check = 0;
         final long start = System.currentTimeMillis();
+        final long deadline = start + testTimeBudgetMillis;
         long lastLog = start;
         long nextLog = start + LOG_PERIOD_MILLIS;
         long lastLogChecksDone = 0;
-        final String testName = "binaryOpsExhaustive-" + opName;
-        do {
-            do {
-                final long now = System.currentTimeMillis();
-                if (now >= nextLog) {
-                    final long checksDoneSinceLastLog = check - lastLogChecksDone;
-                    final long millis = now - lastLog;
-                    System.out.printf("%s: In the last %.1f seconds ran %.1f checks per second; %d checks remaining.%n",
-                            testName,
-                            millis / 1000.0,
-                            (1000.0 * checksDoneSinceLastLog) / millis,
-                            totalChecks - check);
-                    lastLog = now;
-                    nextLog = now + LOG_PERIOD_MILLIS;
-                    lastLogChecksDone = check;
-                }
-                binaryOpHelper(opName, rspOp, osetOp, spec0, spec1);
-                ++check;
-            } while (increment(spec0));
-        } while (increment(spec1));
-        System.out.printf("%s: Done in %.1f seconds.%n",
+        final String testName = "binaryOps-" + op + "-" + mode + "-" + toTimeStr(testTimeBudgetMillis);
+        System.out.printf("%s: Starting, search space for %d blocks is %d combinations.%n", testName, nblocks, totalChecks);
+        while (true) {
+            final long now = System.currentTimeMillis();
+            if (now > deadline) {
+                break;
+            }
+            boolean finished = false;
+            switch (mode) {
+                case RANDOM:
+                    random(spec0);
+                    random(spec1);
+                case EXHAUSTIVE:
+                    // we always increment both in the first pass, to avoid
+                    // checking against the "all empty" case.
+                    final boolean more0 = increment(spec0);
+                    if (!more0 || check == 0) {
+                        final boolean more1 = increment(spec1);
+                        if (!more1) {
+                            finished = true;
+                        }
+                    }
+                    break;
+            }
+            if (finished) {
+                break;
+            }
+            if (now >= nextLog) {
+                final long checksDoneSinceLastLog = check - lastLogChecksDone;
+                final long millis = now - lastLog;
+                System.out.printf(
+                        "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of the space covered; %s to test deadline%n",
+                        testName,
+                        millis / 1000.0,
+                        (1000.0 * checksDoneSinceLastLog) / millis,
+                        (100.0 * check) / totalChecks,
+                        toTimeStr(deadline - now));
+                lastLog = now;
+                nextLog = now + LOG_PERIOD_MILLIS;
+                lastLogChecksDone = check;
+            }
+            binaryOpHelper(op, rspOp, osetOp, spec0, spec1);
+            ++check;
+        }
+        System.out.printf("%s: Done in %s.%n",
                 testName,
-                (System.currentTimeMillis() - start) / 1000.0);
+                toTimeStr(System.currentTimeMillis() - start));
     }
 
-    private void binaryOpHelper(
-            final String opName,
+    private static void binaryOpHelper(
+            final Operation op,
             final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp,
             final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp,
             final int[] spec0,
             final int[] spec1) {
-        final String msg = opName
+        final String msg = op
                 + " && spec0==" + toStr(spec0)
                 + " && spec1==" + toStr(spec1);
         final OrderedLongSet oset0 = fromBlockSpec(spec0);
@@ -201,5 +252,34 @@ public class RspBitmapTimeDrivenTest {
         final RspBitmap rspResult = rspOp.apply(r0, r1);
         final OrderedLongSet osetResult = osetOp.apply(oset0, oset1);
         checkEquals(msg, osetResult, rspResult);
+    }
+
+    @Test
+    public void testBinaryOpsExhaustive() {
+        for (Operation op : rspOps.keySet()) {
+            binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 4, TestSequenceMode.EXHAUSTIVE,
+                    DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
+        }
+    }
+
+    @Test
+    public void testAndNotEqualsRandom() {
+        final Operation op = Operation.AND_NOT_EQUALS;
+        binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
+                DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
+    }
+
+    @Test
+    public void testAndEqualsRandom() {
+        final Operation op = Operation.AND_EQUALS;
+        binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
+                DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
+    }
+
+    @Test
+    public void testOrEqualsRandom() {
+        final Operation op = Operation.OR_EQUALS;
+        binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
+                DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
     }
 }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -44,7 +44,6 @@ import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.codec.Charsets;


### PR DESCRIPTION
JIRA ticket in DHE: https://deephaven.atlassian.net/browse/DH-12544.

The output for running the new test `RspBitmapTimeDrivenTest` in my machine (i9-10900K):

```
[may lines of gradle preamble output removed]

binaryOps-OR_EQUALS-RANDOM-2m0.0s: Starting, search space for 8 blocks is 2821109907456 combinations.
# io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: searching for 'io.deephaven.internal.log.LoggerFactory'...
# io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: found 'io.deephaven.internal.log.LoggerFactorySlf4j'
[Test worker] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.toStdout = true
[Test worker] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.logPeriodSeconds = 30
[Test worker] INFO io.deephaven.configuration.PropertyFile - io.deephaven.engine.rowset.impl.sortedranges.SortedRanges: property SortedRanges.debug = false
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 254680.7 checks per second; 0.000% of the space covered; 1m50.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 273000.2 checks per second; 0.000% of the space covered; 1m40.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 272312.2 checks per second; 0.000% of the space covered; 1m30.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 272304.4 checks per second; 0.000% of the space covered; 1m20.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 271645.2 checks per second; 0.000% of the space covered; 1m10.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 271004.5 checks per second; 0.001% of the space covered; 1m0.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 271668.8 checks per second; 0.001% of the space covered; 0m50.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 272699.7 checks per second; 0.001% of the space covered; 0m40.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 275391.0 checks per second; 0.001% of the space covered; 0m30.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 274573.4 checks per second; 0.001% of the space covered; 0m20.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 274550.5 checks per second; 0.001% of the space covered; 0m10.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 273370.7 checks per second; 0.001% of the space covered; 0m0.0s to test deadline
binaryOps-OR_EQUALS-RANDOM-2m0.0s: Done in 2m0.0s.
binaryOps-AND_EQUALS-RANDOM-2m0.0s: Starting, search space for 8 blocks is 2821109907456 combinations.
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 287596.6 checks per second; 0.000% of the space covered; 1m50.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 289262.9 checks per second; 0.000% of the space covered; 1m40.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 292296.7 checks per second; 0.000% of the space covered; 1m30.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290262.3 checks per second; 0.000% of the space covered; 1m20.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 284142.6 checks per second; 0.001% of the space covered; 1m10.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 292149.3 checks per second; 0.001% of the space covered; 1m0.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 291951.0 checks per second; 0.001% of the space covered; 0m50.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 292870.6 checks per second; 0.001% of the space covered; 0m40.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 293008.5 checks per second; 0.001% of the space covered; 0m30.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 292740.4 checks per second; 0.001% of the space covered; 0m20.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 292631.7 checks per second; 0.001% of the space covered; 0m10.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 292891.5 checks per second; 0.001% of the space covered; 0m0.0s to test deadline
binaryOps-AND_EQUALS-RANDOM-2m0.0s: Done in 2m0.0s.
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Starting, search space for 8 blocks is 2821109907456 combinations.
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 289130.3 checks per second; 0.000% of the space covered; 1m50.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 289599.6 checks per second; 0.000% of the space covered; 1m40.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290294.8 checks per second; 0.000% of the space covered; 1m30.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290340.9 checks per second; 0.000% of the space covered; 1m20.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290306.2 checks per second; 0.001% of the space covered; 1m10.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290294.2 checks per second; 0.001% of the space covered; 1m0.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290255.1 checks per second; 0.001% of the space covered; 0m50.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290391.5 checks per second; 0.001% of the space covered; 0m40.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290133.8 checks per second; 0.001% of the space covered; 0m30.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290253.7 checks per second; 0.001% of the space covered; 0m20.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290365.3 checks per second; 0.001% of the space covered; 0m10.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 10.0 seconds ran 290339.4 checks per second; 0.001% of the space covered; 0m0.0s to test deadline
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Done in 2m0.0s.
binaryOps-AND_EQUALS-EXHAUSTIVE-2m0.0s: Starting, search space for 4 blocks is 1679616 combinations.
binaryOps-AND_EQUALS-EXHAUSTIVE-2m0.0s: Done in 0m2.4s.
binaryOps-OR_EQUALS-EXHAUSTIVE-2m0.0s: Starting, search space for 4 blocks is 1679616 combinations.
binaryOps-OR_EQUALS-EXHAUSTIVE-2m0.0s: Done in 0m2.6s.
binaryOps-AND_NOT_EQUALS-EXHAUSTIVE-2m0.0s: Starting, search space for 4 blocks is 1679616 combinations.
binaryOps-AND_NOT_EQUALS-EXHAUSTIVE-2m0.0s: Done in 0m2.4s.
> Task :engine-rowset:jacocoTestReport UP-TO-DATE
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.1/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 6m 10s
84 actionable tasks: 2 executed, 82 up-to-date
10:37:54 PM: Execution finished ':engine-rowset:testOutOfBand --tests "io.deephaven.engine.rowset.impl.rsp.RspBitmapTimeDrivenTest"'.
```