### PR TITLE
Wrap LivenessScope for advanced resource cleanup

### DIFF
--- a/engine/table/src/test/java/io/deephaven/engine/liveness/TestLiveness.java
+++ b/engine/table/src/test/java/io/deephaven/engine/liveness/TestLiveness.java
@@ -4,7 +4,6 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.engine.table.impl.TstUtils;
-import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,15 +11,13 @@ import org.junit.Test;
 /**
  * Unit tests for liveness code.
  */
-public class TestLiveness extends TestCase {
+public class TestLiveness {
 
     private boolean oldCheckUgp;
     private LivenessScope scope;
 
     @Before
-    @Override
     public void setUp() throws Exception {
-        super.setUp();
         UpdateGraphProcessor.DEFAULT.enableUnitTestMode();
         UpdateGraphProcessor.DEFAULT.resetForUnitTests(false);
         oldCheckUgp = UpdateGraphProcessor.DEFAULT.setCheckTableOperations(false);
@@ -29,16 +26,13 @@ public class TestLiveness extends TestCase {
     }
 
     @After
-    @Override
     public void tearDown() throws Exception {
-        super.tearDown();
         LivenessScopeStack.pop(scope);
         scope.release();
         UpdateGraphProcessor.DEFAULT.setCheckTableOperations(oldCheckUgp);
         UpdateGraphProcessor.DEFAULT.resetForUnitTests(true);
     }
 
-    @SuppressWarnings("JUnit4AnnotatedMethodInJUnit3TestCase")
     @Test
     public void testRecursion() {
         // noinspection AutoBoxing

--- a/py/server/deephaven/liveness_scope.py
+++ b/py/server/deephaven/liveness_scope.py
@@ -25,7 +25,7 @@ class LivenessScope(JObjectWrapper):
     def j_object(self) -> jpy.JType:
         return self.j_scope
 
-    def preserve(self, wrapper: JObjectWrapper):
+    def preserve(self, wrapper: JObjectWrapper) -> None:
         """Preserves a query graph node (usually a Table) to keep it live for the outer scope."""
         _JLivenessScopeStack.pop(self.j_scope)
         _JLivenessScopeStack.peek().manage(wrapper.j_object)
@@ -35,7 +35,11 @@ class LivenessScope(JObjectWrapper):
 @contextlib.contextmanager
 def liveness_scope() -> LivenessScope:
     """Creates a LivenessScope for running a block of code and releases all the query graph resources upon exit. It
-    can be used in a nested way. """
+    can be used in a nested way.
+
+    Returns:
+        a LivenessScope
+    """
     j_scope = _JLivenessScope()
     _JLivenessScopeStack.push(j_scope)
     try:

--- a/py/server/deephaven/liveness_scope.py
+++ b/py/server/deephaven/liveness_scope.py
@@ -1,0 +1,45 @@
+#
+#     Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+#
+"""This module gives the users a finer degree of control over when to clean up unreferenced nodes in the query update
+graph instead of solely relying on garbage collection."""
+import contextlib
+
+import jpy
+from deephaven._wrapper import JObjectWrapper
+
+_JLivenessScopeStack = jpy.get_type("io.deephaven.engine.liveness.LivenessScopeStack")
+_JLivenessScope = jpy.get_type("io.deephaven.engine.liveness.LivenessScope")
+
+
+class LivenessScope(JObjectWrapper):
+    """A LivenessScope automatically manages reference counting of tables and other query resources that are
+    created in it. It should not be instantiated directly but rather through the 'liveness_scope' context manager.
+    """
+    j_object_type = _JLivenessScope
+
+    def __init__(self, j_scope: jpy.JType):
+        self.j_scope = j_scope
+
+    @property
+    def j_object(self) -> jpy.JType:
+        return self.j_scope
+
+    def preserve(self, wrapper: JObjectWrapper):
+        """Preserves a query graph node (usually a Table) to keep it live for the outer scope."""
+        _JLivenessScopeStack.pop(self.j_scope)
+        _JLivenessScopeStack.peek().manage(wrapper.j_object)
+        _JLivenessScopeStack.push(self.j_scope)
+
+
+@contextlib.contextmanager
+def liveness_scope() -> LivenessScope:
+    """Creates a LivenessScope for running a block of code and releases all the query graph resources upon exit. It
+    can be used in a nested way. """
+    j_scope = _JLivenessScope()
+    _JLivenessScopeStack.push(j_scope)
+    try:
+        yield LivenessScope(j_scope=j_scope)
+    finally:
+        _JLivenessScopeStack.pop(j_scope)
+        j_scope.release()

--- a/py/server/tests/test_liveness.py
+++ b/py/server/tests/test_liveness.py
@@ -1,0 +1,60 @@
+#
+#     Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+#
+
+import unittest
+
+from deephaven.pandas import to_pandas
+
+from deephaven import time_table
+
+from deephaven._ugp import ugp_exclusive_lock
+from deephaven.liveness_scope import liveness_scope
+from tests.testbase import BaseTestCase
+
+
+def create_table():
+    with ugp_exclusive_lock():
+        return time_table("00:00:00.001").update(["X=i%11"]).sort("X").tail(16)
+
+
+class LivenessTestCase(BaseTestCase):
+    def test_liveness(self):
+        not_managed = create_table()
+        with liveness_scope() as l_scope:
+            to_discard = create_table()
+            df = to_pandas(to_discard)
+            must_keep = create_table()
+            df = to_pandas(must_keep)
+            l_scope.preserve(must_keep)
+
+        self.assertTrue(not_managed.j_table.tryRetainReference())
+        self.assertTrue(must_keep.j_table.tryRetainReference())
+        self.assertFalse(to_discard.j_table.tryRetainReference())
+
+    def test_liveness_nested(self):
+        with liveness_scope() as l_scope:
+            to_discard = create_table()
+            df = to_pandas(to_discard)
+            must_keep = create_table()
+            df = to_pandas(must_keep)
+            l_scope.preserve(must_keep)
+
+            with liveness_scope() as nested_l_scope:
+                nested_to_discard = create_table()
+                df = to_pandas(nested_to_discard)
+                nested_must_keep = create_table()
+                df = to_pandas(nested_must_keep)
+                nested_l_scope.preserve(nested_must_keep)
+            self.assertTrue(nested_must_keep.j_table.tryRetainReference())
+            self.assertFalse(nested_to_discard.j_table.tryRetainReference())
+            nested_must_keep.j_table.dropReference()
+
+        self.assertTrue(must_keep.j_table.tryRetainReference())
+        self.assertFalse(to_discard.j_table.tryRetainReference())
+        self.assertFalse(nested_must_keep.j_table.tryRetainReference())
+        self.assertFalse(nested_to_discard.j_table.tryRetainReference())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/server/tests/test_liveness.py
+++ b/py/server/tests/test_liveness.py
@@ -47,8 +47,9 @@ class LivenessTestCase(BaseTestCase):
                 df = to_pandas(nested_must_keep)
                 nested_l_scope.preserve(nested_must_keep)
             self.assertTrue(nested_must_keep.j_table.tryRetainReference())
-            self.assertFalse(nested_to_discard.j_table.tryRetainReference())
+            # drop the extra reference obtained by the tryRetainReference() call in the above assert
             nested_must_keep.j_table.dropReference()
+            self.assertFalse(nested_to_discard.j_table.tryRetainReference())
 
         self.assertTrue(must_keep.j_table.tryRetainReference())
         self.assertFalse(to_discard.j_table.tryRetainReference())


### PR DESCRIPTION
Fixes #2250 

1. Added a context manager that returns a scope to be used in the enclosed code block. This also matches the Java use pattern.
2. Cleaned up the Java test code and added Python tests.
