### PR TITLE
Add support for multiple worker threads in RspBitmapTimeDrivenTest.

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-test-conventions.gradle
@@ -46,6 +46,12 @@ project.tasks.withType(Test).all { Test t ->
         if (findProperty('shortTests') == 'true') {
             systemProperty 'TstUtils.shortTests', 'true'
         }
+
+        if (findProperty('showStandardStreams') == 'true') {
+            outputs.upToDateWhen {false}
+            testLogging.showStandardStreams = true
+        }
+
         systemProperty 'Configuration.rootFile', 'dh-tests.prop'
         systemProperty 'devroot', "$rootDir"
         systemProperty 'workspace', "$rootDir/tmp/workspace"

--- a/buildSrc/src/main/groovy/io.deephaven.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-test-conventions.gradle
@@ -48,7 +48,6 @@ project.tasks.withType(Test).all { Test t ->
         }
 
         if (findProperty('showStandardStreams') == 'true') {
-            outputs.upToDateWhen {false}
             testLogging.showStandardStreams = true
         }
 

--- a/engine/rowset/build.gradle
+++ b/engine/rowset/build.gradle
@@ -22,11 +22,3 @@ dependencies {
 }
 
 TestTools.addEngineOutOfBandTest(project)
-
-testOutOfBand {
-    testLogging {
-        outputs.upToDateWhen {false}
-        showStandardStreams = true
-    }
-}
-

--- a/engine/rowset/build.gradle
+++ b/engine/rowset/build.gradle
@@ -22,3 +22,11 @@ dependencies {
 }
 
 TestTools.addEngineOutOfBandTest(project)
+
+testOutOfBand {
+    testLogging {
+        outputs.upToDateWhen {false}
+        showStandardStreams = true
+    }
+}
+

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -23,7 +23,7 @@ public class RspBitmapTimeDrivenTest {
     public static final long FAILURE_CHECK_PERIOD_MILLIS = 2 * 1000;
     public static final long LOG_PERIOD_MILLIS;
     static {
-        final String s = System.getenv("TEST_PERIOD_SECONDS");
+        final String s = System.getenv("TEST_LOG_PERIOD_SECONDS");
         if (s == null) {
             LOG_PERIOD_MILLIS = 15 * 1000;
         } else {

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -53,14 +53,25 @@ public class RspBitmapTimeDrivenTest {
     public static final int SPLIT_SEARCH_SPACE_FIRST_PIECE;
     public static final int SPLIT_SEARCH_SPACE_LAST_PIECE;
     public static final long PER_TEST_TIME_BUDGET_MILLIS;
+    public static final boolean DEFAULT_RANDOM = true;
     static {
         final String s = System.getenv("TEST_MODE");
         if (s == null) {
-            TEST_MODE = TestSequenceMode.RANDOM;
-            SPLIT_SEARCH_SPACE_PIECES = 1;
-            SPLIT_SEARCH_SPACE_FIRST_PIECE = 0;
-            SPLIT_SEARCH_SPACE_LAST_PIECE = 0;
-            PER_TEST_TIME_BUDGET_MILLIS = 2 * 60 * 1000;
+            if (DEFAULT_RANDOM) {
+                // Good for CI / PR checks.
+                TEST_MODE = TestSequenceMode.RANDOM;
+                SPLIT_SEARCH_SPACE_PIECES = 1;
+                SPLIT_SEARCH_SPACE_FIRST_PIECE = 0;
+                SPLIT_SEARCH_SPACE_LAST_PIECE = 0;
+                PER_TEST_TIME_BUDGET_MILLIS = 2 * 60 * 1000;
+            } else {
+                // Good for manual checks.
+                TEST_MODE = TestSequenceMode.EXHAUSTIVE;
+                SPLIT_SEARCH_SPACE_PIECES = 150000;
+                SPLIT_SEARCH_SPACE_FIRST_PIECE = 80000;
+                SPLIT_SEARCH_SPACE_LAST_PIECE = 80009;
+                PER_TEST_TIME_BUDGET_MILLIS = -1;
+            }
         } else {
             String[] parts = s.split(":");
             final String invalidMsg = "Invalid TEST_MODE format: \"" + s +
@@ -470,7 +481,8 @@ public class RspBitmapTimeDrivenTest {
                             nblocks,
                             SPLIT_SEARCH_SPACE_FIRST_PIECE + i,
                             mode,
-                            testTimeBudgetMillis));
+                            testTimeBudgetMillis),
+                    "worker-" + i);
             log("%s: Dispatching worker %d.%n", testName, i);
             workers[i].start();
             if (SEARCH_PIECES > 1 && i < SEARCH_PIECES - 1) {

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -20,7 +20,15 @@ import static org.junit.Assert.*;
 public class RspBitmapTimeDrivenTest {
 
     public static final long RANDOM_SEED_BASE = 6;
-    public static final long LOG_PERIOD_MILLIS = 10 * 1000;
+    public static final long LOG_PERIOD_MILLIS;
+    static {
+        final String s = System.getenv("TEST_PERIOD_SECONDS");
+        if (s == null) {
+            LOG_PERIOD_MILLIS = 10 * 1000;
+        } else {
+            LOG_PERIOD_MILLIS = 1000L * Integer.parseInt(s);
+        }
+    }
 
     // See comment about spec value meanings in caller.
     public static final int SPEC_BASE = 6;

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -6,6 +6,7 @@ import io.deephaven.test.types.OutOfBandTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -14,17 +15,127 @@ import java.util.function.BiFunction;
 import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_LAST;
 import static io.deephaven.engine.rowset.impl.rsp.RspArray.BLOCK_SIZE;
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertFalse;
 
 @Category(OutOfBandTest.class)
 public class RspBitmapTimeDrivenTest {
 
-    public static final int RANDOM_SEED = 4;
-    public static final long DEFAULT_PER_TEST_TIME_BUDGET_MILLIS = 2 * 60 * 1000;
+    public static final long RANDOM_SEED_BASE = 6;
     public static final long LOG_PERIOD_MILLIS = 10 * 1000;
 
     // See comment about spec value meanings in caller.
-    public static final int SPEC_OPTIONS = 6;
+    public static final int SPEC_BASE = 6;
+
+    enum TestSequenceMode {
+        EXHAUSTIVE, RANDOM
+    }
+
+    // We support two modes of operation, controlled by the TEST_MODE environment variable.
+    // * TEST_MODE=EXHAUSTIVE:SPLIT_TOTAL,FIRST_PIECE,LAST_PIECE
+    // Perform an EXHAUSTIVE (string literal "EXHAUSTIVE") search of the total range of possibilities (search space).
+    // Split the space in SPLIT_TOTAL (integer > 0) sub-ranges.
+    // Search over sub-ranges FIRST (integer >= 0) and LAST (integer >= 0).
+    // For every sub-range to search, a separate worker thread will be started.
+    // * TEST_MODE=RANDOM:WORKERS,TIME_BUDGET_SECONDS
+    // Perform a RANDOM (string literal "RANDOM") search of the total range of possibilities (search space).
+    // Start WORKERS (integer > 0) number of worker threads.
+    // Search for TIME_BUDGET_SECONDS (integer > 0) seconds.
+    public static final TestSequenceMode TEST_MODE;
+    public static final int SPLIT_SEARCH_SPACE_PIECES;
+    public static final int SPLIT_SEARCH_SPACE_FIRST_PIECE;
+    public static final int SPLIT_SEARCH_SPACE_LAST_PIECE;
+    public static final long PER_TEST_TIME_BUDGET_MILLIS;
+    static {
+        final String s = System.getenv("TEST_MODE");
+        if (s == null) {
+            TEST_MODE = TestSequenceMode.RANDOM;
+            SPLIT_SEARCH_SPACE_PIECES = 1;
+            SPLIT_SEARCH_SPACE_FIRST_PIECE = 0;
+            SPLIT_SEARCH_SPACE_LAST_PIECE = 0;
+            PER_TEST_TIME_BUDGET_MILLIS = 2 * 60 * 1000;
+        } else {
+            String[] parts = s.split(":");
+            final String invalidMsg = "Invalid TEST_MODE format: \"" + s +
+                    "\"; expected one of " +
+                    "\"EXHAUSTIVE:SPLIT_TOTAL,FIRST_PIECE,LAST_PIECE\"" +
+                    " or " +
+                    "\"TEST_MODE=RANDOM:WORKERS,TIME_BUDGET_SECONDS\"";
+            if (parts.length != 2) {
+                throw new IllegalArgumentException(invalidMsg);
+            }
+            switch (parts[0]) {
+                case "EXHAUSTIVE":
+                case "exhaustive":
+                    TEST_MODE = TestSequenceMode.EXHAUSTIVE;
+                    PER_TEST_TIME_BUDGET_MILLIS = -1;
+                    parts = parts[1].split(",");
+                    if (parts.length != 3) {
+                        throw new IllegalArgumentException(invalidMsg);
+                    }
+                    SPLIT_SEARCH_SPACE_PIECES = Integer.parseInt(parts[0]);
+                    SPLIT_SEARCH_SPACE_FIRST_PIECE = Integer.parseInt(parts[1]);
+                    SPLIT_SEARCH_SPACE_LAST_PIECE = Integer.parseInt(parts[2]);
+                    if (SPLIT_SEARCH_SPACE_PIECES < 1) {
+                        throw new IllegalArgumentException(
+                                "Can't split the space in " + SPLIT_SEARCH_SPACE_PIECES + " pieces");
+                    }
+                    if (SPLIT_SEARCH_SPACE_FIRST_PIECE > SPLIT_SEARCH_SPACE_LAST_PIECE ||
+                            SPLIT_SEARCH_SPACE_FIRST_PIECE < 0 ||
+                            SPLIT_SEARCH_SPACE_LAST_PIECE > SPLIT_SEARCH_SPACE_PIECES - 1) {
+                        throw new IllegalArgumentException(
+                                "Can't process first=" + SPLIT_SEARCH_SPACE_FIRST_PIECE +
+                                        ", last=" + SPLIT_SEARCH_SPACE_LAST_PIECE +
+                                        " in " + SPLIT_SEARCH_SPACE_PIECES + " pieces");
+                    }
+                    break;
+                case "RANDOM":
+                case "random":
+                    TEST_MODE = TestSequenceMode.RANDOM;
+                    parts = parts[1].split(",");
+                    if (parts.length != 2) {
+                        throw new IllegalArgumentException(invalidMsg);
+                    }
+                    SPLIT_SEARCH_SPACE_PIECES = Integer.parseInt(parts[0]);
+                    SPLIT_SEARCH_SPACE_FIRST_PIECE = 0;
+                    SPLIT_SEARCH_SPACE_LAST_PIECE = 0;
+                    PER_TEST_TIME_BUDGET_MILLIS = 1000L * Long.parseLong(parts[1]);
+                    break;
+                default:
+                    throw new IllegalStateException(invalidMsg);
+            }
+        }
+    }
+
+    public static final boolean TEST_OR, TEST_AND, TEST_ANDNOT;
+    static {
+        final boolean testOnlyOr = System.getenv("TEST_ONLY_OR") != null;
+        final boolean testOnlyAnd = System.getenv("TEST_ONLY_AND") != null;
+        final boolean testOnlyAndNot = System.getenv("TEST_ONLY_ANDNOT") != null;
+        int count = 0;
+        if (testOnlyOr)
+            ++count;
+        if (testOnlyAnd)
+            ++count;
+        if (testOnlyAndNot)
+            ++count;
+        if (count > 1) {
+            throw new IllegalStateException("Can set only one of TEST_ONLY_OR, TEST_ONLY_AND, TEST_ONLY_ANDNOT");
+        }
+        if (testOnlyOr) {
+            TEST_OR = true;
+            TEST_AND = false;
+            TEST_ANDNOT = false;
+        } else if (testOnlyAnd) {
+            TEST_OR = false;
+            TEST_AND = true;
+            TEST_ANDNOT = false;
+        } else if (testOnlyAndNot) {
+            TEST_OR = false;
+            TEST_AND = false;
+            TEST_ANDNOT = true;
+        } else {
+            TEST_OR = TEST_AND = TEST_ANDNOT = true;
+        }
+    }
 
     // Each position in the spec array represents one block in a series of consecutive RSP blocks
     // in the result. Position i in the spec array represents the block starting at i*BLOCK_SIZE
@@ -58,11 +169,30 @@ public class RspBitmapTimeDrivenTest {
         return b.getTreeIndexImpl();
     }
 
+    // Convert an int value to a spec (a spec represents a base SPEC_BASE number).
+    private static void intToSpec(final int v, final int[] spec) {
+        int rest = v;
+        for (int i = spec.length - 1; i >= 0; --i) {
+            spec[i] = rest % SPEC_BASE;
+            rest /= SPEC_BASE;
+            if (rest == 0 && i > 0) {
+                for (int j = i - 1; j >= 0; --j) {
+                    spec[j] = 0;
+                }
+                return;
+            }
+        }
+        if (rest != 0) {
+            throw new IllegalStateException(
+                    "v=" + v + " outside of representation range for spec.length=" + spec.length);
+        }
+    }
+
     private static String toStr(final int[] spec) {
         final StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < spec.length; ++i) {
             final long baseKey = BLOCK_SIZE * (long) i;
-            sb.append(" ").append(baseKey).append(" : ");
+            sb.append(" ").append(i).append(" *2^16 : ");
             switch (spec[i]) {
                 case 0: // Key not present.
                     sb.append("{}");
@@ -77,10 +207,10 @@ public class RspBitmapTimeDrivenTest {
                     sb.append("{0,1}");
                     break;
                 case 4: // Container with the range [2, BLOCK_LAST]
-                    sb.append("{2->}");
+                    sb.append("FULL-{0,1}");
                     break;
                 case 5: // Full block span.
-                    sb.append("{0->}");
+                    sb.append("FULL");
                     break;
                 default:
                     throw new IllegalStateException("Unexpected i=" + i + ", spec[i]=" + spec[i]);
@@ -93,30 +223,8 @@ public class RspBitmapTimeDrivenTest {
         return sb.toString();
     }
 
-    private static final Random rand = new Random(RANDOM_SEED);
-
-    private static void random(final int[] spec) {
-        for (int i = 0; i < spec.length; ++i) {
-            spec[i] = rand.nextInt(SPEC_OPTIONS);
-        }
-    }
-
-    // Do a "manual" increment of spec as if it was a number represented in base SPEC_OPTIONS
-    // with one digit per array position.
-    private static boolean increment(final int[] spec) {
-        for (int i = spec.length - 1; i >= 0; --i) {
-            final int v = ++spec[i];
-            if (v < SPEC_OPTIONS) {
-                return true;
-            }
-            spec[i] = 0;
-        }
-        return false;
-    }
-
-    private static void checkEquals(final String msg, final OrderedLongSet oset0, final OrderedLongSet oset1) {
-        assertEquals(msg, oset0.ixCardinality(), oset1.ixCardinality());
-        assertTrue(msg, oset0.ixSubsetOf(oset1));
+    private static boolean areEqual(final OrderedLongSet oset0, final OrderedLongSet oset1) {
+        return oset0.ixCardinality() == oset1.ixCardinality() && oset0.ixSubsetOf(oset1);
     }
 
     // return a^b.
@@ -130,7 +238,13 @@ public class RspBitmapTimeDrivenTest {
     }
 
     enum Operation {
-        AND_NOT_EQUALS, AND_EQUALS, OR_EQUALS
+        AND_NOT_EQUALS(TEST_ANDNOT), AND_EQUALS(TEST_AND), OR_EQUALS(TEST_OR);
+
+        public final boolean enabled;
+
+        Operation(final boolean enabled) {
+            this.enabled = enabled;
+        }
     }
 
     private static final Map<Operation, BiFunction<RspBitmap, RspBitmap, RspBitmap>> rspOps = new HashMap<>();
@@ -147,10 +261,6 @@ public class RspBitmapTimeDrivenTest {
         osetOps.put(Operation.OR_EQUALS, (x, y) -> x.ixCowRef().ixInsert(y));
     }
 
-    enum TestSequenceMode {
-        EXHAUSTIVE, RANDOM
-    }
-
     private static String toTimeStr(final long millis) {
         final long totalDeciSeconds = millis / 100;
         final long totalSeconds = totalDeciSeconds / 10;
@@ -160,126 +270,248 @@ public class RspBitmapTimeDrivenTest {
         return String.format("%dm%d.%ds", minutes, seconds, deciSeconds);
     }
 
-    private static void binaryOpsExhaustiveHelper(
+    private static void valueToSpec(final long value, final int[] spec) {
+        final int nblocks = spec.length;
+        long v = value + 1; // the encoding in value is displaced to avoid the all zeros (empty) case.
+        int i = nblocks - 1;
+        while (i >= 0) {
+            final int m = (int) (v % SPEC_BASE);
+            spec[i] = m;
+            v = v / SPEC_BASE;
+            --i;
+            if (v == 0) {
+                break;
+            }
+        }
+        for (int j = i; j >= 0; --j) {
+            spec[j] = 0;
+        }
+    }
+
+    static class TestWorker implements Runnable {
+        public static volatile String failure = null; // if not null we discovered a failure.
+
+        private final String workerName;
+        private final String testName;
+        private final Operation op;
+        private final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp;
+        private final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp;
+        private final int nblocks;
+        private final int searchPiece;
+        private final long testTimeBudgetMillis;
+        private final Random rand;
+
+        public TestWorker(
+                final int workerIdx,
+                final String testName,
+                final Operation op,
+                final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp,
+                final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp,
+                final int nblocks,
+                final int searchPiece,
+                final TestSequenceMode mode,
+                final long testTimeBudgetMillis) {
+            this.workerName = "" + workerIdx + "/" + SPLIT_SEARCH_SPACE_PIECES;
+            this.testName = testName;
+            this.op = op;
+            this.rspOp = rspOp;
+            this.osetOp = osetOp;
+            this.nblocks = nblocks;
+            this.searchPiece = searchPiece;
+            this.testTimeBudgetMillis = testTimeBudgetMillis;
+            rand = new Random(RANDOM_SEED_BASE * SPLIT_SEARCH_SPACE_PIECES + workerIdx);
+        }
+
+        @Override
+        public void run() {
+            final long nspecs = pow(SPEC_BASE, nblocks) - 1; // avoid using the "all zeroes" (empty) case.
+            final long totalSpaceSize = nspecs * nspecs;
+            final long onePieceSize =
+                    totalSpaceSize / SPLIT_SEARCH_SPACE_PIECES
+                            + (((totalSpaceSize % SPLIT_SEARCH_SPACE_PIECES) > 0) ? 1 : 0);
+            final long firstValueForSearch = onePieceSize * searchPiece;
+            long lastValueForSearch = onePieceSize * (searchPiece + 1) - 1;
+            if (lastValueForSearch > totalSpaceSize - 1) {
+                lastValueForSearch = totalSpaceSize - 1;
+            }
+            final long searchSpaceSize = lastValueForSearch - firstValueForSearch + 1;
+            // We will use an int value to represent a spec of whether to have for a given key:
+            // 0: Key not present
+            // 1: Singleton container with element zero.
+            // 2: Singleton container with element one.
+            // 3: Container with elements zero and one.
+            // 4: Container with elements from two to BLOCK_LAST.
+            // 5: Full block span.
+            final int[] spec0 = new int[nblocks];
+            final int[] spec1 = new int[nblocks];
+            long check = 0;
+            final long start = System.currentTimeMillis();
+            final long deadline = (testTimeBudgetMillis == -1) ? -1 : start + testTimeBudgetMillis;
+            long lastLog = start;
+            long nextLog = start + LOG_PERIOD_MILLIS;
+            long lastLogChecksDone = 0;
+            final String me = String.format("Worker %s %s", workerName, testName);
+            System.out.printf(
+                    "%s: Starting, searching space for %,d blocks between %,d and %,d (%,d out of %,d combinations, %.001f%% of search space).%n",
+                    me, nblocks, firstValueForSearch, lastValueForSearch, searchSpaceSize, totalSpaceSize,
+                    (100.0 * searchSpaceSize) / totalSpaceSize);
+            final long totalChecks = lastValueForSearch - firstValueForSearch + 1;
+            while (true) {
+                if (failure != null) {
+                    System.out.printf("%s: detected failure in another worker, stopping.%n", me);
+                    return;
+                }
+                final long now = System.currentTimeMillis();
+                if (deadline != -1 && now > deadline) {
+                    break;
+                }
+                final long v;
+                switch (TEST_MODE) {
+                    case RANDOM: {
+                        v = firstValueForSearch + (long) (rand.nextDouble() * searchSpaceSize);
+                        break;
+                    }
+                    case EXHAUSTIVE: {
+                        v = firstValueForSearch + check;
+                        break;
+                    }
+                    default:
+                        throw new IllegalStateException(me + " Unexpected mode");
+                }
+                if (TEST_MODE.equals(TestSequenceMode.EXHAUSTIVE) && v > lastValueForSearch) {
+                    break;
+                }
+                final long spec0value = v % nspecs;
+                final long spec1value = v / nspecs;
+                valueToSpec(spec0value, spec0);
+                valueToSpec(spec1value, spec1);
+                if (!checkBinaryOp(rspOp, osetOp, spec0, spec1)) {
+                    final String failed = op
+                            + " && spec0==" + toStr(spec0)
+                            + " && spec1==" + toStr(spec1);
+                    System.out.printf("%s: failed, %s.%n", me, failure);
+                    if (failure != null) {
+                        synchronized (TestWorker.class) {
+                            if (failure != null) {
+                                failure = failed;
+                            }
+                        }
+                    }
+                    return;
+                }
+                if (now >= nextLog) {
+                    final long checksDoneSinceLastLog = check - lastLogChecksDone;
+                    final long millis = now - lastLog;
+                    final String deadlineStr = (deadline == -1) ? "no" : (toTimeStr(deadline - now) + " to");
+                    System.out.printf(
+                            "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of the space covered; %s test deadline.%n",
+                            me,
+                            millis / 1000.0,
+                            (1000.0 * checksDoneSinceLastLog) / millis,
+                            (100.0 * (check + 1)) / totalChecks,
+                            deadlineStr);
+                    System.out.printf(
+                            "%s: Last checked for v=%,d => spec0=%s, spec1=%s.%n",
+                            me,
+                            v,
+                            Arrays.toString(spec0),
+                            Arrays.toString(spec1));
+                    lastLog = now;
+                    nextLog = now + LOG_PERIOD_MILLIS;
+                    lastLogChecksDone = check;
+                }
+                ++check;
+            }
+            System.out.printf("%s: Done in %s.%n",
+                    me,
+                    toTimeStr(System.currentTimeMillis() - start));
+        }
+    }
+
+    private static void binaryOpsHelper(
             final Operation op,
             final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp,
             final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp,
             final int nblocks,
             final TestSequenceMode mode,
             final long testTimeBudgetMillis) {
-        final long nspecs = pow(SPEC_OPTIONS, nblocks);
-        final long totalChecks = nspecs * nspecs;
-        // We will use an int value to represent a spec of whether to have for a given key:
-        // 0: Key not present
-        // 1: Singleton container with element zero.
-        // 2: Singleton container with element one.
-        // 3: Container with elements zero and one.
-        // 4: Container with elements from two to BLOCK_LAST.
-        // 5: Full block span.
-        final int[] spec0 = new int[nblocks];
-        final int[] spec1 = new int[nblocks];
-        long check = 0;
-        final long start = System.currentTimeMillis();
-        final long deadline = start + testTimeBudgetMillis;
-        long lastLog = start;
-        long nextLog = start + LOG_PERIOD_MILLIS;
-        long lastLogChecksDone = 0;
-        final String testName = "binaryOps-" + op + "-" + mode + "-" + toTimeStr(testTimeBudgetMillis);
-        System.out.printf("%s: Starting, search space for %d blocks is %d combinations.%n", testName, nblocks,
-                totalChecks);
-        while (true) {
-            final long now = System.currentTimeMillis();
-            if (now > deadline) {
-                break;
-            }
-            boolean finished = false;
-            switch (mode) {
-                case RANDOM:
-                    random(spec0);
-                    random(spec1);
-                case EXHAUSTIVE:
-                    // we always increment both in the first pass, to avoid
-                    // checking against the "all empty" case.
-                    final boolean more0 = increment(spec0);
-                    if (!more0 || check == 0) {
-                        final boolean more1 = increment(spec1);
-                        if (!more1) {
-                            finished = true;
-                        }
-                    }
-                    break;
-            }
-            if (finished) {
-                break;
-            }
-            if (now >= nextLog) {
-                final long checksDoneSinceLastLog = check - lastLogChecksDone;
-                final long millis = now - lastLog;
-                System.out.printf(
-                        "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of the space covered; %s to test deadline%n",
-                        testName,
-                        millis / 1000.0,
-                        (1000.0 * checksDoneSinceLastLog) / millis,
-                        (100.0 * check) / totalChecks,
-                        toTimeStr(deadline - now));
-                lastLog = now;
-                nextLog = now + LOG_PERIOD_MILLIS;
-                lastLogChecksDone = check;
-            }
-            binaryOpHelper(op, rspOp, osetOp, spec0, spec1);
-            ++check;
+        final String testName = "binaryOps-" + op + "-" + mode + "-"
+                + ((testTimeBudgetMillis == -1) ? "nolimit" : toTimeStr(testTimeBudgetMillis));
+        final int searchPieces = SPLIT_SEARCH_SPACE_LAST_PIECE - SPLIT_SEARCH_SPACE_FIRST_PIECE + 1;
+        final Thread[] workers = new Thread[searchPieces];
+        for (int i = 0; i < searchPieces; ++i) {
+            workers[i] = new Thread(
+                    new TestWorker(
+                            i,
+                            testName,
+                            op, rspOp, osetOp,
+                            nblocks,
+                            SPLIT_SEARCH_SPACE_FIRST_PIECE + i,
+                            mode,
+                            testTimeBudgetMillis));
+            System.out.printf("%s: Dispatching worker %d.%n", testName, i);
+            workers[i].start();
         }
-        System.out.printf("%s: Done in %s.%n",
-                testName,
-                toTimeStr(System.currentTimeMillis() - start));
+        for (int i = 0; i < searchPieces; ++i) {
+            try {
+                workers[i].join();
+            } catch (InterruptedException e) {
+                // ignore.
+            }
+        }
+        System.out.printf("%s: All workers finished.%n", testName);
+        if (TestWorker.failure != null) {
+            assertTrue(TestWorker.failure, TestWorker.failure == null);
+        }
     }
 
-    private static void binaryOpHelper(
-            final Operation op,
+    private static boolean checkBinaryOp(
             final BiFunction<RspBitmap, RspBitmap, RspBitmap> rspOp,
             final BiFunction<OrderedLongSet, OrderedLongSet, OrderedLongSet> osetOp,
             final int[] spec0,
             final int[] spec1) {
-        final String msg = op
-                + " && spec0==" + toStr(spec0)
-                + " && spec1==" + toStr(spec1);
         final OrderedLongSet oset0 = fromBlockSpec(spec0);
-        assertFalse(msg, oset0 instanceof RspBitmap);
+        if (oset0 instanceof RspBitmap) {
+            throw new IllegalStateException("Unexpected OrderedLongSet subtype");
+        }
         final OrderedLongSet oset1 = fromBlockSpec(spec1);
-        assertFalse(msg, oset1 instanceof RspBitmap);
+        if (oset1 instanceof RspBitmap) {
+            throw new IllegalStateException("Unexppected OrderedLongSet subtype");
+        }
         final RspBitmap r0 = oset0.ixToRspOnNew();
         final RspBitmap r1 = oset1.ixToRspOnNew();
         final RspBitmap rspResult = rspOp.apply(r0, r1);
         final OrderedLongSet osetResult = osetOp.apply(oset0, oset1);
-        checkEquals(msg, osetResult, rspResult);
-    }
-
-    @Test
-    public void testBinaryOpsExhaustive() {
-        for (Operation op : rspOps.keySet()) {
-            binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 4, TestSequenceMode.EXHAUSTIVE,
-                    DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
-        }
+        return areEqual(osetResult, rspResult);
     }
 
     @Test
     public void testAndNotEqualsRandom() {
+        if (!TEST_ANDNOT) {
+            return;
+        }
         final Operation op = Operation.AND_NOT_EQUALS;
-        binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
-                DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
+        binaryOpsHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
+                PER_TEST_TIME_BUDGET_MILLIS);
     }
 
     @Test
     public void testAndEqualsRandom() {
+        if (!TEST_AND) {
+            return;
+        }
         final Operation op = Operation.AND_EQUALS;
-        binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
-                DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
+        binaryOpsHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
+                PER_TEST_TIME_BUDGET_MILLIS);
     }
 
     @Test
     public void testOrEqualsRandom() {
+        if (!TEST_OR) {
+            return;
+        }
         final Operation op = Operation.OR_EQUALS;
-        binaryOpsExhaustiveHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
-                DEFAULT_PER_TEST_TIME_BUDGET_MILLIS);
+        binaryOpsHelper(op, rspOps.get(op), osetOps.get(op), 8, TestSequenceMode.RANDOM,
+                PER_TEST_TIME_BUDGET_MILLIS);
     }
 }

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -476,6 +476,10 @@ public class RspBitmapTimeDrivenTest {
                             testTimeBudgetMillis));
             System.out.printf("%s: Dispatching worker %d.%n", testName, i);
             workers[i].start();
+            if (searchPieces > 1 && i < searchPieces - 1) {
+                // minimally stagger
+                try { Thread.sleep(10); } catch (InterruptedException e) { /* ignore */ }
+            }
         }
         for (int i = 0; i < searchPieces; ++i) {
             try {

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -387,12 +387,17 @@ public class RspBitmapTimeDrivenTest {
                 valueToSpec(spec1value, spec1);
                 if (!checkBinaryOp(rspOp, osetOp, spec0, spec1)) {
                     final String failed = op
-                            + " && spec0==" + toStr(spec0)
-                            + " && spec1==" + toStr(spec1);
-                    System.out.printf("%s: failed, %s.%n", me, failure);
-                    if (failure != null) {
+                            + " spec0=" + Arrays.toString(spec0)
+                            + " spec1=" + Arrays.toString(spec1)
+                            + "\n"
+                            + " spec0 => " + toStr(spec0)
+                            + "\n"
+                            + " spec1 => " + toStr(spec1)
+                            + "\n";
+                    System.out.printf("%s: failed, %s.%n", me, failed);
+                    if (failure == null) {
                         synchronized (TestWorker.class) {
-                            if (failure != null) {
+                            if (failure == null) {
                                 failure = failed;
                             }
                         }

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -309,6 +309,11 @@ public class RspBitmapTimeDrivenTest {
         }
     }
 
+    private static void log(final String format, final Object... args) {
+        System.out.printf(format, args);
+        System.out.flush();
+    }
+
     static class TestWorker implements Runnable {
         public static volatile String failure = null; // if not null we discovered a failure.
 
@@ -373,7 +378,7 @@ public class RspBitmapTimeDrivenTest {
             long nextFailureCheck = start + FAILURE_CHECK_PERIOD_MILLIS;
             long lastLogChecksDone = 0;
             final String me = String.format("Worker %s %s", workerName, testName);
-            System.out.printf(
+            log(
                     "%s: Starting, searching space for %,d blocks between %,d and %,d (%,d out of %,d combinations, %.001f%% of search space).%n",
                     me, nblocks, firstValueForSearch, lastValueForSearch, searchSpaceSize, totalSpaceSize,
                     (100.0 * searchSpaceSize) / totalSpaceSize);
@@ -412,7 +417,7 @@ public class RspBitmapTimeDrivenTest {
                             + "\n"
                             + " spec1 => " + toStr(spec1)
                             + "\n";
-                    System.out.printf("%s: failed, %s.%n", me, failed);
+                    log("%s: failed, %s.%n", me, failed);
                     if (failure == null) {
                         synchronized (TestWorker.class) {
                             if (failure == null) {
@@ -424,7 +429,7 @@ public class RspBitmapTimeDrivenTest {
                 }
                 if (now >= nextFailureCheck) {
                     if (failure != null) {
-                        System.out.printf("%s: detected failure in another worker, stopping.%n", me);
+                        log("%s: detected failure in another worker, stopping.%n", me);
                         return;
                     }
                     nextFailureCheck = now + FAILURE_CHECK_PERIOD_MILLIS;
@@ -435,7 +440,7 @@ public class RspBitmapTimeDrivenTest {
                     final String deadlineStr = (deadline == -1) ? "no" : (toTimeStr(deadline - now) + " to");
                     final double checksPerMilli = ((double) checksDoneSinceLastLog) / millis;
                     final double avgChecksPerMilli = ((double) (check + 1)) / (now - start);
-                    System.out.printf("%s: " +
+                    log("%s: " +
                             "In the last %.1f seconds ran %.1f checks per second; " +
                             "%.3f%% of this worker's space covered; %s test deadline, " +
                             "%s to worker's space coverage.%n",
@@ -445,7 +450,7 @@ public class RspBitmapTimeDrivenTest {
                             (100.0 * (check + 1)) / totalChecks,
                             deadlineStr,
                             toTimeStr((long) ((totalChecks - check - 1) / avgChecksPerMilli)));
-                    System.out.printf(
+                    log(
                             "%s: Last checked for v=%,d => spec0=%s, spec1=%s.%n",
                             me,
                             v,
@@ -457,7 +462,7 @@ public class RspBitmapTimeDrivenTest {
                 }
                 ++check;
             }
-            System.out.printf("%s: Done in %s.%n",
+            log("%s: Done in %s.%n",
                     me,
                     toTimeStr(System.currentTimeMillis() - start));
         }
@@ -483,7 +488,7 @@ public class RspBitmapTimeDrivenTest {
                             SPLIT_SEARCH_SPACE_FIRST_PIECE + i,
                             mode,
                             testTimeBudgetMillis));
-            System.out.printf("%s: Dispatching worker %d.%n", testName, i);
+            log("%s: Dispatching worker %d.%n", testName, i);
             workers[i].start();
             if (SEARCH_PIECES > 1 && i < SEARCH_PIECES - 1) {
                 // minimally stagger
@@ -500,7 +505,7 @@ public class RspBitmapTimeDrivenTest {
                 // ignore.
             }
         }
-        System.out.printf("%s: All workers finished.%n", testName);
+        log("%s: All workers finished.%n", testName);
         if (TestWorker.failure != null) {
             assertTrue(TestWorker.failure, TestWorker.failure == null);
         }

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -180,25 +180,6 @@ public class RspBitmapTimeDrivenTest {
         return b.getTreeIndexImpl();
     }
 
-    // Convert an int value to a spec (a spec represents a base SPEC_BASE number).
-    private static void intToSpec(final int v, final int[] spec) {
-        int rest = v;
-        for (int i = spec.length - 1; i >= 0; --i) {
-            spec[i] = rest % SPEC_BASE;
-            rest /= SPEC_BASE;
-            if (rest == 0 && i > 0) {
-                for (int j = i - 1; j >= 0; --j) {
-                    spec[j] = 0;
-                }
-                return;
-            }
-        }
-        if (rest != 0) {
-            throw new IllegalStateException(
-                    "v=" + v + " outside of representation range for spec.length=" + spec.length);
-        }
-    }
-
     private static String toStr(final int[] spec) {
         final StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < spec.length; ++i) {
@@ -293,16 +274,18 @@ public class RspBitmapTimeDrivenTest {
 
     private static void valueToSpec(final long value, final int[] spec) {
         final int nblocks = spec.length;
-        long v = value + 1; // the encoding in value is displaced to avoid the all zeros (empty) case.
+        long v = value + 1; // transform: input is assumed to be offset to avoid the all zeros (empty) case.
         int i = nblocks - 1;
         while (i >= 0) {
-            final int m = (int) (v % SPEC_BASE);
-            spec[i] = m;
+            spec[i] = (int) (v % SPEC_BASE);
             v = v / SPEC_BASE;
             --i;
             if (v == 0) {
                 break;
             }
+        }
+        if (v != 0) {
+            throw new IllegalStateException("value=" + value + " outside of range for nblocks=" + nblocks);
         }
         for (int j = i; j >= 0; --j) {
             spec[j] = 0;

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.*;
 @Category(OutOfBandTest.class)
 public class RspBitmapTimeDrivenTest {
 
-    public static final long RANDOM_SEED_BASE = 6;
+    public static final long RANDOM_SEED_BASE_DEFAULT = 10;
+    public static final boolean RANDOM_SEED_FROM_TIME = System.getenv("TEST_SEED_FROM_TIME") != null;
+
     public static final long FAILURE_CHECK_PERIOD_MILLIS = 2 * 1000;
     public static final long LOG_PERIOD_MILLIS;
     static {
@@ -82,8 +84,7 @@ public class RspBitmapTimeDrivenTest {
             if (parts.length != 2) {
                 throw new IllegalArgumentException(invalidMsg);
             }
-            switch (parts[0]) {
-                case "EXHAUSTIVE":
+            switch (parts[0].toLowerCase()) {
                 case "exhaustive":
                     TEST_MODE = TestSequenceMode.EXHAUSTIVE;
                     PER_TEST_TIME_BUDGET_MILLIS = -1;
@@ -107,7 +108,6 @@ public class RspBitmapTimeDrivenTest {
                                         " in " + SPLIT_SEARCH_SPACE_PIECES + " pieces");
                     }
                     break;
-                case "RANDOM":
                 case "random":
                     TEST_MODE = TestSequenceMode.RANDOM;
                     parts = parts[1].split(",");
@@ -339,7 +339,8 @@ public class RspBitmapTimeDrivenTest {
             this.nblocks = nblocks;
             this.searchPiece = searchPiece;
             this.testTimeBudgetMillis = testTimeBudgetMillis;
-            rand = new Random(RANDOM_SEED_BASE * SPLIT_SEARCH_SPACE_PIECES + workerIdx);
+            final long seedBase = RANDOM_SEED_FROM_TIME ? System.currentTimeMillis() : RANDOM_SEED_BASE_DEFAULT;
+            rand = new Random(seedBase + SPLIT_SEARCH_SPACE_PIECES * workerIdx);
         }
 
         @Override

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -409,7 +409,7 @@ public class RspBitmapTimeDrivenTest {
                     final long millis = now - lastLog;
                     final String deadlineStr = (deadline == -1) ? "no" : (toTimeStr(deadline - now) + " to");
                     System.out.printf(
-                            "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of the space covered; %s test deadline.%n",
+                            "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of this worker's space covered; %s test deadline.%n",
                             me,
                             millis / 1000.0,
                             (1000.0 * checksDoneSinceLastLog) / millis,

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -273,9 +273,19 @@ public class RspBitmapTimeDrivenTest {
         final long totalDeciSeconds = millis / 100;
         final long totalSeconds = totalDeciSeconds / 10;
         final long deciSeconds = totalDeciSeconds % 10;
-        final long minutes = totalSeconds / 60;
+        final long totalMinutes = totalSeconds / 60;
         final long seconds = totalSeconds % 60;
-        return String.format("%dm%d.%ds", minutes, seconds, deciSeconds);
+        final long totalHours = totalMinutes / 60;
+        final long minutes = totalMinutes % 60;
+        final long totalDays = totalHours / 24;
+        final long hours = totalHours % 24;
+        if (totalDays == 0) {
+            if (hours == 0) {
+                return String.format("%dm%d.%ds", totalMinutes, seconds, deciSeconds);
+            }
+            return String.format("%dh%dm%d.%ds", totalHours, minutes, seconds, deciSeconds);
+        }
+        return String.format("%dd%dh%dm%d.%ds", totalDays, hours, minutes, seconds, deciSeconds);
     }
 
     private static void valueToSpec(final long value, final int[] spec) {
@@ -416,13 +426,15 @@ public class RspBitmapTimeDrivenTest {
                     final long checksDoneSinceLastLog = check - lastLogChecksDone;
                     final long millis = now - lastLog;
                     final String deadlineStr = (deadline == -1) ? "no" : (toTimeStr(deadline - now) + " to");
+                    final double checksPerMilli = ((double) checksDoneSinceLastLog) / millis;
                     System.out.printf(
-                            "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of this worker's space covered; %s test deadline.%n",
+                            "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of this worker's space covered; %s test deadline, %s to worker's space coverage.%n",
                             me,
                             millis / 1000.0,
-                            (1000.0 * checksDoneSinceLastLog) / millis,
+                            1000.0 * checksPerMilli,
                             (100.0 * (check + 1)) / totalChecks,
-                            deadlineStr);
+                            deadlineStr,
+                            toTimeStr((long) ((totalChecks - check - 1) / checksPerMilli)));
                     System.out.printf(
                             "%s: Last checked for v=%,d => spec0=%s, spec1=%s.%n",
                             me,

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -427,14 +427,17 @@ public class RspBitmapTimeDrivenTest {
                     final long millis = now - lastLog;
                     final String deadlineStr = (deadline == -1) ? "no" : (toTimeStr(deadline - now) + " to");
                     final double checksPerMilli = ((double) checksDoneSinceLastLog) / millis;
-                    System.out.printf(
-                            "%s: In the last %.1f seconds ran %.1f checks per second; %.3f%% of this worker's space covered; %s test deadline, %s to worker's space coverage.%n",
+                    final double avgChecksPerMilli = ((double) (check + 1)) / (now - start);
+                    System.out.printf("%s: " +
+                            "In the last %.1f seconds ran %.1f checks per second; " +
+                            "%.3f%% of this worker's space covered; %s test deadline, " +
+                            "%s to worker's space coverage.%n",
                             me,
                             millis / 1000.0,
                             1000.0 * checksPerMilli,
                             (100.0 * (check + 1)) / totalChecks,
                             deadlineStr,
-                            toTimeStr((long) ((totalChecks - check - 1) / checksPerMilli)));
+                            toTimeStr((long) ((totalChecks - check - 1) / avgChecksPerMilli)));
                     System.out.printf(
                             "%s: Last checked for v=%,d => spec0=%s, spec1=%s.%n",
                             me,
@@ -478,7 +481,10 @@ public class RspBitmapTimeDrivenTest {
             workers[i].start();
             if (searchPieces > 1 && i < searchPieces - 1) {
                 // minimally stagger
-                try { Thread.sleep(10); } catch (InterruptedException e) { /* ignore */ }
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    /* ignore */ }
             }
         }
         for (int i = 0; i < searchPieces; ++i) {

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -113,6 +113,8 @@ public class RspBitmapTimeDrivenTest {
         }
     }
 
+    public static final int SEARCH_PIECES = SPLIT_SEARCH_SPACE_LAST_PIECE - SPLIT_SEARCH_SPACE_FIRST_PIECE + 1;
+
     public static final boolean TEST_OR, TEST_AND, TEST_ANDNOT;
     static {
         final boolean testOnlyOr = System.getenv("TEST_ONLY_OR") != null;
@@ -329,7 +331,7 @@ public class RspBitmapTimeDrivenTest {
                 final int searchPiece,
                 final TestSequenceMode mode,
                 final long testTimeBudgetMillis) {
-            this.workerName = "" + workerIdx + "/" + SPLIT_SEARCH_SPACE_PIECES;
+            this.workerName = "" + workerIdx + "/" + SEARCH_PIECES;
             this.testName = testName;
             this.op = op;
             this.rspOp = rspOp;
@@ -465,9 +467,8 @@ public class RspBitmapTimeDrivenTest {
             final long testTimeBudgetMillis) {
         final String testName = "binaryOps-" + op + "-" + mode + "-"
                 + ((testTimeBudgetMillis == -1) ? "nolimit" : toTimeStr(testTimeBudgetMillis));
-        final int searchPieces = SPLIT_SEARCH_SPACE_LAST_PIECE - SPLIT_SEARCH_SPACE_FIRST_PIECE + 1;
-        final Thread[] workers = new Thread[searchPieces];
-        for (int i = 0; i < searchPieces; ++i) {
+        final Thread[] workers = new Thread[SEARCH_PIECES];
+        for (int i = 0; i < SEARCH_PIECES; ++i) {
             workers[i] = new Thread(
                     new TestWorker(
                             i,
@@ -479,7 +480,7 @@ public class RspBitmapTimeDrivenTest {
                             testTimeBudgetMillis));
             System.out.printf("%s: Dispatching worker %d.%n", testName, i);
             workers[i].start();
-            if (searchPieces > 1 && i < searchPieces - 1) {
+            if (SEARCH_PIECES > 1 && i < SEARCH_PIECES - 1) {
                 // minimally stagger
                 try {
                     Thread.sleep(10);
@@ -487,7 +488,7 @@ public class RspBitmapTimeDrivenTest {
                     /* ignore */ }
             }
         }
-        for (int i = 0; i < searchPieces; ++i) {
+        for (int i = 0; i < SEARCH_PIECES; ++i) {
             try {
                 workers[i].join();
             } catch (InterruptedException e) {

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/rsp/RspBitmapTimeDrivenTest.java
@@ -24,7 +24,7 @@ public class RspBitmapTimeDrivenTest {
     static {
         final String s = System.getenv("TEST_PERIOD_SECONDS");
         if (s == null) {
-            LOG_PERIOD_MILLIS = 10 * 1000;
+            LOG_PERIOD_MILLIS = 15 * 1000;
         } else {
             LOG_PERIOD_MILLIS = 1000L * Integer.parseInt(s);
         }


### PR DESCRIPTION
Also better separate exhaustive versus random searching of the space; random search is always time bound now, exhaustive search is not time bound.

Example of output when running with defaults:

```
binaryOps-OR_EQUALS-RANDOM-2m0.0s: Dispatching worker 0.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Starting, searching space for 8 blocks between 0 and 2,821,106,548,224 (2,821,106,548,225 out of 2,821,106,548,225 combinations, 100.0% of search space).
# io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: searching for 'io.deephaven.internal.log.LoggerFactory'...
# io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: found 'io.deephaven.internal.log.LoggerFactorySlf4j'
[Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.toStdout = true
[Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.logPeriodSeconds = 30
[Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.engine.rowset.impl.sortedranges.SortedRanges: property SortedRanges.debug = false
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 334273.0 checks per second; 0.000% of this worker's space covered; 1m45.0s to test deadline, 97d16h18m33.6s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=171,346,648,433 => spec0=[2, 3, 3, 0, 4, 4, 5, 3], spec1=[0, 2, 1, 0, 4, 1, 4, 4].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 350365.6 checks per second; 0.000% of this worker's space covered; 1m30.0s to test deadline, 93d4h37m44.3s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=789,564,241,912 => spec0=[2, 3, 5, 4, 5, 1, 0, 3], spec1=[1, 4, 0, 2, 4, 1, 5, 5].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 349659.2 checks per second; 0.001% of this worker's space covered; 1m15.0s to test deadline, 93d9h8m36.1s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=1,505,570,937,288 => spec0=[3, 3, 2, 5, 4, 4, 0, 3], spec1=[3, 1, 1, 1, 3, 5, 2, 3].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 349464.0 checks per second; 0.001% of this worker's space covered; 1m0.0s to test deadline, 93d10h23m27.7s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=965,976,633,812 => spec0=[5, 2, 0, 0, 4, 0, 0, 2], spec1=[2, 0, 1, 5, 4, 3, 3, 0].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 349521.2 checks per second; 0.001% of this worker's space covered; 0m45.0s to test deadline, 93d10h1m11.6s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=2,820,593,178,144 => spec0=[2, 0, 4, 0, 5, 1, 3, 0], spec1=[5, 5, 5, 5, 4, 3, 3, 0].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 349479.4 checks per second; 0.001% of this worker's space covered; 0m30.0s to test deadline, 93d10h17m2.0s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=2,491,395,979,653 => spec0=[4, 2, 0, 1, 3, 4, 2, 3], spec1=[5, 1, 4, 4, 3, 1, 1, 0].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 348716.1 checks per second; 0.001% of this worker's space covered; 0m15.0s to test deadline, 93d15h11m16.9s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=2,178,151,924,950 => spec0=[1, 0, 5, 0, 1, 2, 1, 1], spec1=[4, 3, 4, 4, 3, 4, 4, 1].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 346469.9 checks per second; 0.001% of this worker's space covered; 0m0.0s to test deadline, 94d5h45m7.9s to worker's space coverage.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Last checked for v=541,056,968,380 => spec0=[3, 1, 2, 5, 1, 2, 5, 2], spec1=[1, 0, 5, 2, 3, 2, 0, 4].
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Done in 2m0.0s.
binaryOps-OR_EQUALS-RANDOM-2m0.0s: All workers finished.
binaryOps-AND_EQUALS-RANDOM-2m0.0s: Dispatching worker 0.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Starting, searching space for 8 blocks between 0 and 2,821,106,548,224 (2,821,106,548,225 out of 2,821,106,548,225 combinations, 100.0% of search space).
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 375669.5 checks per second; 0.000% of this worker's space covered; 1m45.0s to test deadline, 86d21h58m49.4s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=2,419,530,458,244 => spec0=[4, 5, 3, 3, 2, 2, 1, 5], spec1=[5, 0, 5, 1, 3, 0, 3, 5].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 370543.8 checks per second; 0.000% of this worker's space covered; 1m30.0s to test deadline, 88d2h49m52.4s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=1,729,000,164,206 => spec0=[4, 0, 0, 3, 1, 3, 3, 3], spec1=[3, 4, 0, 2, 1, 4, 3, 1].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 369593.7 checks per second; 0.001% of this worker's space covered; 1m15.0s to test deadline, 88d8h15m49.5s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=2,231,852,676,317 => spec0=[1, 2, 5, 5, 5, 0, 1, 4], spec1=[4, 4, 2, 5, 1, 4, 4, 5].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 366983.2 checks per second; 0.001% of this worker's space covered; 1m0.0s to test deadline, 88d23h20m30.1s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=498,875,605,241 => spec0=[4, 5, 5, 3, 4, 3, 3, 5], spec1=[1, 0, 2, 1, 1, 0, 3, 0].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 365114.5 checks per second; 0.001% of this worker's space covered; 0m45.0s to test deadline, 89d10h15m58.5s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=2,795,151,509,276 => spec0=[0, 1, 0, 3, 5, 0, 3, 5], spec1=[5, 5, 4, 0, 0, 2, 4, 3].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 372143.7 checks per second; 0.001% of this worker's space covered; 0m30.0s to test deadline, 87d17h43m21.2s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=685,794,152,668 => spec0=[2, 1, 2, 5, 5, 1, 5, 3], spec1=[1, 2, 4, 3, 0, 1, 4, 5].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 372847.4 checks per second; 0.001% of this worker's space covered; 0m15.0s to test deadline, 87d13h44m39.5s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=51,730,812,545 => spec0=[1, 1, 3, 0, 1, 0, 4, 1], spec1=[0, 0, 3, 5, 4, 3, 3, 2].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 371360.1 checks per second; 0.002% of this worker's space covered; 0m0.0s to test deadline, 87d22h9m28.2s to worker's space coverage.
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Last checked for v=2,581,390,864,135 => spec0=[2, 1, 5, 2, 1, 3, 0, 2], spec1=[5, 2, 5, 3, 5, 1, 3, 1].
Worker 0/1 binaryOps-AND_EQUALS-RANDOM-2m0.0s: Done in 2m0.0s.
binaryOps-AND_EQUALS-RANDOM-2m0.0s: All workers finished.
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Dispatching worker 0.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Starting, searching space for 8 blocks between 0 and 2,821,106,548,224 (2,821,106,548,225 out of 2,821,106,548,225 combinations, 100.0% of search space).
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 376934.7 checks per second; 0.000% of this worker's space covered; 1m45.0s to test deadline, 86d14h58m43.2s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=178,203,256,619 => spec0=[4, 0, 3, 0, 4, 0, 4, 5], spec1=[0, 2, 1, 3, 5, 1, 1, 0].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 375569.1 checks per second; 0.000% of this worker's space covered; 1m30.0s to test deadline, 86d22h32m0.5s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=714,830,740,478 => spec0=[0, 0, 4, 1, 4, 3, 4, 3], spec1=[1, 3, 0, 4, 2, 2, 0, 1].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 373519.1 checks per second; 0.001% of this worker's space covered; 1m15.0s to test deadline, 87d9h58m51.3s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=2,488,882,782,188 => spec0=[2, 3, 2, 4, 5, 2, 1, 0], spec1=[5, 1, 4, 3, 2, 1, 3, 4].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 373453.1 checks per second; 0.001% of this worker's space covered; 1m0.0s to test deadline, 87d10h20m52.4s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=1,226,318,702,304 => spec0=[5, 3, 2, 1, 5, 4, 2, 3], spec1=[2, 3, 3, 5, 2, 1, 0, 3].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 373536.2 checks per second; 0.001% of this worker's space covered; 0m45.0s to test deadline, 87d9h52m36.2s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=2,201,729,025,779 => spec0=[2, 2, 1, 2, 2, 5, 3, 3], spec1=[4, 4, 0, 3, 2, 4, 3, 4].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 372972.3 checks per second; 0.001% of this worker's space covered; 0m30.0s to test deadline, 87d13h2m39.0s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=1,732,137,523,312 => spec0=[3, 2, 3, 4, 2, 5, 3, 1], spec1=[3, 4, 0, 3, 4, 2, 2, 3].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 368684.1 checks per second; 0.001% of this worker's space covered; 0m15.0s to test deadline, 88d13h28m40.2s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=2,393,677,821,723 => spec0=[4, 5, 3, 1, 3, 0, 3, 0], spec1=[5, 0, 3, 1, 3, 5, 0, 3].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: In the last 15.0 seconds ran 369067.9 checks per second; 0.002% of this worker's space covered; 0m0.0s to test deadline, 88d11h15m46.6s to worker's space coverage.
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Last checked for v=1,329,117,405,567 => spec0=[3, 5, 4, 0, 1, 3, 3, 4], spec1=[2, 4, 5, 4, 3, 3, 1, 1].
Worker 0/1 binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: Done in 2m0.0s.
binaryOps-AND_NOT_EQUALS-RANDOM-2m0.0s: All workers finished.
> Task :engine-rowset:jacocoTestReport UP-TO-DATE
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.1/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 6m 2s
```

Example of  output on check failure:

```
binaryOps-OR_EQUALS-RANDOM-2m0.0s: Dispatching worker 0.
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: Starting, searching space for 8 blocks between 0 and 2,821,106,548,224 (2,821,106,548,225 out of 2,821,106,548,225 combinations, 100.0% of search space).
# io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: searching for 'io.deephaven.internal.log.LoggerFactory'...
# io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: found 'io.deephaven.internal.log.LoggerFactorySlf4j'
[Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.toStdout = true
[Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.logPeriodSeconds = 30
[Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.engine.rowset.impl.sortedranges.SortedRanges: property SortedRanges.debug = false
Worker 0/1 binaryOps-OR_EQUALS-RANDOM-2m0.0s: failed, OR_EQUALS spec0=[3, 3, 5, 0, 3, 3, 1, 3] spec1=[2, 1, 4, 5, 0, 5, 2, 0]
 spec0 => [ 0 *2^16 : {0,1},  1 *2^16 : {0,1},  2 *2^16 : FULL,  3 *2^16 : {},  4 *2^16 : {0,1},  5 *2^16 : {0,1},  6 *2^16 : {0},  7 *2^16 : {0,1}]
 spec1 => [ 0 *2^16 : {1},  1 *2^16 : {0},  2 *2^16 : FULL-{0,1},  3 *2^16 : FULL,  4 *2^16 : {},  5 *2^16 : FULL,  6 *2^16 : {1},  7 *2^16 : {}]
.
binaryOps-OR_EQUALS-RANDOM-2m0.0s: All workers finished.

OR_EQUALS spec0=[3, 3, 5, 0, 3, 3, 1, 3] spec1=[2, 1, 4, 5, 0, 5, 2, 0]
 spec0 => [ 0 *2^16 : {0,1},  1 *2^16 : {0,1},  2 *2^16 : FULL,  3 *2^16 : {},  4 *2^16 : {0,1},  5 *2^16 : {0,1},  6 *2^16 : {0},  7 *2^16 : {0,1}]
 spec1 => [ 0 *2^16 : {1},  1 *2^16 : {0},  2 *2^16 : FULL-{0,1},  3 *2^16 : FULL,  4 *2^16 : {},  5 *2^16 : FULL,  6 *2^16 : {1},  7 *2^16 : {}]

java.lang.AssertionError: OR_EQUALS spec0=[3, 3, 5, 0, 3, 3, 1, 3] spec1=[2, 1, 4, 5, 0, 5, 2, 0]
 spec0 => [ 0 *2^16 : {0,1},  1 *2^16 : {0,1},  2 *2^16 : FULL,  3 *2^16 : {},  4 *2^16 : {0,1},  5 *2^16 : {0,1},  6 *2^16 : {0},  7 *2^16 : {0,1}]
 spec1 => [ 0 *2^16 : {1},  1 *2^16 : {0},  2 *2^16 : FULL-{0,1},  3 *2^16 : FULL,  4 *2^16 : {},  5 *2^16 : FULL,  6 *2^16 : {1},  7 *2^16 : {}]

	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at io.deephaven.engine.rowset.impl.rsp.RspBitmapTimeDrivenTest.binaryOpsHelper(RspBitmapTimeDrivenTest.java:470)
	at io.deephaven.engine.rowset.impl.rsp.RspBitmapTimeDrivenTest.testOrEqualsRandom(RspBitmapTimeDrivenTest.java:520)
       [...]
```

Example of exhaustive search, including command line invocation and console output:
```
cfs@erke 18:07:15 ~/dh/oss1/deephaven-core
$ TEST_PERIOD_SECONDS=30 TEST_ONLY_OR=true TEST_MODE=exhaustive:100000,0,1 ./gradlew :engine-rowset:testOutOfBand --tests '*RspBitmapTimeDrivenTest.*' --stacktrace

> Task :engine-rowset:compileTestJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :engine-rowset:testOutOfBand
1 compiler directives added

io.deephaven.engine.rowset.impl.rsp.RspBitmapTimeDrivenTest > testOrEqualsRandom STANDARD_OUT
    binaryOps-OR_EQUALS-RANDOM-nolimit: Dispatching worker 0.
    binaryOps-OR_EQUALS-RANDOM-nolimit: Dispatching worker 1.
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Starting, searching space for 8 blocks between 0 and 28,211,065 (28,211,066 out of 2,821,106,548,225 combinations, 0.0% of search space).
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Starting, searching space for 8 blocks between 28,211,066 and 56,422,131 (28,211,066 out of 2,821,106,548,225 combinations, 0.0% of search space).

io.deephaven.engine.rowset.impl.rsp.RspBitmapTimeDrivenTest > testOrEqualsRandom STANDARD_ERROR
    # io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: searching for 'io.deephaven.internal.log.LoggerFactory'...
    # io.deephaven.internal.log.LoggerFactoryServiceLoaderImpl: found 'io.deephaven.internal.log.LoggerFactorySlf4j'
    [Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.toStdout = true
    [Thread-4] INFO io.deephaven.configuration.PropertyFile - io.deephaven.util.metrics.MetricsManager: property MetricsManager.logPeriodSeconds = 30
    [Thread-5] INFO io.deephaven.configuration.PropertyFile - io.deephaven.engine.rowset.impl.sortedranges.SortedRanges: property SortedRanges.debug = false

io.deephaven.engine.rowset.impl.rsp.RspBitmapTimeDrivenTest > testOrEqualsRandom STANDARD_OUT
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 191848.0 checks per second; 20.401% of this worker's space covered; no test deadline, 1m57.0s to worker's space coverage.
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 160484.8 checks per second; 17.066% of this worker's space covered; no test deadline, 2m25.7s to worker's space coverage.
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=5,755,441 => spec0=[2, 3, 2, 0, 5, 3, 2, 5], spec1=[0, 0, 0, 0, 0, 0, 0, 4].
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=33,025,611 => spec0=[3, 5, 5, 0, 4, 2, 3, 5], spec1=[0, 0, 0, 0, 0, 0, 3, 2].
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 158665.3 checks per second; 33.939% of this worker's space covered; no test deadline, 1m57.4s to worker's space coverage.
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 180058.1 checks per second; 39.549% of this worker's space covered; no test deadline, 1m34.7s to worker's space coverage.
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=11,157,184 => spec0=[3, 5, 0, 4, 5, 3, 5, 5], spec1=[0, 0, 0, 0, 0, 0, 1, 1].
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=37,785,569 => spec0=[2, 5, 5, 1, 3, 1, 4, 4], spec1=[0, 0, 0, 0, 0, 0, 3, 5].
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 173193.8 checks per second; 52.356% of this worker's space covered; no test deadline, 1m17.6s to worker's space coverage.
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 163062.1 checks per second; 56.889% of this worker's space covered; no test deadline, 1m14.5s to worker's space coverage.
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=42,981,384 => spec0=[3, 3, 1, 2, 4, 0, 0, 2], spec1=[0, 0, 0, 0, 0, 0, 4, 2].
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=16,049,048 => spec0=[3, 1, 5, 5, 3, 1, 1, 0], spec1=[0, 0, 0, 0, 0, 0, 1, 4].
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 156307.5 checks per second; 68.978% of this worker's space covered; no test deadline, 0m55.9s to worker's space coverage.
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 176854.1 checks per second; 75.696% of this worker's space covered; no test deadline, 0m38.7s to worker's space coverage.
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=47,670,610 => spec0=[2, 1, 4, 2, 5, 2, 2, 3], spec1=[0, 0, 0, 0, 0, 0, 4, 5].
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=21,354,672 => spec0=[4, 1, 4, 1, 2, 1, 4, 1], spec1=[0, 0, 0, 0, 0, 0, 2, 1].
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 168362.9 checks per second; 93.600% of this worker's space covered; no test deadline, 0m10.7s to worker's space coverage.
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: In the last 30.0 seconds ran 173594.9 checks per second; 87.439% of this worker's space covered; no test deadline, 0m20.4s to worker's space coverage.
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=26,405,558 => spec0=[4, 1, 5, 4, 4, 0, 1, 0], spec1=[0, 0, 0, 0, 0, 0, 2, 4].
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Last checked for v=52,878,457 => spec0=[2, 5, 2, 1, 1, 4, 5, 3], spec1=[0, 0, 0, 0, 0, 0, 5, 2].
    Worker 0/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Done in 2m40.6s.
    Worker 1/100000 binaryOps-OR_EQUALS-RANDOM-nolimit: Done in 2m43.2s.
    binaryOps-OR_EQUALS-RANDOM-nolimit: All workers finished.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2m 46s
84 actionable tasks: 2 executed, 82 up-to-date
```