### PR TITLE
Update web to v0.12.0

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
-ARG WEB_VERSION=0.11.7
+ARG WEB_VERSION=0.12.0
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Release Notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.12.0
