### PR TITLE
JS API fix in filter

### DIFF
--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterPrinter.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterPrinter.java
@@ -26,7 +26,7 @@ public class FilterPrinter implements FilterVisitor<Void> {
         FilterPrinter visitor = new FilterPrinter(false);
         visitor.onLiteral(literal);
 
-        return "\"" + visitor.sb.toString() + "\"";
+        return visitor.sb.toString();
     }
 
     public FilterPrinter(boolean escapeStrings) {
@@ -34,10 +34,7 @@ public class FilterPrinter implements FilterVisitor<Void> {
     }
 
     private String stringEscape(String str) {
-        if (escapeStrings) {
-            return "\"" + StringEscapeUtils.escapeJava(str) + "\"";
-        }
-        return str;
+        return "\"" + (escapeStrings ? StringEscapeUtils.escapeJava(str) : str) + "\"";
     }
 
     @Override

--- a/server/src/test/java/io/deephaven/server/table/ops/filter/FilterPrinterTest.java
+++ b/server/src/test/java/io/deephaven/server/table/ops/filter/FilterPrinterTest.java
@@ -49,7 +49,7 @@ public class FilterPrinterTest {
 
     private static void assertSameValue(double expected) {
         Literal literal = lit(expected);
-        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
+        String str = FilterPrinter.printNoEscape(literal);
 
         // test magic values that make sense in java, but Double.parseDouble won't accept directly
         if (Double.isNaN(expected)) {
@@ -73,16 +73,9 @@ public class FilterPrinterTest {
     private static void assertSameValue(long expected) {
         assertTrue("Must be in the range that a double value can represent", Math.abs(expected) < (1L << 53));
         Literal literal = lit(expected);
-        String str = removeQuotes(FilterPrinter.printNoEscape(literal));
+        String str = FilterPrinter.printNoEscape(literal);
 
         assertEquals(Long.toString(expected), str);
-    }
-
-    private static String removeQuotes(String quotedStr) {
-        assertTrue(quotedStr.length() >= 2);
-        assertEquals(quotedStr.charAt(0), '"');
-        assertEquals(quotedStr.charAt(quotedStr.length() - 1), '"');
-        return quotedStr.substring(1, quotedStr.length() - 1);
     }
 
     private static void rotateAndAssert(long longBits) {


### PR DESCRIPTION
Was adding quotes in the wrong spot. Add them in the correct spot.

Fixes #2408.
