### PR TITLE
Wrap QueryLibrary

### DIFF
--- a/py/server/deephaven/query_library.py
+++ b/py/server/deephaven/query_library.py
@@ -1,0 +1,73 @@
+#
+#     Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+#
+"""This module allows users to import Java classes or packages into the query library for the Deephaven query engine.
+These classes or packages then can be used in Deephaven queries. """
+from typing import List
+
+import jpy
+from deephaven import DHError
+
+_JPackage = jpy.get_type("java.lang.Package")
+_JQueryLibrary = jpy.get_type("io.deephaven.engine.table.lang.QueryLibrary")
+_JClass = jpy.get_type("java.lang.Class")
+
+
+def import_class(name: str) -> None:
+    """Imports a Java class into the Query library so that it can be referenced in Deephaven queries. The class must
+    be reachable in the Deephaven server's classpath.
+
+    Args:
+        name (str): the full qualified name of the Java class
+
+    Raises:
+        DHError
+    """
+    try:
+        j_class = _JClass.forName(name)
+        _JQueryLibrary.importClass(j_class)
+    except Exception as e:
+        raise DHError(e, "failed to add the Java class to the Query Library.") from e
+
+
+def import_static(name: str) -> None:
+    """Imports the static members of a Java class into the Query library so that they can be referenced in Deephaven
+    queries. The class must be reachable in the Deephaven server's classpath.
+
+    Args:
+        name (str): the full qualified name of the Java class
+
+    Raises:
+        DHError
+    """
+    try:
+        j_class = _JClass.forName(name)
+        _JQueryLibrary.importStatic(j_class)
+    except Exception as e:
+        raise DHError(e, "failed to import the static members of the Java class to the Query Library.") from e
+
+
+def import_package(name: str) -> None:
+    """Imports a Java package into the Query library so that it can be referenced in Deephaven queries. The package
+    must be reachable in the Deephaven server's classpath.
+
+    Args:
+        name (str): the full qualified name of the Java package
+
+    Raises:
+        DHError
+    """
+    try:
+        j_package = _JPackage.getPackage(name)
+        _JQueryLibrary.importPackage(j_package)
+    except Exception as e:
+        raise DHError(e, "failed to import the Java package into to the Query Library.") from e
+
+
+def imports() -> List[str]:
+    """Returns all the Java import statements currently in the Query Library.
+
+    Returns:
+        a list of strings
+    """
+    return list(_JQueryLibrary.getImportStrings().toArray())[1:]

--- a/py/server/deephaven/query_library.py
+++ b/py/server/deephaven/query_library.py
@@ -2,7 +2,7 @@
 #     Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
 #
 """This module allows users to import Java classes or packages into the query library for the Deephaven query engine.
-These classes or packages then can be used in Deephaven queries. """
+These classes or packages can then be used in Deephaven queries. """
 from typing import List
 
 import jpy
@@ -14,11 +14,11 @@ _JClass = jpy.get_type("java.lang.Class")
 
 
 def import_class(name: str) -> None:
-    """Imports a Java class into the Query library so that it can be referenced in Deephaven queries. The class must
-    be reachable in the Deephaven server's classpath.
+    """Adds a Java class to the query library, making it available to be used in Deephaven query strings (formulas
+    and conditional expressions). The class must be reachable in the Deephaven server's classpath.
 
     Args:
-        name (str): the full qualified name of the Java class
+        name (str): the fully qualified name of the Java class
 
     Raises:
         DHError
@@ -31,11 +31,12 @@ def import_class(name: str) -> None:
 
 
 def import_static(name: str) -> None:
-    """Imports the static members of a Java class into the Query library so that they can be referenced in Deephaven
-    queries. The class must be reachable in the Deephaven server's classpath.
+    """Adds the static members of a Java class to the query library, making them available to be used in Deephaven
+    query strings (formulas and conditional expressions). The class must be reachable in the Deephaven server's
+    classpath.
 
     Args:
-        name (str): the full qualified name of the Java class
+        name (str): the fully qualified name of the Java class
 
     Raises:
         DHError
@@ -44,15 +45,16 @@ def import_static(name: str) -> None:
         j_class = _JClass.forName(name)
         _JQueryLibrary.importStatic(j_class)
     except Exception as e:
-        raise DHError(e, "failed to import the static members of the Java class to the Query Library.") from e
+        raise DHError(e, "failed to add the static members of the Java class to the Query Library.") from e
 
 
 def import_package(name: str) -> None:
-    """Imports a Java package into the Query library so that it can be referenced in Deephaven queries. The package
-    must be reachable in the Deephaven server's classpath.
+    """Adds all the public classes and interfaces of a Java package to the query library, making them available to be
+    used in Deephaven query strings (formulas and conditional expressions). The package must be reachable in the
+    Deephaven server's classpath.
 
     Args:
-        name (str): the full qualified name of the Java package
+        name (str): the fully qualified name of the Java package
 
     Raises:
         DHError
@@ -61,7 +63,7 @@ def import_package(name: str) -> None:
         j_package = _JPackage.getPackage(name)
         _JQueryLibrary.importPackage(j_package)
     except Exception as e:
-        raise DHError(e, "failed to import the Java package into to the Query Library.") from e
+        raise DHError(e, "failed to add the Java package into to the Query Library.") from e
 
 
 def imports() -> List[str]:

--- a/py/server/tests/test_query_library.py
+++ b/py/server/tests/test_query_library.py
@@ -1,0 +1,29 @@
+#
+#   Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+#
+import unittest
+
+from deephaven import query_library
+from tests.testbase import BaseTestCase
+
+
+class QueryLibraryTestCase(BaseTestCase):
+
+    def test_import_class(self):
+        self.assertNotIn("import java.util.concurrent.ConcurrentLinkedDeque;", query_library.imports())
+        query_library.import_class("java.util.concurrent.ConcurrentLinkedDeque")
+        self.assertIn("import java.util.concurrent.ConcurrentLinkedDeque;", query_library.imports())
+
+    def test_import_static(self):
+        self.assertNotIn("import static java.util.concurrent.ConcurrentHashMap.*;", query_library.imports())
+        query_library.import_static("java.util.concurrent.ConcurrentHashMap")
+        self.assertIn("import static java.util.concurrent.ConcurrentHashMap.*;", query_library.imports())
+
+    def test_import_package(self):
+        self.assertNotIn("import java.util.concurrent.*;", query_library.imports())
+        query_library.import_package("java.util.concurrent")
+        self.assertIn("import java.util.concurrent.*;", query_library.imports())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The wrapping is done based on the assumption that the QueryLibrary is global in practice, which means not wrapper class is used and everything is at the module level.

Fixes #2053 
Fixes #1120 