### PR TITLE
Access Control hooks, incomplete

### DIFF
--- a/Util/src/main/java/io/deephaven/util/auth/AuthContext.java
+++ b/Util/src/main/java/io/deephaven/util/auth/AuthContext.java
@@ -47,4 +47,5 @@ public interface AuthContext {
             return "default";
         }
     }
+
 }

--- a/Util/src/main/java/io/deephaven/util/auth/NormalUser.java
+++ b/Util/src/main/java/io/deephaven/util/auth/NormalUser.java
@@ -1,0 +1,16 @@
+package io.deephaven.util.auth;
+
+import org.jetbrains.annotations.NotNull;
+
+public class NormalUser implements AuthContext {
+
+    @NotNull
+    public final String getAuthRoleName() {
+        return "NormalUser";
+    }
+
+    @NotNull
+    public final String getAuthId() {
+        return "normal";
+    }
+}

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -14,10 +14,10 @@ services:
       # with max memory.
       #
       # To turn on debug logging, add: -Dlogback.configurationFile=logback-debug.xml
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+#      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       #
       # For remote debugging switch the line above for the one below (and also change the ports below)
-      # - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+       - JAVA_TOOL_OPTIONS=-DTrivialAuthContextProvider.class=io.deephaven.util.auth.NormalUser -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       #
       # For jprofiler sessions (if you tweaked the jprofiler version in jprofiler-server/Dockerfile you need to tweak path)
       # - JAVA_TOOL_OPTIONS=-agentpath:/opt/jprofiler13.0/bin/linux-x64/libjprofilerti.so=port=8849,nowait -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
@@ -25,8 +25,8 @@ services:
     expose:
       - '8080'
 # For remote debugging (change if using different port)
-#    ports:
-#      - '5005:5005'
+    ports:
+      - '5005:5005'
 # For jprofiler (change if using different port)
 #    ports:
 #      - '8849:8849'

--- a/java-client/session-examples/build.gradle
+++ b/java-client/session-examples/build.gradle
@@ -47,6 +47,7 @@ applicationDistribution.into('bin') {
     from(createApplication('subscribe-fields', 'io.deephaven.client.examples.SubscribeToFields'))
     from(createApplication('connect-check', 'io.deephaven.client.examples.ConnectCheck'))
     from(createApplication('fetch-object', 'io.deephaven.client.examples.FetchObject'))
+    from(createApplication('create-time-table', 'io.deephaven.client.examples.CreateTimeTable'))
     fileMode = 0755
 }
 

--- a/java-client/session-examples/src/main/java/io/deephaven/client/examples/CreateTimeTable.java
+++ b/java-client/session-examples/src/main/java/io/deephaven/client/examples/CreateTimeTable.java
@@ -1,0 +1,33 @@
+package io.deephaven.client.examples;
+
+import io.deephaven.client.impl.Session;
+import io.deephaven.client.impl.TableHandle;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Command(name = "create-time-table", mixinStandardHelpOptions = true,
+        description = "Create a time table", version = "0.1.0")
+class CreateTimeTable extends SingleSessionExampleBase {
+
+    @Parameters(arity = "1", paramLabel = "NAME", description = "The table name.")
+    String name;
+
+    @Parameters(arity = "1", paramLabel = "TIME", description = "The tick time.")
+    Duration tick;
+
+    @Override
+    protected void execute(Session session) throws Exception {
+        try (final TableHandle timeTable = session.timeTable(tick)) {
+            session.publish(name, timeTable).get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    public static void main(String[] args) {
+        int execute = new CommandLine(new CreateTimeTable()).execute(args);
+        System.exit(execute);
+    }
+}

--- a/server/src/main/java/io/deephaven/server/access/Helper.java
+++ b/server/src/main/java/io/deephaven/server/access/Helper.java
@@ -1,0 +1,32 @@
+package io.deephaven.server.access;
+
+import io.deephaven.server.session.SessionService;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+import java.util.stream.Collectors;
+
+public class Helper {
+    public static <T> Optional<T> findOne(SessionService sessionService, Class<T> clazz) {
+        final List<Provider<T>> providers = ServiceLoader.load(clazz).stream().collect(Collectors.toList());
+        if (providers.isEmpty()) {
+            return Optional.empty();
+        }
+        if (providers.size() == 1) {
+            final Class<? extends T> providerClazz = providers.get(0).type();
+            try {
+                return Optional
+                        .of(providerClazz.getDeclaredConstructor(SessionService.class).newInstance(sessionService));
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException
+                    | NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        final String classes =
+                providers.stream().map(Provider::type).map(Class::toString).collect(Collectors.joining(",", "[", "]"));
+        throw new IllegalStateException(String.format("Found multiple '%s', expected one or none: %s", clazz, classes));
+    }
+}

--- a/server/src/main/java/io/deephaven/server/appmode/AppMode.java
+++ b/server/src/main/java/io/deephaven/server/appmode/AppMode.java
@@ -1,14 +1,14 @@
 package io.deephaven.server.appmode;
 
 import io.deephaven.appmode.ApplicationConfig;
-import io.deephaven.server.console.ConsoleServiceGrpcImpl;
+import io.deephaven.server.console.ConsoleAccessDefaultImpl;
 
 public enum AppMode {
     APP_ONLY, HYBRID, CONSOLE_ONLY, API_ONLY;
 
     public static AppMode currentMode() {
         boolean appEnabled = ApplicationConfig.isApplicationModeEnabled();
-        boolean consoleEnabled = !ConsoleServiceGrpcImpl.REMOTE_CONSOLE_DISABLED;
+        boolean consoleEnabled = !ConsoleAccessDefaultImpl.REMOTE_CONSOLE_DISABLED;
         if (appEnabled && consoleEnabled) {
             return HYBRID;
         }

--- a/server/src/main/java/io/deephaven/server/auth/TrivialAuthContextProvider.java
+++ b/server/src/main/java/io/deephaven/server/auth/TrivialAuthContextProvider.java
@@ -1,11 +1,19 @@
 package io.deephaven.server.auth;
 
 import com.google.protobuf.ByteString;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.util.auth.AuthContext;
+import io.deephaven.util.auth.AuthContext.SuperUser;
 
 import javax.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
 
 public class TrivialAuthContextProvider implements AuthContextProvider {
+
+    // TODO: this isn't final configuration, just an example configuration
+    private static final String USER_CLASS = Configuration.getInstance()
+            .getStringWithDefault("TrivialAuthContextProvider.class", SuperUser.class.getName());
+
     @Inject()
     public TrivialAuthContextProvider() {}
 
@@ -19,7 +27,11 @@ public class TrivialAuthContextProvider implements AuthContextProvider {
         if (!supportsProtocol(protocolVersion)) {
             return null;
         }
-
-        return new AuthContext.SuperUser();
+        try {
+            return (AuthContext) Class.forName(USER_CLASS).getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException
+                | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/server/src/main/java/io/deephaven/server/console/ConsoleAccess.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleAccess.java
@@ -1,0 +1,27 @@
+package io.deephaven.server.console;
+
+import io.deephaven.proto.backplane.script.grpc.BindTableToVariableRequest;
+import io.deephaven.proto.backplane.script.grpc.CancelCommandRequest;
+import io.deephaven.proto.backplane.script.grpc.ExecuteCommandRequest;
+import io.deephaven.proto.backplane.script.grpc.GetConsoleTypesRequest;
+import io.deephaven.proto.backplane.script.grpc.LogSubscriptionRequest;
+import io.deephaven.proto.backplane.script.grpc.StartConsoleRequest;
+import io.deephaven.server.session.SessionState;
+
+public interface ConsoleAccess {
+
+    SessionState getConsoleTypes(GetConsoleTypesRequest request);
+
+    SessionState startConsole(StartConsoleRequest request);
+
+    SessionState subscribeToLogs(LogSubscriptionRequest request);
+
+    SessionState executeCommand(ExecuteCommandRequest request);
+
+    SessionState cancelCommand(CancelCommandRequest request);
+
+    SessionState bindTableToVariable(BindTableToVariableRequest request);
+
+    SessionState autoCompleteStream();
+
+}

--- a/server/src/main/java/io/deephaven/server/console/ConsoleAccessDefaultImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleAccessDefaultImpl.java
@@ -1,0 +1,69 @@
+package io.deephaven.server.console;
+
+import com.google.rpc.Code;
+import io.deephaven.configuration.Configuration;
+import io.deephaven.extensions.barrage.util.GrpcUtil;
+import io.deephaven.proto.backplane.script.grpc.BindTableToVariableRequest;
+import io.deephaven.proto.backplane.script.grpc.CancelCommandRequest;
+import io.deephaven.proto.backplane.script.grpc.ExecuteCommandRequest;
+import io.deephaven.proto.backplane.script.grpc.GetConsoleTypesRequest;
+import io.deephaven.proto.backplane.script.grpc.LogSubscriptionRequest;
+import io.deephaven.proto.backplane.script.grpc.StartConsoleRequest;
+import io.deephaven.server.session.SessionService;
+import io.deephaven.server.session.SessionState;
+
+import java.util.Objects;
+
+public class ConsoleAccessDefaultImpl implements ConsoleAccess {
+    public static final String CONSOLE_DISABLED_PROP = "deephaven.console.disable";
+    public static final boolean REMOTE_CONSOLE_DISABLED =
+            Configuration.getInstance().getBooleanWithDefault(CONSOLE_DISABLED_PROP, false);
+
+    private final SessionService sessionService;
+
+    public ConsoleAccessDefaultImpl(SessionService sessionService) {
+        this.sessionService = Objects.requireNonNull(sessionService);
+    }
+
+    private SessionState check() {
+        if (REMOTE_CONSOLE_DISABLED) {
+            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "Remote console disabled");
+        }
+        return sessionService.getCurrentSession();
+    }
+
+    @Override
+    public SessionState getConsoleTypes(GetConsoleTypesRequest request) {
+        return sessionService.getCurrentSession();
+    }
+
+    @Override
+    public SessionState startConsole(StartConsoleRequest request) {
+        return check();
+    }
+
+    @Override
+    public SessionState subscribeToLogs(LogSubscriptionRequest request) {
+        return check();
+    }
+
+    @Override
+    public SessionState executeCommand(ExecuteCommandRequest request) {
+        return check();
+    }
+
+    @Override
+    public SessionState cancelCommand(CancelCommandRequest request) {
+        return check();
+    }
+
+    @Override
+    public SessionState bindTableToVariable(BindTableToVariableRequest request) {
+        return check();
+    }
+
+    @Override
+    public SessionState autoCompleteStream() {
+        return check();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/console/ConsoleAccessDefaultImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleAccessDefaultImpl.java
@@ -11,6 +11,7 @@ import io.deephaven.proto.backplane.script.grpc.LogSubscriptionRequest;
 import io.deephaven.proto.backplane.script.grpc.StartConsoleRequest;
 import io.deephaven.server.session.SessionService;
 import io.deephaven.server.session.SessionState;
+import io.deephaven.util.auth.AuthContext.SuperUser;
 
 import java.util.Objects;
 
@@ -29,7 +30,11 @@ public class ConsoleAccessDefaultImpl implements ConsoleAccess {
         if (REMOTE_CONSOLE_DISABLED) {
             throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "Remote console disabled");
         }
-        return sessionService.getCurrentSession();
+        final SessionState currentSession = sessionService.getCurrentSession();
+        if (currentSession.getAuthContext() instanceof SuperUser) {
+            return currentSession;
+        }
+        throw GrpcUtil.statusRuntimeException(Code.PERMISSION_DENIED, "Only super user is allowed to use the console");
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/console/ConsoleAccessModule.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleAccessModule.java
@@ -1,0 +1,15 @@
+package io.deephaven.server.console;
+
+import dagger.Module;
+import dagger.Provides;
+import io.deephaven.server.access.Helper;
+import io.deephaven.server.session.SessionService;
+
+@Module
+public interface ConsoleAccessModule {
+    @Provides
+    static ConsoleAccess providesAccessControls(SessionService sessionService) {
+        return Helper.findOne(sessionService, ConsoleAccess.class)
+                .orElseGet(() -> new ConsoleAccessDefaultImpl(sessionService));
+    }
+}

--- a/server/src/main/java/io/deephaven/server/console/ConsoleAccessModule.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleAccessModule.java
@@ -2,14 +2,14 @@ package io.deephaven.server.console;
 
 import dagger.Module;
 import dagger.Provides;
-import io.deephaven.server.access.Helper;
+import io.deephaven.server.util.ServiceLoaderUtil;
 import io.deephaven.server.session.SessionService;
 
 @Module
 public interface ConsoleAccessModule {
     @Provides
     static ConsoleAccess providesAccessControls(SessionService sessionService) {
-        return Helper.findOne(sessionService, ConsoleAccess.class)
+        return ServiceLoaderUtil.loadOne(sessionService, ConsoleAccess.class)
                 .orElseGet(() -> new ConsoleAccessDefaultImpl(sessionService));
     }
 }

--- a/server/src/main/java/io/deephaven/server/console/ConsoleModule.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleModule.java
@@ -6,7 +6,7 @@ import dagger.multibindings.IntoSet;
 import io.deephaven.server.session.TicketResolver;
 import io.grpc.BindableService;
 
-@Module
+@Module(includes = {ConsoleAccessModule.class})
 public interface ConsoleModule {
     @Binds
     @IntoSet

--- a/server/src/main/java/io/deephaven/server/table/TableAccess.java
+++ b/server/src/main/java/io/deephaven/server/table/TableAccess.java
@@ -1,0 +1,101 @@
+package io.deephaven.server.table;
+
+import io.deephaven.proto.backplane.grpc.ApplyPreviewColumnsRequest;
+import io.deephaven.proto.backplane.grpc.AsOfJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.BatchTableRequest;
+import io.deephaven.proto.backplane.grpc.ComboAggregateRequest;
+import io.deephaven.proto.backplane.grpc.CreateInputTableRequest;
+import io.deephaven.proto.backplane.grpc.CrossJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.DropColumnsRequest;
+import io.deephaven.proto.backplane.grpc.EmptyTableRequest;
+import io.deephaven.proto.backplane.grpc.ExactJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.ExportedTableUpdatesRequest;
+import io.deephaven.proto.backplane.grpc.FetchTableRequest;
+import io.deephaven.proto.backplane.grpc.FilterTableRequest;
+import io.deephaven.proto.backplane.grpc.FlattenRequest;
+import io.deephaven.proto.backplane.grpc.HeadOrTailByRequest;
+import io.deephaven.proto.backplane.grpc.HeadOrTailRequest;
+import io.deephaven.proto.backplane.grpc.LeftJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.MergeTablesRequest;
+import io.deephaven.proto.backplane.grpc.NaturalJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.RunChartDownsampleRequest;
+import io.deephaven.proto.backplane.grpc.SelectDistinctRequest;
+import io.deephaven.proto.backplane.grpc.SelectOrUpdateRequest;
+import io.deephaven.proto.backplane.grpc.SnapshotTableRequest;
+import io.deephaven.proto.backplane.grpc.SortTableRequest;
+import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.backplane.grpc.TimeTableRequest;
+import io.deephaven.proto.backplane.grpc.UngroupRequest;
+import io.deephaven.proto.backplane.grpc.UnstructuredFilterTableRequest;
+import io.deephaven.server.session.SessionState;
+
+public interface TableAccess {
+
+    // TODO: better as QST TableSpec instead of grpc?
+
+    SessionState emptyTable(EmptyTableRequest request);
+
+    SessionState timeTable(TimeTableRequest request);
+
+    SessionState mergeTables(MergeTablesRequest request);
+
+    SessionState selectDistinct(SelectDistinctRequest request);
+
+    SessionState update(SelectOrUpdateRequest request);
+
+    SessionState lazyUpdate(SelectOrUpdateRequest request);
+
+    SessionState view(SelectOrUpdateRequest request);
+
+    SessionState updateView(SelectOrUpdateRequest request);
+
+    SessionState select(SelectOrUpdateRequest request);
+
+    SessionState headBy(HeadOrTailByRequest request);
+
+    SessionState tailBy(HeadOrTailByRequest request);
+
+    SessionState head(HeadOrTailRequest request);
+
+    SessionState tail(HeadOrTailRequest request);
+
+    SessionState ungroup(UngroupRequest request);
+
+    SessionState comboAggregate(ComboAggregateRequest request);
+
+    SessionState snapshot(SnapshotTableRequest request);
+
+    SessionState dropColumns(DropColumnsRequest request);
+
+    SessionState filter(FilterTableRequest request);
+
+    SessionState unstructuredFilter(UnstructuredFilterTableRequest request);
+
+    SessionState sort(SortTableRequest request);
+
+    SessionState flatten(FlattenRequest request);
+
+    SessionState crossJoinTables(CrossJoinTablesRequest request);
+
+    SessionState naturalJoinTables(NaturalJoinTablesRequest request);
+
+    SessionState exactJoinTables(ExactJoinTablesRequest request);
+
+    SessionState leftJoinTables(LeftJoinTablesRequest request);
+
+    SessionState asOfJoinTables(AsOfJoinTablesRequest request);
+
+    SessionState runChartDownsample(RunChartDownsampleRequest request);
+
+    SessionState fetchTable(FetchTableRequest request);
+
+    SessionState applyPreviewColumns(ApplyPreviewColumnsRequest request);
+
+    SessionState createInputTable(CreateInputTableRequest request);
+
+    SessionState batch(BatchTableRequest request);
+
+    SessionState exportedTableUpdates(ExportedTableUpdatesRequest request);
+
+    SessionState getExportedTableCreationResponse(Ticket request);
+}

--- a/server/src/main/java/io/deephaven/server/table/TableAccessBatchDelegator.java
+++ b/server/src/main/java/io/deephaven/server/table/TableAccessBatchDelegator.java
@@ -1,0 +1,85 @@
+package io.deephaven.server.table;
+
+import io.deephaven.proto.backplane.grpc.BatchTableRequest;
+import io.deephaven.proto.backplane.grpc.BatchTableRequest.Operation;
+import io.deephaven.server.session.SessionState;
+
+public abstract class TableAccessBatchDelegator implements TableAccess {
+    @Override
+    public SessionState batch(BatchTableRequest request) {
+        SessionState sessionState = null;
+        for (Operation operation : request.getOpsList()) {
+            sessionState = batchOperation(operation);
+        }
+        return sessionState;
+    }
+
+    protected SessionState batchOperation(Operation op) {
+        switch (op.getOpCase()) {
+            case EMPTY_TABLE:
+                return emptyTable(op.getEmptyTable());
+            case TIME_TABLE:
+                return timeTable(op.getTimeTable());
+            case DROP_COLUMNS:
+                return dropColumns(op.getDropColumns());
+            case UPDATE:
+                return update(op.getUpdate());
+            case LAZY_UPDATE:
+                return lazyUpdate(op.getLazyUpdate());
+            case VIEW:
+                return view(op.getView());
+            case UPDATE_VIEW:
+                return updateView(op.getUpdateView());
+            case SELECT:
+                return select(op.getSelect());
+            case SELECT_DISTINCT:
+                return selectDistinct(op.getSelectDistinct());
+            case FILTER:
+                return filter(op.getFilter());
+            case UNSTRUCTURED_FILTER:
+                return unstructuredFilter(op.getUnstructuredFilter());
+            case SORT:
+                return sort(op.getSort());
+            case HEAD:
+                return head(op.getHead());
+            case TAIL:
+                return tail(op.getTail());
+            case HEAD_BY:
+                return headBy(op.getHeadBy());
+            case TAIL_BY:
+                return tailBy(op.getTailBy());
+            case UNGROUP:
+                return ungroup(op.getUngroup());
+            case MERGE:
+                return mergeTables(op.getMerge());
+            case COMBO_AGGREGATE:
+                return comboAggregate(op.getComboAggregate());
+            case SNAPSHOT:
+                return snapshot(op.getSnapshot());
+            case FLATTEN:
+                return flatten(op.getFlatten());
+            case RUN_CHART_DOWNSAMPLE:
+                return runChartDownsample(op.getRunChartDownsample());
+            case CROSS_JOIN:
+                return crossJoinTables(op.getCrossJoin());
+            case NATURAL_JOIN:
+                return naturalJoinTables(op.getNaturalJoin());
+            case EXACT_JOIN:
+                return exactJoinTables(op.getExactJoin());
+            case LEFT_JOIN:
+                return leftJoinTables(op.getLeftJoin());
+            case AS_OF_JOIN:
+                return asOfJoinTables(op.getAsOfJoin());
+            case FETCH_TABLE:
+                return fetchTable(op.getFetchTable());
+            case APPLY_PREVIEW_COLUMNS:
+                return applyPreviewColumns(op.getApplyPreviewColumns());
+            case CREATE_INPUT_TABLE:
+                return createInputTable(op.getCreateInputTable());
+            case OP_NOT_SET:
+            case FETCH_PANDAS_TABLE:
+            default:
+                throw new IllegalArgumentException("Unexpected op: " + op.getOpCase());
+        }
+    }
+}

--- a/server/src/main/java/io/deephaven/server/table/TableAccessDefaultImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/TableAccessDefaultImpl.java
@@ -1,0 +1,205 @@
+package io.deephaven.server.table;
+
+import io.deephaven.proto.backplane.grpc.ApplyPreviewColumnsRequest;
+import io.deephaven.proto.backplane.grpc.AsOfJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.ComboAggregateRequest;
+import io.deephaven.proto.backplane.grpc.CreateInputTableRequest;
+import io.deephaven.proto.backplane.grpc.CrossJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.DropColumnsRequest;
+import io.deephaven.proto.backplane.grpc.EmptyTableRequest;
+import io.deephaven.proto.backplane.grpc.ExactJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.ExportedTableUpdatesRequest;
+import io.deephaven.proto.backplane.grpc.FetchTableRequest;
+import io.deephaven.proto.backplane.grpc.FilterTableRequest;
+import io.deephaven.proto.backplane.grpc.FlattenRequest;
+import io.deephaven.proto.backplane.grpc.HeadOrTailByRequest;
+import io.deephaven.proto.backplane.grpc.HeadOrTailRequest;
+import io.deephaven.proto.backplane.grpc.LeftJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.MergeTablesRequest;
+import io.deephaven.proto.backplane.grpc.NaturalJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.RunChartDownsampleRequest;
+import io.deephaven.proto.backplane.grpc.SelectDistinctRequest;
+import io.deephaven.proto.backplane.grpc.SelectOrUpdateRequest;
+import io.deephaven.proto.backplane.grpc.SnapshotTableRequest;
+import io.deephaven.proto.backplane.grpc.SortTableRequest;
+import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.backplane.grpc.TimeTableRequest;
+import io.deephaven.proto.backplane.grpc.UngroupRequest;
+import io.deephaven.proto.backplane.grpc.UnstructuredFilterTableRequest;
+import io.deephaven.server.session.SessionService;
+import io.deephaven.server.session.SessionState;
+
+import java.util.Objects;
+
+public class TableAccessDefaultImpl extends TableAccessBatchDelegator {
+    private final SessionService sessionService;
+
+    public TableAccessDefaultImpl(SessionService sessionService) {
+        this.sessionService = Objects.requireNonNull(sessionService);
+    }
+
+    private SessionState accept() {
+        return sessionService.getCurrentSession();
+    }
+
+    @Override
+    public SessionState emptyTable(EmptyTableRequest request) {
+        return accept();
+    }
+
+
+    @Override
+    public SessionState timeTable(TimeTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState mergeTables(MergeTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState selectDistinct(SelectDistinctRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState update(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState lazyUpdate(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState view(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState updateView(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState select(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState headBy(HeadOrTailByRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState tailBy(HeadOrTailByRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState head(HeadOrTailRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState tail(HeadOrTailRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState ungroup(UngroupRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState comboAggregate(ComboAggregateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState snapshot(SnapshotTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState dropColumns(DropColumnsRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState filter(FilterTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState unstructuredFilter(UnstructuredFilterTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState sort(SortTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState flatten(FlattenRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState crossJoinTables(CrossJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState naturalJoinTables(NaturalJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState exactJoinTables(ExactJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState leftJoinTables(LeftJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState asOfJoinTables(AsOfJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState runChartDownsample(RunChartDownsampleRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState fetchTable(FetchTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState applyPreviewColumns(ApplyPreviewColumnsRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState createInputTable(CreateInputTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState exportedTableUpdates(ExportedTableUpdatesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState getExportedTableCreationResponse(Ticket request) {
+        return accept();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/table/TableAccessDefaultImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/TableAccessDefaultImpl.java
@@ -1,205 +1,92 @@
 package io.deephaven.server.table;
 
-import io.deephaven.proto.backplane.grpc.ApplyPreviewColumnsRequest;
-import io.deephaven.proto.backplane.grpc.AsOfJoinTablesRequest;
+import com.google.rpc.Code;
+import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.ComboAggregateRequest;
-import io.deephaven.proto.backplane.grpc.CreateInputTableRequest;
-import io.deephaven.proto.backplane.grpc.CrossJoinTablesRequest;
-import io.deephaven.proto.backplane.grpc.DropColumnsRequest;
-import io.deephaven.proto.backplane.grpc.EmptyTableRequest;
-import io.deephaven.proto.backplane.grpc.ExactJoinTablesRequest;
-import io.deephaven.proto.backplane.grpc.ExportedTableUpdatesRequest;
-import io.deephaven.proto.backplane.grpc.FetchTableRequest;
+import io.deephaven.proto.backplane.grpc.Condition;
+import io.deephaven.proto.backplane.grpc.Condition.DataCase;
 import io.deephaven.proto.backplane.grpc.FilterTableRequest;
-import io.deephaven.proto.backplane.grpc.FlattenRequest;
 import io.deephaven.proto.backplane.grpc.HeadOrTailByRequest;
-import io.deephaven.proto.backplane.grpc.HeadOrTailRequest;
-import io.deephaven.proto.backplane.grpc.LeftJoinTablesRequest;
-import io.deephaven.proto.backplane.grpc.MergeTablesRequest;
-import io.deephaven.proto.backplane.grpc.NaturalJoinTablesRequest;
-import io.deephaven.proto.backplane.grpc.RunChartDownsampleRequest;
-import io.deephaven.proto.backplane.grpc.SelectDistinctRequest;
 import io.deephaven.proto.backplane.grpc.SelectOrUpdateRequest;
-import io.deephaven.proto.backplane.grpc.SnapshotTableRequest;
-import io.deephaven.proto.backplane.grpc.SortTableRequest;
-import io.deephaven.proto.backplane.grpc.Ticket;
-import io.deephaven.proto.backplane.grpc.TimeTableRequest;
-import io.deephaven.proto.backplane.grpc.UngroupRequest;
 import io.deephaven.proto.backplane.grpc.UnstructuredFilterTableRequest;
 import io.deephaven.server.session.SessionService;
 import io.deephaven.server.session.SessionState;
+import io.deephaven.util.auth.AuthContext.SuperUser;
 
-import java.util.Objects;
-
-public class TableAccessDefaultImpl extends TableAccessBatchDelegator {
-    private final SessionService sessionService;
+public class TableAccessDefaultImpl extends TableAccessOpenImpl {
 
     public TableAccessDefaultImpl(SessionService sessionService) {
-        this.sessionService = Objects.requireNonNull(sessionService);
-    }
-
-    private SessionState accept() {
-        return sessionService.getCurrentSession();
-    }
-
-    @Override
-    public SessionState emptyTable(EmptyTableRequest request) {
-        return accept();
-    }
-
-
-    @Override
-    public SessionState timeTable(TimeTableRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState mergeTables(MergeTablesRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState selectDistinct(SelectDistinctRequest request) {
-        return accept();
+        super(sessionService);
     }
 
     @Override
     public SessionState update(SelectOrUpdateRequest request) {
-        return accept();
+        return superUserOnly("update");
     }
 
     @Override
     public SessionState lazyUpdate(SelectOrUpdateRequest request) {
-        return accept();
+        return superUserOnly("lazyUpdate");
     }
 
     @Override
     public SessionState view(SelectOrUpdateRequest request) {
-        return accept();
+        return superUserOnly("view");
     }
 
     @Override
     public SessionState updateView(SelectOrUpdateRequest request) {
-        return accept();
+        return superUserOnly("updateView");
     }
 
     @Override
     public SessionState select(SelectOrUpdateRequest request) {
-        return accept();
+        return superUserOnly("select");
     }
 
     @Override
     public SessionState headBy(HeadOrTailByRequest request) {
-        return accept();
+        return superUserOnly("headBy");
     }
 
     @Override
     public SessionState tailBy(HeadOrTailByRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState head(HeadOrTailRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState tail(HeadOrTailRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState ungroup(UngroupRequest request) {
-        return accept();
+        return superUserOnly("tailBy");
     }
 
     @Override
     public SessionState comboAggregate(ComboAggregateRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState snapshot(SnapshotTableRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState dropColumns(DropColumnsRequest request) {
-        return accept();
+        return superUserOnly("comboAggregate");
     }
 
     @Override
     public SessionState filter(FilterTableRequest request) {
-        return accept();
+        return check(() -> {
+            for (Condition condition : request.getFiltersList()) {
+                if (condition.getDataCase() == DataCase.INVOKE) {
+                    throw GrpcUtil.statusRuntimeException(Code.PERMISSION_DENIED, "filter condition invoke denied");
+                }
+            }
+        });
     }
 
     @Override
     public SessionState unstructuredFilter(UnstructuredFilterTableRequest request) {
-        return accept();
+        return superUserOnly("unstructuredFilter");
     }
 
-    @Override
-    public SessionState sort(SortTableRequest request) {
-        return accept();
+    private SessionState superUserOnly(String name) {
+        return check(() -> {
+            throw GrpcUtil.statusRuntimeException(Code.PERMISSION_DENIED, String.format("%s denied", name));
+        });
     }
 
-    @Override
-    public SessionState flatten(FlattenRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState crossJoinTables(CrossJoinTablesRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState naturalJoinTables(NaturalJoinTablesRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState exactJoinTables(ExactJoinTablesRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState leftJoinTables(LeftJoinTablesRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState asOfJoinTables(AsOfJoinTablesRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState runChartDownsample(RunChartDownsampleRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState fetchTable(FetchTableRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState applyPreviewColumns(ApplyPreviewColumnsRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState createInputTable(CreateInputTableRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState exportedTableUpdates(ExportedTableUpdatesRequest request) {
-        return accept();
-    }
-
-    @Override
-    public SessionState getExportedTableCreationResponse(Ticket request) {
-        return accept();
+    private SessionState check(Runnable runnable) {
+        final SessionState currentSession = sessionService.getCurrentSession();
+        if (currentSession.getAuthContext() instanceof SuperUser) {
+            return currentSession;
+        }
+        runnable.run();
+        return currentSession;
     }
 }

--- a/server/src/main/java/io/deephaven/server/table/TableAccessModule.java
+++ b/server/src/main/java/io/deephaven/server/table/TableAccessModule.java
@@ -1,0 +1,16 @@
+package io.deephaven.server.table;
+
+import dagger.Module;
+import dagger.Provides;
+import io.deephaven.server.access.Helper;
+import io.deephaven.server.session.SessionService;
+
+@Module
+public interface TableAccessModule {
+
+    @Provides
+    static TableAccess providesAccessControls(SessionService sessionService) {
+        return Helper.findOne(sessionService, TableAccess.class)
+                .orElseGet(() -> new TableAccessDefaultImpl(sessionService));
+    }
+}

--- a/server/src/main/java/io/deephaven/server/table/TableAccessModule.java
+++ b/server/src/main/java/io/deephaven/server/table/TableAccessModule.java
@@ -2,7 +2,7 @@ package io.deephaven.server.table;
 
 import dagger.Module;
 import dagger.Provides;
-import io.deephaven.server.access.Helper;
+import io.deephaven.server.util.ServiceLoaderUtil;
 import io.deephaven.server.session.SessionService;
 
 @Module
@@ -10,7 +10,7 @@ public interface TableAccessModule {
 
     @Provides
     static TableAccess providesAccessControls(SessionService sessionService) {
-        return Helper.findOne(sessionService, TableAccess.class)
+        return ServiceLoaderUtil.loadOne(sessionService, TableAccess.class)
                 .orElseGet(() -> new TableAccessDefaultImpl(sessionService));
     }
 }

--- a/server/src/main/java/io/deephaven/server/table/TableAccessOpenImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/TableAccessOpenImpl.java
@@ -1,0 +1,204 @@
+package io.deephaven.server.table;
+
+import io.deephaven.proto.backplane.grpc.ApplyPreviewColumnsRequest;
+import io.deephaven.proto.backplane.grpc.AsOfJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.ComboAggregateRequest;
+import io.deephaven.proto.backplane.grpc.CreateInputTableRequest;
+import io.deephaven.proto.backplane.grpc.CrossJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.DropColumnsRequest;
+import io.deephaven.proto.backplane.grpc.EmptyTableRequest;
+import io.deephaven.proto.backplane.grpc.ExactJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.ExportedTableUpdatesRequest;
+import io.deephaven.proto.backplane.grpc.FetchTableRequest;
+import io.deephaven.proto.backplane.grpc.FilterTableRequest;
+import io.deephaven.proto.backplane.grpc.FlattenRequest;
+import io.deephaven.proto.backplane.grpc.HeadOrTailByRequest;
+import io.deephaven.proto.backplane.grpc.HeadOrTailRequest;
+import io.deephaven.proto.backplane.grpc.LeftJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.MergeTablesRequest;
+import io.deephaven.proto.backplane.grpc.NaturalJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.RunChartDownsampleRequest;
+import io.deephaven.proto.backplane.grpc.SelectDistinctRequest;
+import io.deephaven.proto.backplane.grpc.SelectOrUpdateRequest;
+import io.deephaven.proto.backplane.grpc.SnapshotTableRequest;
+import io.deephaven.proto.backplane.grpc.SortTableRequest;
+import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.backplane.grpc.TimeTableRequest;
+import io.deephaven.proto.backplane.grpc.UngroupRequest;
+import io.deephaven.proto.backplane.grpc.UnstructuredFilterTableRequest;
+import io.deephaven.server.session.SessionService;
+import io.deephaven.server.session.SessionState;
+
+import java.util.Objects;
+
+public class TableAccessOpenImpl extends TableAccessBatchDelegator {
+    final SessionService sessionService;
+
+    public TableAccessOpenImpl(SessionService sessionService) {
+        this.sessionService = Objects.requireNonNull(sessionService);
+    }
+
+    private SessionState accept() {
+        return sessionService.getCurrentSession();
+    }
+
+    @Override
+    public SessionState emptyTable(EmptyTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState timeTable(TimeTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState mergeTables(MergeTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState selectDistinct(SelectDistinctRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState update(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState lazyUpdate(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState view(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState updateView(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState select(SelectOrUpdateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState headBy(HeadOrTailByRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState tailBy(HeadOrTailByRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState head(HeadOrTailRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState tail(HeadOrTailRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState ungroup(UngroupRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState comboAggregate(ComboAggregateRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState snapshot(SnapshotTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState dropColumns(DropColumnsRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState filter(FilterTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState unstructuredFilter(UnstructuredFilterTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState sort(SortTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState flatten(FlattenRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState crossJoinTables(CrossJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState naturalJoinTables(NaturalJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState exactJoinTables(ExactJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState leftJoinTables(LeftJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState asOfJoinTables(AsOfJoinTablesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState runChartDownsample(RunChartDownsampleRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState fetchTable(FetchTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState applyPreviewColumns(ApplyPreviewColumnsRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState createInputTable(CreateInputTableRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState exportedTableUpdates(ExportedTableUpdatesRequest request) {
+        return accept();
+    }
+
+    @Override
+    public SessionState getExportedTableCreationResponse(Ticket request) {
+        return accept();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/table/TableModule.java
+++ b/server/src/main/java/io/deephaven/server/table/TableModule.java
@@ -35,7 +35,7 @@ import io.grpc.BindableService;
 }
 
 
-@Module
+@Module(includes = {TableAccessModule.class})
 public interface TableModule {
     @Binds
     @IntoSet

--- a/server/src/main/java/io/deephaven/server/util/ServiceLoaderUtil.java
+++ b/server/src/main/java/io/deephaven/server/util/ServiceLoaderUtil.java
@@ -1,4 +1,4 @@
-package io.deephaven.server.access;
+package io.deephaven.server.util;
 
 import io.deephaven.server.session.SessionService;
 
@@ -9,8 +9,8 @@ import java.util.ServiceLoader;
 import java.util.ServiceLoader.Provider;
 import java.util.stream.Collectors;
 
-public class Helper {
-    public static <T> Optional<T> findOne(SessionService sessionService, Class<T> clazz) {
+public class ServiceLoaderUtil {
+    public static <T> Optional<T> loadOne(SessionService sessionService, Class<T> clazz) {
         final List<Provider<T>> providers = ServiceLoader.load(clazz).stream().collect(Collectors.toList());
         if (providers.isEmpty()) {
             return Optional.empty();


### PR DESCRIPTION
I think we need to approach access control in a generic way - allowing servers to completely take control when necessary.

This patch isn't complete (only sketched out table and console services), but essentially hooks up at the very front-end of every single gRPC call, and passes the request details on to an interface that the user is able to override via ServiceLoader mechanism. If service loader is not generic enough in the future, we can provide further means to modify via dagger modules.

As far as our default impl, there is a question of convention vs configuration. At the moment, I'm finding myself wanting the ability to essentially lock "unsafe" things down for eventually letting the public access tables.
