### PR TITLE
Fix slack message key, append useful info about the branch

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           payload: |
             {
-              "slack-message": "Nightly build failure in ${{ matrix.gradle-task }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.event.head_commit.url }}"
+              "slack_message": "Nightly build failure in ${{ matrix.gradle-task }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.head_ref }} ${{ github.sha }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}


### PR DESCRIPTION
With the correct key, we will get a failing message in the slack channel for tonight's build, and I'll follow up with a proper fix to the build.