### PR TITLE
Remove cast to int when getting size from Range

### DIFF
--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/Range.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/Range.java
@@ -110,7 +110,7 @@ public class Range implements Serializable, Comparable<Range> {
     }
 
     public long size() {
-        return (int) (last - first + 1);
+        return last - first + 1;
     }
 
     @Override

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
@@ -408,8 +408,48 @@ public class RangeSetTest {
         assertEquals(of(
                 new Range(5, 10),
                 new Range(15, 20)), rangeSet);
+    }
 
+    @Test
+    public void testLarge() {
+        long largeA = 16535734029L;
+        long largeB = 36535734029L;
 
+        // Add to empty range
+        RangeSet rangeSet = RangeSet.empty();
+        rangeSet.addRange(new Range(0, largeA));
+        assertEquals(of(new Range(0, largeA)), rangeSet);
+
+        rangeSet = RangeSet.empty();
+        rangeSet.addRange(new Range(largeA, largeA));
+        assertEquals(of(new Range(largeA, largeA)), rangeSet);
+
+        rangeSet = RangeSet.empty();
+        rangeSet.addRange(new Range(largeA, largeB));
+        assertEquals(of(new Range(largeA, largeB)), rangeSet);
+
+        // Remove when nothing is present
+        rangeSet = RangeSet.empty();
+        rangeSet.removeRange(new Range(0, largeA));
+        assertEquals(RangeSet.empty(), rangeSet);
+
+        // Remove until nothing is left
+        rangeSet = RangeSet.ofRange(0, largeA);
+        rangeSet.removeRange(new Range(0, largeA));
+        assertEquals(RangeSet.empty(), rangeSet);
+        rangeSet = RangeSet.ofRange(1, largeA);
+        rangeSet.removeRange(new Range(0, largeA));
+        assertEquals(RangeSet.empty(), rangeSet);
+
+        // Remove section before/between/after any actual existing element (no effect)
+        rangeSet = RangeSet.ofRange(largeA, largeB);
+        rangeSet.removeRange(new Range(0, largeA - 2));
+        rangeSet.removeRange(new Range(largeB + 1, largeB + 5));
+        assertEquals(RangeSet.ofRange(largeA, largeB), rangeSet);
+        rangeSet = RangeSet.ofItems(5, largeA, largeB);
+        rangeSet.removeRange(new Range(6, largeA - 1));
+        rangeSet.removeRange(new Range(largeA + 1, largeB - 1));
+        assertEquals(RangeSet.ofItems(5, largeA, largeB), rangeSet);
     }
 
 }

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
@@ -412,8 +412,9 @@ public class RangeSetTest {
 
     @Test
     public void testLarge() {
-        long largeA = 16535734029L;
-        long largeB = 36535734029L;
+        long largeA = (long)Integer.MAX_VALUE + 10L;
+        long largeB = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE;
+        long largeC = Long.MAX_VALUE - 100L;
 
         // Add to empty range
         RangeSet rangeSet = RangeSet.empty();
@@ -428,6 +429,14 @@ public class RangeSetTest {
         rangeSet.addRange(new Range(largeA, largeB));
         assertEquals(of(new Range(largeA, largeB)), rangeSet);
 
+        rangeSet = RangeSet.empty();
+        rangeSet.addRange((new Range(0, largeC)));
+        assertEquals(of(new Range(0, largeC)), rangeSet);
+
+        rangeSet = RangeSet.empty();
+        rangeSet.addRange(new Range(largeA, largeC));
+        assertEquals(of(new Range(largeA, largeC)), rangeSet);
+
         // Remove when nothing is present
         rangeSet = RangeSet.empty();
         rangeSet.removeRange(new Range(0, largeA));
@@ -437,8 +446,13 @@ public class RangeSetTest {
         rangeSet = RangeSet.ofRange(0, largeA);
         rangeSet.removeRange(new Range(0, largeA));
         assertEquals(RangeSet.empty(), rangeSet);
+
         rangeSet = RangeSet.ofRange(1, largeA);
         rangeSet.removeRange(new Range(0, largeA));
+        assertEquals(RangeSet.empty(), rangeSet);
+
+        rangeSet = RangeSet.ofRange(largeA, largeC);
+        rangeSet.removeRange(new Range(0, largeC));
         assertEquals(RangeSet.empty(), rangeSet);
 
         // Remove section before/between/after any actual existing element (no effect)
@@ -446,10 +460,16 @@ public class RangeSetTest {
         rangeSet.removeRange(new Range(0, largeA - 2));
         rangeSet.removeRange(new Range(largeB + 1, largeB + 5));
         assertEquals(RangeSet.ofRange(largeA, largeB), rangeSet);
+
         rangeSet = RangeSet.ofItems(5, largeA, largeB);
         rangeSet.removeRange(new Range(6, largeA - 1));
         rangeSet.removeRange(new Range(largeA + 1, largeB - 1));
         assertEquals(RangeSet.ofItems(5, largeA, largeB), rangeSet);
+
+        rangeSet = RangeSet.ofItems(largeA, largeB);
+        rangeSet.removeRange(new Range(0, largeA - 1));
+        rangeSet.removeRange(new Range(largeB + 1, largeC));
+        assertEquals(RangeSet.ofItems(largeA, largeB), rangeSet);
     }
 
 }

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
@@ -412,8 +412,8 @@ public class RangeSetTest {
 
     @Test
     public void testLarge() {
-        long largeA = (long)Integer.MAX_VALUE + 10L;
-        long largeB = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE;
+        long largeA = (long) Integer.MAX_VALUE + 10L;
+        long largeB = (long) Integer.MAX_VALUE + (long) Integer.MAX_VALUE;
         long largeC = Long.MAX_VALUE - 100L;
 
         // Add to empty range

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeTest.java
@@ -47,11 +47,13 @@ public class RangeTest {
 
     @Test
     public void testLargeRange() {
-        long largeA = 16535734029L;
-        long largeB = 16535734030L;
+        long largeA = (long)Integer.MAX_VALUE + 10L;
+        long largeB = (long)Integer.MAX_VALUE + 11L;
+        long largeC = Long.MAX_VALUE - 100L;
         assertEquals(largeA + 1, new Range(0, largeA).size());
         assertEquals(largeA, new Range(1, largeA).size());
         assertEquals(1, new Range(largeA, largeA).size());
         assertEquals(2, new Range(largeA, largeB).size());
+        assertEquals(largeC + 1, new Range(0, largeC).size());
     }
 }

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeTest.java
@@ -45,4 +45,13 @@ public class RangeTest {
         assertEquals(new Range(0, 5), rangeB.overlap(rangeA));
     }
 
+    @Test
+    public void testLargeRange() {
+        long largeA = 16535734029L;
+        long largeB = 16535734030L;
+        assertEquals(largeA + 1, new Range(0, largeA).size());
+        assertEquals(largeA, new Range(1, largeA).size());
+        assertEquals(1, new Range(largeA, largeA).size());
+        assertEquals(2, new Range(largeA, largeB).size());
+    }
 }

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeTest.java
@@ -47,8 +47,8 @@ public class RangeTest {
 
     @Test
     public void testLargeRange() {
-        long largeA = (long)Integer.MAX_VALUE + 10L;
-        long largeB = (long)Integer.MAX_VALUE + 11L;
+        long largeA = (long) Integer.MAX_VALUE + 10L;
+        long largeB = (long) Integer.MAX_VALUE + 11L;
         long largeC = Long.MAX_VALUE - 100L;
         assertEquals(largeA + 1, new Range(0, largeA).size());
         assertEquals(largeA, new Range(1, largeA).size());


### PR DESCRIPTION
I don't know why we'd cast to int and then cast right back to long.

Fixes #2436
