### PR TITLE
Python server sync - Fixes #1480

### DIFF
--- a/py/client/pydeephaven/_app_service.py
+++ b/py/client/pydeephaven/_app_service.py
@@ -1,0 +1,20 @@
+#
+#  Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+#
+from pydeephaven.dherror import DHError
+from pydeephaven.proto import application_pb2_grpc, application_pb2
+
+class AppService:
+    def __init__(self, session):
+        self.session = session
+        self._grpc_app_stub = application_pb2_grpc.ApplicationServiceStub(session.grpc_channel)
+
+    def list_fields(self):
+        try:
+            fields = self._grpc_app_stub.ListFields(
+                application_pb2.ListFieldsRequest(),
+                metadata=self.session.grpc_metadata
+            )
+            return fields
+        except Exception as e:
+            raise DHError("failed to list fields.") from e

--- a/py/client/pydeephaven/_console_service.py
+++ b/py/client/pydeephaven/_console_service.py
@@ -3,7 +3,7 @@
 #
 
 from pydeephaven.dherror import DHError
-from pydeephaven.proto import console_pb2_grpc, console_pb2, application_pb2_grpc, application_pb2
+from pydeephaven.proto import console_pb2_grpc, console_pb2
 from pydeephaven.table import Table
 
 

--- a/py/client/pydeephaven/_console_service.py
+++ b/py/client/pydeephaven/_console_service.py
@@ -3,7 +3,7 @@
 #
 
 from pydeephaven.dherror import DHError
-from pydeephaven.proto import console_pb2_grpc, console_pb2
+from pydeephaven.proto import console_pb2_grpc, console_pb2, application_pb2_grpc, application_pb2
 from pydeephaven.table import Table
 
 
@@ -11,7 +11,18 @@ class ConsoleService:
     def __init__(self, session):
         self.session = session
         self._grpc_console_stub = console_pb2_grpc.ConsoleServiceStub(session.grpc_channel)
+        self._grpc_app_stub = application_pb2_grpc.ApplicationServiceStub(session.grpc_channel)
         self.console_id = None
+
+    def list_fields(self):
+        try:
+            fields = self._grpc_app_stub.ListFields(
+                application_pb2.ListFieldsRequest(),
+                metadata=self.session.grpc_metadata
+            )
+            return fields
+        except Exception as e:
+            raise DHError("failed to list fields.") from e
 
     def start_console(self):
         if self.console_id:

--- a/py/client/pydeephaven/_console_service.py
+++ b/py/client/pydeephaven/_console_service.py
@@ -11,18 +11,7 @@ class ConsoleService:
     def __init__(self, session):
         self.session = session
         self._grpc_console_stub = console_pb2_grpc.ConsoleServiceStub(session.grpc_channel)
-        self._grpc_app_stub = application_pb2_grpc.ApplicationServiceStub(session.grpc_channel)
         self.console_id = None
-
-    def list_fields(self):
-        try:
-            fields = self._grpc_app_stub.ListFields(
-                application_pb2.ListFieldsRequest(),
-                metadata=self.session.grpc_metadata
-            )
-            return fields
-        except Exception as e:
-            raise DHError("failed to list fields.") from e
 
     def start_console(self):
         if self.console_id:

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -11,6 +11,7 @@ from bitstring import BitArray
 
 from pydeephaven._arrow_flight_service import ArrowFlightService
 from pydeephaven._console_service import ConsoleService
+from pydeephaven._app_service import AppService
 from pydeephaven._session_service import SessionService
 from pydeephaven._table_ops import TimeTableOp, EmptyTableOp, MergeTablesOp, FetchTableOp
 from pydeephaven._table_service import TableService
@@ -65,6 +66,7 @@ class Session:
         self._grpc_barrage_stub = None
         self._console_service = None
         self._flight_service = None
+        self._app_service = None
         self._tables = {}
         self._never_timeout = never_timeout
         self._keep_alive_timer = None
@@ -114,6 +116,13 @@ class Session:
             self._flight_service = ArrowFlightService(self)
 
         return self._flight_service
+    
+    @property
+    def app_service(self):
+        if not self._app_service:
+            self._app_service = AppService(self)
+        
+        return self._app_service
 
     def make_ticket(self, ticket_no=None):
         if not ticket_no:
@@ -158,7 +167,7 @@ class Session:
             if self._never_timeout:
                 self._keep_alive()
             
-            self._list_fields = self.console_service.list_fields()
+            self._list_fields = self.app_service.list_fields()
             self._parse_fields_change(next(self._list_fields))
 
     def _keep_alive(self):

--- a/py/client/tests/suite.py
+++ b/py/client/tests/suite.py
@@ -8,6 +8,7 @@ from tests.test_console import ConsoleTestCase
 from tests.test_query import QueryTestCase
 from tests.test_session import SessionTestCase
 from tests.test_table import TableTestCase
+from tests.test_sync import SyncTestCase
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
@@ -15,6 +16,7 @@ if __name__ == '__main__':
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(QueryTestCase))
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TableTestCase))
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(ConsoleTestCase))
+    suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SyncTestCase))
 
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/py/client/tests/test_console.py
+++ b/py/client/tests/test_console.py
@@ -38,7 +38,7 @@ demo_table = TableTools.emptyTable(table_size) \
     .view("K = vectorized_func(I, J)")
         '''
         self.session.run_script(server_script)
-        for t_name in self.session.tables:
-            pa_table = self.session.open_table(t_name).snapshot()
-            df = pa_table.to_pandas()
-            self.assertEquals(1000, len(df.index))
+        self.assertIn('demo_table', self.session.tables)
+        pa_table = self.session.open_table('demo_table').snapshot()
+        df = pa_table.to_pandas()
+        self.assertEquals(1000, len(df.index))

--- a/py/client/tests/test_sync.py
+++ b/py/client/tests/test_sync.py
@@ -1,0 +1,38 @@
+
+
+import unittest
+from time import sleep
+
+import pyarrow as pa
+from pyarrow import csv
+
+from pydeephaven import DHError
+from pydeephaven import Session
+from tests.testbase import BaseTestCase
+
+
+class SyncTestCase(BaseTestCase):
+    def test_persistent_tables(self):
+        with Session() as session1:
+            session1 = Session()
+            session1.run_script('t = None')
+            t = session1.empty_table(10)
+            session1.bind_table('t', t)
+
+        sleep(1)
+
+        with Session() as session2:
+            self.assertIn('t', session2.tables)
+
+    def test_shared_tables(self):
+        session1 = Session()
+        session1.run_script('t = None')
+        session1.subscribe_fields()
+
+        session2 = Session()
+        t = session2.empty_table(10)
+        session2.bind_table('t', t)
+
+        sleep(1)
+
+        self.assertIn('t', session1.tables)


### PR DESCRIPTION
This PR adds three things.
1. Sessions now request the list of tables when connecting to the server, so tables created before the session starts (from previous sessions, from the web UI, etc.) can be opened.
2. `session.subscribe_fields()` now starts up a thread that checks for new changes to tables, so tables created/deleted in other sessions/the web UI become visible automatically.
3. Tests for the above two features.