### PR TITLE
Array Expansion Kernel O(n^2) -> O(n)

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/BooleanArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/BooleanArrayExpansionKernel.java
@@ -19,7 +19,7 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.chunk.sized.SizedBooleanChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 public class BooleanArrayExpansionKernel implements ArrayExpansionKernel {
     private final static boolean[] ZERO_LEN_ARRAY = new boolean[0];
@@ -33,24 +33,29 @@ public class BooleanArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<boolean[], A> typedSource = source.asObjectChunk();
-        final SizedBooleanChunk<A> resultWrapper = new SizedBooleanChunk<>();
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final boolean[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableBooleanChunk<A> result = WritableBooleanChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final boolean[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableBooleanChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -77,15 +82,13 @@ public class BooleanArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, ZERO_LEN_ARRAY);
             } else {
-                final boolean[] row = new boolean[ROW_LEN];
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final boolean[] row = new boolean[rowLen];
+                typedSource.copyToArray(lenRead, row,0, rowLen);
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/CharArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/CharArrayExpansionKernel.java
@@ -14,7 +14,7 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.chunk.sized.SizedCharChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 public class CharArrayExpansionKernel implements ArrayExpansionKernel {
     private final static char[] ZERO_LEN_ARRAY = new char[0];
@@ -28,24 +28,29 @@ public class CharArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<char[], A> typedSource = source.asObjectChunk();
-        final SizedCharChunk<A> resultWrapper = new SizedCharChunk<>();
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final char[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableCharChunk<A> result = WritableCharChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final char[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableCharChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -72,15 +77,13 @@ public class CharArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, ZERO_LEN_ARRAY);
             } else {
-                final char[] row = new char[ROW_LEN];
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final char[] row = new char[rowLen];
+                typedSource.copyToArray(lenRead, row,0, rowLen);
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/DoubleArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/DoubleArrayExpansionKernel.java
@@ -19,7 +19,7 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.chunk.sized.SizedDoubleChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 public class DoubleArrayExpansionKernel implements ArrayExpansionKernel {
     private final static double[] ZERO_LEN_ARRAY = new double[0];
@@ -33,24 +33,29 @@ public class DoubleArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<double[], A> typedSource = source.asObjectChunk();
-        final SizedDoubleChunk<A> resultWrapper = new SizedDoubleChunk<>();
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final double[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableDoubleChunk<A> result = WritableDoubleChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final double[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableDoubleChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -77,15 +82,13 @@ public class DoubleArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, ZERO_LEN_ARRAY);
             } else {
-                final double[] row = new double[ROW_LEN];
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final double[] row = new double[rowLen];
+                typedSource.copyToArray(lenRead, row,0, rowLen);
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/FloatArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/FloatArrayExpansionKernel.java
@@ -19,7 +19,7 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.chunk.sized.SizedFloatChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 public class FloatArrayExpansionKernel implements ArrayExpansionKernel {
     private final static float[] ZERO_LEN_ARRAY = new float[0];
@@ -33,24 +33,29 @@ public class FloatArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<float[], A> typedSource = source.asObjectChunk();
-        final SizedFloatChunk<A> resultWrapper = new SizedFloatChunk<>();
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final float[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableFloatChunk<A> result = WritableFloatChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final float[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableFloatChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -77,15 +82,13 @@ public class FloatArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, ZERO_LEN_ARRAY);
             } else {
-                final float[] row = new float[ROW_LEN];
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final float[] row = new float[rowLen];
+                typedSource.copyToArray(lenRead, row,0, rowLen);
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/IntArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/IntArrayExpansionKernel.java
@@ -19,7 +19,7 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.chunk.sized.SizedIntChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 public class IntArrayExpansionKernel implements ArrayExpansionKernel {
     private final static int[] ZERO_LEN_ARRAY = new int[0];
@@ -33,24 +33,29 @@ public class IntArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<int[], A> typedSource = source.asObjectChunk();
-        final SizedIntChunk<A> resultWrapper = new SizedIntChunk<>();
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final int[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableIntChunk<A> result = WritableIntChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final int[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableIntChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -77,15 +82,13 @@ public class IntArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, ZERO_LEN_ARRAY);
             } else {
-                final int[] row = new int[ROW_LEN];
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final int[] row = new int[rowLen];
+                typedSource.copyToArray(lenRead, row,0, rowLen);
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/LongArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/LongArrayExpansionKernel.java
@@ -19,7 +19,7 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.chunk.sized.SizedLongChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 public class LongArrayExpansionKernel implements ArrayExpansionKernel {
     private final static long[] ZERO_LEN_ARRAY = new long[0];
@@ -33,24 +33,29 @@ public class LongArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<long[], A> typedSource = source.asObjectChunk();
-        final SizedLongChunk<A> resultWrapper = new SizedLongChunk<>();
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final long[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableLongChunk<A> result = WritableLongChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final long[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableLongChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -77,15 +82,13 @@ public class LongArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, ZERO_LEN_ARRAY);
             } else {
-                final long[] row = new long[ROW_LEN];
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final long[] row = new long[rowLen];
+                typedSource.copyToArray(lenRead, row,0, rowLen);
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ObjectArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ObjectArrayExpansionKernel.java
@@ -8,13 +8,12 @@ import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
 import io.deephaven.datastructures.util.CollectionUtil;
 import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.ChunkType;
 import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
-import io.deephaven.chunk.sized.SizedChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 import java.lang.reflect.Array;
 
@@ -34,24 +33,29 @@ public class ObjectArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<T[], A> typedSource = source.asObjectChunk();
-        final SizedChunk<A> resultWrapper = new SizedChunk<>(ChunkType.Object);
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final T[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableObjectChunk<T, A> result = WritableObjectChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final T[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableObjectChunk<T, A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len).asWritableObjectChunk();
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -78,15 +82,13 @@ public class ObjectArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, CollectionUtil.ZERO_LENGTH_OBJECT_ARRAY);
             } else {
-                final Object[] row = (Object[])Array.newInstance(componentType, ROW_LEN);
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final Object[] row = (Object[])Array.newInstance(componentType, rowLen);
+                typedSource.copyToArray(lenRead, row, 0, rowLen );
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ShortArrayExpansionKernel.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/array/ShortArrayExpansionKernel.java
@@ -19,7 +19,7 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.ChunkPositions;
-import io.deephaven.chunk.sized.SizedShortChunk;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 public class ShortArrayExpansionKernel implements ArrayExpansionKernel {
     private final static short[] ZERO_LEN_ARRAY = new short[0];
@@ -33,24 +33,29 @@ public class ShortArrayExpansionKernel implements ArrayExpansionKernel {
         }
 
         final ObjectChunk<short[], A> typedSource = source.asObjectChunk();
-        final SizedShortChunk<A> resultWrapper = new SizedShortChunk<>();
+
+        long totalSize = 0;
+        for (int i = 0; i < typedSource.size(); ++i) {
+            final short[] row = typedSource.get(i);
+            totalSize += row == null ? 0 : row.length;
+        }
+        final WritableShortChunk<A> result = WritableShortChunk.makeWritableChunk(
+                LongSizedDataStructure.intSize("ExpansionKernel", totalSize));
 
         int lenWritten = 0;
         perElementLengthDest.setSize(source.size() + 1);
         for (int i = 0; i < typedSource.size(); ++i) {
             final short[] row = typedSource.get(i);
-            final int len = row == null ? 0 : row.length;
             perElementLengthDest.set(i, lenWritten);
-            final WritableShortChunk<A> result = resultWrapper.ensureCapacityPreserve(lenWritten + len);
-            for (int j = 0; j < len; ++j) {
-                result.set(lenWritten + j, row[j]);
+            if (row == null) {
+                continue;
             }
-            lenWritten += len;
-            result.setSize(lenWritten);
+            result.copyFromArray(row, 0, lenWritten, row.length);
+            lenWritten += row.length;
         }
         perElementLengthDest.set(typedSource.size(), lenWritten);
 
-        return resultWrapper.get();
+        return result;
     }
 
     @Override
@@ -77,15 +82,13 @@ public class ShortArrayExpansionKernel implements ArrayExpansionKernel {
 
         int lenRead = 0;
         for (int i = 0; i < itemsInBatch; ++i) {
-            final int ROW_LEN = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
-            if (ROW_LEN == 0) {
+            final int rowLen = perElementLengthDest.get(i + 1) - perElementLengthDest.get(i);
+            if (rowLen == 0) {
                 result.set(outOffset + i, ZERO_LEN_ARRAY);
             } else {
-                final short[] row = new short[ROW_LEN];
-                for (int j = 0; j < ROW_LEN; ++j) {
-                    row[j] = typedSource.get(lenRead + j);
-                }
-                lenRead += ROW_LEN;
+                final short[] row = new short[rowLen];
+                typedSource.copyToArray(lenRead, row,0, rowLen);
+                lenRead += rowLen;
                 result.set(outOffset + i, row);
             }
         }


### PR DESCRIPTION
In preparing a query that tickles the size limits of variable list types, I discovered:
- the expansion kernel becomes O(n^2) once the chunk size needed exceed the largest pooled size
- the expansion kernels do not use system array copy when appropriate

The query:
```
n = 1 << 15
arr = new byte[n]
for (ii = 0; ii < n; ++ii) {
    arr[ii] = (ii % 256)
}
t = emptyTable(n).view("ARR = arr")
```

Now runs in just a few seconds when requested from worker to worker.

Now when `n = 1 << 16`, the worker to worker request fails immediately instead of after minutes of excessive copying.