### PR TITLE
Fix closing totals table when aggregations are applied

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -635,9 +635,6 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
                     final RemoverFn remover = addEventListener(
                             INTERNAL_EVENT_STATECHANGED,
                             e -> {
-                                if (wrapped.isClosed()) {
-                                    return;
-                                }
                                 // eat superfluous changes (wait until event loop settles before firing requests).
                                 // IDS-2684 If you disable downsampling, you can lock up the entire websocket with some
                                 // rapid
@@ -650,6 +647,9 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
                                 if (downsample[0]) {
                                     downsample[0] = false;
                                     LazyPromise.runLater(() -> {
+                                        if (wrapped.isClosed()) {
+                                            return;
+                                        }
                                         downsample[0] = true;
                                         // IDS-2684 - comment out the four lines above to reproduce
                                         // when ever the main table changes its state, reload the totals table from the

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
@@ -35,9 +35,6 @@ import java.util.stream.Stream;
 
 @JsType(name = "Figure", namespace = "dh.plot")
 public class JsFigure extends HasEventHandling {
-    private static native Throwable ofObject(Object obj) /*-{
-      return @java.lang.Throwable::of(*)(obj);
-    }-*/;
 
     @JsProperty(namespace = "dh.plot.Figure")
     public static final String EVENT_UPDATED = "updated",
@@ -161,7 +158,7 @@ public class JsFigure extends HasEventHandling {
             fireEvent(EVENT_RECONNECT);
             return Promise.resolve(this);
         }, err -> {
-            final FigureFetchError fetchError = new FigureFetchError(ofObject(err),
+            final FigureFetchError fetchError = new FigureFetchError(LazyPromise.ofObject(err),
                     this.descriptor != null ? this.descriptor.getErrorsList() : new JsArray<>());
             final CustomEventInit init = CustomEventInit.create();
             init.setDetail(fetchError);

--- a/web/client-api/src/main/java/io/deephaven/web/client/fu/LazyPromise.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/fu/LazyPromise.java
@@ -1,5 +1,6 @@
 package io.deephaven.web.client.fu;
 
+import com.google.gwt.core.client.GWT;
 import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.promise.IThenable;
@@ -20,6 +21,9 @@ import jsinterop.base.Js;
  *
  */
 public class LazyPromise<T> implements PromiseLike<T> {
+    public static native Throwable ofObject(Object obj) /*-{
+      return @java.lang.Throwable::of(*)(obj);
+    }-*/;
 
     private T succeeded;
     private boolean isSuccess;
@@ -34,6 +38,9 @@ public class LazyPromise<T> implements PromiseLike<T> {
     public static void runLater(JsRunnable task) {
         Promise.resolve((Object) null).then(ignored -> {
             task.run();
+            return null;
+        }).catch_(e -> {
+            GWT.reportUncaughtException(ofObject(e));
             return null;
         });
     }


### PR DESCRIPTION
Before it would throw an AssertionError as it tried to apply a filter after the table was already closed. Just move the closed check to inside the runLater lambda. Cherry-picked from fix for DH-12511
