### PR TITLE
Reinterpret to primitive in SelectColumnLayer and when propagating groupings

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -489,7 +489,7 @@ public class QueryTable extends BaseTable {
          * MemoizedOperationKey.rollup(aggregations, gbsColumns, includeConstituents); return memoizeResult(rollupKey,
          * () -> { final QueryTable baseLevel = aggNoMemo( AggregationProcessor.forRollupBase(aggregations,
          * includeConstituents), gbsColumns);
-         * 
+         *
          * final Deque<SelectColumn> gbsColumnsToReaggregate = new ArrayDeque<>(Arrays.asList(gbsColumns)); final
          * Deque<String> nullColumnNames = new ArrayDeque<>(groupByColumns.length); QueryTable lastLevel = baseLevel;
          * while (!gbsColumnsToReaggregate.isEmpty()) {
@@ -499,18 +499,18 @@ public class QueryTable extends BaseTable {
          * lastLevelDefinition.getColumn(ncn).getDataType(), Assert::neverInvoked, LinkedHashMap::new)); lastLevel =
          * lastLevel.aggNoMemo(AggregationProcessor.forRollupReaggregated(aggregations, nullColumns),
          * gbsColumnsToReaggregate.toArray(SelectColumn.ZERO_LENGTH_SELECT_COLUMN_ARRAY)); }
-         * 
+         *
          * final String[] internalColumnsToDrop = lastLevel.getDefinition().getColumnStream()
          * .map(ColumnDefinition::getName) .filter(cn -> cn.endsWith(ROLLUP_COLUMN_SUFFIX)).toArray(String[]::new);
          * final QueryTable finalTable = (QueryTable) lastLevel.dropColumns(internalColumnsToDrop); final Object
          * reverseLookup = Require.neqNull(lastLevel.getAttribute(REVERSE_LOOKUP_ATTRIBUTE),
          * "REVERSE_LOOKUP_ATTRIBUTE"); finalTable.setAttribute(Table.REVERSE_LOOKUP_ATTRIBUTE, reverseLookup);
-         * 
+         *
          * final Table result = HierarchicalTable.createFrom(finalTable, new RollupInfo(aggregations, gbsColumns,
          * includeConstituents ? RollupInfo.LeafType.Constituent : RollupInfo.LeafType.Normal));
          * result.setAttribute(Table.HIERARCHICAL_SOURCE_TABLE_ATTRIBUTE, QueryTable.this); copyAttributes(result,
          * CopyAttributeOperation.Rollup); maybeUpdateSortableColumns(result);
-         * 
+         *
          * return result; });
          */
     }
@@ -527,22 +527,22 @@ public class QueryTable extends BaseTable {
          * partitionedTable = partitionBy(false, parentColumn); final QueryTable rootTable = (QueryTable)
          * partitionedTable.table().where(new MatchFilter(parentColumn, (Object) null)); final Table result =
          * HierarchicalTable.createFrom((QueryTable) rootTable.copy(), new TreeTableInfo(idColumn, parentColumn));
-         * 
+         *
          * // If the parent table has an RLL attached to it, we can re-use it. final ReverseLookup reverseLookup; if
          * (hasAttribute(PREPARED_RLL_ATTRIBUTE)) { reverseLookup = (ReverseLookup)
          * getAttribute(PREPARED_RLL_ATTRIBUTE); final String[] listenerCols = reverseLookup.getKeyColumns();
-         * 
+         *
          * if (listenerCols.length != 1 || !listenerCols[0].equals(idColumn)) { final String listenerColError =
          * StringUtils.joinStrings(Arrays.stream(listenerCols).map(col -> "'" + col + "'"), ", "); throw new
          * IllegalStateException( "Table was prepared for Tree table with a different Id column. Expected `" + idColumn
          * + "`, Actual " + listenerColError); } } else { reverseLookup =
          * ReverseLookupListener.makeReverseLookupListenerWithSnapshot(QueryTable.this, idColumn); }
-         * 
+         *
          * result.setAttribute(HIERARCHICAL_CHILDREN_TABLE_MAP_ATTRIBUTE, partitionedTable);
          * result.setAttribute(HIERARCHICAL_SOURCE_TABLE_ATTRIBUTE, QueryTable.this);
          * result.setAttribute(REVERSE_LOOKUP_ATTRIBUTE, reverseLookup); copyAttributes(result,
          * CopyAttributeOperation.Treetable); maybeUpdateSortableColumns(result);
-         * 
+         *
          * return result; });
          */
     }
@@ -1356,8 +1356,10 @@ public class QueryTable extends BaseTable {
                 sourceColumn = (SourceColumn) selectColumn;
             }
             if (sourceColumn != null && !usedOutputColumns.contains(sourceColumn.getSourceName())) {
-                final ColumnSource<?> originalColumnSource = getColumnSource(sourceColumn.getSourceName());
-                final ColumnSource<?> selectedColumnSource = resultTable.getColumnSource(sourceColumn.getName());
+                final ColumnSource<?> originalColumnSource = ReinterpretUtils.maybeConvertToPrimitive(
+                        getColumnSource(sourceColumn.getSourceName()));
+                final ColumnSource<?> selectedColumnSource = ReinterpretUtils.maybeConvertToPrimitive(
+                        resultTable.getColumnSource(sourceColumn.getName()));
                 if (originalColumnSource != selectedColumnSource) {
                     if (originalColumnSource instanceof DeferredGroupingColumnSource) {
                         final DeferredGroupingColumnSource<?> deferredGroupingSelectedSource =

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
@@ -14,6 +14,7 @@ import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.select.SelectColumn;
 import io.deephaven.engine.table.impl.select.VectorChunkAdapter;
 import io.deephaven.engine.table.impl.sources.ChunkedBackingStoreExposedWritableSource;
+import io.deephaven.engine.table.impl.sources.ReinterpretUtils;
 import io.deephaven.engine.table.impl.util.ChunkUtils;
 import io.deephaven.engine.updategraph.UpdateCommitterEx;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
@@ -33,7 +34,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.LARGEST_POOLED_CH
 
 final public class SelectColumnLayer extends SelectOrViewColumnLayer {
     /**
-     * The same reference as super.columnSource, but as a WritableColumnSource
+     * The same reference as super.columnSource, but as a WritableColumnSource and maybe reinterpretted
      */
     private final WritableColumnSource writableSource;
     /**
@@ -64,7 +65,7 @@ final public class SelectColumnLayer extends SelectOrViewColumnLayer {
             boolean flattenedResult, boolean alreadyFlattenedSources) {
         super(inner, name, sc, ws, underlying, deps, mcsBuilder);
         this.parentRowSet = parentRowSet;
-        this.writableSource = ws;
+        this.writableSource = (WritableColumnSource) ReinterpretUtils.maybeConvertToPrimitive(ws);
         this.isRedirected = isRedirected;
 
         dependencyBitSet = new BitSet();
@@ -99,7 +100,7 @@ final public class SelectColumnLayer extends SelectOrViewColumnLayer {
 
     private ChunkSource<Values> getChunkSource() {
         if (chunkSource == null) {
-            chunkSource = selectColumn.getDataView();
+            chunkSource = ReinterpretUtils.maybeConvertToPrimitive(selectColumn.getDataView());
             if (selectColumnHoldsVector) {
                 chunkSource = new VectorChunkAdapter<>(chunkSource);
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/WritableRedirectedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/WritableRedirectedColumnSource.java
@@ -11,12 +11,13 @@ import io.deephaven.engine.rowset.chunkattributes.RowKeys;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.WritableColumnSource;
+import io.deephaven.engine.table.impl.util.RowRedirection;
 import io.deephaven.engine.table.impl.util.WritableRowRedirection;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A {@link ColumnSource} that provides a redirected view into another {@link ColumnSource} by mapping keys using a
- * {@link WritableRowRedirection}.
+ * {@link RowRedirection}.
  */
 public class WritableRedirectedColumnSource<T> extends RedirectedColumnSource<T> implements WritableColumnSource<T> {
     private long maxInnerIndex;
@@ -29,7 +30,7 @@ public class WritableRedirectedColumnSource<T> extends RedirectedColumnSource<T>
      * @param innerSource The column source to redirect
      * @param maxInnerIndex The maximum row key available in innerSource
      */
-    public WritableRedirectedColumnSource(@NotNull final WritableRowRedirection rowRedirection,
+    public WritableRedirectedColumnSource(@NotNull final RowRedirection rowRedirection,
             @NotNull final ColumnSource<T> innerSource,
             final long maxInnerIndex) {
         super(rowRedirection, innerSource);
@@ -125,5 +126,17 @@ public class WritableRedirectedColumnSource<T> extends RedirectedColumnSource<T>
                 redirectionFillFrom.redirections, keys);
         ((WritableColumnSource<T>) innerSource).fillFromChunkUnordered(redirectionFillFrom.innerFillFromContext, src,
                 redirectionFillFrom.redirections);
+    }
+
+    @Override
+    public <ALTERNATE_DATA_TYPE> boolean allowsReinterpret(@NotNull Class<ALTERNATE_DATA_TYPE> alternateDataType) {
+        return innerSource.allowsReinterpret(alternateDataType);
+    }
+
+    @Override
+    protected <ALTERNATE_DATA_TYPE> ColumnSource<ALTERNATE_DATA_TYPE> doReinterpret(
+            @NotNull Class<ALTERNATE_DATA_TYPE> alternateDataType) {
+        return new WritableRedirectedColumnSource<>(
+                rowRedirection, innerSource.reinterpret(alternateDataType), maxInnerIndex);
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
@@ -1009,4 +1009,12 @@ public class QueryTableSelectUpdateTest {
         final Table evens = input.where("C");
         assertTableEquals(evens, evens.flatten().select());
     }
+
+    @Test
+    public void testStaticSelectFlattenDateTimeCol() {
+        final Table input = emptyTable(10).view("A=ii", "B = DateTime.now()").where("A % 2 == 0");
+        final Table output = input.select("B");
+        Assert.assertEquals(5, output.size());
+        Assert.assertTrue(output.isFlat());
+    }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -18,6 +18,9 @@ import io.deephaven.engine.rowset.*;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.indexer.RowSetIndexer;
+import io.deephaven.engine.table.impl.locations.GroupingProvider;
+import io.deephaven.engine.table.impl.sources.DeferredGroupingColumnSource;
+import io.deephaven.engine.table.impl.sources.LongAsDateTimeColumnSource;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.vector.*;
@@ -40,6 +43,8 @@ import io.deephaven.util.QueryConstants;
 import io.deephaven.util.SafeCloseable;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.apache.groovy.util.Maps;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.experimental.categories.Category;
 
@@ -3228,5 +3233,57 @@ public class QueryTableTest extends QueryTableTestBase {
             });
         }
         assertEquals(0, getUpdateErrors().size());
+    }
+
+    private static class TestDateTimeGroupingSource extends LongAsDateTimeColumnSource
+            implements DeferredGroupingColumnSource<DateTime> {
+
+        final GroupingProvider<Object> groupingProvider = new GroupingProvider<>() {
+            @Override
+            public Map<Object, RowSet> getGroupToRange() {
+                return null;
+            }
+
+            @Override
+            public Pair<Map<Object, RowSet>, Boolean> getGroupToRange(RowSet hint) {
+                return null;
+            }
+        };
+
+        TestDateTimeGroupingSource(ColumnSource<Long> realSource) {
+            super(realSource);
+            //noinspection unchecked,rawtypes
+            ((DeferredGroupingColumnSource) realSource).setGroupingProvider(groupingProvider);
+        }
+
+        @Override
+        public GroupingProvider<DateTime> getGroupingProvider() {
+            return null;
+        }
+
+        @Override
+        public void setGroupingProvider(@Nullable GroupingProvider<DateTime> groupingProvider) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public void testDeferredGroupingPropagationDateTimeCol() {
+        // This is a regression test on a class cast exception in QueryTable#propagateGrouping.
+        // RegionedColumnSourceDateTime is a grouping source, but is not an InMemoryColumnSource. The select column
+        // destination is not a grouping source as it is reinterpreted.
+
+        TrackingRowSet rowSet = RowSetFactory.flat(4).toTracking();
+
+        // This dance with a custom column is because an InMemoryColumnSource will be reused at the select layer
+        // which skips propagation of grouping, and avoids the class cast exception.
+        final TestDateTimeGroupingSource cs = new TestDateTimeGroupingSource(colSource(0L, 1, 2, 3));
+        final Map<String, ? extends ColumnSource<?>> columns = Maps.of("T", cs);
+        final QueryTable t1 = new QueryTable(rowSet, columns);
+        final Table t2 = t1.select("T");
+
+        //noinspection rawtypes
+        final DeferredGroupingColumnSource result =
+                (DeferredGroupingColumnSource) t2.getColumnSource("T").reinterpret(long.class);
+        assertSame(cs.groupingProvider, result.getGroupingProvider());
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -3252,7 +3252,7 @@ public class QueryTableTest extends QueryTableTestBase {
 
         TestDateTimeGroupingSource(ColumnSource<Long> realSource) {
             super(realSource);
-            //noinspection unchecked,rawtypes
+            // noinspection unchecked,rawtypes
             ((DeferredGroupingColumnSource) realSource).setGroupingProvider(groupingProvider);
         }
 
@@ -3281,7 +3281,7 @@ public class QueryTableTest extends QueryTableTestBase {
         final QueryTable t1 = new QueryTable(rowSet, columns);
         final Table t2 = t1.select("T");
 
-        //noinspection rawtypes
+        // noinspection rawtypes
         final DeferredGroupingColumnSource result =
                 (DeferredGroupingColumnSource) t2.getColumnSource("T").reinterpret(long.class);
         assertSame(cs.groupingProvider, result.getGroupingProvider());


### PR DESCRIPTION
Larry came across a parquet file with a DateTime column that exposed:
- WritableLongAsDateTimeColumnSource is not a chunk exposed column source
- WritableLongAsDateTimeColumnSource is not a DeferredGroupingColumnSource

Its reinterpreted primitive is both of them, however.