### PR TITLE
Fix a JPY byte conv issue on arm64

### DIFF
--- a/py/jpy/src/main/c/jpy_jtype.c
+++ b/py/jpy/src/main/c/jpy_jtype.c
@@ -455,7 +455,7 @@ int JType_CreateJavaNumberFromPythonInt(JNIEnv* jenv, JPy_JType* type, PyObject*
     j = JPy_AS_JLONG(pyArg);
     i = (int) j;
     s = (short) j;
-    b = (char) j;
+    b = (signed char) j;
 
     if (i != j) {
         value.j = j;


### PR DESCRIPTION
C char type on arm64 is unsigned, resulting in negative Java byte values being created when converting a value in the range of 127 - 255


Fixes: #2469 