### PR TITLE
DhFormulaColumn allow rowSet column name

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
@@ -291,12 +291,12 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
 
     private CodeGenerator generateConstructor() {
         final CodeGenerator g = CodeGenerator.create(
-                "public $CLASSNAME$(final TrackingRowSet rowSet,", CodeGenerator.indent(
+                "public $CLASSNAME$(final TrackingRowSet __rowSet,", CodeGenerator.indent(
                         "final boolean __lazy,",
                         "final java.util.Map<String, ? extends [[COLUMN_SOURCE_CLASSNAME]]> __columnsToData,",
                         "final [[PARAM_CLASSNAME]]... __params)"),
                 CodeGenerator.block(
-                        "super(rowSet);",
+                        "super(__rowSet);",
                         CodeGenerator.repeated("initColumn",
                                 "[[COLUMN_NAME]] = __columnsToData.get(\"[[COLUMN_NAME]]\");"),
                         CodeGenerator.repeated("initNormalColumnArray",

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/FormulaSample.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/FormulaSample.java
@@ -76,11 +76,11 @@ public class FormulaSample extends io.deephaven.engine.table.impl.select.Formula
     private final Map<Object, Object> __lazyResultCache;
 
 
-    public FormulaSample(final TrackingRowSet rowSet,
+    public FormulaSample(final TrackingRowSet __rowSet,
             final boolean __lazy,
             final java.util.Map<String, ? extends io.deephaven.engine.table.ColumnSource> __columnsToData,
             final io.deephaven.engine.table.lang.QueryScopeParam... __params) {
-        super(rowSet);
+        super(__rowSet);
         II = __columnsToData.get("II");
         I = __columnsToData.get("I");
         II_ = new io.deephaven.engine.table.impl.vector.LongVectorColumnWrapper(__columnsToData.get("II"), __rowSet);

--- a/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
+++ b/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
@@ -89,7 +89,7 @@ public class NameValidator {
     }
 
     private static final Set<String> QUERY_LANG_RESERVED_VARIABLE_NAMES =
-            Stream.of("in", "not", "i", "ii", "k").collect(
+            Stream.of("in", "not", "i", "ii", "k", "__rowSet").collect(
                     Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
 
     public static String validateTableName(String name) {
@@ -340,7 +340,7 @@ public class NameValidator {
      * @param customReplace a function that is applied to the name before processing legality
      * @param takenNames the list of names that are already taken
      * @return whether the name is valid for a new table
-     * 
+     *
      */
     public static boolean isLegalTableName(String name, Function<String, String> customReplace,
             Set<String> takenNames) {

--- a/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
+++ b/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
@@ -89,7 +89,7 @@ public class NameValidator {
     }
 
     private static final Set<String> QUERY_LANG_RESERVED_VARIABLE_NAMES =
-            Stream.of("in", "not", "i", "ii", "k", "__rowSet").collect(
+            Stream.of("in", "not", "i", "ii", "k").collect(
                     Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
 
     public static String validateTableName(String name) {
@@ -340,7 +340,6 @@ public class NameValidator {
      * @param customReplace a function that is applied to the name before processing legality
      * @param takenNames the list of names that are already taken
      * @return whether the name is valid for a new table
-     *
      */
     public static boolean isLegalTableName(String name, Function<String, String> customReplace,
             Set<String> takenNames) {


### PR DESCRIPTION
Although `rowSet` would be a rare / arbitrary column name, this PR enables `rowSet` and fails `__rowSet` earlier than it would have been caught.

Here's a failing query (fails on the `other` column in formula generation):
```groovy
t = emptyTable(1).update("rowSet = 0", "other = rowSet")
```