### PR TITLE
Add OutOfBand test category for BarrageMessageRoundTripTest

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -75,3 +75,5 @@ dependencies {
     testRuntimeOnly project(':log-to-slf4j')
     Classpaths.inheritSlf4j(project, 'slf4j-simple', 'testRuntimeOnly')
 }
+
+TestTools.addEngineOutOfBandTest(project)


### PR DESCRIPTION
Check CI test runtime reduced from ~45m to ~15m... oops.