### PR TITLE
ConditionFilter prefix method parameter names

### DIFF
--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/FilterKernelArraySample.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/FilterKernelArraySample.java
@@ -74,26 +74,26 @@ public class FilterKernelArraySample implements io.deephaven.engine.table.impl.s
     private final io.deephaven.vector.ShortVector v1_;
 
 
-    public FilterKernelArraySample(Table table, RowSet fullSet, QueryScopeParam... params) {
+    public FilterKernelArraySample(Table __table, RowSet __fullSet, QueryScopeParam... __params) {
 
         // Array Column Variables
-        v2_ = new io.deephaven.engine.table.impl.vector.DoubleVectorColumnWrapper(table.getColumnSource("v2"), fullSet);
-        v1_ = new io.deephaven.engine.table.impl.vector.ShortVectorColumnWrapper(table.getColumnSource("v1"), fullSet);
+        v2_ = new io.deephaven.engine.table.impl.vector.DoubleVectorColumnWrapper(__table.getColumnSource("v2"), __fullSet);
+        v1_ = new io.deephaven.engine.table.impl.vector.ShortVectorColumnWrapper(__table.getColumnSource("v1"), __fullSet);
     }
     @Override
-    public Context getContext(int maxChunkSize) {
-        return new Context(maxChunkSize);
+    public Context getContext(int __maxChunkSize) {
+        return new Context(__maxChunkSize);
     }
     
     @Override
-    public LongChunk<OrderedRowKeys> filter(Context context, LongChunk<OrderedRowKeys> indices, Chunk... inputChunks) {
-        final int size = indices.size();
-        context.resultChunk.setSize(0);
-        for (int __my_i__ = 0; __my_i__ < size; __my_i__++) {
+    public LongChunk<OrderedRowKeys> filter(Context __context, LongChunk<OrderedRowKeys> __indices, Chunk... __inputChunks) {
+        final int __size = __indices.size();
+        __context.resultChunk.setSize(0);
+        for (int __my_i__ = 0; __my_i__ < __size; __my_i__++) {
             if (eq(v1_.size(), v2_.size())) {
-                context.resultChunk.add(indices.get(__my_i__));
+                __context.resultChunk.add(__indices.get(__my_i__));
             }
         }
-        return context.resultChunk;
+        return __context.resultChunk;
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/FilterKernelSample.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/FilterKernelSample.java
@@ -73,29 +73,29 @@ public class FilterKernelSample implements io.deephaven.engine.table.impl.select
     private final float p2;
     private final java.lang.String p3;
 
-    public FilterKernelSample(Table table, RowSet fullSet, QueryScopeParam... params) {
-        this.p1 = (java.lang.Integer) params[0].getValue();
-        this.p2 = (java.lang.Float) params[1].getValue();
-        this.p3 = (java.lang.String) params[2].getValue();
+    public FilterKernelSample(Table __table, RowSet __fullSet, QueryScopeParam... __params) {
+        this.p1 = (java.lang.Integer) __params[0].getValue();
+        this.p2 = (java.lang.Float) __params[1].getValue();
+        this.p3 = (java.lang.String) __params[2].getValue();
     }
     @Override
-    public Context getContext(int maxChunkSize) {
-        return new Context(maxChunkSize);
+    public Context getContext(int __maxChunkSize) {
+        return new Context(__maxChunkSize);
     }
     
     @Override
-    public LongChunk<OrderedRowKeys> filter(Context context, LongChunk<OrderedRowKeys> indices, Chunk... inputChunks) {
-        final ShortChunk __columnChunk0 = inputChunks[0].asShortChunk();
-        final DoubleChunk __columnChunk1 = inputChunks[1].asDoubleChunk();
-        final int size = indices.size();
-        context.resultChunk.setSize(0);
-        for (int __my_i__ = 0; __my_i__ < size; __my_i__++) {
+    public LongChunk<OrderedRowKeys> filter(Context __context, LongChunk<OrderedRowKeys> __indices, Chunk... __inputChunks) {
+        final ShortChunk __columnChunk0 = __inputChunks[0].asShortChunk();
+        final DoubleChunk __columnChunk1 = __inputChunks[1].asDoubleChunk();
+        final int __size = __indices.size();
+        __context.resultChunk.setSize(0);
+        for (int __my_i__ = 0; __my_i__ < __size; __my_i__++) {
             final short v1 =  (short)__columnChunk0.get(__my_i__);
             final double v2 =  (double)__columnChunk1.get(__my_i__);
             if ("foo".equals((plus(plus(plus(p1, p2), v1), v2))+p3)) {
-                context.resultChunk.add(indices.get(__my_i__));
+                __context.resultChunk.add(__indices.get(__my_i__));
             }
         }
-        return context.resultChunk;
+        return __context.resultChunk;
     }
 }


### PR DESCRIPTION
I was able to construct a few failing condition filter queries.

Redefine local variable:
```groovy
t = emptyTable(1).update("size = ii").where("ii == 0 + size")
```

Redefine method param:
```groovy
t = emptyTable(1).update("context = 0").where("ii == context + 1")
```

External param is shadowed by method param:
```groovy
context = 0
t = emptyTable(1).where("ii == context + 1")
```

etc