### PR TITLE
Disable intrinsic for Thread::currentThread

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -90,45 +90,10 @@ tasks.withType(JavaCompile).configureEach {
   }
 }
 
+// Opting to leave dummy excludes in place.
+// A useful structuring that will get make it easier to re-introduce later if necessary.
 def tier4CompilationExcludes = [
-  // All ChunkedSumOperators
-  'io.deephaven.engine.table.impl.by.BigDecimalChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.BigIntegerChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.BooleanChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.ByteChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.CharChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.DoubleChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.FloatChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.IntChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.LongChunkedSumOperator':['addChunk'],
-  'io.deephaven.engine.table.impl.by.ShortChunkedSumOperator':['addChunk'],
-
-  // All PercentileTypeMedianHelpers
-  'io.deephaven.engine.table.impl.by.ssmpercentile.BooleanPercentileTypeMedianHelper':['setResult'],
-  'io.deephaven.engine.table.impl.by.ssmpercentile.BytePercentileTypeMedianHelper':['setResult'],
-  'io.deephaven.engine.table.impl.by.ssmpercentile.CharPercentileTypeMedianHelper':['setResult'],
-  'io.deephaven.engine.table.impl.by.ssmpercentile.DoublePercentileTypeMedianHelper':['setResult'],
-  'io.deephaven.engine.table.impl.by.ssmpercentile.FloatPercentileTypeMedianHelper':['setResult'],
-  'io.deephaven.engine.table.impl.by.ssmpercentile.IntPercentileTypeMedianHelper':['setResult'],
-  'io.deephaven.engine.table.impl.by.ssmpercentile.LongPercentileTypeMedianHelper':['setResult'],
-  'io.deephaven.engine.table.impl.by.ssmpercentile.ShortPercentileTypeMedianHelper':['setResult'],
-
-  'io.deephaven.engine.table.impl.by.ssmpercentile.SsmChunkedPercentileOperator':['addChunk'],
-
-  // All types emitted by ReplicateHashTable
-  'io.deephaven.engine.table.impl.IncrementalChunkedNaturalJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.RightIncrementalChunkedNaturalJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.StaticChunkedAsOfJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.StaticChunkedNaturalJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.RightIncrementalChunkedAsOfJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.SymbolTableCombiner':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.LeftOnlyIncrementalChunkedCrossJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.RightIncrementalChunkedCrossJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.StaticChunkedCrossJoinStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.by.StaticChunkedOperatorAggregationStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-  'io.deephaven.engine.table.impl.by.IncrementalChunkedOperatorAggregationStateManager':['addToIndex', 'buildTable', 'decorationProbe'],
-
-  'io.deephaven.engine.table.impl.by.AddOnlyFirstOrLastChunkedOperator':['addChunk', 'updateRedirections']
+  'io.deephaven.ClassToExclude':['methodToExclude'],
 ]
 def createCompilerDirectives = tasks.register('createCompilerDirectives') {
   def compilerDirectivesFile = project.layout.buildDirectory.file('dh-compiler-directives.txt')
@@ -156,6 +121,7 @@ def c2ExcludesJvmArgs = { String c2ExcludesFile ->
   return [
           '-XX:+UnlockDiagnosticVMOptions',
           "-XX:CompilerDirectivesFile=${c2ExcludesFile}",
+          '-XX:DisableIntrinsic=_currentThread'
   ]
 }
 

--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -90,38 +90,28 @@ tasks.withType(JavaCompile).configureEach {
   }
 }
 
-// Opting to leave dummy excludes in place.
-// A useful structuring that will get make it easier to re-introduce later if necessary.
-def tier4CompilationExcludes = [
-  'io.deephaven.ClassToExclude':['methodToExclude'],
-]
 def createCompilerDirectives = tasks.register('createCompilerDirectives') {
   def compilerDirectivesFile = project.layout.buildDirectory.file('dh-compiler-directives.txt')
   it.outputs.file(compilerDirectivesFile)
 
   doFirst {
-    def excludesAsList = []
-    tier4CompilationExcludes.forEach({type, methods ->
-      methods.forEach {method ->
-        excludesAsList += "${type}::${method}"
-      }
-    })
     def builder = new JsonBuilder([{
-       match excludesAsList
-       c2 {
-         Exclude true
-       }
+      match (['*.*'] as List)
+      // Note: there seems to be a bug where this option doesn't actually get picked up
+      // So using '-XX:DisableIntrinsic=_currentThread' explicitly
+      // DisableIntrinsic('_currentThread')
     }])
-
     compilerDirectivesFile.get().asFile.text = builder.toPrettyString()
   }
 }
 
-def c2ExcludesJvmArgs = { String c2ExcludesFile ->
+def compilerArgs = { String compilerDirectivesFile ->
   return [
           '-XX:+UnlockDiagnosticVMOptions',
-          "-XX:CompilerDirectivesFile=${c2ExcludesFile}",
-          '-XX:DisableIntrinsic=_currentThread'
+          "-XX:CompilerDirectivesFile=${compilerDirectivesFile}",
+          '-XX:DisableIntrinsic=_currentThread',
+          // '-XX:+CompilerDirectivesPrint',
+          // '-XX:+LogCompilation',
   ]
 }
 
@@ -133,18 +123,18 @@ def devJvmArgs = [
 ]
 
 tasks.withType(JavaExec).configureEach {
-  def c2ExcludesFile = createCompilerDirectives.get().outputs.files
-  inputs.files c2ExcludesFile
+  def compilerDirectivesFile = createCompilerDirectives.get().outputs.files
+  inputs.files compilerDirectivesFile
   javaLauncher.set runtimeLauncher
-  jvmArgs += c2ExcludesJvmArgs(c2ExcludesFile.singleFile.path) + devJvmArgs
+  jvmArgs += compilerArgs(compilerDirectivesFile.singleFile.path) + devJvmArgs
 }
 
 tasks.withType(Test).configureEach {
-  def c2ExcludesFile = createCompilerDirectives.get().outputs.files
-  inputs.files c2ExcludesFile
+  def compilerDirectivesFile = createCompilerDirectives.get().outputs.files
+  inputs.files compilerDirectivesFile
 
   javaLauncher.set testRuntimeLauncher
-  jvmArgs += c2ExcludesJvmArgs(c2ExcludesFile.singleFile.path) + devJvmArgs
+  jvmArgs += compilerArgs(compilerDirectivesFile.singleFile.path) + devJvmArgs
 }
 
 tasks.withType(GroovyCompile).configureEach {
@@ -168,9 +158,9 @@ tasks.withType(CreateStartScripts).configureEach {
 //  inputs.files windowsStartScript
 //  windowsStartScriptGenerator.template = windowsStartScript
 
-  // Note that we don't call c2ExcludesJvmArgs() at this time, there is no way to template those strings.
+  // Note that we don't call compilerArgs() at this time, there is no way to template those strings.
   // Instead, we hard code the expected paths in the above templates to match the path lib/dh-compiler-directives.txt
-//  defaultJvmOpts += c2ExcludesJvmArgs(c2ExcludesFile.singleFile.path)
+//  defaultJvmOpts += compilerArgs(compilerDirectivesFile.singleFile.path)
 
   defaultJvmOpts += devJvmArgs
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -109,6 +109,7 @@ def compilerArgs = { String compilerDirectivesFile ->
   return [
           '-XX:+UnlockDiagnosticVMOptions',
           "-XX:CompilerDirectivesFile=${compilerDirectivesFile}",
+          // (deephaven-core#2500): Remove DisableIntrinsic for currentThread
           '-XX:DisableIntrinsic=_currentThread',
           // '-XX:+CompilerDirectivesPrint',
           // '-XX:+LogCompilation',

--- a/py/embedded-server/deephaven_server/start_jvm.py
+++ b/py/embedded-server/deephaven_server/start_jvm.py
@@ -30,6 +30,8 @@ DEFAULT_JVM_ARGS = [
     # Disable JIT in certain cases
     '-XX:+UnlockDiagnosticVMOptions',
     '-XX:CompilerDirectivesFile=' + os.path.join(os.path.dirname(__file__), 'jars', 'dh-compiler-directives.txt'),
+    # (deephaven-core#2500): Remove DisableIntrinsic for currentThread
+    '-XX:DisableIntrinsic=_currentThread',
 ]
 
 # Provide a util func to start the JVM, will use its own defaults if none are offered


### PR DESCRIPTION
Allows us to remove all of the compiler excludes we had to previously maintain.

Investigated from https://github.com/openjdk/jdk/pull/9060