### PR TITLE
Missing licenses

### DIFF
--- a/Generators/src/main/java/io/deephaven/libs/GroovyStaticImportGenerator.java
+++ b/Generators/src/main/java/io/deephaven/libs/GroovyStaticImportGenerator.java
@@ -264,9 +264,9 @@ public class GroovyStaticImportGenerator {
 
     private String generateCode() {
 
-        String code = "/*\n" +
-                " * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending\n" +
-                " */\n\n" +
+        String code = "/**\n" +
+                " * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending\n" +
+                " */\n" +
                 "/****************************************************************************************************************************\n"
                 +
                 " ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - Run GroovyStaticImportGenerator or \"./gradlew :Generators:groovyStaticImportGenerator\" to regenerate\n"

--- a/Generators/src/main/java/io/deephaven/plot/util/GenerateFigureImmutable.java
+++ b/Generators/src/main/java/io/deephaven/plot/util/GenerateFigureImmutable.java
@@ -215,9 +215,9 @@ public class GenerateFigureImmutable {
 
     private String generateCode() {
 
-        String code = "/*\n" +
-                " * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending\n" +
-                " */\n\n" +
+        String code = "/**\n" +
+                " * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending\n" +
+                " */\n" +
                 "/****************************************************************************************************************************\n"
                 +
                 " ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - Run GenerateFigureImmutable or \"./gradlew :Generators:generateFigureImmutable\" to regenerate\n"

--- a/Generators/src/main/java/io/deephaven/plot/util/GeneratePlottingConvenience.java
+++ b/Generators/src/main/java/io/deephaven/plot/util/GeneratePlottingConvenience.java
@@ -192,9 +192,9 @@ public class GeneratePlottingConvenience {
 
     private String generateCode() {
 
-        String code = "/*\n" +
-                " * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending\n" +
-                " */\n\n" +
+        String code = "/**\n" +
+                " * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending\n" +
+                " */\n" +
                 "/****************************************************************************************************************************\n"
                 +
                 " ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - Run GeneratePlottingConvenience or \"./gradlew :Generators:generatePlottingConvenience\" to regenerate\n"

--- a/Generators/src/main/java/io/deephaven/plot/util/GeneratePyV2FigureAPI.java
+++ b/Generators/src/main/java/io/deephaven/plot/util/GeneratePyV2FigureAPI.java
@@ -72,7 +72,7 @@ public class GeneratePyV2FigureAPI {
             String oldCode = new String(Files.readAllBytes(Paths.get(figureWrapperOutput)));
             if (!pyCode.equals(oldCode)) {
                 throw new RuntimeException(
-                        "Change in generated code.  Run GeneratePyV2FigureAPI or \"./gradlew :Generators:generatePlottingConvenience\" to regenerate\n");
+                        "Change in generated code.  Run GeneratePyV2FigureAPI or \"./gradlew :Generators:generatePythonFigureWrapper\" to regenerate\n");
             }
         } else {
             try (final PrintWriter out = new PrintWriter(pythonFile)) {

--- a/Generators/src/main/java/io/deephaven/pythonPreambles/plotV2.py
+++ b/Generators/src/main/java/io/deephaven/pythonPreambles/plotV2.py
@@ -1,6 +1,7 @@
 #
-#   Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+# Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
 #
+
 ######################################################################################################################
 #               This code is auto generated. DO NOT EDIT FILE!
 # Run generatePythonFigureWrapper or "./gradlew :Generators:generatePythonFigureWrapper" to generate

--- a/Plot/src/main/java/io/deephaven/plot/Figure.java
+++ b/Plot/src/main/java/io/deephaven/plot/Figure.java
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
-
 /****************************************************************************************************************************
  ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - Run GenerateFigureImmutable or "./gradlew :Generators:generateFigureImmutable" to regenerate
  ****************************************************************************************************************************/

--- a/Plot/src/main/java/io/deephaven/plot/FigureImpl.java
+++ b/Plot/src/main/java/io/deephaven/plot/FigureImpl.java
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
-
 /****************************************************************************************************************************
  ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - Run GenerateFigureImmutable or "./gradlew :Generators:generateFigureImmutable" to regenerate
  ****************************************************************************************************************************/

--- a/Plot/src/main/java/io/deephaven/plot/PlottingConvenience.java
+++ b/Plot/src/main/java/io/deephaven/plot/PlottingConvenience.java
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
-
 /****************************************************************************************************************************
  ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - Run GeneratePlottingConvenience or "./gradlew :Generators:generatePlottingConvenience" to regenerate
  ****************************************************************************************************************************/

--- a/buildSrc/src/main/groovy/io.deephaven.java-header-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-header-conventions.gradle
@@ -5,8 +5,10 @@ plugins {
 
 license {
     header rootProject.file('license-header')
-    include "**/*.java"
+    include '**/*.java'
     strictCheck true
     useDefaultMappings true
     ignoreFailures true
 }
+
+project.tasks.getByName('quick').dependsOn project.tasks.getByName('license')

--- a/buildSrc/src/main/groovy/io.deephaven.python-wheel.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.python-wheel.gradle
@@ -1,11 +1,32 @@
 plugins {
     id 'com.bmuschko.docker-remote-api'
     id 'io.deephaven.project.register'
+    id 'license'
 }
 
 import io.deephaven.python.PythonWheelExtension
 
 project.extensions.create('wheel', PythonWheelExtension, project.objects)
+
+license {
+    header rootProject.file('license-header')
+    include '**/*.py'
+    strictCheck true
+    useDefaultMappings true
+    ignoreFailures true
+}
+
+tasks.getByName('license').dependsOn(tasks.create("licensePy", com.hierynomus.gradle.license.tasks.LicenseCheck))
+tasks.getByName('licenseFormat').dependsOn(tasks.create("licenseFormatPy", com.hierynomus.gradle.license.tasks.LicenseFormat))
+afterEvaluate {
+    tasks.named("licensePy") { task ->
+        task.source = wheel.src()
+    }
+    tasks.named("licenseFormatPy") { task ->
+        task.source = wheel.src()
+    }
+}
+project.tasks.getByName('quick').dependsOn project.tasks.getByName('license')
 
 configurations {
     pythonWheel

--- a/buildSrc/src/main/groovy/io/deephaven/python/PythonWheelExtension.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/python/PythonWheelExtension.groovy
@@ -9,12 +9,14 @@ import org.gradle.util.ConfigureUtil
 
 class PythonWheelExtension {
     private Action<? super CopySpec> contents
+    private List<String> sourceDirs;
 
     PythonWheelExtension(ObjectFactory objectFactory) {
         //objectFactory.newInstance(DefaultCopySpec.class)
         contents {
             exclude 'build', 'dist'
         }
+        sourceDirs = []
     }
 
     void contents(Action<? super CopySpec> action) {
@@ -26,5 +28,12 @@ class PythonWheelExtension {
 
     Action<? super CopySpec> contents() {
         return contents;
+    }
+
+    void src(String srcDir) {
+        sourceDirs += srcDir
+    }
+    List<String> src() {
+        return sourceDirs
     }
 }

--- a/cpp-client/build.gradle
+++ b/cpp-client/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'io.deephaven.project.register'
+    id 'license'
+}
+
+license {
+    header rootProject.file('license-header')
+    include '**/*.h'
+    include '**/*.cc'
+    strictCheck true
+    useDefaultMappings true
+    ignoreFailures true
+}
+tasks.getByName('license').dependsOn(tasks.create("licensePy", com.hierynomus.gradle.license.tasks.LicenseCheck) {
+    source = ['deephaven', 'tests', '../cpp-examples']
+})
+tasks.getByName('licenseFormat').dependsOn(tasks.create("licenseFormatPy", com.hierynomus.gradle.license.tasks.LicenseFormat) {
+    source = ['deephaven', 'tests', '../cpp-examples']
+})
+
+project.tasks.getByName('quick').dependsOn project.tasks.getByName('license')

--- a/cpp-client/gradle.properties
+++ b/cpp-client/gradle.properties
@@ -1,0 +1,1 @@
+io.deephaven.project.ProjectType=BASIC

--- a/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
+++ b/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
@@ -1,7 +1,6 @@
-/*
- * Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
-
 /****************************************************************************************************************************
  ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - Run GroovyStaticImportGenerator or "./gradlew :Generators:groovyStaticImportGenerator" to regenerate
  ****************************************************************************************************************************/

--- a/license-header
+++ b/license-header
@@ -1,1 +1,1 @@
-Copyright (c) 2016-2021 Deephaven Data Labs and Patent Pending
+Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending

--- a/proto/proto-backplane-grpc/build.gradle
+++ b/proto/proto-backplane-grpc/build.gradle
@@ -42,6 +42,10 @@ dependencies {
   Classpaths.inheritArrow(project, 'flight-core', 'download')
 }
 
+license {
+  include 'src/**/*.proto'
+}
+
 TaskProvider<Task> generateProtobuf = Docker.registerDockerTask(project, 'generateProtobuf') {
   copyIn {
     from(project.projectDir) {

--- a/py/client/build.gradle
+++ b/py/client/build.gradle
@@ -10,6 +10,12 @@ plugins {
     id 'io.deephaven.python-wheel'
 }
 
+wheel {
+    src 'pydeephaven'
+    src 'examples'
+    src 'tests'
+}
+
 // Start up a docker container for the grpc server, then run pydeephaven test
 evaluationDependsOn(':docker-server')
 String randomSuffix = UUID.randomUUID().toString();

--- a/py/embedded-server/build.gradle
+++ b/py/embedded-server/build.gradle
@@ -13,6 +13,7 @@ wheel {
             into('deephaven_server/jars')
         }
     }
+    src 'deephaven_server'
 }
 
 dependencies {

--- a/py/server/build.gradle
+++ b/py/server/build.gradle
@@ -5,3 +5,10 @@ plugins {
 dependencies {
     pythonWheel project(path: ':deephaven-jpy', targetConfiguration: 'pythonWheel')
 }
+
+wheel {
+    src 'deephaven'
+    src 'integration-tests'
+    src 'test_helper'
+    src 'tests'
+}

--- a/py/server/deephaven/plot/figure.py
+++ b/py/server/deephaven/plot/figure.py
@@ -1,6 +1,7 @@
 #
-#   Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+# Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
 #
+
 ######################################################################################################################
 #               This code is auto generated. DO NOT EDIT FILE!
 # Run generatePythonFigureWrapper or "./gradlew :Generators:generatePythonFigureWrapper" to generate

--- a/settings.gradle
+++ b/settings.gradle
@@ -142,6 +142,8 @@ include(':ParquetHadoop')
 
 include(':codegen')
 
+include(':cpp-client')
+
 include(':replication-util')
 project(':replication-util').projectDir = file('replication/util')
 


### PR DESCRIPTION
This is the "readable" version of this patch, and the first to land to lock us in with correct license headers going forward.

The next PR will include all of the source files (~7700) to change to correctly reflect these changes, the result of calling `./gradlew licenseFormat`.

After that, the third commit will make the build fail, by flipping `ignoreFailures` to false after all other changes have been made.

This update addresses python, cpp, java, and proto files (which are in a java project).

Fixes #404?