### PR TITLE
jsapi: fix null check for optional color param

### DIFF
--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -761,6 +761,9 @@ public class FigureWidgetTranslator {
     }
 
     private String toCssColorString(io.deephaven.gui.color.Paint color) {
+        if (color == null) {
+            return null;
+        }
         if (!(color instanceof io.deephaven.gui.color.Color)) {
             errorList.add("OpenAPI does not presently support paint of type " + color);
             return null;


### PR DESCRIPTION
This just fixes some whining when an optional parameter is not specified.