### PR TITLE
Add myself as codeowner for docker directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,4 +18,4 @@
 /README.md @chipkent @rcaudy @margaretkennedy
 /TRIAGE.md @chipkent
 /licenses @chipkent
-/docker @devinrsmith
+/docker @devinrsmith @jcferretti

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,3 +18,4 @@
 /README.md @chipkent @rcaudy @margaretkennedy
 /TRIAGE.md @chipkent
 /licenses @chipkent
+/docker @devinrsmith


### PR DESCRIPTION
I should have reviewer status for docker/ changes. https://github.com/deephaven/deephaven-core/pull/2532 unintentionally broke part of the build (that isn't tested via CI).

Changes to the requirements files is managed via https://github.com/deephaven/deephaven-base-images, will follow up with a fix there and here.

```shell
./gradlew docker-server:buildDocker-server-pytorch
```