### PR TITLE
jsapi: fix non deterministic behavior on table order for figures

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
@@ -657,9 +657,15 @@ public class JsFigure extends HasEventHandling {
                     JsTable table = new JsTable(connection, cts);
                     // never attempt a reconnect, since we might have a different figure schema entirely
                     table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
-                    tables[tables.length] = table;
                     return Promise.resolve(table);
                 });
+                return null;
+            });
+
+            Promise.all(promises).then((allTables) -> {
+                for (int ii = 0; ii < allTables.length; ++ii) {
+                    tables[ii] = (JsTable) allTables[ii];
+                }
                 return null;
             });
 


### PR DESCRIPTION
Fixes #2214. The issue is that the ETCR would arrive in any order, not in the requested order.