### PR TITLE
Switch to Parquet-specific snappy codec, and limit input stream size

### DIFF
--- a/ParquetHadoop/build.gradle
+++ b/ParquetHadoop/build.gradle
@@ -12,9 +12,9 @@ sourceSets {
 }
 
 dependencies {
-    api('org.apache.parquet:parquet-hadoop:1.12.0')
+    api('org.apache.parquet:parquet-hadoop:1.12.3')
 
-    api('org.apache.hadoop:hadoop-common:3.3.2') {
+    api('org.apache.hadoop:hadoop-common:3.3.3') {
         // do not take any dependencies of this project,
         // we just want a few classes (Configuration, Path) for
         // simplified prototyping work, and api compatibility.

--- a/extensions/parquet/compression/build.gradle
+++ b/extensions/parquet/compression/build.gradle
@@ -9,12 +9,18 @@ dependencies {
 
     implementation depCommonsIo
 
+    implementation 'com.google.guava:guava:19.0'
+
     runtimeOnly('org.lz4:lz4-java:1.8.0') {
         // also consider lz4-pure-java to avoid native code
         because 'hadoop-common required dependency for LZ4Codec'
     }
     // Pick up default jvm-compatible compression codecs
     implementation('io.airlift:aircompressor:0.21') {
-        because 'Provides Lz4, snappy, LZO, Zstd compression support for parquet'
+        because 'Provides Lz4, LZO, Zstd compression support for parquet'
+    }
+
+    implementation('org.xerial.snappy:snappy-java:1.1.8.4') {
+        because 'Provides snappy compression for parquet, with native support for all platforms deephaven works on'
     }
 }

--- a/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCodecFactory.java
+++ b/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCodecFactory.java
@@ -31,8 +31,9 @@ public class DeephavenCodecFactory {
 
     // Default codecs to list in the configuration rather than rely on the classloader
     private static final Set<String> DEFAULT_CODECS = Set.of(
-            // Use the aircompressor codec for snappy by default - this is implemented in Java, rather than using
-            // the native xerial implementation.
+            // Manually specify the "parquet" codec rather than the ServiceLoader-selected snappy codec, which is
+            // apparently incompatible with other parquet files which use snappy. This codec does use platform-specific
+            // implementations, but has native implementations for the platforms we support today.
             "org.apache.parquet.hadoop.codec.SnappyCodec");
     private static final List<Class<?>> CODECS = io.deephaven.configuration.Configuration.getInstance()
             .getStringSetFromPropertyWithDefault("DeephavenCodecFactory.codecs", DEFAULT_CODECS).stream()

--- a/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCodecFactory.java
+++ b/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCodecFactory.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.parquet.compress;
 
+import com.google.common.io.ByteStreams;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CodecPool;
@@ -16,7 +17,6 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,7 +33,7 @@ public class DeephavenCodecFactory {
     private static final Set<String> DEFAULT_CODECS = Set.of(
             // Use the aircompressor codec for snappy by default - this is implemented in Java, rather than using
             // the native xerial implementation.
-            "io.airlift.compress.snappy.SnappyCodec");
+            "org.apache.parquet.hadoop.codec.SnappyCodec");
     private static final List<Class<?>> CODECS = io.deephaven.configuration.Configuration.getInstance()
             .getStringSetFromPropertyWithDefault("DeephavenCodecFactory.codecs", DEFAULT_CODECS).stream()
             .map((String className) -> {
@@ -103,7 +103,7 @@ public class DeephavenCodecFactory {
             try {
                 // Note that we don't close this, we assume the caller will close their input stream when ready,
                 // and this won't need to be closed.
-                InputStream buffered = IOUtils.buffer(inputStream, compressedSize);
+                InputStream buffered = ByteStreams.limit(IOUtils.buffer(inputStream), compressedSize);
                 CompressionInputStream decompressed = compressionCodec.createInputStream(buffered, decompressor);
                 return BytesInput.copy(BytesInput.from(decompressed, uncompressedSize));
             } finally {

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -300,4 +300,11 @@ public class ParquetTableReadWriteTest {
     public void testParquetGzipCompressionCodec() {
         compressionCodecTestHelper("GZIP");
     }
+
+    @Test
+    public void testParquetSnappyCompressionCodec() {
+        // while Snappy is covered by other tests, this is a very fast test to quickly confirm that it works in the same
+        // way as the other similar codec tests.
+        compressionCodecTestHelper("SNAPPY");
+    }
 }


### PR DESCRIPTION
This restores the native parquet codec for snappy, but with a version that supports aarch64 on macs. The other snappy codec was for hadoop, not for parquet, and apparently there are differences between those two. 

The input stream size must be set correctly - The earlier patch was written under the mistaken impression that the "size" field of the IOUtils.buffer() method would set a max size to buffer. Not all codecs fail with this error, since some stop decoding or are able to decode other payloads in the parquet file, but this change at least will speed up those implementations too.

Fixes #2495