### PR TITLE
Fix ColumnHeader.checkName() so it throws on failure.

### DIFF
--- a/qst/src/main/java/io/deephaven/qst/column/header/ColumnHeader.java
+++ b/qst/src/main/java/io/deephaven/qst/column/header/ColumnHeader.java
@@ -198,6 +198,6 @@ public abstract class ColumnHeader<T1> implements TableHeader.Buildable {
 
     @Check
     void checkName() {
-        NameValidator.isValidColumnName(name());
+        NameValidator.validateColumnName(name());
     }
 }


### PR DESCRIPTION
ColumnHeader.checkName() was intended to throw if the name is not valid.
However, the existing implementation checks isValid but then discards
the true/false result.