### PR TITLE
Fix filter precision for float/decimal columns

### DIFF
--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
@@ -27,6 +27,7 @@ import io.deephaven.proto.backplane.grpc.Value;
 import io.deephaven.time.DateTime;
 import io.deephaven.time.TimeZone;
 
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.List;
 import java.util.Set;
@@ -124,7 +125,8 @@ public class FilterFactory implements FilterVisitor<WhereFilter> {
                 valueString = value.getStringValue();
                 break;
             case DOUBLE_VALUE:
-                DecimalFormat format = new DecimalFormat("##0");
+                // doubles can hold up to 16 decimal places of precision
+                DecimalFormat format = new DecimalFormat("##0.################");
                 format.setDecimalSeparatorAlwaysShown(false);
                 format.setGroupingUsed(false);
                 valueString = format.format(value.getDoubleValue());

--- a/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/table_filter.html
@@ -159,11 +159,11 @@
           ide = await connection.startSession("python");
           await ide.runCode(`
 from deephaven import time_table
-remoteTable = time_table("00:00:01").update_view(["I=i", "J=I*I", "K=I%100"]).last_by("K")
+remoteTable = time_table("00:00:01").update_view(["I=i", "J=I*I", "K=I%100", "L=(double)I/100.0"]).last_by("K")
 `)
       } else if (types.indexOf("groovy") !== -1) {
           ide = await connection.startSession("groovy");
-          await ide.runCode('remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")')
+          await ide.runCode('remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100", "L=(double)I/100.0").lastBy("K")')
       }
 
       openTable(await ide.getTable('remoteTable'));


### PR DESCRIPTION
- Filter value was getting rounded by DecimalFormat. Added maximum number of digits to the format so precision is not lost
- Added a decimal column to the table_filter.html example to test decimal values
