### PR TITLE
Add PartitionedTable keys() helper method

### DIFF
--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1455,6 +1455,10 @@ class PartitionedTable(JObjectWrapper):
             self._key_columns = list(self.j_partitioned_table.keyColumnNames().toArray())
         return self._key_columns
 
+    def keys(self) -> Table:
+        """Returns a Table containing all the keys of the underlying partitioned table."""
+        return self.table.select_distinct(self.key_columns)
+
     @property
     def unique_keys(self) -> bool:
         """Whether the keys in the underlying table must always be unique. If keys must be unique, one can expect

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1457,7 +1457,11 @@ class PartitionedTable(JObjectWrapper):
 
     def keys(self) -> Table:
         """Returns a Table containing all the keys of the underlying partitioned table."""
-        return self.table.select_distinct(self.key_columns)
+        if self.unique_keys:
+            return self.table.view(self.key_columns)
+        else:
+            return self.table.select_distinct(self.key_columns)
+
 
     @property
     def unique_keys(self) -> bool:

--- a/py/server/tests/test_partitioned_table.py
+++ b/py/server/tests/test_partitioned_table.py
@@ -206,6 +206,14 @@ class PartitionedTableTestCase(BaseTestCase):
         select_distinct_table = self.test_table.select_distinct(["c", "e"])
         self.assertEqual(keys_table.size, select_distinct_table.size)
 
+        with ugp.shared_lock():
+            test_table = time_table("00:00:00.001").update(["X=i", "Y=i%13", "Z=X*Y"])
+        pt = test_table.partition_by("Y")
+        self.wait_ticking_table_update(test_table, row_count=20, timeout=5)
+        keys_table = pt.keys()
+        select_distinct_table = test_table.select_distinct(["Y"])
+        self.assertEqual(keys_table.size, select_distinct_table.size)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/server/tests/test_partitioned_table.py
+++ b/py/server/tests/test_partitioned_table.py
@@ -201,6 +201,11 @@ class PartitionedTableTestCase(BaseTestCase):
         with self.subTest("Compatible table definition"):
             pt = PartitionedTable.from_constituent_tables([test_table, test_table1, test_table3], test_table.columns)
 
+    def test_keys(self):
+        keys_table = self.partitioned_table.keys()
+        select_distinct_table = self.test_table.select_distinct(["c", "e"])
+        self.assertEqual(keys_table.size, select_distinct_table.size)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It is equivalent to performing the select_distinct(key_columns) op on the underlying partitioned table.

Fixes #2520 