### PR TITLE
Remove unnecessary null checks in js api for figures

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
@@ -149,15 +149,11 @@ public class JsFigure extends HasEventHandling {
 
             for (int i = 0; i < tables.length; i++) {
                 JsTable table = tables[i];
-                if (table != null) {
-                    registerTableWithId(table, Js.cast(JsArray.of((double) i)));
-                }
+                registerTableWithId(table, Js.cast(JsArray.of((double) i)));
             }
             for (int i = 0; i < partitionedTables.length; i++) {
                 JsPartitionedTable partitionedTable = partitionedTables[i];
-                if (partitionedTable != null) {
-                    registerPartitionedTableWithId(partitionedTable, Js.cast(JsArray.of((double) i)));
-                }
+                registerPartitionedTableWithId(partitionedTable, Js.cast(JsArray.of((double) i)));
             }
             Arrays.stream(charts)
                     .flatMap(c -> Arrays.stream(c.getSeries()))
@@ -496,7 +492,7 @@ public class JsFigure extends HasEventHandling {
     public void enqueueSubscriptionCheck() {
         if (!subCheckEnqueued) {
             for (JsTable table : tables) {
-                if (table != null && table.isClosed()) {
+                if (table.isClosed()) {
                     throw new IllegalStateException("Cannot subscribe, at least one table is disconnected");
                 }
             }
@@ -535,7 +531,7 @@ public class JsFigure extends HasEventHandling {
         }
 
         if (tables != null) {
-            Arrays.stream(tables).filter(t -> t != null && !t.isClosed()).forEach(JsTable::close);
+            Arrays.stream(tables).filter(t -> !t.isClosed()).forEach(JsTable::close);
         }
         if (partitionedTables != null) {
             Arrays.stream(partitionedTables).forEach(JsPartitionedTable::close);


### PR DESCRIPTION
These were introduced as part of the partitioned table work but never removed when rendered unnecessary.

Follow-up to #2612, #2617, as well as #2485.