### PR TITLE
UpdateBy config changes in support of gRPC

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateBy.java
@@ -87,10 +87,10 @@ public abstract class UpdateBy {
             @NotNull final UpdateByControl control) {
 
         WritableRowRedirection rowRedirection = null;
-        if (control.useRedirection()) {
+        if (control.useRedirectionOrDefault()) {
             if (!source.isRefreshing()) {
                 if (!source.isFlat() && SparseConstants.sparseStructureExceedsOverhead(source.getRowSet(),
-                        control.maxStaticSparseMemoryOverhead())) {
+                        control.maxStaticSparseMemoryOverheadOrDefault())) {
                     rowRedirection = new InverseRowRedirectionImpl(source.getRowSet());
                 }
             } else {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateByOperatorFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateByOperatorFactory.java
@@ -225,28 +225,28 @@ public class UpdateByOperatorFactory {
             final long timeScaleUnits = ema.timeScale().timescaleUnits();
 
             if (csType == byte.class || csType == Byte.class) {
-                return new ByteEMAOperator(pair, affectingColumns, ema.control(), recorder, timeScaleUnits,
+                return new ByteEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder, timeScaleUnits,
                         columnSource, rowRedirection);
             } else if (csType == short.class || csType == Short.class) {
-                return new ShortEMAOperator(pair, affectingColumns, ema.control(), recorder, timeScaleUnits,
+                return new ShortEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder, timeScaleUnits,
                         columnSource, rowRedirection);
             } else if (csType == int.class || csType == Integer.class) {
-                return new IntEMAOperator(pair, affectingColumns, ema.control(), recorder, timeScaleUnits,
+                return new IntEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder, timeScaleUnits,
                         columnSource, rowRedirection);
             } else if (csType == long.class || csType == Long.class) {
-                return new LongEMAOperator(pair, affectingColumns, ema.control(), recorder, timeScaleUnits,
+                return new LongEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder, timeScaleUnits,
                         columnSource, rowRedirection);
             } else if (csType == float.class || csType == Float.class) {
-                return new FloatEMAOperator(pair, affectingColumns, ema.control(), recorder, timeScaleUnits,
+                return new FloatEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder, timeScaleUnits,
                         columnSource, rowRedirection);
             } else if (csType == double.class || csType == Double.class) {
-                return new DoubleEMAOperator(pair, affectingColumns, ema.control(), recorder,
+                return new DoubleEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder,
                         timeScaleUnits, columnSource, rowRedirection);
             } else if (csType == BigDecimal.class) {
-                return new BigDecimalEMAOperator(pair, affectingColumns, ema.control(), recorder,
+                return new BigDecimalEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder,
                         timeScaleUnits, columnSource, rowRedirection);
             } else if (csType == BigInteger.class) {
-                return new BigIntegerEMAOperator(pair, affectingColumns, ema.control(), recorder,
+                return new BigIntegerEMAOperator(pair, affectingColumns, ema.controlOrDefault(), recorder,
                         timeScaleUnits, columnSource, rowRedirection);
             }
 
@@ -285,7 +285,7 @@ public class UpdateByOperatorFactory {
             } else if (csType == double.class || csType == Double.class) {
                 return new DoubleCumProdOperator(fc, rowRedirection);
             } else if (csType == BigDecimal.class) {
-                return new BigDecimalCumProdOperator(fc, rowRedirection, control.mathContext());
+                return new BigDecimalCumProdOperator(fc, rowRedirection, control.mathContextOrDefault());
             } else if (csType == BigInteger.class) {
                 return new BigIntegerCumProdOperator(fc, rowRedirection);
             }
@@ -333,7 +333,7 @@ public class UpdateByOperatorFactory {
             } else if (csType == double.class || csType == Double.class) {
                 return new DoubleCumSumOperator(fc, rowRedirection);
             } else if (csType == BigDecimal.class) {
-                return new BigDecimalCumSumOperator(fc, rowRedirection, control.mathContext());
+                return new BigDecimalCumSumOperator(fc, rowRedirection, control.mathContextOrDefault());
             } else if (csType == BigInteger.class) {
                 return new BigIntegerCumSumOperator(fc, rowRedirection);
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ZeroKeyUpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ZeroKeyUpdateBy.java
@@ -133,9 +133,10 @@ class ZeroKeyUpdateBy extends UpdateBy {
         UpdateContext(@NotNull final TableUpdate upstream,
                 @Nullable final ModifiedColumnSet[] inputModifiedColumnSets,
                 final boolean isInitializeStep) {
-            final int updateSize = UpdateSizeCalculator.chunkSize(upstream, control.chunkCapacity());
+            final int updateSize = UpdateSizeCalculator.chunkSize(upstream, control.chunkCapacityOrDefault());
 
-            this.chunkSize = UpdateSizeCalculator.chunkSize(updateSize, upstream.shifted(), control.chunkCapacity());
+            this.chunkSize =
+                    UpdateSizeCalculator.chunkSize(updateSize, upstream.shifted(), control.chunkCapacityOrDefault());
             this.opAffected = new boolean[operators.length];
             // noinspection unchecked
             this.fillContexts = new SizedSafeCloseable[operators.length];
@@ -413,7 +414,7 @@ class ZeroKeyUpdateBy extends UpdateBy {
             final RowSet sourceRowSet = source.getRowSet();
             try (final RowSet indexToReprocess =
                     sourceRowSet.subSetByKeyRange(smallestModifiedKey, sourceRowSet.lastRowKey())) {
-                final int newChunkSize = (int) Math.min(control.chunkCapacity(), indexToReprocess.size());
+                final int newChunkSize = (int) Math.min(control.chunkCapacityOrDefault(), indexToReprocess.size());
                 setChunkSize(newChunkSize);
 
                 final long keyBefore;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BasePrimitiveEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BasePrimitiveEMAOperator.java
@@ -288,25 +288,25 @@ public abstract class BasePrimitiveEMAOperator extends BaseDoubleUpdateByOperato
             final boolean isNullTime) {
         boolean doReset = false;
         if (isNull) {
-            if (control.onNullValue() == BadDataBehavior.Throw) {
+            if (control.onNullValueOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered null value during EMA processing");
             }
-            doReset = control.onNullValue() == BadDataBehavior.Reset;
+            doReset = control.onNullValueOrDefault() == BadDataBehavior.RESET;
         } else if (isNan) {
-            if (control.onNanValue() == BadDataBehavior.Throw) {
+            if (control.onNanValueOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered NaN value during EMA processing");
-            } else if (control.onNanValue() == BadDataBehavior.Poison) {
+            } else if (control.onNanValueOrDefault() == BadDataBehavior.POISON) {
                 ctx.curVal = Double.NaN;
             } else {
-                doReset = control.onNanValue() == BadDataBehavior.Reset;
+                doReset = control.onNanValueOrDefault() == BadDataBehavior.RESET;
             }
         }
 
         if (isNullTime) {
-            if (control.onNullTime() == BadDataBehavior.Throw) {
+            if (control.onNullTimeOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered null timestamp during EMA processing");
             }
-            doReset = control.onNullTime() == BadDataBehavior.Reset;
+            doReset = control.onNullTimeOrDefault() == BadDataBehavior.RESET;
         }
 
         if (doReset) {
@@ -318,15 +318,15 @@ public abstract class BasePrimitiveEMAOperator extends BaseDoubleUpdateByOperato
     void handleBadTime(@NotNull final EmaContext ctx, final long dt) {
         boolean doReset = false;
         if (dt == 0) {
-            if (control.onZeroDeltaTime() == BadDataBehavior.Throw) {
+            if (control.onZeroDeltaTimeOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered zero delta time during EMA processing");
             }
-            doReset = control.onZeroDeltaTime() == BadDataBehavior.Reset;
+            doReset = control.onZeroDeltaTimeOrDefault() == BadDataBehavior.RESET;
         } else if (dt < 0) {
-            if (control.onNegativeDeltaTime() == BadDataBehavior.Throw) {
+            if (control.onNegativeDeltaTimeOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered negative delta time during EMA processing");
             }
-            doReset = control.onNegativeDeltaTime() == BadDataBehavior.Reset;
+            doReset = control.onNegativeDeltaTimeOrDefault() == BadDataBehavior.RESET;
         }
 
         if (doReset) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigDecimalEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigDecimalEMAOperator.java
@@ -57,9 +57,9 @@ public class BigDecimalEMAOperator extends BigNumberEMAOperator<BigDecimal> {
                 if (ctx.curVal == null) {
                     ctx.curVal = input;
                 } else {
-                    ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContext())
-                            .add(input.multiply(ctx.oneMinusAlpha, control.bigValueContext()),
-                                    control.bigValueContext());
+                    ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContextOrDefault())
+                            .add(input.multiply(ctx.oneMinusAlpha, control.bigValueContextOrDefault()),
+                                    control.bigValueContextOrDefault());
                 }
             }
 
@@ -90,11 +90,11 @@ public class BigDecimalEMAOperator extends BigNumberEMAOperator<BigDecimal> {
                         handleBadTime(ctx, dt);
                     } else {
                         ctx.alpha = BigDecimal.valueOf(Math.exp(-dt / timeScaleUnits));
-                        ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContext())
+                        ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContextOrDefault())
                                 .add(input.multiply(
-                                        BigDecimal.ONE.subtract(ctx.alpha, control.bigValueContext()),
-                                        control.bigValueContext()),
-                                        control.bigValueContext());
+                                        BigDecimal.ONE.subtract(ctx.alpha, control.bigValueContextOrDefault()),
+                                        control.bigValueContextOrDefault()),
+                                        control.bigValueContextOrDefault());
                         ctx.lastStamp = timestamp;
                     }
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigIntegerEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigIntegerEMAOperator.java
@@ -55,15 +55,15 @@ public class BigIntegerEMAOperator extends BigNumberEMAOperator<BigInteger> {
             if(input == null) {
                 handleBadData(ctx, true, false);
             } else {
-                final BigDecimal decimalInput = new BigDecimal(input, control.bigValueContext());
+                final BigDecimal decimalInput = new BigDecimal(input, control.bigValueContextOrDefault());
                 if(ctx.curVal == null) {
                     ctx.curVal = decimalInput;
                 } else {
-                    ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContext())
+                    ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContextOrDefault())
                             .add(decimalInput.multiply(
-                                            BigDecimal.ONE.subtract(ctx.alpha, control.bigValueContext()),
-                                            control.bigValueContext()),
-                                    control.bigValueContext());
+                                            BigDecimal.ONE.subtract(ctx.alpha, control.bigValueContextOrDefault()),
+                                            control.bigValueContextOrDefault()),
+                                    control.bigValueContextOrDefault());
                 }
             }
 
@@ -86,7 +86,7 @@ public class BigIntegerEMAOperator extends BigNumberEMAOperator<BigInteger> {
             if(isNull || isNullTime) {
                 handleBadData(ctx, isNull, isNullTime);
             } else {
-                final BigDecimal decimalInput = new BigDecimal(input, control.bigValueContext());
+                final BigDecimal decimalInput = new BigDecimal(input, control.bigValueContextOrDefault());
                 if(ctx.curVal == null) {
                     ctx.curVal = decimalInput;
                     ctx.lastStamp = timestamp;
@@ -96,9 +96,9 @@ public class BigIntegerEMAOperator extends BigNumberEMAOperator<BigInteger> {
                         handleBadTime(ctx, dt);
                     } else {
                         ctx.alpha = BigDecimal.valueOf(Math.exp(-dt / timeScaleUnits));
-                        ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContext())
-                                .add(decimalInput.multiply(BigDecimal.ONE.subtract(ctx.alpha, control.bigValueContext()), control.bigValueContext()),
-                                        control.bigValueContext());
+                        ctx.curVal = ctx.curVal.multiply(ctx.alpha, control.bigValueContextOrDefault())
+                                .add(decimalInput.multiply(BigDecimal.ONE.subtract(ctx.alpha, control.bigValueContextOrDefault()), control.bigValueContextOrDefault()),
+                                        control.bigValueContextOrDefault());
                         ctx.lastStamp = timestamp;
                     }
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigNumberEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigNumberEMAOperator.java
@@ -43,7 +43,7 @@ public abstract class BigNumberEMAOperator<T> extends BaseObjectUpdateByOperator
     class EmaContext extends Context {
         BigDecimal alpha = BigDecimal.valueOf(Math.exp(-1 / timeScaleUnits));
         BigDecimal oneMinusAlpha =
-                timeRecorder == null ? BigDecimal.ONE.subtract(alpha, control.bigValueContext()) : null;
+                timeRecorder == null ? BigDecimal.ONE.subtract(alpha, control.bigValueContextOrDefault()) : null;
         long lastStamp = NULL_LONG;
 
         EmaContext(final int chunkSize) {
@@ -291,17 +291,17 @@ public abstract class BigNumberEMAOperator<T> extends BaseObjectUpdateByOperator
             final boolean isNullTime) {
         boolean doReset = false;
         if (isNull) {
-            if (control.onNullValue() == BadDataBehavior.Throw) {
+            if (control.onNullValueOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered invalid data during EMA processing");
             }
-            doReset = control.onNullValue() == BadDataBehavior.Reset;
+            doReset = control.onNullValueOrDefault() == BadDataBehavior.RESET;
         }
 
         if (isNullTime) {
-            if (control.onNullTime() == BadDataBehavior.Throw) {
+            if (control.onNullTimeOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered null timestamp during EMA processing");
             }
-            doReset = control.onNullTime() == BadDataBehavior.Reset;
+            doReset = control.onNullTimeOrDefault() == BadDataBehavior.RESET;
         }
 
         if (doReset) {
@@ -313,15 +313,15 @@ public abstract class BigNumberEMAOperator<T> extends BaseObjectUpdateByOperator
     void handleBadTime(@NotNull final EmaContext ctx, final long dt) {
         boolean doReset = false;
         if (dt == 0) {
-            if (control.onZeroDeltaTime() == BadDataBehavior.Throw) {
+            if (control.onZeroDeltaTimeOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered zero delta time during EMA processing");
             }
-            doReset = control.onZeroDeltaTime() == BadDataBehavior.Reset;
+            doReset = control.onZeroDeltaTimeOrDefault() == BadDataBehavior.RESET;
         } else if (dt < 0) {
-            if (control.onNegativeDeltaTime() == BadDataBehavior.Throw) {
+            if (control.onNegativeDeltaTimeOrDefault() == BadDataBehavior.THROW) {
                 throw new TableDataException("Encountered negative delta time during EMA processing");
             }
-            doReset = control.onNegativeDeltaTime() == BadDataBehavior.Reset;
+            doReset = control.onNegativeDeltaTimeOrDefault() == BadDataBehavior.RESET;
         }
 
         if (doReset) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/DoubleEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/DoubleEMAOperator.java
@@ -128,6 +128,6 @@ public class DoubleEMAOperator extends BasePrimitiveEMAOperator {
 
         // Note that we don't care about Reset because in that case the current EMA at this key would be null
         // and the superclass will do the right thing.
-        return !Double.isNaN(value) || control.onNanValue() != BadDataBehavior.Skip;
+        return !Double.isNaN(value) || control.onNanValueOrDefault() != BadDataBehavior.SKIP;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/FloatEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/FloatEMAOperator.java
@@ -123,6 +123,6 @@ public class FloatEMAOperator extends BasePrimitiveEMAOperator {
 
         // Note that we don't care about Reset because in that case the current EMA at this key would be null
         // and the superclass will do the right thing.
-        return !Float.isNaN(value) || control.onNanValue() != BadDataBehavior.Skip;
+        return !Float.isNaN(value) || control.onNanValueOrDefault() != BadDataBehavior.SKIP;
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
@@ -289,7 +289,7 @@ public class TestCumProd extends BaseUpdateByTest {
                 result[i] = result[i - 1];
             } else if (isBD) {
                 result[i] = ((BigDecimal) result[i - 1]).multiply((BigDecimal) values[i],
-                        UpdateByControl.defaultInstance().mathContext());
+                        UpdateByControl.mathContextDefault());
             } else {
                 result[i] = ((BigInteger) result[i - 1]).multiply((BigInteger) values[i]);
             }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
@@ -321,7 +321,7 @@ public class TestCumSum extends BaseUpdateByTest {
                 result[i] = result[i - 1];
             } else if (isBD) {
                 result[i] = ((BigDecimal) result[i - 1]).add((BigDecimal) values[i],
-                        UpdateByControl.defaultInstance().mathContext());
+                        UpdateByControl.mathContextDefault());
             } else {
                 result[i] = ((BigInteger) result[i - 1]).add((BigInteger) values[i]);
             }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestEma.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestEma.java
@@ -48,12 +48,12 @@ public class TestEma extends BaseUpdateByTest {
                         convertDateTime("2022-03-09T16:30:00.000 NY"))}).t;
 
         final EmaControl skipControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Skip)
-                .onNanValue(BadDataBehavior.Skip).build();
+                .onNullValue(BadDataBehavior.SKIP)
+                .onNanValue(BadDataBehavior.SKIP).build();
 
         final EmaControl resetControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Reset)
-                .onNanValue(BadDataBehavior.Reset).build();
+                .onNullValue(BadDataBehavior.RESET)
+                .onNanValue(BadDataBehavior.RESET).build();
 
         computeEma((TableWithDefaults) t.dropColumns("ts"), null, 100, skipControl);
         computeEma((TableWithDefaults) t.dropColumns("ts"), null, 100, resetControl);
@@ -82,12 +82,12 @@ public class TestEma extends BaseUpdateByTest {
                         convertDateTime("2022-03-09T16:30:00.000 NY"))}).t;
 
         final EmaControl skipControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Skip)
-                .onNanValue(BadDataBehavior.Skip).build();
+                .onNullValue(BadDataBehavior.SKIP)
+                .onNanValue(BadDataBehavior.SKIP).build();
 
         final EmaControl resetControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Reset)
-                .onNanValue(BadDataBehavior.Reset).build();
+                .onNullValue(BadDataBehavior.RESET)
+                .onNanValue(BadDataBehavior.RESET).build();
         computeEma((TableWithDefaults) t.dropColumns("ts"), null, 100, skipControl, "Sym");
         computeEma((TableWithDefaults) t.dropColumns("ts"), null, 100, resetControl, "Sym");
 
@@ -98,7 +98,7 @@ public class TestEma extends BaseUpdateByTest {
     @Test
     public void testThrowBehaviors() {
         final EmaControl throwControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Throw).build();
+                .onNullValue(BadDataBehavior.THROW).build();
 
         final TableWithDefaults bytes = testTable(RowSetFactory.flat(4).toTracking(),
                 byteCol("col", (byte) 0, (byte) 1, NULL_BYTE, (byte) 3));
@@ -133,12 +133,12 @@ public class TestEma extends BaseUpdateByTest {
 
         assertThrows(TableDataException.class,
                 () -> floats.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNullValue(BadDataBehavior.Throw).build(), 10)),
+                        UpdateByClause.Ema(EmaControl.builder().onNullValue(BadDataBehavior.THROW).build(), 10)),
                 "Encountered null value during EMA processing");
 
         assertThrows(TableDataException.class,
                 () -> floats.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNanValue(BadDataBehavior.Throw).build(), 10)),
+                        UpdateByClause.Ema(EmaControl.builder().onNanValue(BadDataBehavior.THROW).build(), 10)),
                 "Encountered NaN value during EMA processing");
 
         TableWithDefaults doubles = testTable(RowSetFactory.flat(4).toTracking(),
@@ -146,12 +146,12 @@ public class TestEma extends BaseUpdateByTest {
 
         assertThrows(TableDataException.class,
                 () -> doubles.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNullValue(BadDataBehavior.Throw).build(), 10)),
+                        UpdateByClause.Ema(EmaControl.builder().onNullValue(BadDataBehavior.THROW).build(), 10)),
                 "Encountered null value during EMA processing");
 
         assertThrows(TableDataException.class,
                 () -> doubles.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNanValue(BadDataBehavior.Throw).build(), 10)),
+                        UpdateByClause.Ema(EmaControl.builder().onNanValue(BadDataBehavior.THROW).build(), 10)),
                 "Encountered NaN value during EMA processing");
 
 
@@ -227,16 +227,16 @@ public class TestEma extends BaseUpdateByTest {
         assertThrows(TableDataException.class,
                 () -> table.updateBy(UpdateByClause.Ema(
                         EmaControl.builder()
-                                .onNegativeDeltaTime(BadDataBehavior.Skip)
-                                .onZeroDeltaTime(BadDataBehavior.Throw).build(),
+                                .onNegativeDeltaTime(BadDataBehavior.SKIP)
+                                .onZeroDeltaTime(BadDataBehavior.THROW).build(),
                         "ts", 100)),
                 "Encountered zero delta time during EMA processing");
 
         assertThrows(TableDataException.class,
                 () -> table.updateBy(UpdateByClause.Ema(
                         EmaControl.builder()
-                                .onNegativeDeltaTime(BadDataBehavior.Skip)
-                                .onNullTime(BadDataBehavior.Throw).build(),
+                                .onNegativeDeltaTime(BadDataBehavior.SKIP)
+                                .onNullTime(BadDataBehavior.THROW).build(),
                         "ts", 100)),
                 "Encountered null timestamp during EMA processing");
     }
@@ -283,7 +283,7 @@ public class TestEma extends BaseUpdateByTest {
 
         // Test reset for NaN values
         final EmaControl resetControl = EmaControl.builder()
-                .onNanValue(BadDataBehavior.Reset)
+                .onNanValue(BadDataBehavior.RESET)
                 .build();
 
         TableWithDefaults input = testTable(RowSetFactory.flat(3).toTracking(), doubleCol("col", 0, Double.NaN, 1));
@@ -298,9 +298,9 @@ public class TestEma extends BaseUpdateByTest {
     }
 
     private void testResetBehaviorInternal(Table expected, final ColumnHolder ts, final ColumnHolder col) {
-        final EmaControl resetControl = EmaControl.builder().onNegativeDeltaTime(BadDataBehavior.Reset)
-                .onNullTime(BadDataBehavior.Reset)
-                .onZeroDeltaTime(BadDataBehavior.Reset)
+        final EmaControl resetControl = EmaControl.builder().onNegativeDeltaTime(BadDataBehavior.RESET)
+                .onNullTime(BadDataBehavior.RESET)
+                .onZeroDeltaTime(BadDataBehavior.RESET)
                 .build();
 
         TableWithDefaults input = testTable(RowSetFactory.flat(6).toTracking(), ts, col);
@@ -310,10 +310,10 @@ public class TestEma extends BaseUpdateByTest {
 
     @Test
     public void testPoison() {
-        final EmaControl nanCtl = EmaControl.builder().onNanValue(BadDataBehavior.Poison)
-                .onNullValue(BadDataBehavior.Reset)
-                .onNullTime(BadDataBehavior.Reset)
-                .onNegativeDeltaTime(BadDataBehavior.Reset)
+        final EmaControl nanCtl = EmaControl.builder().onNanValue(BadDataBehavior.POISON)
+                .onNullValue(BadDataBehavior.RESET)
+                .onNullTime(BadDataBehavior.RESET)
+                .onNegativeDeltaTime(BadDataBehavior.RESET)
                 .build();
 
         Table expected = testTable(RowSetFactory.flat(5).toTracking(),
@@ -381,12 +381,12 @@ public class TestEma extends BaseUpdateByTest {
         }
 
         final EmaControl skipControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Skip)
-                .onNanValue(BadDataBehavior.Skip).build();
+                .onNullValue(BadDataBehavior.SKIP)
+                .onNanValue(BadDataBehavior.SKIP).build();
 
         final EmaControl resetControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Reset)
-                .onNanValue(BadDataBehavior.Reset).build();
+                .onNullValue(BadDataBehavior.RESET)
+                .onNanValue(BadDataBehavior.RESET).build();
 
         final EvalNugget[] nuggets = new EvalNugget[] {
                 new EvalNugget() {
@@ -464,10 +464,10 @@ public class TestEma extends BaseUpdateByTest {
             String... groups) {
         final boolean useTicks = StringUtils.isNullOrEmpty(tsCol);
         final ByEmaSimple bes = new ByEmaSimple(
-                control.onNullValue() == BadDataBehavior.Reset
+                control.onNullValueOrDefault() == BadDataBehavior.RESET
                         ? ByEma.BadDataBehavior.BD_RESET
                         : ByEma.BadDataBehavior.BD_SKIP,
-                control.onNanValue() == BadDataBehavior.Reset
+                control.onNanValueOrDefault() == BadDataBehavior.RESET
                         ? ByEma.BadDataBehavior.BD_RESET
                         : ByEma.BadDataBehavior.BD_SKIP,
                 useTicks ? AbstractMa.Mode.TICK : AbstractMa.Mode.TIME,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
@@ -76,8 +76,8 @@ public class TestUpdateByGeneral extends BaseUpdateByTest {
         }
 
         final EmaControl skipControl = EmaControl.builder()
-                .onNullValue(BadDataBehavior.Skip)
-                .onNanValue(BadDataBehavior.Skip).build();
+                .onNullValue(BadDataBehavior.SKIP)
+                .onNanValue(BadDataBehavior.SKIP).build();
 
         final EvalNugget[] nuggets = new EvalNugget[] {
                 new EvalNugget() {
@@ -100,19 +100,7 @@ public class TestUpdateByGeneral extends BaseUpdateByTest {
                                 UpdateByClause.CumMax(makeOpColNames(columnNamesArray, "_max", "boolCol")),
                                 UpdateByClause
                                         .CumProd(makeOpColNames(columnNamesArray, "_prod", "Sym", "ts", "boolCol")));
-
-                        final UpdateByControl control;
-                        if (redirected) {
-                            control = new UpdateByControl() {
-                                @Override
-                                public boolean useRedirection() {
-                                    return true;
-                                }
-                            };
-                        } else {
-                            control = UpdateByControl.defaultInstance();
-                        }
-
+                        final UpdateByControl control = UpdateByControl.builder().useRedirection(redirected).build();
                         return bucketed
                                 ? base.updateBy(control, clauses, Selectable.from("Sym"))
                                 : base.updateBy(control, clauses);

--- a/table-api/src/main/java/io/deephaven/api/updateby/BadDataBehavior.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/BadDataBehavior.java
@@ -5,14 +5,14 @@ package io.deephaven.api.updateby;
  */
 public enum BadDataBehavior {
     /** Reset the state for the bucket to {@code null} when invalid data is encountered */
-    Reset,
+    RESET,
 
     /** Skip and do not process the invalid data without changing state */
-    Skip,
+    SKIP,
 
     /** Throw an exception and abort processing when bad data is encountered */
-    Throw,
+    THROW,
 
     /** Allow the bad data to poison the result. This is only valid for use with NaN */
-    Poison
+    POISON
 }

--- a/table-api/src/main/java/io/deephaven/api/updateby/EmaControl.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/EmaControl.java
@@ -1,10 +1,11 @@
 package io.deephaven.api.updateby;
 
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
-import org.immutables.value.Value.Default;
 import io.deephaven.annotations.BuildableStyle;
 
 import java.math.MathContext;
+import java.util.Optional;
 
 /**
  * <p>
@@ -29,67 +30,95 @@ public abstract class EmaControl {
         return ImmutableEmaControl.builder();
     }
 
-    public final static EmaControl DEFAULT = ImmutableEmaControl.builder().build();
+    public static EmaControl defaultInstance() {
+        return builder().build();
+    }
+
+    public abstract Optional<BadDataBehavior> onNullValue();
+
+    public abstract Optional<BadDataBehavior> onNanValue();
+
+    public abstract Optional<BadDataBehavior> onNullTime();
+
+    public abstract Optional<BadDataBehavior> onNegativeDeltaTime();
+
+    public abstract Optional<BadDataBehavior> onZeroDeltaTime();
+
+    public abstract Optional<MathContext> bigValueContext();
 
     /**
-     * Get the behavior for when null values are encountered.
+     * Get the behavior for when {@code null} values are encountered. Defaults to {@link BadDataBehavior#SKIP SKIP}.
      * 
-     * @return the behavior for null values.
+     * @return the behavior for {@code null} values.
      */
-    @Default
-    public BadDataBehavior onNullValue() {
-        return BadDataBehavior.Skip;
+    @Value.Derived
+    public BadDataBehavior onNullValueOrDefault() {
+        return onNullValue().orElse(BadDataBehavior.SKIP);
     }
 
     /**
-     * Get the behavior for when NaN values are encountered.
+     * Get the behavior for when {@link Double#NaN} values are encountered. Defaults to {@link BadDataBehavior#SKIP
+     * SKIP}.
      * 
-     * @return the behavior for NaN values
+     * @return the behavior for {@link Double#NaN} values
      */
-    @Default
-    public BadDataBehavior onNanValue() {
-        return BadDataBehavior.Skip;
+    @Value.Derived
+    public BadDataBehavior onNanValueOrDefault() {
+        return onNanValue().orElse(BadDataBehavior.SKIP);
     }
 
     /**
-     * Get the behavior for when null timestamps are encountered.
+     * Get the behavior for when {@code null} timestamps are encountered. Defaults to {@link BadDataBehavior#SKIP SKIP}.
      * 
-     * @return the behavior for null timestamps.
+     * @return the behavior for {@code null} timestamps.
      */
-    @Default
-    public BadDataBehavior onNullTime() {
-        return BadDataBehavior.Skip;
+    @Value.Derived
+    public BadDataBehavior onNullTimeOrDefault() {
+        return onNullTime().orElse(BadDataBehavior.SKIP);
     }
 
     /**
-     * Get the behavior for when negative sample-to-sample time differences are encountered
+     * Get the behavior for when negative sample-to-sample time differences are encountered. Defaults to
+     * {@link BadDataBehavior#THROW THROW}.
      * 
      * @return the behavior for when dt is negative
      */
-    @Default
-    public BadDataBehavior onNegativeDeltaTime() {
-        return BadDataBehavior.Throw;
+    @Value.Derived
+    public BadDataBehavior onNegativeDeltaTimeOrDefault() {
+        return onNegativeDeltaTime().orElse(BadDataBehavior.THROW);
     }
 
     /**
-     * Get the behavior for when zero sample-to-sample-time differences are encountered.
+     * Get the behavior for when zero sample-to-sample-time differences are encountered. Defaults to
+     * {@link BadDataBehavior#SKIP SKIP}.
      * 
      * @return the behavior for when dt is zero
      */
-    @Default
-    public BadDataBehavior onZeroDeltaTime() {
-        return BadDataBehavior.Skip;
+    @Value.Derived
+    public BadDataBehavior onZeroDeltaTimeOrDefault() {
+        return onZeroDeltaTime().orElse(BadDataBehavior.SKIP);
     }
 
     /**
      * Get the {@link MathContext} to use when processing {@link java.math.BigInteger} and {@link java.math.BigDecimal}
-     * values.
+     * values. Defaults to {@link MathContext#DECIMAL128}.
      * 
      * @return the {@link MathContext}
      */
-    @Default
-    public MathContext bigValueContext() {
-        return MathContext.DECIMAL128;
+    @Value.Derived
+    public MathContext bigValueContextOrDefault() {
+        return bigValueContext().orElse(MathContext.DECIMAL128);
+    }
+
+    public final EmaControl materialize() {
+        return builder()
+                .onNullValue(onNullValueOrDefault())
+                .onNanValue(onNanValueOrDefault())
+                .onNullTime(onNullTimeOrDefault())
+                .onNegativeDeltaTime(onNegativeDeltaTimeOrDefault())
+                .onZeroDeltaTime(onZeroDeltaTimeOrDefault())
+                .bigValueContext(bigValueContextOrDefault())
+                .build();
     }
 
     public interface Builder {

--- a/table-api/src/main/java/io/deephaven/api/updateby/EmaControl.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/EmaControl.java
@@ -110,6 +110,13 @@ public abstract class EmaControl {
         return bigValueContext().orElse(MathContext.DECIMAL128);
     }
 
+    /**
+     * Create a new instance with all of the explicit-or-default values from {@code this}. This may be useful from the
+     * context of a client who wants to use client-side configuration defaults instead of server-side configuration
+     * defaults.
+     *
+     * @return the explicit new instance
+     */
     public final EmaControl materialize() {
         return builder()
                 .onNullValue(onNullValueOrDefault())

--- a/table-api/src/main/java/io/deephaven/api/updateby/UpdateByControl.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/UpdateByControl.java
@@ -1,11 +1,16 @@
 package io.deephaven.api.updateby;
 
 import io.deephaven.annotations.BuildableStyle;
+import org.immutables.value.Value;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Default;
 
+import javax.annotation.Nullable;
 import java.math.MathContext;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 
 /**
  * An interface to control the behavior of an {@code Table#updateBy}
@@ -26,8 +31,63 @@ public abstract class UpdateByControl {
         return builder().build();
     }
 
+    public static boolean useRedirectionDefault() {
+        return Boolean.getBoolean("UpdateByControl.useRedirection");
+    }
+
+    public static int chunkCapacityDefault() {
+        return Integer.getInteger("UpdateByControl.chunkCapacity", 4096);
+    }
+
+    public static double maximumStaticMemoryOverheadDefault() {
+        return Double.parseDouble(System.getProperty("UpdateByControl.maximumStaticMemoryOverhead", "1.1"));
+    }
+
+    public static int initialHashTableSizeDefault() {
+        return Integer.getInteger("UpdateByControl.initialHashTableSize", 4096);
+    }
+
+    public static double maximumLoadFactorDefault() {
+        return Double.parseDouble(System.getProperty("UpdateByControl.maximumLoadFactor", "0.75"));
+    }
+
+    public static double targetLoadFactorDefault() {
+        return Double.parseDouble(System.getProperty("UpdateByControl.targetLoadFactor", "0.7"));
+    }
+
+    public static MathContext mathContextDefault() {
+        final String p = System.getProperty("UpdateByControl.mathContext", "DECIMAL64");
+        switch (p) {
+            case "UNLIMITED":
+                return MathContext.UNLIMITED;
+            case "DECIMAL32":
+                return MathContext.DECIMAL32;
+            case "DECIMAL64":
+                return MathContext.DECIMAL64;
+            case "DECIMAL128":
+                return MathContext.DECIMAL128;
+            default:
+                throw new IllegalArgumentException("Unexpected UpdateByControl.mathContext: " + p);
+        }
+    }
+
+    @Nullable
+    public abstract Boolean useRedirection();
+
+    public abstract OptionalInt chunkCapacity();
+
+    public abstract OptionalDouble maxStaticSparseMemoryOverhead();
+
+    public abstract OptionalInt initialHashTableSize();
+
+    public abstract OptionalDouble maximumLoadFactor();
+
+    public abstract OptionalDouble targetLoadFactor();
+
+    public abstract Optional<MathContext> mathContext();
+
     /**
-     * if redirections should be used for output sources instead of sparse array sources.
+     * If redirections should be used for output sources instead of sparse array sources.
      *
      * <p>
      * Default is `false`. Can be changed with system property {@code UpdateByControl.useRedirection} or by providing a
@@ -35,13 +95,14 @@ public abstract class UpdateByControl {
      *
      * @return true if redirections should be used.
      */
-    @Default
-    public boolean useRedirection() {
-        return Boolean.getBoolean("UpdateByControl.useRedirectionOutput");
+    @Value.Derived
+    public boolean useRedirectionOrDefault() {
+        final Boolean useRedirection = useRedirection();
+        return useRedirection == null ? useRedirectionDefault() : useRedirection;
     }
 
     /**
-     * Get the default maximum chunk capacity.
+     * Get the maximum chunk capacity.
      *
      * <p>
      * Default is `4096`. Can be changed with system property {@code UpdateByControl.chunkCapacity} or by providing a
@@ -49,9 +110,9 @@ public abstract class UpdateByControl {
      *
      * @return the maximum chunk capacity.
      */
-    @Default
-    public int chunkCapacity() {
-        return Integer.getInteger("UpdateByControl.chunkCapacity", 4096);
+    @Value.Derived
+    public int chunkCapacityOrDefault() {
+        return chunkCapacity().orElseGet(UpdateByControl::chunkCapacityDefault);
     }
 
     /**
@@ -65,9 +126,9 @@ public abstract class UpdateByControl {
      *
      * @return the maximum fractional memory overhead.
      */
-    @Default
-    public double maxStaticSparseMemoryOverhead() {
-        return Double.parseDouble(System.getProperty("UpdateByControl.maximumStaticMemoryOverhead", "1.1"));
+    @Value.Derived
+    public double maxStaticSparseMemoryOverheadOrDefault() {
+        return maxStaticSparseMemoryOverhead().orElseGet(UpdateByControl::maximumStaticMemoryOverheadDefault);
     }
 
     /**
@@ -79,9 +140,9 @@ public abstract class UpdateByControl {
      *
      * @return the initial hash table size
      */
-    @Default
-    public int initialHashTableSize() {
-        return Integer.getInteger("UpdateByControl.initialHashTableSize", 4096);
+    @Value.Derived
+    public int initialHashTableSizeOrDefault() {
+        return initialHashTableSize().orElseGet(UpdateByControl::initialHashTableSizeDefault);
     }
 
     /**
@@ -93,9 +154,9 @@ public abstract class UpdateByControl {
      *
      * @return the maximum load factor
      */
-    @Default
-    public double maximumLoadFactor() {
-        return Double.parseDouble(System.getProperty("UpdateByControl.maximumLoadFactor", "0.75"));
+    @Value.Derived
+    public double maximumLoadFactorOrDefault() {
+        return maximumLoadFactor().orElseGet(UpdateByControl::maximumLoadFactorDefault);
     }
 
     /**
@@ -107,59 +168,76 @@ public abstract class UpdateByControl {
      *
      * @return the target load factor
      */
-    @Default
-    public double targetLoadFactor() {
-        return Double.parseDouble(System.getProperty("UpdateByControl.targetLoadFactor", "0.7"));
+    @Value.Derived
+    public double targetLoadFactorOrDefault() {
+        return targetLoadFactor().orElseGet(UpdateByControl::targetLoadFactorDefault);
     }
 
-    @Default
-    public MathContext mathContext() {
-        return MathContext.DECIMAL64;
+    @Value.Derived
+    public MathContext mathContextOrDefault() {
+        return mathContext().orElseGet(UpdateByControl::mathContextDefault);
+    }
+
+    public final UpdateByControl materialize() {
+        return builder()
+                .useRedirection(useRedirectionOrDefault())
+                .chunkCapacity(chunkCapacityOrDefault())
+                .maxStaticSparseMemoryOverhead(maxStaticSparseMemoryOverheadOrDefault())
+                .initialHashTableSize(initialHashTableSizeOrDefault())
+                .maximumLoadFactor(maximumLoadFactorOrDefault())
+                .targetLoadFactor(targetLoadFactorOrDefault())
+                .mathContext(mathContextOrDefault())
+                .build();
     }
 
     @Check
     final void checkChunkCapacity() {
-        if (chunkCapacity() <= 0) {
-            throw new IllegalArgumentException(
-                    String.format("UpdateByControl.chunkCapacity() must be greater than 0, is %d", chunkCapacity()));
+        if (chunkCapacityOrDefault() <= 0) {
+            throw new IllegalArgumentException(String
+                    .format("UpdateByControl.chunkCapacity() must be greater than 0, is %d", chunkCapacityOrDefault()));
         }
     }
 
     @Check
     final void checkInitialHashTableSize() {
-        if (initialHashTableSize() <= 0) {
-            throw new IllegalArgumentException(String.format(
-                    "UpdateByControl.initialHashTableSize() must be greater than 0, is %d", initialHashTableSize()));
+        if (initialHashTableSizeOrDefault() <= 0) {
+            throw new IllegalArgumentException(
+                    String.format("UpdateByControl.initialHashTableSize() must be greater than 0, is %d",
+                            initialHashTableSizeOrDefault()));
         }
     }
 
     @Check
     final void checkMaximumLoadFactor() {
-        if (Double.isNaN(maximumLoadFactor()) || maximumLoadFactor() <= 0.0 || maximumLoadFactor() >= 1.0) {
-            throw new IllegalArgumentException(String.format(
-                    "UpdateByControl.maximumLoadFactor() must be in the range (0.0, 1.0), is %f", maximumLoadFactor()));
+        if (Double.isNaN(maximumLoadFactorOrDefault()) || maximumLoadFactorOrDefault() <= 0.0
+                || maximumLoadFactorOrDefault() >= 1.0) {
+            throw new IllegalArgumentException(
+                    String.format("UpdateByControl.maximumLoadFactor() must be in the range (0.0, 1.0), is %f",
+                            maximumLoadFactorOrDefault()));
         }
     }
 
     @Check
     final void checkTargetLoadFactor() {
-        if (Double.isNaN(targetLoadFactor()) || targetLoadFactor() <= 0.0 || targetLoadFactor() >= 1.0) {
-            throw new IllegalArgumentException(String.format(
-                    "UpdateByControl.targetLoadFactor() must be in the range (0.0, 1.0), is %f", targetLoadFactor()));
+        if (Double.isNaN(targetLoadFactorOrDefault()) || targetLoadFactorOrDefault() <= 0.0
+                || targetLoadFactorOrDefault() >= 1.0) {
+            throw new IllegalArgumentException(
+                    String.format("UpdateByControl.targetLoadFactor() must be in the range (0.0, 1.0), is %f",
+                            targetLoadFactorOrDefault()));
         }
     }
 
     @Check
     final void checkTargetLTEMaximum() {
-        if (targetLoadFactor() > maximumLoadFactor()) {
+        if (targetLoadFactorOrDefault() > maximumLoadFactorOrDefault()) {
             throw new IllegalArgumentException(String.format(
                     "UpdateByControl.targetLoadFactor() must be less than or equal to UpdateByControl.maximumLoadFactor(). targetLoadFactor=%f, maximumLoadFactor=%f",
-                    targetLoadFactor(), maximumLoadFactor()));
+                    targetLoadFactorOrDefault(), maximumLoadFactorOrDefault()));
         }
     }
 
     public interface Builder {
-        Builder useRedirection(boolean useRedirection);
+        Builder useRedirection(Boolean useRedirection);
 
         Builder chunkCapacity(int chunkCapacity);
 

--- a/table-api/src/main/java/io/deephaven/api/updateby/UpdateByControl.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/UpdateByControl.java
@@ -4,7 +4,6 @@ import io.deephaven.annotations.BuildableStyle;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
-import org.immutables.value.Value.Default;
 
 import javax.annotation.Nullable;
 import java.math.MathContext;
@@ -18,45 +17,76 @@ import java.util.OptionalInt;
 @Immutable
 @BuildableStyle
 public abstract class UpdateByControl {
+
+    public static final String USE_REDIRECTION_PROPERTY = "UpdateByControl.useRedirection";
+    public static final String CHUNK_CAPACITY_PROPERTY = "UpdateByControl.chunkCapacity";
+    public static final String MAXIMUM_STATIC_MEMORY_OVERHEAD_PROPERTY = "UpdateByControl.maximumStaticMemoryOverhead";
+    public static final String INITIAL_HASH_TABLE_SIZE_PROPERTY = "UpdateByControl.initialHashTableSize";
+    public static final String MAXIMUM_LOAD_FACTOR_PROPERTY = "UpdateByControl.maximumLoadFactor";
+    public static final String TARGET_LOAD_FACTOR_PROPERTY = "UpdateByControl.targetLoadFactor";
+    public static final String MATH_CONTEXT_PROPERTY = "UpdateByControl.mathContext";
+
     public static Builder builder() {
         return ImmutableUpdateByControl.builder();
     }
 
     /**
-     * Get an instance of UpdateByControl with the defaults from the system properties applied.
+     * Creates an instance with none of the values explicitly set. Equivalent to {@code builder().build()}.
      *
-     * @return default UpdateByControl
+     * @return the default instance
      */
     public static UpdateByControl defaultInstance() {
         return builder().build();
     }
 
+    /**
+     * Default is {@code false}. Can be changed with system property {@value USE_REDIRECTION_PROPERTY}.
+     */
     public static boolean useRedirectionDefault() {
-        return Boolean.getBoolean("UpdateByControl.useRedirection");
+        return Boolean.getBoolean(USE_REDIRECTION_PROPERTY);
     }
 
+    /**
+     * Default is {@code 4096}. Can be changed with system property {@value CHUNK_CAPACITY_PROPERTY}.
+     */
     public static int chunkCapacityDefault() {
-        return Integer.getInteger("UpdateByControl.chunkCapacity", 4096);
+        return Integer.getInteger(CHUNK_CAPACITY_PROPERTY, 4096);
     }
 
+    /**
+     * Default is {@code 1.1}. Can be changed with system property {@value MAXIMUM_STATIC_MEMORY_OVERHEAD_PROPERTY}.
+     */
     public static double maximumStaticMemoryOverheadDefault() {
-        return Double.parseDouble(System.getProperty("UpdateByControl.maximumStaticMemoryOverhead", "1.1"));
+        return Double.parseDouble(System.getProperty(MAXIMUM_STATIC_MEMORY_OVERHEAD_PROPERTY, "1.1"));
     }
 
+    /**
+     * Default is {@code 4096}. Can be changed with system property {@value INITIAL_HASH_TABLE_SIZE_PROPERTY}.
+     */
     public static int initialHashTableSizeDefault() {
-        return Integer.getInteger("UpdateByControl.initialHashTableSize", 4096);
+        return Integer.getInteger(INITIAL_HASH_TABLE_SIZE_PROPERTY, 4096);
     }
 
+    /**
+     * Default is {@code 0.75}. Can be changed with system property {@value MAXIMUM_LOAD_FACTOR_PROPERTY}.
+     */
     public static double maximumLoadFactorDefault() {
-        return Double.parseDouble(System.getProperty("UpdateByControl.maximumLoadFactor", "0.75"));
+        return Double.parseDouble(System.getProperty(MAXIMUM_LOAD_FACTOR_PROPERTY, "0.75"));
     }
 
+    /**
+     * Default is {@code 0.7}. Can be changed with system property {@value TARGET_LOAD_FACTOR_PROPERTY}.
+     */
     public static double targetLoadFactorDefault() {
-        return Double.parseDouble(System.getProperty("UpdateByControl.targetLoadFactor", "0.7"));
+        return Double.parseDouble(System.getProperty(TARGET_LOAD_FACTOR_PROPERTY, "0.7"));
     }
 
+    /**
+     * Default is {@link MathContext#DECIMAL64 DECIMAL64}. Can be changed with system property
+     * {@value MATH_CONTEXT_PROPERTY}.
+     */
     public static MathContext mathContextDefault() {
-        final String p = System.getProperty("UpdateByControl.mathContext", "DECIMAL64");
+        final String p = System.getProperty(MATH_CONTEXT_PROPERTY, "DECIMAL64");
         switch (p) {
             case "UNLIMITED":
                 return MathContext.UNLIMITED;
@@ -67,33 +97,52 @@ public abstract class UpdateByControl {
             case "DECIMAL128":
                 return MathContext.DECIMAL128;
             default:
-                throw new IllegalArgumentException("Unexpected UpdateByControl.mathContext: " + p);
+                throw new IllegalArgumentException(String.format("Unexpected '%s': %s", MATH_CONTEXT_PROPERTY, p));
         }
     }
 
+    /**
+     * If redirections should be used for output sources instead of sparse array sources.
+     */
     @Nullable
     public abstract Boolean useRedirection();
 
+    /**
+     * The maximum chunk capacity.
+     */
     public abstract OptionalInt chunkCapacity();
 
+    /**
+     * The maximum fractional memory overhead allowable for sparse redirections as a fraction (e.g. 1.1 is 10%
+     * overhead). Values less than zero disable overhead checking, and result in always using the sparse structure. A
+     * value of zero results in never using the sparse structure.
+     */
     public abstract OptionalDouble maxStaticSparseMemoryOverhead();
 
+    /**
+     * The initial hash table size.
+     */
     public abstract OptionalInt initialHashTableSize();
 
+    /**
+     * The maximum load factor for the hash table.
+     */
     public abstract OptionalDouble maximumLoadFactor();
 
+    /**
+     * The target load factor for the hash table.
+     */
     public abstract OptionalDouble targetLoadFactor();
 
+    /**
+     * The math context.
+     */
     public abstract Optional<MathContext> mathContext();
 
     /**
-     * If redirections should be used for output sources instead of sparse array sources.
+     * Equivalent to {@code useRedirection() == null ? useRedirectionDefault() : useRedirection()}.
      *
-     * <p>
-     * Default is `false`. Can be changed with system property {@code UpdateByControl.useRedirection} or by providing a
-     * value to {@link Builder#useRedirection(boolean)}.
-     *
-     * @return true if redirections should be used.
+     * @see #useRedirectionDefault()
      */
     @Value.Derived
     public boolean useRedirectionOrDefault() {
@@ -102,13 +151,9 @@ public abstract class UpdateByControl {
     }
 
     /**
-     * Get the maximum chunk capacity.
+     * Equivalent to {@code chunkCapacity().orElseGet(UpdateByControl::chunkCapacityDefault)}.
      *
-     * <p>
-     * Default is `4096`. Can be changed with system property {@code UpdateByControl.chunkCapacity} or by providing a
-     * value to {@link Builder#chunkCapacity(int)}.
-     *
-     * @return the maximum chunk capacity.
+     * @see #chunkCapacityDefault()
      */
     @Value.Derived
     public int chunkCapacityOrDefault() {
@@ -116,15 +161,10 @@ public abstract class UpdateByControl {
     }
 
     /**
-     * The maximum fractional memory overhead allowable for sparse redirections as a fraction (e.g. 1.1 is 10%
-     * overhead). Values less than zero disable overhead checking, and result in always using the sparse structure. A
-     * value of zero results in never using the sparse structure.
+     * Equivalent to
+     * {@code maxStaticSparseMemoryOverhead().orElseGet(UpdateByControl::maximumStaticMemoryOverheadDefault)}.
      *
-     * <p>
-     * Default is `1.1`. Can be changed with system property {@code UpdateByControl.maximumStaticMemoryOverhead} or by
-     * providing a value to {@link Builder#maxStaticSparseMemoryOverhead(double)}.
-     *
-     * @return the maximum fractional memory overhead.
+     * @see #maximumStaticMemoryOverheadDefault()
      */
     @Value.Derived
     public double maxStaticSparseMemoryOverheadOrDefault() {
@@ -132,13 +172,9 @@ public abstract class UpdateByControl {
     }
 
     /**
-     * Get the initial hash table size
+     * Equivalent to {@code initialHashTableSize().orElseGet(UpdateByControl::initialHashTableSizeDefault)}.
      *
-     * <p>
-     * Default is `4096`. Can be changed with system property {@code UpdateByControl.initialHashTableSize} or by
-     * providing a value to {@link Builder#initialHashTableSize(int)}.
-     *
-     * @return the initial hash table size
+     * @see #initialHashTableSizeDefault()
      */
     @Value.Derived
     public int initialHashTableSizeOrDefault() {
@@ -146,13 +182,9 @@ public abstract class UpdateByControl {
     }
 
     /**
-     * Get the maximum load factor for the hash table.
+     * Equivalent to {@code maximumLoadFactor().orElseGet(UpdateByControl::maximumLoadFactorDefault)}.
      *
-     * <p>
-     * Default is `0.75`. Can be changed with system property {@code UpdateByControl.maximumLoadFactor} or by providing
-     * a value to {@link Builder#maximumLoadFactor(double)}.
-     *
-     * @return the maximum load factor
+     * @see #maximumLoadFactorDefault()
      */
     @Value.Derived
     public double maximumLoadFactorOrDefault() {
@@ -160,24 +192,32 @@ public abstract class UpdateByControl {
     }
 
     /**
-     * Get the target load factor for the hash table.
+     * Equivalent to {@code targetLoadFactor().orElseGet(UpdateByControl::targetLoadFactorDefault)}.
      *
-     * <p>
-     * Default is `0.7`. Can be changed with system property {@code UpdateByControl.targetLoadFactor} or by providing a
-     * value to {@link Builder#targetLoadFactor(double)}.
-     *
-     * @return the target load factor
+     * @see #targetLoadFactorDefault()
      */
     @Value.Derived
     public double targetLoadFactorOrDefault() {
         return targetLoadFactor().orElseGet(UpdateByControl::targetLoadFactorDefault);
     }
 
+    /**
+     * Equivalent to {@code mathContext().orElseGet(UpdateByControl::mathContextDefault)}.
+     *
+     * @see #mathContextDefault()
+     */
     @Value.Derived
     public MathContext mathContextOrDefault() {
         return mathContext().orElseGet(UpdateByControl::mathContextDefault);
     }
 
+    /**
+     * Create a new instance with all of the explicit-or-default values from {@code this}. This may be useful from the
+     * context of a client who wants to use client-side configuration defaults instead of server-side configuration
+     * defaults.
+     *
+     * @return the explicit new instance
+     */
     public final UpdateByControl materialize() {
         return builder()
                 .useRedirection(useRedirectionOrDefault())

--- a/table-api/src/main/java/io/deephaven/api/updateby/spec/EmaSpec.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/spec/EmaSpec.java
@@ -3,9 +3,9 @@ package io.deephaven.api.updateby.spec;
 import io.deephaven.annotations.BuildableStyle;
 import io.deephaven.api.updateby.EmaControl;
 import org.immutables.value.Value.Immutable;
-import org.immutables.value.Value.Parameter;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * A {@link UpdateBySpec} for performing an Exponential Moving Average across the specified columns
@@ -13,57 +13,50 @@ import java.time.Duration;
 @Immutable
 @BuildableStyle
 public abstract class EmaSpec extends UpdateBySpecBase {
+
+    public static EmaSpec of(EmaControl control, TimeScale timeScale) {
+        return ImmutableEmaSpec.builder().control(control).timeScale(timeScale).build();
+    }
+
+    public static EmaSpec of(TimeScale timeScale) {
+        return ImmutableEmaSpec.builder().timeScale(timeScale).build();
+    }
+
     public static EmaSpec ofTime(final EmaControl control,
             final String timestampCol,
             long timeScaleNanos) {
-        return ImmutableEmaSpec.builder()
-                .control(control)
-                .timeScale(TimeScale.ofTime(timestampCol, timeScaleNanos))
-                .build();
+        return of(control, TimeScale.ofTime(timestampCol, timeScaleNanos));
     }
 
     public static EmaSpec ofTime(final String timestampCol, long timeScaleNanos) {
-        return ImmutableEmaSpec.builder()
-                .control(EmaControl.DEFAULT)
-                .timeScale(TimeScale.ofTime(timestampCol, timeScaleNanos))
-                .build();
+        return of(TimeScale.ofTime(timestampCol, timeScaleNanos));
     }
 
     public static EmaSpec ofTime(final EmaControl control,
             final String timestampCol,
             Duration emaDuration) {
-        return ImmutableEmaSpec.builder()
-                .control(control)
-                .timeScale(TimeScale.ofTime(timestampCol, emaDuration))
-                .build();
+        return of(control, TimeScale.ofTime(timestampCol, emaDuration));
     }
 
     public static EmaSpec ofTime(final String timestampCol, Duration emaDuration) {
-        return ImmutableEmaSpec.builder()
-                .control(EmaControl.DEFAULT)
-                .timeScale(TimeScale.ofTime(timestampCol, emaDuration))
-                .build();
+        return of(TimeScale.ofTime(timestampCol, emaDuration));
     }
 
     public static EmaSpec ofTicks(EmaControl control, long tickWindow) {
-        return ImmutableEmaSpec.builder()
-                .control(control)
-                .timeScale(TimeScale.ofTicks(tickWindow))
-                .build();
+        return of(control, TimeScale.ofTicks(tickWindow));
     }
 
     public static EmaSpec ofTicks(long tickWindow) {
-        return ImmutableEmaSpec.builder()
-                .control(EmaControl.DEFAULT)
-                .timeScale(TimeScale.ofTicks(tickWindow))
-                .build();
+        return of(TimeScale.ofTicks(tickWindow));
     }
 
-    @Parameter
-    public abstract EmaControl control();
+    public abstract Optional<EmaControl> control();
 
-    @Parameter
     public abstract TimeScale timeScale();
+
+    public final EmaControl controlOrDefault() {
+        return control().orElseGet(EmaControl::defaultInstance);
+    }
 
     @Override
     public final boolean applicableTo(Class<?> inputType) {


### PR DESCRIPTION
These changes allow the consumer to determine if they caller left the values at default, or if they were explicitly set. This may become important when we are sending configuration bits over the wire, where the caller might want to override some values, but not others.