### PR TITLE
Add support for single string arg for DTW

### DIFF
--- a/py/server/deephaven/table_factory.py
+++ b/py/server/deephaven/table_factory.py
@@ -11,6 +11,7 @@ from deephaven import DHError
 from deephaven._wrapper import JObjectWrapper
 from deephaven.column import InputColumn
 from deephaven.dtypes import DType
+from deephaven.jcompat import to_sequence
 from deephaven.table import Table
 from deephaven.ugp import auto_locking_op
 
@@ -180,6 +181,7 @@ class DynamicTableWriter(JObjectWrapper):
              DHError
         """
         try:
-            self._j_table_writer.logRowPermissive(*values)
+            values = to_sequence(values)
+            self._j_table_writer.logRowPermissive(values)
         except Exception as e:
             raise DHError(e, "failed to write a row.") from e

--- a/py/server/tests/test_table_factory.py
+++ b/py/server/tests/test_table_factory.py
@@ -169,15 +169,30 @@ class TableFactoryTestCase(BaseTestCase):
                 b_array = dtypes.array(dtypes.byte, [1, 1, 1])
                 s_array = dtypes.array(dtypes.short, [128, 228, 328])
                 i_array = dtypes.array(dtypes.int32, [32768, 42768, 52768])
-                l_array = dtypes.array(dtypes.long, [2**32, 2**33, 2**36])
+                l_array = dtypes.array(dtypes.long, [2 ** 32, 2 ** 33, 2 ** 36])
                 f_array = dtypes.array(dtypes.float32, [1.0, 1.1, 1.2])
-                d_array = dtypes.array(dtypes.double, [1.0/2**32, 1.1/2**33, 1.2/2**36])
+                d_array = dtypes.array(dtypes.double, [1.0 / 2 ** 32, 1.1 / 2 ** 33, 1.2 / 2 ** 36])
                 str_array = dtypes.array(dtypes.string, ["some", "not so random", "text"])
-                table_writer.write_row(b_array, s_array,i_array,l_array,f_array,d_array,str_array
+                table_writer.write_row(b_array, s_array, i_array, l_array, f_array, d_array, str_array
                                        )
                 t = table_writer.table
                 self.wait_ticking_table_update(t, row_count=1, timeout=5)
                 self.assertNotIn("null", t.to_string())
+
+    def test_dtw_single_string_arg(self):
+        col_defs = {"A_String": dtypes.string}
+        table_writer = DynamicTableWriter(col_defs)
+        table_writer.write_row("Hello world!")
+        t = table_writer.table
+        self.wait_ticking_table_update(t, row_count=1, timeout=5)
+        self.assertIn("Hello", t.to_string())
+
+        col_defs = {"A_Long": dtypes.long}
+        table_writer = DynamicTableWriter(col_defs)
+        table_writer.write_row(10**10)
+        t = table_writer.table
+        self.wait_ticking_table_update(t, row_count=1, timeout=5)
+        self.assertIn("10000000000", t.to_string())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The changes follows the method signature design pattern for table operations with a slight difference due to how JPY converts Python arguments to Java Object varargs.

Fixes #2643