### PR TITLE
Update redpanda docker repo

### DIFF
--- a/containers/python-examples-redpanda/docker-compose.yml
+++ b/containers/python-examples-redpanda/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
     - --advertise-kafka-addr
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
-    image: docker.vectorized.io/vectorized/redpanda:v21.4.13
+    image: docker.redpanda.com/vectorized:v21.4.13
     ports:
     - 9092:9092
     - 29092:29092

--- a/containers/python-examples-redpanda/docker-compose.yml
+++ b/containers/python-examples-redpanda/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
     - --advertise-kafka-addr
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
-    image: docker.redpanda.com/vectorized:v21.4.13
+    image: docker.redpanda.com/vectorized/redpanda:v21.4.13
     ports:
     - 9092:9092
     - 29092:29092

--- a/debezium/docker-compose-debezium-common.yml
+++ b/debezium/docker-compose-debezium-common.yml
@@ -5,7 +5,7 @@ version: '3.4'
 
 services:
   redpanda:
-    image: docker.vectorized.io/vectorized/redpanda:${REDPANDA_VERSION}
+    image: docker.redpanda.com/vectorized:${REDPANDA_VERSION}
     command:
       - redpanda start
       - --reactor-backend=epoll

--- a/debezium/docker-compose-debezium-common.yml
+++ b/debezium/docker-compose-debezium-common.yml
@@ -5,7 +5,7 @@ version: '3.4'
 
 services:
   redpanda:
-    image: docker.redpanda.com/vectorized:${REDPANDA_VERSION}
+    image: docker.redpanda.com/vectorized/redpanda:${REDPANDA_VERSION}
     command:
       - redpanda start
       - --reactor-backend=epoll

--- a/debezium/perf/redpanda/Dockerfile
+++ b/debezium/perf/redpanda/Dockerfile
@@ -1,5 +1,5 @@
 ARG REDPANDA_VERSION
 
-FROM docker.vectorized.io/vectorized/redpanda:${REDPANDA_VERSION}
+FROM docker.redpanda.com/vectorized:${REDPANDA_VERSION}
 
 COPY --chown=redpanda:redpanda redpanda.yaml /etc/redpanda

--- a/debezium/perf/redpanda/Dockerfile
+++ b/debezium/perf/redpanda/Dockerfile
@@ -1,5 +1,5 @@
 ARG REDPANDA_VERSION
 
-FROM docker.redpanda.com/vectorized:${REDPANDA_VERSION}
+FROM docker.redpanda.com/vectorized/redpanda:${REDPANDA_VERSION}
 
 COPY --chown=redpanda:redpanda redpanda.yaml /etc/redpanda

--- a/redpanda-standalone/docker-compose.yml
+++ b/redpanda-standalone/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized:v21.9.5
+    image: docker.redpanda.com/vectorized/redpanda:v21.9.5
     ports:
     - 8081:8081
     - 8082:8082

--- a/redpanda-standalone/docker-compose.yml
+++ b/redpanda-standalone/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.vectorized.io/vectorized/redpanda:v21.9.5
+    image: docker.redpanda.com/vectorized:v21.9.5
     ports:
     - 8081:8081
     - 8082:8082


### PR DESCRIPTION
Was getting an unauthorized error from docker.vectorized.io/redpanda:
```
➜  main git:(heap-size-api) PATH=/usr/lib/jvm/java-11-openjdk-amd64/bin/:$PATH ./gradlew :Integrations:composeUp

> Task :Integrations:composeUp
redpanda uses an image, skipping
Building with native build. Learn about native build in Compose here: https://docs.docker.com/go/compose-native-build/
Building with native build. Learn about native build in Compose here: https://docs.docker.com/go/compose-native-build/
Pulling redpanda (docker.vectorized.io/vectorized/redpanda:v21.9.5)...
unauthorized: authentication required
Removing network 7068f1a4e250e19015aa8e4c8be5964a_integrations__default

> Task :Integrations:composeUp FAILED

FAILURE: Build failed with an exception.
```

Check to use docker.redpanda.com/vectorized instead, and now it works again.
