### PR TITLE
Add port to the Embedded server instance

### DIFF
--- a/py/embedded-server/README.md
+++ b/py/embedded-server/README.md
@@ -3,7 +3,7 @@
 Embeds the Deephaven Core server into a python module, so that it can be started from python, with tables produced
 directly as part of startup.
 
-## Dev envirnoment setup
+## Dev environment setup
 Java 11 and Docker are required to build this project, as most of the repository is needed to properly build it.
 Note that jpy or deephaven-jpy (built for your OS and archetecture) and the deephaven server apiwheel is also
 required. 

--- a/py/embedded-server/deephaven_server/server.py
+++ b/py/embedded-server/deephaven_server/server.py
@@ -19,6 +19,10 @@ class Server:
     def j_object(self):
         return self.j_server
 
+    @property
+    def port(self):
+        return self.j_server.getPort()
+
     def __init__(self, host: Optional[str] = None, port: Optional[int] = None, jvm_args: Optional[List[str]] = None, dh_args: Dict[str, str] = {}):
         """
         Creates a Deephaven embedded server. Only one instance can be created at this time.

--- a/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
+++ b/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
@@ -100,4 +100,8 @@ public class EmbeddedServer {
             checkGlobals(scriptSession, s);
         });
     }
+
+    public int getPort() {
+        return server.server().getPort();
+    }
 }


### PR DESCRIPTION
That way you can get the port for the currently running server, which is useful for deephaven-ipywidgets

**Testing Done**:
- Installed into a .venv running Python as a library
- Able to get the port of the running server using `Server.instance.port`