### PR TITLE
Improve usability and docs for UpdateBy

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1810,7 +1810,7 @@ public interface Table extends
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
      * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
      * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
-     * for the row group (as determined by the {@code byColumns})
+     * for the row group (as determined by the {@code byColumns}).
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1726,11 +1726,10 @@ public interface Table extends
     // -----------------------------------------------------------------------------------------------------------------
 
     /**
-     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
-     * to the specified {@code operation}. Operations apply position or time-based windowing functions in order to
-     * determine the set of responsive rows from the parent table, and then compute the output column value(s) as an
-     * incremental aggregation over the responsive rows. In contrast to update or select, updateBy has no correctness
-     * concerns for multi-row computations.
+     * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
+     * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
+     * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
+     * over the entire table.
      *
      * @param operation the operation to apply to the table.
      * @return a table with the same rowset, with the specified operation applied to the entire table
@@ -1739,11 +1738,10 @@ public interface Table extends
     Table updateBy(@NotNull final UpdateByClause operation);
 
     /**
-     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
-     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
-     * determine the set of responsive rows from the parent table, and then compute the output column value(s) as an
-     * incremental aggregation over the responsive rows. In contrast to update or select, updateBy has no correctness
-     * concerns for multi-row computations.
+     * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
+     * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
+     * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
+     * over the entire table.
      *
      * @param operations the operations to apply to the table.
      * @return a table with the same rowset, with the specified operations applied to the entire table.
@@ -1752,11 +1750,10 @@ public interface Table extends
     Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations);
 
     /**
-     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
-     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
-     * determine the set of responsive rows from the parent table, and then compute the output column value(s) as an
-     * incremental aggregation over the responsive rows. In contrast to update or select, updateBy has no correctness
-     * concerns for multi-row computations.
+     * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
+     * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
+     * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
+     * over the entire table.
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.
@@ -1767,11 +1764,10 @@ public interface Table extends
             @NotNull final Collection<? extends UpdateByClause> operations);
 
     /**
-     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
-     * to the specified {@code operation}. Operations apply position or time-based windowing functions in order to
-     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
-     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
-     * update or select, updateBy has no correctness concerns for multi-row computations.
+     * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
+     * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
+     * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
+     * for the row group (as determined by the {@code byColumns})
      *
      * @param operation the operation to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1782,11 +1778,10 @@ public interface Table extends
     Table updateBy(@NotNull final UpdateByClause operation, final String... byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
-     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
-     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
-     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
-     * update or select, updateBy has no correctness concerns for multi-row computations.
+     * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
+     * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
+     * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
+     * for the row group (as determined by the {@code byColumns})
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1797,11 +1792,10 @@ public interface Table extends
     Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations, final String... byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
-     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
-     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
-     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
-     * update or select, updateBy has no correctness concerns for multi-row computations.
+     * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
+     * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
+     * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
+     * for the row group (as determined by the {@code byColumns})
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1813,11 +1807,10 @@ public interface Table extends
             @NotNull Collection<? extends Selectable> byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
-     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
-     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
-     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
-     * update or select, updateBy has no correctness concerns for multi-row computations.
+     * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
+     * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
+     * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
+     * for the row group (as determined by the {@code byColumns})
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1781,7 +1781,7 @@ public interface Table extends
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
      * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
      * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
-     * for the row group (as determined by the {@code byColumns})
+     * for the row group (as determined by the {@code byColumns}).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1727,10 +1727,10 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operation to it.
+     * based operations to it.
      *
      * @param operation the operation to apply to the table.
-     * @return a table with the same index, with the specified operations applied to the entire table
+     * @return a table with the same rowset, with the specified operations applied to the entire table
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final UpdateByClause operation);
@@ -1741,7 +1741,7 @@ public interface Table extends
      * capable of processing state between rows.
      *
      * @param operations the operations to apply to the table.
-     * @return a table with the same index, with the specified operations applied to the entire table.
+     * @return a table with the same rowset, with the specified operations applied to the entire table.
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations);
@@ -1749,12 +1749,11 @@ public interface Table extends
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
      * based operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. This operation will group the table by the specified set of keys if
-     * provided before applying the operation.
+     * capable of processing state between rows.
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.
-     * @return a table with the same index, with the specified operations applied to each group defined by the
+     * @return a table with the same rowset, with the specified operations applied to each group defined by the
      *         {@code byColumns}
      */
     @ConcurrentMethod
@@ -1763,40 +1762,41 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operation to it. This operation will group the table by the specified set of keys if provided before applying the
-     * operation.
+     * operation to it. As opposed to {@link #update(String...)} these operations are more restricted but are
+     * capable of processing state between rows. The operation will be applied to each group individually (identified
+     * by the set of key columns provided by the user).
      *
      * @param operation the operation to apply to the table.
      * @param byColumns the columns to group by before applying.
-     * @return a table with the same index, with the specified operations applied to each group defined by the
+     * @return a table with the same rowSet, with the specified operations applied to each group defined by the
      *         {@code byColumns}
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final UpdateByClause operation, final String... byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. This operation will group the table by the specified set of keys if
-     * provided before applying the operation.
+     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
+     * capable of processing state between rows. The operation will be applied to each group individually (identified
+     * by the set of key columns provided by the user).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
-     * @return a table with the same index, with the specified operations applied to each group defined by the
+     * @return a table with the same rowSet, with the specified operations applied to each group defined by the
      *         {@code byColumns}
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations, final String... byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. This operation will group the table by the specified set of keys if
-     * provided before applying the operation.
+     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
+     * capable of processing state between rows. The operation will be applied to each group individually (identified
+     * by the set of key columns provided by the user).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
-     * @return a table with the same index, with the specified operations applied to each group defined by the
+     * @return a table with the same rowSet, with the specified operations applied to each group defined by the
      *         {@code byColumns}
      */
     @ConcurrentMethod
@@ -1804,15 +1804,15 @@ public interface Table extends
             @NotNull Collection<? extends Selectable> byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. This operation will group the table by the specified set of keys if
-     * provided before applying the operation.
+     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
+     * capable of processing state between rows. The operation will be applied to each group individually (identified
+     * by the set of key columns provided by the user).
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
-     * @return a table with the same index, with the specified operations applied to each group defined by the
+     * @return a table with the same rowSet, with the specified operations applied to each group defined by the
      *         {@code byColumns}
      */
     @ConcurrentMethod

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1762,9 +1762,9 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operation to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. The operation will be applied to each group individually (identified
-     * by the set of key columns provided by the user).
+     * operation to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable of
+     * processing state between rows. The operation will be applied to each group individually (identified by the set of
+     * key columns provided by the user).
      *
      * @param operation the operation to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1776,9 +1776,9 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. The operation will be applied to each group individually (identified
-     * by the set of key columns provided by the user).
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
+     * of processing state between rows. The operation will be applied to each group individually (identified by the set
+     * of key columns provided by the user).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1790,9 +1790,9 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. The operation will be applied to each group individually (identified
-     * by the set of key columns provided by the user).
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
+     * of processing state between rows. The operation will be applied to each group individually (identified by the set
+     * of key columns provided by the user).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1805,9 +1805,9 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows. The operation will be applied to each group individually (identified
-     * by the set of key columns provided by the user).
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
+     * of processing state between rows. The operation will be applied to each group individually (identified by the set
+     * of key columns provided by the user).
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1795,7 +1795,7 @@ public interface Table extends
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
      * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
      * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
-     * for the row group (as determined by the {@code byColumns})
+     * for the row group (as determined by the {@code byColumns}).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1727,10 +1727,11 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operations to it.
+     * based operation to it. As opposed to {@link #update(String...)} these operations are more restricted but are
+     * capable of processing state between rows.
      *
      * @param operation the operation to apply to the table.
-     * @return a table with the same rowset, with the specified operations applied to the entire table
+     * @return a table with the same rowset, with the specified operation applied to the entire table
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final UpdateByClause operation);
@@ -1753,8 +1754,7 @@ public interface Table extends
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.
-     * @return a table with the same rowset, with the specified operations applied to each group defined by the
-     *         {@code byColumns}
+     * @return a table with the same rowset, with the specified operations applied to the entire table
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final UpdateByControl control,
@@ -1768,7 +1768,7 @@ public interface Table extends
      *
      * @param operation the operation to apply to the table.
      * @param byColumns the columns to group by before applying.
-     * @return a table with the same rowSet, with the specified operations applied to each group defined by the
+     * @return a table with the same rowSet, with the specified operation applied to each group defined by the
      *         {@code byColumns}
      */
     @ConcurrentMethod
@@ -1806,8 +1806,8 @@ public interface Table extends
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
      * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows. The operation will be applied to each group individually (identified by the set
-     * of key columns provided by the user).
+     * of processing state between rows. The operations will be applied to each group individually (identified by the
+     * set of key columns provided by the user).
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1726,9 +1726,9 @@ public interface Table extends
     // -----------------------------------------------------------------------------------------------------------------
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operation to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows.
+     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
+     * operation to it. As opposed to {@link #update(String...)} this operation is more restricted but is capable of
+     * processing state between rows.
      *
      * @param operation the operation to apply to the table.
      * @return a table with the same rowset, with the specified operation applied to the entire table
@@ -1737,9 +1737,9 @@ public interface Table extends
     Table updateBy(@NotNull final UpdateByClause operation);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows.
+     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
+     * of processing state between rows.
      *
      * @param operations the operations to apply to the table.
      * @return a table with the same rowset, with the specified operations applied to the entire table.
@@ -1748,9 +1748,9 @@ public interface Table extends
     Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified set of row
-     * based operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are
-     * capable of processing state between rows.
+     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
+     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
+     * of processing state between rows.
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.
@@ -1762,7 +1762,7 @@ public interface Table extends
 
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operation to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable of
+     * operation to it. As opposed to {@link #update(String...)} this operation is more restricted but is capable of
      * processing state between rows. The operation will be applied to each group individually (identified by the set of
      * key columns provided by the user).
      *
@@ -1777,8 +1777,8 @@ public interface Table extends
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
      * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows. The operation will be applied to each group individually (identified by the set
-     * of key columns provided by the user).
+     * of processing state between rows. The operations will be applied to each group individually (identified by the
+     * set of key columns provided by the user).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1791,8 +1791,8 @@ public interface Table extends
     /**
      * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
      * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows. The operation will be applied to each group individually (identified by the set
-     * of key columns provided by the user).
+     * of processing state between rows. The operations will be applied to each group individually (identified by the
+     * set of key columns provided by the user).
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1726,9 +1726,11 @@ public interface Table extends
     // -----------------------------------------------------------------------------------------------------------------
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operation to it. As opposed to {@link #update(String...)} this operation is more restricted but is capable of
-     * processing state between rows.
+     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
+     * to the specified {@code operation}. Operations apply position or time-based windowing functions in order to
+     * determine the set of responsive rows from the parent table, and then compute the output column value(s) as an
+     * incremental aggregation over the responsive rows. In contrast to update or select, updateBy has no correctness
+     * concerns for multi-row computations.
      *
      * @param operation the operation to apply to the table.
      * @return a table with the same rowset, with the specified operation applied to the entire table
@@ -1737,9 +1739,11 @@ public interface Table extends
     Table updateBy(@NotNull final UpdateByClause operation);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows.
+     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
+     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
+     * determine the set of responsive rows from the parent table, and then compute the output column value(s) as an
+     * incremental aggregation over the responsive rows. In contrast to update or select, updateBy has no correctness
+     * concerns for multi-row computations.
      *
      * @param operations the operations to apply to the table.
      * @return a table with the same rowset, with the specified operations applied to the entire table.
@@ -1748,9 +1752,11 @@ public interface Table extends
     Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows.
+     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
+     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
+     * determine the set of responsive rows from the parent table, and then compute the output column value(s) as an
+     * incremental aggregation over the responsive rows. In contrast to update or select, updateBy has no correctness
+     * concerns for multi-row computations.
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.
@@ -1761,10 +1767,11 @@ public interface Table extends
             @NotNull final Collection<? extends UpdateByClause> operations);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operation to it. As opposed to {@link #update(String...)} this operation is more restricted but is capable of
-     * processing state between rows. The operation will be applied to each group individually (identified by the set of
-     * key columns provided by the user).
+     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
+     * to the specified {@code operation}. Operations apply position or time-based windowing functions in order to
+     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
+     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
+     * update or select, updateBy has no correctness concerns for multi-row computations.
      *
      * @param operation the operation to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1775,10 +1782,11 @@ public interface Table extends
     Table updateBy(@NotNull final UpdateByClause operation, final String... byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows. The operations will be applied to each group individually (identified by the
-     * set of key columns provided by the user).
+     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
+     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
+     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
+     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
+     * update or select, updateBy has no correctness concerns for multi-row computations.
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1789,10 +1797,11 @@ public interface Table extends
     Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations, final String... byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows. The operations will be applied to each group individually (identified by the
-     * set of key columns provided by the user).
+     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
+     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
+     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
+     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
+     * update or select, updateBy has no correctness concerns for multi-row computations.
      *
      * @param operations the operations to apply to the table.
      * @param byColumns the columns to group by before applying.
@@ -1804,10 +1813,11 @@ public interface Table extends
             @NotNull Collection<? extends Selectable> byColumns);
 
     /**
-     * Create a table with the same {@link #getRowSet() rowSet} as its parent that will perform the specified row based
-     * operations to it. As opposed to {@link #update(String...)} these operations are more restricted but are capable
-     * of processing state between rows. The operations will be applied to each group individually (identified by the
-     * set of key columns provided by the user).
+     * Create a table with the same {@link #getRowSet() row set} as its parent, with additional columns added according
+     * to the specified {@code operations}. Operations apply position or time-based windowing functions in order to
+     * determine the set of responsive rows from a given input row’s group (as determined by the {@code byColumns}), and
+     * then compute the output column value(s) as an incremental aggregation over the responsive rows. In contrast to
+     * update or select, updateBy has no correctness concerns for multi-row computations.
      *
      * @param control the {@link UpdateByControl control} to use when updating the table.
      * @param operations the operations to apply to the table.

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -1767,7 +1767,7 @@ public interface Table extends
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
      * aggregations are defined by the {@code operations}, which support incremental aggregation over the corresponding
      * rows in the parent table. The aggregations will apply position or time-based windowing and compute the results
-     * for the row group (as determined by the {@code byColumns})
+     * for the row group (as determined by the {@code byColumns}).
      *
      * @param operation the operation to apply to the table.
      * @param byColumns the columns to group by before applying.

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -541,6 +541,8 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
                 "import static io.deephaven.time.TimeZone.*;\n" +
                 "import static io.deephaven.engine.table.impl.lang.QueryLanguageFunctionUtils.*;\n" +
                 "import static io.deephaven.api.agg.Aggregation.*;\n" +
+                "import static io.deephaven.api.updateby.UpdateByClause.*;\n" +
+
                 StringUtils.joinStrings(scriptImports, "\n") + "\n";
         return new Pair<>(commandPrefix, commandPrefix + command
                 + "\n\n// this final true prevents Groovy from interpreting a trailing class definition as something to execute\n;\ntrue;\n");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static io.deephaven.engine.table.impl.GenerateTableUpdates.generateAppends;
@@ -28,7 +29,7 @@ public class TestCumMinMax extends BaseUpdateByTest {
     public void testStaticZeroKey() {
         final QueryTable t = createTestTable(100000, false, false, false, 0x2134BCFA).t;
 
-        final Table result = t.updateBy(UpdateByClause.of(
+        final Table result = t.updateBy(List.of(
                 UpdateByClause.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
                         "longColMin=longCol", "floatColMin=floatCol", "doubleColMin=doubleCol",
                         "bigIntColMin=bigIntCol", "bigDecimalColMin=bigDecimalCol"),
@@ -61,7 +62,7 @@ public class TestCumMinMax extends BaseUpdateByTest {
     private void doTestStaticBucketed(boolean grouped) {
         final QueryTable t = createTestTable(100000, true, grouped, false, 0xACDB4321).t;
 
-        final Table result = t.updateBy(UpdateByClause.of(
+        final Table result = t.updateBy(List.of(
                 UpdateByClause.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
                         "longColMin=longCol", "floatColMin=floatCol", "doubleColMin=doubleCol",
                         "bigIntColMin=bigIntCol", "bigDecimalColMin=bigDecimalCol"),

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static io.deephaven.engine.table.impl.GenerateTableUpdates.generateAppends;
@@ -62,7 +63,7 @@ public class TestCumProd extends BaseUpdateByTest {
                 longCol("ShortValProd", 1, 2, NULL_LONG, 3),
                 longCol("IntValProd", 1, 2, NULL_LONG, 3));
 
-        final Table r = t.updateBy(UpdateByClause.of(
+        final Table r = t.updateBy(List.of(
                 UpdateByClause.CumProd("ByteValProd=ByteVal"),
                 UpdateByClause.CumProd("ShortValProd=ShortVal"),
                 UpdateByClause.CumProd("IntValProd=IntVal")), "Sym");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static io.deephaven.engine.table.impl.GenerateTableUpdates.generateAppends;
@@ -62,7 +63,7 @@ public class TestCumSum extends BaseUpdateByTest {
                 longCol("ShortValSum", 1, 3, NULL_LONG, 3),
                 longCol("IntValSum", 1, 3, NULL_LONG, 3));
 
-        final Table r = t.updateBy(UpdateByClause.of(
+        final Table r = t.updateBy(List.of(
                 UpdateByClause.CumSum("ByteValSum=ByteVal"),
                 UpdateByClause.CumSum("ShortValSum=ShortVal"),
                 UpdateByClause.CumSum("IntValSum=IntVal")), "Sym");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
@@ -14,10 +14,7 @@ import io.deephaven.test.types.ParallelTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static io.deephaven.engine.table.impl.GenerateTableUpdates.generateAppends;
 import static io.deephaven.engine.table.impl.RefreshingTableTestCase.simulateShiftAwareStep;
@@ -91,7 +88,7 @@ public class TestUpdateByGeneral extends BaseUpdateByTest {
                         }
 
                         final String[] columnNamesArray = base.getDefinition().getColumnNamesArray();
-                        final Collection<? extends UpdateByClause> clauses = UpdateByClause.of(
+                        final Collection<? extends UpdateByClause> clauses = List.of(
                                 UpdateByClause.Fill(),
                                 UpdateByClause.Ema(skipControl, "ts", 10 * MINUTE,
                                         makeOpColNames(columnNamesArray, "_ema", "Sym", "ts", "boolCol")),

--- a/table-api/src/main/java/io/deephaven/api/updateby/UpdateByClause.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/UpdateByClause.java
@@ -36,17 +36,6 @@ public interface UpdateByClause {
     }
 
     /**
-     * Simply wrap the input specs as a collection suitable for Table#updateBy(). This is functionally equivalent to
-     * {@link Arrays#asList(Object[])}.
-     *
-     * @param operations the operations to wrap.
-     * @return a collection for use with Table#updateBy()}
-     */
-    static Collection<UpdateByClause> of(final UpdateByClause... operations) {
-        return Arrays.asList(operations);
-    }
-
-    /**
      * Create an {@link CumSumSpec cumulative sum} for the supplied column name pairs.
      *
      * @param pairs The input/output column name pairs
@@ -108,7 +97,7 @@ public interface UpdateByClause {
      *     ema_next = a * ema_last + (1 - a) * value
      * </pre>
      *
-     * @param timeScaleTicks the decay rate (tau) in ticks
+     * @param timeScaleTicks the decay rate in ticks
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
@@ -130,7 +119,7 @@ public interface UpdateByClause {
      *
      * @param control a {@link EmaControl control} object that defines how special cases should behave. See
      *        {@link EmaControl} for further details.
-     * @param timeScaleTicks the decay rate (tau) in ticks
+     * @param timeScaleTicks the decay rate in ticks
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
@@ -151,7 +140,7 @@ public interface UpdateByClause {
      * </pre>
      *
      * @param timestampColumn the column in the source table to use for timestamps
-     * @param timeScaleNanos the decay rate (tau) in nanoseconds
+     * @param timeScaleNanos the decay rate in nanoseconds
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
@@ -174,7 +163,7 @@ public interface UpdateByClause {
      * @param control a {@link EmaControl control} object that defines how special cases should behave. See
      *        {@link EmaControl} for further details.
      * @param timestampColumn the column in the source table to use for timestamps
-     * @param timeScaleNanos the decay rate (tau) in nanoseconds
+     * @param timeScaleNanos the decay rate in nanoseconds
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
@@ -195,7 +184,7 @@ public interface UpdateByClause {
      * </pre>
      *
      * @param timestampColumn the column in the source table to use for timestamps
-     * @param emaDuration the decay rate (tau) as {@Link Duration duration}
+     * @param emaDuration the decay rate as {@Link Duration duration}
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
@@ -218,7 +207,7 @@ public interface UpdateByClause {
      * @param control a {@link EmaControl control} object that defines how special cases should behave. See
      *        {@link EmaControl} for further details.
      * @param timestampColumn the column in the source table to use for timestamps
-     * @param emaDuration the decay rate (tau) as {@Link Duration duration}
+     * @param emaDuration the decay rate as {@Link Duration duration}
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */


### PR DESCRIPTION
After this change should be able to call `updateBy` without needing explicit imports.  Some examples:

```
import io.deephaven.api.updateby.UpdateByClause;
import static io.deephaven.api.updateby.UpdateByClause.*;

cumulative_sum=emptyTable(10).update("RowNum=ii").updateBy(UpdateByClause.of(CumSum("RowNumSum=RowNum")))

cumulative_sum_grouped=emptyTable(10).update("RowNum=ii", "Group=RowNum%3").updateBy(UpdateByClause.of(CumSum("RowNumSum=RowNum")), "Group")

cumulative_multi_grouped=emptyTable(10).update("RowNum=ii", "Group=RowNum%3").updateBy([UpdateByClause.of(CumSum("RowNumSum=RowNum")), UpdateByClause.of(CumMin("RowNumMin=RowNum"))], "Group")

```
can be written as
```
cumulative_sum=emptyTable(10).update("RowNum=ii").updateBy(CumSum("RowNumSum=RowNum"))

cumulative_sum_grouped=emptyTable(10).update("RowNum=ii", "Group=RowNum%3").updateBy(CumSum("RowNumSum=RowNum"), "Group")

cumulative_multi_grouped=emptyTable(10).update("RowNum=ii", "Group=RowNum%3").updateBy([CumSum("RowNumSum=RowNum")),CumMin("RowNumMin=RowNum")], "Group")
```

Closes #2647