### PR TITLE
Renamed Java updateBy objects

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -7,7 +7,7 @@ import io.deephaven.api.*;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.engine.liveness.LivenessNode;
 import io.deephaven.engine.rowset.TrackingRowSet;
@@ -1735,7 +1735,7 @@ public interface Table extends
      * @return a table with the same rowset, with the specified operation applied to the entire table
      */
     @ConcurrentMethod
-    Table updateBy(@NotNull final UpdateByClause operation);
+    Table updateBy(@NotNull final UpdateByOperation operation);
 
     /**
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
@@ -1747,7 +1747,7 @@ public interface Table extends
      * @return a table with the same rowset, with the specified operations applied to the entire table.
      */
     @ConcurrentMethod
-    Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations);
+    Table updateBy(@NotNull final Collection<? extends UpdateByOperation> operations);
 
     /**
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
@@ -1761,7 +1761,7 @@ public interface Table extends
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final UpdateByControl control,
-            @NotNull final Collection<? extends UpdateByClause> operations);
+            @NotNull final Collection<? extends UpdateByOperation> operations);
 
     /**
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
@@ -1775,7 +1775,7 @@ public interface Table extends
      *         {@code byColumns}
      */
     @ConcurrentMethod
-    Table updateBy(@NotNull final UpdateByClause operation, final String... byColumns);
+    Table updateBy(@NotNull final UpdateByOperation operation, final String... byColumns);
 
     /**
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
@@ -1789,7 +1789,7 @@ public interface Table extends
      *         {@code byColumns}
      */
     @ConcurrentMethod
-    Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations, final String... byColumns);
+    Table updateBy(@NotNull final Collection<? extends UpdateByOperation> operations, final String... byColumns);
 
     /**
      * Creates a table with additional columns calculated from window-based aggregations of columns in its parent. The
@@ -1803,7 +1803,7 @@ public interface Table extends
      *         {@code byColumns}
      */
     @ConcurrentMethod
-    Table updateBy(@NotNull Collection<? extends UpdateByClause> operations,
+    Table updateBy(@NotNull Collection<? extends UpdateByOperation> operations,
             @NotNull Collection<? extends Selectable> byColumns);
 
     /**
@@ -1820,7 +1820,7 @@ public interface Table extends
      */
     @ConcurrentMethod
     Table updateBy(@NotNull final UpdateByControl control,
-            @NotNull final Collection<? extends UpdateByClause> operations,
+            @NotNull final Collection<? extends UpdateByOperation> operations,
             @NotNull final Collection<? extends Selectable> byColumns);
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
@@ -5,7 +5,7 @@ package io.deephaven.engine.table.impl;
 
 import io.deephaven.api.Selectable;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.base.reference.SimpleReference;
 import io.deephaven.base.verify.Assert;
@@ -269,7 +269,7 @@ public class DeferredViewTable extends RedefinableTable {
 
     @Override
     public Table updateBy(@NotNull final UpdateByControl control,
-            @NotNull final Collection<? extends UpdateByClause> ops,
+            @NotNull final Collection<? extends UpdateByOperation> ops,
             @NotNull final Collection<? extends Selectable> byColumns) {
         return QueryPerformanceRecorder.withNugget("updateBy()", sizeForInstrumentation(),
                 () -> UpdateBy.updateBy((QueryTable) this.coalesce(), ops, byColumns, control));

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -13,7 +13,7 @@ import io.deephaven.api.agg.*;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.agg.spec.AggSpecColumnReferences;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.Require;
@@ -3024,7 +3024,7 @@ public class QueryTable extends BaseTable {
 
     @Override
     public Table updateBy(@NotNull final UpdateByControl control,
-            @NotNull final Collection<? extends UpdateByClause> ops,
+            @NotNull final Collection<? extends UpdateByOperation> ops,
             @NotNull final Collection<? extends Selectable> byColumns) {
         return QueryPerformanceRecorder.withNugget("updateBy()", sizeForInstrumentation(),
                 () -> UpdateBy.updateBy(this, ops, byColumns, control));

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SimpleSourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SimpleSourceTable.java
@@ -7,7 +7,7 @@ import io.deephaven.api.Selectable;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.updategraph.UpdateSourceRegistrar;
 import io.deephaven.engine.table.impl.locations.TableLocationProvider;
@@ -68,7 +68,7 @@ public class SimpleSourceTable extends SourceTable {
 
     @Override
     public Table updateBy(@NotNull final UpdateByControl control,
-            @NotNull final Collection<? extends UpdateByClause> ops,
+            @NotNull final Collection<? extends UpdateByOperation> ops,
             @NotNull final Collection<? extends Selectable> byColumns) {
         return QueryPerformanceRecorder.withNugget("updateBy()", sizeForInstrumentation(),
                 () -> UpdateBy.updateBy((QueryTable) this.coalesce(), ops, byColumns, control));

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableWithDefaults.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableWithDefaults.java
@@ -7,7 +7,7 @@ import io.deephaven.api.*;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.base.Pair;
 import io.deephaven.base.StringUtils;
@@ -1121,34 +1121,35 @@ public interface TableWithDefaults extends Table {
 
     @ConcurrentMethod
     default Table updateBy(@NotNull final UpdateByControl control,
-            @NotNull final Collection<? extends UpdateByClause> operations) {
+            @NotNull final Collection<? extends UpdateByOperation> operations) {
         return updateBy(control, operations, Collections.emptyList());
     }
 
     @ConcurrentMethod
-    default Table updateBy(@NotNull Collection<? extends UpdateByClause> operations,
+    default Table updateBy(@NotNull Collection<? extends UpdateByOperation> operations,
             @NotNull Collection<? extends Selectable> byColumns) {
         return updateBy(UpdateByControl.defaultInstance(), operations, byColumns);
     }
 
     @ConcurrentMethod
-    default Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations, final String... byColumns) {
+    default Table updateBy(@NotNull final Collection<? extends UpdateByOperation> operations,
+            final String... byColumns) {
         return updateBy(UpdateByControl.defaultInstance(), operations, Selectable.from(byColumns));
     }
 
     @ConcurrentMethod
-    default Table updateBy(@NotNull final Collection<? extends UpdateByClause> operations) {
+    default Table updateBy(@NotNull final Collection<? extends UpdateByOperation> operations) {
         return updateBy(UpdateByControl.defaultInstance(), operations, Collections.emptyList());
     }
 
     @ConcurrentMethod
-    default Table updateBy(@NotNull final UpdateByClause operation, final String... byColumns) {
+    default Table updateBy(@NotNull final UpdateByOperation operation, final String... byColumns) {
         return updateBy(UpdateByControl.defaultInstance(), Collections.singletonList(operation),
                 Selectable.from(byColumns));
     }
 
     @ConcurrentMethod
-    default Table updateBy(@NotNull final UpdateByClause operation) {
+    default Table updateBy(@NotNull final UpdateByOperation operation) {
         return updateBy(UpdateByControl.defaultInstance(), Collections.singletonList(operation),
                 Collections.emptyList());
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
@@ -9,7 +9,7 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.liveness.Liveness;
@@ -483,7 +483,7 @@ public abstract class UncoalescedTable extends BaseTable implements TableWithDef
     @Override
     @ConcurrentMethod
     public Table updateBy(@NotNull final UpdateByControl control,
-            @NotNull final Collection<? extends UpdateByClause> ops,
+            @NotNull final Collection<? extends UpdateByOperation> ops,
             @NotNull final Collection<? extends Selectable> byColumns) {
         return UpdateBy.updateBy((QueryTable) this.coalesce(), ops, byColumns, control);
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateBy.java
@@ -3,7 +3,7 @@ package io.deephaven.engine.table.impl;
 import gnu.trove.map.hash.TObjectIntHashMap;
 import io.deephaven.api.Selectable;
 import io.deephaven.api.Strings;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.LongChunk;
@@ -82,7 +82,7 @@ public abstract class UpdateBy {
      * @return a new table with the same index as the source with all the operations applied.
      */
     public static Table updateBy(@NotNull final QueryTable source,
-            @NotNull final Collection<? extends UpdateByClause> clauses,
+            @NotNull final Collection<? extends UpdateByOperation> clauses,
             @NotNull final Collection<? extends Selectable> byColumns,
             @NotNull final UpdateByControl control) {
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateByOperatorFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UpdateByOperatorFactory.java
@@ -1,8 +1,8 @@
 package io.deephaven.engine.table.impl;
 
 import io.deephaven.api.agg.Pair;
-import io.deephaven.api.updateby.ColumnUpdateClause;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.ColumnUpdateOperation;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.api.updateby.spec.*;
 import io.deephaven.engine.table.ColumnSource;
@@ -30,7 +30,7 @@ import static io.deephaven.util.BooleanUtils.NULL_BOOLEAN_AS_BYTE;
 import static io.deephaven.util.QueryConstants.NULL_BYTE;
 
 /**
- * A factory to visit all of the {@link UpdateByClause}s to produce a set of {@link UpdateByOperator}s that
+ * A factory to visit all of the {@link UpdateByOperation}s to produce a set of {@link UpdateByOperator}s that
  * {@link UpdateBy} can use to produce a result.
  */
 public class UpdateByOperatorFactory {
@@ -51,7 +51,7 @@ public class UpdateByOperatorFactory {
         this.control = control;
     }
 
-    final Collection<UpdateByOperator> getOperators(@NotNull final Collection<? extends UpdateByClause> specs) {
+    final Collection<UpdateByOperator> getOperators(@NotNull final Collection<? extends UpdateByOperation> specs) {
         final OperationVisitor v = new OperationVisitor();
         specs.forEach(s -> s.walk(v));
         return v.ops;
@@ -102,17 +102,17 @@ public class UpdateByOperatorFactory {
                 .toArray(MatchPair[]::new);
     }
 
-    public String describe(Collection<? extends UpdateByClause> clauses) {
+    public String describe(Collection<? extends UpdateByOperation> clauses) {
         final Describer d = new Describer();
         clauses.forEach(c -> c.walk(d));
         return d.descriptionBuilder.toString();
     }
 
-    private static class Describer implements UpdateByClause.Visitor<Void> {
+    private static class Describer implements UpdateByOperation.Visitor<Void> {
         final StringBuilder descriptionBuilder = new StringBuilder();
 
         @Override
-        public Void visit(ColumnUpdateClause clause) {
+        public Void visit(ColumnUpdateOperation clause) {
             final MatchPair[] pairs = parseMatchPairs(clause.columns());
             final String columnStr;
             if (pairs.length == 0) {
@@ -126,7 +126,7 @@ public class UpdateByOperatorFactory {
         }
     }
 
-    private class OperationVisitor implements UpdateBySpec.Visitor<Void>, UpdateByClause.Visitor<Void> {
+    private class OperationVisitor implements UpdateBySpec.Visitor<Void>, UpdateByOperation.Visitor<Void> {
         private final List<UpdateByOperator> ops = new ArrayList<>();
         private MatchPair[] pairs;
 
@@ -142,7 +142,7 @@ public class UpdateByOperatorFactory {
         }
 
         @Override
-        public Void visit(@NotNull final ColumnUpdateClause clause) {
+        public Void visit(@NotNull final ColumnUpdateOperation clause) {
             final UpdateBySpec spec = clause.spec();
             pairs = createColumnsToAddIfMissing(source, parseMatchPairs(clause.columns()), spec, groupByColumns);
             spec.walk(this);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
@@ -7,7 +7,7 @@ import io.deephaven.api.*;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.engine.liveness.LivenessArtifact;
 import io.deephaven.engine.table.MatchPair;
@@ -665,38 +665,39 @@ class PartitionedTableProxyImpl extends LivenessArtifact implements PartitionedT
     }
 
     @Override
-    public PartitionedTable.Proxy updateBy(UpdateByClause operation) {
+    public PartitionedTable.Proxy updateBy(UpdateByOperation operation) {
         return basicTransform(ct -> ct.updateBy(operation));
     }
 
     @Override
-    public PartitionedTable.Proxy updateBy(UpdateByClause operation, String... byColumns) {
+    public PartitionedTable.Proxy updateBy(UpdateByOperation operation, String... byColumns) {
         return basicTransform(ct -> ct.updateBy(operation, byColumns));
     }
 
     @Override
-    public PartitionedTable.Proxy updateBy(Collection<? extends UpdateByClause> operations) {
+    public PartitionedTable.Proxy updateBy(Collection<? extends UpdateByOperation> operations) {
         return basicTransform(ct -> ct.updateBy(operations));
     }
 
     @Override
-    public PartitionedTable.Proxy updateBy(Collection<? extends UpdateByClause> operations, String... byColumns) {
+    public PartitionedTable.Proxy updateBy(Collection<? extends UpdateByOperation> operations, String... byColumns) {
         return basicTransform(ct -> ct.updateBy(operations, byColumns));
     }
 
     @Override
-    public PartitionedTable.Proxy updateBy(Collection<? extends UpdateByClause> operations,
+    public PartitionedTable.Proxy updateBy(Collection<? extends UpdateByOperation> operations,
             Collection<? extends Selectable> byColumns) {
         return basicTransform(ct -> ct.updateBy(operations, byColumns));
     }
 
     @Override
-    public PartitionedTable.Proxy updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations) {
+    public PartitionedTable.Proxy updateBy(UpdateByControl control,
+            Collection<? extends UpdateByOperation> operations) {
         return basicTransform(ct -> ct.updateBy(control, operations));
     }
 
     @Override
-    public PartitionedTable.Proxy updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations,
+    public PartitionedTable.Proxy updateBy(UpdateByControl control, Collection<? extends UpdateByOperation> operations,
             Collection<? extends Selectable> byColumns) {
         return basicTransform(ct -> ct.updateBy(control, operations, byColumns));
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BasePrimitiveEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BasePrimitiveEMAOperator.java
@@ -1,5 +1,6 @@
 package io.deephaven.engine.table.impl.updateby.ema;
 
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.LongChunk;
@@ -10,7 +11,6 @@ import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.chunkattributes.RowKeys;
 import io.deephaven.api.updateby.BadDataBehavior;
-import io.deephaven.api.updateby.EmaControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.TableUpdate;
 import io.deephaven.engine.table.impl.UpdateBy;
@@ -30,7 +30,7 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 import static io.deephaven.util.QueryConstants.NULL_LONG;
 
 public abstract class BasePrimitiveEMAOperator extends BaseDoubleUpdateByOperator {
-    protected final EmaControl control;
+    protected final OperationControl control;
     protected final LongRecordingUpdateByOperator timeRecorder;
     protected final double timeScaleUnits;
     private LongArraySource bucketLastTimestamp;
@@ -63,7 +63,7 @@ public abstract class BasePrimitiveEMAOperator extends BaseDoubleUpdateByOperato
      */
     public BasePrimitiveEMAOperator(@NotNull final MatchPair pair,
             @NotNull final String[] affectingColumns,
-            @NotNull final EmaControl control,
+            @NotNull final OperationControl control,
             @Nullable final LongRecordingUpdateByOperator timeRecorder,
             final long timeScaleUnits,
             @Nullable final RowRedirection rowRedirection) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigDecimalEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigDecimalEMAOperator.java
@@ -4,7 +4,7 @@ import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -31,7 +31,7 @@ public class BigDecimalEMAOperator extends BigNumberEMAOperator<BigDecimal> {
      */
     public BigDecimalEMAOperator(@NotNull final MatchPair pair,
             @NotNull final String[] affectingColumns,
-            @NotNull final EmaControl control,
+            @NotNull final OperationControl control,
             @Nullable final LongRecordingUpdateByOperator timeRecorder,
             final long timeScaleUnits,
             @NotNull final ColumnSource<BigDecimal> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigIntegerEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigIntegerEMAOperator.java
@@ -1,10 +1,10 @@
 package io.deephaven.engine.table.impl.updateby.ema;
 
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -31,7 +31,7 @@ public class BigIntegerEMAOperator extends BigNumberEMAOperator<BigInteger> {
      */
     public BigIntegerEMAOperator(@NotNull final MatchPair pair,
                                  @NotNull final String[] affectingColumns,
-                                 @NotNull final EmaControl control,
+                                 @NotNull final OperationControl control,
                                  @Nullable final LongRecordingUpdateByOperator timeRecorder,
                                  final long timeScaleUnits,
                                  @NotNull final ColumnSource<BigInteger> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigNumberEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/BigNumberEMAOperator.java
@@ -1,7 +1,7 @@
 package io.deephaven.engine.table.impl.updateby.ema;
 
 import io.deephaven.api.updateby.BadDataBehavior;
-import io.deephaven.api.updateby.EmaControl;
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.LongChunk;
@@ -31,7 +31,7 @@ import static io.deephaven.util.QueryConstants.NULL_LONG;
 public abstract class BigNumberEMAOperator<T> extends BaseObjectUpdateByOperator<BigDecimal> {
     protected final ColumnSource<T> valueSource;
 
-    protected final EmaControl control;
+    protected final OperationControl control;
     protected final LongRecordingUpdateByOperator timeRecorder;
     protected final double timeScaleUnits;
 
@@ -65,7 +65,7 @@ public abstract class BigNumberEMAOperator<T> extends BaseObjectUpdateByOperator
      */
     public BigNumberEMAOperator(@NotNull final MatchPair pair,
             @NotNull final String[] affectingColumns,
-            @NotNull final EmaControl control,
+            @NotNull final OperationControl control,
             @Nullable final LongRecordingUpdateByOperator timeRecorder,
             final long timeScaleUnits,
             @NotNull ColumnSource<T> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/ByteEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/ByteEMAOperator.java
@@ -10,7 +10,7 @@ import io.deephaven.chunk.ByteChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -36,7 +36,7 @@ public class ByteEMAOperator extends BasePrimitiveEMAOperator {
      */
     public ByteEMAOperator(@NotNull final MatchPair pair,
                             @NotNull final String[] affectingColumns,
-                            @NotNull final EmaControl control,
+                            @NotNull final OperationControl control,
                             @Nullable final LongRecordingUpdateByOperator timeRecorder,
                             final long timeScaleUnits,
                             @NotNull final ColumnSource<Byte> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/DoubleEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/DoubleEMAOperator.java
@@ -5,13 +5,13 @@
  */
 package io.deephaven.engine.table.impl.updateby.ema;
 
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.DoubleChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.api.updateby.BadDataBehavior;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -37,7 +37,7 @@ public class DoubleEMAOperator extends BasePrimitiveEMAOperator {
      */
     public DoubleEMAOperator(@NotNull final MatchPair pair,
                             @NotNull final String[] affectingColumns,
-                            @NotNull final EmaControl control,
+                            @NotNull final OperationControl control,
                             @Nullable final LongRecordingUpdateByOperator timeRecorder,
                             final long timeScaleUnits,
                             @NotNull final ColumnSource<Double> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/FloatEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/FloatEMAOperator.java
@@ -1,12 +1,12 @@
 package io.deephaven.engine.table.impl.updateby.ema;
 
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.FloatChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.api.updateby.BadDataBehavior;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -32,7 +32,7 @@ public class FloatEMAOperator extends BasePrimitiveEMAOperator {
      */
     public FloatEMAOperator(@NotNull final MatchPair pair,
                             @NotNull final String[] affectingColumns,
-                            @NotNull final EmaControl control,
+                            @NotNull final OperationControl control,
                             @Nullable final LongRecordingUpdateByOperator timeRecorder,
                             final long timeScaleUnits,
                             @NotNull final ColumnSource<Float> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/IntEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/IntEMAOperator.java
@@ -10,7 +10,7 @@ import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -36,7 +36,7 @@ public class IntEMAOperator extends BasePrimitiveEMAOperator {
      */
     public IntEMAOperator(@NotNull final MatchPair pair,
                             @NotNull final String[] affectingColumns,
-                            @NotNull final EmaControl control,
+                            @NotNull final OperationControl control,
                             @Nullable final LongRecordingUpdateByOperator timeRecorder,
                             final long timeScaleUnits,
                             @NotNull final ColumnSource<Integer> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/LongEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/LongEMAOperator.java
@@ -10,7 +10,7 @@ import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -36,7 +36,7 @@ public class LongEMAOperator extends BasePrimitiveEMAOperator {
      */
     public LongEMAOperator(@NotNull final MatchPair pair,
                             @NotNull final String[] affectingColumns,
-                            @NotNull final EmaControl control,
+                            @NotNull final OperationControl control,
                             @Nullable final LongRecordingUpdateByOperator timeRecorder,
                             final long timeScaleUnits,
                             @NotNull final ColumnSource<Long> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/ShortEMAOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ema/ShortEMAOperator.java
@@ -1,11 +1,11 @@
 package io.deephaven.engine.table.impl.updateby.ema;
 
+import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.ShortChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.api.updateby.EmaControl;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.impl.updateby.internal.LongRecordingUpdateByOperator;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -31,7 +31,7 @@ public class ShortEMAOperator extends BasePrimitiveEMAOperator {
      */
     public ShortEMAOperator(@NotNull final MatchPair pair,
                             @NotNull final String[] affectingColumns,
-                            @NotNull final EmaControl control,
+                            @NotNull final OperationControl control,
                             @Nullable final LongRecordingUpdateByOperator timeRecorder,
                             final long timeScaleUnits,
                             @NotNull final ColumnSource<Short> valueSource,

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -541,7 +541,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
                 "import static io.deephaven.time.TimeZone.*;\n" +
                 "import static io.deephaven.engine.table.impl.lang.QueryLanguageFunctionUtils.*;\n" +
                 "import static io.deephaven.api.agg.Aggregation.*;\n" +
-                "import static io.deephaven.api.updateby.UpdateByClause.*;\n" +
+                "import static io.deephaven.api.updateby.UpdateByOperation.*;\n" +
 
                 StringUtils.joinStrings(scriptImports, "\n") + "\n";
         return new Pair<>(commandPrefix, commandPrefix + command

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
@@ -1,8 +1,8 @@
 package io.deephaven.engine.table.impl.updateby;
 
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.table.PartitionedTable;
 import io.deephaven.engine.table.Table;
-import io.deephaven.api.updateby.UpdateByClause;
 import io.deephaven.engine.table.impl.EvalNugget;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TstUtils;
@@ -30,10 +30,10 @@ public class TestCumMinMax extends BaseUpdateByTest {
         final QueryTable t = createTestTable(100000, false, false, false, 0x2134BCFA).t;
 
         final Table result = t.updateBy(List.of(
-                UpdateByClause.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
+                UpdateByOperation.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
                         "longColMin=longCol", "floatColMin=floatCol", "doubleColMin=doubleCol",
                         "bigIntColMin=bigIntCol", "bigDecimalColMin=bigDecimalCol"),
-                UpdateByClause.CumMax("byteColMax=byteCol", "shortColMax=shortCol", "intColMax=intCol",
+                UpdateByOperation.CumMax("byteColMax=byteCol", "shortColMax=shortCol", "intColMax=intCol",
                         "longColMax=longCol", "floatColMax=floatCol", "doubleColMax=doubleCol",
                         "bigIntColMax=bigIntCol", "bigDecimalColMax=bigDecimalCol")));
         for (String col : t.getDefinition().getColumnNamesArray()) {
@@ -63,10 +63,10 @@ public class TestCumMinMax extends BaseUpdateByTest {
         final QueryTable t = createTestTable(100000, true, grouped, false, 0xACDB4321).t;
 
         final Table result = t.updateBy(List.of(
-                UpdateByClause.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
+                UpdateByOperation.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
                         "longColMin=longCol", "floatColMin=floatCol", "doubleColMin=doubleCol",
                         "bigIntColMin=bigIntCol", "bigDecimalColMin=bigDecimalCol"),
-                UpdateByClause.CumMax("byteColMax=byteCol", "shortColMax=shortCol", "intColMax=intCol",
+                UpdateByOperation.CumMax("byteColMax=byteCol", "shortColMax=shortCol", "intColMax=intCol",
                         "longColMax=longCol", "floatColMax=floatCol", "doubleColMax=doubleCol",
                         "bigIntColMax=bigIntCol", "bigDecimalColMax=bigDecimalCol")),
                 "Sym");
@@ -122,15 +122,15 @@ public class TestCumMinMax extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return bucketed ? t.updateBy(UpdateByClause.CumMin(), "Sym")
-                                : t.updateBy(UpdateByClause.CumMin());
+                        return bucketed ? t.updateBy(UpdateByOperation.CumMin(), "Sym")
+                                : t.updateBy(UpdateByOperation.CumMin());
                     }
                 },
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return bucketed ? t.updateBy(UpdateByClause.CumMax(), "Sym")
-                                : t.updateBy(UpdateByClause.CumMax());
+                        return bucketed ? t.updateBy(UpdateByOperation.CumMax(), "Sym")
+                                : t.updateBy(UpdateByOperation.CumMax());
                     }
                 }
         };

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
@@ -3,7 +3,7 @@ package io.deephaven.engine.table.impl.updateby;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.engine.table.PartitionedTable;
 import io.deephaven.engine.table.Table;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.table.impl.*;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.function.Numeric;
@@ -34,7 +34,7 @@ public class TestCumProd extends BaseUpdateByTest {
     @Test
     public void testStaticZeroKey() {
         final QueryTable t = createTestTable(1000, false, false, false, 0xABCD1234).t;
-        final Table result = t.updateBy(UpdateByClause.CumProd());
+        final Table result = t.updateBy(UpdateByOperation.CumProd());
         for (String col : t.getDefinition().getColumnNamesArray()) {
             if ("boolCol".equals(col)) {
                 continue;
@@ -64,9 +64,9 @@ public class TestCumProd extends BaseUpdateByTest {
                 longCol("IntValProd", 1, 2, NULL_LONG, 3));
 
         final Table r = t.updateBy(List.of(
-                UpdateByClause.CumProd("ByteValProd=ByteVal"),
-                UpdateByClause.CumProd("ShortValProd=ShortVal"),
-                UpdateByClause.CumProd("IntValProd=IntVal")), "Sym");
+                UpdateByOperation.CumProd("ByteValProd=ByteVal"),
+                UpdateByOperation.CumProd("ShortValProd=ShortVal"),
+                UpdateByOperation.CumProd("IntValProd=IntVal")), "Sym");
 
         assertTableEquals(expected, r);
     }
@@ -84,8 +84,9 @@ public class TestCumProd extends BaseUpdateByTest {
     private void doTestStaticBucketed(boolean grouped) {
         final QueryTable t = createTestTable(10000, true, grouped, false, 0x4321CBDA).t;
 
-        final Table result = t.updateBy(UpdateByClause.CumProd("byteCol", "shortCol", "intCol", "longCol", "floatCol",
-                "doubleCol", "bigIntCol", "bigDecimalCol"), "Sym");
+        final Table result =
+                t.updateBy(UpdateByOperation.CumProd("byteCol", "shortCol", "intCol", "longCol", "floatCol",
+                        "doubleCol", "bigIntCol", "bigDecimalCol"), "Sym");
 
         final PartitionedTable preOp = t.partitionBy("Sym");
         final PartitionedTable postOp = result.partitionBy("Sym");
@@ -125,8 +126,8 @@ public class TestCumProd extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return bucketed ? t.updateBy(UpdateByClause.CumProd(), "Sym")
-                                : t.updateBy(UpdateByClause.CumProd());
+                        return bucketed ? t.updateBy(UpdateByOperation.CumProd(), "Sym")
+                                : t.updateBy(UpdateByOperation.CumProd());
                     }
                 }
         };
@@ -147,7 +148,7 @@ public class TestCumProd extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return t.updateBy(UpdateByClause.CumProd());
+                        return t.updateBy(UpdateByOperation.CumProd());
                     }
                 }
         };
@@ -169,7 +170,7 @@ public class TestCumProd extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return t.updateBy(UpdateByClause.CumProd(), "Sym");
+                        return t.updateBy(UpdateByOperation.CumProd(), "Sym");
                     }
                 }
         };

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
@@ -1,9 +1,9 @@
 package io.deephaven.engine.table.impl.updateby;
 
 import io.deephaven.api.updateby.UpdateByControl;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.table.PartitionedTable;
 import io.deephaven.engine.table.Table;
-import io.deephaven.api.updateby.UpdateByClause;
 import io.deephaven.engine.table.impl.*;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.function.Numeric;
@@ -37,7 +37,7 @@ public class TestCumSum extends BaseUpdateByTest {
         final QueryTable t = createTestTable(100000, false, false, false, 0x31313131).t;
         t.setRefreshing(false);
 
-        final Table summed = t.updateBy(UpdateByClause.CumSum());
+        final Table summed = t.updateBy(UpdateByOperation.CumSum());
         for (String col : t.getDefinition().getColumnNamesArray()) {
             assertWithCumSum(t.getColumn(col).getDirect(), summed.getColumn(col).getDirect(),
                     summed.getColumn(col).getType());
@@ -64,9 +64,9 @@ public class TestCumSum extends BaseUpdateByTest {
                 longCol("IntValSum", 1, 3, NULL_LONG, 3));
 
         final Table r = t.updateBy(List.of(
-                UpdateByClause.CumSum("ByteValSum=ByteVal"),
-                UpdateByClause.CumSum("ShortValSum=ShortVal"),
-                UpdateByClause.CumSum("IntValSum=IntVal")), "Sym");
+                UpdateByOperation.CumSum("ByteValSum=ByteVal"),
+                UpdateByOperation.CumSum("ShortValSum=ShortVal"),
+                UpdateByOperation.CumSum("IntValSum=IntVal")), "Sym");
 
         assertTableEquals(expected, r);
     }
@@ -84,7 +84,7 @@ public class TestCumSum extends BaseUpdateByTest {
     private void doTestStaticBucketed(boolean grouped) {
         final QueryTable t = createTestTable(100000, true, grouped, false, 0x31313131).t;
 
-        final Table summed = t.updateBy(UpdateByClause.CumSum("byteCol", "shortCol", "intCol", "longCol", "floatCol",
+        final Table summed = t.updateBy(UpdateByOperation.CumSum("byteCol", "shortCol", "intCol", "longCol", "floatCol",
                 "doubleCol", "boolCol", "bigIntCol", "bigDecimalCol"), "Sym");
 
 
@@ -126,8 +126,8 @@ public class TestCumSum extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return bucketed ? t.updateBy(UpdateByClause.CumSum(), "Sym")
-                                : t.updateBy(UpdateByClause.CumSum());
+                        return bucketed ? t.updateBy(UpdateByOperation.CumSum(), "Sym")
+                                : t.updateBy(UpdateByOperation.CumSum());
                     }
                 }
         };
@@ -148,7 +148,7 @@ public class TestCumSum extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return t.updateBy(UpdateByClause.CumSum());
+                        return t.updateBy(UpdateByOperation.CumSum());
                     }
                 }
         };
@@ -170,7 +170,7 @@ public class TestCumSum extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return t.updateBy(UpdateByClause.CumSum(), "Sym");
+                        return t.updateBy(UpdateByOperation.CumSum(), "Sym");
                     }
                 }
         };

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestEma.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestEma.java
@@ -1,10 +1,10 @@
 package io.deephaven.engine.table.impl.updateby;
 
+import io.deephaven.api.updateby.OperationControl;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.api.updateby.BadDataBehavior;
-import io.deephaven.api.updateby.EmaControl;
 import io.deephaven.engine.table.Table;
-import io.deephaven.api.updateby.UpdateByClause;
 import io.deephaven.engine.table.impl.EvalNugget;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableWithDefaults;
@@ -47,11 +47,11 @@ public class TestEma extends BaseUpdateByTest {
                         convertDateTime("2022-03-09T09:00:00.000 NY"),
                         convertDateTime("2022-03-09T16:30:00.000 NY"))}).t;
 
-        final EmaControl skipControl = EmaControl.builder()
+        final OperationControl skipControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.SKIP)
                 .onNanValue(BadDataBehavior.SKIP).build();
 
-        final EmaControl resetControl = EmaControl.builder()
+        final OperationControl resetControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.RESET)
                 .onNanValue(BadDataBehavior.RESET).build();
 
@@ -81,11 +81,11 @@ public class TestEma extends BaseUpdateByTest {
                         convertDateTime("2022-03-09T09:00:00.000 NY"),
                         convertDateTime("2022-03-09T16:30:00.000 NY"))}).t;
 
-        final EmaControl skipControl = EmaControl.builder()
+        final OperationControl skipControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.SKIP)
                 .onNanValue(BadDataBehavior.SKIP).build();
 
-        final EmaControl resetControl = EmaControl.builder()
+        final OperationControl resetControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.RESET)
                 .onNanValue(BadDataBehavior.RESET).build();
         computeEma((TableWithDefaults) t.dropColumns("ts"), null, 100, skipControl, "Sym");
@@ -97,48 +97,50 @@ public class TestEma extends BaseUpdateByTest {
 
     @Test
     public void testThrowBehaviors() {
-        final EmaControl throwControl = EmaControl.builder()
+        final OperationControl throwControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.THROW).build();
 
         final TableWithDefaults bytes = testTable(RowSetFactory.flat(4).toTracking(),
                 byteCol("col", (byte) 0, (byte) 1, NULL_BYTE, (byte) 3));
 
         assertThrows(TableDataException.class,
-                () -> bytes.updateBy(UpdateByClause.Ema(throwControl, 10)));
+                () -> bytes.updateBy(UpdateByOperation.Ema(throwControl, 10)));
 
 
         assertThrows(TableDataException.class,
-                () -> bytes.updateBy(UpdateByClause.Ema(throwControl, 10)));
+                () -> bytes.updateBy(UpdateByOperation.Ema(throwControl, 10)));
 
         TableWithDefaults shorts = testTable(RowSetFactory.flat(4).toTracking(),
                 shortCol("col", (short) 0, (short) 1, NULL_SHORT, (short) 3));
 
         assertThrows(TableDataException.class,
-                () -> shorts.updateBy(UpdateByClause.Ema(throwControl, 10)));
+                () -> shorts.updateBy(UpdateByOperation.Ema(throwControl, 10)));
 
         TableWithDefaults ints = testTable(RowSetFactory.flat(4).toTracking(),
                 intCol("col", 0, 1, NULL_INT, 3));
 
         assertThrows(TableDataException.class,
-                () -> ints.updateBy(UpdateByClause.Ema(throwControl, 10)));
+                () -> ints.updateBy(UpdateByOperation.Ema(throwControl, 10)));
 
         TableWithDefaults longs = testTable(RowSetFactory.flat(4).toTracking(),
                 longCol("col", 0, 1, NULL_LONG, 3));
 
         assertThrows(TableDataException.class,
-                () -> longs.updateBy(UpdateByClause.Ema(throwControl, 10)));
+                () -> longs.updateBy(UpdateByOperation.Ema(throwControl, 10)));
 
         TableWithDefaults floats = testTable(RowSetFactory.flat(4).toTracking(),
                 floatCol("col", 0, 1, NULL_FLOAT, Float.NaN));
 
         assertThrows(TableDataException.class,
                 () -> floats.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNullValue(BadDataBehavior.THROW).build(), 10)),
+                        UpdateByOperation.Ema(OperationControl.builder().onNullValue(BadDataBehavior.THROW).build(),
+                                10)),
                 "Encountered null value during EMA processing");
 
         assertThrows(TableDataException.class,
                 () -> floats.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNanValue(BadDataBehavior.THROW).build(), 10)),
+                        UpdateByOperation.Ema(OperationControl.builder().onNanValue(BadDataBehavior.THROW).build(),
+                                10)),
                 "Encountered NaN value during EMA processing");
 
         TableWithDefaults doubles = testTable(RowSetFactory.flat(4).toTracking(),
@@ -146,12 +148,14 @@ public class TestEma extends BaseUpdateByTest {
 
         assertThrows(TableDataException.class,
                 () -> doubles.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNullValue(BadDataBehavior.THROW).build(), 10)),
+                        UpdateByOperation.Ema(OperationControl.builder().onNullValue(BadDataBehavior.THROW).build(),
+                                10)),
                 "Encountered null value during EMA processing");
 
         assertThrows(TableDataException.class,
                 () -> doubles.updateBy(
-                        UpdateByClause.Ema(EmaControl.builder().onNanValue(BadDataBehavior.THROW).build(), 10)),
+                        UpdateByOperation.Ema(OperationControl.builder().onNanValue(BadDataBehavior.THROW).build(),
+                                10)),
                 "Encountered NaN value during EMA processing");
 
 
@@ -159,13 +163,13 @@ public class TestEma extends BaseUpdateByTest {
                 col("col", BigInteger.valueOf(0), BigInteger.valueOf(1), null, BigInteger.valueOf(3)));
 
         assertThrows(TableDataException.class,
-                () -> bi.updateBy(UpdateByClause.Ema(throwControl, 10)));
+                () -> bi.updateBy(UpdateByOperation.Ema(throwControl, 10)));
 
         TableWithDefaults bd = testTable(RowSetFactory.flat(4).toTracking(),
                 col("col", BigDecimal.valueOf(0), BigDecimal.valueOf(1), null, BigDecimal.valueOf(3)));
 
         assertThrows(TableDataException.class,
-                () -> bd.updateBy(UpdateByClause.Ema(throwControl, 10)));
+                () -> bd.updateBy(UpdateByOperation.Ema(throwControl, 10)));
     }
 
     @Test
@@ -220,21 +224,21 @@ public class TestEma extends BaseUpdateByTest {
 
     private void testThrowsInternal(TableWithDefaults table) {
         assertThrows(TableDataException.class,
-                () -> table.updateBy(UpdateByClause.Ema(
-                        EmaControl.builder().build(), "ts", 100)),
+                () -> table.updateBy(UpdateByOperation.Ema(
+                        OperationControl.builder().build(), "ts", 100)),
                 "Encountered negative delta time during EMA processing");
 
         assertThrows(TableDataException.class,
-                () -> table.updateBy(UpdateByClause.Ema(
-                        EmaControl.builder()
+                () -> table.updateBy(UpdateByOperation.Ema(
+                        OperationControl.builder()
                                 .onNegativeDeltaTime(BadDataBehavior.SKIP)
                                 .onZeroDeltaTime(BadDataBehavior.THROW).build(),
                         "ts", 100)),
                 "Encountered zero delta time during EMA processing");
 
         assertThrows(TableDataException.class,
-                () -> table.updateBy(UpdateByClause.Ema(
-                        EmaControl.builder()
+                () -> table.updateBy(UpdateByOperation.Ema(
+                        OperationControl.builder()
                                 .onNegativeDeltaTime(BadDataBehavior.SKIP)
                                 .onNullTime(BadDataBehavior.THROW).build(),
                         "ts", 100)),
@@ -282,35 +286,35 @@ public class TestEma extends BaseUpdateByTest {
                         BigDecimal.valueOf(5)));
 
         // Test reset for NaN values
-        final EmaControl resetControl = EmaControl.builder()
+        final OperationControl resetControl = OperationControl.builder()
                 .onNanValue(BadDataBehavior.RESET)
                 .build();
 
         TableWithDefaults input = testTable(RowSetFactory.flat(3).toTracking(), doubleCol("col", 0, Double.NaN, 1));
-        Table result = input.updateBy(UpdateByClause.Ema(resetControl, 100));
+        Table result = input.updateBy(UpdateByOperation.Ema(resetControl, 100));
         expected = testTable(RowSetFactory.flat(3).toTracking(), doubleCol("col", 0, NULL_DOUBLE, 1));
         assertTableEquals(expected, result);
 
         input = testTable(RowSetFactory.flat(3).toTracking(), floatCol("col", 0, Float.NaN, 1));
-        result = input.updateBy(UpdateByClause.Ema(resetControl, 100));
+        result = input.updateBy(UpdateByOperation.Ema(resetControl, 100));
         expected = testTable(RowSetFactory.flat(3).toTracking(), doubleCol("col", 0, NULL_DOUBLE, 1));
         assertTableEquals(expected, result);
     }
 
     private void testResetBehaviorInternal(Table expected, final ColumnHolder ts, final ColumnHolder col) {
-        final EmaControl resetControl = EmaControl.builder().onNegativeDeltaTime(BadDataBehavior.RESET)
+        final OperationControl resetControl = OperationControl.builder().onNegativeDeltaTime(BadDataBehavior.RESET)
                 .onNullTime(BadDataBehavior.RESET)
                 .onZeroDeltaTime(BadDataBehavior.RESET)
                 .build();
 
         TableWithDefaults input = testTable(RowSetFactory.flat(6).toTracking(), ts, col);
-        final Table result = input.updateBy(UpdateByClause.Ema(resetControl, "ts", 1_000_000_000));
+        final Table result = input.updateBy(UpdateByOperation.Ema(resetControl, "ts", 1_000_000_000));
         assertTableEquals(expected, result);
     }
 
     @Test
     public void testPoison() {
-        final EmaControl nanCtl = EmaControl.builder().onNanValue(BadDataBehavior.POISON)
+        final OperationControl nanCtl = OperationControl.builder().onNanValue(BadDataBehavior.POISON)
                 .onNullValue(BadDataBehavior.RESET)
                 .onNullTime(BadDataBehavior.RESET)
                 .onNegativeDeltaTime(BadDataBehavior.RESET)
@@ -320,9 +324,9 @@ public class TestEma extends BaseUpdateByTest {
                 doubleCol("col", 0, Double.NaN, NULL_DOUBLE, Double.NaN, Double.NaN));
         TableWithDefaults input = testTable(RowSetFactory.flat(5).toTracking(),
                 doubleCol("col", 0, Double.NaN, NULL_DOUBLE, Double.NaN, 4));
-        assertTableEquals(expected, input.updateBy(UpdateByClause.Ema(nanCtl, 10)));
+        assertTableEquals(expected, input.updateBy(UpdateByOperation.Ema(nanCtl, 10)));
         input = testTable(RowSetFactory.flat(5).toTracking(), floatCol("col", 0, Float.NaN, NULL_FLOAT, Float.NaN, 4));
-        assertTableEquals(expected, input.updateBy(UpdateByClause.Ema(nanCtl, 10)));
+        assertTableEquals(expected, input.updateBy(UpdateByOperation.Ema(nanCtl, 10)));
 
         final ColumnHolder ts = col("ts",
                 convertDateTime("2022-03-11T09:30:00.000 NY"),
@@ -336,12 +340,12 @@ public class TestEma extends BaseUpdateByTest {
                 doubleCol("col", 0, Double.NaN, NULL_DOUBLE, Double.NaN, Double.NaN, NULL_DOUBLE));
         input = testTable(RowSetFactory.flat(6).toTracking(), ts,
                 doubleCol("col", 0, Double.NaN, 2, Double.NaN, 4, 5));
-        Table result = input.updateBy(UpdateByClause.Ema(nanCtl, "ts", 10));
+        Table result = input.updateBy(UpdateByOperation.Ema(nanCtl, "ts", 10));
         assertTableEquals(expected, result);
 
         input = testTable(RowSetFactory.flat(6).toTracking(), ts,
                 floatCol("col", 0, Float.NaN, 2, Float.NaN, 4, 5));
-        assertTableEquals(expected, input.updateBy(UpdateByClause.Ema(nanCtl, "ts", 10)));
+        assertTableEquals(expected, input.updateBy(UpdateByOperation.Ema(nanCtl, "ts", 10)));
     }
 
     // endregion
@@ -380,11 +384,11 @@ public class TestEma extends BaseUpdateByTest {
             timeResult.t.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, Boolean.TRUE);
         }
 
-        final EmaControl skipControl = EmaControl.builder()
+        final OperationControl skipControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.SKIP)
                 .onNanValue(BadDataBehavior.SKIP).build();
 
-        final EmaControl resetControl = EmaControl.builder()
+        final OperationControl resetControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.RESET)
                 .onNanValue(BadDataBehavior.RESET).build();
 
@@ -393,16 +397,16 @@ public class TestEma extends BaseUpdateByTest {
                     @Override
                     protected Table e() {
                         return bucketed
-                                ? tickResult.t.updateBy(UpdateByClause.Ema(skipControl, 100), "Sym")
-                                : tickResult.t.updateBy(UpdateByClause.Ema(skipControl, 100));
+                                ? tickResult.t.updateBy(UpdateByOperation.Ema(skipControl, 100), "Sym")
+                                : tickResult.t.updateBy(UpdateByOperation.Ema(skipControl, 100));
                     }
                 },
                 new EvalNugget() {
                     @Override
                     protected Table e() {
                         return bucketed
-                                ? tickResult.t.updateBy(UpdateByClause.Ema(resetControl, 100), "Sym")
-                                : tickResult.t.updateBy(UpdateByClause.Ema(resetControl, 100));
+                                ? tickResult.t.updateBy(UpdateByOperation.Ema(resetControl, 100), "Sym")
+                                : tickResult.t.updateBy(UpdateByOperation.Ema(resetControl, 100));
                     }
                 }
         };
@@ -416,8 +420,8 @@ public class TestEma extends BaseUpdateByTest {
                             base = (TableWithDefaults) base.sort("ts");
                         }
                         return bucketed
-                                ? base.updateBy(UpdateByClause.Ema(skipControl, "ts", 10 * MINUTE), "Sym")
-                                : base.updateBy(UpdateByClause.Ema(skipControl, "ts", 10 * MINUTE));
+                                ? base.updateBy(UpdateByOperation.Ema(skipControl, "ts", 10 * MINUTE), "Sym")
+                                : base.updateBy(UpdateByOperation.Ema(skipControl, "ts", 10 * MINUTE));
                     }
                 },
                 new EvalNugget() {
@@ -428,8 +432,8 @@ public class TestEma extends BaseUpdateByTest {
                             base = (TableWithDefaults) base.sort("ts");
                         }
                         return bucketed
-                                ? base.updateBy(UpdateByClause.Ema(resetControl, "ts", 10 * MINUTE), "Sym")
-                                : base.updateBy(UpdateByClause.Ema(resetControl, "ts", 10 * MINUTE));
+                                ? base.updateBy(UpdateByOperation.Ema(resetControl, "ts", 10 * MINUTE), "Sym")
+                                : base.updateBy(UpdateByOperation.Ema(resetControl, "ts", 10 * MINUTE));
                     }
                 }
         };
@@ -460,7 +464,7 @@ public class TestEma extends BaseUpdateByTest {
     private void computeEma(TableWithDefaults source,
             final String tsCol,
             long scale,
-            EmaControl control,
+            OperationControl control,
             String... groups) {
         final boolean useTicks = StringUtils.isNullOrEmpty(tsCol);
         final ByEmaSimple bes = new ByEmaSimple(
@@ -501,11 +505,11 @@ public class TestEma extends BaseUpdateByTest {
                         "bigIntCol= Double.isNaN(bigIntCol) ? NULL_DOUBLE : bigIntCol",
                         "bigDecimalCol= Double.isNaN(bigDecimalCol) ? NULL_DOUBLE : bigDecimalCol");
 
-        final UpdateByClause emaClause;
+        final UpdateByOperation emaClause;
         if (useTicks) {
-            emaClause = UpdateByClause.Ema(control, scale);
+            emaClause = UpdateByOperation.Ema(control, scale);
         } else {
-            emaClause = UpdateByClause.Ema(control, tsCol, scale);
+            emaClause = UpdateByOperation.Ema(control, tsCol, scale);
         }
 
         final Table result = source.updateBy(emaClause, groups)

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestForwardFill.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestForwardFill.java
@@ -1,10 +1,10 @@
 package io.deephaven.engine.table.impl.updateby;
 
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.PartitionedTable;
 import io.deephaven.engine.table.Table;
-import io.deephaven.api.updateby.UpdateByClause;
 import io.deephaven.engine.table.impl.*;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.util.TableTools;
@@ -37,7 +37,7 @@ public class TestForwardFill extends BaseUpdateByTest {
         final QueryTable t = createTestTable(100000, true, false, false, 0x507A70,
                 new String[] {"charCol"}, new TstUtils.Generator[] {new TstUtils.CharGenerator('A', 'Z', .1)}).t;
 
-        final Table filled = t.updateBy(UpdateByClause.Fill());
+        final Table filled = t.updateBy(UpdateByOperation.Fill());
         for (String col : t.getDefinition().getColumnNamesArray()) {
             assertWithForwardFill(t.getColumn(col).getDirect(), filled.getColumn(col).getDirect());
         }
@@ -50,7 +50,7 @@ public class TestForwardFill extends BaseUpdateByTest {
                 stringCol("Sentinel", null, null, null, "G", "H", null, "K", "L"),
                 intCol("Val", 1, 3, 5, NULL_INT, NULL_INT, 9, 10, NULL_INT));
 
-        final Table result = src.updateBy(UpdateByClause.Fill());
+        final Table result = src.updateBy(UpdateByOperation.Fill());
         final TableUpdateValidator validator = TableUpdateValidator.make((QueryTable) result);
         final FailureListener failureListener = new FailureListener();
         validator.getResultTable().listenForUpdates(failureListener);
@@ -108,7 +108,7 @@ public class TestForwardFill extends BaseUpdateByTest {
                 stringCol("Sentinel", null, null, null, "G", "H", null, "K", "L"),
                 intCol("Val", 1, 3, 5, NULL_INT, NULL_INT, 9, 10, NULL_INT));
 
-        final Table result = src.updateBy(UpdateByClause.Fill());
+        final Table result = src.updateBy(UpdateByOperation.Fill());
         final TableUpdateValidator validator = TableUpdateValidator.make((QueryTable) result);
         final FailureListener failureListener = new FailureListener();
         validator.getResultTable().listenForUpdates(failureListener);
@@ -160,7 +160,7 @@ public class TestForwardFill extends BaseUpdateByTest {
                 stringCol("Sentinel", null, null, null, "G", "H", null, "time toK", "L"),
                 intCol("Val", 1, 3, 5, NULL_INT, NULL_INT, 9, 10, NULL_INT));
 
-        final Table result = src.updateBy(UpdateByClause.Fill());
+        final Table result = src.updateBy(UpdateByOperation.Fill());
         final TableUpdateValidator validator = TableUpdateValidator.make((QueryTable) result);
         final FailureListener failureListener = new FailureListener();
         validator.getResultTable().listenForUpdates(failureListener);
@@ -232,7 +232,7 @@ public class TestForwardFill extends BaseUpdateByTest {
                 stringCol("Sentinel", "A", "B", "C", "D", "E", null, "G"),
                 intCol("Val", 0, 1, 2, 3, 4, 5, 6));
 
-        final Table result = src.updateBy(UpdateByClause.Fill());
+        final Table result = src.updateBy(UpdateByOperation.Fill());
         updateAndValidate(src, result, () -> {
             final RowSet idx = i(2, 3, 4);
             addToTable(src, idx,
@@ -259,12 +259,12 @@ public class TestForwardFill extends BaseUpdateByTest {
         final EvalNuggetInterface[] en = new EvalNuggetInterface[] {
                 new EvalNugget() {
                     public Table e() {
-                        return queryTable.updateBy(UpdateByClause.Fill());
+                        return queryTable.updateBy(UpdateByOperation.Fill());
                     }
                 },
                 new EvalNugget() {
                     public Table e() {
-                        return ((TableWithDefaults) queryTable.sort("intCol")).updateBy(UpdateByClause.Fill());
+                        return ((TableWithDefaults) queryTable.sort("intCol")).updateBy(UpdateByOperation.Fill());
                     }
                 },
         };
@@ -328,7 +328,7 @@ public class TestForwardFill extends BaseUpdateByTest {
         final QueryTable t = createTestTable(100000, true, false, false, 0x507A70,
                 new String[] {"charCol"}, new Generator[] {new CharGenerator('A', 'Z', .1)}).t;
 
-        final Table filled = t.updateBy(UpdateByClause.Fill(), "Sym");
+        final Table filled = t.updateBy(UpdateByOperation.Fill(), "Sym");
 
         final PartitionedTable preOp = t.partitionBy("Sym");
         final PartitionedTable postOp = filled.partitionBy("Sym");
@@ -349,7 +349,7 @@ public class TestForwardFill extends BaseUpdateByTest {
         final QueryTable t = createTestTable(100000, true, true, false, 0x507A70,
                 new String[] {"charCol"}, new Generator[] {new CharGenerator('A', 'Z', .1)}).t;
 
-        final Table filled = t.updateBy(UpdateByClause.Fill(), "Sym");
+        final Table filled = t.updateBy(UpdateByOperation.Fill(), "Sym");
 
         final PartitionedTable preOp = t.partitionBy("Sym");
         final PartitionedTable postOp = filled.partitionBy("Sym");
@@ -385,8 +385,8 @@ public class TestForwardFill extends BaseUpdateByTest {
                 new EvalNugget() {
                     @Override
                     protected Table e() {
-                        return bucketed ? t.updateBy(UpdateByClause.Fill(), "Sym")
-                                : t.updateBy(UpdateByClause.Fill());
+                        return bucketed ? t.updateBy(UpdateByOperation.Fill(), "Sym")
+                                : t.updateBy(UpdateByOperation.Fill());
                     }
                 }
         };

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
@@ -2,9 +2,9 @@ package io.deephaven.engine.table.impl.updateby;
 
 import io.deephaven.api.Selectable;
 import io.deephaven.api.updateby.BadDataBehavior;
-import io.deephaven.api.updateby.EmaControl;
+import io.deephaven.api.updateby.OperationControl;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.table.Table;
-import io.deephaven.api.updateby.UpdateByClause;
 import io.deephaven.engine.table.impl.EvalNugget;
 import io.deephaven.engine.table.impl.TableWithDefaults;
 import io.deephaven.engine.table.impl.TstUtils;
@@ -72,7 +72,7 @@ public class TestUpdateByGeneral extends BaseUpdateByTest {
             result.t.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, Boolean.TRUE);
         }
 
-        final EmaControl skipControl = EmaControl.builder()
+        final OperationControl skipControl = OperationControl.builder()
                 .onNullValue(BadDataBehavior.SKIP)
                 .onNanValue(BadDataBehavior.SKIP).build();
 
@@ -88,14 +88,14 @@ public class TestUpdateByGeneral extends BaseUpdateByTest {
                         }
 
                         final String[] columnNamesArray = base.getDefinition().getColumnNamesArray();
-                        final Collection<? extends UpdateByClause> clauses = List.of(
-                                UpdateByClause.Fill(),
-                                UpdateByClause.Ema(skipControl, "ts", 10 * MINUTE,
+                        final Collection<? extends UpdateByOperation> clauses = List.of(
+                                UpdateByOperation.Fill(),
+                                UpdateByOperation.Ema(skipControl, "ts", 10 * MINUTE,
                                         makeOpColNames(columnNamesArray, "_ema", "Sym", "ts", "boolCol")),
-                                UpdateByClause.CumSum(makeOpColNames(columnNamesArray, "_sum", "Sym", "ts")),
-                                UpdateByClause.CumMin(makeOpColNames(columnNamesArray, "_min", "boolCol")),
-                                UpdateByClause.CumMax(makeOpColNames(columnNamesArray, "_max", "boolCol")),
-                                UpdateByClause
+                                UpdateByOperation.CumSum(makeOpColNames(columnNamesArray, "_sum", "Sym", "ts")),
+                                UpdateByOperation.CumMin(makeOpColNames(columnNamesArray, "_min", "boolCol")),
+                                UpdateByOperation.CumMax(makeOpColNames(columnNamesArray, "_max", "boolCol")),
+                                UpdateByOperation
                                         .CumProd(makeOpColNames(columnNamesArray, "_prod", "Sym", "ts", "boolCol")));
                         final UpdateByControl control = UpdateByControl.builder().useRedirection(redirected).build();
                         return bucketed

--- a/qst/src/main/java/io/deephaven/qst/table/TableBase.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableBase.java
@@ -14,7 +14,7 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.qst.TableCreationLogic;
 
@@ -457,7 +457,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final UpdateByTable updateBy(UpdateByClause operation) {
+    public final UpdateByTable updateBy(UpdateByOperation operation) {
         return UpdateByTable.builder()
                 .parent(this)
                 .addOperations(operation)
@@ -465,7 +465,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final UpdateByTable updateBy(UpdateByClause operation, String... byColumns) {
+    public final UpdateByTable updateBy(UpdateByOperation operation, String... byColumns) {
         UpdateByTable.Builder builder = UpdateByTable.builder()
                 .parent(this)
                 .addOperations(operation);
@@ -476,7 +476,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final UpdateByTable updateBy(Collection<? extends UpdateByClause> operations,
+    public final UpdateByTable updateBy(Collection<? extends UpdateByOperation> operations,
             Collection<? extends Selectable> byColumns) {
         return UpdateByTable.builder()
                 .parent(this)
@@ -486,7 +486,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final UpdateByTable updateBy(Collection<? extends UpdateByClause> operations) {
+    public final UpdateByTable updateBy(Collection<? extends UpdateByOperation> operations) {
         return UpdateByTable.builder()
                 .parent(this)
                 .addAllOperations(operations)
@@ -494,7 +494,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final UpdateByTable updateBy(Collection<? extends UpdateByClause> operations, String... byColumns) {
+    public final UpdateByTable updateBy(Collection<? extends UpdateByOperation> operations, String... byColumns) {
         UpdateByTable.Builder builder = UpdateByTable.builder()
                 .parent(this)
                 .addAllOperations(operations);
@@ -505,7 +505,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final UpdateByTable updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations) {
+    public final UpdateByTable updateBy(UpdateByControl control, Collection<? extends UpdateByOperation> operations) {
         return UpdateByTable.builder()
                 .parent(this)
                 .control(control)
@@ -514,7 +514,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final UpdateByTable updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations,
+    public final UpdateByTable updateBy(UpdateByControl control, Collection<? extends UpdateByOperation> operations,
             Collection<? extends Selectable> byColumns) {
         return UpdateByTable.builder()
                 .parent(this)

--- a/qst/src/main/java/io/deephaven/qst/table/UpdateByTable.java
+++ b/qst/src/main/java/io/deephaven/qst/table/UpdateByTable.java
@@ -4,7 +4,7 @@
 package io.deephaven.qst.table;
 
 import io.deephaven.annotations.NodeStyle;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
@@ -22,7 +22,7 @@ public abstract class UpdateByTable extends ByTableBase {
 
     public abstract Optional<UpdateByControl> control();
 
-    public abstract List<UpdateByClause> operations();
+    public abstract List<UpdateByOperation> operations();
 
     @Override
     public final <V extends Visitor> V walk(V visitor) {
@@ -40,10 +40,10 @@ public abstract class UpdateByTable extends ByTableBase {
     public interface Builder extends ByTableBase.Builder<UpdateByTable, Builder> {
         Builder control(UpdateByControl control);
 
-        Builder addOperations(UpdateByClause element);
+        Builder addOperations(UpdateByOperation element);
 
-        Builder addOperations(UpdateByClause... elements);
+        Builder addOperations(UpdateByOperation... elements);
 
-        Builder addAllOperations(Iterable<? extends UpdateByClause> elements);
+        Builder addAllOperations(Iterable<? extends UpdateByOperation> elements);
     }
 }

--- a/qst/src/test/java/io/deephaven/qst/table/TableCreatorImplTest.java
+++ b/qst/src/test/java/io/deephaven/qst/table/TableCreatorImplTest.java
@@ -5,7 +5,7 @@ package io.deephaven.qst.table;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.qst.examples.EmployeesExample;
 import io.deephaven.qst.column.Column;
 
@@ -111,11 +111,11 @@ public class TableCreatorImplTest {
     }
 
     static TableSpec updateByFooCumSum(TableSpec table) {
-        return table.updateBy(UpdateByClause.CumSum("Foo"));
+        return table.updateBy(UpdateByOperation.CumSum("Foo"));
     }
 
     static TableSpec updateByFooCumSumByBar(TableSpec table) {
-        return table.updateBy(UpdateByClause.CumSum("Foo"), "Bar");
+        return table.updateBy(UpdateByOperation.CumSum("Foo"), "Bar");
     }
 
     static TableSpec selectFoo(TableSpec table) {

--- a/table-api/src/main/java/io/deephaven/api/TableOperations.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperations.java
@@ -6,7 +6,7 @@ package io.deephaven.api;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 
 import java.util.Collection;
@@ -519,19 +519,19 @@ public interface TableOperations<TOPS extends TableOperations<TOPS, TABLE>, TABL
 
     // -------------------------------------------------------------------------------------------
 
-    TOPS updateBy(UpdateByClause operation);
+    TOPS updateBy(UpdateByOperation operation);
 
-    TOPS updateBy(Collection<? extends UpdateByClause> operations);
+    TOPS updateBy(Collection<? extends UpdateByOperation> operations);
 
-    TOPS updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations);
+    TOPS updateBy(UpdateByControl control, Collection<? extends UpdateByOperation> operations);
 
-    TOPS updateBy(UpdateByClause operation, final String... byColumns);
+    TOPS updateBy(UpdateByOperation operation, final String... byColumns);
 
-    TOPS updateBy(Collection<? extends UpdateByClause> operations, final String... byColumns);
+    TOPS updateBy(Collection<? extends UpdateByOperation> operations, final String... byColumns);
 
-    TOPS updateBy(Collection<? extends UpdateByClause> operations, Collection<? extends Selectable> byColumns);
+    TOPS updateBy(Collection<? extends UpdateByOperation> operations, Collection<? extends Selectable> byColumns);
 
-    TOPS updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations,
+    TOPS updateBy(UpdateByControl control, Collection<? extends UpdateByOperation> operations,
             Collection<? extends Selectable> byColumns);
 
     // -------------------------------------------------------------------------------------------

--- a/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
@@ -6,7 +6,7 @@ package io.deephaven.api;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.api.agg.spec.AggSpec;
 import io.deephaven.api.filter.Filter;
-import io.deephaven.api.updateby.UpdateByClause;
+import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.api.updateby.UpdateByControl;
 
 import java.util.Collection;
@@ -318,38 +318,38 @@ public abstract class TableOperationsAdapter<TOPS_1 extends TableOperations<TOPS
 
 
     @Override
-    public final TOPS_1 updateBy(UpdateByClause operation) {
+    public final TOPS_1 updateBy(UpdateByOperation operation) {
         return adapt(delegate.updateBy(operation));
     }
 
     @Override
-    public final TOPS_1 updateBy(UpdateByClause operation, String... byColumns) {
+    public final TOPS_1 updateBy(UpdateByOperation operation, String... byColumns) {
         return adapt(delegate.updateBy(operation, byColumns));
     }
 
     @Override
-    public final TOPS_1 updateBy(Collection<? extends UpdateByClause> operations) {
+    public final TOPS_1 updateBy(Collection<? extends UpdateByOperation> operations) {
         return adapt(delegate.updateBy(operations));
     }
 
     @Override
-    public final TOPS_1 updateBy(Collection<? extends UpdateByClause> operations, String... byColumns) {
+    public final TOPS_1 updateBy(Collection<? extends UpdateByOperation> operations, String... byColumns) {
         return adapt(delegate.updateBy(operations, byColumns));
     }
 
     @Override
-    public final TOPS_1 updateBy(Collection<? extends UpdateByClause> operations,
+    public final TOPS_1 updateBy(Collection<? extends UpdateByOperation> operations,
             Collection<? extends Selectable> byColumns) {
         return adapt(delegate.updateBy(operations, byColumns));
     }
 
     @Override
-    public final TOPS_1 updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations) {
+    public final TOPS_1 updateBy(UpdateByControl control, Collection<? extends UpdateByOperation> operations) {
         return adapt(delegate.updateBy(control, operations));
     }
 
     @Override
-    public final TOPS_1 updateBy(UpdateByControl control, Collection<? extends UpdateByClause> operations,
+    public final TOPS_1 updateBy(UpdateByControl control, Collection<? extends UpdateByOperation> operations,
             Collection<? extends Selectable> byColumns) {
         return adapt(delegate.updateBy(control, operations, byColumns));
     }

--- a/table-api/src/main/java/io/deephaven/api/updateby/ColumnUpdateOperation.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/ColumnUpdateOperation.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 @Immutable
 @BuildableStyle
-public abstract class ColumnUpdateClause implements UpdateByClause {
+public abstract class ColumnUpdateOperation implements UpdateByOperation {
     public static Builder builder() {
-        return ImmutableColumnUpdateClause.builder();
+        return ImmutableColumnUpdateOperation.builder();
     }
 
 
@@ -40,6 +40,6 @@ public abstract class ColumnUpdateClause implements UpdateByClause {
 
         Builder addAllColumns(Iterable<? extends Pair> elements);
 
-        ColumnUpdateClause build();
+        ColumnUpdateOperation build();
     }
 }

--- a/table-api/src/main/java/io/deephaven/api/updateby/OperationControl.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/OperationControl.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 /**
  * <p>
- * Control parameters for performing EMAs with Table#updateBy()
+ * Control parameters for performing operations with Table#updateBy()
  * </p>
  * <p>
  * Defaults are as follows
@@ -25,12 +25,12 @@ import java.util.Optional;
  */
 @Immutable
 @BuildableStyle
-public abstract class EmaControl {
+public abstract class OperationControl {
     public static Builder builder() {
-        return ImmutableEmaControl.builder();
+        return ImmutableOperationControl.builder();
     }
 
-    public static EmaControl defaultInstance() {
+    public static OperationControl defaultInstance() {
         return builder().build();
     }
 
@@ -117,7 +117,7 @@ public abstract class EmaControl {
      *
      * @return the explicit new instance
      */
-    public final EmaControl materialize() {
+    public final OperationControl materialize() {
         return builder()
                 .onNullValue(onNullValueOrDefault())
                 .onNanValue(onNanValueOrDefault())
@@ -141,6 +141,6 @@ public abstract class EmaControl {
 
         Builder bigValueContext(MathContext context);
 
-        EmaControl build();
+        OperationControl build();
     }
 }

--- a/table-api/src/main/java/io/deephaven/api/updateby/UpdateByOperation.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/UpdateByOperation.java
@@ -4,22 +4,20 @@ import io.deephaven.api.agg.Pair;
 import io.deephaven.api.updateby.spec.*;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * Defines an operation that can be applied to a table with Table#updateBy()}
  */
-public interface UpdateByClause {
+public interface UpdateByOperation {
     /**
      * Conjoin an {@link UpdateBySpec} with columns for it to be applied to so the engine can construct the proper
      * operators.
      * 
      * @param spec the {@link UpdateBySpec} that defines the operation to perform
      * @param columns the columns to apply the operation to.
-     * @return a {@link ColumnUpdateClause} that will be used to construct operations for each column
+     * @return a {@link ColumnUpdateOperation} that will be used to construct operations for each column
      */
-    static ColumnUpdateClause of(final UpdateBySpec spec, final String... columns) {
+    static ColumnUpdateOperation of(final UpdateBySpec spec, final String... columns) {
         return spec.clause(columns);
     }
 
@@ -29,9 +27,9 @@ public interface UpdateByClause {
      *
      * @param spec the {@link UpdateBySpec} that defines the operation to perform
      * @param columns the columns to apply the operation to.
-     * @return a {@link ColumnUpdateClause} that will be used to construct operations for each column
+     * @return a {@link ColumnUpdateOperation} that will be used to construct operations for each column
      */
-    static ColumnUpdateClause of(final UpdateBySpec spec, final Pair... columns) {
+    static ColumnUpdateOperation of(final UpdateBySpec spec, final Pair... columns) {
         return spec.clause(columns);
     }
 
@@ -41,7 +39,7 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause CumSum(String... pairs) {
+    static UpdateByOperation CumSum(String... pairs) {
         return CumSumSpec.of().clause(pairs);
     }
 
@@ -51,7 +49,7 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause CumProd(String... pairs) {
+    static UpdateByOperation CumProd(String... pairs) {
         return CumProdSpec.of().clause(pairs);
     }
 
@@ -61,7 +59,7 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause CumMin(String... pairs) {
+    static UpdateByOperation CumMin(String... pairs) {
         return CumMinMaxSpec.of(false).clause(pairs);
     }
 
@@ -71,7 +69,7 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause CumMax(String... pairs) {
+    static UpdateByOperation CumMax(String... pairs) {
         return CumMinMaxSpec.of(true).clause(pairs);
     }
 
@@ -81,13 +79,13 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause Fill(String... pairs) {
+    static UpdateByOperation Fill(String... pairs) {
         return FillBySpec.of().clause(pairs);
     }
 
     /**
      * Create an {@link EmaSpec exponential moving average} for the supplied column name pairs, using ticks as the decay
-     * unit. Uses the default EmaControl settings.
+     * unit. Uses the default OperationControl settings.
      * <p>
      * The formula used is
      * </p>
@@ -101,7 +99,7 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause Ema(long timeScaleTicks, String... pairs) {
+    static UpdateByOperation Ema(long timeScaleTicks, String... pairs) {
         return EmaSpec.ofTicks(timeScaleTicks).clause(pairs);
     }
 
@@ -117,19 +115,19 @@ public interface UpdateByClause {
      *     ema_next = a * ema_last + (1 - a) * value
      * </pre>
      *
-     * @param control a {@link EmaControl control} object that defines how special cases should behave. See
-     *        {@link EmaControl} for further details.
+     * @param control a {@link OperationControl control} object that defines how special cases should behave. See
+     *        {@link OperationControl} for further details.
      * @param timeScaleTicks the decay rate in ticks
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause Ema(final EmaControl control, long timeScaleTicks, String... pairs) {
+    static UpdateByOperation Ema(final OperationControl control, long timeScaleTicks, String... pairs) {
         return EmaSpec.ofTicks(control, timeScaleTicks).clause(pairs);
     }
 
     /**
      * Create an {@link EmaSpec exponential moving average} for the supplied column name pairs, using time as the decay
-     * unit. Uses the default EmaControl settings.
+     * unit. Uses the default OperationControl settings.
      * <p>
      * The formula used is
      * </p>
@@ -144,7 +142,7 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause Ema(String timestampColumn, long timeScaleNanos, String... pairs) {
+    static UpdateByOperation Ema(String timestampColumn, long timeScaleNanos, String... pairs) {
         return EmaSpec.ofTime(timestampColumn, timeScaleNanos).clause(pairs);
     }
 
@@ -160,20 +158,21 @@ public interface UpdateByClause {
      *     ema_next = a * ema_last + (1 - a) * value
      * </pre>
      *
-     * @param control a {@link EmaControl control} object that defines how special cases should behave. See
-     *        {@link EmaControl} for further details.
+     * @param control a {@link OperationControl control} object that defines how special cases should behave. See
+     *        {@link OperationControl} for further details.
      * @param timestampColumn the column in the source table to use for timestamps
      * @param timeScaleNanos the decay rate in nanoseconds
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause Ema(EmaControl control, String timestampColumn, long timeScaleNanos, String... pairs) {
+    static UpdateByOperation Ema(OperationControl control, String timestampColumn, long timeScaleNanos,
+            String... pairs) {
         return EmaSpec.ofTime(control, timestampColumn, timeScaleNanos).clause(pairs);
     }
 
     /**
      * Create an {@link EmaSpec exponential moving average} for the supplied column name pairs, using time as the decay
-     * unit. Uses the default EmaControl settings.
+     * unit. Uses the default OperationControl settings.
      * <p>
      * The formula used is
      * </p>
@@ -188,7 +187,7 @@ public interface UpdateByClause {
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause Ema(String timestampColumn, Duration emaDuration, String... pairs) {
+    static UpdateByOperation Ema(String timestampColumn, Duration emaDuration, String... pairs) {
         return EmaSpec.ofTime(timestampColumn, emaDuration).clause(pairs);
     }
 
@@ -204,20 +203,21 @@ public interface UpdateByClause {
      *     ema_next = a * ema_last + (1 - a) * value
      * </pre>
      *
-     * @param control a {@link EmaControl control} object that defines how special cases should behave. See
-     *        {@link EmaControl} for further details.
+     * @param control a {@link OperationControl control} object that defines how special cases should behave. See
+     *        {@link OperationControl} for further details.
      * @param timestampColumn the column in the source table to use for timestamps
      * @param emaDuration the decay rate as {@Link Duration duration}
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    static UpdateByClause Ema(EmaControl control, String timestampColumn, Duration emaDuration, String... pairs) {
+    static UpdateByOperation Ema(OperationControl control, String timestampColumn, Duration emaDuration,
+            String... pairs) {
         return EmaSpec.ofTime(control, timestampColumn, emaDuration).clause(pairs);
     }
 
     <T> T walk(Visitor<T> visitor);
 
     interface Visitor<T> {
-        T visit(ColumnUpdateClause clause);
+        T visit(ColumnUpdateOperation clause);
     }
 }

--- a/table-api/src/main/java/io/deephaven/api/updateby/spec/EmaSpec.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/spec/EmaSpec.java
@@ -1,7 +1,7 @@
 package io.deephaven.api.updateby.spec;
 
 import io.deephaven.annotations.BuildableStyle;
-import io.deephaven.api.updateby.EmaControl;
+import io.deephaven.api.updateby.OperationControl;
 import org.immutables.value.Value.Immutable;
 
 import java.time.Duration;
@@ -14,7 +14,7 @@ import java.util.Optional;
 @BuildableStyle
 public abstract class EmaSpec extends UpdateBySpecBase {
 
-    public static EmaSpec of(EmaControl control, TimeScale timeScale) {
+    public static EmaSpec of(OperationControl control, TimeScale timeScale) {
         return ImmutableEmaSpec.builder().control(control).timeScale(timeScale).build();
     }
 
@@ -22,7 +22,7 @@ public abstract class EmaSpec extends UpdateBySpecBase {
         return ImmutableEmaSpec.builder().timeScale(timeScale).build();
     }
 
-    public static EmaSpec ofTime(final EmaControl control,
+    public static EmaSpec ofTime(final OperationControl control,
             final String timestampCol,
             long timeScaleNanos) {
         return of(control, TimeScale.ofTime(timestampCol, timeScaleNanos));
@@ -32,7 +32,7 @@ public abstract class EmaSpec extends UpdateBySpecBase {
         return of(TimeScale.ofTime(timestampCol, timeScaleNanos));
     }
 
-    public static EmaSpec ofTime(final EmaControl control,
+    public static EmaSpec ofTime(final OperationControl control,
             final String timestampCol,
             Duration emaDuration) {
         return of(control, TimeScale.ofTime(timestampCol, emaDuration));
@@ -42,7 +42,7 @@ public abstract class EmaSpec extends UpdateBySpecBase {
         return of(TimeScale.ofTime(timestampCol, emaDuration));
     }
 
-    public static EmaSpec ofTicks(EmaControl control, long tickWindow) {
+    public static EmaSpec ofTicks(OperationControl control, long tickWindow) {
         return of(control, TimeScale.ofTicks(tickWindow));
     }
 
@@ -50,12 +50,12 @@ public abstract class EmaSpec extends UpdateBySpecBase {
         return of(TimeScale.ofTicks(tickWindow));
     }
 
-    public abstract Optional<EmaControl> control();
+    public abstract Optional<OperationControl> control();
 
     public abstract TimeScale timeScale();
 
-    public final EmaControl controlOrDefault() {
-        return control().orElseGet(EmaControl::defaultInstance);
+    public final OperationControl controlOrDefault() {
+        return control().orElseGet(OperationControl::defaultInstance);
     }
 
     @Override

--- a/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpec.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpec.java
@@ -1,7 +1,7 @@
 package io.deephaven.api.updateby.spec;
 
 import io.deephaven.api.agg.Pair;
-import io.deephaven.api.updateby.ColumnUpdateClause;
+import io.deephaven.api.updateby.ColumnUpdateOperation;
 
 import java.util.Collection;
 
@@ -19,44 +19,44 @@ public interface UpdateBySpec {
     boolean applicableTo(final Class<?> inputType);
 
     /**
-     * Build a {@link ColumnUpdateClause} for this UpdateBySpec.
+     * Build a {@link ColumnUpdateOperation} for this UpdateBySpec.
      *
      * @param pair The input/output column name pair
      * @return The clause
      */
-    ColumnUpdateClause clause(String pair);
+    ColumnUpdateOperation clause(String pair);
 
     /**
-     * Build a {@link ColumnUpdateClause} for this UpdateBySpec.
+     * Build a {@link ColumnUpdateOperation} for this UpdateBySpec.
      *
      * @param pair The input/output column name pair
      * @return The clause
      */
-    ColumnUpdateClause clause(Pair pair);
+    ColumnUpdateOperation clause(Pair pair);
 
     /**
-     * Build a {@link ColumnUpdateClause} clause for this UpdateBySpec.
+     * Build a {@link ColumnUpdateOperation} clause for this UpdateBySpec.
      *
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    ColumnUpdateClause clause(String... pairs);
+    ColumnUpdateOperation clause(String... pairs);
 
     /**
-     * Build a {@link ColumnUpdateClause} clause for this UpdateBySpec.
+     * Build a {@link ColumnUpdateOperation} clause for this UpdateBySpec.
      *
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    ColumnUpdateClause clause(Pair... pairs);
+    ColumnUpdateOperation clause(Pair... pairs);
 
     /**
-     * Build a {@link ColumnUpdateClause} clause for this UpdateBySpec.
+     * Build a {@link ColumnUpdateOperation} clause for this UpdateBySpec.
      *
      * @param pairs The input/output column name pairs
      * @return The aggregation
      */
-    ColumnUpdateClause clause(Collection<? extends Pair> pairs);
+    ColumnUpdateOperation clause(Collection<? extends Pair> pairs);
 
     // region Visitor
     <T> T walk(Visitor<T> visitor);

--- a/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpecBase.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpecBase.java
@@ -1,7 +1,7 @@
 package io.deephaven.api.updateby.spec;
 
 import io.deephaven.api.agg.Pair;
-import io.deephaven.api.updateby.ColumnUpdateClause;
+import io.deephaven.api.updateby.ColumnUpdateOperation;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -10,36 +10,36 @@ import java.util.stream.Collectors;
 public abstract class UpdateBySpecBase implements UpdateBySpec {
 
     @Override
-    public final ColumnUpdateClause clause(String pair) {
+    public final ColumnUpdateOperation clause(String pair) {
         return clause(Pair.parse(pair));
     }
 
     @Override
-    public final ColumnUpdateClause clause(Pair pair) {
-        return ColumnUpdateClause.builder()
+    public final ColumnUpdateOperation clause(Pair pair) {
+        return ColumnUpdateOperation.builder()
                 .spec(this)
                 .addColumns(pair)
                 .build();
     }
 
     @Override
-    public final ColumnUpdateClause clause(String... pairs) {
+    public final ColumnUpdateOperation clause(String... pairs) {
         return clause(Arrays.stream(pairs)
                 .map(Pair::parse)
                 .collect(Collectors.toList()));
     }
 
     @Override
-    public final ColumnUpdateClause clause(Pair... pairs) {
-        return ColumnUpdateClause.builder()
+    public final ColumnUpdateOperation clause(Pair... pairs) {
+        return ColumnUpdateOperation.builder()
                 .spec(this)
                 .addColumns(pairs)
                 .build();
     }
 
     @Override
-    public final ColumnUpdateClause clause(Collection<? extends Pair> pairs) {
-        return ColumnUpdateClause.builder()
+    public final ColumnUpdateOperation clause(Collection<? extends Pair> pairs) {
+        return ColumnUpdateOperation.builder()
                 .spec(this)
                 .addAllColumns(pairs)
                 .build();


### PR DESCRIPTION
Rename `UpdateByClause` to `UpdateByOperation` and `EmaControl` to `OperationControl`.  

Closes #2679