### PR TITLE
Fix broken link in Go client docs

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -40,7 +40,7 @@ The source code is available in the directory for each example.
 
 To add the client as a dependency to your project, run:
 ```bash
-go get github.com/deephaven/deephaven-core/go
+go get github.com/deephaven/deephaven-core/go/pkg/client
 ```
 The client package can then be imported:
 ```go

--- a/go/pkg/client/client.go
+++ b/go/pkg/client/client.go
@@ -4,13 +4,13 @@
 // To get started, use client.NewClient to connect to the server. The Client can then be used to perform operations.
 // See the provided examples in the examples/ folder or the individual code documentation for more.
 //
-// Online docs for the client can be found at https://pkg.go.dev/github.com/deephaven/deephaven-core/go/client
+// Online docs for the client can be found at https://pkg.go.dev/github.com/deephaven/deephaven-core/go/pkg/client
 //
 // The Go API uses Records from the Apache Arrow package as tables.
 // The docs for the Arrow package can be found at the following link:
 // https://pkg.go.dev/github.com/apache/arrow/go/v8
 //
-// All methods for all structs in this package are thread-safe unless otherwise specified.
+// All methods for all structs in this package are goroutine-safe unless otherwise specified.
 package client
 
 import (


### PR DESCRIPTION
This fixes a command in the README and a link in the client package documentation which lead to the wrong place.