### PR TITLE
Fixed a race condition in one of the examples

### DIFF
--- a/go/pkg/client/flight_stub.go
+++ b/go/pkg/client/flight_stub.go
@@ -54,10 +54,10 @@ func (fs *flightStub) snapshotRecord(ctx context.Context, ticket *ticketpb2.Tick
 	defer req.CloseSend()
 
 	reader, err := flight.NewRecordReader(req)
-	defer reader.Release()
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Release()
 
 	rec1, err := reader.Read()
 	if err != nil {


### PR DESCRIPTION
In the input table example code, I added some rows to an input table and then immediately snapshotted a table derived from it. Sometimes the server doesn't have time to propogate the new rows, though, so the snapshot returns the wrong data.

This fix just snapshots in a loop until we find the correct data. I don't use an explicit timeout here to keep the example simple. `go test` has a default timeout of 1 minute so we don't have to worry about CI hanging.