### PR TITLE
Fixed C++ build instructions and some missing headers

### DIFF
--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -49,7 +49,7 @@ C++ compiler and tool suite (cmake etc).
    cd $DHSRC/deephaven-core/cpp-client/deephaven/
    mkdir build && cd build
    export PFX=$HOME/dhcpp/local  # This should reflect your selection in the previous point.
-   export CMAKE_PREFIX_PATH=${PFX}/abseil:${PFX}/cares:${PFX}/flatbuffers:${PFX}/gflags:${PFX}/protobuf:${PFX}/re2:${PFX}/zlib:${PFX}/grpc:${PFX}/arrow:${PFX}/deephaven
+   export CMAKE_PREFIX_PATH=${PFX}/abseil:${PFX}/boost:${PFX}/cares:${PFX}/flatbuffers:${PFX}/gflags:${PFX}/immer:${PFX}/protobuf:${PFX}/re2:${PFX}/zlib:${PFX}/grpc:${PFX}/arrow:${PFX}/deephaven
    export NCPUS=$(getconf _NPROCESSORS_ONLN)
    cmake -DCMAKE_INSTALL_PREFIX=${PFX}/deephaven .. && make -j$NCPUS install
    ```

--- a/cpp-client/deephaven/client/src/container/row_sequence.cc
+++ b/cpp-client/deephaven/client/src/container/row_sequence.cc
@@ -2,6 +2,8 @@
  * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/container/row_sequence.h"
+
+#include <optional>
 #include "deephaven/client/utility/utility.h"
 
 using deephaven::client::utility::stringf;

--- a/cpp-client/deephaven/client/src/subscription/space_mapper.cc
+++ b/cpp-client/deephaven/client/src/subscription/space_mapper.cc
@@ -2,6 +2,8 @@
  * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/subscription/space_mapper.h"
+
+#include <optional>
 #include "deephaven/client/utility/utility.h"
 
 using deephaven::client::container::RowSequence;


### PR DESCRIPTION
The C++ client now uses Boost and Immer as external libraries, but they were not added to the build instructions.

Also, some missing `#include <optional>` statements made some of the files not compile. After these fixes, the instructions to build the client work fine.