### PR TITLE
Don't submit parallel initialization jobs from the parallel initialization thread pool. Don't allow FORCE_PARALLEL_SELECT_AND_UPDATE to break the query engine.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/OperationInitializationThreadPool.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/OperationInitializationThreadPool.java
@@ -12,8 +12,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class OperationInitializationThreadPool {
-    public final static int NUM_THREADS =
+
+    public static final int NUM_THREADS =
             Configuration.getInstance().getIntegerWithDefault("OperationInitializationThreadPool.threads", 1);
+
+    private static final ThreadLocal<Boolean> isInitializationThread = ThreadLocal.withInitial(() -> false);
+
+    public static boolean isInitializationThread() {
+        return isInitializationThread.get();
+    }
 
     public final static ExecutorService executorService;
     static {
@@ -24,6 +31,7 @@ public class OperationInitializationThreadPool {
                     @Override
                     public Thread newThread(@NotNull Runnable r) {
                         return super.newThread(() -> {
+                            isInitializationThread.set(true);
                             MultiChunkPool.enableDedicatedPoolForThisThread();
                             r.run();
                         });

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1254,8 +1254,10 @@ public class QueryTable extends BaseTable {
 
                     final CompletableFuture<Void> waitForResult = new CompletableFuture<>();
                     final SelectAndViewAnalyzer.JobScheduler jobScheduler;
-                    if (QueryTable.FORCE_PARALLEL_SELECT_AND_UPDATE || (QueryTable.ENABLE_PARALLEL_SELECT_AND_UPDATE
-                            && OperationInitializationThreadPool.NUM_THREADS > 1)
+                    if ((QueryTable.FORCE_PARALLEL_SELECT_AND_UPDATE ||
+                            (QueryTable.ENABLE_PARALLEL_SELECT_AND_UPDATE
+                                    && OperationInitializationThreadPool.NUM_THREADS > 1))
+                            && !OperationInitializationThreadPool.isInitializationThread()
                             && analyzer.allowCrossColumnParallelization()) {
                         jobScheduler = new SelectAndViewAnalyzer.OperationInitializationPoolJobScheduler();
                     } else {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SelectOrUpdateListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SelectOrUpdateListener.java
@@ -58,8 +58,9 @@ class SelectOrUpdateListener extends BaseTable.ListenerImpl {
         transformer = parent.newModifiedColumnSetTransformer(parentNames, mcss);
         this.analyzer = analyzer;
         this.enableParallelUpdate =
-                QueryTable.FORCE_PARALLEL_SELECT_AND_UPDATE || (QueryTable.ENABLE_PARALLEL_SELECT_AND_UPDATE
-                        && UpdateGraphProcessor.DEFAULT.getUpdateThreads() > 1)
+                (QueryTable.FORCE_PARALLEL_SELECT_AND_UPDATE ||
+                        (QueryTable.ENABLE_PARALLEL_SELECT_AND_UPDATE
+                                && UpdateGraphProcessor.DEFAULT.getUpdateThreads() > 1))
                         && analyzer.allowCrossColumnParallelization();
         analyzer.setAllNewColumns(allNewColumns);
     }


### PR DESCRIPTION
Fixes #2746