### PR TITLE
Improve `SortedRanges` iterator performance through caching

### DIFF
--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/sortedranges/SortedRanges.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/sortedranges/SortedRanges.java
@@ -808,7 +808,9 @@ public abstract class SortedRanges extends RefCountedCow<SortedRanges> implement
             if (neg) {
                 currRangeStart = currRangeEnd = -data;
                 nextRangeIdx = i + 1;
-                cachedNextValue = sar.unpackedGet(nextRangeIdx);
+                if (nextRangeIdx < sar.count) {
+                    cachedNextValue = sar.unpackedGet(nextRangeIdx);
+                }
                 return currRangeStart;
             }
             final int next = i + 1;
@@ -825,7 +827,9 @@ public abstract class SortedRanges extends RefCountedCow<SortedRanges> implement
                         (final long v) -> comp.compareTargetTo(v, dir));
                 currRangeEnd = -nextData;
                 nextRangeIdx = next + 1;
-                cachedNextValue = sar.unpackedGet(nextRangeIdx);
+                if (nextRangeIdx < sar.count) {
+                    cachedNextValue = sar.unpackedGet(nextRangeIdx);
+                }
                 return currRangeStart;
             }
             currRangeStart = currRangeEnd = data;

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/sortedranges/SortedRangesTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/sortedranges/SortedRangesTest.java
@@ -1079,15 +1079,42 @@ public class SortedRangesTest {
     @Test
     public void testSearchIteratorBinarySearchCases() {
         SortedRanges sar = new SortedRangesLong(2);
+
+        // search for last when single value is final entry
         sar.appendRange(4, 10);
         sar.append(25);
         sar.append(32);
-        final RowSet.SearchIterator sit = sar.getSearchIterator();
-        final long v = sar.last();
-        final RowSet.TargetComparator comp =
-                (final long key, final int dir) -> Long.signum(dir * (v - key));
-        final long r = sit.binarySearchValue(comp, 1);
-        assertEquals(v, r);
+        try (final RowSet.SearchIterator sit = sar.getSearchIterator()) {
+            final long v = sar.last();
+            final RowSet.TargetComparator comp =
+                    (final long key, final int dir) -> Long.signum(dir * (v - key));
+            final long r = sit.binarySearchValue(comp, 1);
+            assertEquals(v, r);
+        }
+
+        // search for last when a range is the final entry
+        sar.clear();
+        sar.appendRange(4, 10);
+        sar.appendRange(25,32);
+        try (final RowSet.SearchIterator sit = sar.getSearchIterator()) {
+            final long v = sar.last();
+            final RowSet.TargetComparator comp =
+                    (final long key, final int dir) -> Long.signum(dir * (v - key));
+            final long r = sit.binarySearchValue(comp, 1);
+            assertEquals(v, r);
+        }
+
+        // search for value in the final range when a range is the final entry
+        sar.clear();
+        sar.appendRange(4, 10);
+        sar.appendRange(25,32);
+        try (final RowSet.SearchIterator sit = sar.getSearchIterator()) {
+            final long v = sar.last() - 1;
+            final RowSet.TargetComparator comp =
+                    (final long key, final int dir) -> Long.signum(dir * (v - key));
+            final long r = sit.binarySearchValue(comp, 1);
+            assertEquals(v, r);
+        }
     }
 
     @Test

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/sortedranges/SortedRangesTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/sortedranges/SortedRangesTest.java
@@ -1095,7 +1095,7 @@ public class SortedRangesTest {
         // search for last when a range is the final entry
         sar.clear();
         sar.appendRange(4, 10);
-        sar.appendRange(25,32);
+        sar.appendRange(25, 32);
         try (final RowSet.SearchIterator sit = sar.getSearchIterator()) {
             final long v = sar.last();
             final RowSet.TargetComparator comp =
@@ -1107,7 +1107,7 @@ public class SortedRangesTest {
         // search for value in the final range when a range is the final entry
         sar.clear();
         sar.appendRange(4, 10);
-        sar.appendRange(25,32);
+        sar.appendRange(25, 32);
         try (final RowSet.SearchIterator sit = sar.getSearchIterator()) {
             final long v = sar.last() - 1;
             final RowSet.TargetComparator comp =


### PR DESCRIPTION
While examining profiler data for `partitionBy`/`groupBy` found that a lot of time was spent in `nextRange()`, specifically the call to `sar.unpackedGet()`.

The current code computes the call `sar.unpackedGet(nextRangeIdx)` then discards the results if the range is a single value.  Rowsets that are sparse (consist of few consecutive values) will benefit by storing this value for the next call to `nextRange()` and this change will not penalize the non-sparse rowsets because the lookup must be performed anyway.

Performance metrics (average of 5 consecutive runs):
```
Zulu11.54+23-CA (build 11.0.14+9-LTS) on MacOS, M1                
Rows            Buckets     partitionBy (ms)    partitionBy_opt (ms)    speedup
100,000,000     100         1,384               1,382                   0.1%
100,000,000     25,000      124,946             93,637                  25.1%
100,000,000     1,000,000   30,775              30,373                  1.3%
                
Rows            Buckets     groupBy (ms)        groupBy_opt (ms)        speedup
100,000,000     100         1,445               1,406                   2.7%
100,000,000     25,000      124,256             101,950                 18.0%
100,000,000     1,000,000   30,402              28,202                  7.2%
                
Zulu17.34+19-CA (build 17.0.3+7-LTS) on MacOS, M1                
Rows            Buckets     partitionBy (ms)    partitionBy_opt (ms)    speedup
100,000,000     100         1,855               1,492                   19.6%
100,000,000     25,000      110,660             87,067                  21.3%
100,000,000     1,000,000   30,857              30,997                  -0.5%
                 
Rows            Buckets     groupBy (ms)        groupBy_opt (ms)        speedup
100,000,000     100         1,884               1,493                   20.8%
100,000,000     25,000      107,324             85,797                  20.1%
100,000,000     1,000,000   30,524              29,773                  2.5%
```

Note: this only is useful because `unpackedGet()` is more expensive in practice than expected given the simplicity of the  implementation.
