### PR TITLE
Support reading composite Kafka JSON fields as a JsonNode. Fixes #2754.

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
@@ -63,9 +63,13 @@ public class JsonNodeChunkAdapter extends MultiFieldChunkAdapter {
             case Double:
                 return new JsonNodeDoubleFieldCopier(fieldName);
             case Object:
-                return (dataType == String.class)
-                        ? new JsonNodeStringFieldCopier(fieldName)
-                        : new JsonNodeObjectFieldCopier(fieldName);
+                if (dataType == String.class) {
+                    return new JsonNodeStringFieldCopier(fieldName);
+                }
+                if (dataType.isAssignableFrom(com.fasterxml.jackson.databind.JsonNode.class)) {
+                    return new JsonNodeJsonNodeFieldCopier(fieldName);
+                }
+                throw new UncheckedDeephavenException("Type " + dataType.getSimpleName() + " not supported for JSON");
         }
         throw new IllegalArgumentException("Can not convert field of type " + dataType);
     }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
@@ -63,11 +63,10 @@ public class JsonNodeChunkAdapter extends MultiFieldChunkAdapter {
             case Double:
                 return new JsonNodeDoubleFieldCopier(fieldName);
             case Object:
-                if (dataType == String.class) {
-                    return new JsonNodeStringFieldCopier(fieldName);
-                } else {
-                    throw new UncheckedDeephavenException("Raw objects not supported for JSON");
-                }
+                return (dataType == String.class)
+                        ? new JsonNodeStringFieldCopier(fieldName)
+                        : new JsonNodeObjectFieldCopier(fieldName)
+                        ;
         }
         throw new IllegalArgumentException("Can not convert field of type " + dataType);
     }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeChunkAdapter.java
@@ -65,8 +65,7 @@ public class JsonNodeChunkAdapter extends MultiFieldChunkAdapter {
             case Object:
                 return (dataType == String.class)
                         ? new JsonNodeStringFieldCopier(fieldName)
-                        : new JsonNodeObjectFieldCopier(fieldName)
-                        ;
+                        : new JsonNodeObjectFieldCopier(fieldName);
         }
         throw new IllegalArgumentException("Can not convert field of type " + dataType);
     }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeJsonNodeFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeJsonNodeFieldCopier.java
@@ -10,10 +10,10 @@ import io.deephaven.chunk.WritableObjectChunk;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.deephaven.chunk.attributes.Values;
 
-public class JsonNodeObjectFieldCopier implements FieldCopier {
+public class JsonNodeJsonNodeFieldCopier implements FieldCopier {
     private final JsonPointer fieldPointer;
 
-    public JsonNodeObjectFieldCopier(final String fieldPointerStr) {
+    public JsonNodeJsonNodeFieldCopier(final String fieldPointerStr) {
         this.fieldPointer = JsonPointer.compile(fieldPointerStr);
     }
 

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeObjectFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeObjectFieldCopier.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.kafka.ingest;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.deephaven.chunk.attributes.Values;
+
+public class JsonNodeObjectFieldCopier implements FieldCopier {
+    private final JsonPointer fieldPointer;
+
+    public JsonNodeObjectFieldCopier(final String fieldPointerStr) {
+        this.fieldPointer = JsonPointer.compile(fieldPointerStr);
+    }
+
+    @Override
+    public void copyField(
+            final ObjectChunk<Object, Values> inputChunk,
+            final WritableChunk<Values> publisherChunk,
+            final int sourceOffset,
+            final int destOffset,
+            final int length) {
+        final WritableObjectChunk<Object, Values> output = publisherChunk.asWritableObjectChunk();
+        for (int ii = 0; ii < length; ++ii) {
+            final JsonNode baseNode = (JsonNode) inputChunk.get(ii + sourceOffset);
+            final JsonNode node = (baseNode == null) ? null : baseNode.at(fieldPointer);
+            output.set(ii + destOffset, node);
+        }
+    }
+}


### PR DESCRIPTION
```
cfs@guanaco 14:58:30 ~/dh/oss1/deephaven-core/redpanda/examples/python
$ python3 kafka-produce.py orders 0 '' 'str:{ "Symbol" : "MSFT", "Side" : "BUY", "Price" : "278.85", "Qty" : "200", "User" : { "Name" : "Pepo", "Id" : 1234 } }'
Message key=|b''|, value=|b'{ "Symbol" : "MSFT", "Side" : "BUY", "Price" : "278.85", "Qty" : "200", "User" : { "Name" : "Pepo", "Id" : 1234 } }'| delivered to topic orders partition 0
(confluent-kafka)
```

![Deephaven - Google Chrome_005](https://user-images.githubusercontent.com/37232625/186241541-7ea16586-f127-4c88-8b31-29d355355a5a.png)
