### PR TITLE
Use Sample for getHeapInfo

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RuntimeMemory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RuntimeMemory.java
@@ -123,11 +123,13 @@ public class RuntimeMemory {
          */
         public long totalMemory;
         /**
-         * The total number of GC collections since program start. The sum of {@link GarbageCollectorMXBean#getCollectionCount()}.
+         * The total number of GC collections since program start. The sum of
+         * {@link GarbageCollectorMXBean#getCollectionCount()}.
          */
         public long totalCollections;
         /**
-         * The approximated total time of GC collections since program start, in milliseconds. The sum of the {@link GarbageCollectorMXBean#getCollectionTime()}.
+         * The approximated total time of GC collections since program start, in milliseconds. The sum of the
+         * {@link GarbageCollectorMXBean#getCollectionTime()}.
          */
         public long totalCollectionTimeMs;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RuntimeMemory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/RuntimeMemory.java
@@ -68,6 +68,13 @@ public class RuntimeMemory {
          * The approximated total time of GC collections since program start, in milliseconds.
          */
         long totalCollectionTimeMs;
+
+        private void readInto(Sample buf) {
+            buf.freeMemory = lastFreeMemory;
+            buf.totalMemory = lastTotalMemory;
+            buf.totalCollections = totalCollections;
+            buf.totalCollectionTimeMs = totalCollectionTimeMs;
+        }
     }
 
     private volatile Snapshot currSnapshot;
@@ -108,19 +115,19 @@ public class RuntimeMemory {
 
     public static class Sample {
         /**
-         * What is the last free memory value we retrieved from the Runtime.
+         * What is the last free memory value we retrieved from the {@link Runtime#freeMemory()}.
          */
         public long freeMemory;
         /**
-         * What is the last total memory value we retrieved from the Runtime.
+         * What is the last total memory value we retrieved from the {@link Runtime#totalMemory()}.
          */
         public long totalMemory;
         /**
-         * The total number of GC collections since program start.
+         * The total number of GC collections since program start. The sum of {@link GarbageCollectorMXBean#getCollectionCount()}.
          */
         public long totalCollections;
         /**
-         * The approximated total time of GC collections since program start, in milliseconds.
+         * The approximated total time of GC collections since program start, in milliseconds. The sum of the {@link GarbageCollectorMXBean#getCollectionTime()}.
          */
         public long totalCollectionTimeMs;
 
@@ -145,7 +152,7 @@ public class RuntimeMemory {
     }
 
     /**
-     * Read last collected samples.
+     * Read last collected samples. Triggers a new snapshot if the last snapshot is older than {@code cacheInterval}.
      *
      * @param buf a user provided buffer object to store the samples.
      */
@@ -172,10 +179,7 @@ public class RuntimeMemory {
                 }
             }
         }
-        buf.freeMemory = snapshot.lastFreeMemory;
-        buf.totalMemory = snapshot.lastTotalMemory;
-        buf.totalCollections = snapshot.totalCollections;
-        buf.totalCollectionTimeMs = snapshot.totalCollectionTimeMs;
+        snapshot.readInto(buf);
         if (logInterval > 0 && now >= snapshot.nextLog) {
             synchronized (this) {
                 if (now >= currSnapshot.nextLog) {
@@ -189,17 +193,12 @@ public class RuntimeMemory {
     }
 
     /**
-     * See {@link Runtime#freeMemory()}.
+     * Read last collected samples.
+     *
+     * @param buf a user provided buffer object to store the samples.
      */
-    public long freeMemory() {
-        return currSnapshot.lastFreeMemory;
-    }
-
-    /**
-     * See {@link Runtime#totalMemory()}.
-     */
-    public long totalMemory() {
-        return currSnapshot.lastTotalMemory;
+    public void readOnly(final Sample buf) {
+        currSnapshot.readInto(buf);
     }
 
     /**

--- a/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
@@ -187,7 +187,7 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
         GrpcUtil.rpcWrapper(log, responseObserver, () -> {
             final RuntimeMemory runtimeMemory = RuntimeMemory.getInstance();
             final Sample sample = new Sample();
-            runtimeMemory.readOnly(sample);
+            runtimeMemory.read(sample);
             final GetHeapInfoResponse infoResponse = GetHeapInfoResponse.newBuilder()
                     .setTotalMemory(sample.totalMemory)
                     .setFreeMemory(sample.freeMemory)

--- a/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
@@ -7,6 +7,7 @@ import com.google.rpc.Code;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.util.RuntimeMemory;
+import io.deephaven.engine.table.impl.util.RuntimeMemory.Sample;
 import io.deephaven.engine.updategraph.DynamicNode;
 import io.deephaven.engine.util.DelegatingScriptSession;
 import io.deephaven.engine.util.ScriptSession;
@@ -185,12 +186,13 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
     public void getHeapInfo(GetHeapInfoRequest request, StreamObserver<GetHeapInfoResponse> responseObserver) {
         GrpcUtil.rpcWrapper(log, responseObserver, () -> {
             final RuntimeMemory runtimeMemory = RuntimeMemory.getInstance();
+            final Sample sample = new Sample();
+            runtimeMemory.readOnly(sample);
             final GetHeapInfoResponse infoResponse = GetHeapInfoResponse.newBuilder()
-                    .setTotalMemory(runtimeMemory.totalMemory())
-                    .setFreeMemory(runtimeMemory.freeMemory())
+                    .setTotalMemory(sample.totalMemory)
+                    .setFreeMemory(sample.freeMemory)
                     .setMaxMemory(runtimeMemory.maxMemory())
                     .build();
-
             responseObserver.onNext(infoResponse);
             responseObserver.onCompleted();
         });


### PR DESCRIPTION
Quick fix that saves a volatile read and ensures we grab consistent values from currSnapshot. This also preserves the (potentially unintentional) semantics that getHeapInfo does *not* trigger a new snapshot.