### PR TITLE
BaseArrayBackedMutableTable#run never reset processedSequence to -1

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedMutableTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedMutableTable.java
@@ -145,7 +145,7 @@ abstract class BaseArrayBackedMutableTable extends UpdatableTable {
     public void run() {
         super.run();
         synchronized (pendingChanges) {
-            if (processedSequence < 0) {
+            if (pendingProcessed < 0) {
                 return;
             }
             processedSequence = pendingProcessed;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedMutableTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedMutableTable.java
@@ -145,6 +145,9 @@ abstract class BaseArrayBackedMutableTable extends UpdatableTable {
     public void run() {
         super.run();
         synchronized (pendingChanges) {
+            if (processedSequence < 0) {
+                return;
+            }
             processedSequence = pendingProcessed;
             pendingProcessed = -1L;
             pendingChanges.notifyAll();


### PR DESCRIPTION
Fixes #2721.

I think in the past the UGP used to only refresh the subset of live tables that requested a refresh. Today, it refreshes all tables every time any one of them request a refresh. `BaseArrayBackedMutableTable#run` unconditionally sets `processedSequence = pendingProcessed` even if `pendingProcessed` is `-1`. This is naturally a problem for the user waiting on a sequence if the UGP happens to be invoked when the queue is empty because their request was processed by a UGP refresh requested by another source table.