### PR TITLE
Fix DoPutObserver memory leaks

### DIFF
--- a/engine/updategraph/src/main/java/io/deephaven/engine/liveness/LivenessArtifact.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/liveness/LivenessArtifact.java
@@ -18,7 +18,15 @@ public class LivenessArtifact extends ReferenceCountedLivenessNode implements Se
     private static final long serialVersionUID = 1L;
 
     protected LivenessArtifact() {
-        super(false);
+        this(false);
+    }
+
+    /**
+     * @param enforceStrongReachability Whether this {@link LivenessArtifact} should maintain strong references to its
+     *        referents
+     */
+    protected LivenessArtifact(final boolean enforceStrongReachability) {
+        super(enforceStrongReachability);
         manageWithCurrentScope();
     }
 

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -529,16 +529,15 @@ public class SessionState {
          * @param exportId the export id for this export
          */
         private ExportObject(final SessionState session, final int exportId) {
+            super(true);
             this.session = session;
             this.exportId = exportId;
             this.logIdentity =
                     isNonExport() ? Integer.toHexString(System.identityHashCode(this)) : Long.toString(exportId);
             setState(ExportNotification.State.UNKNOWN);
 
-            // non-exports stay alive until they have been exported
-            if (isNonExport()) {
-                retainReference();
-            }
+            // we retain a reference until a non-export becomes EXPORTED or a regular export becomes RELEASED
+            retainReference();
         }
 
         /**
@@ -548,6 +547,7 @@ public class SessionState {
          * @param result the object to wrap in an export
          */
         private ExportObject(final T result) {
+            super(true);
             this.session = null;
             this.exportId = NON_EXPORT_ID;
             this.state = ExportNotification.State.EXPORTED;
@@ -1341,9 +1341,7 @@ public class SessionState {
                         throw GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED, "session has expired");
                     }
 
-                    final ExportObject<Object> retval = new ExportObject<>(SessionState.this, key);
-                    retval.retainReference();
-                    return retval;
+                    return new ExportObject<>(SessionState.this, key);
                 }
             };
 }


### PR DESCRIPTION
The DoPutObserver never removed its onCancel callbacks. The callback referenced the observer which referenced the result table. Additionally, there was an extra retained reference to the result export object that prevented it from being `destroy()`'d causing yet another leak of a hard-reference to the result table.

This change makes the ExportObject enforce reachability. This is necessary to be able to hand off a hard reference from the gRPC observer when the server side is completed but before the published export is satisfied. This pattern will be required anytime the gRPC server side observer might be cleaned by gRPC (cause no more messages come from the client) and the published export object cannot be completed until after the UGP finishes a refresh cycle (or any other deferred work pattern that weakly references the result).