### PR TITLE
Web version bump to v0.16.0, embeddable iframe for charts

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
-ARG WEB_VERSION=0.15.5-embed-chart.1
+ARG WEB_VERSION=0.16.0
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \

--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -1,7 +1,7 @@
 FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
-ARG WEB_VERSION=0.15.6
+ARG WEB_VERSION=0.15.5-embed-chart.1
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \
@@ -15,7 +15,16 @@ RUN set -eux; \
 RUN set -eux; \
     npm pack @deephaven/embed-grid@${WEB_VERSION}; \
     tar --touch -xf deephaven-embed-grid-${WEB_VERSION}.tgz; \
-    mkdir iframe; \
+    mkdir -p iframe; \
     mv package/build iframe/table; \
     rm -r package; \
     rm deephaven-embed-grid-${WEB_VERSION}.tgz;
+
+# Pull in the published embed-chart package from npmjs and extract is
+RUN set -eux; \
+    npm pack @deephaven/embed-chart@${WEB_VERSION}; \
+    tar --touch -xf deephaven-embed-chart-${WEB_VERSION}.tgz; \
+    mkdir -p iframe; \
+    mv package/build iframe/chart; \
+    rm -r package; \
+    rm deephaven-embed-chart-${WEB_VERSION}.tgz;


### PR DESCRIPTION
- iframes for charts in deephaven-core
- Web version bump to v0.16.0
- Full release notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.16.0
- Open an embeddable chart by navigating to `http://localhost:10000/iframe/chart/?name=<chartName>`, e.g.: `http://localhost:10000/iframe/chart/?name=s_and_p_treemap`