### PR TITLE
ConstructSnapshot's SharedContext needs to be reset per rowset

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
@@ -1474,6 +1474,9 @@ public class ConstructSnapshot {
                 } else {
                     chunkSize = (int) (size - offset);
                 }
+
+                // a shared context is good for only one chunk of rows
+                sharedContext.reset();
             }
         }
         return result;


### PR DESCRIPTION
Fixes #2801. 