### PR TITLE
Make DeephavenSessionTestBase use NoLanguageDeephavenSession

### DIFF
--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryLibrary.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryLibrary.java
@@ -108,4 +108,8 @@ public class QueryLibrary {
     public void updateVersionString() {
         versionString = UuidCreator.toString(UuidCreator.getRandomBased());
     }
+
+    public void updateVersionString(String version) {
+        versionString = version;
+    }
 }

--- a/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
+++ b/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
@@ -11,6 +11,7 @@ import io.deephaven.integrations.python.PyLogOutputStream;
 import io.deephaven.io.log.LogLevel;
 import io.deephaven.io.logger.LogBuffer;
 import io.deephaven.io.logger.LogBufferOutputStream;
+import io.deephaven.server.console.SessionToExecutionStateModule;
 import io.deephaven.server.console.groovy.GroovyConsoleSessionModule;
 import io.deephaven.server.console.python.PythonConsoleSessionModule;
 import io.deephaven.server.console.python.PythonGlobalScopeModule;
@@ -48,6 +49,7 @@ public class EmbeddedServer {
             JettyServerModule.class,
             PythonConsoleSessionModule.class,
             GroovyConsoleSessionModule.class,
+            SessionToExecutionStateModule.class,
     })
     public interface PythonServerComponent extends DeephavenApiServerComponent {
         @Component.Builder

--- a/server/jetty/build.gradle
+++ b/server/jetty/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation project(':grpc-java:grpc-mtls')
 
     testImplementation project(':server-test')
+    testImplementation TestTools.projectDependency(project, ':server')
 
     testRuntimeOnly project(':log-to-slf4j')
     Classpaths.inheritSlf4j(project, 'slf4j-simple', 'testRuntimeOnly')

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyServerComponent.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyServerComponent.java
@@ -5,6 +5,7 @@ package io.deephaven.server.jetty;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import io.deephaven.server.console.SessionToExecutionStateModule;
 import io.deephaven.server.console.groovy.GroovyConsoleSessionModule;
 import io.deephaven.server.console.python.PythonConsoleSessionModule;
 import io.deephaven.server.console.python.PythonGlobalScopeCopyModule;
@@ -28,6 +29,7 @@ import javax.inject.Singleton;
         JettyServerModule.class,
         PythonConsoleSessionModule.class,
         GroovyConsoleSessionModule.class,
+        SessionToExecutionStateModule.class,
 })
 public interface JettyServerComponent extends DeephavenApiServerComponent {
     @Component.Builder

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
@@ -7,7 +7,7 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import io.deephaven.server.arrow.ArrowModule;
-import io.deephaven.server.log.LogModule;
+import io.deephaven.server.runner.ExecutionContextUnitTestModule;
 import io.deephaven.server.session.SessionModule;
 import io.deephaven.server.test.AuthTestModule;
 import io.deephaven.server.test.FlightMessageRoundTripTest;
@@ -31,7 +31,8 @@ public class JettyFlightRoundTripTest extends FlightMessageRoundTripTest {
             SessionModule.class,
             AuthTestModule.class,
             JettyServerModule.class,
-            JettyTestConfig.class
+            JettyTestConfig.class,
+            ExecutionContextUnitTestModule.class,
     })
     public interface JettyTestComponent extends TestComponent {
     }

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
@@ -7,6 +7,7 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import io.deephaven.server.arrow.ArrowModule;
+import io.deephaven.server.log.LogModule;
 import io.deephaven.server.session.SessionModule;
 import io.deephaven.server.test.AuthTestModule;
 import io.deephaven.server.test.FlightMessageRoundTripTest;

--- a/server/netty/build.gradle
+++ b/server/netty/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation project(':grpc-java:grpc-mtls')
 
     testImplementation project(':server-test')
+    testImplementation TestTools.projectDependency(project, ':server')
 
     testRuntimeOnly project(':log-to-slf4j')
     Classpaths.inheritSlf4j(project, 'slf4j-simple', 'testRuntimeOnly')

--- a/server/netty/src/main/java/io/deephaven/server/netty/NettyServerComponent.java
+++ b/server/netty/src/main/java/io/deephaven/server/netty/NettyServerComponent.java
@@ -5,6 +5,7 @@ package io.deephaven.server.netty;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import io.deephaven.server.console.SessionToExecutionStateModule;
 import io.deephaven.server.console.groovy.GroovyConsoleSessionModule;
 import io.deephaven.server.console.python.PythonConsoleSessionModule;
 import io.deephaven.server.console.python.PythonGlobalScopeCopyModule;
@@ -28,6 +29,7 @@ import javax.inject.Singleton;
         NettyServerModule.class,
         PythonConsoleSessionModule.class,
         GroovyConsoleSessionModule.class,
+        SessionToExecutionStateModule.class,
 })
 public interface NettyServerComponent extends DeephavenApiServerComponent {
     @Component.Builder

--- a/server/netty/src/test/java/io/deephaven/server/netty/NettyFlightRoundTripTest.java
+++ b/server/netty/src/test/java/io/deephaven/server/netty/NettyFlightRoundTripTest.java
@@ -7,6 +7,7 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import io.deephaven.server.arrow.ArrowModule;
+import io.deephaven.server.runner.ExecutionContextUnitTestModule;
 import io.deephaven.server.session.SessionModule;
 import io.deephaven.server.test.AuthTestModule;
 import io.deephaven.server.test.FlightMessageRoundTripTest;
@@ -30,7 +31,8 @@ public class NettyFlightRoundTripTest extends FlightMessageRoundTripTest {
             SessionModule.class,
             AuthTestModule.class,
             NettyServerModule.class,
-            NettyTestConfig.class
+            NettyTestConfig.class,
+            ExecutionContextUnitTestModule.class,
     })
     public interface NettyTestComponent extends TestComponent {
     }

--- a/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.server.console;
+
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoMap;
+import dagger.multibindings.StringKey;
+import io.deephaven.engine.util.NoLanguageDeephavenSession;
+import io.deephaven.engine.util.ScriptSession;
+import io.deephaven.server.console.groovy.InitScriptsModule;
+
+@Module(includes = InitScriptsModule.ServiceLoader.class)
+public class NoConsoleSessionModule {
+    @Provides
+    @IntoMap
+    @StringKey("none")
+    ScriptSession bindScriptSession(NoLanguageDeephavenSession noLanguageSession) {
+        return noLanguageSession;
+    }
+
+    @Provides
+    NoLanguageDeephavenSession bindNoLanguageSession() {
+        return new NoLanguageDeephavenSession();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/console/SessionToExecutionStateModule.java
+++ b/server/src/main/java/io/deephaven/server/console/SessionToExecutionStateModule.java
@@ -1,0 +1,14 @@
+package io.deephaven.server.console;
+
+import dagger.Module;
+import dagger.Provides;
+import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.util.ScriptSession;
+
+@Module
+public class SessionToExecutionStateModule {
+    @Provides
+    ExecutionContext bindExecutionContext(ScriptSession session) {
+        return session.getExecutionContext();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
+++ b/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
@@ -5,6 +5,7 @@ package io.deephaven.server.runner;
 
 import io.deephaven.auth.AuthenticationRequestHandler;
 import io.deephaven.configuration.Configuration;
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.perf.UpdatePerformanceTracker;
 import io.deephaven.engine.table.impl.util.MemoryTableLoggers;
@@ -51,6 +52,7 @@ public class DeephavenApiServer {
     private final UriResolvers uriResolvers;
     private final SessionService sessionService;
     private final Map<String, AuthenticationRequestHandler> authenticationHandlers;
+    private final Provider<ExecutionContext> executionContextProvider;
 
     @Inject
     public DeephavenApiServer(
@@ -62,7 +64,8 @@ public class DeephavenApiServer {
             final ApplicationInjector applicationInjector,
             final UriResolvers uriResolvers,
             final SessionService sessionService,
-            final Map<String, AuthenticationRequestHandler> authenticationHandlers) {
+            final Map<String, AuthenticationRequestHandler> authenticationHandlers,
+            final Provider<ExecutionContext> executionContextProvider) {
         this.server = server;
         this.ugp = ugp;
         this.logInit = logInit;
@@ -72,6 +75,7 @@ public class DeephavenApiServer {
         this.uriResolvers = uriResolvers;
         this.sessionService = sessionService;
         this.authenticationHandlers = authenticationHandlers;
+        this.executionContextProvider = executionContextProvider;
     }
 
     @VisibleForTesting
@@ -162,6 +166,8 @@ public class DeephavenApiServer {
     void startForUnitTests() throws Exception {
         pluginRegistration.registerAll();
         applicationInjector.run();
+        executionContextProvider.get().getQueryLibrary().updateVersionString("DEFAULT");
+
         log.info().append("Starting server...").endl();
         server.start();
     }

--- a/server/src/main/java/io/deephaven/server/runner/DeephavenApiServerInProcessGroovyComponent.java
+++ b/server/src/main/java/io/deephaven/server/runner/DeephavenApiServerInProcessGroovyComponent.java
@@ -5,6 +5,7 @@ package io.deephaven.server.runner;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import io.deephaven.server.console.SessionToExecutionStateModule;
 import io.deephaven.server.console.groovy.GroovyConsoleSessionModule;
 import io.deephaven.server.log.LogModule;
 import io.grpc.ManagedChannelBuilder;
@@ -18,7 +19,8 @@ import java.io.PrintStream;
         DeephavenApiServerModule.class,
         LogModule.class,
         GroovyConsoleSessionModule.class,
-        ServerBuilderInProcessModule.class
+        ServerBuilderInProcessModule.class,
+        SessionToExecutionStateModule.class,
 })
 public interface DeephavenApiServerInProcessGroovyComponent {
 

--- a/server/src/main/java/io/deephaven/server/runner/DeephavenApiServerInProcessPythonComponent.java
+++ b/server/src/main/java/io/deephaven/server/runner/DeephavenApiServerInProcessPythonComponent.java
@@ -5,6 +5,7 @@ package io.deephaven.server.runner;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import io.deephaven.server.console.SessionToExecutionStateModule;
 import io.deephaven.server.console.python.PythonConsoleSessionModule;
 import io.deephaven.server.console.python.PythonGlobalScopeCopyModule;
 import io.deephaven.server.log.LogModule;
@@ -20,7 +21,8 @@ import java.io.PrintStream;
         LogModule.class,
         PythonConsoleSessionModule.class,
         PythonGlobalScopeCopyModule.class,
-        ServerBuilderInProcessModule.class
+        ServerBuilderInProcessModule.class,
+        SessionToExecutionStateModule.class,
 })
 public interface DeephavenApiServerInProcessPythonComponent {
 

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -136,13 +136,13 @@ public class SessionState {
 
     @AssistedInject
     public SessionState(final Scheduler scheduler,
-            final Provider<ScriptSession> scriptSessionProvider,
+            final Provider<ExecutionContext> executionContextProvider,
             @Assisted final AuthContext authContext) {
         this.sessionId = UuidCreator.toString(UuidCreator.getRandomBased());
         this.logPrefix = "SessionState{" + sessionId + "}: ";
         this.scheduler = scheduler;
         this.authContext = authContext;
-        this.executionContext = scriptSessionProvider.get().getExecutionContext();
+        this.executionContext = executionContextProvider.get();
         log.info().append(logPrefix).append("session initialized").endl();
     }
 

--- a/server/src/test/java/io/deephaven/server/appmode/ApplicationServiceGrpcImplTest.java
+++ b/server/src/test/java/io/deephaven/server/appmode/ApplicationServiceGrpcImplTest.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.server.appmode;
 
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.util.NoLanguageDeephavenSession;
 import io.deephaven.engine.util.ScriptSession;
@@ -42,7 +43,7 @@ public class ApplicationServiceGrpcImplTest {
         livenessScope = LivenessScopeStack.open();
         scheduler = new TestControlledScheduler();
         sessionService = new SessionService(scheduler,
-                authContext -> new SessionState(scheduler, NoLanguageDeephavenSession::new, authContext),
+                authContext -> new SessionState(scheduler, ExecutionContext::createForUnitTests, authContext),
                 TOKEN_EXPIRE_MS, Optional.empty(), Collections.emptyMap());
         applicationServiceGrpcImpl = new ApplicationServiceGrpcImpl(scheduler, sessionService,
                 new TypeLookup(ObjectTypeLookup.NoOp.INSTANCE));

--- a/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
+++ b/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
@@ -3,12 +3,17 @@
  */
 package io.deephaven.server.runner;
 
+import dagger.BindsInstance;
+import dagger.Component;
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.liveness.LivenessScope;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.io.logger.LogBuffer;
 import io.deephaven.io.logger.LogBufferGlobal;
 import io.deephaven.proto.DeephavenChannel;
+import io.deephaven.server.console.NoConsoleSessionModule;
+import io.deephaven.server.log.LogModule;
 import io.deephaven.util.SafeCloseable;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -17,17 +22,54 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Manages a single instance of {@link DeephavenApiServer}.
  */
 public abstract class DeephavenApiServerTestBase {
+    @Singleton
+    @Component(modules = {
+            DeephavenApiServerModule.class,
+            LogModule.class,
+            NoConsoleSessionModule.class,
+            ServerBuilderInProcessModule.class
+    })
+    public interface TestComponent {
+
+        DeephavenApiServer getServer();
+
+        ManagedChannelBuilder<?> channelBuilder();
+
+        @Component.Builder
+        interface Builder {
+
+            @BindsInstance
+            Builder withSchedulerPoolSize(@Named("scheduler.poolSize") int numThreads);
+
+            @BindsInstance
+            Builder withSessionTokenExpireTmMs(@Named("session.tokenExpireMs") long tokenExpireMs);
+
+            @BindsInstance
+            Builder withOut(@Named("out") PrintStream out);
+
+            @BindsInstance
+            Builder withErr(@Named("err") PrintStream err);
+
+            @BindsInstance
+            Builder withExecutionContext(ExecutionContext context);
+
+            TestComponent build();
+        }
+    }
 
     @Rule
     public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
-    private DeephavenApiServerInProcessGroovyComponent serverComponent;
+    private TestComponent serverComponent;
     private LogBuffer logBuffer;
     private DeephavenApiServer server;
     private SafeCloseable scopeCloseable;
@@ -40,8 +82,8 @@ public abstract class DeephavenApiServerTestBase {
         logBuffer = new LogBuffer(128);
         LogBufferGlobal.setInstance(logBuffer);
 
-        serverComponent = DaggerDeephavenApiServerInProcessGroovyComponent
-                .builder()
+        serverComponent = DaggerDeephavenApiServerTestBase_TestComponent.builder()
+                .withExecutionContext(ExecutionContext.createForUnitTests())
                 .withSchedulerPoolSize(4)
                 .withSessionTokenExpireTmMs(sessionTokenExpireTmMs())
                 .withOut(System.out)

--- a/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
+++ b/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
@@ -36,7 +36,8 @@ public abstract class DeephavenApiServerTestBase {
             DeephavenApiServerModule.class,
             LogModule.class,
             NoConsoleSessionModule.class,
-            ServerBuilderInProcessModule.class
+            ServerBuilderInProcessModule.class,
+            ExecutionContextUnitTestModule.class,
     })
     public interface TestComponent {
 
@@ -59,9 +60,6 @@ public abstract class DeephavenApiServerTestBase {
             @BindsInstance
             Builder withErr(@Named("err") PrintStream err);
 
-            @BindsInstance
-            Builder withExecutionContext(ExecutionContext context);
-
             TestComponent build();
         }
     }
@@ -83,7 +81,6 @@ public abstract class DeephavenApiServerTestBase {
         LogBufferGlobal.setInstance(logBuffer);
 
         serverComponent = DaggerDeephavenApiServerTestBase_TestComponent.builder()
-                .withExecutionContext(ExecutionContext.createForUnitTests())
                 .withSchedulerPoolSize(4)
                 .withSessionTokenExpireTmMs(sessionTokenExpireTmMs())
                 .withOut(System.out)

--- a/server/src/test/java/io/deephaven/server/runner/ExecutionContextUnitTestModule.java
+++ b/server/src/test/java/io/deephaven/server/runner/ExecutionContextUnitTestModule.java
@@ -1,0 +1,16 @@
+package io.deephaven.server.runner;
+
+import dagger.Module;
+import dagger.Provides;
+import io.deephaven.engine.context.ExecutionContext;
+
+import javax.inject.Singleton;
+
+@Module
+public class ExecutionContextUnitTestModule {
+    @Provides
+    @Singleton
+    public ExecutionContext provideExecutionContext() {
+        return ExecutionContext.createForUnitTests();
+    }
+}

--- a/server/src/test/java/io/deephaven/server/session/SessionServiceTest.java
+++ b/server/src/test/java/io/deephaven/server/session/SessionServiceTest.java
@@ -4,6 +4,7 @@
 package io.deephaven.server.session;
 
 import io.deephaven.base.verify.Assert;
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.util.NoLanguageDeephavenSession;
 import io.deephaven.server.util.TestControlledScheduler;
@@ -30,7 +31,7 @@ public class SessionServiceTest {
         livenessScope = LivenessScopeStack.open();
         scheduler = new TestControlledScheduler();
         sessionService = new SessionService(scheduler,
-                authContext -> new SessionState(scheduler, NoLanguageDeephavenSession::new, authContext),
+                authContext -> new SessionState(scheduler, ExecutionContext::createForUnitTests, authContext),
                 TOKEN_EXPIRE_MS, Optional.empty(), Collections.emptyMap());
     }
 

--- a/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
+++ b/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
@@ -5,6 +5,7 @@ package io.deephaven.server.session;
 
 import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.AssertionFailure;
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.util.NoLanguageDeephavenSession;
 import io.deephaven.proto.util.ExportTicketHelper;
 import io.deephaven.server.table.ExportTableUpdateListenerTest;
@@ -61,7 +62,7 @@ public class SessionStateTest {
         livenessScope = new LivenessScope();
         LivenessScopeStack.push(livenessScope);
         scheduler = new TestControlledScheduler();
-        session = new SessionState(scheduler, NoLanguageDeephavenSession::new, AUTH_CONTEXT);
+        session = new SessionState(scheduler, ExecutionContext::createForUnitTests, AUTH_CONTEXT);
         session.initializeExpiration(new SessionService.TokenExpiration(UUID.randomUUID(),
                 DateTimeUtils.nanosToTime(Long.MAX_VALUE), session));
         nextExportId = 1;
@@ -637,7 +638,7 @@ public class SessionStateTest {
 
     @Test
     public void testVerifyExpirationSession() {
-        final SessionState session = new SessionState(scheduler, NoLanguageDeephavenSession::new, AUTH_CONTEXT);
+        final SessionState session = new SessionState(scheduler, ExecutionContext::createForUnitTests, AUTH_CONTEXT);
         final SessionService.TokenExpiration expiration =
                 new SessionService.TokenExpiration(UUID.randomUUID(), DateTimeUtils.nanosToTime(Long.MAX_VALUE),
                         session);

--- a/server/src/test/java/io/deephaven/server/table/ExportTableUpdateListenerTest.java
+++ b/server/src/test/java/io/deephaven/server/table/ExportTableUpdateListenerTest.java
@@ -4,6 +4,7 @@
 package io.deephaven.server.table;
 
 import io.deephaven.base.verify.Assert;
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.util.NoLanguageDeephavenSession;
@@ -340,7 +341,7 @@ public class ExportTableUpdateListenerTest {
 
     public class TestSessionState extends SessionState {
         public TestSessionState() {
-            super(scheduler, NoLanguageDeephavenSession::new, AUTH_CONTEXT);
+            super(scheduler, ExecutionContext::createForUnitTests, AUTH_CONTEXT);
             initializeExpiration(new SessionService.TokenExpiration(UUID.randomUUID(),
                     DateTimeUtils.nanosToTime(Long.MAX_VALUE), this));
         }

--- a/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -15,6 +15,7 @@ import io.deephaven.barrage.flatbuf.BarrageSnapshotOptions;
 import io.deephaven.barrage.flatbuf.BarrageSnapshotRequest;
 import io.deephaven.barrage.flatbuf.ColumnConversionMode;
 import io.deephaven.base.verify.Assert;
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
@@ -132,6 +133,11 @@ public abstract class FlightMessageRoundTripTest {
         ScheduledExecutorService provideExecutorService() {
             return null;
         }
+
+        @Provides
+        ExecutionContext provideExecutionContext() {
+            return ExecutionContext.createForUnitTests();
+        }
     }
 
     public interface TestComponent {
@@ -150,6 +156,8 @@ public abstract class FlightMessageRoundTripTest {
         AuthTestModule.BasicAuthTestImpl basicAuthHandler();
 
         Map<String, AuthenticationRequestHandler> authRequestHandlers();
+
+        ExecutionContext executionContext();
     }
 
     private GrpcServer server;
@@ -174,7 +182,7 @@ public abstract class FlightMessageRoundTripTest {
 
         scriptSession = component.scriptSession();
         sessionService = component.sessionService();
-        executionContext = scriptSession.getExecutionContext().open();
+        executionContext = component.executionContext().open();
 
         serverLocation = Location.forGrpcInsecure("localhost", actualPort);
         currentSession = sessionService.newSession(new AuthContext.SuperUser());

--- a/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -133,11 +133,6 @@ public abstract class FlightMessageRoundTripTest {
         ScheduledExecutorService provideExecutorService() {
             return null;
         }
-
-        @Provides
-        ExecutionContext provideExecutionContext() {
-            return ExecutionContext.createForUnitTests();
-        }
     }
 
     public interface TestComponent {


### PR DESCRIPTION
`AnnotatedTableTest` began to take ~20m to execute after the ExecutionContext merge. Groovy sessions were running their init scripts and many tests required a query compilation as no results were being cached. It now runs all 968 tests within 10-20s (back to where it originally was). 