### PR TITLE
Remove Python specific checks for parallel evaluation of formulas

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/ColumnSource.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/ColumnSource.java
@@ -174,19 +174,6 @@ public interface ColumnSource<T>
     }
 
     /**
-     * Can this column source be evaluated on an arbitrary thread?
-     *
-     * Most column sources can be evaluated on an arbitrary thread, however those that do call into Python can not be
-     * evaluated on an arbitrary thread as the calling thread may already have the GIL, which would result in a deadlock
-     * when the column source takes the GIL to evaluate formulas.
-     *
-     * @return true if this column prevents parallelization
-     */
-    default boolean preventsParallelism() {
-        return false;
-    }
-
-    /**
      * Most column sources will return the same value for a given row without respect to the order that the rows are
      * read. Those columns sources are considered "stateless" and should return true.
      *

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
@@ -522,11 +522,6 @@ class NaturalJoinHelper {
         }
 
         @Override
-        public boolean preventsParallelism() {
-            return symbolSource.preventsParallelism();
-        }
-
-        @Override
         public boolean isStateless() {
             return symbolSource.isStateless();
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PrevColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PrevColumnSource.java
@@ -168,11 +168,6 @@ public final class PrevColumnSource<T> extends AbstractColumnSource<T> {
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return originalSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return originalSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UnboxedDateTimeColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UnboxedDateTimeColumnSource.java
@@ -50,11 +50,6 @@ public class UnboxedDateTimeColumnSource extends AbstractColumnSource<Long>
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return alternateColumnSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return alternateColumnSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/BiTableTransformationColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/BiTableTransformationColumn.java
@@ -71,7 +71,7 @@ class BiTableTransformationColumn extends BaseTableTransformationColumn {
     @NotNull
     @Override
     public ColumnSource<?> getDataView() {
-        return new ViewColumnSource<>(Table.class, new OutputFormula(), false, true);
+        return new ViewColumnSource<>(Table.class, new OutputFormula(), true);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
@@ -56,7 +56,7 @@ class LongConstantColumn implements SelectColumn {
     @NotNull
     @Override
     public ColumnSource<?> getDataView() {
-        return new ViewColumnSource<>(long.class, new OutputFormula(), false, true);
+        return new ViewColumnSource<>(long.class, new OutputFormula(), true);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/TableTransformationColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/TableTransformationColumn.java
@@ -66,7 +66,7 @@ public class TableTransformationColumn extends BaseTableTransformationColumn {
     @NotNull
     @Override
     public ColumnSource<?> getDataView() {
-        return new ViewColumnSource<>(Table.class, new OutputFormula(), false, true);
+        return new ViewColumnSource<>(Table.class, new OutputFormula(), true);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -198,7 +198,6 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
 
     @NotNull
     private ColumnSource<?> getViewColumnSource(boolean lazy) {
-        final boolean preventsParallelization = preventsParallelization();
         final boolean isStateless = isStateless();
 
         final SecurityManager sm = System.getSecurityManager();
@@ -219,17 +218,15 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
                 final Formula formula = getFormula(lazy, columnSources, params);
                 // noinspection unchecked,rawtypes
                 return new ViewColumnSource((returnedType == boolean.class ? Boolean.class : returnedType), formula,
-                        preventsParallelization, isStateless);
+                        isStateless);
             }, context);
         } else {
             final Formula formula = getFormula(lazy, columnSources, params);
             // noinspection unchecked,rawtypes
             return new ViewColumnSource((returnedType == boolean.class ? Boolean.class : returnedType), formula,
-                    preventsParallelization, isStateless);
+                    isStateless);
         }
     }
-
-    public abstract boolean preventsParallelization();
 
     private Formula getFormula(boolean initLazyMap,
             Map<String, ? extends ColumnSource<?>> columnsToData,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
@@ -831,35 +831,8 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
         return TypeUtils.isBoxedType(type);
     }
 
-    /**
-     * Is this parameter possibly a Python type?
-     *
-     * Immutable types are not Python, known Python wrappers are Python, and anything else from a PythonScope is Python.
-     *
-     * @return true if this query scope parameter may be a Python type
-     */
-    private static boolean isPythonType(QueryScopeParam<?> param) {
-        if (isImmutableType(param)) {
-            return false;
-        }
-
-        // we want to catch PyObjects, and CallableWrappers even if they were hand inserted into a scope
-        final Object value = param.getValue();
-        if (value instanceof PyObject || value instanceof PythonScopeJpyImpl.CallableWrapper
-                || value instanceof PyListWrapper || value instanceof PyDictWrapper) {
-            return true;
-        }
-
-        // beyond the immutable types, we must assume that anything coming from Python is python
-        return ExecutionContext.getContext().getQueryScope() instanceof PythonScope;
-    }
-
     private boolean isUsedColumnStateless(String columnName) {
         return columnSources.get(columnName).isStateless();
-    }
-
-    private boolean usedColumnUsesPython(String columnName) {
-        return columnSources.get(columnName).preventsParallelism();
     }
 
     @Override
@@ -869,14 +842,4 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
                 && usedColumnArrays.stream().allMatch(this::isUsedColumnStateless);
     }
 
-    /**
-     * Does this formula column use Python (which would cause us to hang the GIL if we evaluate it off thread?)
-     *
-     * @return true if this column has the potential to hang the gil
-     */
-    public boolean preventsParallelization() {
-        return Arrays.stream(params).anyMatch(DhFormulaColumn::isPythonType)
-                || usedColumns.stream().anyMatch(this::usedColumnUsesPython)
-                || usedColumnArrays.stream().anyMatch(this::usedColumnUsesPython);
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumn.java
@@ -177,7 +177,7 @@ public class FunctionalColumn<S, D> implements SelectColumn {
                 final FunctionalColumnFillContext ctx = (FunctionalColumnFillContext) fillContext;
                 ctx.chunkFiller.fillByIndices(this, rowSequence, destination);
             }
-        }, sourceColumnSource.preventsParallelism(), false);
+        }, false);
     }
 
     private static class FunctionalColumnFillContext implements Formula.FillContext {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
@@ -94,8 +94,6 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
         sourceColumns = localSources.toArray(ColumnSource.ZERO_LENGTH_COLUMN_SOURCE_ARRAY);
         prevSources = localPrev.toArray(ColumnSource.ZERO_LENGTH_COLUMN_SOURCE_ARRAY);
 
-        usesPython = Arrays.stream(sourceColumns).anyMatch(ColumnSource::preventsParallelism);
-
         return getColumns();
     }
 
@@ -175,7 +173,7 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
                 final FunctionalColumnFillContext ctx = (FunctionalColumnFillContext) fillContext;
                 ctx.chunkFiller.fillByIndices(this, rowSequence, destination);
             }
-        }, usesPython, false);
+        }, false);
     }
 
     private static class FunctionalColumnFillContext implements Formula.FillContext {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
@@ -56,7 +56,6 @@ final public class SelectColumnLayer extends SelectOrViewColumnLayer {
     private final boolean flattenedResult;
     private final boolean alreadyFlattenedSources;
     private final BitSet dependencyBitSet;
-    private final boolean canUseThreads;
     private final boolean canParallelizeThisColumn;
     private final boolean isSystemic;
     private final boolean resultTypeIsLivenessReferent;
@@ -86,13 +85,9 @@ final public class SelectColumnLayer extends SelectOrViewColumnLayer {
         this.flattenedResult = flattenedResult;
         this.alreadyFlattenedSources = alreadyFlattenedSources;
 
-        // We can't use threads at all if we have column that uses a Python query scope, because we are likely operating
-        // under the GIL which will cause a deadlock
-        canUseThreads = !sc.getDataView().preventsParallelism();
-
         // We can only parallelize this column if we are not redirected, our destination provides ensure previous, and
         // the select column is stateless
-        canParallelizeThisColumn = canUseThreads && !isRedirected
+        canParallelizeThisColumn = !isRedirected
                 && WritableSourceWithPrepareForParallelPopulation.supportsParallelPopulation(ws) && sc.isStateless();
 
         // If we were created on a systemic thread, we want to be sure to make sure that any updates are also
@@ -573,6 +568,6 @@ final public class SelectColumnLayer extends SelectOrViewColumnLayer {
 
     @Override
     public boolean allowCrossColumnParallelization() {
-        return canUseThreads && inner.allowCrossColumnParallelization();
+        return inner.allowCrossColumnParallelization();
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/python/FormulaColumnPython.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/python/FormulaColumnPython.java
@@ -58,11 +58,6 @@ public class FormulaColumnPython extends AbstractFormulaColumn implements Formul
     }
 
     @Override
-    public boolean preventsParallelization() {
-        return true;
-    }
-
-    @Override
     protected final FormulaSourceDescriptor getSourceDescriptor() {
         return new FormulaSourceDescriptor(
                 returnedType,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BitMaskingColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BitMaskingColumnSource.java
@@ -479,11 +479,6 @@ public class BitMaskingColumnSource<T> extends AbstractColumnSource<T> implement
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BitShiftingColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BitShiftingColumnSource.java
@@ -496,11 +496,6 @@ public class BitShiftingColumnSource<T> extends AbstractColumnSource<T> implemen
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BooleanAsByteColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BooleanAsByteColumnSource.java
@@ -92,11 +92,6 @@ public class BooleanAsByteColumnSource extends AbstractColumnSource<Byte> implem
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return alternateColumnSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return alternateColumnSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BoxedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BoxedColumnSource.java
@@ -156,11 +156,6 @@ public abstract class BoxedColumnSource<DATA_TYPE> extends AbstractColumnSource<
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return originalSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return originalSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteAsBooleanColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteAsBooleanColumnSource.java
@@ -133,11 +133,6 @@ public class ByteAsBooleanColumnSource extends AbstractColumnSource<Boolean> imp
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return alternateColumnSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return alternateColumnSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/CrossJoinRightColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/CrossJoinRightColumnSource.java
@@ -688,11 +688,6 @@ public class CrossJoinRightColumnSource<T> extends AbstractColumnSource<T> imple
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DateTimeAsLongColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DateTimeAsLongColumnSource.java
@@ -94,11 +94,6 @@ public class DateTimeAsLongColumnSource extends AbstractColumnSource<Long> imple
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return alternateColumnSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return alternateColumnSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DelegatingColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DelegatingColumnSource.java
@@ -203,11 +203,6 @@ public class DelegatingColumnSource<T, R> extends AbstractColumnSource<T> {
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return delegate.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return delegate.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/LongAsDateTimeColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/LongAsDateTimeColumnSource.java
@@ -137,11 +137,6 @@ public class LongAsDateTimeColumnSource extends AbstractColumnSource<DateTime> i
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return alternateColumnSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return alternateColumnSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/RedirectedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/RedirectedColumnSource.java
@@ -728,11 +728,6 @@ public class RedirectedColumnSource<T> extends AbstractColumnSource<T>
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ReversedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ReversedColumnSource.java
@@ -176,11 +176,6 @@ public class ReversedColumnSource<T> extends AbstractColumnSource<T> {
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SwitchColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SwitchColumnSource.java
@@ -299,11 +299,6 @@ public class SwitchColumnSource<T> extends AbstractColumnSource<T> {
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return currentSource.preventsParallelism() || (!prevInvalid() && prevSource.preventsParallelism());
-    }
-
-    @Override
     public boolean isStateless() {
         return currentSource.isStateless() && (prevInvalid() || prevSource.isStateless());
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedByteArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedByteArrayColumnSource.java
@@ -61,11 +61,6 @@ public class UngroupedByteArrayColumnSource extends UngroupedColumnSource<Byte> 
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedByteVectorColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedByteVectorColumnSource.java
@@ -112,11 +112,6 @@ public class UngroupedByteVectorColumnSource extends UngroupedColumnSource<Byte>
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedCharArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedCharArrayColumnSource.java
@@ -56,11 +56,6 @@ public class UngroupedCharArrayColumnSource extends UngroupedColumnSource<Charac
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedCharVectorColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedCharVectorColumnSource.java
@@ -107,11 +107,6 @@ public class UngroupedCharVectorColumnSource extends UngroupedColumnSource<Chara
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedDoubleArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedDoubleArrayColumnSource.java
@@ -61,11 +61,6 @@ public class UngroupedDoubleArrayColumnSource extends UngroupedColumnSource<Doub
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedDoubleVectorColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedDoubleVectorColumnSource.java
@@ -112,11 +112,6 @@ public class UngroupedDoubleVectorColumnSource extends UngroupedColumnSource<Dou
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedFloatArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedFloatArrayColumnSource.java
@@ -61,11 +61,6 @@ public class UngroupedFloatArrayColumnSource extends UngroupedColumnSource<Float
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedFloatVectorColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedFloatVectorColumnSource.java
@@ -112,11 +112,6 @@ public class UngroupedFloatVectorColumnSource extends UngroupedColumnSource<Floa
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedIntArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedIntArrayColumnSource.java
@@ -61,11 +61,6 @@ public class UngroupedIntArrayColumnSource extends UngroupedColumnSource<Integer
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedIntVectorColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedIntVectorColumnSource.java
@@ -112,11 +112,6 @@ public class UngroupedIntVectorColumnSource extends UngroupedColumnSource<Intege
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedLongArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedLongArrayColumnSource.java
@@ -61,11 +61,6 @@ public class UngroupedLongArrayColumnSource extends UngroupedColumnSource<Long> 
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedLongVectorColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedLongVectorColumnSource.java
@@ -112,11 +112,6 @@ public class UngroupedLongVectorColumnSource extends UngroupedColumnSource<Long>
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedShortArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedShortArrayColumnSource.java
@@ -61,11 +61,6 @@ public class UngroupedShortArrayColumnSource extends UngroupedColumnSource<Short
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedShortVectorColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UngroupedShortVectorColumnSource.java
@@ -112,11 +112,6 @@ public class UngroupedShortVectorColumnSource extends UngroupedColumnSource<Shor
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return innerSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return innerSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionColumnSource.java
@@ -18,7 +18,6 @@ import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
 import io.deephaven.chunk.ResettableWritableChunk;
 import io.deephaven.chunk.WritableChunk;
-import io.deephaven.qst.column.Column;
 import io.deephaven.util.SafeCloseable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -760,16 +759,6 @@ public class UnionColumnSource<T> extends AbstractColumnSource<T> {
         }
         try (final Stream<ColumnSource<T>> sources = sourceLookup.currSources()) {
             return sources.allMatch(ColumnSource::isImmutable);
-        }
-    }
-
-    @Override
-    public boolean preventsParallelism() {
-        if (!unionSourceManager.isUsingComponentsSafe()) {
-            return true;
-        }
-        try (final Stream<ColumnSource<T>> sources = sourceLookup.currSources()) {
-            return sources.anyMatch(ColumnSource::preventsParallelism);
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ViewColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ViewColumnSource.java
@@ -41,21 +41,18 @@ public class ViewColumnSource<T> extends AbstractColumnSource<T> {
                     new ProtectionDomain[] {new ProtectionDomain(
                             new CodeSource(groovyShellUrl, (java.security.cert.Certificate[]) null), perms)}));
 
-    private final boolean preventsParallelization;
     private final boolean isStateless;
 
-    public ViewColumnSource(Class<T> type, Formula formula, boolean preventsParallelization, boolean isStateless) {
+    public ViewColumnSource(Class<T> type, Formula formula, boolean isStateless) {
         super(type);
         this.formula = formula;
-        this.preventsParallelization = preventsParallelization;
         this.isStateless = isStateless;
     }
 
-    public ViewColumnSource(Class<T> type, Class elementType, Formula formula, boolean preventsParallelization,
+    public ViewColumnSource(Class<T> type, Class elementType, Formula formula,
             boolean isStateless) {
         super(type, elementType);
         this.formula = formula;
-        this.preventsParallelization = preventsParallelization;
         this.isStateless = isStateless;
     }
 
@@ -286,10 +283,6 @@ public class ViewColumnSource<T> extends AbstractColumnSource<T> {
         public void close() {
             underlyingFillContext.close();
         }
-    }
-
-    public boolean preventsParallelism() {
-        return preventsParallelization;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/BaseAggregateColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/aggregate/BaseAggregateColumnSource.java
@@ -245,11 +245,6 @@ abstract class BaseAggregateColumnSource<DB_ARRAY_TYPE extends Vector, COMPONENT
     }
 
     @Override
-    public boolean preventsParallelism() {
-        return aggregatedSource.preventsParallelism() || groupRowSetSource.preventsParallelism();
-    }
-
-    @Override
     public boolean isStateless() {
         return aggregatedSource.isStateless() && groupRowSetSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ColumnsToRowsTransform.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ColumnsToRowsTransform.java
@@ -616,11 +616,6 @@ public class ColumnsToRowsTransform {
         }
 
         @Override
-        public boolean preventsParallelism() {
-            return Arrays.stream(transposeColumns).anyMatch(ColumnSource::preventsParallelism);
-        }
-
-        @Override
         public boolean isStateless() {
             return Arrays.stream(transposeColumns).allMatch(ColumnSource::isStateless);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/MergeSortedHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/MergeSortedHelper.java
@@ -279,11 +279,6 @@ public class MergeSortedHelper {
         }
 
         @Override
-        public boolean preventsParallelism() {
-            return innerSources.stream().anyMatch(ColumnSource::preventsParallelism);
-        }
-
-        @Override
         public boolean isStateless() {
             return innerSources.stream().allMatch(ColumnSource::isStateless);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
@@ -462,11 +462,6 @@ public class WindowCheck {
         }
 
         @Override
-        public boolean preventsParallelism() {
-            return timeStampSource.preventsParallelism();
-        }
-
-        @Override
         public boolean isStateless() {
             return timeStampSource.isStateless();
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestPartitionAwareSourceTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestPartitionAwareSourceTable.java
@@ -425,7 +425,6 @@ public class TestPartitionAwareSourceTable extends RefreshingTableTestCase {
                     will(returnValue(columnDefinition.getDataType()));
                     allowing(columnSource).getComponentType();
                     will(returnValue(columnDefinition.getComponentType()));
-                    will(returnValue(false));
                     allowing(columnSource).isStateless();
                     will(returnValue(true));
                 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestPartitionAwareSourceTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestPartitionAwareSourceTable.java
@@ -425,7 +425,6 @@ public class TestPartitionAwareSourceTable extends RefreshingTableTestCase {
                     will(returnValue(columnDefinition.getDataType()));
                     allowing(columnSource).getComponentType();
                     will(returnValue(columnDefinition.getComponentType()));
-                    allowing(columnSource).preventsParallelism();
                     will(returnValue(false));
                     allowing(columnSource).isStateless();
                     will(returnValue(true));

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestSimpleSourceTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestSimpleSourceTable.java
@@ -75,7 +75,6 @@ public class TestSimpleSourceTable extends RefreshingTableTestCase {
                     will(returnValue(cd.getDataType()));
                     allowing(mocked).getComponentType();
                     will(returnValue(cd.getComponentType()));
-                    allowing(mocked).preventsParallelism();
                     will(returnValue(false));
                     allowing(mocked).isStateless();
                     will(returnValue(true));

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestSimpleSourceTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestSimpleSourceTable.java
@@ -75,7 +75,6 @@ public class TestSimpleSourceTable extends RefreshingTableTestCase {
                     will(returnValue(cd.getDataType()));
                     allowing(mocked).getComponentType();
                     will(returnValue(cd.getComponentType()));
-                    will(returnValue(false));
                     allowing(mocked).isStateless();
                     will(returnValue(true));
                 }


### PR DESCRIPTION
The change in JPY to release the GIL whenever a Java method is called has made the check to prevent potential deadlock unnecessary. 

Fixes #2742 