### PR TITLE
Parse date times correctly when importing CSV

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/i18n/JsTimeZone.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/i18n/JsTimeZone.java
@@ -502,6 +502,16 @@ public class JsTimeZone {
         addMapping("MOS", "Europe/Moscow");
         addMapping("SHG", "Asia/Shanghai");
 
+        // Add short time codes from Deephaven Enterprise
+        addMapping("NY", "America/New_York");
+        addMapping("MTL", "America/Toronto");
+        addMapping("MEX", "America/Mexico_City");
+        addMapping("SKM", "Europe/Stockholm");
+        addMapping("OSL", "Europe/Oslo");
+        addMapping("MAD", "Europe/Madrid");
+        addMapping("JNB", "Africa/Johannesburg");
+        addMapping("KL", "Asia/Kuala_Lumpur");
+
         // Add GMT mappings
         TimeZone gmtTimeZone = TimeZone.createTimeZone(0);
         addMapping("UTC", gmtTimeZone);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
@@ -118,12 +118,12 @@ public enum JsDataHandler {
             return context.dateTimePattern + "." + stringBuilder;
         }
 
-        private long parseDateString(String str, ParseContext context ) {
+        private long parseDateString(String str, ParseContext context) {
             final String s = ensureSeparator(str, context);
             final int spaceIndex = s.indexOf(' ');
             final String dateTimeString;
             final String timeZoneString;
-            if (spaceIndex == - 1) {
+            if (spaceIndex == -1) {
                 // Zulu is an exception to the space rule
                 if (s.endsWith("Z")) {
                     dateTimeString = s.substring(0, s.length() - 1);
@@ -133,14 +133,15 @@ public enum JsDataHandler {
                     timeZoneString = null;
                 }
             } else {
-                dateTimeString =  s.substring(0, spaceIndex);
+                dateTimeString = s.substring(0, spaceIndex);
                 timeZoneString = s.substring(spaceIndex + 1);
             }
             final String pattern = getSubsecondPattern(dateTimeString, context);
             final TimeZone timeZone = timeZoneString == null
                     ? context.timeZone.unwrap()
                     : JsTimeZone.getTimeZone(timeZoneString).unwrap();
-            return JsDateTimeFormat.getFormat(pattern).parseWithTimezoneAsLong(dateTimeString, timeZone, JsTimeZone.needsDstAdjustment(timeZoneString));
+            return JsDateTimeFormat.getFormat(pattern).parseWithTimezoneAsLong(dateTimeString, timeZone,
+                    JsTimeZone.needsDstAdjustment(timeZoneString));
         }
 
         @Override


### PR DESCRIPTION
- Wasn't taking into account subsecond patterns and time zones
- Copied logic over from CsvTypeParser in Enterprise
- Optimize by only changing the pattern when it fails to parse
- Added additional short code time zones to match what is on Enterprise
- Fixes #2814
- Tested with a file with multiple formats for dates:
[multiple-formats.csv](https://github.com/deephaven/deephaven-core/files/9538411/multiple-formats.csv)
