### PR TITLE
If a TeeStream is gc'd, don't close underlying streams

### DIFF
--- a/py/server/deephaven_internal/stream.py
+++ b/py/server/deephaven_internal/stream.py
@@ -89,3 +89,7 @@ class TeeStream(io.TextIOBase):
         self.close_func()
         if self.should_write_to_orig_stream:
             self._stream.close()
+
+    def __del__(self):
+        # Do nothing, override superclass which would call close()
+        pass


### PR DESCRIPTION
Fixes #2812