### PR TITLE
Package proto files in the top level of the jar based on them

### DIFF
--- a/proto/proto-backplane-grpc/build.gradle
+++ b/proto/proto-backplane-grpc/build.gradle
@@ -105,6 +105,9 @@ sourceSets {
       srcDir 'build/generated/source/proto/main/grpc'
       srcDir 'build/generated/source/proto/main/java'
     }
+    resources {
+      srcDir 'src/main/proto/deephaven/proto'
+    }
   }
 }
 


### PR DESCRIPTION
This follows the pattern in use by flight-core with its Flight.proto file.

Fixes #2840