### PR TITLE
TicketResolver: return failed export object instead of throwing

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
@@ -41,9 +41,9 @@ public class GrpcUtil {
             } else {
                 log.error().append(err).endl();
             }
-            response.onError(err);
+            safelyError(response, err);
         } catch (final RuntimeException | IOException err) {
-            response.onError(securelyWrapError(log, err));
+            safelyError(response, securelyWrapError(log, err));
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
+++ b/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
@@ -6,6 +6,7 @@ package io.deephaven.server.console;
 import com.google.protobuf.ByteStringAccess;
 import com.google.rpc.Code;
 import io.deephaven.base.string.EncodingInfo;
+import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.DynamicNode;
@@ -96,22 +97,23 @@ public class ScopeTicketResolver extends TicketResolverBase {
 
     private <T> SessionState.ExportObject<T> resolve(
             @Nullable final SessionState session, final String scopeName, final String logId) {
-        // if we are not attached to a session, check the scope for a variable right now
+        // fetch the variable from the scope right now
         final T export = UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> {
             final ScriptSession gss = scriptSessionProvider.get();
-            // noinspection unchecked
-            T scopeVar = (T) gss.unwrapObject(gss.getVariable(scopeName));
-            if (scopeVar == null) {
-                throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
-                        "Could not resolve '" + logId + "': no variable exists with name '" + scopeName + "'");
+            T scopeVar = null;
+            try {
+                // noinspection unchecked
+                scopeVar = (T) gss.unwrapObject(gss.getVariable(scopeName));
+            } catch (QueryScope.MissingVariableException ignored) {
             }
             return scopeVar;
         });
 
         if (export == null) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
-                    "Could not resolve '" + logId + "': no variable exists with name '" + scopeName + "'");
+            return SessionState.wrapAsFailedExport(GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+                    "Could not resolve '" + logId + "': no variable exists with name '" + scopeName + "'"));
         }
+
         return SessionState.wrapAsExport(export);
     }
 

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -21,7 +21,6 @@ import io.deephaven.engine.table.impl.util.MemoryTableLoggers;
 import io.deephaven.engine.tablelogger.QueryOperationPerformanceLogLogger;
 import io.deephaven.engine.tablelogger.QueryPerformanceLogLogger;
 import io.deephaven.engine.updategraph.DynamicNode;
-import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.hash.KeyedIntObjectHash;
 import io.deephaven.hash.KeyedIntObjectHashMap;
@@ -101,6 +100,20 @@ public class SessionState {
      */
     public static <T> ExportObject<T> wrapAsExport(final T export) {
         return new ExportObject<>(export);
+    }
+
+    /**
+     * Wrap an exception in an ExportObject to make it conform to the session export API. The export behaves as if it
+     * has already failed.
+     *
+     * @param caughtException the exception to propagate
+     * @param <T> the type of the object
+     * @return a sessionless export object
+     */
+    public static <T> ExportObject<T> wrapAsFailedExport(final Exception caughtException) {
+        ExportObject<T> exportObject = new ExportObject<>(null);
+        exportObject.caughtException = caughtException;
+        return exportObject;
     }
 
     private static final Logger log = LoggerFactory.getLogger(SessionState.class);
@@ -551,10 +564,16 @@ public class SessionState {
             super(true);
             this.session = null;
             this.exportId = NON_EXPORT_ID;
-            this.state = ExportNotification.State.EXPORTED;
             this.result = result;
             this.dependentCount = 0;
             this.logIdentity = Integer.toHexString(System.identityHashCode(this)) + "-sessionless";
+
+            if (result == null) {
+                assignErrorId();
+                state = ExportNotification.State.FAILED;
+            } else {
+                state = ExportNotification.State.EXPORTED;
+            }
 
             if (result instanceof LivenessReferent && DynamicNode.notDynamicOrIsRefreshing(result)) {
                 manage((LivenessReferent) result);
@@ -733,8 +752,9 @@ public class SessionState {
                 exportListenerVersion = session.exportListenerVersion;
                 session.exportListeners.forEach(listener -> listener.notify(notification));
             } else {
-                log.debug().append(session.logPrefix).append("non-export '").append(logIdentity)
-                        .append("' is ExportState.").append(state.name()).endl();
+                log.debug().append(session == null ? "Session " : session.logPrefix)
+                        .append("non-export '").append(logIdentity).append("' is ExportState.")
+                        .append(state.name()).endl();
             }
 
             if (isExportStateFailure(state) && errorHandler != null) {
@@ -978,7 +998,10 @@ public class SessionState {
         protected synchronized void destroy() {
             super.destroy();
             result = null;
-            caughtException = null;
+            // keep SREs since error propagation won't reference a real errorId on the server
+            if (!(caughtException instanceof StatusRuntimeException)) {
+                caughtException = null;
+            }
         }
 
         /**


### PR DESCRIPTION
The scope ticket resolver no longer throws an exception but instead returns an export object that is in a failed state. This allows commands downstream of a failed dependency to 1) be created, and 2) assume a dependency_failed state.