### PR TITLE
Netty enable SO_REUSEADDR to fix bind to port 8080 races

### DIFF
--- a/server/netty/src/main/java/io/deephaven/server/netty/NettyServerModule.java
+++ b/server/netty/src/main/java/io/deephaven/server/netty/NettyServerModule.java
@@ -18,6 +18,7 @@ import io.grpc.Server;
 import io.grpc.ServerInterceptor;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
+import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import nl.altindag.ssl.SSLFactory;
@@ -45,6 +46,8 @@ public interface NettyServerModule {
         } else {
             serverBuilder = NettyServerBuilder.forPort(serverConfig.port());
         }
+        serverBuilder.withOption(ChannelOption.SO_REUSEADDR, true);
+
         services.forEach(serverBuilder::addService);
         interceptors.forEach(serverBuilder::intercept);
         serverBuilder.intercept(MTlsCertificate.DEFAULT_INTERCEPTOR);

--- a/server/netty/src/test/java/io/deephaven/server/netty/NettyFlightRoundTripTest.java
+++ b/server/netty/src/test/java/io/deephaven/server/netty/NettyFlightRoundTripTest.java
@@ -20,7 +20,9 @@ public class NettyFlightRoundTripTest extends FlightMessageRoundTripTest {
     public interface NettyTestConfig {
         @Provides
         static NettyConfig providesNettyConfig() {
-            return NettyConfig.defaultConfig();
+            return NettyConfig.builder()
+                    .port(0)
+                    .build();
         }
     }
 


### PR DESCRIPTION
This should fix this rare-ish CI failure:
```
  io.deephaven.server.netty.NettyFlightRoundTripTest > testDoExchangeProtocol FAILED
      java.io.IOException at NettyServer.java:328
          Caused by: java.net.BindException at Net.java:-2
      java.lang.NullPointerException at FlightMessageRoundTripTest.java:204
```

I would also be willing to set the default port to 0, but does not seem necessary.