### PR TITLE
SessionState should tryManage as dependencies may no longer be live

### DIFF
--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -596,7 +596,7 @@ public class SessionState {
 
             this.parents = parents;
             dependentCount = parents.size();
-            parents.stream().filter(Objects::nonNull).forEach(this::manage);
+            parents.stream().filter(Objects::nonNull).forEach(this::tryManage);
 
             if (log.isDebugEnabled()) {
                 final Exception e = new RuntimeException();
@@ -767,7 +767,7 @@ public class SessionState {
             if (state == ExportNotification.State.EXPORTED || isExportStateTerminal(state)) {
                 children.forEach(child -> child.onResolveOne(this));
                 children = Collections.emptyList();
-                parents.stream().filter(Objects::nonNull).forEach(this::unmanage);
+                parents.stream().filter(Objects::nonNull).forEach(this::tryUnmanage);
                 parents = Collections.emptyList();
                 exportMain = null;
                 errorHandler = null;

--- a/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
+++ b/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import static io.deephaven.proto.backplane.grpc.ExportNotification.State.CANCELLED;
@@ -438,10 +439,12 @@ public class SessionStateTest {
         Assert.eq(e1.getState(), "e1.getState()", ExportNotification.State.RELEASED);
 
         final MutableBoolean errored = new MutableBoolean();
-        expectException(LivenessStateException.class, () -> session.newExport(nextExportId++)
+        final SessionState.ExportObject<?> e2 = session.newExport(nextExportId++)
                 .require(e1)
                 .onErrorHandler(err -> errored.setTrue())
-                .submit(() -> Assert.gt(e1.get().refCount, "e1.get().refCount", 0)));
+                .submit((Callable<Object>) Assert::statementNeverExecuted);
+        Assert.eqTrue(errored.booleanValue(), "errored.booleanValue()");
+        Assert.eq(e2.getState(), "e2.getState()", ExportNotification.State.DEPENDENCY_RELEASED);
     }
 
     @Test


### PR DESCRIPTION
This change allows for correct error propagation of StatusRuntimeExceptions from dependencies to downstream exports. The depending exports were failing with Internal errors instead, as non-exports are no longer kept live once put into a terminal state.