### PR TITLE
Add query language functions to get data structure sizes.

### DIFF
--- a/engine/function/src/templates/Basic.ftl
+++ b/engine/function/src/templates/Basic.ftl
@@ -154,7 +154,7 @@ public class Basic {
      */
     @SuppressWarnings("rawtypes")
     static public long len(LongSizedDataStructure values) {
-        if (values == null){
+        if (values == null) {
             return NULL_LONG;
         }
 

--- a/engine/function/src/templates/Basic.ftl
+++ b/engine/function/src/templates/Basic.ftl
@@ -5,6 +5,7 @@
 package io.deephaven.function;
 
 import io.deephaven.vector.*;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.util.QueryConstants;
 import gnu.trove.list.array.*;
 import gnu.trove.set.*;
@@ -129,6 +130,35 @@ public class Basic {
         }
 
         return result;
+    }
+
+    /**
+     * Returns the length of the input.
+     *
+     * @param values values.
+     * @return length of the input or zero for null inputs.
+     */
+    static public <T> long len(T[] values) {
+        if (values == null) {
+            return 0;
+        }
+
+        return values.length;
+    }
+
+    /**
+     * Returns the length of the input.
+     *
+     * @param values values.
+     * @return length of the input or zero for null inputs.
+     */
+    @SuppressWarnings("rawtypes")
+    static public long len(LongSizedDataStructure values) {
+        if(values == null){
+            return 0;
+        }
+
+        return values.size();
     }
 
     /**
@@ -847,6 +877,20 @@ public class Basic {
         }
 
         return result;
+    }
+
+    /**
+     * Returns the length of the input.
+     *
+     * @param values values.
+     * @return length of the input or zero for null inputs.
+     */
+    static public long len(${pt.primitive}[] values) {
+        if (values == null) {
+            return 0;
+        }
+
+        return values.length;
     }
 
     /**

--- a/engine/function/src/templates/Basic.ftl
+++ b/engine/function/src/templates/Basic.ftl
@@ -136,11 +136,11 @@ public class Basic {
      * Returns the length of the input.
      *
      * @param values values.
-     * @return length of the input or zero for null inputs.
+     * @return length of the input or the Deephaven null constant for null inputs.
      */
     static public <T> long len(T[] values) {
         if (values == null) {
-            return 0;
+            return NULL_LONG;
         }
 
         return values.length;
@@ -150,12 +150,12 @@ public class Basic {
      * Returns the length of the input.
      *
      * @param values values.
-     * @return length of the input or zero for null inputs.
+     * @return length of the input or the Deephaven null constant for null inputs.
      */
     @SuppressWarnings("rawtypes")
     static public long len(LongSizedDataStructure values) {
-        if(values == null){
-            return 0;
+        if (values == null){
+            return NULL_LONG;
         }
 
         return values.size();
@@ -883,11 +883,11 @@ public class Basic {
      * Returns the length of the input.
      *
      * @param values values.
-     * @return length of the input or zero for null inputs.
+     * @return length of the input or the Deephaven null constant for null inputs.
      */
     static public long len(${pt.primitive}[] values) {
         if (values == null) {
-            return 0;
+            return NULL_LONG;
         }
 
         return values.length;

--- a/engine/function/src/templates/TestBasic.ftl
+++ b/engine/function/src/templates/TestBasic.ftl
@@ -78,6 +78,22 @@ public class TestBasic extends BaseArrayTestCase {
         assertFalse(inRange(Integer.valueOf(4), Integer.valueOf(1), Integer.valueOf(3)));
     }
 
+    public void testObjLen() {
+        assertEquals(0, len((ObjectVector)null));
+        assertEquals(3, len(new ObjectVectorDirect<Integer>(40, 50, 60)));
+        assertEquals(0, len(new ObjectVectorDirect<Integer>()));
+        assertEquals(1, len(new ObjectVectorDirect<Integer>(new Integer[]{null})));
+        assertEquals(3, len(new ObjectVectorDirect<Integer>(5, null, 15)));
+        assertEquals(4, len(new ObjectVectorDirect<Integer>(5, null, 15, NULL_INT)));
+
+        assertEquals(0, len((Integer[])null));
+        assertEquals(3, len(new Integer[]{40, 50, 60}));
+        assertEquals(0, len(new Integer[]{}));
+        assertEquals(1, len(new Integer[]{null}));
+        assertEquals(3, len(new Integer[]{5, null, 15}));
+        assertEquals(4, len(new Integer[]{5, null, 15, NULL_INT}));
+    }
+
     public void testObjCount() {
         assertEquals(NULL_LONG, countObj((ObjectVector)null));
         assertEquals(3, countObj(new ObjectVectorDirect<Integer>(40, 50, 60)));
@@ -319,6 +335,20 @@ public class TestBasic extends BaseArrayTestCase {
         assertEquals(new Boolean[]{true, false, false}, replaceIfNull(new Boolean[]{Boolean.TRUE, null, Boolean.FALSE}, false));
     }
 
+    public void testBooleanLen() {
+        assertEquals(3, len(new Boolean[]{true, false, true}));
+        assertEquals(0, len(new Boolean[]{}));
+        assertEquals(1, len(new Boolean[]{QueryConstants.NULL_BOOLEAN}));
+        assertEquals(3, len(new Boolean[]{true, QueryConstants.NULL_BOOLEAN, true}));
+        assertEquals(0, len((Boolean[])null));
+
+        assertEquals(3, len(new ObjectVectorDirect<>(new Boolean[]{true, false, true})));
+        assertEquals(0, len(new ObjectVectorDirect<>()));
+        assertEquals(1, len(new ObjectVectorDirect<>(QueryConstants.NULL_BOOLEAN)));
+        assertEquals(3, len(new ObjectVectorDirect<>(new Boolean[]{true, QueryConstants.NULL_BOOLEAN, true})));
+        assertEquals(0, len((ObjectVector)null));
+    }
+
     public void testBooleanCount(){
         assertEquals(3,countObj(new Boolean[]{true, false, true}));
         assertEquals(0,countObj(new Boolean[]{}));
@@ -508,6 +538,20 @@ public class TestBasic extends BaseArrayTestCase {
         assertEquals(new ${pt.primitive}[]{(${pt.primitive}) 3, (${pt.primitive}) 7, (${pt.primitive}) 11}, replaceIfNull(new ${pt.dbArrayDirect}(new ${pt.primitive}[]{(${pt.primitive}) 3, ${pt.null}, (${pt.primitive}) 11}), (${pt.primitive}) 7));
 
         assertEquals(new ${pt.primitive}[]{(${pt.primitive}) 3, (${pt.primitive}) 7, (${pt.primitive}) 11}, replaceIfNull(new ${pt.primitive}[]{(${pt.primitive}) 3, ${pt.null}, (${pt.primitive}) 11}, (${pt.primitive}) 7));
+    }
+
+    public void test${pt.boxed}Len() {
+        assertEquals(0, len((${pt.primitive}[])null));
+        assertEquals(3, len(new ${pt.primitive}[]{40,50,60}));
+        assertEquals(0, len(new ${pt.primitive}[]{}));
+        assertEquals(1, len(new ${pt.primitive}[]{${pt.null}}));
+        assertEquals(3, len(new ${pt.primitive}[]{5, ${pt.null},15}));
+
+        assertEquals(0, len((${pt.dbArray})null));
+        assertEquals(3, len(new ${pt.dbArrayDirect}(new ${pt.primitive}[]{40,50,60})));
+        assertEquals(0, len(new ${pt.dbArrayDirect}()));
+        assertEquals(1, len(new ${pt.dbArrayDirect}(${pt.null})));
+        assertEquals(3, len(new ${pt.dbArrayDirect}(new ${pt.primitive}[]{5, ${pt.null},15})));
     }
 
     public void test${pt.boxed}Count(){

--- a/engine/function/src/templates/TestBasic.ftl
+++ b/engine/function/src/templates/TestBasic.ftl
@@ -79,14 +79,14 @@ public class TestBasic extends BaseArrayTestCase {
     }
 
     public void testObjLen() {
-        assertEquals(0, len((ObjectVector)null));
+        assertEquals(NULL_LONG, len((ObjectVector)null));
         assertEquals(3, len(new ObjectVectorDirect<Integer>(40, 50, 60)));
         assertEquals(0, len(new ObjectVectorDirect<Integer>()));
         assertEquals(1, len(new ObjectVectorDirect<Integer>(new Integer[]{null})));
         assertEquals(3, len(new ObjectVectorDirect<Integer>(5, null, 15)));
         assertEquals(4, len(new ObjectVectorDirect<Integer>(5, null, 15, NULL_INT)));
 
-        assertEquals(0, len((Integer[])null));
+        assertEquals(NULL_LONG, len((Integer[])null));
         assertEquals(3, len(new Integer[]{40, 50, 60}));
         assertEquals(0, len(new Integer[]{}));
         assertEquals(1, len(new Integer[]{null}));
@@ -340,13 +340,13 @@ public class TestBasic extends BaseArrayTestCase {
         assertEquals(0, len(new Boolean[]{}));
         assertEquals(1, len(new Boolean[]{QueryConstants.NULL_BOOLEAN}));
         assertEquals(3, len(new Boolean[]{true, QueryConstants.NULL_BOOLEAN, true}));
-        assertEquals(0, len((Boolean[])null));
+        assertEquals(NULL_LONG, len((Boolean[])null));
 
         assertEquals(3, len(new ObjectVectorDirect<>(new Boolean[]{true, false, true})));
         assertEquals(0, len(new ObjectVectorDirect<>()));
         assertEquals(1, len(new ObjectVectorDirect<>(QueryConstants.NULL_BOOLEAN)));
         assertEquals(3, len(new ObjectVectorDirect<>(new Boolean[]{true, QueryConstants.NULL_BOOLEAN, true})));
-        assertEquals(0, len((ObjectVector)null));
+        assertEquals(NULL_LONG, len((ObjectVector)null));
     }
 
     public void testBooleanCount(){
@@ -541,13 +541,13 @@ public class TestBasic extends BaseArrayTestCase {
     }
 
     public void test${pt.boxed}Len() {
-        assertEquals(0, len((${pt.primitive}[])null));
+        assertEquals(NULL_LONG, len((${pt.primitive}[])null));
         assertEquals(3, len(new ${pt.primitive}[]{40,50,60}));
         assertEquals(0, len(new ${pt.primitive}[]{}));
         assertEquals(1, len(new ${pt.primitive}[]{${pt.null}}));
         assertEquals(3, len(new ${pt.primitive}[]{5, ${pt.null},15}));
 
-        assertEquals(0, len((${pt.dbArray})null));
+        assertEquals(NULL_LONG, len((${pt.dbArray})null));
         assertEquals(3, len(new ${pt.dbArrayDirect}(new ${pt.primitive}[]{40,50,60})));
         assertEquals(0, len(new ${pt.dbArrayDirect}()));
         assertEquals(1, len(new ${pt.dbArrayDirect}(${pt.null})));

--- a/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
+++ b/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
@@ -16,6 +16,7 @@ import io.deephaven.function.Numeric;
 import io.deephaven.function.Parse;
 import io.deephaven.function.Random;
 import io.deephaven.function.Sort;
+import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.vector.BooleanVector;
 import io.deephaven.vector.ByteVector;
 import io.deephaven.vector.CharVector;
@@ -1835,6 +1836,24 @@ public class GroovyStaticImports {
     public static <T> T lastObj( T[] values ) {return Basic.lastObj( values );}
     /** @see io.deephaven.function.Basic#lastObj(io.deephaven.vector.ObjectVector) */
     public static <T> T lastObj( io.deephaven.vector.ObjectVector<T> values ) {return Basic.lastObj( values );}
+    /** @see io.deephaven.function.Basic#len(T[]) */
+    public static <T> long len( T[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(byte[]) */
+    public static  long len( byte[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(char[]) */
+    public static  long len( char[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(double[]) */
+    public static  long len( double[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(float[]) */
+    public static  long len( float[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(int[]) */
+    public static  long len( int[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(long[]) */
+    public static  long len( long[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(short[]) */
+    public static  long len( short[] values ) {return Basic.len( values );}
+    /** @see io.deephaven.function.Basic#len(io.deephaven.util.datastructures.LongSizedDataStructure) */
+    public static  long len( io.deephaven.util.datastructures.LongSizedDataStructure values ) {return Basic.len( values );}
     /** @see io.deephaven.function.Numeric#log(byte) */
     public static  double log( byte value ) {return Numeric.log( value );}
     /** @see io.deephaven.function.Numeric#log(double) */


### PR DESCRIPTION
Add query language functions to get data structure (`Vector` and java array) sizes.

Fixes #2883.
