### PR TITLE
Fix improper call to "manage" for static snapshot tables in Table.snapshot implementation

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
@@ -48,7 +48,9 @@ public class SnapshotInternalListener extends BaseTable.ListenerImpl {
         this.resultLeftColumns = resultLeftColumns;
         this.resultRightColumns = resultRightColumns;
         this.resultRowSet = resultRowSet;
-        manage(snapshotTable);
+        if (snapshotTable.isRefreshing()) {
+            manage(snapshotTable);
+        }
         triggerStampColumns = SnapshotUtils.generateTriggerStampColumns(triggerTable);
         snapshotDataColumns = SnapshotUtils.generateSnapshotDataColumns(snapshotTable);
     }


### PR DESCRIPTION
Closes #2888 