### PR TITLE
Support automatically using all processors for UGP/OpInitThreadPool

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/OperationInitializationThreadPool.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/OperationInitializationThreadPool.java
@@ -13,8 +13,17 @@ import java.util.concurrent.Executors;
 
 public class OperationInitializationThreadPool {
 
-    public static final int NUM_THREADS =
-            Configuration.getInstance().getIntegerWithDefault("OperationInitializationThreadPool.threads", 1);
+    public static final int NUM_THREADS;
+
+    static {
+        final int numThreads =
+                Configuration.getInstance().getIntegerWithDefault("OperationInitializationThreadPool.threads", 1);
+        if (numThreads <= 0) {
+            NUM_THREADS = Runtime.getRuntime().availableProcessors();
+        } else {
+            NUM_THREADS = numThreads;
+        }
+    }
 
     private static final ThreadLocal<Boolean> isInitializationThread = ThreadLocal.withInitial(() -> false);
 

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
@@ -232,9 +232,7 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
      * The number of threads in our executor service for dispatching notifications. If 1, then we don't actually use the
      * executor service; but instead dispatch all the notifications on the UpdateGraphProcessor run thread.
      */
-    private final int updateThreads = Require.geq(
-            Configuration.getInstance().getIntegerWithDefault("UpdateGraphProcessor.updateThreads", 1), "updateThreads",
-            1);
+    private final int updateThreads;
 
     /**
      * Is this one of the threads engaged in notification processing? (Either the solitary run thread, or one of the
@@ -280,6 +278,14 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
             }
         };
         refreshThread.setDaemon(true);
+
+        final int updateThreads =
+                Configuration.getInstance().getIntegerWithDefault("UpdateGraphProcessor.updateThreads", 1);
+        if (updateThreads <= 0) {
+            this.updateThreads = Runtime.getRuntime().availableProcessors();
+        } else {
+            this.updateThreads = updateThreads;
+        }
     }
 
     @Override


### PR DESCRIPTION
Support automatically using all processors for `UpdateGraphProcessor` and `OperationInitializationThreadPool` by setting their nThreads properties <= 0.