### PR TITLE
Fix modified row set for QueryTable.snapshot when rows have been added, and correct row set cleanup when not notifying. Also port some DHE fixes.

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/ModifiedColumnSet.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/ModifiedColumnSet.java
@@ -299,7 +299,8 @@ public class ModifiedColumnSet {
     public Transformer newTransformer(final String[] columnNames, final ModifiedColumnSet[] columnSets) {
         Assert.eq(columnNames.length, "columnNames.length", columnSets.length, "columnSets.length");
         if (columnNames.length == 0) {
-            return (input, output) -> {};
+            return (input, output) -> {
+            };
         }
 
         final int[] columnBits = new int[columnNames.length];

--- a/engine/api/src/main/java/io/deephaven/engine/table/ModifiedColumnSet.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/ModifiedColumnSet.java
@@ -244,10 +244,6 @@ public class ModifiedColumnSet {
          * @param output result table's columns to propagate dirty columns to
          */
         default void transform(final ModifiedColumnSet input, final ModifiedColumnSet output) {
-            if (input == ALL) {
-                output.setAllDirty();
-                return;
-            }
             if (input == null || input.empty()) {
                 return;
             }
@@ -302,6 +298,10 @@ public class ModifiedColumnSet {
      */
     public Transformer newTransformer(final String[] columnNames, final ModifiedColumnSet[] columnSets) {
         Assert.eq(columnNames.length, "columnNames.length", columnSets.length, "columnSets.length");
+        if (columnNames.length == 0) {
+            return (input, output) -> {};
+        }
+
         final int[] columnBits = new int[columnNames.length];
         for (int i = 0; i < columnNames.length; ++i) {
             final int bitIndex = idMap.get(columnNames[i]);
@@ -313,7 +313,16 @@ public class ModifiedColumnSet {
             Assert.eq(columnSets[0].columns, "columnSets[0].columns", columnSets[i].columns, "columnSets[i].columns");
         }
 
+        final ModifiedColumnSet allColumns = new ModifiedColumnSet(columnSets[0]);
+        for (int i = 0; i < columnNames.length; ++i) {
+            allColumns.setAll(columnSets[i]);
+        }
+
         return (input, output) -> {
+            if (input == ALL) {
+                output.setAll(allColumns);
+                return;
+            }
             verifyCompatibilityWith(input);
             for (int i = 0; i < columnBits.length; ++i) {
                 if (input.dirtyColumns.get(columnBits[i])) {
@@ -339,6 +348,10 @@ public class ModifiedColumnSet {
         }
 
         return (input, output) -> {
+            if (input == ALL) {
+                output.setAllDirty();
+                return;
+            }
             if (input.columns != columns || output.columns != newColumns) {
                 throw new IllegalArgumentException(
                         "Provided ModifiedColumnSets are not compatible with this Transformer!");

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1137,7 +1137,14 @@ public class QueryTable extends BaseTable {
                 sizeForInstrumentation(), () -> {
                     checkInitiateOperation(rightTable);
 
-                    final Table distinctValues = rightTable.selectDistinct(MatchPair.getRightColumns(columnsToMatch));
+                    final Table distinctValues;
+                    final boolean setRefreshing = rightTable.isRefreshing();
+                    if (setRefreshing) {
+                        distinctValues = rightTable.selectDistinct(MatchPair.getRightColumns(columnsToMatch));
+                    } else {
+                        distinctValues = rightTable;
+                    }
+
                     final DynamicWhereFilter dynamicWhereFilter =
                             new DynamicWhereFilter((QueryTable) distinctValues, inclusion, columnsToMatch);
                     final Table where = whereInternal(dynamicWhereFilter);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
@@ -195,6 +195,14 @@ public class TableUpdateValidator implements QueryTable.Operation {
 
             // modified
             updateValues(upstream.modifiedColumnSet(), upstream.modified(), false);
+            if (upstream.added().overlaps(upstream.modified())) {
+                noteIssue(() -> "added contains rows that are modified (post-shift): "
+                        + upstream.added().intersect(upstream.modified()));
+            }
+            if (upstream.removed().overlaps(upstream.getModifiedPreShift())) {
+                noteIssue(() -> "removed contains rows that are modified (pre-shift): "
+                        + upstream.removed().intersect(upstream.getModifiedPreShift()));
+            }
 
             if (!issues.isEmpty()) {
                 StringBuilder result =

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DynamicWhereFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DynamicWhereFilter.java
@@ -33,8 +33,9 @@ import java.util.*;
 public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implements NotificationQueue.Dependency {
     private static final int CHUNK_SIZE = 1 << 16;
 
+    private final boolean setRefreshing;
     private final MatchPair[] matchPairs;
-    private final TupleSource setTupleSource;
+    private final TupleSource<?> setTupleSource;
     private final boolean inclusion;
 
     private final HashSet<Object> liveValues = new HashSet<>();
@@ -54,22 +55,22 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
     private QueryTable resultTable;
 
     public DynamicWhereFilter(final QueryTable setTable, final boolean inclusion, final MatchPair... setColumnsNames) {
-        if (setTable.isRefreshing()) {
+        setRefreshing = setTable.isRefreshing();
+        if (setRefreshing) {
             UpdateGraphProcessor.DEFAULT.checkInitiateTableOperation();
         }
 
         this.matchPairs = setColumnsNames;
         this.inclusion = inclusion;
 
-        this.setTable = setTable;
-        final ColumnSource[] setColumns =
-                Arrays.stream(matchPairs).map(mp -> setTable.getColumnSource(mp.rightColumn()))
-                        .toArray(ColumnSource[]::new);
-        setTupleSource = TupleSourceFactory.makeTupleSource(setColumns);
+        final ColumnSource<?>[] setColumns = Arrays.stream(matchPairs)
+                .map(mp -> setTable.getColumnSource(mp.rightColumn())).toArray(ColumnSource[]::new);
 
-        setTable.getRowSet().forAllRowKeys((final long v) -> addKey(makeKey(v)));
+        if (setRefreshing) {
+            this.setTable = setTable;
+            setTupleSource = TupleSourceFactory.makeTupleSource(setColumns);
+            setTable.getRowSet().forAllRowKeys((final long v) -> addKey(makeKey(v)));
 
-        if (DynamicNode.isDynamicAndIsRefreshing(setTable)) {
             final String[] columnNames = Arrays.stream(matchPairs).map(MatchPair::rightColumn).toArray(String[]::new);
             final ModifiedColumnSet modTokenSet = setTable.newModifiedColumnSet(columnNames);
             setUpdateListener = new InstrumentedTableUpdateListenerAdapter(
@@ -128,12 +129,22 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
 
             manage(setUpdateListener);
         } else {
+            this.setTable = null;
+            setTupleSource = null;
+            final TupleSource<?> temporaryTupleSource = TupleSourceFactory.makeTupleSource(setColumns);
+            setTable.getRowSet().forAllRowKeys((final long v) -> addKeyUnchecked(makeKey(temporaryTupleSource, v)));
+            kernelValid = liveValuesArrayValid = false;
+            setInclusionKernel = null;
             setUpdateListener = null;
         }
     }
 
     private Object makeKey(long index) {
-        return setTupleSource.createTuple(index);
+        return makeKey(setTupleSource, index);
+    }
+
+    private static Object makeKey(TupleSource<?> tupleSource, long index) {
+        return tupleSource.createTuple(index);
     }
 
     private Object makePrevKey(long index) {
@@ -158,6 +169,10 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
         setInclusionKernel = null;
     }
 
+    private void addKeyUnchecked(Object key) {
+        liveValues.add(key);
+    }
+
     @Override
     public List<String> getColumns() {
         return Arrays.asList(MatchPair.getLeftColumns(matchPairs));
@@ -177,10 +192,9 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
             throw new PreviousFilteringNotSupported();
         }
 
-        final ColumnSource[] keyColumns =
-                Arrays.stream(matchPairs).map(mp -> table.getColumnSource(mp.leftColumn()))
-                        .toArray(ColumnSource[]::new);
-        final TupleSource tupleSource = TupleSourceFactory.makeTupleSource(keyColumns);
+        final ColumnSource<?>[] keyColumns = Arrays.stream(matchPairs)
+                .map(mp -> table.getColumnSource(mp.leftColumn())).toArray(ColumnSource[]::new);
+        final TupleSource<?> tupleSource = TupleSourceFactory.makeTupleSource(keyColumns);
         final TrackingRowSet trackingSelection = selection.isTracking() ? selection.trackingCast() : null;
 
         if (matchPairs.length == 1) {
@@ -208,12 +222,10 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
                 return filterGrouping(trackingSelection, selectionIndexer, tupleSource);
             }
 
-            final ColumnSource[] sourcesWithGroupings =
-                    Arrays.stream(keyColumns).filter(selectionIndexer::hasGrouping)
-                            .toArray(ColumnSource[]::new);
-            final OptionalInt minGroupCount =
-                    Arrays.stream(sourcesWithGroupings).mapToInt(x -> selectionIndexer.getGrouping(x).size())
-                            .min();
+            final ColumnSource<?>[] sourcesWithGroupings = Arrays.stream(keyColumns)
+                    .filter(selectionIndexer::hasGrouping).toArray(ColumnSource[]::new);
+            final OptionalInt minGroupCount = Arrays.stream(sourcesWithGroupings)
+                    .mapToInt(x -> selectionIndexer.getGrouping(x).size()).min();
             if (minGroupCount.isPresent() && (minGroupCount.getAsInt() * 4L) < selection.size()) {
                 return filterGrouping(trackingSelection, selectionIndexer, tupleSource);
             }
@@ -222,20 +234,19 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
     }
 
     private WritableRowSet filterGrouping(TrackingRowSet selection, RowSetIndexer selectionIndexer,
-            TupleSource tupleSource) {
+            TupleSource<?> tupleSource) {
         final RowSet matchingKeys = selectionIndexer.getSubSetForKeySet(liveValues, tupleSource);
         return (inclusion ? matchingKeys.copy() : selection.minus(matchingKeys));
     }
 
     private WritableRowSet filterGrouping(TrackingRowSet selection, RowSetIndexer selectionIndexer, Table table) {
-        final ColumnSource[] keyColumns =
-                Arrays.stream(matchPairs).map(mp -> table.getColumnSource(mp.leftColumn()))
-                        .toArray(ColumnSource[]::new);
-        final TupleSource tupleSource = TupleSourceFactory.makeTupleSource(keyColumns);
+        final ColumnSource<?>[] keyColumns = Arrays.stream(matchPairs)
+                .map(mp -> table.getColumnSource(mp.leftColumn())).toArray(ColumnSource[]::new);
+        final TupleSource<?> tupleSource = TupleSourceFactory.makeTupleSource(keyColumns);
         return filterGrouping(selection, selectionIndexer, tupleSource);
     }
 
-    private WritableRowSet filterLinear(RowSet selection, ColumnSource[] keyColumns, TupleSource tupleSource) {
+    private WritableRowSet filterLinear(RowSet selection, ColumnSource<?>[] keyColumns, TupleSource<?> tupleSource) {
         if (keyColumns.length == 1) {
             return filterLinearOne(selection, keyColumns[0]);
         } else {
@@ -243,7 +254,7 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
         }
     }
 
-    private WritableRowSet filterLinearOne(RowSet selection, ColumnSource keyColumn) {
+    private WritableRowSet filterLinearOne(RowSet selection, ColumnSource<?> keyColumn) {
         if (selection.isEmpty()) {
             return RowSetFactory.empty();
         }
@@ -257,14 +268,13 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
 
         try (final ColumnSource.GetContext getContext = keyColumn.makeGetContext(CHUNK_SIZE);
                 final RowSequence.Iterator rsIt = selection.getRowSequenceIterator()) {
-            final WritableLongChunk<OrderedRowKeys> keyIndices =
-                    WritableLongChunk.makeWritableChunk(CHUNK_SIZE);
+            final WritableLongChunk<OrderedRowKeys> keyIndices = WritableLongChunk.makeWritableChunk(CHUNK_SIZE);
             final WritableBooleanChunk<Values> matches = WritableBooleanChunk.makeWritableChunk(CHUNK_SIZE);
 
             while (rsIt.hasMore()) {
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(CHUNK_SIZE);
 
-                final Chunk<Values> chunk = keyColumn.getChunk(getContext, chunkOk);
+                final Chunk<Values> chunk = Chunk.downcast(keyColumn.getChunk(getContext, chunkOk));
                 setInclusionKernel.matchValues(chunk, matches);
 
                 keyIndices.setSize(chunk.size());
@@ -282,7 +292,7 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
         return indexBuilder.build();
     }
 
-    private WritableRowSet filterLinearTuple(RowSet selection, TupleSource tupleSource) {
+    private WritableRowSet filterLinearTuple(RowSet selection, TupleSource<?> tupleSource) {
         final RowSetBuilderSequential indexBuilder = RowSetFactory.builderSequential();
 
         for (final RowSet.Iterator it = selection.iterator(); it.hasNext();) {
@@ -304,7 +314,7 @@ public class DynamicWhereFilter extends WhereFilterLivenessArtifactImpl implemen
 
     @Override
     public boolean isRefreshing() {
-        return setTable.isRefreshing();
+        return setRefreshing;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
@@ -4,17 +4,12 @@
 package io.deephaven.engine.table.impl.snapshot;
 
 import io.deephaven.chunk.attributes.Values;
-import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.TrackingWritableRowSet;
-import io.deephaven.engine.rowset.TrackingRowSet;
-import io.deephaven.engine.table.ChunkSource;
-import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.engine.table.Table;
-import io.deephaven.engine.table.TableUpdate;
+import io.deephaven.engine.rowset.*;
+import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.LazySnapshotTable;
 import io.deephaven.engine.table.impl.QueryTable;
+import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.sources.ArrayBackedColumnSource;
 import io.deephaven.engine.table.impl.sources.SingleValueColumnSource;
 import io.deephaven.util.SafeCloseable;
@@ -84,32 +79,18 @@ public class SnapshotInternalListener extends BaseTable.ListenerImpl {
             }
         }
         if (snapshotPrevLength < snapshotSize) {
-            // If the table got larger then:
-            // - added is (the suffix)
-            // - modified is (the old RowSet)
-            // - resultRowSet updated (by including added) for next time
-            final RowSet addedRange = RowSetFactory.fromRange(snapshotPrevLength, snapshotSize - 1);
-            try (final SafeCloseable ignored = notifyListeners ? null : addedRange) {
+            try (final RowSet addedRange = RowSetFactory.fromRange(snapshotPrevLength, snapshotSize - 1)) {
                 resultRowSet.insert(addedRange);
-                if (notifyListeners) {
-                    result.notifyListeners(addedRange, RowSetFactory.empty(), resultRowSet.copyPrev());
-                }
             }
         } else if (snapshotPrevLength > snapshotSize) {
-            // If the table got smaller, then:
-            // - removed is (the suffix)
-            // - resultRowSet updated (by removing 'removed') for next time
-            // - modified is (just use the new RowSet)
-            final RowSet removedRange = RowSetFactory.fromRange(snapshotSize, snapshotPrevLength - 1);
-            try (final SafeCloseable ignored = notifyListeners ? null : removedRange) {
+            try (RowSet removedRange = RowSetFactory.fromRange(snapshotSize, snapshotPrevLength - 1)) {
                 resultRowSet.remove(removedRange);
-                if (notifyListeners) {
-                    result.notifyListeners(RowSetFactory.empty(), removedRange, resultRowSet.copy());
-                }
             }
-        } else if (notifyListeners) {
-            // If the table stayed the same size, then modified = the RowSet
-            result.notifyListeners(RowSetFactory.empty(), RowSetFactory.empty(), resultRowSet.copy());
+        }
+        if (notifyListeners) {
+            result.notifyListeners(new TableUpdateImpl(
+                    resultRowSet.copy(), resultRowSet.copyPrev(),
+                    RowSetFactory.empty(), RowSetShiftData.EMPTY, ModifiedColumnSet.EMPTY));
         }
         snapshotPrevLength = snapshotTable.size();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
@@ -12,7 +12,6 @@ import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.sources.ArrayBackedColumnSource;
 import io.deephaven.engine.table.impl.sources.SingleValueColumnSource;
-import io.deephaven.util.SafeCloseable;
 
 import java.util.Map;
 
@@ -79,13 +78,9 @@ public class SnapshotInternalListener extends BaseTable.ListenerImpl {
             }
         }
         if (snapshotPrevLength < snapshotSize) {
-            try (final RowSet addedRange = RowSetFactory.fromRange(snapshotPrevLength, snapshotSize - 1)) {
-                resultRowSet.insert(addedRange);
-            }
+            resultRowSet.insertRange(snapshotPrevLength, snapshotSize - 1);
         } else if (snapshotPrevLength > snapshotSize) {
-            try (RowSet removedRange = RowSetFactory.fromRange(snapshotSize, snapshotPrevLength - 1)) {
-                resultRowSet.remove(removedRange);
-            }
+            resultRowSet.removeRange(snapshotSize, snapshotPrevLength - 1);
         }
         if (notifyListeners) {
             result.notifyListeners(new TableUpdateImpl(

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -1442,8 +1442,8 @@ public class QueryTableTest extends QueryTableTestBase {
         });
         TableTools.show(snappedOfSnap);
 
-        TestCase.assertEquals(snappedOfSnap.size(), 1);
-        TestCase.assertEquals(snappedOfSnap.getColumn("B").get(0), 1);
+        TestCase.assertEquals(1, snappedOfSnap.size());
+        TestCase.assertEquals(2, snappedOfSnap.getColumn("B").get(0));
     }
 
     public void testSnapshotIncrementalDependencies() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -736,7 +736,7 @@ public class QueryTableTest extends QueryTableTestBase {
                         new TstUtils.IntGenerator(10, 100),
                         new TstUtils.SetGenerator<>(10.1, 20.1, 30.1)));
 
-        final EvalNugget en[] = new EvalNugget[] {
+        final EvalNugget[] en = new EvalNugget[] {
                 EvalNugget.from(() -> queryTable.renameColumns(List.of())),
                 EvalNugget.from(() -> queryTable.renameColumns("Symbol=Sym")),
                 EvalNugget.from(() -> queryTable.renameColumns("Symbol=Sym", "Symbols=Sym")),
@@ -911,7 +911,7 @@ public class QueryTableTest extends QueryTableTestBase {
         final DateTime lower = DateTimeUtils.plus(startTime, DateTimeUtils.SECOND);
         final DateTime upper = DateTimeUtils.plus(startTime, DateTimeUtils.SECOND * 2);
 
-        final EvalNuggetInterface en[] = new EvalNuggetInterface[] {
+        final EvalNuggetInterface[] en = new EvalNuggetInterface[] {
                 new TableComparator(
                         table.where(filter.apply(
                                 "Timestamp >= '" + lower.toString() + "' && Timestamp <= '" + upper.toString() + "'")),
@@ -971,7 +971,7 @@ public class QueryTableTest extends QueryTableTestBase {
         final DateTime lower = DateTimeUtils.plus(startTime, DateTimeUtils.SECOND);
         final DateTime upper = DateTimeUtils.plus(startTime, DateTimeUtils.SECOND * 2);
 
-        final EvalNuggetInterface en[] = new EvalNuggetInterface[] {
+        final EvalNuggetInterface[] en = new EvalNuggetInterface[] {
                 new TableComparator(
                         table.where(filter.apply(
                                 "Timestamp >= '" + lower.toString() + "' && Timestamp <= '" + upper.toString() + "'")),
@@ -1050,7 +1050,7 @@ public class QueryTableTest extends QueryTableTestBase {
         // noinspection unchecked
         final DataColumn<Long> licsr = bigReversed.getColumn("LICS");
         assertEquals((long) Integer.MAX_VALUE * 2L, (long) licsr.get(0));
-        assertEquals((long) Integer.MAX_VALUE, (long) licsr.get(1));
+        assertEquals(Integer.MAX_VALUE, (long) licsr.get(1));
         assertEquals(0, (long) licsr.get(2));
 
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
@@ -1062,7 +1062,7 @@ public class QueryTableTest extends QueryTableTestBase {
 
         assertEquals(Long.MAX_VALUE, (long) licsr.get(0));
         assertEquals((long) Integer.MAX_VALUE * 2L, (long) licsr.get(1));
-        assertEquals((long) Integer.MAX_VALUE, (long) licsr.get(2));
+        assertEquals(Integer.MAX_VALUE, (long) licsr.get(2));
         assertEquals(0, (long) licsr.get(3));
 
     }
@@ -1402,39 +1402,39 @@ public class QueryTableTest extends QueryTableTestBase {
         final Table snappedOfSnap = left.snapshot(snappedDep);
 
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
         });
 
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
             addToTable(left, i(2), c("T", 2));
             left.notifyListeners(i(2), i(), i());
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // this will do the notification for left; at which point we can do the first snapshot
             boolean flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
 
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the select
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the second snapshot
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertFalse(flushed);
@@ -1458,9 +1458,9 @@ public class QueryTableTest extends QueryTableTestBase {
 
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
             System.out.println("Checking everything is satisfied with no updates.");
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
             System.out.println("Simple Update Cycle Complete.");
         });
 
@@ -1470,9 +1470,9 @@ public class QueryTableTest extends QueryTableTestBase {
             left.notifyListeners(i(2), i(), i());
 
             System.out.println("Checking initial satisfaction.");
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing first notification.");
             // this will do the notification for left
@@ -1480,18 +1480,18 @@ public class QueryTableTest extends QueryTableTestBase {
 
             System.out.println("Checking satisfaction after #1.");
             TestCase.assertTrue(flushed);
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing second notification, which should be our listener recorder");
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
 
             System.out.println("Checking satisfaction after #2.");
             TestCase.assertTrue(flushed);
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing third notification, which should be our merged listener");
 
@@ -1499,30 +1499,30 @@ public class QueryTableTest extends QueryTableTestBase {
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             // this will do the merged notification; which means the snaphsot is satisfied
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the select
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the second snapshot recorder
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the second snapshot merged listener
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // nothing left
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
@@ -1539,9 +1539,9 @@ public class QueryTableTest extends QueryTableTestBase {
             right.notifyListeners(i(2), i(), i());
 
             System.out.println("Checking initial satisfaction.");
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing first notification.");
             // this will do the notification for right; at which point we can should get the update going through
@@ -1549,18 +1549,18 @@ public class QueryTableTest extends QueryTableTestBase {
 
             System.out.println("Checking satisfaction after #1.");
             TestCase.assertTrue(flushed);
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing second notification, which should be our merged listener");
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
 
             System.out.println("Checking satisfaction after #2.");
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // nothing left
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
@@ -1581,65 +1581,65 @@ public class QueryTableTest extends QueryTableTestBase {
             left.notifyListeners(i(3), i(), i());
 
             System.out.println("Checking initial satisfaction.");
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing first notification.");
             boolean flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             System.out.println("Checking satisfaction after #1.");
             TestCase.assertTrue(flushed);
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing second notification, which should be the recorder for our second snapshot");
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
 
             System.out.println("Checking satisfaction after #2.");
             TestCase.assertTrue(flushed);
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing third notification, which should be our right recorder");
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
 
             System.out.println("Checking satisfaction after #3.");
             TestCase.assertTrue(flushed);
-            TestCase.assertFalse(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             System.out.println("Flushing fourth notification, which should be our MergedListener");
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
 
             System.out.println("Checking satisfaction after #4.");
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the select
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the second snapshot recorder
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now we should flush the second snapshot merged listener
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
-            TestCase.assertTrue(((QueryTable) snappedFirst).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedDep).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) snappedOfSnap).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedFirst.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedDep.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(snappedOfSnap.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // nothing left
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
@@ -1671,18 +1671,18 @@ public class QueryTableTest extends QueryTableTestBase {
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
             TestCase.assertTrue(dynamicFilter1.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertTrue(dynamicFilter2.satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) composed).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(composed.satisfied(LogicalClock.DEFAULT.currentStep()));
         });
 
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
             addToTable(setTable, i(103), c("A", 5), c("B", 8));
             setTable.notifyListeners(i(103), i(), i());
 
-            TestCase.assertFalse(((QueryTable) setTable1).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) setTable2).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(setTable1.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(setTable2.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertFalse(dynamicFilter1.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertFalse(dynamicFilter2.satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) composed).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(composed.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // this will do the notification for table; which should first fire the recorder for setTable1
             UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
@@ -1692,52 +1692,52 @@ public class QueryTableTest extends QueryTableTestBase {
             boolean flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
 
-            TestCase.assertTrue(((QueryTable) setTable1).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) setTable2).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable1.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(setTable2.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertFalse(dynamicFilter1.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertFalse(dynamicFilter2.satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) composed).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(composed.satisfied(LogicalClock.DEFAULT.currentStep()));
 
 
             // the next notification should be the merged listener for setTable2
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
 
-            TestCase.assertTrue(((QueryTable) setTable1).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) setTable2).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable1.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable2.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertFalse(dynamicFilter1.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertFalse(dynamicFilter2.satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) composed).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(composed.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // the dynamicFilter1 updates
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
 
-            TestCase.assertTrue(((QueryTable) setTable1).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) setTable2).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable1.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable2.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertTrue(dynamicFilter1.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertFalse(dynamicFilter2.satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) composed).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(composed.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // the dynamicFilter2 updates
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
 
-            TestCase.assertTrue(((QueryTable) setTable1).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) setTable2).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable1.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable2.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertTrue(dynamicFilter1.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertTrue(dynamicFilter2.satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertFalse(((QueryTable) composed).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertFalse(composed.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // now that both filters are complete, we can run the composed listener
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();
             TestCase.assertTrue(flushed);
 
-            TestCase.assertTrue(((QueryTable) setTable1).satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) setTable2).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable1.satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(setTable2.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertTrue(dynamicFilter1.satisfied(LogicalClock.DEFAULT.currentStep()));
             TestCase.assertTrue(dynamicFilter2.satisfied(LogicalClock.DEFAULT.currentStep()));
-            TestCase.assertTrue(((QueryTable) composed).satisfied(LogicalClock.DEFAULT.currentStep()));
+            TestCase.assertTrue(composed.satisfied(LogicalClock.DEFAULT.currentStep()));
 
             // and we are done
             flushed = UpdateGraphProcessor.DEFAULT.flushOneNotificationForUnitTests();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -3325,11 +3325,10 @@ public class QueryTableTest extends QueryTableTestBase {
         final QueryTable validatorTable = validator.getResultTable();
         final TableUpdateListener validatorTableListener =
                 // NB: We specify retain=true to ensure the listener is not GC'd. It will be dropped when
-                //     the enclosing LivenessScope is released.
+                // the enclosing LivenessScope is released.
                 new InstrumentedTableUpdateListenerAdapter(validatorTable, true) {
                     @Override
-                    public void onUpdate(TableUpdate upstream) {
-                    }
+                    public void onUpdate(TableUpdate upstream) {}
 
                     @Override
                     public void onFailureInternal(Throwable originalException, Entry sourceEntry) {


### PR DESCRIPTION
Fixes #2919 