### PR TITLE
Plumb ungroup through TableOperations. 

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -853,23 +853,7 @@ public interface Table extends
     // Disaggregation Operations
     // -----------------------------------------------------------------------------------------------------------------
 
-    /**
-     * Ungroups a table by converting arrays into columns.
-     *
-     * @param nullFill indicates if the ungrouped table should allow disparate sized arrays filling shorter columns with
-     *        null values. If set to false, then all arrays should be the same length.
-     * @param columnsToUngroup the columns to ungroup
-     * @return the ungrouped table
-     */
-    Table ungroup(boolean nullFill, String... columnsToUngroup);
-
-    Table ungroup(String... columnsToUngroup);
-
     Table ungroupAllBut(String... columnsNotToUngroup);
-
-    Table ungroup();
-
-    Table ungroup(boolean nullFill);
 
     // -----------------------------------------------------------------------------------------------------------------
     // PartitionBy Operations

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/HierarchicalTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/HierarchicalTable.java
@@ -161,7 +161,7 @@ public class HierarchicalTable extends QueryTable {
     }
 
     @Override
-    public Table ungroup(boolean nullFill, String... columnsToUngroup) {
+    public Table ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup) {
         return throwUnsupported("ungroup()");
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
@@ -541,35 +541,12 @@ public interface TableDefaults extends Table, TableOperationsDefaults<Table, Tab
 
     @Override
     @FinalDefault
-    default Table ungroup(String... columnsToUngroup) {
-        return ungroup(false, columnsToUngroup);
-    }
-
-    @Override
-    @FinalDefault
     default Table ungroupAllBut(String... columnsNotToUngroup) {
         final Set<String> columnsNotToUnwrapSet = Arrays.stream(columnsNotToUngroup).collect(Collectors.toSet());
         return ungroup(getDefinition().getColumnStream()
                 .filter(c -> !columnsNotToUnwrapSet.contains(c.getName())
                         && (c.getDataType().isArray() || QueryLanguageParser.isTypedVector(c.getDataType())))
                 .map(ColumnDefinition::getName).toArray(String[]::new));
-    }
-
-    @Override
-    @FinalDefault
-    default Table ungroup() {
-        return ungroup(getDefinition().getColumnStream()
-                .filter(c -> c.getDataType().isArray() || QueryLanguageParser.isTypedVector(c.getDataType()))
-                .map(ColumnDefinition::getName).toArray(String[]::new));
-    }
-
-    @Override
-    @FinalDefault
-    default Table ungroup(boolean nullFill) {
-        return ungroup(nullFill,
-                getDefinition().getColumnStream()
-                        .filter(c -> c.getDataType().isArray() || QueryLanguageParser.isTypedVector(c.getDataType()))
-                        .map(ColumnDefinition::getName).toArray(String[]::new));
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
@@ -367,7 +367,7 @@ public abstract class UncoalescedTable extends BaseTable {
     }
 
     @Override
-    public Table ungroup(boolean nullFill, String... columnsToUngroup) {
+    public Table ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup) {
         return coalesce().ungroup(nullFill, columnsToUngroup);
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
@@ -541,5 +541,10 @@ class PartitionedTableProxyImpl extends LivenessArtifact implements PartitionedT
         return basicTransform(ct -> ct.selectDistinct(SelectColumn.copyFrom(selectColumns)));
     }
 
+    @Override
+    public PartitionedTable.Proxy ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup) {
+        return basicTransform(ct -> ct.ungroup(nullFill, columnsToUngroup));
+    }
+
     // endregion TableOperations Implementation
 }

--- a/java-client/session/src/main/java/io/deephaven/client/impl/BatchTableRequestBuilder.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/BatchTableRequestBuilder.java
@@ -472,7 +472,8 @@ class BatchTableRequestBuilder {
         public void visit(UngroupTable ungroupTable) {
             final UngroupRequest.Builder request = UngroupRequest.newBuilder()
                     .setResultId(ticket)
-                    .setSourceId(ref(ungroupTable.parent()));
+                    .setSourceId(ref(ungroupTable.parent()))
+                    .setNullFill(ungroupTable.nullFill());
             for (ColumnName ungroupColumn : ungroupTable.ungroupColumns()) {
                 request.addColumnsToUngroup(ungroupColumn.name());
             }

--- a/java-client/session/src/main/java/io/deephaven/client/impl/BatchTableRequestBuilder.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/BatchTableRequestBuilder.java
@@ -62,6 +62,7 @@ import io.deephaven.proto.backplane.grpc.SortTableRequest;
 import io.deephaven.proto.backplane.grpc.TableReference;
 import io.deephaven.proto.backplane.grpc.Ticket;
 import io.deephaven.proto.backplane.grpc.TimeTableRequest;
+import io.deephaven.proto.backplane.grpc.UngroupRequest;
 import io.deephaven.proto.backplane.grpc.UnstructuredFilterTableRequest;
 import io.deephaven.proto.backplane.grpc.UpdateByRequest;
 import io.deephaven.proto.util.ExportTicketHelper;
@@ -96,6 +97,7 @@ import io.deephaven.qst.table.TicketTable;
 import io.deephaven.qst.table.TimeProvider.Visitor;
 import io.deephaven.qst.table.TimeProviderSystem;
 import io.deephaven.qst.table.TimeTable;
+import io.deephaven.qst.table.UngroupTable;
 import io.deephaven.qst.table.UpdateByTable;
 import io.deephaven.qst.table.UpdateTable;
 import io.deephaven.qst.table.UpdateViewTable;
@@ -464,6 +466,17 @@ class BatchTableRequestBuilder {
                     .setResultId(ticket)
                     .setSourceId(ref(updateByTable.parent()));
             out = op(Builder::setUpdateBy, request);
+        }
+
+        @Override
+        public void visit(UngroupTable ungroupTable) {
+            final UngroupRequest.Builder request = UngroupRequest.newBuilder()
+                    .setResultId(ticket)
+                    .setSourceId(ref(ungroupTable.parent()));
+            for (ColumnName ungroupColumn : ungroupTable.ungroupColumns()) {
+                request.addColumnsToUngroup(ungroupColumn.name());
+            }
+            out = op(Builder::setUngroup, request);
         }
 
         private SelectOrUpdateRequest selectOrUpdate(SingleParentTable x,

--- a/qst/graphviz/src/main/java/io/deephaven/graphviz/LabelBuilder.java
+++ b/qst/graphviz/src/main/java/io/deephaven/graphviz/LabelBuilder.java
@@ -27,6 +27,7 @@ import io.deephaven.qst.table.TableVisitorGeneric;
 import io.deephaven.qst.table.TailTable;
 import io.deephaven.qst.table.TicketTable;
 import io.deephaven.qst.table.TimeTable;
+import io.deephaven.qst.table.UngroupTable;
 import io.deephaven.qst.table.UpdateByTable;
 import io.deephaven.qst.table.UpdateTable;
 import io.deephaven.qst.table.UpdateViewTable;
@@ -196,6 +197,13 @@ public class LabelBuilder extends TableVisitorGeneric {
         sb.append("updateBy([");
         append(Strings::of, updateByTable.groupByColumns(), sb);
         sb.append("],[ todo ])");
+    }
+
+    @Override
+    public void visit(UngroupTable ungroupTable) {
+        sb.append("ungroup(").append(ungroupTable.nullFill()).append(",[");
+        append(Strings::of, ungroupTable.ungroupColumns(), sb);
+        sb.append("])");
     }
 
     private void join(String name, Join j) {

--- a/qst/src/main/java/io/deephaven/qst/TableAdapterImpl.java
+++ b/qst/src/main/java/io/deephaven/qst/TableAdapterImpl.java
@@ -33,6 +33,7 @@ import io.deephaven.qst.table.TableSpec.Visitor;
 import io.deephaven.qst.table.TailTable;
 import io.deephaven.qst.table.TicketTable;
 import io.deephaven.qst.table.TimeTable;
+import io.deephaven.qst.table.UngroupTable;
 import io.deephaven.qst.table.UpdateByTable;
 import io.deephaven.qst.table.UpdateTable;
 import io.deephaven.qst.table.UpdateViewTable;
@@ -308,6 +309,12 @@ class TableAdapterImpl<TOPS extends TableOperations<TOPS, TABLE>, TABLE> impleme
                     updateByTable.operations(),
                     updateByTable.groupByColumns()));
         }
+    }
+
+    @Override
+    public void visit(UngroupTable ungroupTable) {
+        addOp(ungroupTable, parentOps(ungroupTable)
+                .ungroup(ungroupTable.nullFill(), ungroupTable.ungroupColumns()));
     }
 
     private final class OutputTable implements Output<TOPS, TABLE> {

--- a/qst/src/main/java/io/deephaven/qst/table/ParentsVisitor.java
+++ b/qst/src/main/java/io/deephaven/qst/table/ParentsVisitor.java
@@ -296,6 +296,11 @@ public class ParentsVisitor implements Visitor {
         out = single(updateByTable);
     }
 
+    @Override
+    public void visit(UngroupTable ungroupTable) {
+        out = single(ungroupTable);
+    }
+
     private static class Search {
 
         private final Predicate<TableSpec> excludePaths;

--- a/qst/src/main/java/io/deephaven/qst/table/TableBase.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableBase.java
@@ -858,6 +858,51 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
+    public final UngroupTable ungroup() {
+        return UngroupTable.builder()
+                .parent(this)
+                .build();
+    }
+
+    @Override
+    public final UngroupTable ungroup(boolean nullFill) {
+        return UngroupTable.builder()
+                .parent(this)
+                .nullFill(nullFill)
+                .build();
+    }
+
+    @Override
+    public final UngroupTable ungroup(String... columnsToUngroup) {
+        final UngroupTable.Builder builder = UngroupTable.builder()
+                .parent(this);
+        for (String columnToUngroup : columnsToUngroup) {
+            builder.addUngroupColumns(ColumnName.of(columnToUngroup));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public final UngroupTable ungroup(boolean nullFill, String... columnsToUngroup) {
+        final UngroupTable.Builder builder = UngroupTable.builder()
+                .parent(this)
+                .nullFill(nullFill);
+        for (String columnToUngroup : columnsToUngroup) {
+            builder.addUngroupColumns(ColumnName.of(columnToUngroup));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public final UngroupTable ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup) {
+        return UngroupTable.builder()
+                .parent(this)
+                .nullFill(nullFill)
+                .addAllUngroupColumns(columnsToUngroup)
+                .build();
+    }
+
+    @Override
     public final <V extends TableSchema.Visitor> V walk(V visitor) {
         visitor.visit(this);
         return visitor;

--- a/qst/src/main/java/io/deephaven/qst/table/TableSpec.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableSpec.java
@@ -157,5 +157,7 @@ public interface TableSpec extends TableOperations<TableSpec, TableSpec>, TableS
         void visit(CountByTable countByTable);
 
         void visit(UpdateByTable updateByTable);
+
+        void visit(UngroupTable ungroupTable);
     }
 }

--- a/qst/src/main/java/io/deephaven/qst/table/TableVisitorGeneric.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableVisitorGeneric.java
@@ -151,4 +151,9 @@ public abstract class TableVisitorGeneric implements TableSpec.Visitor {
     public void visit(UpdateByTable updateByTable) {
         accept(updateByTable);
     }
+
+    @Override
+    public void visit(UngroupTable ungroupTable) {
+        accept(ungroupTable);
+    }
 }

--- a/qst/src/main/java/io/deephaven/qst/table/UngroupTable.java
+++ b/qst/src/main/java/io/deephaven/qst/table/UngroupTable.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.qst.table;
+
+import io.deephaven.annotations.NodeStyle;
+import io.deephaven.api.ColumnName;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import java.util.List;
+
+@Immutable
+@NodeStyle
+public abstract class UngroupTable extends TableBase implements SingleParentTable {
+
+    public static Builder builder() {
+        return ImmutableUngroupTable.builder();
+    }
+
+    public abstract TableSpec parent();
+
+    public abstract List<ColumnName> ungroupColumns();
+
+    @Default
+    public boolean nullFill() {
+        return false;
+    }
+
+    @Override
+    public final <V extends Visitor> V walk(V visitor) {
+        visitor.visit(this);
+        return visitor;
+    }
+
+    interface Builder {
+        Builder parent(TableSpec parent);
+
+        Builder addUngroupColumns(ColumnName element);
+
+        Builder addUngroupColumns(ColumnName... elements);
+
+        Builder addAllUngroupColumns(Iterable<? extends ColumnName> elements);
+
+        Builder nullFill(boolean nullFill);
+
+        UngroupTable build();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/table/ops/UngroupGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/UngroupGrpcImpl.java
@@ -3,8 +3,8 @@
  */
 package io.deephaven.server.table.ops;
 
+import io.deephaven.api.ColumnName;
 import io.deephaven.base.verify.Assert;
-import io.deephaven.datastructures.util.CollectionUtil;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
@@ -14,6 +14,7 @@ import io.deephaven.server.session.SessionState;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Singleton
 public class UngroupGrpcImpl extends GrpcTableOperation<UngroupRequest> {
@@ -29,10 +30,11 @@ public class UngroupGrpcImpl extends GrpcTableOperation<UngroupRequest> {
     @Override
     public Table create(final UngroupRequest request, final List<SessionState.ExportObject<Table>> sourceTables) {
         Assert.eq(sourceTables.size(), "sourceTables.size()", 1);
-
         final Table parent = sourceTables.get(0).get();
-        final String[] columnsToUngroup =
-                request.getColumnsToUngroupList().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
+        final List<ColumnName> columnsToUngroup = request.getColumnsToUngroupList()
+                .stream()
+                .map(ColumnName::of)
+                .collect(Collectors.toList());
         return updateGraphProcessor.sharedLock()
                 .computeLocked(() -> parent.ungroup(request.getNullFill(), columnsToUngroup));
     }

--- a/table-api/src/main/java/io/deephaven/api/TableOperations.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperations.java
@@ -1246,16 +1246,53 @@ public interface TableOperations<TOPS extends TableOperations<TOPS, TABLE>, TABL
 
     // -------------------------------------------------------------------------------------------
 
+    /**
+     * Ungroups a table by expanding all columns of arrays or vectors into columns of singular values, creating one row
+     * in the output table for each value in the columns to be ungrouped. Columns that are not ungrouped have their
+     * values duplicated in each output row corresponding to a given input row. All arrays and vectors must be the same
+     * size.
+     *
+     * @return the ungrouped table
+     */
     TOPS ungroup();
 
+    /**
+     * Ungroups a table by expanding all columns of arrays or vectors into columns of singular values, creating one row
+     * in the output table for each value in the columns to be ungrouped. Columns that are not ungrouped have their
+     * values duplicated in each output row corresponding to a given input row.
+     *
+     * @param nullFill indicates if the ungrouped table should allow disparate sized arrays filling shorter columns with
+     *        null values. If set to false, then all arrays should be the same length.
+     * @return the ungrouped table
+     */
     TOPS ungroup(boolean nullFill);
 
+    /**
+     * Ungroups a table by expanding columns of arrays or vectors into columns of singular values, creating one row in
+     * the output table for each value in the columns to be ungrouped. Columns that are not ungrouped have their values
+     * duplicated in each output row corresponding to a given input row. The arrays and vectors must be the same size.
+     *
+     * @param columnsToUngroup the columns to ungroup
+     * @return the ungrouped table
+     */
     TOPS ungroup(String... columnsToUngroup);
 
+    /**
+     * Ungroups a table by expanding columns of arrays or vectors into columns of singular values, creating one row in
+     * the output table for each value in the columns to be ungrouped. Columns that are not ungrouped have their values
+     * duplicated in each output row corresponding to a given input row.
+     *
+     * @param nullFill indicates if the ungrouped table should allow disparate sized arrays filling shorter columns with
+     *        null values. If set to false, then all arrays should be the same length.
+     * @param columnsToUngroup the columns to ungroup
+     * @return the ungrouped table
+     */
     TOPS ungroup(boolean nullFill, String... columnsToUngroup);
 
     /**
-     * Ungroups a table by converting arrays into columns.
+     * Ungroups a table by expanding columns of arrays or vectors into columns of singular values, creating one row in
+     * the output table for each value in the columns to be ungrouped. Columns that are not ungrouped have their values
+     * duplicated in each output row corresponding to a given input row.
      *
      * @param nullFill indicates if the ungrouped table should allow disparate sized arrays filling shorter columns with
      *        null values. If set to false, then all arrays should be the same length.

--- a/table-api/src/main/java/io/deephaven/api/TableOperations.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperations.java
@@ -1245,4 +1245,24 @@ public interface TableOperations<TOPS extends TableOperations<TOPS, TABLE>, TABL
     TOPS wavgBy(String weightColumn, Collection<String> groupByColumns);
 
     // -------------------------------------------------------------------------------------------
+
+    TOPS ungroup();
+
+    TOPS ungroup(boolean nullFill);
+
+    TOPS ungroup(String... columnsToUngroup);
+
+    TOPS ungroup(boolean nullFill, String... columnsToUngroup);
+
+    /**
+     * Ungroups a table by converting arrays into columns.
+     *
+     * @param nullFill indicates if the ungrouped table should allow disparate sized arrays filling shorter columns with
+     *        null values. If set to false, then all arrays should be the same length.
+     * @param columnsToUngroup the columns to ungroup
+     * @return the ungrouped table
+     */
+    TOPS ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup);
+
+    // -------------------------------------------------------------------------------------------
 }

--- a/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
@@ -655,4 +655,29 @@ public abstract class TableOperationsAdapter<TOPS_1 extends TableOperations<TOPS
     public final TOPS_1 wavgBy(String weightColumn, Collection<String> groupByColumns) {
         return adapt(delegate.wavgBy(weightColumn, groupByColumns));
     }
+
+    @Override
+    public final TOPS_1 ungroup() {
+        return adapt(delegate.ungroup());
+    }
+
+    @Override
+    public final TOPS_1 ungroup(boolean nullFill) {
+        return adapt(delegate.ungroup(nullFill));
+    }
+
+    @Override
+    public final TOPS_1 ungroup(String... columnsToUngroup) {
+        return adapt(delegate.ungroup(columnsToUngroup));
+    }
+
+    @Override
+    public final TOPS_1 ungroup(boolean nullFill, String... columnsToUngroup) {
+        return adapt(delegate.ungroup(nullFill, columnsToUngroup));
+    }
+
+    @Override
+    public final TOPS_1 ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup) {
+        return adapt(delegate.ungroup(nullFill, columnsToUngroup));
+    }
 }

--- a/table-api/src/main/java/io/deephaven/api/TableOperationsDefaults.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperationsDefaults.java
@@ -232,6 +232,28 @@ public interface TableOperationsDefaults<TOPS extends TableOperations<TOPS, TABL
     // -------------------------------------------------------------------------------------------
 
     @Override
+    default TOPS ungroup() {
+        return ungroup(false, Collections.emptyList());
+    }
+
+    @Override
+    default TOPS ungroup(boolean nullFill) {
+        return ungroup(nullFill, Collections.emptyList());
+    }
+
+    @Override
+    default TOPS ungroup(String... columnsToUngroup) {
+        return ungroup(false, Arrays.stream(columnsToUngroup).map(ColumnName::of).collect(Collectors.toList()));
+    }
+
+    @Override
+    default TOPS ungroup(boolean nullFill, String... columnsToUngroup) {
+        return ungroup(nullFill, Arrays.stream(columnsToUngroup).map(ColumnName::of).collect(Collectors.toList()));
+    }
+
+    // -------------------------------------------------------------------------------------------
+
+    @Override
     @ConcurrentMethod
     default TOPS aggAllBy(AggSpec spec) {
         return aggAllBy(spec, Collections.emptyList());


### PR DESCRIPTION
Ensure empty array uses all array/vector columns.