### PR TITLE
Barrage: apply redirection mapping is broken into disjoint groups

### DIFF
--- a/Util/src/main/java/io/deephaven/util/datastructures/SizeException.java
+++ b/Util/src/main/java/io/deephaven/util/datastructures/SizeException.java
@@ -14,9 +14,11 @@ import org.jetbrains.annotations.Nullable;
  */
 public class SizeException extends UncheckedDeephavenException {
 
+    private final long maximumSize;
+
     /**
      * Construct an exception, with a message appropriate for the given arguments.
-     * 
+     *
      * @param messagePrefix An optional prefix for the message
      * @param inputSize The input size for the message
      * @param maximumSize The maximum size for the message
@@ -24,12 +26,13 @@ public class SizeException extends UncheckedDeephavenException {
     public SizeException(@Nullable final String messagePrefix, final long inputSize, final long maximumSize) {
         super((messagePrefix == null ? "" : messagePrefix + ": ") + "Input size " + inputSize + " larger than maximum "
                 + maximumSize);
+        this.maximumSize = maximumSize;
     }
 
     /**
      * Construct an exception, with a message appropriate for the given arguments. Maximum size is assumed to be
      * {@link Integer#MAX_VALUE}.
-     * 
+     *
      * @param messagePrefix An optional prefix for the message
      * @param inputSize The input size for the message
      */
@@ -40,11 +43,20 @@ public class SizeException extends UncheckedDeephavenException {
     /**
      * Construct an exception, with a message appropriate for the given arguments. Maximum size is assumed to be
      * {@link Integer#MAX_VALUE}, and no prefix is included.
-     * 
+     *
      * @param inputSize The input size for the message
      */
     @SuppressWarnings("unused")
     public SizeException(final long inputSize) {
         this(null, inputSize, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Get the maximum size that was exceeded.
+     *
+     * @return The maximum size
+     */
+    public long getMaximumSize() {
+        return maximumSize;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/distinct/LongChunkedDistinctOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/distinct/LongChunkedDistinctOperator.java
@@ -8,6 +8,7 @@
  */
 package io.deephaven.engine.table.impl.by.ssmcountdistinct.distinct;
 
+import io.deephaven.engine.table.impl.sources.BoxedColumnSource;
 import io.deephaven.time.DateTime;
 import io.deephaven.engine.table.impl.by.ssmcountdistinct.DateTimeSsmSourceWrapper;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/distinct/LongRollupDistinctOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/distinct/LongRollupDistinctOperator.java
@@ -8,6 +8,7 @@
  */
 package io.deephaven.engine.table.impl.by.ssmcountdistinct.distinct;
 
+import io.deephaven.engine.table.impl.sources.BoxedColumnSource;
 import io.deephaven.time.DateTime;
 import io.deephaven.engine.table.impl.by.ssmcountdistinct.DateTimeSsmSourceWrapper;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/unique/LongChunkedUniqueOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/unique/LongChunkedUniqueOperator.java
@@ -10,6 +10,7 @@ package io.deephaven.engine.table.impl.by.ssmcountdistinct.unique;
 
 import io.deephaven.engine.table.impl.sources.BoxedColumnSource;
 import io.deephaven.time.DateTime;
+import io.deephaven.engine.table.impl.by.ssmcountdistinct.DateTimeSsmSourceWrapper;
 
 import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.rowset.RowSet;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/unique/LongRollupUniqueOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmcountdistinct/unique/LongRollupUniqueOperator.java
@@ -10,6 +10,7 @@ package io.deephaven.engine.table.impl.by.ssmcountdistinct.unique;
 
 import io.deephaven.engine.table.impl.sources.BoxedColumnSource;
 import io.deephaven.time.DateTime;
+import io.deephaven.engine.table.impl.by.ssmcountdistinct.DateTimeSsmSourceWrapper;
 
 import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.rowset.RowSet;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
@@ -34,7 +34,8 @@ import static io.deephaven.util.QueryConstants.*;
 public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<ByteChunk<Values>> {
     private static final String DEBUG_NAME = "ByteChunkInputStreamGenerator";
 
-    public static ByteChunkInputStreamGenerator convertBoxed(final ObjectChunk<Byte, Values> inChunk) {
+    public static ByteChunkInputStreamGenerator convertBoxed(
+            final ObjectChunk<Byte, Values> inChunk, final long rowOffset) {
         // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
         WritableByteChunk<Values> outChunk = WritableByteChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
@@ -44,11 +45,11 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
         }
-        return new ByteChunkInputStreamGenerator(outChunk, Byte.BYTES);
+        return new ByteChunkInputStreamGenerator(outChunk, Byte.BYTES, rowOffset);
     }
 
-    ByteChunkInputStreamGenerator(final ByteChunk<Values> chunk, final int elementSize) {
-        super(chunk, elementSize);
+    ByteChunkInputStreamGenerator(final ByteChunk<Values> chunk, final int elementSize, final long rowOffset) {
+        super(chunk, elementSize, rowOffset);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
@@ -226,10 +226,12 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (options.useDeephavenNulls()) {
-                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-            } else {
-                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+            if (totalRows > 0) {
+                if (options.useDeephavenNulls()) {
+                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+                } else {
+                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+                }
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkInputStreamGenerator.java
@@ -226,12 +226,10 @@ public class ByteChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (totalRows > 0) {
-                if (options.useDeephavenNulls()) {
-                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-                } else {
-                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
-                }
+            if (options.useDeephavenNulls()) {
+                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
@@ -29,7 +29,8 @@ import static io.deephaven.util.QueryConstants.*;
 public class CharChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<CharChunk<Values>> {
     private static final String DEBUG_NAME = "CharChunkInputStreamGenerator";
 
-    public static CharChunkInputStreamGenerator convertBoxed(final ObjectChunk<Character, Values> inChunk) {
+    public static CharChunkInputStreamGenerator convertBoxed(
+            final ObjectChunk<Character, Values> inChunk, final long rowOffset) {
         // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
         WritableCharChunk<Values> outChunk = WritableCharChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
@@ -39,11 +40,11 @@ public class CharChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
         }
-        return new CharChunkInputStreamGenerator(outChunk, Character.BYTES);
+        return new CharChunkInputStreamGenerator(outChunk, Character.BYTES, rowOffset);
     }
 
-    CharChunkInputStreamGenerator(final CharChunk<Values> chunk, final int elementSize) {
-        super(chunk, elementSize);
+    CharChunkInputStreamGenerator(final CharChunk<Values> chunk, final int elementSize, final long rowOffset) {
+        super(chunk, elementSize, rowOffset);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
@@ -221,10 +221,12 @@ public class CharChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (options.useDeephavenNulls()) {
-                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-            } else {
-                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+            if (totalRows > 0) {
+                if (options.useDeephavenNulls()) {
+                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+                } else {
+                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+                }
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/CharChunkInputStreamGenerator.java
@@ -221,12 +221,10 @@ public class CharChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (totalRows > 0) {
-                if (options.useDeephavenNulls()) {
-                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-                } else {
-                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
-                }
+            if (options.useDeephavenNulls()) {
+                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
@@ -34,7 +34,8 @@ import static io.deephaven.util.QueryConstants.*;
 public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<DoubleChunk<Values>> {
     private static final String DEBUG_NAME = "DoubleChunkInputStreamGenerator";
 
-    public static DoubleChunkInputStreamGenerator convertBoxed(final ObjectChunk<Double, Values> inChunk) {
+    public static DoubleChunkInputStreamGenerator convertBoxed(
+            final ObjectChunk<Double, Values> inChunk, final long rowOffset) {
         // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
         WritableDoubleChunk<Values> outChunk = WritableDoubleChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
@@ -44,11 +45,11 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
         }
-        return new DoubleChunkInputStreamGenerator(outChunk, Double.BYTES);
+        return new DoubleChunkInputStreamGenerator(outChunk, Double.BYTES, rowOffset);
     }
 
-    DoubleChunkInputStreamGenerator(final DoubleChunk<Values> chunk, final int elementSize) {
-        super(chunk, elementSize);
+    DoubleChunkInputStreamGenerator(final DoubleChunk<Values> chunk, final int elementSize, final long rowOffset) {
+        super(chunk, elementSize, rowOffset);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
@@ -226,12 +226,10 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (totalRows > 0) {
-                if (options.useDeephavenNulls()) {
-                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-                } else {
-                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
-                }
+            if (options.useDeephavenNulls()) {
+                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkInputStreamGenerator.java
@@ -226,10 +226,12 @@ public class DoubleChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (options.useDeephavenNulls()) {
-                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-            } else {
-                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+            if (totalRows > 0) {
+                if (options.useDeephavenNulls()) {
+                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+                } else {
+                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+                }
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
@@ -34,7 +34,8 @@ import static io.deephaven.util.QueryConstants.*;
 public class FloatChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<FloatChunk<Values>> {
     private static final String DEBUG_NAME = "FloatChunkInputStreamGenerator";
 
-    public static FloatChunkInputStreamGenerator convertBoxed(final ObjectChunk<Float, Values> inChunk) {
+    public static FloatChunkInputStreamGenerator convertBoxed(
+            final ObjectChunk<Float, Values> inChunk, final long rowOffset) {
         // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
         WritableFloatChunk<Values> outChunk = WritableFloatChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
@@ -44,11 +45,11 @@ public class FloatChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
         }
-        return new FloatChunkInputStreamGenerator(outChunk, Float.BYTES);
+        return new FloatChunkInputStreamGenerator(outChunk, Float.BYTES, rowOffset);
     }
 
-    FloatChunkInputStreamGenerator(final FloatChunk<Values> chunk, final int elementSize) {
-        super(chunk, elementSize);
+    FloatChunkInputStreamGenerator(final FloatChunk<Values> chunk, final int elementSize, final long rowOffset) {
+        super(chunk, elementSize, rowOffset);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
@@ -226,12 +226,10 @@ public class FloatChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (totalRows > 0) {
-                if (options.useDeephavenNulls()) {
-                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-                } else {
-                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
-                }
+            if (options.useDeephavenNulls()) {
+                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkInputStreamGenerator.java
@@ -226,10 +226,12 @@ public class FloatChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (options.useDeephavenNulls()) {
-                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-            } else {
-                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+            if (totalRows > 0) {
+                if (options.useDeephavenNulls()) {
+                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+                } else {
+                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+                }
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
@@ -34,7 +34,8 @@ import static io.deephaven.util.QueryConstants.*;
 public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<IntChunk<Values>> {
     private static final String DEBUG_NAME = "IntChunkInputStreamGenerator";
 
-    public static IntChunkInputStreamGenerator convertBoxed(final ObjectChunk<Integer, Values> inChunk) {
+    public static IntChunkInputStreamGenerator convertBoxed(
+            final ObjectChunk<Integer, Values> inChunk, final long rowOffset) {
         // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
         WritableIntChunk<Values> outChunk = WritableIntChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
@@ -44,11 +45,11 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
         }
-        return new IntChunkInputStreamGenerator(outChunk, Integer.BYTES);
+        return new IntChunkInputStreamGenerator(outChunk, Integer.BYTES, rowOffset);
     }
 
-    IntChunkInputStreamGenerator(final IntChunk<Values> chunk, final int elementSize) {
-        super(chunk, elementSize);
+    IntChunkInputStreamGenerator(final IntChunk<Values> chunk, final int elementSize, final long rowOffset) {
+        super(chunk, elementSize, rowOffset);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
@@ -226,10 +226,12 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (options.useDeephavenNulls()) {
-                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-            } else {
-                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+            if (totalRows > 0) {
+                if (options.useDeephavenNulls()) {
+                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+                } else {
+                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+                }
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkInputStreamGenerator.java
@@ -226,12 +226,10 @@ public class IntChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (totalRows > 0) {
-                if (options.useDeephavenNulls()) {
-                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-                } else {
-                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
-                }
+            if (options.useDeephavenNulls()) {
+                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
@@ -34,7 +34,8 @@ import static io.deephaven.util.QueryConstants.*;
 public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<LongChunk<Values>> {
     private static final String DEBUG_NAME = "LongChunkInputStreamGenerator";
 
-    public static LongChunkInputStreamGenerator convertBoxed(final ObjectChunk<Long, Values> inChunk) {
+    public static LongChunkInputStreamGenerator convertBoxed(
+            final ObjectChunk<Long, Values> inChunk, final long rowOffset) {
         // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
         WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
@@ -44,11 +45,11 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
         }
-        return new LongChunkInputStreamGenerator(outChunk, Long.BYTES);
+        return new LongChunkInputStreamGenerator(outChunk, Long.BYTES, rowOffset);
     }
 
-    LongChunkInputStreamGenerator(final LongChunk<Values> chunk, final int elementSize) {
-        super(chunk, elementSize);
+    LongChunkInputStreamGenerator(final LongChunk<Values> chunk, final int elementSize, final long rowOffset) {
+        super(chunk, elementSize, rowOffset);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
@@ -226,10 +226,12 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (options.useDeephavenNulls()) {
-                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-            } else {
-                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+            if (totalRows > 0) {
+                if (options.useDeephavenNulls()) {
+                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+                } else {
+                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+                }
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkInputStreamGenerator.java
@@ -226,12 +226,10 @@ public class LongChunkInputStreamGenerator extends BaseChunkInputStreamGenerator
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (totalRows > 0) {
-                if (options.useDeephavenNulls()) {
-                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-                } else {
-                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
-                }
+            if (options.useDeephavenNulls()) {
+                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
@@ -34,7 +34,8 @@ import static io.deephaven.util.QueryConstants.*;
 public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerator<ShortChunk<Values>> {
     private static final String DEBUG_NAME = "ShortChunkInputStreamGenerator";
 
-    public static ShortChunkInputStreamGenerator convertBoxed(final ObjectChunk<Short, Values> inChunk) {
+    public static ShortChunkInputStreamGenerator convertBoxed(
+            final ObjectChunk<Short, Values> inChunk, final long rowOffset) {
         // This code path is utilized for arrays and vectors of DateTimes, which cannot be reinterpreted.
         WritableShortChunk<Values> outChunk = WritableShortChunk.makeWritableChunk(inChunk.size());
         for (int i = 0; i < inChunk.size(); ++i) {
@@ -44,11 +45,11 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
         if (inChunk instanceof PoolableChunk) {
             ((PoolableChunk) inChunk).close();
         }
-        return new ShortChunkInputStreamGenerator(outChunk, Short.BYTES);
+        return new ShortChunkInputStreamGenerator(outChunk, Short.BYTES, rowOffset);
     }
 
-    ShortChunkInputStreamGenerator(final ShortChunk<Values> chunk, final int elementSize) {
-        super(chunk, elementSize);
+    ShortChunkInputStreamGenerator(final ShortChunk<Values> chunk, final int elementSize, final long rowOffset) {
+        super(chunk, elementSize, rowOffset);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
@@ -226,10 +226,12 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (options.useDeephavenNulls()) {
-                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-            } else {
-                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+            if (totalRows > 0) {
+                if (options.useDeephavenNulls()) {
+                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+                } else {
+                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
+                }
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkInputStreamGenerator.java
@@ -226,12 +226,10 @@ public class ShortChunkInputStreamGenerator extends BaseChunkInputStreamGenerato
                 throw new IllegalStateException("payload buffer is too short for expected number of elements");
             }
 
-            if (totalRows > 0) {
-                if (options.useDeephavenNulls()) {
-                    useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
-                } else {
-                    useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
-                }
+            if (options.useDeephavenNulls()) {
+                useDeephavenNulls(conversion, is, nodeInfo, chunk, outOffset);
+            } else {
+                useValidityBuffer(elementSize, conversion, is, nodeInfo, chunk, outOffset, isValid);
             }
 
             final long overhangPayload = payloadBuffer - payloadRead;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarBinaryChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarBinaryChunkInputStreamGenerator.java
@@ -190,8 +190,9 @@ public class VarBinaryChunkInputStreamGenerator<T> extends BaseChunkInputStreamG
     }
 
     VarBinaryChunkInputStreamGenerator(final ObjectChunk<T, Values> chunk,
+                                       final long rowOffset,
                                        final Appender<T> appendItem) {
-        super(chunk, 0);
+        super(chunk, 0, rowOffset);
         this.appendItem = appendItem;
     }
 

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarListChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarListChunkInputStreamGenerator.java
@@ -37,8 +37,8 @@ public class VarListChunkInputStreamGenerator<T> extends BaseChunkInputStreamGen
     private WritableIntChunk<ChunkPositions> offsets;
     private ChunkInputStreamGenerator innerGenerator;
 
-    VarListChunkInputStreamGenerator(final Class<T> type, final ObjectChunk<T, Values> chunk) {
-        super(chunk, 0);
+    VarListChunkInputStreamGenerator(final Class<T> type, final ObjectChunk<T, Values> chunk, final long rowOffset) {
+        super(chunk, 0, rowOffset);
         this.type = type;
     }
 
@@ -55,7 +55,7 @@ public class VarListChunkInputStreamGenerator<T> extends BaseChunkInputStreamGen
 
         final WritableChunk<Values> innerChunk = kernel.expand(chunk, offsets);
         innerGenerator = ChunkInputStreamGenerator.makeInputStreamGenerator(
-                chunkType, myType, myComponentType, innerChunk);
+                chunkType, myType, myComponentType, innerChunk, 0);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VectorChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VectorChunkInputStreamGenerator.java
@@ -38,9 +38,12 @@ public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
     private WritableIntChunk<ChunkPositions> offsets;
     private ChunkInputStreamGenerator innerGenerator;
 
-    VectorChunkInputStreamGenerator(final Class<Vector<?>> type, final Class<?> componentType,
-                                    final ObjectChunk<Vector<?>, Values> chunk) {
-        super(chunk, 0);
+    VectorChunkInputStreamGenerator(
+            final Class<Vector<?>> type,
+            final Class<?> componentType,
+            final ObjectChunk<Vector<?>, Values> chunk,
+            final long rowOffset) {
+        super(chunk, 0, rowOffset);
         this.componentType = VectorExpansionKernel.getComponentType(type, componentType);
     }
 
@@ -56,7 +59,7 @@ public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
 
         final WritableChunk<Values> innerChunk = kernel.expand(chunk, offsets);
         innerGenerator = ChunkInputStreamGenerator.makeInputStreamGenerator(
-                chunkType, componentType, innerComponentType, innerChunk);
+                chunkType, componentType, innerComponentType, innerChunk, 0);
     }
 
     @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
@@ -270,7 +270,9 @@ public class BarrageStreamReader implements StreamReader {
                             final int chunkOffset;
                             long rowOffset = numModRowsRead - lastModStartIndex;
                             // this batch might overflow the chunk
-                            if (rowOffset + Math.min(remaining, batch.length()) > chunkSize) {
+                            final int numRowsToRead = LongSizedDataStructure.intSize("BarrageStreamReader",
+                                    Math.min(remaining, batch.length()));
+                            if (rowOffset + numRowsToRead > chunkSize) {
                                 lastModStartIndex += chunkSize;
 
                                 // create a new chunk before trying to write again
@@ -288,7 +290,7 @@ public class BarrageStreamReader implements StreamReader {
                             mcd.data.set(lastChunkIndex,
                                     ChunkInputStreamGenerator.extractChunkFromInputStream(options, columnChunkTypes[ci],
                                             columnTypes[ci], componentTypes[ci], fieldNodeIter, bufferInfoIter, ois,
-                                            chunk, chunkOffset, chunkSize));
+                                            chunk, chunkOffset, numRowsToRead));
                         }
                         numModRowsRead += batch.length();
                     }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
@@ -194,7 +194,6 @@ public class BarrageStreamReader implements StreamReader {
                 // noinspection UnstableApiUsage
                 try (final LittleEndianDataInputStream ois =
                         new LittleEndianDataInputStream(new BarrageProtoUtil.ObjectInputStreamAdapter(decoder, size))) {
-                    final MutableInt bufferOffset = new MutableInt();
                     final Iterator<ChunkInputStreamGenerator.FieldNodeInfo> fieldNodeIter =
                             new FlatBufferIteratorAdapter<>(batch.nodesLength(),
                                     i -> new ChunkInputStreamGenerator.FieldNodeInfo(batch.nodes(i)));
@@ -209,7 +208,6 @@ public class BarrageStreamReader implements StreamReader {
                             // our parsers handle overhanging buffers
                             length += Math.max(0, nextOffset - offset - length);
                         }
-                        bufferOffset.setValue(offset + length);
                         bufferInfo.add(length);
                     }
                     final TLongIterator bufferInfoIter = bufferInfo.iterator();

--- a/extensions/barrage/src/test/java/io/deephaven/extensions/barrage/chunk/BarrageColumnRoundTripTest.java
+++ b/extensions/barrage/src/test/java/io/deephaven/extensions/barrage/chunk/BarrageColumnRoundTripTest.java
@@ -509,7 +509,7 @@ public class BarrageColumnRoundTripTest extends RefreshingTableTestCase {
         initData.accept(data);
 
         try (ChunkInputStreamGenerator generator =
-                ChunkInputStreamGenerator.makeInputStreamGenerator(chunkType, type, type.getComponentType(), data)) {
+                ChunkInputStreamGenerator.makeInputStreamGenerator(chunkType, type, type.getComponentType(), data, 0)) {
 
             // full sub logic
             try (final BarrageProtoUtil.ExposedByteArrayOutputStream baos =

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -260,6 +260,7 @@ public class ArrowFlightUtil {
         private final TicketRouter ticketRouter;
         private final StreamObserver<Flight.PutResult> observer;
 
+        private long totalRowsRead = 0;
         private BarrageTable resultTable;
         private SessionState.ExportBuilder<Table> resultExportBuilder;
         private Flight.FlightDescriptor flightDescriptor;
@@ -376,10 +377,10 @@ public class ArrowFlightUtil {
                     acd.componentType = componentTypes[ci];
                 }
 
-                msg.rowsAdded =
-                        RowSetFactory.fromRange(resultTable.size(), resultTable.size() + numRowsAdded - 1);
+                msg.rowsAdded = RowSetFactory.fromRange(totalRowsRead, totalRowsRead + numRowsAdded - 1);
                 msg.rowsIncluded = msg.rowsAdded.copy();
                 msg.modColumnData = ZERO_MOD_COLUMNS;
+                totalRowsRead += numRowsAdded;
 
                 resultTable.handleBarrageMessage(msg);
 

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -2000,16 +2000,20 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
 
         final RowSet.Iterator vit = values.iterator();
         keys.forAllRowKeys(lkey -> {
-            long[] mapping = mappings.get(arrIdx.intValue());
-            int keyIdx = LongSizedDataStructure.intSize("applyRedirMapping", lkey - arrOffset.longValue());
+            int keyIdx;
+            long[] mapping;
+
+            do {
+                mapping = mappings.get(arrIdx.intValue());
+                keyIdx = LongSizedDataStructure.intSize("applyRedirMapping", lkey - arrOffset.longValue());
+                if (keyIdx >= mapping.length) {
+                    arrOffset.add(mapping.length);
+                    arrIdx.increment();
+                }
+            } while (keyIdx >= mapping.length);
 
             Assert.eq(mapping[keyIdx], "mapping[keyIdx]", RowSequence.NULL_ROW_KEY, "RowSet.NULL_ROW_KEY");
             mapping[keyIdx] = vit.nextLong();
-
-            if (keyIdx == mapping.length - 1) {
-                arrOffset.add(mapping.length);
-                arrIdx.add(1);
-            }
         });
     }
 

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -1801,8 +1801,8 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
             final class ColumnInfo {
                 final WritableRowSet modified = RowSetFactory.empty();
                 final WritableRowSet recordedMods = RowSetFactory.empty();
-                ArrayList<long[]> addedMappings = new ArrayList<>();
-                ArrayList<long[]> modifiedMappings = new ArrayList<>();
+                long[][] addedMappings;
+                long[][] modifiedMappings;
             }
 
             final HashMap<BitSet, ColumnInfo> infoCache = new HashMap<>();
@@ -1835,23 +1835,8 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
                 retval.modified.remove(coalescer.added);
                 retval.recordedMods.remove(coalescer.added);
 
-                try (final RowSequence.Iterator it = localAdded.getRowSequenceIterator()) {
-                    while (it.hasMore()) {
-                        final RowSequence rs = it.getNextRowSequenceWithLength(SNAPSHOT_CHUNK_SIZE);
-                        long[] addedMapping = new long[rs.intSize()];
-                        Arrays.fill(addedMapping, RowSequence.NULL_ROW_KEY);
-                        retval.addedMappings.add(addedMapping);
-                    }
-                }
-
-                try (final RowSequence.Iterator it = retval.recordedMods.getRowSequenceIterator()) {
-                    while (it.hasMore()) {
-                        final RowSequence rs = it.getNextRowSequenceWithLength(SNAPSHOT_CHUNK_SIZE);
-                        long[] modifiedMapping = new long[rs.intSize()];
-                        Arrays.fill(modifiedMapping, RowSequence.NULL_ROW_KEY);
-                        retval.modifiedMappings.add(modifiedMapping);
-                    }
-                }
+                retval.addedMappings = newMappingArray(localAdded.size());
+                retval.modifiedMappings = newMappingArray(retval.recordedMods.size());
 
                 final WritableRowSet unfilledAdds = localAdded.isEmpty() ? RowSetFactory.empty()
                         : RowSetFactory.flat(localAdded.size());
@@ -1987,33 +1972,32 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         return downstream;
     }
 
-    // Updates provided mapping so that mapping[i] returns values.get(i) for all i in keys.
-    private static void applyRedirMapping(final RowSet keys, final RowSet values, final ArrayList<long[]> mappings) {
-        Assert.eq(keys.size(), "keys.size()", values.size(), "values.size()");
-        MutableLong mapCount = new MutableLong(0L);
-        mappings.forEach((arr) -> mapCount.add(arr.length));
-        Assert.leq(keys.size(), "keys.size()", mapCount.longValue(), "mapping.length");
+    private static long[][] newMappingArray(final long size) {
+        final int numAddChunks = LongSizedDataStructure.intSize("BarrageMessageProducer",
+                (size + SNAPSHOT_CHUNK_SIZE - 1) / SNAPSHOT_CHUNK_SIZE);
+        final long[][] result = new long[numAddChunks][];
+        for (int ii = 0; ii < numAddChunks; ++ii) {
+            final int chunkSize = (ii < numAddChunks - 1 || size % SNAPSHOT_CHUNK_SIZE == 0)
+                    ? SNAPSHOT_CHUNK_SIZE
+                    : (int)(size % SNAPSHOT_CHUNK_SIZE);
+            final long[] newChunk = new long[chunkSize];
+            result[ii] = newChunk;
+            Arrays.fill(newChunk, RowSequence.NULL_ROW_KEY);
+        }
+        return result;
+    }
 
-        // we need to track our progress through multiple mapping arrays
-        MutableLong arrOffset = new MutableLong(0L);
-        MutableInt arrIdx = new MutableInt(0);
+    // Updates provided mapping so that mapping[i] returns values.get(i) for all i in keys.
+    private static void applyRedirMapping(final RowSet keys, final RowSet values, final long[][] mapping) {
+        Assert.eq(keys.size(), "keys.size()", values.size(), "values.size()");
 
         final RowSet.Iterator vit = values.iterator();
         keys.forAllRowKeys(lkey -> {
-            int keyIdx;
-            long[] mapping;
-
-            do {
-                mapping = mappings.get(arrIdx.intValue());
-                keyIdx = LongSizedDataStructure.intSize("applyRedirMapping", lkey - arrOffset.longValue());
-                if (keyIdx >= mapping.length) {
-                    arrOffset.add(mapping.length);
-                    arrIdx.increment();
-                }
-            } while (keyIdx >= mapping.length);
-
-            Assert.eq(mapping[keyIdx], "mapping[keyIdx]", RowSequence.NULL_ROW_KEY, "RowSet.NULL_ROW_KEY");
-            mapping[keyIdx] = vit.nextLong();
+            final int arrIdx = (int)(lkey / SNAPSHOT_CHUNK_SIZE);
+            final int keyIdx = (int)(lkey % SNAPSHOT_CHUNK_SIZE);
+            final long[] chunk = mapping[arrIdx];
+            Assert.eq(chunk[keyIdx], "chunk[keyIdx]", RowSequence.NULL_ROW_KEY, "RowSet.NULL_ROW_KEY");
+            chunk[keyIdx] = vit.nextLong();
         });
     }
 

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -1979,7 +1979,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
         for (int ii = 0; ii < numAddChunks; ++ii) {
             final int chunkSize = (ii < numAddChunks - 1 || size % SNAPSHOT_CHUNK_SIZE == 0)
                     ? SNAPSHOT_CHUNK_SIZE
-                    : (int)(size % SNAPSHOT_CHUNK_SIZE);
+                    : (int) (size % SNAPSHOT_CHUNK_SIZE);
             final long[] newChunk = new long[chunkSize];
             result[ii] = newChunk;
             Arrays.fill(newChunk, RowSequence.NULL_ROW_KEY);
@@ -1993,8 +1993,8 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
 
         final RowSet.Iterator vit = values.iterator();
         keys.forAllRowKeys(lkey -> {
-            final int arrIdx = (int)(lkey / SNAPSHOT_CHUNK_SIZE);
-            final int keyIdx = (int)(lkey % SNAPSHOT_CHUNK_SIZE);
+            final int arrIdx = (int) (lkey / SNAPSHOT_CHUNK_SIZE);
+            final int keyIdx = (int) (lkey % SNAPSHOT_CHUNK_SIZE);
             final long[] chunk = mapping[arrIdx];
             Assert.eq(chunk[keyIdx], "chunk[keyIdx]", RowSequence.NULL_ROW_KEY, "RowSet.NULL_ROW_KEY");
             chunk[keyIdx] = vit.nextLong();

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -759,9 +759,6 @@ public class BarrageStreamGenerator implements
             try {
                 final InputStream is =
                         getInputStream(view, offset, batchSize, actualBatchSize, metadata, columnVisitor);
-                if (actualBatchSize.intValue() == 0) {
-                    getInputStream(view, offset, batchSize, actualBatchSize, metadata, columnVisitor);
-                }
                 int bytesToWrite = is.available();
 
                 // treat this as a hard limit, exceeding fails a client or w2w (unless we are sending a single

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -857,8 +857,8 @@ public class BarrageStreamGenerator implements
 
         // all column generators have the same boundaries, so we can re-use the offsets internal to this chunkIdx
         try (final RowSet allowedRange = RowSetFactory.fromRange(startPos, endPos);
-             final WritableRowSet myAddedOffsets = view.addRowOffsets().intersect(allowedRange);
-             final RowSet adjustedOffsets = shift == 0 ? null : myAddedOffsets.shift(shift)) {
+                final WritableRowSet myAddedOffsets = view.addRowOffsets().intersect(allowedRange);
+                final RowSet adjustedOffsets = shift == 0 ? null : myAddedOffsets.shift(shift)) {
             // every column must write to the stream
             for (final ChunkListInputStreamGenerator data : addColumnData) {
                 if (myAddedOffsets.isEmpty() || data.generators.length == 0) {

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageStreamGenerator.java
@@ -761,6 +761,10 @@ public class BarrageStreamGenerator implements
                         getInputStream(view, offset, batchSize, actualBatchSize, metadata, columnVisitor);
                 int bytesToWrite = is.available();
 
+                if (actualBatchSize.intValue() == 0) {
+                    throw new IllegalStateException("No data was written for a batch");
+                }
+
                 // treat this as a hard limit, exceeding fails a client or w2w (unless we are sending a single
                 // row then we must send and let it potentially fail)
                 if (sendAllowed && (bytesToWrite < maxMessageSize || batchSize == 1)) {
@@ -833,7 +837,7 @@ public class BarrageStreamGenerator implements
             final Consumer<InputStream> addStream, final ChunkInputStreamGenerator.FieldNodeListener fieldNodeListener,
             final ChunkInputStreamGenerator.BufferListener bufferListener) throws IOException {
         if (addColumnData.length == 0) {
-            return 0;
+            return view.addRowOffsets().size();
         }
 
         // find the generator for the initial position-space key

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -1225,7 +1225,7 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
         final int numDeltas = 4;
         for (int ii = 0; ii < numDeltas; ++ii) {
             final RowSetBuilderSequential newRowsBuilder = RowSetFactory.builderSequential();
-            final Integer[] values = new Integer[sz/numDeltas];
+            final Integer[] values = new Integer[sz / numDeltas];
             for (int jj = ii; jj < sz; jj += numDeltas) {
                 newRowsBuilder.appendKey(jj);
                 values[jj / numDeltas] = ii;
@@ -1250,7 +1250,7 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
         // Modify all of our rows spread over multiple deltas.
         for (int ii = 0; ii < numDeltas; ++ii) {
             final RowSetBuilderSequential modRowsBuilder = RowSetFactory.builderSequential();
-            final Integer[] values = new Integer[sz/numDeltas];
+            final Integer[] values = new Integer[sz / numDeltas];
             for (int jj = ii; jj < sz; jj += numDeltas) {
                 modRowsBuilder.appendKey(jj);
                 values[jj / numDeltas] = numDeltas + ii;

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -739,7 +739,6 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
     }
 
     // These test mid-cycle subscription changes and snapshot content
-
     private abstract class SubscriptionChangingHelper extends SharedProducerForAllClients {
         SubscriptionChangingHelper(final int numProducerCoalesce, final int numConsumerCoalesce, final int size,
                 final int seed, final MutableInt numSteps) {

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -69,6 +69,7 @@ import static io.deephaven.engine.table.impl.TstUtils.c;
 import static io.deephaven.engine.table.impl.TstUtils.getTable;
 import static io.deephaven.engine.table.impl.TstUtils.i;
 import static io.deephaven.engine.table.impl.TstUtils.initColumnInfos;
+import static io.deephaven.engine.table.impl.remote.ConstructSnapshot.SNAPSHOT_CHUNK_SIZE;
 
 @Category(OutOfBandTest.class)
 public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
@@ -1194,6 +1195,83 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
         remoteNugget.flushClientEvents();
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(updateSourceCombiner::run);
         remoteNugget.validate("new viewport with modification");
+    }
+
+    public void testCoalescingLargeUpdates() {
+        final BitSet allColumns = new BitSet(1);
+        allColumns.set(0);
+
+        final QueryTable queryTable = TstUtils.testRefreshingTable(i(0).toTracking(), c("intCol", 0));
+        TstUtils.removeRows(queryTable, i(0));
+
+        final RemoteNugget remoteNugget = new RemoteNugget(() -> queryTable);
+
+        // Create a few interesting clients around the mapping boundary.
+        final int mb = SNAPSHOT_CHUNK_SIZE;
+        final int sz = 2 * mb;
+        final RemoteClient[] remoteClients = new RemoteClient[] {
+                remoteNugget.newClient(null, allColumns, "full"),
+                remoteNugget.newClient(RowSetFactory.fromRange(0, 100), allColumns, "start"),
+                remoteNugget.newClient(RowSetFactory.fromRange(mb - 100, mb + 100), allColumns, "middle"),
+                remoteNugget.newClient(RowSetFactory.fromRange(sz - 100, sz + 100), allColumns, "end"),
+        };
+
+        // Obtain snapshot of original viewport.
+        flushProducerTable();
+        remoteNugget.flushClientEvents();
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(updateSourceCombiner::run);
+        remoteNugget.validate("original viewport");
+
+        // Add all of our new rows spread over multiple deltas.
+        final int numDeltas = 4;
+        for (int ii = 0; ii < numDeltas; ++ii) {
+            final RowSetBuilderSequential newRowsBuilder = RowSetFactory.builderSequential();
+            final Integer[] values = new Integer[sz/numDeltas];
+            for (int jj = ii; jj < sz; jj += numDeltas) {
+                newRowsBuilder.appendKey(jj);
+                values[jj / numDeltas] = ii;
+            }
+            final RowSet newRows = newRowsBuilder.build();
+            UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+                TstUtils.addToTable(queryTable, newRows, c("intCol", values));
+                queryTable.notifyListeners(new TableUpdateImpl(
+                        newRows,
+                        RowSetFactory.empty(),
+                        RowSetFactory.empty(),
+                        RowSetShiftData.EMPTY, ModifiedColumnSet.ALL));
+            });
+        }
+
+        // Coalesce these to ensure mappings larger than a single chunk are handled correctly.
+        flushProducerTable();
+        remoteNugget.flushClientEvents();
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(updateSourceCombiner::run);
+        remoteNugget.validate("large add rows update");
+
+        // Modify all of our rows spread over multiple deltas.
+        for (int ii = 0; ii < numDeltas; ++ii) {
+            final RowSetBuilderSequential modRowsBuilder = RowSetFactory.builderSequential();
+            final Integer[] values = new Integer[sz/numDeltas];
+            for (int jj = ii; jj < sz; jj += numDeltas) {
+                modRowsBuilder.appendKey(jj);
+                values[jj / numDeltas] = numDeltas + ii;
+            }
+            final RowSet modRows = modRowsBuilder.build();
+            UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+                TstUtils.addToTable(queryTable, modRows, c("intCol", values));
+                queryTable.notifyListeners(new TableUpdateImpl(
+                        RowSetFactory.empty(),
+                        RowSetFactory.empty(),
+                        modRows,
+                        RowSetShiftData.EMPTY, ModifiedColumnSet.ALL));
+            });
+        }
+
+        // Coalesce these to ensure mappings larger than a single chunk are handled correctly.
+        flushProducerTable();
+        remoteNugget.flushClientEvents();
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(updateSourceCombiner::run);
+        remoteNugget.validate("large mod rows update");
     }
 
     public void testAllUniqueChunkTypeColumnSourcesWithValidityBuffers() {


### PR DESCRIPTION
Fixes #2938 

Redirection mapping is performed in four distinct groups:
1) adds that are new adds
2) mods that replace rows scope into a subscribed viewport
3) mods that propagate as adds (the adds have not yet been propagated, but this modifies an add)
4) mods that are just mods

Each one share the ArrayList of redirection mappings. Existing logic only would advance to the next mapping if the key matches the last row of that chunk -- however that row is only in one of the four groups. I now skip until I find the appropriate chunk that should be modified.

