### PR TITLE
Upgrade to Jetty images

### DIFF
--- a/containers/groovy-examples/docker-compose.yml
+++ b/containers/groovy-examples/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-slim-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/groovy-examples/docker-compose.yml
+++ b/containers/groovy-examples/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-slim-jetty:latest
+    image: ghcr.io/deephaven/server-slim:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/groovy-examples/docker-compose.yml
+++ b/containers/groovy-examples/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples
+    image: ghcr.io/deephaven/examples:latest
     volumes:
       - ./data:/data
     command: initialize

--- a/containers/groovy-examples/docker-compose.yml
+++ b/containers/groovy-examples/docker-compose.yml
@@ -1,49 +1,17 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=groovy
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
-volumes:
-    web-tmp:
-    api-cache:
-      

--- a/containers/groovy/docker-compose.yml
+++ b/containers/groovy/docker-compose.yml
@@ -1,43 +1,11 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-slim-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=groovy
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
-
-volumes:
-    web-tmp:
-    api-cache:
-      
+      - JAVA_OPTS=-Xmx4g

--- a/containers/groovy/docker-compose.yml
+++ b/containers/groovy/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-slim-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-slim-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/groovy/docker-compose.yml
+++ b/containers/groovy/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-slim-jetty:latest
+    image: ghcr.io/deephaven/server-slim:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples-redpanda/docker-compose.yml
+++ b/containers/python-examples-redpanda/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-jetty:latest
+    image: ghcr.io/deephaven/server:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples-redpanda/docker-compose.yml
+++ b/containers/python-examples-redpanda/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples-redpanda/docker-compose.yml
+++ b/containers/python-examples-redpanda/docker-compose.yml
@@ -1,48 +1,20 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '80'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
 
   redpanda:
     command:
@@ -75,8 +47,3 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       APPLICATION_ID: registry_id
       APPLICATION_SERVER: localhost:9000
-
-volumes:
-    web-tmp:
-    api-cache:
-      

--- a/containers/python-examples/All-AI/docker-compose.yml
+++ b/containers/python-examples/All-AI/docker-compose.yml
@@ -1,50 +1,17 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-all-ai:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-all-ai-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-    ports:
-      - 6006:6006
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples:latest
+    image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
-volumes:
-    web-tmp:
-    api-cache:

--- a/containers/python-examples/All-AI/docker-compose.yml
+++ b/containers/python-examples/All-AI/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-all-ai-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-all-ai-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/All-AI/docker-compose.yml
+++ b/containers/python-examples/All-AI/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples
+    image: ghcr.io/deephaven/examples:latest
     volumes:
       - ./data:/data
     command: initialize

--- a/containers/python-examples/All-AI/docker-compose.yml
+++ b/containers/python-examples/All-AI/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-all-ai-jetty:latest
+    image: ghcr.io/deephaven/server-all-ai:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/NLTK/docker-compose.yml
+++ b/containers/python-examples/NLTK/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-nltk-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-nltk-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/NLTK/docker-compose.yml
+++ b/containers/python-examples/NLTK/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples
+    image: ghcr.io/deephaven/examples:latest
     volumes:
       - ./data:/data
     command: initialize

--- a/containers/python-examples/NLTK/docker-compose.yml
+++ b/containers/python-examples/NLTK/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-nltk-jetty:latest
+    image: ghcr.io/deephaven/server-nltk:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/NLTK/docker-compose.yml
+++ b/containers/python-examples/NLTK/docker-compose.yml
@@ -1,48 +1,17 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-nltk:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-nltk-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples:latest
+    image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
-volumes:
-    web-tmp:
-    api-cache:

--- a/containers/python-examples/PyTorch/docker-compose.yml
+++ b/containers/python-examples/PyTorch/docker-compose.yml
@@ -1,50 +1,17 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-pytorch:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-pytorch-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-    ports:
-      - 6006:6006
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples:latest
+    image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
-volumes:
-    web-tmp:
-    api-cache:

--- a/containers/python-examples/PyTorch/docker-compose.yml
+++ b/containers/python-examples/PyTorch/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-pytorch-jetty:latest
+    image: ghcr.io/deephaven/server-pytorch:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/PyTorch/docker-compose.yml
+++ b/containers/python-examples/PyTorch/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-pytorch-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-pytorch-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/PyTorch/docker-compose.yml
+++ b/containers/python-examples/PyTorch/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/deephaven/server-pytorch:latest
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
+      - 6006:6006
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/PyTorch/docker-compose.yml
+++ b/containers/python-examples/PyTorch/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples
+    image: ghcr.io/deephaven/examples:latest
     volumes:
       - ./data:/data
     command: initialize

--- a/containers/python-examples/SciKit-Learn/docker-compose.yml
+++ b/containers/python-examples/SciKit-Learn/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-sklearn-jetty:latest
+    image: ghcr.io/deephaven/server-sklearn:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/SciKit-Learn/docker-compose.yml
+++ b/containers/python-examples/SciKit-Learn/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples
+    image: ghcr.io/deephaven/examples:latest
     volumes:
       - ./data:/data
     command: initialize

--- a/containers/python-examples/SciKit-Learn/docker-compose.yml
+++ b/containers/python-examples/SciKit-Learn/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-sklearn-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-sklearn-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/SciKit-Learn/docker-compose.yml
+++ b/containers/python-examples/SciKit-Learn/docker-compose.yml
@@ -1,48 +1,17 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-sklearn:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-sklearn-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples:latest
+    image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
-volumes:
-    web-tmp:
-    api-cache:

--- a/containers/python-examples/TensorFlow/docker-compose.yml
+++ b/containers/python-examples/TensorFlow/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples
+    image: ghcr.io/deephaven/examples:latest
     volumes:
       - ./data:/data
     command: initialize

--- a/containers/python-examples/TensorFlow/docker-compose.yml
+++ b/containers/python-examples/TensorFlow/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-tensorflow-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-tensorflow-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/TensorFlow/docker-compose.yml
+++ b/containers/python-examples/TensorFlow/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/deephaven/server-tensorflow:latest
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
+      - 6006:6006
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/TensorFlow/docker-compose.yml
+++ b/containers/python-examples/TensorFlow/docker-compose.yml
@@ -1,50 +1,17 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-tensorflow:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-tensorflow-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-    ports:
-      - 6006:6006
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples:latest
+    image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
-volumes:
-    web-tmp:
-    api-cache:

--- a/containers/python-examples/TensorFlow/docker-compose.yml
+++ b/containers/python-examples/TensorFlow/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-tensorflow-jetty:latest
+    image: ghcr.io/deephaven/server-tensorflow:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/base/docker-compose.yml
+++ b/containers/python-examples/base/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-jetty:latest
+    image: ghcr.io/deephaven/server:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/base/docker-compose.yml
+++ b/containers/python-examples/base/docker-compose.yml
@@ -1,49 +1,17 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
+      - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples:latest
+    image: ghcr.io/deephaven/examples
     volumes:
       - ./data:/data
     command: initialize
-
-volumes:
-    web-tmp:
-    api-cache:
-      

--- a/containers/python-examples/base/docker-compose.yml
+++ b/containers/python-examples/base/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python-examples/base/docker-compose.yml
+++ b/containers/python-examples/base/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - JAVA_OPTS=-Xmx4g
 
   examples:
-    image: ghcr.io/deephaven/examples
+    image: ghcr.io/deephaven/examples:latest
     volumes:
       - ./data:/data
     command: initialize

--- a/containers/python/All-AI/docker-compose.yml
+++ b/containers/python/All-AI/docker-compose.yml
@@ -1,44 +1,11 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-all-ai:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-all-ai-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-    ports:
-      - 6006:6006
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
-
-volumes:
-    web-tmp:
-    api-cache:
+      - JAVA_OPTS=-Xmx4g

--- a/containers/python/All-AI/docker-compose.yml
+++ b/containers/python/All-AI/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-all-ai-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-all-ai-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/All-AI/docker-compose.yml
+++ b/containers/python/All-AI/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-all-ai-jetty:latest
+    image: ghcr.io/deephaven/server-all-ai:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/NLTK/docker-compose.yml
+++ b/containers/python/NLTK/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-nltk-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-nltk-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/NLTK/docker-compose.yml
+++ b/containers/python/NLTK/docker-compose.yml
@@ -1,42 +1,11 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-nltk:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-nltk-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
-
-volumes:
-    web-tmp:
-    api-cache:
+      - JAVA_OPTS=-Xmx4g

--- a/containers/python/NLTK/docker-compose.yml
+++ b/containers/python/NLTK/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-nltk-jetty:latest
+    image: ghcr.io/deephaven/server-nltk:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/PyTorch/docker-compose.yml
+++ b/containers/python/PyTorch/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-pytorch-jetty:latest
+    image: ghcr.io/deephaven/server-pytorch:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/PyTorch/docker-compose.yml
+++ b/containers/python/PyTorch/docker-compose.yml
@@ -1,44 +1,11 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-pytorch:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-pytorch-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-    ports:
-      - 6006:6006
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
-
-volumes:
-    web-tmp:
-    api-cache:
+      - JAVA_OPTS=-Xmx4g

--- a/containers/python/PyTorch/docker-compose.yml
+++ b/containers/python/PyTorch/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-pytorch-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-pytorch-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/PyTorch/docker-compose.yml
+++ b/containers/python/PyTorch/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/deephaven/server-pytorch:latest
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
+      - 6006:6006
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/SciKit-Learn/docker-compose.yml
+++ b/containers/python/SciKit-Learn/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-sklearn-jetty:latest
+    image: ghcr.io/deephaven/server-sklearn:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/SciKit-Learn/docker-compose.yml
+++ b/containers/python/SciKit-Learn/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-sklearn-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-sklearn-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/SciKit-Learn/docker-compose.yml
+++ b/containers/python/SciKit-Learn/docker-compose.yml
@@ -1,42 +1,11 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-sklearn:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-sklearn-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server 
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
-
-volumes:
-    web-tmp:
-    api-cache:
+      - JAVA_OPTS=-Xmx4g

--- a/containers/python/TensorFlow/docker-compose.yml
+++ b/containers/python/TensorFlow/docker-compose.yml
@@ -1,44 +1,11 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server-tensorflow:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-tensorflow-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-    ports:
-      - 6006:6006
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
-
-volumes:
-    web-tmp:
-    api-cache:
+      - JAVA_OPTS=-Xmx4g

--- a/containers/python/TensorFlow/docker-compose.yml
+++ b/containers/python/TensorFlow/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-tensorflow-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-tensorflow-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/TensorFlow/docker-compose.yml
+++ b/containers/python/TensorFlow/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/deephaven/server-tensorflow:latest
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
+      - 6006:6006
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/TensorFlow/docker-compose.yml
+++ b/containers/python/TensorFlow/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-tensorflow-jetty:latest
+    image: ghcr.io/deephaven/server-tensorflow:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/base/docker-compose.yml
+++ b/containers/python/base/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-jetty:latest
+    image: ghcr.io/deephaven/server:latest
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/base/docker-compose.yml
+++ b/containers/python/base/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server-netty:latest
-    labels:
-      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
+    image: ghcr.io/deephaven/server-jetty:latest
     volumes:
       - ./data:/data
     environment:

--- a/containers/python/base/docker-compose.yml
+++ b/containers/python/base/docker-compose.yml
@@ -1,43 +1,11 @@
 version: "3.4"
 
 services:
-  server:
-    image: ghcr.io/deephaven/server:${VERSION:-latest}
-    expose:
-      - '8080'
+  deephaven:
+    image: ghcr.io/deephaven/server-netty:latest
+    labels:
+      - 'traefik.http.routers.deephaven.rule=Host(`localhost`)'
     volumes:
       - ./data:/data
-      - api-cache:/cache
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python
-
-  web:
-    image: ghcr.io/deephaven/web:${VERSION:-latest}
-    expose:
-      - '8080'
-    volumes:
-      - ./data:/data
-      - web-tmp:/tmp
-
-  grpc-proxy:
-    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
-    environment:
-      - BACKEND_ADDR=server:8080
-    depends_on:
-      - server
-    expose:
-      - '8080'
-
-  envoy:
-    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
-    depends_on:
-      - web
-      - grpc-proxy
-      - server
-    ports:
-      - "${DEEPHAVEN_PORT:-10000}:10000"
-
-volumes:
-    web-tmp:
-    api-cache:
-      
+      - JAVA_OPTS=-Xmx4g


### PR DESCRIPTION
Docker-compose files all share one service. Builds with examples have one additional service, and the redpanda setup has a third image.

I'm not sure if this needs a `documentation` or `NoDocumentationNeeded` tag.