### PR TITLE
Upload error logs on pydoc failure

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -140,6 +140,14 @@ jobs:
           remote_user: ${{ secrets.DOCS_USER }}
           remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
 
+      - name: Upload JVM Error Logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: docs-ci-pydoc-jvm-err
+          path: '**/*_pid*.log'
+          if-no-files-found: ignore
+
   cppdoc:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This is meant to catch JVM error logs of the format `**/*_pid*.log`. This is something we've seen from the pydoc task / sphinx / jpy.