### PR TITLE
Bump dagger to 2.44

### DIFF
--- a/buildSrc/src/main/groovy/Classpaths.groovy
+++ b/buildSrc/src/main/groovy/Classpaths.groovy
@@ -59,7 +59,7 @@ class Classpaths {
     static final String DAGGER_GROUP = 'com.google.dagger'
     static final String DAGGER_NAME = 'dagger'
     static final String DAGGER_COMPILER = 'dagger-compiler'
-    static final String DAGGER_VERSION = '2.31.1'
+    static final String DAGGER_VERSION = '2.44'
 
     static final String AUTOSERVICE_GROUP = 'com.google.auto.service'
     static final String AUTOSERVICE_NAME = 'auto-service-annotations'

--- a/server/jetty/build.gradle
+++ b/server/jetty/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     Classpaths.inheritGrpcPlatform(project)
     Classpaths.inheritJetty11Platform(project)
 
+    api 'jakarta.servlet:jakarta.servlet-api:5.0.0'
     implementation 'org.eclipse.jetty:jetty-servlet'
     implementation 'org.eclipse.jetty:jetty-webapp'
     implementation 'org.eclipse.jetty.http2:http2-server'


### PR DESCRIPTION
The api dependency is a good find by dagger - GrpcFilter extends HttpFilter, so HttpFilter should be part of public api.

For reference, this is the error without the api dependency:

  Dependency trace:
      => element (CLASS): io.deephaven.server.jetty.GrpcFilter
      => type (ERROR superclass): jakarta.servlet.http.HttpFilter

  If type 'jakarta.servlet.http.HttpFilter' is a generated type, check above for compilation errors that may have prevented the type from being generated. Otherwise, ensure that type 'jakarta.servlet.http.HttpFilter' is on your classpath.