### PR TITLE
Update web code studio to v0.19.1

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -1,7 +1,10 @@
 FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
-ARG WEB_VERSION=0.19.0
+# Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
+ARG WEB_VERSION=0.19.1
+ARG GRID_VERSION=0.19.0
+ARG CHART_VERSION=0.19.0
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \
@@ -13,18 +16,18 @@ RUN set -eux; \
 
 # Pull in the published embed-grid package from npmjs and extract is
 RUN set -eux; \
-    npm pack @deephaven/embed-grid@${WEB_VERSION}; \
-    tar --touch -xf deephaven-embed-grid-${WEB_VERSION}.tgz; \
+    npm pack @deephaven/embed-grid@${GRID_VERSION}; \
+    tar --touch -xf deephaven-embed-grid-${GRID_VERSION}.tgz; \
     mkdir -p iframe; \
     mv package/build iframe/table; \
     rm -r package; \
-    rm deephaven-embed-grid-${WEB_VERSION}.tgz;
+    rm deephaven-embed-grid-${GRID_VERSION}.tgz;
 
 # Pull in the published embed-chart package from npmjs and extract is
 RUN set -eux; \
-    npm pack @deephaven/embed-chart@${WEB_VERSION}; \
-    tar --touch -xf deephaven-embed-chart-${WEB_VERSION}.tgz; \
+    npm pack @deephaven/embed-chart@${CHART_VERSION}; \
+    tar --touch -xf deephaven-embed-chart-${CHART_VERSION}.tgz; \
     mkdir -p iframe; \
     mv package/build iframe/chart; \
     rm -r package; \
-    rm deephaven-embed-chart-${WEB_VERSION}.tgz;
+    rm deephaven-embed-chart-${CHART_VERSION}.tgz;


### PR DESCRIPTION
- Needed to split up web versions, as we don't always publish 3 different packages with each version bump
- Release notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.19.1