### PR TITLE
Better handling for session expiry

### DIFF
--- a/server/src/main/java/io/deephaven/server/session/SessionService.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionService.java
@@ -5,6 +5,7 @@ package io.deephaven.server.session;
 
 import com.github.f4b6a3.uuid.UuidCreator;
 import com.google.protobuf.ByteString;
+import com.google.rpc.Code;
 import io.deephaven.auth.AuthenticationException;
 import io.deephaven.auth.AuthenticationRequestHandler;
 import io.deephaven.configuration.Configuration;
@@ -383,6 +384,9 @@ public class SessionService {
 
         @Override
         void onClose() {
+            GrpcUtil.safelyExecuteLocked(responseObserver, () -> {
+                responseObserver.onError(GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED, "Session has ended"));
+            });
             terminationListeners.remove(this);
         }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -438,8 +438,11 @@ public class WorkerConnection {
                             // restart the termination notification
                             subscribeToTerminationNotification();
                             return;
+                        } else {
+                            info.notifyConnectionError(Js.cast(fail));
                         }
                     }
+                    assert success != null;
 
                     // welp; the server is gone -- let everyone know
                     info.notifyConnectionError(new ResponseStreamWrapper.Status() {


### PR DESCRIPTION
Server should send a non-empty message when the session ends, and js client should notify user of failure in all cases.

Partial #2985