### PR TITLE
Remove explicit JVM flags around GC

### DIFF
--- a/containers/groovy-examples/docker-compose.yml
+++ b/containers/groovy-examples/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples:latest

--- a/containers/groovy/docker-compose.yml
+++ b/containers/groovy/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g

--- a/containers/python-examples-redpanda/docker-compose.yml
+++ b/containers/python-examples-redpanda/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples

--- a/containers/python-examples/All-AI/docker-compose.yml
+++ b/containers/python-examples/All-AI/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples:latest

--- a/containers/python-examples/NLTK/docker-compose.yml
+++ b/containers/python-examples/NLTK/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples:latest

--- a/containers/python-examples/PyTorch/docker-compose.yml
+++ b/containers/python-examples/PyTorch/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples:latest

--- a/containers/python-examples/SciKit-Learn/docker-compose.yml
+++ b/containers/python-examples/SciKit-Learn/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples:latest

--- a/containers/python-examples/TensorFlow/docker-compose.yml
+++ b/containers/python-examples/TensorFlow/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples:latest

--- a/containers/python-examples/base/docker-compose.yml
+++ b/containers/python-examples/base/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g
 
   examples:
     image: ghcr.io/deephaven/examples:latest

--- a/containers/python/All-AI/docker-compose.yml
+++ b/containers/python/All-AI/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g

--- a/containers/python/NLTK/docker-compose.yml
+++ b/containers/python/NLTK/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g

--- a/containers/python/PyTorch/docker-compose.yml
+++ b/containers/python/PyTorch/docker-compose.yml
@@ -9,4 +9,4 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g

--- a/containers/python/SciKit-Learn/docker-compose.yml
+++ b/containers/python/SciKit-Learn/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g

--- a/containers/python/TensorFlow/docker-compose.yml
+++ b/containers/python/TensorFlow/docker-compose.yml
@@ -9,4 +9,4 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g

--- a/containers/python/base/docker-compose.yml
+++ b/containers/python/base/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JAVA_OPTS=-Xmx4g
+      - START_OPTS=-Xmx4g

--- a/debezium/perf/docker-compose.yml
+++ b/debezium/perf/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     # For jprofiler, uncomment the next line.
     # build: ../../jprofiler-server
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx${DEEPHAVEN_HEAP} -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+      - START_OPTS=-Xmx${DEEPHAVEN_HEAP} -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       - PERF_TAG  # Used to specify a subdirectory under ./logs where to store perf samples logs
       # For jprofiler sessions (if you tweaked the jprofiler version in jprofiler-server/Dockerfile you need to tweak the path below):
       # Then use this startup options:

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -14,13 +14,13 @@ services:
       # with max memory.
       #
       # To turn on debug logging, add: -Dlogback.configurationFile=logback-debug.xml
-      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+      - START_OPTS=-Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       #
       # For remote debugging switch the line above for the one below (and also change the ports below)
-      # - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+      # - START_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
       #
       # For jprofiler sessions (if you tweaked the jprofiler version in jprofiler-server/Dockerfile you need to tweak path)
-      # - JAVA_TOOL_OPTIONS=-agentpath:/opt/jprofiler13.0/bin/linux-x64/libjprofilerti.so=port=8849,nowait -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
+      # - START_OPTS=-agentpath:/opt/jprofiler13.0/bin/linux-x64/libjprofilerti.so=port=8849,nowait -Xmx4g -Ddeephaven.console.type=${DEEPHAVEN_CONSOLE_TYPE} -Ddeephaven.application.dir=${DEEPHAVEN_APPLICATION_DIR}
 
     ports:
       - '10000:10000'

--- a/docker/server-jetty/src/main/docker/Dockerfile
+++ b/docker/server-jetty/src/main/docker/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=install / /
 VOLUME /data
 VOLUME /cache
 HEALTHCHECK --interval=3s --retries=3 --timeout=11s CMD /bin/grpc_health_probe -addr=localhost:10000 -connect-timeout=10s || exit 1
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication"
 ENTRYPOINT [ "/opt/deephaven/server/bin/start", "image-bootstrap.properties" ]
 ARG DEEPHAVEN_VERSION
 ARG SERVER

--- a/docker/server/src/main/docker/Dockerfile
+++ b/docker/server/src/main/docker/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=install / /
 VOLUME /data
 VOLUME /cache
 HEALTHCHECK --interval=3s --retries=3 --timeout=11s CMD /bin/grpc_health_probe -addr=localhost:8080 -connect-timeout=10s || exit 1
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication"
 ENTRYPOINT [ "/opt/deephaven/server/bin/start", "image-bootstrap.properties" ]
 ARG DEEPHAVEN_VERSION
 ARG SERVER

--- a/java-client/barrage-examples/build.gradle
+++ b/java-client/barrage-examples/build.gradle
@@ -29,10 +29,8 @@ def createApplication = { String name, String mainClass ->
         script.classpath = startScripts.classpath
         script.defaultJvmOpts = [
                 '-server',
-                '-XX:+UseG1GC',
-                '-XX:MaxGCPauseMillis=100',
-                '-XX:+UseStringDeduplication',
-                '-DConfiguration.rootFile=dh-defaults.prop']
+                '-DConfiguration.rootFile=dh-defaults.prop'
+        ]
     }
 }
 

--- a/java-client/flight-examples/build.gradle
+++ b/java-client/flight-examples/build.gradle
@@ -31,9 +31,7 @@ def createApplication = { String name, String mainClass ->
         script.classpath = startScripts.classpath
         script.defaultJvmOpts = [
                 '-server',
-                '-XX:+UseG1GC',
-                '-XX:MaxGCPauseMillis=100',
-                '-XX:+UseStringDeduplication' ]
+        ]
     }
 }
 

--- a/java-client/session-examples/build.gradle
+++ b/java-client/session-examples/build.gradle
@@ -31,9 +31,7 @@ def createApplication = { String name, String mainClass ->
         script.classpath = startScripts.classpath
         script.defaultJvmOpts = [
                 '-server',
-                '-XX:+UseG1GC',
-                '-XX:MaxGCPauseMillis=100',
-                '-XX:+UseStringDeduplication' ]
+        ]
     }
 }
 

--- a/py/embedded-server/deephaven_server/start_jvm.py
+++ b/py/embedded-server/deephaven_server/start_jvm.py
@@ -28,13 +28,6 @@ DEFAULT_JVM_PROPERTIES = {
     # 'deephaven.console.disable': 'true',
 }
 DEFAULT_JVM_ARGS = [
-    # Uee the G1 GC
-    '-XX:+UseG1GC',
-    # G1GC: Set a goal for the max duration of a GC pause
-    '-XX:MaxGCPauseMillis=100',
-    # G1GC: Try to deduplicate strings on the Java heap
-    '-XX:+UseStringDeduplication',
-
     # Disable the JVM's signal handling for interactive python consoles - if python will
     # not be handling signals like ctrl-c (for KeyboardInterrupt), this should be safe to
     # remove for a small performance gain.

--- a/py/server/test_helper/__init__.py
+++ b/py/server/test_helper/__init__.py
@@ -66,10 +66,6 @@ def start_jvm(jvm_props: Dict[str, str] = None):
             jvm_properties.update(jvm_props)
 
         jvm_options = {
-            '-XX:+UseG1GC',
-            '-XX:MaxGCPauseMillis=100',
-            '-XX:+UseStringDeduplication',
-
             '-XX:InitialRAMPercentage=25.0',
             '-XX:MinRAMPercentage=70.0',
             '-XX:MaxRAMPercentage=80.0',

--- a/server/jetty-app/README.md
+++ b/server/jetty-app/README.md
@@ -55,7 +55,7 @@ produces
 The above artifacts can be uncompressed and their `bin/start` script can be executed:
 
 ```shell
- JAVA_OPTS="-Ddeephaven.console.type=groovy" bin/start
+START_OPTS="-Ddeephaven.console.type=groovy" bin/start
 ```
 
 Alternatively, the uncompressed installation can be built directly by gradle:
@@ -67,7 +67,7 @@ Alternatively, the uncompressed installation can be built directly by gradle:
 And then run via:
 
 ```shell
-JAVA_OPTS="-Ddeephaven.console.type=groovy" ./server/jetty-app/build/install/server-jetty/bin/start
+START_OPTS="-Ddeephaven.console.type=groovy" ./server/jetty-app/build/install/server-jetty/bin/start
 ```
 
 Finally, Gradle can be used to update the build and run the application in a single step:

--- a/server/jetty-app/build.gradle
+++ b/server/jetty-app/build.gradle
@@ -65,8 +65,12 @@ if (hasProperty('gcApplication')) {
 tasks.withType(JavaExec).configureEach {
     // This appends to the existing jvm args, so that java-open-nio still takes effect
     jvmArgs extraJvmArgs
-    // For development in this repository via Gradle, use the top-level data directory
-    jvmArgs "-Dstorage.path=${rootDir}/data"
+
+    jvmArgs '-XX:+UseG1GC',
+            '-XX:MaxGCPauseMillis=100',
+            '-XX:+UseStringDeduplication',
+            // For development in this repository via Gradle, use the top-level data directory
+            "-Dstorage.path=${rootDir}/data"
 }
 
 tasks.withType(CreateStartScripts).configureEach {

--- a/server/jetty-app/build.gradle
+++ b/server/jetty-app/build.gradle
@@ -24,9 +24,6 @@ distributions {
 
 def extraJvmArgs = [
         '-server',
-        '-XX:+UseG1GC',
-        '-XX:MaxGCPauseMillis=100',
-        '-XX:+UseStringDeduplication',
         '-XshowSettings:vm',
 ]
 

--- a/server/netty-app/README.md
+++ b/server/netty-app/README.md
@@ -16,7 +16,7 @@ produces
 The above artifacts can be uncompressed and their `bin/start` script can be executed:
 
 ```shell
- JAVA_OPTS="-Ddeephaven.console.type=groovy" bin/start
+START_OPTS="-Ddeephaven.console.type=groovy" bin/start
 ```
 
 Alternatively, the uncompressed installation can be built directly by gradle:
@@ -28,7 +28,7 @@ Alternatively, the uncompressed installation can be built directly by gradle:
 And then run via:
 
 ```shell
-JAVA_OPTS="-Ddeephaven.console.type=groovy" ./server/netty-app/build/install/server/bin/start
+START_OPTS="-Ddeephaven.console.type=groovy" ./server/netty-app/build/install/server/bin/start
 ```
 
 Finally, Gradle can be used to update the build and run the application in a single step:

--- a/server/netty-app/build.gradle
+++ b/server/netty-app/build.gradle
@@ -65,6 +65,12 @@ if (hasProperty('gcApplication')) {
 tasks.withType(JavaExec).configureEach {
     // This appends to the existing jvm args, so that java-open-nio still takes effect
     jvmArgs extraJvmArgs
+
+    jvmArgs '-XX:+UseG1GC',
+            '-XX:MaxGCPauseMillis=100',
+            '-XX:+UseStringDeduplication',
+            // For development in this repository via Gradle, use the top-level data directory
+            "-Dstorage.path=${rootDir}/data"
 }
 
 tasks.withType(CreateStartScripts).configureEach {

--- a/server/netty-app/build.gradle
+++ b/server/netty-app/build.gradle
@@ -24,9 +24,6 @@ distributions {
 
 def extraJvmArgs = [
         '-server',
-        '-XX:+UseG1GC',
-        '-XX:MaxGCPauseMillis=100',
-        '-XX:+UseStringDeduplication',
         '-XshowSettings:vm',
 ]
 


### PR DESCRIPTION
We currently bake-in some GC options that would be better left to default JDK ergonomics or the user.

For example, we are currently unable to (easily) change the garbage collector:

```
$ docker run --env "JAVA_OPTS=-XX:+UseZGC" --rm ghcr.io/deephaven/server:0.17.0             
Error occurred during initialization of VM
Multiple garbage collectors selected
```