### PR TITLE
Bump boringssl tcnative

### DIFF
--- a/buildSrc/src/main/groovy/Classpaths.groovy
+++ b/buildSrc/src/main/groovy/Classpaths.groovy
@@ -96,6 +96,7 @@ class Classpaths {
 
     static final String GRPC_GROUP = 'io.grpc'
     static final String GRPC_NAME = 'grpc-bom'
+    // Only bump this in concert w/ BORINGSSL_VERSION
     static final String GRPC_VERSION = '1.49.2'
 
     // TODO(deephaven-core#1685): Create strategy around updating and maintaining protoc version
@@ -106,7 +107,8 @@ class Classpaths {
     // See dependency matrix for particular gRPC versions at https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
     static final String BORINGSSL_GROUP = 'io.netty'
     static final String BORINGSSL_NAME = 'netty-tcnative-boringssl-static'
-    static final String BORINGSSL_VERSION = '2.0.46.Final'
+    // Only bump this in concert w/ GRPC_VERSION
+    static final String BORINGSSL_VERSION = '2.0.53.Final'
 
     static final String JACKSON_GROUP = 'com.fasterxml.jackson'
     static final String JACKSON_NAME = 'jackson-bom'


### PR DESCRIPTION
Fixes issue with URI resolution:

```
java.lang.NoClassDefFoundError: io/netty/internal/tcnative/CertificateCompressionAlgo
	at io.netty.handler.ssl.SslContext.newClientContextInternal(SslContext.java:831)
	at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:611)
	at io.deephaven.client.impl.ChannelHelper.channel(ChannelHelper.java:57)
	at io.deephaven.server.uri.BarrageTableResolver.newSession(BarrageTableResolver.java:307)
	at io.deephaven.server.uri.BarrageTableResolver.newSession(BarrageTableResolver.java:299)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at io.deephaven.server.uri.BarrageTableResolver.session(BarrageTableResolver.java:295)
	at io.deephaven.server.uri.BarrageTableResolver.subscribe(BarrageTableResolver.java:145)
	at io.deephaven.server.uri.BarrageTableResolver.subscribe(BarrageTableResolver.java:121)
	at io.deephaven.server.uri.BarrageTableResolver.resolve(BarrageTableResolver.java:106)
	at io.deephaven.server.uri.BarrageTableResolver.resolve(BarrageTableResolver.java:44)
	at io.deephaven.uri.resolver.UriResolvers.resolve(UriResolvers.java:65)
	at io.deephaven.uri.ResolveTools.resolve(ResolveTools.java:39)
	at io.deephaven.uri.ResolveTools.resolve(ResolveTools.java:29)
```

Added comment to help remind us to always check boringssl tcnative version bump when bumping gRPC.