### PR TITLE
Update web UI to v0.20.0

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,9 +2,9 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.19.1
-ARG GRID_VERSION=0.19.0
-ARG CHART_VERSION=0.19.0
+ARG WEB_VERSION=0.20.0
+ARG GRID_VERSION=0.20.0
+ARG CHART_VERSION=0.20.0
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Release Notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.20.0

NOTE: Before merging this, I want to investigate #3011 and merge a fix for that, as this will break everybody because there's (still) a caching issue lurking.