### PR TITLE
Update caching for web assets

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -68,7 +68,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
         // https://create-react-app.dev/docs/production-build/#static-file-caching
         context.addFilter(NoCacheFilter.class, "/ide/*", EnumSet.noneOf(DispatcherType.class));
         context.addFilter(NoCacheFilter.class, "/jsapi/*", EnumSet.noneOf(DispatcherType.class));
-        context.addFilter(CacheFilter.class, "/ide/static/*", EnumSet.noneOf(DispatcherType.class));
+        context.addFilter(CacheFilter.class, "/ide/assets/*", EnumSet.noneOf(DispatcherType.class));
 
         // Always add eTags
         context.setInitParameter("org.eclipse.jetty.servlet.Default.etags", "true");


### PR DESCRIPTION
- Web updated build system: https://github.com/deephaven/web-client-ui/pull/711
- With that build system change, production assets are now in `assets` folder instead of `static`
- Update to allow caching of `assets` directory
- Vite assets directory guide here: https://vitebook.dev/guides/assets.html

**Testing Done**
- Loaded up Web UI, ensured the response for the chunked files was cached and loaded from memory:
![image](https://user-images.githubusercontent.com/4505624/197562931-7577d3e7-8970-42f1-8f74-9c3d44667811.png)

Other files still have no-cache header and verify against ETag:
![image](https://user-images.githubusercontent.com/4505624/197563040-14074b42-14c6-4f38-b014-01ae35bf59c6.png)
