### PR TITLE
Update check-ci-results path to include all build/test-results

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -49,7 +49,7 @@ jobs:
         if: always()
         with:
           name: check-ci-results
-          path: '**/build/test-results/*/TEST-*.xml'
+          path: '**/build/test-results/**'
 
       - name: Upload Test Reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -51,7 +51,7 @@ jobs:
           name: check-ci-results
           path: |
             **/build/test-results/**
-            !**/test*/binary/**
+            !**/build/test-results/**/binary/**
 
       - name: Upload Test Reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -49,7 +49,9 @@ jobs:
         if: always()
         with:
           name: check-ci-results
-          path: '**/build/test-results/**'
+          path: |
+            **/build/test-results/**
+            !**/test*/binary/**
 
       - name: Upload Test Reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -66,8 +66,9 @@ jobs:
         with:
           name: nightly-${{ matrix.gradle-task }}-java${{ matrix.test-jvm-version }}-ci-results
           path: |
-            **/build/test-results/*/TEST-*.xml
+            **/build/test-results/**
             **/build/reports/tests/**
+            !**/test*/binary/**
 
       - name: Upload JVM Error Logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -68,7 +68,7 @@ jobs:
           path: |
             **/build/test-results/**
             **/build/reports/tests/**
-            !**/test*/binary/**
+            !**/build/test-results/**/binary/**
 
       - name: Upload JVM Error Logs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
go and cpp-client are missing test and log data

```
$ find cpp-client/build/test-results -type f    
cpp-client/build/test-results/cpp-test.log
cpp-client/build/test-results/cpp-test.xml

$ find go/build/test-results -type f
go/build/test-results/go-test.xml
```

The check-ci-results path is too specific, and was built before these client tests existed.