### PR TITLE
Disable weak etags provided by Jetty

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -70,8 +70,6 @@ public class JettyBackedGrpcServer implements GrpcServer {
         context.addFilter(NoCacheFilter.class, "/jsapi/*", EnumSet.noneOf(DispatcherType.class));
         context.addFilter(CacheFilter.class, "/ide/assets/*", EnumSet.noneOf(DispatcherType.class));
 
-        // Always add eTags
-        context.setInitParameter("org.eclipse.jetty.servlet.Default.etags", "true");
         context.setSecurityHandler(new ConstraintSecurityHandler());
 
         // Add an extra filter to redirect from / to /ide/


### PR DESCRIPTION
While in theory a weak etag should be sufficient, Jetty's implementation is based only on name, file length, and last modified date. Gradle defautls to giving all files the same last modified date to avoid two builds of the same contents having different jar outputs, so for a given file name, only its length can change, and if that length is the same with different bytes, browsers will not get updates. While asking gradle to not remove last modified dates would work, it also would require the build to be slower by rebuilding downstream artifacts even though contents did not change.

Fixes #3011