### PR TITLE
Wrap Jetty's Resource type to force an invalid last-modified header

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheResource.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheResource.java
@@ -1,0 +1,122 @@
+package io.deephaven.server.jetty;
+
+import org.eclipse.jetty.util.resource.Resource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.channels.ReadableByteChannel;
+
+/**
+ * Simple wrapper around the Jetty Resource type, to grant us control over caching features. The current implementation
+ * only removes the last-modified value, but a future version could provide a "real" weak/strong etag.
+ */
+public class ControlledCacheResource extends Resource {
+    private final Resource wrapped;
+
+    public ControlledCacheResource(Resource wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public boolean isContainedIn(Resource r) throws MalformedURLException {
+        return wrapped.isContainedIn(r);
+    }
+
+    @Override
+    public void close() {
+        wrapped.close();
+    }
+
+    @Override
+    public boolean exists() {
+        return wrapped.exists();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return wrapped.isDirectory();
+    }
+
+    @Override
+    public long lastModified() {
+        // Always return -1, so that we don't get the build system timestamp. In theory we could return the app startup
+        // time as well, so that clients that connect don't need to revalidate quite as often, but this could have other
+        // side effects such as in load balancing with a short-lived old build against a seconds-older new build.
+        return -1;
+    }
+
+    @Override
+    public long length() {
+        return wrapped.length();
+    }
+
+    @Override
+    public URI getURI() {
+        return wrapped.getURI();
+    }
+
+    @Override
+    public File getFile() throws IOException {
+        return wrapped.getFile();
+    }
+
+    @Override
+    public String getName() {
+        return wrapped.getName();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return wrapped.getInputStream();
+    }
+
+    @Override
+    public ReadableByteChannel getReadableByteChannel() throws IOException {
+        return wrapped.getReadableByteChannel();
+    }
+
+    @Override
+    public boolean delete() throws SecurityException {
+        return wrapped.delete();
+    }
+
+    @Override
+    public boolean renameTo(Resource dest) throws SecurityException {
+        return wrapped.renameTo(dest);
+    }
+
+    @Override
+    public String[] list() {
+        return wrapped.list();
+    }
+
+    @Override
+    public Resource addPath(String path) throws IOException, MalformedURLException {
+        // Re-wrap any instance that might be returned
+        return new ControlledCacheResource(wrapped.addPath(path));
+    }
+
+    @Override
+    public String toString() {
+        // Jetty's CachedContentFactory.CachedHttpContent requires that toString return the underlying URL found on
+        // disk, or else the mime lookup from content type won't resolve anything.
+        return wrapped.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        // As with toString, delegating this to the wrapped instance, just in case there is some specific, expected
+        // behavior
+        return wrapped.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // As with toString, delegating this to the wrapped instance, just in case there is some specific, expected
+        // behavior
+        return wrapped.equals(obj);
+    }
+}

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheResource.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheResource.java
@@ -14,9 +14,16 @@ import java.nio.channels.ReadableByteChannel;
  * only removes the last-modified value, but a future version could provide a "real" weak/strong etag.
  */
 public class ControlledCacheResource extends Resource {
+    public static ControlledCacheResource wrap(Resource wrapped) {
+        if (wrapped instanceof ControlledCacheResource) {
+            return (ControlledCacheResource) wrapped;
+        }
+        return new ControlledCacheResource(wrapped);
+    }
+
     private final Resource wrapped;
 
-    public ControlledCacheResource(Resource wrapped) {
+    private ControlledCacheResource(Resource wrapped) {
         this.wrapped = wrapped;
     }
 
@@ -96,7 +103,7 @@ public class ControlledCacheResource extends Resource {
     @Override
     public Resource addPath(String path) throws IOException, MalformedURLException {
         // Re-wrap any instance that might be returned
-        return new ControlledCacheResource(wrapped.addPath(path));
+        return wrap(wrapped.addPath(path));
     }
 
     @Override

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/DropIfModifiedSinceHeader.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/DropIfModifiedSinceHeader.java
@@ -1,0 +1,70 @@
+package io.deephaven.server.jetty;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpHeader;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * Removes the if-modified-since header from any request that contains it.
+ */
+public class DropIfModifiedSinceHeader extends HttpFilter {
+
+    @Override
+    protected void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        String ifModifiedSince = HttpHeader.IF_MODIFIED_SINCE.asString();
+        if (req.getHeader(ifModifiedSince) != null) {
+            chain.doFilter(new HeaderRemovingHttpServletRequestWrapper(req, ifModifiedSince), res);
+        } else {
+            chain.doFilter(req, res);
+        }
+    }
+
+    static class HeaderRemovingHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+        private final String headerToRemove;
+
+        /**
+         * Constructs a request object wrapping the given request.
+         *
+         * @param request the {@link HttpServletRequest} to be wrapped.
+         * @throws IllegalArgumentException if the request is null
+         */
+        public HeaderRemovingHttpServletRequestWrapper(HttpServletRequest request, String headerToRemove) {
+            super(request);
+            this.headerToRemove = headerToRemove;
+        }
+
+        @Override
+        public String getHeader(String name) {
+            if (name.equalsIgnoreCase(headerToRemove)) {
+                return null;
+            }
+            return super.getHeader(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            if (name.equalsIgnoreCase(headerToRemove)) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getHeaders(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            List<String> replacement = Collections.list(super.getHeaderNames());
+            replacement.remove(headerToRemove);
+            return Collections.enumeration(replacement);
+        }
+    }
+}

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/DropIfModifiedSinceHeader.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/DropIfModifiedSinceHeader.java
@@ -53,6 +53,22 @@ public class DropIfModifiedSinceHeader extends HttpFilter {
         }
 
         @Override
+        public long getDateHeader(String name) {
+            if (name.equalsIgnoreCase(headerToRemove)) {
+                return -1;
+            }
+            return super.getDateHeader(name);
+        }
+
+        @Override
+        public int getIntHeader(String name) {
+            if (name.equalsIgnoreCase(headerToRemove)) {
+                return -1;
+            }
+            return super.getIntHeader(name);
+        }
+
+        @Override
         public Enumeration<String> getHeaders(String name) {
             if (name.equalsIgnoreCase(headerToRemove)) {
                 return Collections.emptyEnumeration();

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -3,7 +3,6 @@
  */
 package io.deephaven.server.jetty;
 
-import io.deephaven.server.config.ServerConfig;
 import io.deephaven.server.runner.GrpcServer;
 import io.deephaven.ssl.config.CiphersIntermediate;
 import io.deephaven.ssl.config.ProtocolsIntermediate;
@@ -12,7 +11,6 @@ import io.deephaven.ssl.config.TrustJdk;
 import io.deephaven.ssl.config.impl.KickstartUtils;
 import io.grpc.servlet.web.websocket.GrpcWebsocket;
 import io.grpc.servlet.web.websocket.MultiplexedWebSocketServerStream;
-import io.grpc.servlet.web.websocket.MultiplexedWebsocketStreamImpl;
 import io.grpc.servlet.web.websocket.WebSocketServerStream;
 import io.grpc.servlet.jakarta.web.GrpcWebFilter;
 import jakarta.servlet.DispatcherType;
@@ -43,8 +41,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -71,7 +67,8 @@ public class JettyBackedGrpcServer implements GrpcServer {
         try {
             String knownFile = "/ide/index.html";
             URL ide = JettyBackedGrpcServer.class.getResource(knownFile);
-            context.setBaseResource(Resource.newResource(ide.toExternalForm().replace("!" + knownFile, "!/")));
+            Resource jarContents = Resource.newResource(ide.toExternalForm().replace("!" + knownFile, "!/"));
+            context.setBaseResource(new ControlledCacheResource(jarContents));
         } catch (IOException ioException) {
             throw new UncheckedIOException(ioException);
         }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -78,6 +78,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
         context.addFilter(NoCacheFilter.class, "/ide/*", EnumSet.noneOf(DispatcherType.class));
         context.addFilter(NoCacheFilter.class, "/jsapi/*", EnumSet.noneOf(DispatcherType.class));
         context.addFilter(CacheFilter.class, "/ide/assets/*", EnumSet.noneOf(DispatcherType.class));
+        context.addFilter(DropIfModifiedSinceHeader.class, "/*", EnumSet.noneOf(DispatcherType.class));
 
         context.setSecurityHandler(new ConstraintSecurityHandler());
 

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -68,7 +68,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
             String knownFile = "/ide/index.html";
             URL ide = JettyBackedGrpcServer.class.getResource(knownFile);
             Resource jarContents = Resource.newResource(ide.toExternalForm().replace("!" + knownFile, "!/"));
-            context.setBaseResource(new ControlledCacheResource(jarContents));
+            context.setBaseResource(ControlledCacheResource.wrap(jarContents));
         } catch (IOException ioException) {
             throw new UncheckedIOException(ioException);
         }


### PR DESCRIPTION
Jetty always returns the last-modified date of the file, but Gradle unsets the "true" last modified date in favor of ensuring that build files cache only based on their contents. Disabling this feature is possible, but still may present as buggy in Jetty, such as if a 1.0 release occurred, then 2.0, then a 1.1 hotfix - if an installation of 1.1 were later replaced with 2.0, the 1.1 files would be "newer" so would be considered up to date.

This patch removes the last-modified value by only returning -1 when requested. We could go further and return an etag that actually maps to the release version or the contents of the file, but that is left for future work.

Fixes #3011