### PR TITLE
Add js-plugins pre-built support

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.util.resource.Resource;
@@ -73,6 +74,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
         } catch (IOException ioException) {
             throw new UncheckedIOException(ioException);
         }
+        context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");
 
         // For the Web UI, cache everything in the static folder
         // https://create-react-app.dev/docs/production-build/#static-file-caching
@@ -122,13 +124,11 @@ public class JettyBackedGrpcServer implements GrpcServer {
             });
         }
 
+        // Note: handler order matters
         HandlerCollection handlers = new HandlerCollection();
-
         // Set up /js-plugins/*
         JsPlugins.maybeAdd(handlers::addHandler);
-
         handlers.addHandler(context);
-
         jetty.setHandler(handlers);
     }
 

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -94,6 +94,9 @@ public class JettyBackedGrpcServer implements GrpcServer {
         // Wire up the provided grpc filter
         context.addFilter(new FilterHolder(filter), "/*", EnumSet.noneOf(DispatcherType.class));
 
+        // Set up /js-plugins/*
+        JsPlugins.maybeAdd(context);
+
         // Set up websockets for grpc-web - depending on configuration, we can register both in case we encounter a
         // client using "vanilla"
         // grpc-websocket, that can't multiplex all streams on a single socket

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -51,7 +51,7 @@ import java.util.function.Supplier;
 
 import static io.grpc.servlet.web.websocket.MultiplexedWebSocketServerStream.GRPC_WEBSOCKETS_MULTIPLEX_PROTOCOL;
 import static io.grpc.servlet.web.websocket.WebSocketServerStream.GRPC_WEBSOCKETS_PROTOCOL;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
+import static org.eclipse.jetty.servlet.ServletContextHandler.NO_SESSIONS;
 
 public class JettyBackedGrpcServer implements GrpcServer {
 
@@ -65,7 +65,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
         jetty.addConnector(createConnector(jetty, config));
 
         final WebAppContext context =
-                new WebAppContext(null, "/", null, null, null, new ErrorPageErrorHandler(), SESSIONS);
+                new WebAppContext(null, "/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
         try {
             String knownFile = "/ide/index.html";
             URL ide = JettyBackedGrpcServer.class.getResource(knownFile);
@@ -124,10 +124,11 @@ public class JettyBackedGrpcServer implements GrpcServer {
             });
         }
 
-        // Note: handler order matters
+        // Note: handler order matters due to pathSpec order
         HandlerCollection handlers = new HandlerCollection();
         // Set up /js-plugins/*
         JsPlugins.maybeAdd(handlers::addHandler);
+        // Set up /*
         handlers.addHandler(context);
         jetty.setHandler(handlers);
     }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
@@ -3,6 +3,7 @@ package io.deephaven.server.jetty;
 import io.deephaven.configuration.Configuration;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -24,13 +25,12 @@ class JsPlugins {
             return;
         }
         try {
-            Resource resource = ControlledCacheResource.wrap(Resource.resolveAlias(Resource.newResource(resourceBase)));
+            Resource resource = ControlledCacheResource.wrap(Resource.newResource(resourceBase));
             WebAppContext context = new WebAppContext(null, "/js-plugins/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
             context.setBaseResource(resource);
-
+            context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");
             // Suppress warnings about security handlers
             context.setSecurityHandler(new ConstraintSecurityHandler());
-
             addHandler.accept(context);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
@@ -34,7 +34,7 @@ class JsPlugins {
             context.setSecurityHandler(new ConstraintSecurityHandler());
             addHandler.accept(context);
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new IllegalStateException(String.format("Unable to resolve resourceBase '%s'", resourceBase), e);
         }
     }
 }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
@@ -26,7 +26,8 @@ class JsPlugins {
         }
         try {
             Resource resource = ControlledCacheResource.wrap(Resource.newResource(resourceBase));
-            WebAppContext context = new WebAppContext(null, "/js-plugins/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
+            WebAppContext context =
+                    new WebAppContext(null, "/js-plugins/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
             context.setBaseResource(resource);
             context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");
             // Suppress warnings about security handlers

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
@@ -1,0 +1,29 @@
+package io.deephaven.server.jetty;
+
+import io.deephaven.configuration.Configuration;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+class JsPlugins {
+
+    public static void maybeAdd(ServletContextHandler context) {
+        // Note: this would probably be better to live in JettyConfig - but until we establish more formal expectations
+        // for js plugin configuration and workflows, we'll keep this here.
+        final String resourceBase =
+                Configuration.getInstance().getStringWithDefault("deephaven.jsPlugins.resourceBase", null);
+        if (resourceBase == null) {
+            return;
+        }
+        context.addServlet(createServlet("js-plugins", resourceBase), "/js-plugins/*");
+    }
+
+    private static ServletHolder createServlet(String name, String resourceBase) {
+        final ServletHolder jsPlugins = new ServletHolder(name, DefaultServlet.class);
+        jsPlugins.setInitParameter("resourceBase", resourceBase);
+        jsPlugins.setInitParameter("pathInfoOnly", "true");
+        jsPlugins.setInitParameter("dirAllowed", "false");
+        jsPlugins.setAsyncSupported(true);
+        return jsPlugins;
+    }
+}


### PR DESCRIPTION
Fast and simple js plugin support via the configuration property `deephaven.jsPlugins.resourceBase` - assumes the user has already built a js plugins compatible directory to the necessary specifications (the server transparently passes through the data with no knowledge of the structure).

Niceties _can_ be added as documentation and additional follow-up. For example, the user can extend from the Deephaven official images and use the web-plugin-packager or similar construction in a multi-stage Dockerfile build to add the necessary structure to their own image.