### PR TITLE
Provide default directory for js plugins

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
@@ -1,15 +1,20 @@
 package io.deephaven.server.jetty;
 
+import io.deephaven.configuration.ConfigDir;
 import io.deephaven.configuration.Configuration;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
+import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.eclipse.jetty.servlet.ServletContextHandler.NO_SESSIONS;
@@ -17,24 +22,44 @@ import static org.eclipse.jetty.servlet.ServletContextHandler.NO_SESSIONS;
 class JsPlugins {
 
     public static void maybeAdd(Consumer<Handler> addHandler) {
+        resource()
+                .map(ControlledCacheResource::wrap)
+                .ifPresent(resource -> addResource(addHandler, resource));
+    }
+
+    private static void addResource(Consumer<Handler> addHandler, ControlledCacheResource resource) {
+        WebAppContext context =
+                new WebAppContext(null, "/js-plugins/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
+        context.setBaseResource(resource);
+        context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");
+        // Suppress warnings about security handlers
+        context.setSecurityHandler(new ConstraintSecurityHandler());
+        addHandler.accept(context);
+    }
+
+    private static Optional<Resource> resource() {
         // Note: this would probably be better to live in JettyConfig - but until we establish more formal expectations
         // for js plugin configuration and workflows, we'll keep this here.
         final String resourceBase =
                 Configuration.getInstance().getStringWithDefault("deephaven.jsPlugins.resourceBase", null);
         if (resourceBase == null) {
-            return;
+            // defaults to "<configDir>/js-plugins/" if it exists
+            return defaultJsPluginsDirectory()
+                    .filter(Files::exists)
+                    .map(PathResource::new);
         }
         try {
-            Resource resource = ControlledCacheResource.wrap(Resource.newResource(resourceBase));
-            WebAppContext context =
-                    new WebAppContext(null, "/js-plugins/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
-            context.setBaseResource(resource);
-            context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");
-            // Suppress warnings about security handlers
-            context.setSecurityHandler(new ConstraintSecurityHandler());
-            addHandler.accept(context);
+            return Optional.of(Resource.newResource(resourceBase));
         } catch (IOException e) {
             throw new IllegalStateException(String.format("Unable to resolve resourceBase '%s'", resourceBase), e);
         }
+    }
+
+    private static Optional<Path> defaultJsPluginsDirectory() {
+        return ConfigDir.get().map(JsPlugins::jsPluginsDir);
+    }
+
+    private static Path jsPluginsDir(Path configDir) {
+        return configDir.resolve("js-plugins");
     }
 }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JsPlugins.java
@@ -2,6 +2,8 @@ package io.deephaven.server.jetty;
 
 import io.deephaven.configuration.ConfigDir;
 import io.deephaven.configuration.Configuration;
+import io.deephaven.internal.log.LoggerFactory;
+import io.deephaven.io.logger.Logger;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -9,7 +11,6 @@ import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.util.resource.PathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,6 +22,8 @@ import static org.eclipse.jetty.servlet.ServletContextHandler.NO_SESSIONS;
 
 class JsPlugins {
 
+    private static final Logger log = LoggerFactory.getLogger(JsPlugins.class);
+
     public static void maybeAdd(Consumer<Handler> addHandler) {
         resource()
                 .map(ControlledCacheResource::wrap)
@@ -28,6 +31,7 @@ class JsPlugins {
     }
 
     private static void addResource(Consumer<Handler> addHandler, ControlledCacheResource resource) {
+        log.info().append("Creating JsPlugins context with resource '").append(resource.toString()).append('\'').endl();
         WebAppContext context =
                 new WebAppContext(null, "/js-plugins/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
         context.setBaseResource(resource);


### PR DESCRIPTION
I'd like to consider moving towards a model where "if you follow directory conventions, you don't need to explicitly set configuration properties".

As a motivating example, I'd like consumers of our docker images to install a JS plugins without needing to explicitly include a configuration property (file or system property).

```Dockerfile
# syntax=docker/dockerfile:1.4

FROM ghcr.io/deephaven/web-plugin-packager:latest as build
RUN ./pack-plugins.sh @deephaven/js-plugin-matplotlib

FROM ghcr.io/deephaven/server:latest
RUN pip install deephaven-plugin-matplotlib
COPY --link --from=build js-plugins/ /opt/deephaven/config/js-plugins/
```

As it stands now, the user would either need to explicitly add `deephaven.prop`:

```properties
includefiles=dh-defaults.prop

deephaven.jsPlugins.resourceBase=/opt/deephaven/config/js-plugins
```

```Dockerfile
COPY --link deephaven.prop /opt/deephaven/config/deephaven.prop
```

or, add a system property (which I want to try and discourage as much as possible):

```Dockerfile
ENV START_OPTS="-Ddeephaven.jsPlugins.resourceBase=/opt/deephaven/config/js-plugins"
```

This example is based off of https://github.com/deephaven-examples/deephaven-matplotlib-base/pull/3