### PR TITLE
JS API stream tables should only adjust sizes if they have a viewport

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/state/ClientTableState.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/state/ClientTableState.java
@@ -357,7 +357,7 @@ public final class ClientTableState extends TableConfig {
         JsConsumer<JsTable> doSetSize = table -> {
             long localSize = size;
             final ActiveTableBinding binding = getActiveBinding(table);
-            if (binding != null && table.isStreamTable()) {
+            if (binding != null && table.isStreamTable() && binding.getRows() != null) {
                 localSize = Math.min(size, binding.getRows().size());
             }
             table.setSize(localSize);


### PR DESCRIPTION
Fixes #3067