### PR TITLE
Use the PyCallableWrapper in formula code generation

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -1805,7 +1805,7 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
                 if (!n.getNameAsString().equals("call")) {
                     // to be backwards compatible with the syntax func.call(...)
                     innerPrinter.append("getAttribute(\"" + n.getName() + "\")");
-                    printer.append("(new io.deephaven.engine.util.PythonScopeJpyImpl.CallableWrapper(");
+                    printer.append("(new io.deephaven.engine.util.PyCallableWrapper(");
                     printer.append(innerPrinter);
                     printer.append(")).");
                 } else {


### PR DESCRIPTION
The problem was caused by the move to elevate CallWrapper from an inner class to a top level one but the code-gen been left unchanged.

Fixes 3103