### PR TITLE
Bump to gradle 7.6

### DIFF
--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -586,15 +586,16 @@ class Docker {
             inspect.imageId.set imageName
             inspect.mustRunAfter pullImage
             inspect.onNext { InspectImageResponse message ->
-                if (message.repoDigests.isEmpty()) {
+                def m = (InspectImageResponse) message
+                if (m.repoDigests.isEmpty()) {
                     throw new RuntimeException("Image '${imageName}' from the (local) repository does not have a repo digest. " +
                             "This is an unexpected situation, unless you are manually building the image.")
                 }
-                if (message.repoDigests.size() > 1) {
-                    throw new RuntimeException("Unable to bump the imageId for '${imageName}' since there are mulitple digests: '${message.repoDigests}'.\n" +
+                if (m.repoDigests.size() > 1) {
+                    throw new RuntimeException("Unable to bump the imageId for '${imageName}' since there are mulitple digests: '${m.repoDigests}'.\n" +
                             "Please update the property `deephaven.registry.imageId` in the file '${project.projectDir}/gradle.properties' manually.")
                 }
-                def repoDigest = message.repoDigests.get(0)
+                def repoDigest = m.repoDigests.get(0)
 
                 if (repoDigest != imageId) {
                     new File(project.projectDir, 'gradle.properties').text =
@@ -614,13 +615,14 @@ class Docker {
             inspect.imageId.set imageName
             inspect.mustRunAfter pullImage
             inspect.onNext { InspectImageResponse message ->
-                if (message.repoDigests.isEmpty()) {
+                def m = (InspectImageResponse) message
+                if (m.repoDigests.isEmpty()) {
                     throw new RuntimeException("Image '${imageName}' from the (local) repository does not have a repo digest. " +
                             "This is an unexpected situation, unless you are manually building the image.")
                 }
-                if (!(imageId in message.repoDigests)) {
+                if (!(imageId in m.repoDigests)) {
                     String text = "The imageId for '${imageName}' appears to be out-of-sync with the (local) repository. " +
-                            "Possible repo digests are '${message.repoDigests}'.\n" +
+                            "Possible repo digests are '${m.repoDigests}'.\n" +
                             "Consider running one of the following, and retrying the compare, to see if the issue persists:\n" +
                             "\t`./gradlew ${project.name}:${pullImage.get().name}`, or\n" +
                             "\t`docker pull ${imageName}`\n\n" +

--- a/buildSrc/src/main/groovy/io/deephaven/tools/docker/DiffTask.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/tools/docker/DiffTask.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.internal.file.FileLookup
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -32,7 +33,7 @@ abstract class DiffTask extends DefaultTask {
     abstract Property<Object> getExpectedContents()
     // In contrast, this is assumed to be a source directory, to easily allow some Sync action
     // to easily be the "fix this mistake" counterpart to this task
-    @Input
+    @InputDirectory
     abstract DirectoryProperty getActualContents()
 
     private final PatternSet ignoreInActual = new PatternSet();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionSha256Sum=312eb12875e1747e05c2f81a4789902d7e4ec5defbd1eefeaccc08acf096505d
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Groovy compilation is stricter now, failing out with "[Static type checking]" on places where generics were being used. Explicitly casting fixes the issue.

Solved for issue incorrect usage of `@Input` annotation, see https://docs.gradle.org/7.6/userguide/validation_problems.html#incorrect_use_of_input_annotation