### PR TITLE
Fix writing files when shorter than previous files

### DIFF
--- a/server/src/main/java/io/deephaven/server/notebook/FilesystemStorageServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/notebook/FilesystemStorageServiceGrpcImpl.java
@@ -33,7 +33,6 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.DirectoryNotEmptyException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -207,12 +206,12 @@ public class FilesystemStorageServiceGrpcImpl extends StorageServiceGrpc.Storage
             Path path = resolveOrThrow(request.getPath());
             requireNotRoot(path, "Can't overwrite the root directory");
             StandardOpenOption option =
-                    request.getAllowOverwrite() ? StandardOpenOption.CREATE : StandardOpenOption.CREATE_NEW;
+                    request.getAllowOverwrite() ? StandardOpenOption.TRUNCATE_EXISTING : StandardOpenOption.CREATE_NEW;
 
             byte[] bytes = request.getContents().toByteArray();
             String etag = ByteSource.wrap(bytes).hash(HASH_FUNCTION).toString();
             try {
-                Files.write(path, bytes, option);
+                Files.write(path, bytes, StandardOpenOption.CREATE, option);
             } catch (FileAlreadyExistsException alreadyExistsException) {
                 throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "File already exists");
             } catch (NoSuchFileException noSuchFileException) {


### PR DESCRIPTION
- We were not zero'ing out the previous files contents when overwriting an existing file, so any file that was saved shorter than it was previously had the remainder of previous file still included.
- Use `TRUNCATE_EXISTING` to truncate the length of file to 0 before overwriting: https://docs.oracle.com/javase/7/docs/api/java/nio/file/StandardOpenOption.html#TRUNCATE_EXISTING
- Always pass the `CREATE` flag. It is needed when using `TRUNCATE_EXISTING`, and ignored if the `CREATE_NEW` flag is also passed: https://docs.oracle.com/javase/7/docs/api/java/nio/file/StandardOpenOption.html#CREATE_NEW
- Fixes #3115

Tested using the snippet from the bug report, plus an additional check to make sure passing `false` doesn't allow overwriting an existing file.
Also tested making new files using the UI and saving them.
```
// Get the file storage service
const client = new dh.CoreClient("http://localhost:10000");
await client.login({type:dh.CoreClient.LOGIN_TYPE_ANONYMOUS});
const store = client.getStorageService();

// Use a new file name for each iteration of the test
const filename = '/notebooks/test-3.py';

// Save the initial text to the file
const text1 = '#1 Line 1\n#2 Line 2\n#3 Line 3\n#4 Line 4\n#5 Line 5\n#6 Line 6';
await store.saveFile(filename, dh.storage.FileContents.text(text1), true)
const result1 = await (await store.loadFile(filename)).text();
console.log('First load', result1, 'matches?', result1 == text1);

// Save the file again, with the two middle lines spliced out
const text2 = '#1 Line 1\n#2 Line 2\n#5 Line 5\n#6 Line 6'
await store.saveFile(filename, dh.storage.FileContents.text(text2), true)
const result2 = await (await store.loadFile(filename)).text();
console.log('Second load', result2, 'matches?', result2 == text2);

// Make sure it doesn't overwrite if the `false` flag is passed
try {
    await store.saveFile(filename, dh.storage.FileContents.text('should not write'), false)
    console.error('File was overwritten when it should not have been!');
} catch (e) {
    console.log('Received expected error while writing', e);
}

// Check that the loaded contents are still what we expect
const result3 = await (await store.loadFile(filename)).text();
console.log('Third load', result3, 'matches?', result3 == text2);
```