### PR TITLE
DeferredViewTable's filter ordering logic needs to respect view side effects

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -148,28 +149,55 @@ public class DeferredViewTable extends RedefinableTable {
 
         for (WhereFilter filter : filters) {
             filter.init(definition);
-            ArrayList<String> usedColumns = new ArrayList<>();
+            final Set<String> usedColumns = new HashSet<>();
             usedColumns.addAll(filter.getColumns());
             usedColumns.addAll(filter.getColumnArrays());
 
-            Map<String, String> renames = new HashMap<>();
             boolean postFilter = false;
+            Map<String, String> renames = new HashMap<>();
+            final Map<String, Set<String>> reverseLookup = new HashMap<>();
 
-            for (String column : usedColumns) {
-                for (SelectColumn selectColumn : deferredViewColumns) {
-                    if (selectColumn.getName().equals(column)) {
-                        if (selectColumn instanceof SwitchColumn) {
-                            selectColumn.initDef(tableReference.getDefinition().getColumnNameMap());
-                            selectColumn = ((SwitchColumn) selectColumn).getRealColumn();
-                        }
+            // determine if filter has any dependencies on deferred columns
+            for (int ii = deferredViewColumns.length - 1; ii >= 0; --ii) {
+                // traverse columns in reverse order to handle scenarios where a deferred column is renamed
+                SelectColumn selectColumn = deferredViewColumns[ii];
+                final String columnName = selectColumn.getName();
+                if (selectColumn.isRetain()) {
+                    continue;
+                }
+                if (!usedColumns.contains(columnName) && !reverseLookup.containsKey(columnName)) {
+                    continue;
+                }
+                if (selectColumn instanceof SwitchColumn) {
+                    selectColumn.initDef(tableReference.getDefinition().getColumnNameMap());
+                    selectColumn = ((SwitchColumn) selectColumn).getRealColumn();
+                }
 
-                        // we need to rename this column
-                        if (selectColumn instanceof SourceColumn) {
-                            // this is a rename of the getSourceName to the innerName
-                            renames.put(selectColumn.getName(), ((SourceColumn) selectColumn).getSourceName());
-                        } else {
-                            postFilter = true;
-                            break;
+                final String innerName;
+                if (selectColumn instanceof SourceColumn) {
+                    innerName = ((SourceColumn) selectColumn).getSourceName();
+                } else {
+                    // this is a deferred column
+                    postFilter = true;
+                    break;
+                }
+
+                // we need to rename this column
+                renames.put(columnName, innerName);
+                reverseLookup.putIfAbsent(innerName, new HashSet<>());
+
+                // check if this is an explicit rename
+                if (usedColumns.remove(columnName)) {
+                    reverseLookup.get(innerName).add(columnName);
+                }
+
+                // apply this rename to any other deferred columns that depend on this one
+                if (!selectColumn.isRetain()) {
+                    final Set<String> multiLevelRenames = reverseLookup.remove(columnName);
+                    if (multiLevelRenames != null) {
+                        for (final String resultColumnName : multiLevelRenames) {
+                            renames.put(resultColumnName, innerName);
+                            reverseLookup.get(innerName).add(resultColumnName);
                         }
                     }
                 }
@@ -177,24 +205,20 @@ public class DeferredViewTable extends RedefinableTable {
 
             if (postFilter) {
                 postViewFilters.add(filter);
+            } else if (renames.isEmpty()) {
+                preViewFilters.add(filter);
+            } else if (filter instanceof io.deephaven.engine.table.impl.select.MatchFilter) {
+                io.deephaven.engine.table.impl.select.MatchFilter matchFilter =
+                        (io.deephaven.engine.table.impl.select.MatchFilter) filter;
+                Assert.assertion(renames.size() == 1, "Match Filters should only use one column!");
+                String newName = renames.get(matchFilter.getColumnName());
+                Assert.neqNull(newName, "newName");
+                preViewFilters.add(matchFilter.renameFilter(newName));
+            } else if (filter instanceof ConditionFilter) {
+                ConditionFilter conditionFilter = (ConditionFilter) filter;
+                preViewFilters.add(conditionFilter.renameFilter(renames));
             } else {
-                if (!renames.isEmpty()) {
-                    if (filter instanceof io.deephaven.engine.table.impl.select.MatchFilter) {
-                        io.deephaven.engine.table.impl.select.MatchFilter matchFilter =
-                                (io.deephaven.engine.table.impl.select.MatchFilter) filter;
-                        Assert.assertion(renames.size() == 1, "Match Filters should only use one column!");
-                        String newName = renames.get(matchFilter.getColumnName());
-                        Assert.neqNull(newName, "newName");
-                        preViewFilters.add(matchFilter.renameFilter(newName));
-                    } else if (filter instanceof ConditionFilter) {
-                        ConditionFilter conditionFilter = (ConditionFilter) filter;
-                        preViewFilters.add(conditionFilter.renameFilter(renames));
-                    } else {
-                        postViewFilters.add(filter);
-                    }
-                } else {
-                    preViewFilters.add(filter);
-                }
+                postViewFilters.add(filter);
             }
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static io.deephaven.engine.table.impl.select.DhFormulaColumn.COLUMN_SUFFIX;
 
@@ -65,20 +66,18 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
 
     @Override
     public List<String> getColumns() {
-        final ArrayList<String> result = new ArrayList<>(usedColumns.size());
-        for (final String usedColumn : usedColumns) {
-            result.add(outerToInnerNames.getOrDefault(usedColumn, usedColumn));
-        }
-        return result;
+        return usedColumns.stream()
+                .map(name -> outerToInnerNames.getOrDefault(name, name))
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<String> getColumnArrays() {
-        final ArrayList<String> result = new ArrayList<>(usedColumnArrays.size());
-        for (final String usedColumn : usedColumnArrays) {
-            result.add(outerToInnerNames.getOrDefault(usedColumn, usedColumn));
-        }
-        return result;
+        return usedColumnArrays.stream()
+                .map(name -> outerToInnerNames.getOrDefault(name, name))
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -116,7 +115,7 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
                 possibleVariables.put(columnName, column.getDataType());
                 possibleVariables.put(columnName + COLUMN_SUFFIX, vectorType);
 
-                Class<?> compType = column.getComponentType();
+                final Class<?> compType = column.getComponentType();
                 if (compType != null && !compType.isPrimitive()) {
                     possibleVariableParameterizedTypes.put(columnName, new Class[] {compType});
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
@@ -32,13 +32,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static io.deephaven.engine.table.impl.select.DhFormulaColumn.COLUMN_SUFFIX;
 
 public abstract class AbstractConditionFilter extends WhereFilterImpl {
     private static final Logger log = LoggerFactory.getLogger(AbstractConditionFilter.class);
     final Map<String, String> outerToInnerNames;
-    final Map<String, String> innerToOuterNames;
     @NotNull
     protected final String formula;
     List<String> usedColumns;
@@ -55,27 +55,30 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
         this.formula = formula;
         this.unboxArguments = unboxArguments;
         this.outerToInnerNames = Collections.emptyMap();
-        this.innerToOuterNames = Collections.emptyMap();
     }
 
     protected AbstractConditionFilter(@NotNull String formula, Map<String, String> renames, boolean unboxArguments) {
         this.formula = formula;
         this.outerToInnerNames = renames;
         this.unboxArguments = unboxArguments;
-        this.innerToOuterNames = new HashMap<>();
-        for (Map.Entry<String, String> outerInnerEntry : outerToInnerNames.entrySet()) {
-            innerToOuterNames.put(outerInnerEntry.getValue(), outerInnerEntry.getKey());
-        }
     }
 
     @Override
     public List<String> getColumns() {
-        return usedColumns;
+        final ArrayList<String> result = new ArrayList<>(usedColumns.size());
+        for (final String usedColumn : usedColumns) {
+            result.add(outerToInnerNames.getOrDefault(usedColumn, usedColumn));
+        }
+        return result;
     }
 
     @Override
     public List<String> getColumnArrays() {
-        return usedColumnArrays;
+        final ArrayList<String> result = new ArrayList<>(usedColumnArrays.size());
+        for (final String usedColumn : usedColumnArrays) {
+            result.add(outerToInnerNames.getOrDefault(usedColumn, usedColumn));
+        }
+        return result;
     }
 
     @Override
@@ -107,15 +110,13 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
                 }
             }
 
-            Class<?> compType;
-            for (ColumnDefinition<?> column : tableDefinition.getColumns()) {
+            final BiConsumer<String, ColumnDefinition<?>> createColumnMappings = (columnName, column) -> {
                 final Class<?> vectorType = DhFormulaColumn.getVectorType(column.getDataType());
-                final String columnName = innerToOuterNames.getOrDefault(column.getName(), column.getName());
 
                 possibleVariables.put(columnName, column.getDataType());
                 possibleVariables.put(columnName + COLUMN_SUFFIX, vectorType);
 
-                compType = column.getComponentType();
+                Class<?> compType = column.getComponentType();
                 if (compType != null && !compType.isPrimitive()) {
                     possibleVariableParameterizedTypes.put(columnName, new Class[] {compType});
                 }
@@ -123,6 +124,17 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
                     possibleVariableParameterizedTypes.put(columnName + COLUMN_SUFFIX,
                             new Class[] {column.getDataType()});
                 }
+            };
+
+            // By default all columns are available to the formula
+            for (final ColumnDefinition<?> column : tableDefinition.getColumns()) {
+                createColumnMappings.accept(column.getName(), column);
+            }
+            // Overwrite any existing column mapping using the provided renames.
+            for (final Map.Entry<String, String> entry : outerToInnerNames.entrySet()) {
+                final String columnName = entry.getKey();
+                final ColumnDefinition<?> column = tableDefinition.getColumn(entry.getValue());
+                createColumnMappings.accept(columnName, column);
             }
 
             log.debug("Expression (before) : " + formula);
@@ -149,11 +161,13 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
             for (String variable : result.getVariablesUsed()) {
                 final String columnToFind = outerToInnerNames.getOrDefault(variable, variable);
                 final String arrayColumnToFind;
+                final String arrayColumnOuterName;
                 if (variable.endsWith(COLUMN_SUFFIX)) {
-                    final String originalName = variable.substring(0, variable.length() - COLUMN_SUFFIX.length());
-                    arrayColumnToFind = outerToInnerNames.getOrDefault(originalName, originalName);
+                    arrayColumnOuterName = variable.substring(0, variable.length() - COLUMN_SUFFIX.length());
+                    arrayColumnToFind = outerToInnerNames.getOrDefault(arrayColumnOuterName, arrayColumnOuterName);
                 } else {
                     arrayColumnToFind = null;
+                    arrayColumnOuterName = null;
                 }
 
                 if (variable.equals("i")) {
@@ -163,9 +177,9 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
                 } else if (variable.equals("k")) {
                     usesK = true;
                 } else if (tableDefinition.getColumn(columnToFind) != null) {
-                    usedColumns.add(columnToFind);
+                    usedColumns.add(variable);
                 } else if (arrayColumnToFind != null && tableDefinition.getColumn(arrayColumnToFind) != null) {
-                    usedColumnArrays.add(arrayColumnToFind);
+                    usedColumnArrays.add(arrayColumnOuterName);
                 } else if (possibleParams.containsKey(variable)) {
                     paramsList.add(possibleParams.get(variable));
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ConditionFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ConditionFilter.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
@@ -822,7 +822,7 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                         .captureQueryLibrary()
                         .newQueryScope()
                         .build().open()) {
-                    ;
+
                     ExecutionContext.getContext().getQueryScope().putParam("queryScopeVar", "queryScopeValue");
                     ExecutionContext.getContext().getQueryScope().putParam("queryScopeFilter", 50000);
 

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -428,7 +428,8 @@ public class TestParquetTools {
                 t -> t.updateView("Y = X").where("(X_[ii] + Y_[ii]) % 2 == 0"));
     }
 
-    @Test public void testMultipleRenamesWithSameOuterName() {
+    @Test
+    public void testMultipleRenamesWithSameOuterName() {
         testWriteRead(emptyTable(10).update("X = ii", "Y = ii", "Z = ii % 3"),
                 t -> t.updateView("Y = Z", "Y = X").where("Y % 2 == 0"));
     }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -428,6 +428,11 @@ public class TestParquetTools {
                 t -> t.updateView("Y = X").where("(X_[ii] + Y_[ii]) % 2 == 0"));
     }
 
+    @Test public void testMultipleRenamesWithSameOuterName() {
+        testWriteRead(emptyTable(10).update("X = ii", "Y = ii", "Z = ii % 3"),
+                t -> t.updateView("Y = Z", "Y = X").where("Y % 2 == 0"));
+    }
+
     private void testWriteRead(Table source, Function<Table, Table> transform) {
         final File f2w = new File(testRoot, "testWriteRead.parquet");
         ParquetTools.writeTable(source, f2w);

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -404,6 +404,30 @@ public class TestParquetTools {
                 t -> t.view("T = X_[i-1]"));
     }
 
+    @Test
+    public void testMultipleIdenticalRenames() {
+        testWriteRead(emptyTable(10).update("X = `` + ii"),
+                t -> t.updateView("A = X", "B = X").where("(A + B).length() > 0"));
+        testWriteRead(emptyTable(10).update("X = `` + ii"),
+                t -> t.updateView("A = X", "B = X").where("(A_[ii] + B_[ii]).length() > 0"));
+    }
+
+    @Test
+    public void testChangedThenRenamed() {
+        testWriteRead(emptyTable(10).update("X = ii", "Y = ii"),
+                t -> t.updateView("Y = ii * 2", "X = Y").where("X % 2 == 0"));
+        testWriteRead(emptyTable(10).update("X = ii", "Y = ii"),
+                t -> t.updateView("Y = ii * 2", "X = Y").where("X_[ii] % 2 == 0"));
+    }
+
+    @Test
+    public void testOverloadAsRename() {
+        testWriteRead(emptyTable(10).update("X = ii"),
+                t -> t.updateView("Y = X").where("(X + Y) % 2 == 0"));
+        testWriteRead(emptyTable(10).update("X = ii"),
+                t -> t.updateView("Y = X").where("(X_[ii] + Y_[ii]) % 2 == 0"));
+    }
+
     private void testWriteRead(Table source, Function<Table, Table> transform) {
         final File f2w = new File(testRoot, "testWriteRead.parquet");
         ParquetTools.writeTable(source, f2w);


### PR DESCRIPTION
Fixes #2701. This fix requires the fix for #1683 in #3120; this fix is the first commit in the PR.

DeferredViewTable was being reckless when looking for column renames. We now look for multiple renames including renames of otherwise deferred columns. Additionally, abstract condition filter was not generating compilable code if two columns were renamed from the same source column. For example, `source.update("A = X", "B = X").where("(A + B).length() > 0")` would generate two local variables both named `X` in the filter, but still refer to them as `A` and `B`. Note that `X` in this context is a string -- but the only requirement is that the filter is an abstract condition filter.

I've added a few tests to catch both the original issue as well as other similar issues that I discovered during the spelunking process.