### PR TITLE
Add a reference to the descriptor when creating a contains filter

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/filter/FilterValue.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/filter/FilterValue.java
@@ -178,6 +178,7 @@ public class FilterValue {
 
     private FilterCondition makeContains(FilterValue term, double casesensitivity) {
         ContainsCondition contains = new ContainsCondition();
+        contains.setReference(this.descriptor.getReference());
         contains.setSearchString(term.descriptor.getLiteral().getStringValue());
         contains.setCaseSensitivity(casesensitivity);
 


### PR DESCRIPTION
- No reference we being set, so it didn't know which column to apply to
- Fixes #3128

Tested by using query:
```
from deephaven import empty_table
t = empty_table(1_000_000).update_view(["z=``+i"])
```
Used the right click menu to add contains filters, does not contains filters, and combinations of the two.