### PR TITLE
Update Web version to v0.22.2

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,9 +2,9 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.21.1
-ARG GRID_VERSION=0.21.1
-ARG CHART_VERSION=0.21.1
+ARG WEB_VERSION=0.22.2
+ARG GRID_VERSION=0.22.2
+ARG CHART_VERSION=0.22.2
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Release notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.22.2

Release notes needed for identifying restriction on copying/downloading CSV:

#### :rocket: Enhancement
* `code-studio`
  * [#904](https://github.com/deephaven/web-client-ui/pull/904) Added support for canCopy and canDownloadCsv server properties ([@Zhou-Ziheng](https://github.com/Zhou-Ziheng))