### PR TITLE
Shut down LogBuffer listeners when the client stream has closed

### DIFF
--- a/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
@@ -323,7 +323,7 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
         }
 
         @Override
-        public void onClose() {
+        protected void onClose() {
             logBuffer.unsubscribe(this);
         }
 

--- a/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
@@ -131,7 +131,7 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
                 return;
             }
             SessionState session = sessionService.getCurrentSession();
-            logBuffer.subscribe(new LogBufferStreamAdapter(session, request, responseObserver));
+            logBuffer.subscribe(new LogBufferStreamAdapter(session, request, responseObserver, logBuffer));
         });
     }
 
@@ -310,13 +310,21 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
     private static class LogBufferStreamAdapter extends SessionCloseableObserver<LogSubscriptionData>
             implements LogBufferRecordListener {
         private final LogSubscriptionRequest request;
+        private final LogBuffer logBuffer;
 
         public LogBufferStreamAdapter(
                 final SessionState session,
                 final LogSubscriptionRequest request,
-                final StreamObserver<LogSubscriptionData> responseObserver) {
+                final StreamObserver<LogSubscriptionData> responseObserver,
+                final LogBuffer logBuffer) {
             super(session, responseObserver);
             this.request = request;
+            this.logBuffer = logBuffer;
+        }
+
+        @Override
+        public void onClose() {
+            logBuffer.unsubscribe(this);
         }
 
         @Override

--- a/server/src/main/java/io/deephaven/server/session/SessionCloseableObserver.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionCloseableObserver.java
@@ -42,7 +42,7 @@ public abstract class SessionCloseableObserver<T> implements Closeable {
     /**
      * Override this to perform any additional specific clean up that must be performed.
      */
-    void onClose() {
+    public void onClose() {
 
     }
 }

--- a/server/src/main/java/io/deephaven/server/session/SessionCloseableObserver.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionCloseableObserver.java
@@ -42,7 +42,7 @@ public abstract class SessionCloseableObserver<T> implements Closeable {
     /**
      * Override this to perform any additional specific clean up that must be performed.
      */
-    public void onClose() {
+    protected void onClose() {
 
     }
 }

--- a/server/src/main/java/io/deephaven/server/session/SessionService.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionService.java
@@ -380,7 +380,7 @@ public class SessionService {
         }
 
         @Override
-        void onClose() {
+        public void onClose() {
             GrpcUtil.safelyExecuteLocked(responseObserver, () -> {
                 responseObserver.onError(GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED, "Session has ended"));
             });

--- a/server/src/main/java/io/deephaven/server/session/SessionService.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionService.java
@@ -380,7 +380,7 @@ public class SessionService {
         }
 
         @Override
-        public void onClose() {
+        protected void onClose() {
             GrpcUtil.safelyExecuteLocked(responseObserver, () -> {
                 responseObserver.onError(GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED, "Session has ended"));
             });


### PR DESCRIPTION
Discovered accidentally while debugging with a breakpoint set in guava's Preconditions checks, to try to catch other issues in progress.