### PR TITLE
Bump confluent platform to 7.3.0

### DIFF
--- a/extensions/kafka/build.gradle
+++ b/extensions/kafka/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     // Using io.confluent dependencies requires code in the toplevel build.gradle to add their maven repository.
     // Note: the -ccs flavor is provided by confluent as their community edition. It is equivalent to the maven central
     // version, but has a different version to make it easier to keep confluent dependencies aligned.
-    api 'org.apache.kafka:kafka-clients:7.2.1-ccs'
-    api 'io.confluent:kafka-avro-serializer:7.2.1'
+    api 'org.apache.kafka:kafka-clients:7.3.0-ccs'
+    api 'io.confluent:kafka-avro-serializer:7.3.0'
 
     implementation project(':Configuration')
     implementation project(':log-factory')


### PR DESCRIPTION
https://www.confluent.io/blog/introducing-confluent-platform-7-3/
https://docs.confluent.io/platform/7.3.0/release-notes/index.html