### PR TITLE
Bump hadoop-common to 3.3.4

### DIFF
--- a/ParquetHadoop/build.gradle
+++ b/ParquetHadoop/build.gradle
@@ -19,7 +19,7 @@ tasks.withType(License) {
 dependencies {
     api('org.apache.parquet:parquet-hadoop:1.12.3')
 
-    api('org.apache.hadoop:hadoop-common:3.3.3') {
+    api('org.apache.hadoop:hadoop-common:3.3.4') {
         // do not take any dependencies of this project,
         // we just want a few classes (Configuration, Path) for
         // simplified prototyping work, and api compatibility.


### PR DESCRIPTION
https://hadoop.apache.org/docs/r3.3.4/

Two things of potential interest:

* ARM Support
* Adoption of lz4-java and snappy-java
  * >For LZ4 and Snappy compression codec, Hadoop now moves to use lz4-java and snappy-java instead of requring the native libraries of these to be installed on the systems running Hadoop.