### PR TITLE
Modify OA `doRehash()` functions to properly debit `rehashCredits`

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/RightIncrementalAsOfJoinStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/RightIncrementalAsOfJoinStateManagerTypedBase.java
@@ -277,6 +277,9 @@ public abstract class RightIncrementalAsOfJoinStateManagerTypedBase extends Righ
             while (rsIt.hasMore()) {
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(bc.chunkSize);
 
+                // reset the rehash credits for this chunk
+                bc.rehashCredits.setValue(0);
+
                 while (doRehash(initialBuild, bc.rehashCredits, chunkOk.intSize())) {
                     migrateFront();
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/RightIncrementalAsOfJoinStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/RightIncrementalAsOfJoinStateManagerTypedBase.java
@@ -276,10 +276,6 @@ public abstract class RightIncrementalAsOfJoinStateManagerTypedBase extends Righ
 
             while (rsIt.hasMore()) {
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(bc.chunkSize);
-
-                // reset the rehash credits for this chunk
-                bc.rehashCredits.setValue(0);
-
                 while (doRehash(initialBuild, bc.rehashCredits, chunkOk.intSize())) {
                     migrateFront();
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/RightIncrementalAsOfJoinStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/RightIncrementalAsOfJoinStateManagerTypedBase.java
@@ -286,7 +286,12 @@ public abstract class RightIncrementalAsOfJoinStateManagerTypedBase extends Righ
 
                 getKeyChunks(buildSources, bc.getContexts, sourceKeyChunks, chunkOk);
 
+                final long oldEntries = numEntries;
                 buildHandler.doBuild(chunkOk, sourceKeyChunks);
+                final long entriesAdded = numEntries - oldEntries;
+                // if we actually added anything, then take away from the "equity" we've built up rehashing, otherwise
+                // don't penalize this build call with additional rehashing
+                bc.rehashCredits.subtract(entriesAdded);
 
                 bc.resetSharedContexts();
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/OperatorAggregationStateManagerOpenAddressedAlternateBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/OperatorAggregationStateManagerOpenAddressedAlternateBase.java
@@ -106,7 +106,6 @@ public abstract class OperatorAggregationStateManagerOpenAddressedAlternateBase
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(bc.chunkSize);
                 final int nextChunkSize = chunkOk.intSize();
                 onNextChunk(nextChunkSize);
-
                 while (doRehash(bc.rehashCredits, nextChunkSize)) {
                     migrateFront();
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/OperatorAggregationStateManagerOpenAddressedAlternateBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/OperatorAggregationStateManagerOpenAddressedAlternateBase.java
@@ -106,6 +106,10 @@ public abstract class OperatorAggregationStateManagerOpenAddressedAlternateBase
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(bc.chunkSize);
                 final int nextChunkSize = chunkOk.intSize();
                 onNextChunk(nextChunkSize);
+
+                // reset the rehash credits for this chunk
+                bc.rehashCredits.setValue(0);
+
                 while (doRehash(bc.rehashCredits, nextChunkSize)) {
                     migrateFront();
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/OperatorAggregationStateManagerOpenAddressedAlternateBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/OperatorAggregationStateManagerOpenAddressedAlternateBase.java
@@ -107,9 +107,6 @@ public abstract class OperatorAggregationStateManagerOpenAddressedAlternateBase
                 final int nextChunkSize = chunkOk.intSize();
                 onNextChunk(nextChunkSize);
 
-                // reset the rehash credits for this chunk
-                bc.rehashCredits.setValue(0);
-
                 while (doRehash(bc.rehashCredits, nextChunkSize)) {
                     migrateFront();
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/IncrementalNaturalJoinStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/IncrementalNaturalJoinStateManagerTypedBase.java
@@ -220,7 +220,7 @@ public abstract class IncrementalNaturalJoinStateManagerTypedBase extends Static
     public boolean doRehash(boolean fullRehash, MutableInt rehashCredits, int nextChunkSize,
             NaturalJoinModifiedSlotTracker modifiedSlotTracker) {
         if (rehashPointer > 0) {
-            final int requiredRehash = nextChunkSize - rehashCredits.intValue();
+            final int requiredRehash = Math.min(nextChunkSize, rehashPointer);
             if (requiredRehash <= 0) {
                 return false;
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/IncrementalNaturalJoinStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/IncrementalNaturalJoinStateManagerTypedBase.java
@@ -172,6 +172,10 @@ public abstract class IncrementalNaturalJoinStateManagerTypedBase extends Static
             while (rsIt.hasMore()) {
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(bc.chunkSize);
                 final int nextChunkSize = chunkOk.intSize();
+
+                // reset the rehash credits for this chunk
+                bc.rehashCredits.setValue(0);
+
                 while (doRehash(initialBuild, bc.rehashCredits, nextChunkSize, modifiedSlotTracker)) {
                     migrateFront(modifiedSlotTracker);
                 }
@@ -220,7 +224,7 @@ public abstract class IncrementalNaturalJoinStateManagerTypedBase extends Static
     public boolean doRehash(boolean fullRehash, MutableInt rehashCredits, int nextChunkSize,
             NaturalJoinModifiedSlotTracker modifiedSlotTracker) {
         if (rehashPointer > 0) {
-            final int requiredRehash = Math.min(nextChunkSize, rehashPointer);
+            final int requiredRehash = nextChunkSize - rehashCredits.intValue();
             if (requiredRehash <= 0) {
                 return false;
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/UpdateByStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/UpdateByStateManagerTypedBase.java
@@ -214,10 +214,6 @@ public abstract class UpdateByStateManagerTypedBase extends UpdateByStateManager
 
             while (rsIt.hasMore()) {
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(bc.chunkSize);
-
-                // reset the rehash credits for this chunk
-                bc.rehashCredits.setValue(0);
-
                 while (doRehash(initialBuild, bc.rehashCredits, chunkOk.intSize(), outputPositions)) {
                     migrateFront(outputPositions);
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/UpdateByStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/UpdateByStateManagerTypedBase.java
@@ -215,6 +215,9 @@ public abstract class UpdateByStateManagerTypedBase extends UpdateByStateManager
             while (rsIt.hasMore()) {
                 final RowSequence chunkOk = rsIt.getNextRowSequenceWithLength(bc.chunkSize);
 
+                // reset the rehash credits for this chunk
+                bc.rehashCredits.setValue(0);
+
                 while (doRehash(initialBuild, bc.rehashCredits, chunkOk.intSize(), outputPositions)) {
                     migrateFront(outputPositions);
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/UpdateByStateManagerTypedBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/UpdateByStateManagerTypedBase.java
@@ -224,7 +224,12 @@ public abstract class UpdateByStateManagerTypedBase extends UpdateByStateManager
 
                 getKeyChunks(buildSources, bc.getContexts, sourceKeyChunks, chunkOk);
 
+                final long oldEntries = numEntries;
                 buildHandler.doBuild(chunkOk, sourceKeyChunks);
+                final long entriesAdded = numEntries - oldEntries;
+                // if we actually added anything, then take away from the "equity" we've built up rehashing, otherwise
+                // don't penalize this build call with additional rehashing
+                bc.rehashCredits.subtract(entriesAdded);
 
                 bc.resetSharedContexts();
             }


### PR DESCRIPTION
This change prevents the rehash queue from being starved when there are frequent large updates.

Will close #3202