### PR TITLE
Fix default_groovy.env

### DIFF
--- a/default_groovy.env
+++ b/default_groovy.env
@@ -2,4 +2,4 @@ COMPOSE_PROJECT_NAME=core
 DEEPHAVEN_PORT=10000
 DEEPHAVEN_CONSOLE_TYPE=groovy
 DEEPHAVEN_APPLICATION_DIR=/data/app.d
-DEEPHAVEN_SERVER_IMAGE=deephaven/server-slim:local-build
+DEEPHAVEN_SERVER_IMAGE=deephaven/server-jetty:local-build


### PR DESCRIPTION
DEEPHAVEN_SERVER_IMAGE was set to an outdated image. This sets it correctly. Tested with:

```
./gradlew prepareCompose
docker compose --env-file default_groovy.env up
```