### PR TITLE
Add JAVA_OPTS and START_OPTS environment variable parsing for gradle

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -213,7 +213,4 @@ tasks.withType(CreateStartScripts).configureEach {
   // Note that we don't call compilerArgs() at this time, there is no way to template those strings.
   // Instead, we hard code the expected paths in the above templates to match the path etc/dh-compiler-directives.txt
 //  defaultJvmOpts += compilerArgs(compilerDirectivesFile.singleFile.path)
-
-  // The start script has its own logic for parsing the START_OPTS environment variable
-  // defaultJvmOpts += START_OPTS
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -116,12 +116,24 @@ def compilerArgs = { String compilerDirectivesFile ->
   ]
 }
 
-// Utility to add jvm args to all executions, whether intellij or from a application script or gradle javaexec
-def devJvmArgs = [
-//  '-XX:Tier4CompileThreshold=1000', // this optional line makes it easier to trigger the c2 error on the above methods
-//  '-XX:+PrintFlagsFinal',           // this optional line makes it easier to explore the final values for compiler args
-//  '-XX:+PrintCompilation',          // this optional line shows jit operations as they happen
-]
+def parseJvmArgumentsFromEnv = { String envName, List<String> orElse ->
+  def s = System.getenv(envName)
+  if (s == null) {
+    return orElse
+  }
+  // Note: this logic could be improved to handle quotes and other cases, but hopefully this suffices for now.
+  return s.split('\\s+').findAll { it -> !it.trim().isEmpty() } as List<String>
+}
+
+// Note: the gradle logic is explicitly reading the JAVA_OPTS and START_OPTS environment variables to provide
+// developers a model that more closely matches with the native application script
+// https://deephaven.io/core/docs/how-to-guides/configuration/native-application/#native-application-script.
+//
+// For example:
+//
+// ```
+// START_OPTS="-Xmx1g -Dmy.system.property=123" ./gradlew server-jetty-app:run
+// ```
 
 // These are supposed to be generally applicable and recommended JVM options, but they aren't hard requirements.
 // Overly specific options do *not* belong here. For example, we should _not_ be setting something like `-Xmx4g` here.
@@ -130,15 +142,22 @@ def devJvmArgs = [
 //
 // From the perspective of our application distribution, these options will be used as defaults for JAVA_OPTS
 // (if the user already has JAVA_OPTS set, these VM options will _not_ apply).
-def defaultJvmOptions = [
+def JAVA_OPTS = parseJvmArgumentsFromEnv('JAVA_OPTS', [
   '-XX:+UseG1GC',
   '-XX:MaxGCPauseMillis=100',
   '-XX:+UseStringDeduplication',
-]
+])
+
+// Utility to add jvm args to all executions, whether intellij or from a application script or gradle javaexec
+def START_OPTS = parseJvmArgumentsFromEnv('START_OPTS', [
+//  '-XX:Tier4CompileThreshold=1000', // this optional line makes it easier to trigger the c2 error on the above methods
+//  '-XX:+PrintFlagsFinal',           // this optional line makes it easier to explore the final values for compiler args
+//  '-XX:+PrintCompilation',          // this optional line shows jit operations as they happen
+])
 
 def createVmOptions = tasks.register('createVmOptions') {
   def vmOptionsFile = project.layout.buildDirectory.file('dh-default.vmoptions')
-  def vmOptionsText = defaultJvmOptions.join('\n')
+  def vmOptionsText = JAVA_OPTS.join('\n')
   it.inputs.property('vmOptionsText', vmOptionsText)
   it.outputs.file(vmOptionsFile)
   doFirst {
@@ -154,7 +173,7 @@ tasks.withType(JavaExec).configureEach {
   javaLauncher.set runtimeLauncher
   // Note: we _could_ have the vmOptionsFile constituents directly listed instead of using -XX:VMOptionsFile.
   // That said, the current approach used here more closely matches how the application start script is defined.
-  jvmArgs += compilerArgs(compilerDirectivesFile.singleFile.path) + ["-XX:VMOptionsFile=${vmOptionsFile.singleFile.path}"] + devJvmArgs
+  jvmArgs += compilerArgs(compilerDirectivesFile.singleFile.path) + ["-XX:VMOptionsFile=${vmOptionsFile.singleFile.path}"] + START_OPTS
 }
 
 tasks.withType(Test).configureEach {
@@ -165,7 +184,7 @@ tasks.withType(Test).configureEach {
   javaLauncher.set testRuntimeLauncher
   // Note: we _could_ have the vmOptionsFile constituents directly listed instead of using -XX:VMOptionsFile.
   // That said, the current approach used here more closely matches how the application start script is defined.
-  jvmArgs += compilerArgs(compilerDirectivesFile.singleFile.path) + ["-XX:VMOptionsFile=${vmOptionsFile.singleFile.path}"] + devJvmArgs
+  jvmArgs += compilerArgs(compilerDirectivesFile.singleFile.path) + ["-XX:VMOptionsFile=${vmOptionsFile.singleFile.path}"] + START_OPTS
 }
 
 tasks.withType(GroovyCompile).configureEach {
@@ -192,8 +211,9 @@ tasks.withType(CreateStartScripts).configureEach {
 //  windowsStartScriptGenerator.template = windowsStartScript
 
   // Note that we don't call compilerArgs() at this time, there is no way to template those strings.
-  // Instead, we hard code the expected paths in the above templates to match the path lib/dh-compiler-directives.txt
+  // Instead, we hard code the expected paths in the above templates to match the path etc/dh-compiler-directives.txt
 //  defaultJvmOpts += compilerArgs(compilerDirectivesFile.singleFile.path)
 
-  defaultJvmOpts += devJvmArgs
+  // The start script has its own logic for parsing the START_OPTS environment variable
+  // defaultJvmOpts += START_OPTS
 }


### PR DESCRIPTION
Add gradle logic to explicitly read JAVA_OPTS and START_OPTS environment variables to provide developers a model that more closely matches with the native application script.

For example:

```sh
START_OPTS="-Xmx1g" ./gradlew server-jetty-app:run
```