### PR TITLE
Port DH-11635: Correct notification queue race in dependency satisfaction

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
@@ -50,8 +50,8 @@ public abstract class MergedListener extends LivenessArtifact implements Notific
     private final String logPrefix;
 
     private long notificationStep = -1;
-    private long queuedNotificationStep = -1;
-    private long lastCompletedStep;
+    private volatile long queuedNotificationStep = -1;
+    private volatile long lastCompletedStep;
     private Throwable upstreamError;
     private TableListener.Entry errorSourceEntry;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SelectOrUpdateListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SelectOrUpdateListener.java
@@ -3,19 +3,15 @@
  */
 package io.deephaven.engine.table.impl;
 
-import io.deephaven.engine.exceptions.UncheckedTableException;
 import io.deephaven.engine.rowset.TrackingRowSet;
 import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.ModifiedColumnSet;
 import io.deephaven.engine.table.TableUpdate;
 import io.deephaven.engine.table.impl.perf.BasePerformanceEntry;
 import io.deephaven.engine.table.impl.select.analyzers.SelectAndViewAnalyzer;
-import io.deephaven.engine.table.impl.util.AsyncClientErrorNotifier;
 import io.deephaven.engine.updategraph.TerminalNotification;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
-import io.deephaven.engine.util.systemicmarking.SystemicObjectTracker;
 
-import java.io.IOException;
 import java.util.BitSet;
 import java.util.Map;
 

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
@@ -1731,6 +1731,8 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
             Assert.eqNull(refreshScope, "refreshScope");
             refreshScope = new LivenessScope();
             final long updatingCycleValue = LogicalClock.DEFAULT.startUpdateCycle();
+            logDependencies().append("Beginning UpdateGraphProcessor cycle step=")
+                    .append(LogicalClock.DEFAULT.currentStep()).endl();
             try (final SafeCloseable ignored = LivenessScopeStack.open(refreshScope, true)) {
                 refreshFunction.run();
                 flushNotificationsAndCompleteCycle();
@@ -1738,6 +1740,8 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
                 LogicalClock.DEFAULT.ensureUpdateCycleCompleted(updatingCycleValue);
                 refreshScope = null;
             }
+            logDependencies().append("Completed UpdateGraphMonitor cycle step=")
+                    .append(LogicalClock.DEFAULT.currentStep()).endl();
         });
     }
 

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
@@ -1740,7 +1740,7 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
                 LogicalClock.DEFAULT.ensureUpdateCycleCompleted(updatingCycleValue);
                 refreshScope = null;
             }
-            logDependencies().append("Completed UpdateGraphMonitor cycle step=")
+            logDependencies().append("Completed UpdateGraphProcessor cycle step=")
                     .append(LogicalClock.DEFAULT.currentStep()).endl();
         });
     }


### PR DESCRIPTION
Most of this work was ported as part of #2455. Here are the tiny few omissions.