### PR TITLE
Add chart series support for point shapes and sizes

### DIFF
--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -300,6 +300,19 @@ public class FigureWidgetTranslator {
                             // with the x and y we have so far mapped to this
 
                             if (s instanceof AbstractXYDataSeries) {
+                                AbstractXYDataSeries abstractSeries = (AbstractXYDataSeries) s;
+
+                                // TODO color label
+                                Double pointSize = abstractSeries.getPointSize(0);
+                                if (pointSize != null) {
+                                    clientSeries.setShapeSize(pointSize);
+                                }
+
+                                Shape pointShape = abstractSeries.getPointShape(0);
+                                if (pointShape != null) {
+                                    clientSeries.setShape(pointShape.toString());
+                                }
+
                                 if (s instanceof IntervalXYDataSeriesArray) {
                                     // interval (aka histogram)
                                     IntervalXYDataSeriesArray series = (IntervalXYDataSeriesArray) s;
@@ -334,8 +347,6 @@ public class FigureWidgetTranslator {
                                     // warn about other unsupported series types
                                     errorList.add("OpenAPI presently does not support series of type " + s.getClass());
                                 }
-
-                                // TODO color label size shape
                             } else if (s instanceof AbstractCategoryDataSeries) {
                                 if (s instanceof CategoryDataSeriesPartitionedTable) {// bar and pie from a table
                                     CategoryDataSeriesPartitionedTable series = (CategoryDataSeriesPartitionedTable) s;

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -313,9 +313,12 @@ public class FigureWidgetTranslator {
                                 // TODO: Individual point shapes/sizes/labels
                                 // Right now just gets one set for the whole series
                                 AbstractXYDataSeries abstractSeries = (AbstractXYDataSeries) s;
-                                assignOptionalStringField(abstractSeries.getPointShape(0), clientSeries::setShape, clientSeries::clearShape);
-                                assignOptionalField(abstractSeries.getPointSize(0), clientSeries::setShapeSize, clientSeries::clearShapeSize);
-                                assignOptionalField(abstractSeries.getPointLabel(0), clientSeries::setShapeLabel, clientSeries::clearShapeLabel);
+                                assignOptionalStringField(abstractSeries.getPointShape(0), clientSeries::setShape,
+                                        clientSeries::clearShape);
+                                assignOptionalField(abstractSeries.getPointSize(0), clientSeries::setShapeSize,
+                                        clientSeries::clearShapeSize);
+                                assignOptionalField(abstractSeries.getPointLabel(0), clientSeries::setShapeLabel,
+                                        clientSeries::clearShapeLabel);
 
                                 if (s instanceof IntervalXYDataSeriesArray) {
                                     // interval (aka histogram)
@@ -355,9 +358,12 @@ public class FigureWidgetTranslator {
                                 // TODO: Individual point shapes/sizes/labels
                                 // Right now just gets one set for the whole series
                                 AbstractCategoryDataSeries abstractSeries = (AbstractCategoryDataSeries) s;
-                                assignOptionalStringField(abstractSeries.getPointShape(0), clientSeries::setShape, clientSeries::clearShape);
-                                assignOptionalField(abstractSeries.getPointSize(0), clientSeries::setShapeSize, clientSeries::clearShapeSize);
-                                assignOptionalField(abstractSeries.getLabel(0), clientSeries::setShapeLabel, clientSeries::clearShapeLabel);
+                                assignOptionalStringField(abstractSeries.getPointShape(0), clientSeries::setShape,
+                                        clientSeries::clearShape);
+                                assignOptionalField(abstractSeries.getPointSize(0), clientSeries::setShapeSize,
+                                        clientSeries::clearShapeSize);
+                                assignOptionalField(abstractSeries.getLabel(0), clientSeries::setShapeLabel,
+                                        clientSeries::clearShapeLabel);
 
                                 if (s instanceof CategoryDataSeriesPartitionedTable) {// bar and pie from a table
                                     CategoryDataSeriesPartitionedTable series = (CategoryDataSeriesPartitionedTable) s;


### PR DESCRIPTION
- Add point shape and size to series info, so markers can be plotted with the correct shapes and sizes
- Tested with Web UI branch https://github.com/mofojed/web-client-ui/tree/figure-point-shapes
- Used the following code in Python:
```
from deephaven import empty_table
from deephaven.plot import Figure
import math

math_funcs = ["sin", "cos"]
shapes = ["SQUARE", "CIRCLE", "UP_TRIANGLE", "DOWN_TRIANGLE", "RIGHT_TRIANGLE", "LEFT_TRIANGLE", "DIAMOND"]
# Unsupported shapes: ["ELLIPSE", "HORIZONTAL_RECTANGLE", "VERTICAL_RECTANGLE"]

# Create a generic table that has enough columns to display all the shapes
# Re-uses some of the funcs
t = empty_table(50).update(["x=i*0.1"])
for i in range(len(shapes)):
    t = t.update([f"y{i}=Math.{math_funcs[i % len(math_funcs)]}(x+{math.floor(i / len(math_funcs))})"])

# Generate the table and figure based on the shapes created
p = Figure()
for i in range(len(shapes)):
    p = p.plot_xy(series_name=shapes[i], t=t, x="x", y=f"y{i}").point(shape=shapes[i], size=len(shapes) - i)

p = p.show();
```