### PR TITLE
Address issues for PartitionedTable.transform and PartitionedTable.partitionedTransform with static inputs and refreshing result constituents

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/PartitionedTable.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/PartitionedTable.java
@@ -14,6 +14,7 @@ import io.deephaven.engine.liveness.LivenessNode;
 import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.util.annotations.FinalDefault;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Set;
@@ -200,6 +201,10 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      * Apply {@code transformer} to all constituent {@link Table tables}, and produce a new PartitionedTable containing
      * the results.
      * <p>
+     * This overload uses the {@link ExecutionContext#getContextToRecord enclosing ExecutionContext} and expects
+     * {@code transformer} to produce {@link Table#isRefreshing() refreshing} results if and only if this
+     * PartitionedTable's {@link #table() underlying table} is refreshing.
+     * <p>
      *
      * @apiNote {@code transformer} must be stateless, safe for concurrent use, and able to return a valid result for an
      *          empty input table. It is required to install an ExecutionContext to access any
@@ -209,7 +214,7 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      * @return The new PartitionedTable containing the resulting constituents
      */
     default PartitionedTable transform(@NotNull UnaryOperator<Table> transformer) {
-        return transform(ExecutionContext.getContextToRecord(), transformer);
+        return transform(ExecutionContext.getContextToRecord(), transformer, table().isRefreshing());
     }
 
     /**
@@ -222,9 +227,15 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      *
      * @param executionContext The ExecutionContext to use for the {@code transformer}
      * @param transformer The {@link UnaryOperator} to apply to all constituent {@link Table tables}
+     * @param expectRefreshingResults Whether to expect that the results of applying {@code transformer} <em>may</em> be
+     *        {@link Table#isRefreshing() refreshing}. If {@code true}, the resulting PartitionedTable will always be
+     *        backed by a refreshing {@link #table() table}.
      * @return The new PartitionedTable containing the resulting constituents
      */
-    PartitionedTable transform(ExecutionContext executionContext, @NotNull UnaryOperator<Table> transformer);
+    PartitionedTable transform(
+            @Nullable ExecutionContext executionContext,
+            @NotNull UnaryOperator<Table> transformer,
+            boolean expectRefreshingResults);
 
     /**
      * <p>
@@ -242,6 +253,10 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      * {@link ColumnSource#getType() data type} and {@link ColumnSource#getComponentType() component type}.</li>
      * </ol>
      * <p>
+     * This overload uses the {@link ExecutionContext#getContextToRecord enclosing ExecutionContext} and expects
+     * {@code transformer} to produce {@link Table#isRefreshing() refreshing} results if and only if {@code this} or
+     * {@code other} has a refreshing {@link #table() underlying table}.
+     * <p>
      *
      * @apiNote {@code transformer} must be stateless, safe for concurrent use, and able to return a valid result for
      *          empty input tables. It is required to install an ExecutionContext to access any
@@ -254,7 +269,8 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
     default PartitionedTable partitionedTransform(
             @NotNull PartitionedTable other,
             @NotNull BinaryOperator<Table> transformer) {
-        return partitionedTransform(other, ExecutionContext.getContextToRecord(), transformer);
+        return partitionedTransform(other, ExecutionContext.getContextToRecord(), transformer,
+                table().isRefreshing() || other.table().isRefreshing());
     }
 
     /**
@@ -281,12 +297,16 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      * @param other The other PartitionedTable to find constituents in
      * @param executionContext The ExecutionContext to use for the {@code transformer}
      * @param transformer The {@link BinaryOperator} to apply to all pairs of constituent {@link Table tables}
+     * @param expectRefreshingResults Whether to expect that the results of applying {@code transformer} <em>may</em> be
+     *        {@link Table#isRefreshing() refreshing}. If {@code true}, the resulting PartitionedTable will always be
+     *        backed by a refreshing {@link #table() table}.
      * @return The new PartitionedTable containing the resulting constituents
      */
     PartitionedTable partitionedTransform(
             @NotNull PartitionedTable other,
-            ExecutionContext executionContext,
-            @NotNull BinaryOperator<Table> transformer);
+            @Nullable ExecutionContext executionContext,
+            @NotNull BinaryOperator<Table> transformer,
+            boolean expectRefreshingResults);
 
     /**
      * <p>

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
@@ -150,7 +150,10 @@ class PartitionedTableProxyImpl extends LivenessArtifact implements PartitionedT
     private PartitionedTable.Proxy basicTransform(
             final boolean requiresFullContext, @NotNull final UnaryOperator<Table> transformer) {
         return new PartitionedTableProxyImpl(
-                target.transform(getOrCreateExecutionContext(requiresFullContext), transformer),
+                target.transform(
+                        getOrCreateExecutionContext(requiresFullContext),
+                        transformer,
+                        target.table().isRefreshing()),
                 requireMatchingKeys,
                 sanityCheckJoins);
     }
@@ -170,17 +173,19 @@ class PartitionedTableProxyImpl extends LivenessArtifact implements PartitionedT
         final ExecutionContext context = getOrCreateExecutionContext(requiresFullContext);
         if (other instanceof Table) {
             final Table otherTable = (Table) other;
-            if ((target.table().isRefreshing() || otherTable.isRefreshing()) && joinMatches != null) {
+            final boolean refreshingResults = target.table().isRefreshing() || otherTable.isRefreshing();
+            if (refreshingResults && joinMatches != null) {
                 UpdateGraphProcessor.DEFAULT.checkInitiateTableOperation();
             }
             return new PartitionedTableProxyImpl(
-                    target.transform(context, ct -> transformer.apply(ct, otherTable)),
+                    target.transform(context, ct -> transformer.apply(ct, otherTable), refreshingResults),
                     requireMatchingKeys,
                     sanityCheckJoins);
         }
         if (other instanceof PartitionedTable.Proxy) {
             final PartitionedTable.Proxy otherProxy = (PartitionedTable.Proxy) other;
             final PartitionedTable otherTarget = otherProxy.target();
+            final boolean refreshingResults = target.table().isRefreshing() || otherTarget.table().isRefreshing();
 
             if (target.table().isRefreshing() || otherTarget.table().isRefreshing()) {
                 UpdateGraphProcessor.DEFAULT.checkInitiateTableOperation();
@@ -203,7 +208,7 @@ class PartitionedTableProxyImpl extends LivenessArtifact implements PartitionedT
             final PartitionedTable rhsToUse = maybeRewrap(validatedRhsTable, otherTarget);
 
             return new PartitionedTableProxyImpl(
-                    lhsToUse.partitionedTransform(rhsToUse, context, transformer),
+                    lhsToUse.partitionedTransform(rhsToUse, context, transformer, refreshingResults),
                     requireMatchingKeys,
                     sanityCheckJoins);
         }
@@ -350,8 +355,11 @@ class PartitionedTableProxyImpl extends LivenessArtifact implements PartitionedT
         // NB: At the moment, we are assuming that constituents appear only once per partitioned table in scenarios
         // where overlapping join keys are concerning.
         final AtomicLong sequenceCounter = new AtomicLong(0);
-        final PartitionedTable stamped = input.transform(null, table -> table
-                .updateView(new LongConstantColumn(ENCLOSING_CONSTITUENT.name(), sequenceCounter.getAndIncrement())));
+        final PartitionedTable stamped = input.transform(
+                null,
+                table -> table.updateView(
+                        new LongConstantColumn(ENCLOSING_CONSTITUENT.name(), sequenceCounter.getAndIncrement())),
+                input.table().isRefreshing());
         final Table merged = stamped.merge();
         final Table mergedWithUniqueAgg = merged.aggAllBy(AggSpec.unique(), joinKeyColumnNames);
         final Table overlappingJoinKeys = mergedWithUniqueAgg.where(Filter.isNull(ENCLOSING_CONSTITUENT));

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/FuzzerTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/FuzzerTest.java
@@ -333,7 +333,7 @@ public class FuzzerTest {
                     final QueryTable coalesced = (QueryTable) table.coalesce();
                     addValidator(hardReferences, description, coalesced);
                     return coalesced;
-                });
+                }, true);
                 hardReferences.put(k.toString(), validated);
             }
         });

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
@@ -262,7 +262,7 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                     protected Table e() {
                         return partitionedTable
                                 .transform(executionContext,
-                                        t -> t.update("K2=Key * 2").update("K3=Key + K2").update("K5 = K3 + K2"))
+                                        t -> t.update("K2=Key * 2").update("K3=Key + K2").update("K5 = K3 + K2"), true)
                                 .merge().sort("Key");
                     }
                 },
@@ -271,7 +271,7 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                     protected Table e() {
                         return partitionedTable
                                 .partitionedTransform(partitionedTable, executionContext,
-                                        (l, r) -> l.naturalJoin(r.lastBy("Key"), "Key", "Sentinel2=Sentinel"))
+                                        (l, r) -> l.naturalJoin(r.lastBy("Key"), "Key", "Sentinel2=Sentinel"), true)
                                 .merge().sort("Key");
                     }
                 }
@@ -471,7 +471,7 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                 .build();
         final PartitionedTable result2 =
                 sourceTable2.update("SlowItDown=pauseHelper.pauseValue(k)").partitionBy("USym2")
-                        .transform(executionContext, t -> t.update("SlowItDown2=pauseHelper2.pauseValue(2 * k)"));
+                        .transform(executionContext, t -> t.update("SlowItDown2=pauseHelper2.pauseValue(2 * k)"), true);
 
         // pauseHelper.pause();
         pauseHelper2.pause();
@@ -557,7 +557,7 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                 .captureQueryCompiler()
                 .build();
         final PartitionedTable result2 = sourceTable2.partitionBy("USym2")
-                .transform(executionContext, t -> t.update("SlowItDown2=pauseHelper.pauseValue(2 * k)"));
+                .transform(executionContext, t -> t.update("SlowItDown2=pauseHelper.pauseValue(2 * k)"), true);
 
         final PartitionedTable joined = result.partitionedTransform(result2, (l, r) -> {
             System.out.println("Doing naturalJoin");
@@ -889,7 +889,7 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                 }
             });
             return tableOut;
-        });
+        }, true);
 
         final PartitionedTable filtered = PartitionedTableFactory.of(transformed.table().whereIn(filter, "First=Only"),
                 transformed.keyColumnNames(), transformed.uniqueKeys(), transformed.constituentColumnName(),
@@ -897,7 +897,7 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
         // If we (incorrectly) deliver PT notifications ahead of constituent notifications, we will cause a
         // notification-on-instantiation-step error for this update.
         final PartitionedTable filteredTransformed = filtered.transform(executionContext,
-                t -> t.update("Third=22.2*Second"));
+                t -> t.update("Third=22.2*Second"), true);
 
         TestCase.assertEquals(1, filteredTransformed.table().size());
 
@@ -911,5 +911,43 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
         }
 
         TestCase.assertEquals(2, filteredTransformed.table().size());
+    }
+
+    public void testTransformStaticToRefreshing() {
+        final Random random = new Random(0);
+        final Table staticInput = newTable(
+                getRandomIntCol("a", 100, random),
+                getRandomIntCol("b", 100, random),
+                getRandomIntCol("c", 100, random),
+                getRandomIntCol("d", 100, random),
+                getRandomIntCol("e", 100, random));
+        final Table refreshingInput = staticInput.withAttributes(Map.of("refreshingClone", true));
+        refreshingInput.setRefreshing(true);
+
+        final PartitionedTable partitionedTable = staticInput.partitionBy("c");
+        assertFalse(partitionedTable.table().isRefreshing());
+
+        final PartitionedTable.Proxy staticProxy = partitionedTable.proxy();
+
+        final PartitionedTable.Proxy joinedProxy = staticProxy.join(refreshingInput, "c", "c2=c");
+        assertTrue(joinedProxy.target().table().isRefreshing());
+        assertEquals(staticProxy.target().constituents().length, joinedProxy.target().constituents().length);
+
+        final PartitionedTable partitionedTransformResult = partitionedTable.partitionedTransform(partitionedTable,
+                null, (t, u) -> t.join(refreshingInput, "c", "c2=c"), true);
+        assertTrue(partitionedTransformResult.table().isRefreshing());
+        assertEquals(partitionedTable.constituents().length, partitionedTransformResult.constituents().length);
+
+        try {
+            partitionedTable.transform(t -> t.join(refreshingInput, "c", "c2=c"));
+            TestCase.fail("Expected exception");
+        } catch (IllegalStateException expected) {
+        }
+
+        try {
+            partitionedTable.partitionedTransform(partitionedTable, (t, u) -> t.join(refreshingInput, "c", "c2=c"));
+            TestCase.fail("Expected exception");
+        } catch (IllegalStateException expected) {
+        }
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestGroupingProviders.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestGroupingProviders.java
@@ -80,7 +80,7 @@ public class TestGroupingProviders {
         final Table raw = TableTools.emptyTable(26 * 10 * 1000).update("Part=String.format(`%04d`, (long)(ii/1000))",
                 "Sym=(char)('A' + ii % 26)", "Other=ii");
         final Table[] partitions = raw.partitionBy("Part")
-                .transform(null, rp -> rp.groupBy("Sym").ungroup())
+                .transform(null, rp -> rp.groupBy("Sym").ungroup(), false)
                 .constituents();
 
         if (!missingGroups) {


### PR DESCRIPTION
Fixes #3276