### PR TITLE
Upgrade to com.avast.gradle:gradle-docker-compose-plugin:0.16.11

### DIFF
--- a/Integrations/build.gradle
+++ b/Integrations/build.gradle
@@ -95,9 +95,9 @@ dockerCompose {
 }
 
 Closure composeConfig = { task ->
-    task.network = dockerCompose.projectName.toLowerCase() + '_default'
-    task.containerDependencies.dependsOn = dockerCompose.upTask
-    task.containerDependencies.finalizedBy = dockerCompose.downTask
+    task.network = "${dockerCompose.projectName.get()}_default"
+    task.containerDependencies.dependsOn = dockerCompose.tasksConfigurator.upTask
+    task.containerDependencies.finalizedBy = dockerCompose.tasksConfigurator.downTask
 }
 
 def pyTest = runInDocker('test-py-deephaven', '../py/server', ['python3', '-m', 'xmlrunner', 'discover', '-s', 'tests', '-t', '.', '-v', '-o', '/out/report'], composeConfig)

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -26,7 +26,7 @@ dependencies {
         because('needed by plugin com.bmuschko.docker-remote-api')
     }
 
-    implementation('com.avast.gradle:gradle-docker-compose-plugin:0.14.9') {
+    implementation('com.avast.gradle:gradle-docker-compose-plugin:0.16.11') {
         because('needed by plugin com.avast.gradle.docker-compose')
     }
 


### PR DESCRIPTION
This is primarily to pick up support for docker compose v2 output, https://github.com/avast/gradle-docker-compose-plugin/pull/339.

Note: the plugin still requires `docker-compose` (see https://github.com/avast/gradle-docker-compose-plugin/issues/322). In my case, I was able to simply proxy via bash to `docker compose`:

```
$ cat ~/.local/bin/docker-compose
#!/usr/bin/env bash

docker compose $@
```

There may be more official ways to create this shim layer.