### PR TITLE
Corrected generated JS bindings for aggregation protobufs

### DIFF
--- a/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/AggSpec.java
+++ b/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/AggSpec.java
@@ -23,7 +23,6 @@ import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggs
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec.AggSpecUnique;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec.AggSpecVar;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec.AggSpecWeighted;
-import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec.TypeCase;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
@@ -934,7 +933,7 @@ public class AggSpec {
 
     public native AggSpecTDigest getTDigest();
 
-    public native TypeCase getTypeCase();
+    public native int getTypeCase();
 
     public native AggSpecUnique getUnique();
 

--- a/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/Aggregation.java
+++ b/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/Aggregation.java
@@ -6,7 +6,6 @@ import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggr
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggregation.AggregationCount;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggregation.AggregationPartition;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggregation.AggregationRowKey;
-import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggregation.TypeCase;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
@@ -1094,7 +1093,7 @@ public class Aggregation {
 
     public native AggregationPartition getPartition();
 
-    public native TypeCase getTypeCase();
+    public native int getTypeCase();
 
     public native boolean hasColumns();
 

--- a/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggregation/TypeCase.java
+++ b/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggregation/TypeCase.java
@@ -1,12 +1,17 @@
 package io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggregation;
 
-import jsinterop.annotations.JsEnum;
 import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
 
-@JsEnum(
+@JsType(
         isNative = true,
         name = "dhinternal.io.deephaven.proto.table_pb.Aggregation.TypeCase",
         namespace = JsPackage.GLOBAL)
-public enum TypeCase {
-    COLUMNS, COUNT, FIRST_ROW_KEY, LAST_ROW_KEY, PARTITION, TYPE_NOT_SET;
+public class TypeCase {
+    public static int COLUMNS,
+            COUNT,
+            FIRST_ROW_KEY,
+            LAST_ROW_KEY,
+            PARTITION,
+            TYPE_NOT_SET;
 }

--- a/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggspec/AggSpecNonUniqueSentinel.java
+++ b/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggspec/AggSpecNonUniqueSentinel.java
@@ -1,7 +1,6 @@
 package io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec;
 
 import elemental2.core.Uint8Array;
-import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec.aggspecnonuniquesentinel.TypeCase;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
@@ -201,7 +200,7 @@ public class AggSpecNonUniqueSentinel {
 
     public native String getStringValue();
 
-    public native TypeCase getTypeCase();
+    public native int getTypeCase();
 
     public native boolean hasBoolValue();
 

--- a/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggspec/TypeCase.java
+++ b/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggspec/TypeCase.java
@@ -1,12 +1,35 @@
 package io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec;
 
-import jsinterop.annotations.JsEnum;
 import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
 
-@JsEnum(
+@JsType(
         isNative = true,
         name = "dhinternal.io.deephaven.proto.table_pb.AggSpec.TypeCase",
         namespace = JsPackage.GLOBAL)
-public enum TypeCase {
-    ABS_SUM, APPROXIMATE_PERCENTILE, AVG, COUNT_DISTINCT, DISTINCT, FIRST, FORMULA, FREEZE, GROUP, LAST, MAX, MEDIAN, MIN, PERCENTILE, SORTED_FIRST, SORTED_LAST, STD, SUM, TYPE_NOT_SET, T_DIGEST, UNIQUE, VAR, WEIGHTED_AVG, WEIGHTED_SUM;
+public class TypeCase {
+    public static int ABS_SUM,
+            APPROXIMATE_PERCENTILE,
+            AVG,
+            COUNT_DISTINCT,
+            DISTINCT,
+            FIRST,
+            FORMULA,
+            FREEZE,
+            GROUP,
+            LAST,
+            MAX,
+            MEDIAN,
+            MIN,
+            PERCENTILE,
+            SORTED_FIRST,
+            SORTED_LAST,
+            STD,
+            SUM,
+            TYPE_NOT_SET,
+            T_DIGEST,
+            UNIQUE,
+            VAR,
+            WEIGHTED_AVG,
+            WEIGHTED_SUM;
 }

--- a/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggspec/aggspecnonuniquesentinel/TypeCase.java
+++ b/web/client-backplane/src/main/java/io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggspec/aggspecnonuniquesentinel/TypeCase.java
@@ -1,12 +1,22 @@
 package io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.aggspec.aggspecnonuniquesentinel;
 
-import jsinterop.annotations.JsEnum;
 import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
 
-@JsEnum(
+@JsType(
         isNative = true,
         name = "dhinternal.io.deephaven.proto.table_pb.AggSpec.AggSpecNonUniqueSentinel.TypeCase",
         namespace = JsPackage.GLOBAL)
-public enum TypeCase {
-    BOOL_VALUE, BYTE_VALUE, CHAR_VALUE, DOUBLE_VALUE, FLOAT_VALUE, INT_VALUE, LONG_VALUE, NULL_VALUE, SHORT_VALUE, STRING_VALUE, TYPE_NOT_SET;
+public class TypeCase {
+    public static int BOOL_VALUE,
+            BYTE_VALUE,
+            CHAR_VALUE,
+            DOUBLE_VALUE,
+            FLOAT_VALUE,
+            INT_VALUE,
+            LONG_VALUE,
+            NULL_VALUE,
+            SHORT_VALUE,
+            STRING_VALUE,
+            TYPE_NOT_SET;
 }


### PR DESCRIPTION
In addition to making this values usable, it also removes these build warnings:
```
   Warnings in io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/AggSpec.java
      [WARN] Line 937: [unusable-by-js] Return type of 'TypeCase AggSpec.getTypeCase()' is not usable by but exposed to JavaScript.
   Warnings in io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/Aggregation.java
      [WARN] Line 1097: [unusable-by-js] Return type of 'TypeCase Aggregation.getTypeCase()' is not usable by but exposed to JavaScript.
   Warnings in io/deephaven/javascript/proto/dhinternal/io/deephaven/proto/table_pb/aggspec/AggSpecNonUniqueSentinel.java
      [WARN] Line 204: [unusable-by-js] Return type of 'TypeCase AggSpecNonUniqueSentinel.getTypeCase()' is not usable by but exposed to JavaScript.
```