### PR TITLE
SessionService#release - Quietly and Gracefully handle OutOfOrder/Premature Releases/Cancels

### DIFF
--- a/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
@@ -140,16 +140,8 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
                 return;
             }
 
-            // noinspection SynchronizationOnLocalVariableOrMethodParameter
-            synchronized (export) {
-                final ExportNotification.State currState = export.getState();
-                if (SessionState.isExportStateTerminal(currState)) {
-                    responseObserver.onError(
-                            GrpcUtil.statusRuntimeException(Code.NOT_FOUND, "Ticket already in state: " + currState));
-                    return;
-                }
-            }
-
+            // If the export is already in a terminal state, the implementation quietly ignores the request as there
+            // are no additional resources to release.
             export.cancel();
             responseObserver.onNext(ReleaseResponse.getDefaultInstance());
             responseObserver.onCompleted();

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -515,7 +515,7 @@ public class SessionState {
         private volatile int exportListenerVersion = 0;
 
         /** Indicates whether this export has already been well defined. This prevents export object reuse. */
-        private volatile boolean hasHadWorkSet = false;
+        private boolean hasHadWorkSet = false;
 
         /** This indicates whether or not this export should use the serial execution queue. */
         private boolean requiresSerialQueue;

--- a/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
+++ b/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
@@ -220,9 +220,9 @@ public class SessionStateTest {
         exportObj.cancel();
         Assert.eq(exportObj.getState(), "exportObj.getState()", ExportNotification.State.CANCELLED);
 
+        // We should be able to cancel prior to definition without error.
         final MutableBoolean submitted = new MutableBoolean();
-        expectException(StatusRuntimeException.class,
-                () -> session.newExport(nextExportId++).submit(submitted::setTrue));
+        session.newExport(nextExportId++).submit(submitted::setTrue);
         scheduler.runUntilQueueEmpty();
 
         Assert.eq(exportObj.getState(), "exportObj.getState()", ExportNotification.State.CANCELLED);


### PR DESCRIPTION
@niloc132 was running into this in some work of his where his cancel/release would race with him defining what the export is actually going to export.