### PR TITLE
When DoExchange is closed by the client, don't respond with an error

### DIFF
--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -672,11 +672,6 @@ public class ArrowFlightUtil {
 
             @Override
             public synchronized void close() {
-                if (onExportResolvedContinuation != null) {
-                    onExportResolvedContinuation.cancel();
-                    onExportResolvedContinuation = null;
-                }
-
                 if (bmp != null) {
                     bmp.removeSubscription(listener);
                     bmp = null;
@@ -685,6 +680,12 @@ public class ArrowFlightUtil {
                     htvs = null;
                 } else {
                     GrpcUtil.safelyComplete(listener);
+                }
+
+                // After we've signaled that the stream should close, cancel the export
+                if (onExportResolvedContinuation != null) {
+                    onExportResolvedContinuation.cancel();
+                    onExportResolvedContinuation = null;
                 }
 
                 if (preExportSubscriptions != null) {

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -563,10 +563,12 @@ public class ArrowFlightUtil {
                     final SessionState.ExportObject<Object> parent =
                             ticketRouter.resolve(session, subscriptionRequest.ticketAsByteBuffer(), "ticket");
 
-                    onExportResolvedContinuation = session.nonExport()
-                            .require(parent)
-                            .onErrorHandler(DoExchangeMarshaller.this::onError)
-                            .submit(() -> onExportResolved(parent));
+                    synchronized (this) {
+                        onExportResolvedContinuation = session.nonExport()
+                                .require(parent)
+                                .onErrorHandler(DoExchangeMarshaller.this::onError)
+                                .submit(() -> onExportResolved(parent));
+                    }
                 }
             }
 

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -1294,9 +1294,14 @@ public class SessionState {
 
                 final String dependentStr = dependentExportId == null ? ""
                         : (" (related parent export id: " + dependentExportId + ")");
-                errorHandler.onError(GrpcUtil.statusRuntimeException(
-                        Code.FAILED_PRECONDITION,
-                        "Details Logged w/ID '" + errorContext + "'" + dependentStr));
+                if (cause == null) {
+                    errorHandler.onError(GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+                            "Export in state " + resultState + dependentStr));
+                } else {
+                    errorHandler.onError(GrpcUtil.statusRuntimeException(
+                            Code.FAILED_PRECONDITION,
+                            "Details Logged w/ID '" + errorContext + "'" + dependentStr));
+                }
             }));
         }
 


### PR DESCRIPTION
Also sends a different message to the client when canceled and there is no stack trace to reference.