### PR TITLE
Update authorization codegen

### DIFF
--- a/authorization-codegen/protoc-gen-contextual-auth-wiring
+++ b/authorization-codegen/protoc-gen-contextual-auth-wiring
@@ -1,0 +1,2 @@
+# protoc-gen-contextual-auth-wiring
+java -cp authorization-codegen/build/libs/deephaven-authorization-codegen-0.20.0-all.jar io.deephaven.auth.codegen.GenerateContextualAuthWiring

--- a/authorization-codegen/protoc-gen-service-auth-wiring
+++ b/authorization-codegen/protoc-gen-service-auth-wiring
@@ -1,0 +1,2 @@
+# protoc-gen-service-auth-wiring
+java -cp authorization-codegen/build/libs/deephaven-authorization-codegen-0.20.0-all.jar io.deephaven.auth.codegen.GenerateServiceAuthWiring

--- a/authorization/README.md
+++ b/authorization/README.md
@@ -31,7 +31,7 @@ OUT_DIR=authorization/src/main/java/
 PROTO_DIR=proto/proto-backplane-grpc/src/main/proto/
 ROOT_DIR=$PROTO_DIR/deephaven/proto
 
-PATH=.:$PATH protoc --service-auth-wiring_out=$OUT_DIR -I $PROTO_DIR    \
+PATH=authorization-codegen:$PATH protoc --service-auth-wiring_out=$OUT_DIR -I $PROTO_DIR    \
      $ROOT_DIR/application.proto                                        \
      $ROOT_DIR/console.proto                                            \
      $ROOT_DIR/config.proto                                             \
@@ -41,15 +41,16 @@ PATH=.:$PATH protoc --service-auth-wiring_out=$OUT_DIR -I $PROTO_DIR    \
      $ROOT_DIR/storage.proto                                            \
      $ROOT_DIR/ticket.proto
 
-PATH=.:$PATH protoc --contextual-auth-wiring_out=$OUT_DIR -I $PROTO_DIR \
+PATH=authorization-codegen:$PATH protoc --contextual-auth-wiring_out=$OUT_DIR -I $PROTO_DIR \
      $ROOT_DIR/table.proto                                              \
      $ROOT_DIR/inputtable.proto                                         \
-     $ROOT_DIR/partitionedtable.proto
+     $ROOT_DIR/partitionedtable.proto                                   \
+     $ROOT_DIR/hierarchicaltable.proto
 
 OUT_DIR=authorization/src/main/java/
 PROTO_DIR=../grpc/src/proto/grpc/health/v1/
 ROOT_DIR=$PROTO_DIR
 
-PATH=.:$PATH protoc --service-auth-wiring_out=$OUT_DIR -I $PROTO_DIR    \
+PATH=authorization-codegen:$PATH protoc --service-auth-wiring_out=$OUT_DIR -I $PROTO_DIR    \
      $ROOT_DIR/health.proto
 ```


### PR DESCRIPTION
The readme now reflects the current set of proto files, and the plugin scripts are now checked in. Plugin scripts are in the authorization-codegen directory, to keep them out of the root dir for now.