### PR TITLE
Update start script to support extending the classpath

### DIFF
--- a/buildSrc/src/main/resources/unixStartScript.txt
+++ b/buildSrc/src/main/resources/unixStartScript.txt
@@ -165,11 +165,9 @@ case "\$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-if [ -z "\$EXTRA_CLASSPATH" ]; then
-    CLASSPATH=$classpath
-else
-    CLASSPATH="\$EXTRA_CLASSPATH":$classpath
-fi
+# Deephaven edit.
+# Prepend EXTRA_CLASSPATH and colon if EXTRA_CLASSPATH is non-empty.
+CLASSPATH=\${EXTRA_CLASSPATH:+"\$EXTRA_CLASSPATH":}$classpath
 
 <% if ( mainClassName.startsWith('--module ') ) { %>
 MODULE_PATH=$modulePath

--- a/buildSrc/src/main/resources/unixStartScript.txt
+++ b/buildSrc/src/main/resources/unixStartScript.txt
@@ -165,11 +165,11 @@ case "\$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-EXTRA_CLASSPATHS="\${EXTRA_CLASSPATHS:-/apps/libs/*:}"
-echo "Extra classpaths: \$EXTRA_CLASSPATHS"
-
-CLASSPATH="\$EXTRA_CLASSPATHS":$classpath
-echo "Final classpath: \$CLASSPATH"
+if [ -z "\$EXTRA_CLASSPATH" ]; then
+    CLASSPATH=$classpath
+else
+    CLASSPATH="\$EXTRA_CLASSPATH":$classpath
+fi
 
 <% if ( mainClassName.startsWith('--module ') ) { %>
 MODULE_PATH=$modulePath

--- a/buildSrc/src/main/resources/unixStartScript.txt
+++ b/buildSrc/src/main/resources/unixStartScript.txt
@@ -167,7 +167,7 @@ esac
 
 # Deephaven edit.
 # Prepend EXTRA_CLASSPATH and colon if EXTRA_CLASSPATH is non-empty.
-CLASSPATH=\${EXTRA_CLASSPATH:+"\$EXTRA_CLASSPATH":}$classpath
+CLASSPATH=\${EXTRA_CLASSPATH:+\$EXTRA_CLASSPATH:}$classpath
 
 <% if ( mainClassName.startsWith('--module ') ) { %>
 MODULE_PATH=$modulePath

--- a/buildSrc/src/main/resources/unixStartScript.txt
+++ b/buildSrc/src/main/resources/unixStartScript.txt
@@ -165,7 +165,12 @@ case "\$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=/apps/libs/*:$classpath
+EXTRA_CLASSPATHS="\${EXTRA_CLASSPATHS:-/apps/libs/*:}"
+echo "Extra classpaths: \$EXTRA_CLASSPATHS"
+
+CLASSPATH="\$EXTRA_CLASSPATHS":$classpath
+echo "Final classpath: \$CLASSPATH"
+
 <% if ( mainClassName.startsWith('--module ') ) { %>
 MODULE_PATH=$modulePath
 <% } %>

--- a/buildSrc/src/main/resources/unixStartScript.txt
+++ b/buildSrc/src/main/resources/unixStartScript.txt
@@ -165,7 +165,7 @@ case "\$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=$classpath
+CLASSPATH=/apps/libs/*:$classpath
 <% if ( mainClassName.startsWith('--module ') ) { %>
 MODULE_PATH=$modulePath
 <% } %>

--- a/docker/server-jetty/src/main/docker/Dockerfile
+++ b/docker/server-jetty/src/main/docker/Dockerfile
@@ -32,7 +32,8 @@ HEALTHCHECK --interval=3s --retries=3 --timeout=11s CMD /bin/grpc_health_probe -
 ENV \
     DEEPHAVEN_CACHE_DIR="/cache" \
     DEEPHAVEN_CONFIG_DIR="/opt/deephaven/config" \
-    DEEPHAVEN_DATA_DIR="/data"
+    DEEPHAVEN_DATA_DIR="/data" \
+    EXTRA_CLASSPATH="/apps/libs/*"
 ENTRYPOINT [ "/opt/deephaven/server/bin/start" ]
 ARG DEEPHAVEN_VERSION
 ARG SERVER

--- a/docker/server-slim/src/main/docker/Dockerfile
+++ b/docker/server-slim/src/main/docker/Dockerfile
@@ -32,6 +32,7 @@ ENV \
     DEEPHAVEN_CACHE_DIR="/cache" \
     DEEPHAVEN_CONFIG_DIR="/opt/deephaven/config" \
     DEEPHAVEN_DATA_DIR="/data" \
+    EXTRA_CLASSPATH="/apps/libs/*" \
     START_OPTS="-Ddeephaven.console.type=groovy"
 ENTRYPOINT [ "/opt/deephaven/server/bin/start" ]
 

--- a/docker/server/src/main/docker/Dockerfile
+++ b/docker/server/src/main/docker/Dockerfile
@@ -32,7 +32,8 @@ HEALTHCHECK --interval=3s --retries=3 --timeout=11s CMD /bin/grpc_health_probe -
 ENV \
     DEEPHAVEN_CACHE_DIR="/cache" \
     DEEPHAVEN_CONFIG_DIR="/opt/deephaven/config" \
-    DEEPHAVEN_DATA_DIR="/data"
+    DEEPHAVEN_DATA_DIR="/data" \
+    EXTRA_CLASSPATH="/apps/libs/*"
 ENTRYPOINT [ "/opt/deephaven/server/bin/start" ]
 ARG DEEPHAVEN_VERSION
 ARG SERVER


### PR DESCRIPTION
Update start script to support extending the classpath based on the `EXTRA_CLASSPATH` environment variable. Use `/apps/libs/*` as default `EXTRA_CLASSPATH` in test images.