### PR TITLE
Port DH-8170: OuterJoinTools including bugfix DH-12658

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/StaticChunkedCrossJoinStateManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/StaticChunkedCrossJoinStateManager.java
@@ -1662,7 +1662,8 @@ class StaticChunkedCrossJoinStateManager
 
     // region extraction functions
     ResultOnlyCrossJoinStateManager getResultOnlyStateManager() {
-        return new ResultOnlyCrossJoinStateManager(rightRowSetSource, leftRowSetToSlot, getNumShiftBits(), false);
+        return new ResultOnlyCrossJoinStateManager(rightRowSetSource, leftRowSetToSlot, getNumShiftBits(),
+                leftOuterJoin());
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
@@ -19,7 +19,7 @@ public class NullSelectColumn<T> implements SelectColumn {
     private final String name;
     private final NullValueColumnSource<T> nvcs;
 
-    public NullSelectColumn(final Class<T> type, final Class<T> elementType, final String name) {
+    public NullSelectColumn(final Class<T> type, final Class<?> elementType, final String name) {
         nvcs = NullValueColumnSource.getInstance(type, elementType);
         this.name = name;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/NullValueColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/NullValueColumnSource.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -28,7 +27,7 @@ import java.util.stream.Collectors;
  */
 public class NullValueColumnSource<T> extends AbstractColumnSource<T> implements ShiftData.ShiftCallback {
     private static final KeyedObjectKey.Basic<Pair<Class<?>, Class<?>>, NullValueColumnSource<?>> KEY_TYPE =
-            new KeyedObjectKey.Basic<Pair<Class<?>, Class<?>>, NullValueColumnSource<?>>() {
+            new KeyedObjectKey.Basic<>() {
                 @Override
                 public Pair<Class<?>, Class<?>> getKey(NullValueColumnSource columnSource) {
                     // noinspection unchecked,rawtypes
@@ -41,10 +40,10 @@ public class NullValueColumnSource<T> extends AbstractColumnSource<T> implements
     private static final ColumnSource<Byte> BOOL_AS_BYTE_SOURCE =
             new BooleanAsByteColumnSource(getInstance(Boolean.class, null));
 
-    public static <T2> NullValueColumnSource<T2> getInstance(Class<T2> clazz, @Nullable final Class elementType) {
+    public static <T2> NullValueColumnSource<T2> getInstance(Class<T2> clazz, @Nullable final Class<?> elementType) {
         // noinspection unchecked,rawtypes
         return (NullValueColumnSource) INSTANCES.putIfAbsent(new Pair<>(clazz, elementType),
-                p -> new NullValueColumnSource<T2>(clazz, elementType));
+                p -> new NullValueColumnSource<>(clazz, elementType));
     }
 
     public static LinkedHashMap<String, ColumnSource<?>> createColumnSourceMap(TableDefinition definition) {
@@ -55,7 +54,7 @@ public class NullValueColumnSource<T> extends AbstractColumnSource<T> implements
                 LinkedHashMap::new));
     }
 
-    private NullValueColumnSource(Class<T> type, @Nullable final Class elementType) {
+    private NullValueColumnSource(Class<T> type, @Nullable final Class<?> elementType) {
         super(type, elementType);
     }
 
@@ -174,7 +173,7 @@ public class NullValueColumnSource<T> extends AbstractColumnSource<T> implements
         if ((type == Boolean.class || type == boolean.class) &&
                 (alternateDataType == byte.class || alternateDataType == Byte.class)) {
             // noinspection unchecked
-            return (ColumnSource) BOOL_AS_BYTE_SOURCE;
+            return (ColumnSource<ALTERNATE_DATA_TYPE>) BOOL_AS_BYTE_SOURCE;
         }
 
         return getInstance(alternateDataType, null);

--- a/engine/table/src/main/java/io/deephaven/engine/util/OuterJoinTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/OuterJoinTools.java
@@ -1,0 +1,410 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.util;
+
+import com.google.common.collect.Streams;
+import io.deephaven.api.Selectable;
+import io.deephaven.api.TableOperationsDefaults;
+import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.MatchPair;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.CrossJoinHelper;
+import io.deephaven.engine.table.impl.QueryTable;
+import io.deephaven.engine.table.impl.select.MatchPairFactory;
+import io.deephaven.engine.table.impl.select.SelectColumn;
+import io.deephaven.engine.table.impl.select.SourceColumn;
+import io.deephaven.engine.table.impl.sources.NullValueColumnSource;
+import io.deephaven.util.annotations.ScriptApi;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Provides static methods to perform SQL-style left outer and full outer joins.
+ */
+public class OuterJoinTools {
+
+    /**
+     * Returns a table that has one column for each of table1 columns, and one column corresponding to each of table2
+     * columns listed in the columns to add (or all the columns whose names don't overlap with the name of a column from
+     * table1 if the columnsToAdd is length zero). The returned table will have one row for each matching set of keys
+     * between the first and second tables, plus one row for any first table key set that doesn't match the second table
+     * and one row for each key set from the second table that doesn't match the first table. Columns from either table
+     * for which there was no match in the other table will have null values. Note that this method will cause tick
+     * expansion with ticking tables.
+     * <p>
+     *
+     * @param table1 input table
+     * @param table2 input table
+     * @param columnsToMatch match criteria
+     * @param columnsToAdd columns to add
+     * @return a table that has one column for each of table1's columns, and one column corresponding to each of
+     *         table2's columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     *         of a column from table1 if the columnsToAdd is length zero). The returned table will have one row for
+     *         each matching set of keys between the first and second tables, plus one row for any first table key set
+     *         that doesn't match the second table and one row for each key set from the second table that doesn't match
+     *         the first table. Columns from either table for which there was no match in the other table will have null
+     *         values.
+     */
+    @ScriptApi
+    public static Table fullOuterJoin(
+            @NotNull final Table table1,
+            @NotNull final Table table2,
+            @NotNull final MatchPair[] columnsToMatch,
+            @NotNull final MatchPair[] columnsToAdd) {
+        // perform the leftOuterJoin; it's missing right-side only rows
+        final Table leftTable = leftOuterJoin(table1, table2, columnsToMatch, columnsToAdd);
+
+        // find a sentinel column name to use to identify right-side only rows
+        int numAttempts = 0;
+        String sentinelColumnName;
+        final Map<String, ? extends ColumnSource<?>> resultColumns = leftTable.getColumnSourceMap();
+        do {
+            sentinelColumnName = "__sentinel_" + (numAttempts++) + "__";
+        } while (resultColumns.containsKey(sentinelColumnName));
+
+        // handle the simpler scenario where no conflicts may exist otherwise leftOuterJoin would have failed
+        if (columnsToAdd.length == 0) {
+            final MatchPair[] matchPairs = Arrays.stream(columnsToMatch)
+                    .map(mp -> new MatchPair(mp.rightColumn(), mp.leftColumn()))
+                    .toArray(MatchPair[]::new);
+
+            final Table leftWithSentinel = table1.coalesce().updateView(sentinelColumnName + " = true");
+
+            // we must use leftOuterJoin again as there may be multiple matches per group
+            final Table rightTable = CrossJoinHelper.leftOuterJoin(
+                    (QueryTable) table2.coalesce(),
+                    (QueryTable) leftWithSentinel,
+                    matchPairs,
+                    createColumnsToAdd(leftWithSentinel, matchPairs, MatchPair.ZERO_LENGTH_MATCH_PAIR_ARRAY),
+                    CrossJoinHelper.DEFAULT_NUM_RIGHT_BITS_TO_RESERVE).where(sentinelColumnName + " == null")
+                    .dropColumns(sentinelColumnName);
+
+            return TableTools.merge(leftTable, rightTable);
+        }
+
+        // only need match columns from the left; rename and drop remaining to avoid column name conflicts
+        final SelectColumn[] leftColumns = Streams.concat(
+                Arrays.stream(columnsToMatch).map(mp -> new SourceColumn(mp.leftColumn(), mp.rightColumn())),
+                List.of(SelectColumn.of(Selectable.parse(sentinelColumnName + " = true"))).stream())
+                .toArray(SelectColumn[]::new);
+
+        // we will modify the join to use exact matches
+        final MatchPair[] matchColumns = Arrays.stream(columnsToMatch)
+                .map(mp -> new MatchPair(mp.rightColumn(), mp.rightColumn()))
+                .toArray(MatchPair[]::new);
+
+        // prepare filter for columnsToAdd
+        final SelectColumn[] rightColumns = Arrays.stream(columnsToAdd)
+                .map(mp -> new SourceColumn(mp.rightColumn(), mp.leftColumn()))
+                .toArray(SelectColumn[]::new);
+
+        // we must use leftOuterJoin again as there may be multiple matches per group
+        final Table rightOnlyTable = CrossJoinHelper.leftOuterJoin(
+                (QueryTable) table2.coalesce(),
+                (QueryTable) table1.coalesce().view(leftColumns),
+                matchColumns,
+                new MatchPair[] {new MatchPair(sentinelColumnName, sentinelColumnName)},
+                CrossJoinHelper.DEFAULT_NUM_RIGHT_BITS_TO_RESERVE).where(sentinelColumnName + " == null")
+                .view(rightColumns);
+
+        final Table nullLeftTable = TableTools.newTable(
+                1, NullValueColumnSource.createColumnSourceMap(table1.getDefinition()));
+
+        return TableTools.merge(leftTable, nullLeftTable.join(rightOnlyTable));
+    }
+
+    private static MatchPair[] createColumnsToAdd(@NotNull final Table rightTable,
+            @NotNull final MatchPair[] columnsToMatch,
+            @NotNull final MatchPair[] columnsToAdd) {
+        if (columnsToAdd.length > 0) {
+            return columnsToAdd;
+        }
+
+        final Set<String> matchColumns = Arrays.stream(columnsToMatch)
+                .map(MatchPair::leftColumn)
+                .collect(Collectors.toCollection(HashSet::new));
+        return rightTable.getDefinition().getColumnStream().map(ColumnDefinition::getName)
+                .filter((name) -> !matchColumns.contains(name))
+                .map(name -> new MatchPair(name, name))
+                .toArray(MatchPair[]::new);
+    }
+
+    /**
+     * Returns a table that has one column for each of the left table columns, and one column corresponding to each of
+     * the right table columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     * of a column from the source table if the columnsToAdd is length zero). The returned table will have one row for
+     * each matching set of keys between the left table and right table plus one row for any left table key set that
+     * doesn't match the right table. Columns from the right table for which there was no match will have null values.
+     * Note that this method will cause tick expansion with ticking tables.
+     * <p>
+     *
+     * @param leftTable input table
+     * @param rightTable input table
+     * @param columnsToMatch match criteria
+     * @param columnsToAdd columns to add
+     * @return a table that has one column for each of the left table columns, and one column corresponding to each
+     *         column listed in columnsToAdd. If columnsToAdd.length==0 one column corresponding to each column of the
+     *         right table columns whose names don't overlap with the name of a column from the left table is added. The
+     *         returned table will have one row for each matching set of keys between the left table and right table
+     *         plus one row for any left table key set that doesn't match the right table. Columns from the right table
+     *         for which there was no match will have null values.
+     */
+    @ScriptApi
+    public static Table leftOuterJoin(
+            @NotNull final Table leftTable,
+            @NotNull final Table rightTable,
+            @NotNull final MatchPair[] columnsToMatch,
+            @NotNull final MatchPair[] columnsToAdd) {
+        final MatchPair[] useColumnsToAdd = createColumnsToAdd(rightTable, columnsToMatch, columnsToAdd);
+        return CrossJoinHelper.leftOuterJoin(
+                (QueryTable) leftTable.coalesce(),
+                (QueryTable) rightTable.coalesce(),
+                columnsToMatch,
+                useColumnsToAdd,
+                CrossJoinHelper.DEFAULT_NUM_RIGHT_BITS_TO_RESERVE);
+    }
+
+    /**
+     * Returns a table that has one column for each of the left table columns, and one column corresponding to each of
+     * the right table columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     * of a column from the source table if the columnsToAdd is length zero). The returned table will have one row for
+     * each matching set of keys between the left table and right table plus one row for any left table key set that
+     * doesn't match the right table. Columns from the right table for which there was no match will have null values.
+     * Note that this method will cause tick expansion with ticking tables.
+     * <p>
+     *
+     * @param leftTable input table
+     * @param rightTable input table
+     * @param columnsToMatch match criteria
+     * @param columnsToAdd columns to add
+     * @return a table that has one column for each of the left table columns, and one column corresponding to each
+     *         column listed in columnsToAdd. If columnsToAdd.length==0 one column corresponding to each column of the
+     *         right table columns whose names don't overlap with the name of a column from the left table is added. The
+     *         returned table will have one row for each matching set of keys between the left table and right table
+     *         plus one row for any left table key set that doesn't match the right table. Columns from the right table
+     *         for which there was no match will have null values.
+     */
+    @ScriptApi
+    public static Table leftOuterJoin(
+            @NotNull final Table leftTable,
+            @NotNull final Table rightTable,
+            @NotNull final Collection<String> columnsToMatch,
+            @NotNull final Collection<String> columnsToAdd) {
+        return leftOuterJoin(
+                leftTable,
+                rightTable,
+                MatchPairFactory.getExpressions(columnsToMatch),
+                MatchPairFactory.getExpressions(columnsToAdd));
+    }
+
+    /**
+     * Returns a table that has one column for each of leftTable columns, and all the columns from rightTable whose
+     * names don't overlap with the name of a column from leftTable. The returned table will have one row for each
+     * matching set of keys between the left table and right table plus one row for any left table key set that doesn't
+     * match the right table. Columns from the right table for which there was no match will have null values.
+     * <p>
+     * <p>
+     *
+     * @param leftTable input table
+     * @param rightTable input table
+     * @param columnsToMatch match criteria
+     * @return a table that has one column for each of the left table columns, and one column corresponding to each
+     *         column listed in columnsToAdd. If columnsToAdd.length==0 one column corresponding to each column of the
+     *         right table columns whose names don't overlap with the name of a column from the left table is added. The
+     *         returned table will have one row for each matching set of keys between the left table and right table
+     *         plus one row for any left table key set that doesn't match the right table. Columns from the right table
+     *         for which there was no match will have null values. Note that this method will cause tick expansion with
+     *         ticking tables.
+     */
+    @ScriptApi
+    public static Table leftOuterJoin(
+            @NotNull final Table leftTable,
+            @NotNull final Table rightTable,
+            @NotNull final Collection<String> columnsToMatch) {
+        return leftOuterJoin(leftTable, rightTable, columnsToMatch, Collections.emptyList());
+    }
+
+    /**
+     * Returns a table that has one column for each of the left table columns, and one column corresponding to each of
+     * the right table columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     * of a column from the source table if the columnsToAdd is length zero). The returned table will have one row for
+     * each matching set of keys between the left table and right table plus one row for any left table key set that
+     * doesn't match the right table. Columns from the right table for which there was no match will have null values.
+     * Note that this method will cause tick expansion with ticking tables.
+     * <p>
+     *
+     * @param leftTable input table
+     * @param rightTable input table
+     * @param columnsToMatch match criteria
+     * @param columnsToAdd columns to add
+     * @return a table that has one column for each of the left table columns, and one column corresponding to each
+     *         column listed in columnsToAdd. If columnsToAdd.length==0 one column corresponding to each column of the
+     *         right table columns whose names don't overlap with the name of a column from the left table is added. The
+     *         returned table will have one row for each matching set of keys between the left table and right table
+     *         plus one row for any left table key set that doesn't match the right table. Columns from the right table
+     *         for which there was no match will have null values.
+     */
+    @ScriptApi
+    public static Table leftOuterJoin(@NotNull final Table leftTable, @NotNull final Table rightTable,
+            @NotNull final String columnsToMatch, @NotNull final String columnsToAdd) {
+        return leftOuterJoin(leftTable, rightTable, TableOperationsDefaults.splitToCollection(columnsToMatch),
+                TableOperationsDefaults.splitToCollection(columnsToAdd));
+    }
+
+    /**
+     * Returns a table that has one column for each of leftTable columns, and all the columns from rightTable whose
+     * names don't overlap with the name of a column from leftTable. The returned table will have one row for each
+     * matching set of keys between the left table and right table plus one row for any left table key set that doesn't
+     * match the right table. Columns from the right table for which there was no match will have null values.
+     * <p>
+     *
+     * @param leftTable input table
+     * @param rightTable input table
+     * @param columnsToMatch match criteria
+     * @return a table that has one column for each of the left table columns, and one column corresponding to each
+     *         column listed in columnsToAdd. If columnsToAdd.length==0 one column corresponding to each column of the
+     *         right table columns whose names don't overlap with the name of a column from the left table is added. The
+     *         returned table will have one row for each matching set of keys between the left table and right table
+     *         plus one row for any left table key set that doesn't match the right table. Columns from the right table
+     *         for which there was no match will have null values. Note that this method will cause tick expansion with
+     *         ticking tables.
+     */
+    @ScriptApi
+    public static Table leftOuterJoin(
+            @NotNull final Table leftTable,
+            @NotNull final Table rightTable,
+            @NotNull final String columnsToMatch) {
+        return leftOuterJoin(leftTable, rightTable, TableOperationsDefaults.splitToCollection(columnsToMatch));
+    }
+
+    /**
+     * Returns a table that has one column for each of table1 columns, and one column corresponding to each of table2
+     * columns listed in the columns to add (or all the columns whose names don't overlap with the name of a column from
+     * table1 if the columnsToAdd is length zero). The returned table will have one row for each matching set of keys
+     * between the first and second tables, plus one row for any first table key set that doesn't match the second table
+     * and one row for each key set from the second table that doesn't match the first table. Columns from the either
+     * table for which there was no match in the other table will have null values. Note that this method will cause
+     * tick expansion with ticking tables.
+     * <p>
+     *
+     * @param table1 input table
+     * @param table2 input table
+     * @param columnsToMatch match criteria
+     * @param columnsToAdd columns to add
+     * @return a table that has one column for each of table1's columns, and one column corresponding to each of
+     *         table2's columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     *         of a column from table1 if the columnsToAdd is length zero). The returned table will have one row for
+     *         each matching set of keys between the first and second tables, plus one row for any first table key set
+     *         that doesn't match the second table and one row for each key set from the second table that doesn't match
+     *         the first table. Columns from the either table for which there was no match in the other table will have
+     *         null values.
+     */
+    @ScriptApi
+    public static Table fullOuterJoin(
+            @NotNull final Table table1,
+            @NotNull final Table table2,
+            @NotNull final Collection<String> columnsToMatch,
+            @NotNull final Collection<String> columnsToAdd) {
+        return fullOuterJoin(table1, table2, MatchPairFactory.getExpressions(columnsToMatch),
+                MatchPairFactory.getExpressions(columnsToAdd));
+    }
+
+    /**
+     * Returns a table that has one column for each of table1 columns, and all the columns from table2 whose names don't
+     * overlap with the name of a column from table1. The returned table will have one row for each matching set of keys
+     * between the first and second tables, plus one row for any first table key set that doesn't match the second table
+     * and one row for each key set from the second table that doesn't match the first table. Columns from the either
+     * table for which there was no match in the other table will have null values. Note that this method will cause
+     * tick expansion with ticking tables.
+     * <p>
+     * <p>
+     *
+     * @param table1 input table
+     * @param table2 input table
+     * @param columnsToMatch match criteria
+     * @return a table that has one column for each of table1's columns, and one column corresponding to each of
+     *         table2's columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     *         of a column from table1 if the columnsToAdd is length zero). The returned table will have one row for
+     *         each matching set of keys between the first and second tables, plus one row for any first table key set
+     *         that doesn't match the second table and one row for each key set from the second table that doesn't match
+     *         the first table. Columns from the either table for which there was no match in the other table will have
+     *         null values.
+     */
+    @ScriptApi
+    public static Table fullOuterJoin(
+            @NotNull final Table table1,
+            @NotNull final Table table2,
+            @NotNull final Collection<String> columnsToMatch) {
+        return fullOuterJoin(table1, table2, columnsToMatch, Collections.emptyList());
+    }
+
+    /**
+     * Returns a table that has one column for each of table1 columns, and one column corresponding to each of table2
+     * columns listed in the columns to add (or all the columns whose names don't overlap with the name of a column from
+     * table1 if the columnsToAdd is length zero). The returned table will have one row for each matching set of keys
+     * between the first and second tables, plus one row for any first table key set that doesn't match the second table
+     * and one row for each key set from the second table that doesn't match the first table. Columns from the either
+     * table for which there was no match in the other table will have null values. Note that this method will cause
+     * tick expansion with ticking tables.
+     * <p>
+     *
+     * @param table1 input table
+     * @param table2 input table
+     * @param columnsToMatch match criteria
+     * @param columnsToAdd columns to add
+     * @return a table that has one column for each of table1's columns, and one column corresponding to each of
+     *         table2's columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     *         of a column from table1 if the columnsToAdd is length zero). The returned table will have one row for
+     *         each matching set of keys between the first and second tables, plus one row for any first table key set
+     *         that doesn't match the second table and one row for each key set from the second table that doesn't match
+     *         the first table. Columns from the either table for which there was no match in the other table will have
+     *         null values.
+     */
+    @ScriptApi
+    public static Table fullOuterJoin(
+            @NotNull final Table table1,
+            @NotNull final Table table2,
+            @NotNull final String columnsToMatch,
+            @NotNull final String columnsToAdd) {
+        return fullOuterJoin(table1, table2, TableOperationsDefaults.splitToCollection(columnsToMatch),
+                TableOperationsDefaults.splitToCollection(columnsToAdd));
+    }
+
+    /**
+     * Returns a table that has one column for each of table1 columns, and all the columns from table2 whose names don't
+     * overlap with the name of a column from table1. The returned table will have one row for each matching set of keys
+     * between the first and second tables, plus one row for any first table key set that doesn't match the second table
+     * and one row for each key set from the second table that doesn't match the first table. Columns from the either
+     * table for which there was no match in the other table will have null values. Note that this method will cause
+     * tick expansion with ticking tables.
+     * <p>
+     *
+     * @param table1 input table
+     * @param table2 input table
+     * @param columnsToMatch match criteria
+     * @return a table that has one column for each of table1's columns, and one column corresponding to each of
+     *         table2's columns listed in the columns to add (or all the columns whose names don't overlap with the name
+     *         of a column from table1 if the columnsToAdd is length zero). The returned table will have one row for
+     *         each matching set of keys between the first and second tables, plus one row for any first table key set
+     *         that doesn't match the second table and one row for each key set from the second table that doesn't match
+     *         the first table. Columns from the either table for which there was no match in the other table will have
+     *         null values.
+     */
+    @ScriptApi
+    public static Table fullOuterJoin(
+            @NotNull final Table table1,
+            @NotNull final Table table2,
+            @NotNull final String columnsToMatch) {
+        return fullOuterJoin(table1, table2, TableOperationsDefaults.splitToCollection(columnsToMatch));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestOuterJoinTools.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestOuterJoinTools.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.util;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static io.deephaven.engine.testutil.TstUtils.testRefreshingTable;
+import static io.deephaven.engine.testutil.TstUtils.testTable;
+import static io.deephaven.engine.util.TableTools.col;
+import static io.deephaven.engine.util.TableTools.intCol;
+import static org.junit.Assert.assertEquals;
+
+public class TestOuterJoinTools {
+    @Rule
+    public EngineCleanup cleanup = new EngineCleanup();
+
+    @Test
+    public void testLeftOuterJoin() {
+        Table lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        Table rTable = testRefreshingTable(col("Y", "a", "b", "b"), intCol("Z", 1, 2, 3));
+        Table result = OuterJoinTools.leftOuterJoin(lTable, rTable, "X=Y");
+        assertEquals(4, result.size());
+        assertEquals(3, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals("Z", result.getColumns()[2].getName());
+        assertEquals(Arrays.asList("a", "b", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("a", "b", "b", null), Arrays.asList(result.getColumn("Y").get(0, 4)));
+        assertEquals(Arrays.asList(1, 2, 3, null), Arrays.asList(result.getColumn("Z").get(0, 4)));
+
+        lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        rTable = testRefreshingTable(col("Y", "a", "b"));
+        result = OuterJoinTools.leftOuterJoin(lTable, rTable, "X=Y");
+        TableTools.show(result);
+        assertEquals(3, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 3)));
+        assertEquals(Arrays.asList("a", "b", null), Arrays.asList(result.getColumn("Y").get(0, 3)));
+
+        lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        rTable = testRefreshingTable(col("X", "a", "b", "d"));
+        result = OuterJoinTools.leftOuterJoin(lTable, rTable, "X");
+        TableTools.show(result);
+        assertEquals(3, result.size());
+        assertEquals(1, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals(Arrays.asList("a", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 3)));
+    }
+
+    @Test
+    public void testLeftOuterJoinStatic() {
+        Table lTable = testTable(col("X", "a", "b", "c"));
+        Table rTable = testTable(col("Y", "a", "b", "b"), col("Z", 1, 2, 3));
+        Table result = OuterJoinTools.leftOuterJoin(lTable, rTable, "X=Y").select();
+        assertEquals(4, result.size());
+        assertEquals(3, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals("Z", result.getColumns()[2].getName());
+        assertEquals(Arrays.asList("a", "b", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("a", "b", "b", null), Arrays.asList(result.getColumn("Y").get(0, 4)));
+        assertEquals(Arrays.asList(1, 2, 3, null), Arrays.asList(result.getColumn("Z").get(0, 4)));
+
+        lTable = testTable(col("X", "a", "b", "c"));
+        rTable = testTable(col("Y", "a", "b"));
+        result = OuterJoinTools.leftOuterJoin(lTable, rTable, "X=Y").select();
+        TableTools.show(result);
+        assertEquals(3, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 3)));
+        assertEquals(Arrays.asList("a", "b", null), Arrays.asList(result.getColumn("Y").get(0, 3)));
+
+        lTable = testTable(col("X", "a", "b", "c"));
+        rTable = testTable(col("X", "a", "b", "d"));
+        result = OuterJoinTools.leftOuterJoin(lTable, rTable, "X").select();
+        TableTools.show(result);
+        assertEquals(3, result.size());
+        assertEquals(1, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals(Arrays.asList("a", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 3)));
+    }
+
+    @Test
+    public void testFullOuterJoin() {
+        Table lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        Table rTable = testRefreshingTable(col("Y", "a", "b", "b"), intCol("Z", 1, 2, 3));
+        Table result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y");
+        assertEquals(4, result.size());
+        assertEquals(3, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals("Z", result.getColumns()[2].getName());
+        assertEquals(Arrays.asList("a", "b", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("a", "b", "b", null), Arrays.asList(result.getColumn("Y").get(0, 4)));
+        assertEquals(Arrays.asList(1, 2, 3, null), Arrays.asList(result.getColumn("Z").get(0, 4)));
+
+        lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        rTable = testRefreshingTable(col("Y", "a", "b", "d"), intCol("Z", 1, 2, 3));
+        result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y", "Y");
+        TableTools.showWithRowSet(lTable);
+        TableTools.showWithRowSet(rTable);
+        TableTools.showWithRowSet(result);
+        assertEquals(4, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "c", null), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("a", "b", null, "d"), Arrays.asList(result.getColumn("Y").get(0, 4)));
+
+        lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        rTable = testRefreshingTable(col("Y", "a", "b"));
+        result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y");
+        TableTools.show(result);
+        assertEquals(3, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 3)));
+        assertEquals(Arrays.asList("a", "b", null), Arrays.asList(result.getColumn("Y").get(0, 3)));
+
+        lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        rTable = testRefreshingTable(col("Y", "a", "b", "d"));
+        result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y");
+        TableTools.show(result);
+        assertEquals(4, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "c", null), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("a", "b", null, "d"), Arrays.asList(result.getColumn("Y").get(0, 4)));
+
+        lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        rTable = testRefreshingTable(col("Y", "a", "b", "b"));
+        result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y");
+        TableTools.show(result);
+        assertEquals(4, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "b", "c"), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("a", "b", "b", null), Arrays.asList(result.getColumn("Y").get(0, 4)));
+
+        lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        rTable = testRefreshingTable(col("X", "a", "b", "d"));
+        result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X");
+        TableTools.show(result);
+        assertEquals(4, result.size());
+        assertEquals(1, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals(Arrays.asList("a", "b", "c", "d"), Arrays.asList(result.getColumn("X").get(0, 4)));
+    }
+
+    @Test
+    public void testFullOuterJoinAddColumnsDoesNotIncludeRightMatchColumns() {
+        Table lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        Table rTable = testRefreshingTable(col("Y", "a", "b", "d"), intCol("Z", 1, 2, 3));
+        Table result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y", "A=Y");
+        assertEquals(4, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("A", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "c", null), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("a", "b", null, "d"), Arrays.asList(result.getColumn("A").get(0, 4)));
+    }
+
+    @Test
+    public void testFullOuterJoinAddColumnRenamesToOverrideMatchColumnName() {
+        Table lTable = testRefreshingTable(col("X", "a", "b", "c"));
+        Table rTable = testRefreshingTable(col("Y", "a", "b", "d"), col("Z", "e", "f", "g"));
+        Table result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y", "Y=Z");
+        assertEquals(4, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "b", "c", null), Arrays.asList(result.getColumn("X").get(0, 4)));
+        assertEquals(Arrays.asList("e", "f", null, "g"), Arrays.asList(result.getColumn("Y").get(0, 4)));
+    }
+
+    @Test
+    public void testFullOuterJoinMultipleMatchesBothSides() {
+        Table lTable = testRefreshingTable(col("X", "a", "a", "b", "c"));
+        Table rTable = testRefreshingTable(
+                col("Y", "a", "b", "b", "d"),
+                intCol("Z", 1, 2, 3, 4));
+        Table result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y");
+        assertEquals(6, result.size());
+        assertEquals(3, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals("Z", result.getColumns()[2].getName());
+        assertEquals(Arrays.asList("a", "a", "b", "b", "c", null), Arrays.asList(result.getColumn("X").get(0, 6)));
+        assertEquals(Arrays.asList("a", "a", "b", "b", null, "d"), Arrays.asList(result.getColumn("Y").get(0, 6)));
+        assertEquals(Arrays.asList(1, 1, 2, 3, null, 4), Arrays.asList(result.getColumn("Z").get(0, 6)));
+
+        lTable = testRefreshingTable(col("X", "a", "a", "b", "c"));
+        rTable = testRefreshingTable(col("Y", "a", "b", "b", "d"), intCol("Z", 1, 2, 3, 4));
+        result = OuterJoinTools.fullOuterJoin(lTable, rTable, "X=Y", "Y");
+        TableTools.showWithRowSet(lTable);
+        TableTools.showWithRowSet(rTable);
+        TableTools.showWithRowSet(result);
+        assertEquals(6, result.size());
+        assertEquals(2, result.getColumns().length);
+        assertEquals("X", result.getColumns()[0].getName());
+        assertEquals("Y", result.getColumns()[1].getName());
+        assertEquals(Arrays.asList("a", "a", "b", "b", "c", null), Arrays.asList(result.getColumn("X").get(0, 6)));
+        assertEquals(Arrays.asList("a", "a", "b", "b", null, "d"), Arrays.asList(result.getColumn("Y").get(0, 6)));
+    }
+}


### PR DESCRIPTION
Note that fullOuterJoin is an alternative implementation that should A) be more efficient when table2 is refreshing, and B) behaves like join/naturalJoin/etc w.r.t. columns to add.