### PR TITLE
Port DH-11558: QueryTable#selectOrUpdate do not Redirect Flat Tables

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1177,8 +1177,8 @@ public class QueryTable extends BaseTable<QueryTable> {
                     checkInitiateOperation();
                     final SelectAndViewAnalyzer.Mode mode;
                     if (isRefreshing()) {
-                        if (!isFlat() && (flavor == Flavor.Update && USE_REDIRECTED_COLUMNS_FOR_UPDATE)
-                                || (flavor == Flavor.Select && USE_REDIRECTED_COLUMNS_FOR_SELECT)) {
+                        if (!isFlat() && ((flavor == Flavor.Update && USE_REDIRECTED_COLUMNS_FOR_UPDATE)
+                                || (flavor == Flavor.Select && USE_REDIRECTED_COLUMNS_FOR_SELECT))) {
                             mode = SelectAndViewAnalyzer.Mode.SELECT_REDIRECTED_REFRESHING;
                         } else {
                             mode = SelectAndViewAnalyzer.Mode.SELECT_REFRESHING;


### PR DESCRIPTION
The internal JIRA Ticket: [DH-11558](https://deephaven.atlassian.net/browse/DH-11558)
The internal [commit](https://github.com/deephaven-ent/iris/commit/72500600da3f5c9648e69078d72aa849d4ec38bb/).

Skipped the AbstractColumnSource change as DHC is not serializable.

It looks like we attempted to fix this in DHC, but the regression test said otherwise; a pair of parentheses were omitted.
I opted not to re-run nightlies for this PR.