### PR TITLE
Port DH-11933: Constant Formulas Should use SingleValueColumnSources

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/JavaExpressionParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/JavaExpressionParser.java
@@ -7,10 +7,15 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseResult;
 import com.github.javaparser.ParseStart;
 import com.github.javaparser.Providers;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.LiteralExpr;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.LinkedList;
 
 /**
  * Helpful class which parses expressions and performs extra "this is exactly one expression" validation
@@ -40,5 +45,30 @@ public class JavaExpressionParser {
         } catch (IOException ignored) {
         }
         return expr;
+    }
+
+    /**
+     * returns true if the expression evaluates to constant value.
+     *
+     * @param expression the expression to evaluate
+     * @return true if the expression evaluates to constant value
+     */
+    public static boolean isConstantValueExpression(Expression expression) {
+        LinkedList<Expression> expressionsQueue = new LinkedList<>();
+        expressionsQueue.add(expression);
+        while (!expressionsQueue.isEmpty()) {
+            Expression currExpr = expressionsQueue.poll();
+            if (currExpr instanceof EnclosedExpr) {
+                expressionsQueue.add(((EnclosedExpr) currExpr).getInner());
+            } else if (currExpr instanceof AssignExpr) {
+                expressionsQueue.add(((AssignExpr) currExpr).getValue());
+            } else if (currExpr instanceof BinaryExpr) {
+                expressionsQueue.add(((BinaryExpr) currExpr).getLeft());
+                expressionsQueue.add(((BinaryExpr) currExpr).getRight());
+            } else if (!(currExpr instanceof LiteralExpr)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -220,7 +220,8 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
 
         final VisitArgs printer = VisitArgs.create();
         try {
-            Expression expr = JavaExpressionParser.parseExpression(expression);
+            final Expression expr = JavaExpressionParser.parseExpression(expression);
+            final boolean isConstantValueExpression = JavaExpressionParser.isConstantValueExpression(expr);
 
             Class<?> type = expr.accept(this, printer);
 
@@ -228,7 +229,7 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
                 type = Object.class;
             }
 
-            result = new Result(type, printer.builder.toString(), variablesUsed);
+            result = new Result(type, printer.builder.toString(), variablesUsed, isConstantValueExpression);
         } catch (Throwable e) {
             // need to catch it and make a new one because it contains unserializable variables...
             final StringBuilder exceptionMessageBuilder = new StringBuilder(1024)
@@ -2372,11 +2373,13 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
         private final Class<?> type;
         private final String source;
         private final HashSet<String> variablesUsed;
+        private final boolean isConstantValueExpression;
 
-        Result(Class<?> type, String source, HashSet<String> variablesUsed) {
+        Result(Class<?> type, String source, HashSet<String> variablesUsed, boolean isConstantValueExpression) {
             this.type = type;
             this.source = source;
             this.variablesUsed = variablesUsed;
+            this.isConstantValueExpression = isConstantValueExpression;
         }
 
         public Class<?> getType() {
@@ -2385,6 +2388,10 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
 
         public String getConvertedExpression() {
             return source;
+        }
+
+        public boolean isConstantValueExpression() {
+            return isConstantValueExpression;
         }
 
         public HashSet<String> getVariablesUsed() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
@@ -62,6 +62,7 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
             Configuration.getInstance().getBooleanWithDefault("FormulaColumn.useKernelFormulasProperty", false);
 
     private FormulaAnalyzer.Result analyzedFormula;
+    private boolean hasConstantValue;
 
     public FormulaColumnPython getFormulaColumnPython() {
         return formulaColumnPython;
@@ -189,6 +190,7 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
                     timeConversionResult);
             analyzedFormula = FormulaAnalyzer.analyze(formulaString, columnDefinitionMap,
                     timeConversionResult, result);
+            hasConstantValue = result.isConstantValueExpression();
 
             log.debug().append("Expression (after language conversion) : ").append(analyzedFormula.cookedFormulaString)
                     .endl();
@@ -728,11 +730,17 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
         final DhFormulaColumn copy = new DhFormulaColumn(columnName, formulaString);
         if (formulaFactory != null) {
             copy.analyzedFormula = analyzedFormula;
+            copy.hasConstantValue = hasConstantValue;
             copy.returnedType = returnedType;
             copy.formulaColumnPython = formulaColumnPython;
             onCopy(copy);
         }
         return copy;
+    }
+
+    @Override
+    public boolean hasConstantValue() {
+        return hasConstantValue;
     }
 
     private FormulaFactory createFormulaFactory() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FormulaColumn.java
@@ -20,4 +20,11 @@ public interface FormulaColumn extends SelectColumn {
     static FormulaColumn createFormulaColumn(String columnName, String formulaString) {
         return createFormulaColumn(columnName, formulaString, FormulaParserConfiguration.parser);
     }
+
+    /**
+     * @return true if all rows have a single constant value
+     */
+    default boolean hasConstantValue() {
+        return false;
+    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/ConstantColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/ConstantColumnLayer.java
@@ -1,0 +1,77 @@
+package io.deephaven.engine.table.impl.select.analyzers;
+
+import io.deephaven.base.log.LogOutput;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.liveness.LivenessNode;
+import io.deephaven.engine.rowset.RowSequence;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.ChunkSource;
+import io.deephaven.engine.table.ModifiedColumnSet;
+import io.deephaven.engine.table.TableUpdate;
+import io.deephaven.engine.table.WritableColumnSource;
+import io.deephaven.engine.table.impl.select.SelectColumn;
+import io.deephaven.engine.table.impl.select.VectorChunkAdapter;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.BitSet;
+
+public class ConstantColumnLayer extends SelectOrViewColumnLayer {
+    private final BitSet dependencyBitSet;
+
+    ConstantColumnLayer(
+            SelectAndViewAnalyzer inner,
+            String name,
+            SelectColumn sc,
+            WritableColumnSource<?> ws,
+            String[] deps,
+            ModifiedColumnSet mcsBuilder) {
+        super(inner, name, sc, ws, null, deps, mcsBuilder);
+        this.dependencyBitSet = new BitSet();
+        Arrays.stream(deps).mapToInt(inner::getLayerIndexFor).forEach(dependencyBitSet::set);
+        initialize(ws);
+    }
+
+    /**
+     * Initialize the column source with the constant value. Note that parent TableUpdates are ignored.
+     */
+    private void initialize(final WritableColumnSource<?> writableSource) {
+        ChunkSource.WithPrev<Values> chunkSource = selectColumn.getDataView();
+        if (selectColumnHoldsVector) {
+            chunkSource = new VectorChunkAdapter<>(chunkSource);
+        }
+
+        try (final WritableColumnSource.FillFromContext destContext = writableSource.makeFillFromContext(1);
+             final ChunkSource.GetContext chunkSourceContext = chunkSource.makeGetContext(1);
+             final RowSequence keys = RowSetFactory.fromKeys(0)) {
+            writableSource.fillFromChunk(destContext, chunkSource.getChunk(chunkSourceContext, keys), keys);
+        }
+    }
+
+    @Override
+    public void applyUpdate(final TableUpdate upstream, final RowSet toClear, final UpdateHelper helper,
+            final JobScheduler jobScheduler, @Nullable final LivenessNode liveResultOwner,
+            final SelectLayerCompletionHandler onCompletion) {
+        // Nothing to do at this level, but need to recurse because my inner layers might need to be called (e.g.
+        // because they are SelectColumnLayers)
+        inner.applyUpdate(upstream, toClear, helper, jobScheduler, liveResultOwner,
+                new SelectLayerCompletionHandler(dependencyBitSet, onCompletion) {
+                    @Override
+                    public void onAllRequiredColumnsCompleted() {
+                        // we don't need to do anything specific here; our result value is constant
+                        onCompletion.onLayerCompleted(getLayerIndex());
+                    }
+                });
+    }
+
+    @Override
+    public LogOutput append(LogOutput logOutput) {
+        return logOutput.append("{ConstantColumnLayer: ").append(selectColumn.toString()).append("}");
+    }
+
+    @Override
+    public boolean allowCrossColumnParallelization() {
+        return inner.allowCrossColumnParallelization();
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
@@ -17,11 +17,12 @@ import io.deephaven.engine.rowset.TrackingRowSet;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.OperationInitializationThreadPool;
 import io.deephaven.engine.table.impl.perf.BasePerformanceEntry;
+import io.deephaven.engine.table.impl.select.FormulaColumn;
 import io.deephaven.engine.table.impl.select.SelectColumn;
 import io.deephaven.engine.table.impl.select.SourceColumn;
 import io.deephaven.engine.table.impl.select.SwitchColumn;
 import io.deephaven.engine.table.impl.sources.InMemoryColumnSource;
-import io.deephaven.engine.table.impl.sources.RedirectedColumnSource;
+import io.deephaven.engine.table.impl.sources.SingleValueColumnSource;
 import io.deephaven.engine.table.impl.sources.WritableRedirectedColumnSource;
 import io.deephaven.engine.table.impl.util.InverseRowRedirectionImpl;
 import io.deephaven.engine.table.impl.util.WritableRowRedirection;
@@ -114,6 +115,14 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
             final String[] distinctDeps = allDependencies.distinct().toArray(String[]::new);
             final ModifiedColumnSet mcsBuilder = new ModifiedColumnSet(parentMcs);
 
+            if (hasConstantValue(sc)) {
+                final WritableColumnSource<?> constViewSource =
+                        SingleValueColumnSource.getSingleValueColumnSource(sc.getReturnedType());
+                analyzer = analyzer.createLayerForConstantView(
+                        sc.getName(), sc, constViewSource, distinctDeps, mcsBuilder);
+                continue;
+            }
+
             if (shouldPreserve(sc)) {
                 if (numberOfInternallyFlattenedColumns > 0) {
                     // we must preserve this column, but have already created an analyzer for the internally flattened
@@ -187,6 +196,18 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
         return analyzer;
     }
 
+    private static boolean hasConstantValue(final SelectColumn sc) {
+        if (sc instanceof FormulaColumn) {
+            return ((FormulaColumn) sc).hasConstantValue();
+        } else if (sc instanceof SwitchColumn) {
+            final SelectColumn realColumn = ((SwitchColumn) sc).getRealColumn();
+            if (realColumn instanceof FormulaColumn) {
+                return ((FormulaColumn) realColumn).hasConstantValue();
+            }
+        }
+        return false;
+    }
+
     private static boolean shouldPreserve(final SelectColumn sc) {
         if (!(sc instanceof SourceColumn)
                 && (!(sc instanceof SwitchColumn) || !(((SwitchColumn) sc).getRealColumn() instanceof SourceColumn))) {
@@ -251,6 +272,11 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
             boolean alreadyFlattened) {
         return new SelectColumnLayer(parentRowset, this, name, sc, cs, underlyingSource, parentColumnDependencies,
                 mcsBuilder, isRedirected, flatten, alreadyFlattened);
+    }
+
+    private SelectAndViewAnalyzer createLayerForConstantView(String name, SelectColumn sc, WritableColumnSource<?> cs,
+            String[] parentColumnDependencies, ModifiedColumnSet mcsBuilder) {
+        return new ConstantColumnLayer(this, name, sc, cs, parentColumnDependencies, mcsBuilder);
     }
 
     private SelectAndViewAnalyzer createLayerForView(String name, SelectColumn sc, ColumnSource<?> cs,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
@@ -279,9 +279,6 @@ final public class SelectColumnLayer extends SelectOrViewColumnLayer {
         final RowSet preMoveKeys = helper.getPreShifted(!modifiesAffectUs);
         final RowSet postMoveKeys = helper.getPostShifted(!modifiesAffectUs);
 
-        // Note that applyUpdate is called during initialization. If the table begins empty, we still want to force that
-        // an initial call to getDataView() (via getChunkSource()) or else the formula will only be computed later when
-        // data begins to flow; start-of-day is likely a bad time to find formula errors for our customers.
         final ChunkSource<Values> chunkSource = getChunkSource();
 
         final boolean needGetContext = upstream.added().isNonempty() || modifiesAffectUs;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
@@ -13,7 +13,6 @@ import io.deephaven.time.DateTimeUtils;
 import io.deephaven.vector.ObjectVector;
 import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.table.impl.select.DhFormulaColumn;
-import io.deephaven.engine.table.impl.select.FormulaCompilationException;
 import io.deephaven.engine.table.impl.select.formula.FormulaSourceDescriptor;
 import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.rowset.TrackingWritableRowSet;
@@ -38,7 +37,9 @@ public class FormulaAnalyzer {
         }
 
         log.debug().append("Expression (after language conversion) : ")
-                .append(queryLanguageResult.getConvertedExpression()).endl();
+                .append(queryLanguageResult.getConvertedExpression())
+                .append(" isConstantValueExpression=").append(queryLanguageResult.isConstantValueExpression())
+                .endl();
 
         final List<String> usedColumns = new ArrayList<>();
         final List<String> userParams = new ArrayList<>();
@@ -68,7 +69,8 @@ public class FormulaAnalyzer {
                 usedColumns.toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY),
                 usedColumnArrays.toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY),
                 userParams.toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY),
-                rawFormulaString, cookedFormulaString, timeInstanceVariables);
+                rawFormulaString, cookedFormulaString, timeInstanceVariables,
+                queryLanguageResult.isConstantValueExpression());
     }
 
     public static QueryLanguageParser.Result getCompiledFormula(Map<String, ColumnDefinition<?>> availableColumns,
@@ -138,13 +140,16 @@ public class FormulaAnalyzer {
         public final String rawFormulaString;
         public final String cookedFormulaString;
         public final String timeInstanceVariables;
+        public final boolean isConstantValueFormula;
 
         public Result(Class<?> returnedType, String[] usedColumns, String[] usedArrays, String[] usedParams,
-                String rawFormulaString, String cookedFormulaString, String timeInstanceVariables) {
+                String rawFormulaString, String cookedFormulaString, String timeInstanceVariables,
+                boolean isConstantValueFormula) {
             this.sourceDescriptor = new FormulaSourceDescriptor(returnedType, usedColumns, usedArrays, usedParams);
             this.rawFormulaString = rawFormulaString;
             this.cookedFormulaString = cookedFormulaString;
             this.timeInstanceVariables = timeInstanceVariables;
+            this.isConstantValueFormula = isConstantValueFormula;
         }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/NullValueColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/NullValueColumnSource.java
@@ -25,7 +25,8 @@ import java.util.stream.Collectors;
 /**
  * A column source that returns null for all keys.
  */
-public class NullValueColumnSource<T> extends AbstractColumnSource<T> implements ShiftData.ShiftCallback {
+public class NullValueColumnSource<T> extends AbstractColumnSource<T>
+        implements ShiftData.ShiftCallback, InMemoryColumnSource {
     private static final KeyedObjectKey.Basic<Pair<Class<?>, Class<?>>, NullValueColumnSource<?>> KEY_TYPE =
             new KeyedObjectKey.Basic<>() {
                 @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SingleValueColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SingleValueColumnSource.java
@@ -9,12 +9,8 @@ import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.table.impl.AbstractColumnSource;
 import io.deephaven.engine.table.impl.util.ShiftData;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.Serializable;
-
 public abstract class SingleValueColumnSource<T> extends AbstractColumnSource<T>
-        implements WritableColumnSource<T>, ChunkSink<Values>, ShiftData.ShiftCallback {
+        implements WritableColumnSource<T>, ChunkSink<Values>, ShiftData.ShiftCallback, InMemoryColumnSource {
 
     protected transient long changeTime;
     protected boolean isTrackingPrevValues;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestConstantFormulaEvaluation.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestConstantFormulaEvaluation.java
@@ -1,0 +1,419 @@
+package io.deephaven.engine.table.impl.select;
+
+import com.github.javaparser.ast.expr.Expression;
+import io.deephaven.engine.context.QueryScope;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.QueryTable;
+import io.deephaven.engine.table.impl.lang.JavaExpressionParser;
+import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
+import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
+import io.deephaven.engine.table.impl.sources.SingleValueColumnSource;
+import io.deephaven.engine.testutil.TstUtils;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.engine.updategraph.UpdateGraphProcessor;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.deephaven.engine.testutil.TstUtils.i;
+import static io.deephaven.engine.util.TableTools.col;
+
+public class TestConstantFormulaEvaluation {
+    @Rule
+    public final EngineCleanup cleanup = new EngineCleanup();
+
+    private static Integer calculate(Integer x, Integer y) {
+        return x * y;
+    }
+
+    @Test
+    public void multiColumnSimpleFormulasTestCase() {
+        final AtomicInteger atomicValue = new AtomicInteger(0);
+        QueryScope.addParam("atomicValue", atomicValue);
+        String[] formulas = new String[] {
+                "A=k", // increasing long values
+                "B=ii", // increasing long values
+                "C=i", // increasing int values
+                "D=7", // constant integer value of 7
+                "E=\"\" + k", // increasing long values as String
+                "F=4 + 3", // constant integer value of 7
+                "G=(2 + 3) * 2", // constant integer value of 10
+                "H=F + 3", // Formula using prev constant column as dependent variable
+                "I=C * D", // Formula using two prev columns as dependent variable
+                "J=2*4", // constant integer value of 8
+                "K=atomicValue.getAndIncrement()", // Predictable QueryScope Usage in Formula
+                "L=K*G", // Formula using two prev columns as dependent variable
+                "M=K*H", // Formula using two prev columns as dependent variable
+                "Exists=true", // constant boolean value of true
+                "Foo=\"Bar\"", // constant String value of Bar
+                "Z=K_[i-1]" // arrayAccess
+        };
+        final Table table = TableTools.emptyTable(7).update(formulas);
+        AtomicLong atomicLong = new AtomicLong(0);
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+
+        String[] columns = table.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("length of columns = " + formulas.length, columns.length, formulas.length);
+
+        table.getRowSet().forAllRowKeys(key -> {
+            final long expectedLongValue = atomicLong.getAndIncrement(); // for columns A and B
+            ColumnSource<?> cs = table.getColumnSource("A");
+            Assert.assertFalse("Col A is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "A=k"
+            Assert.assertEquals("Col A expected value is an increasing long value", expectedLongValue, cs.get(key));
+
+            cs = table.getColumnSource("B");
+            Assert.assertFalse("Col B is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "B=ii"
+            Assert.assertEquals("Col B expected value is an increasing long value", expectedLongValue, cs.get(key));
+
+            final int expectedIntValue = atomicInteger.getAndIncrement();
+            cs = table.getColumnSource("C");
+            Assert.assertFalse("Col C is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "C=i"
+            Assert.assertEquals("Col C expected value is an increasing int value", expectedIntValue, cs.get(key));
+
+            final int expectedColDValue = 7;
+            cs = table.getColumnSource("D");
+            Assert.assertTrue("Col D is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "D=7"
+            Assert.assertEquals("Col D expected value is " + expectedColDValue, expectedColDValue, cs.get(key));
+
+            final String expectedColEValue = "" + expectedLongValue;
+            cs = table.getColumnSource("E");
+            Assert.assertFalse("Col E is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // E="" + k increasing long values as String
+            Assert.assertEquals("Col E expected value is an increasing long values as String", expectedColEValue,
+                    cs.get(key));
+
+            final int expectedColFValue = 7;
+            cs = table.getColumnSource("F");
+            Assert.assertTrue("Col F is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "F=4 + 3", constant integer value
+            Assert.assertEquals("Col F expected value is " + expectedColFValue, expectedColFValue, cs.get(key));
+
+            final int expectedColGValue = 10;
+            cs = table.getColumnSource("G");
+            Assert.assertTrue("Col G is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "G=(2 + 3) * 2", constant integer value
+            Assert.assertEquals("Col G expected value is " + expectedColGValue, expectedColGValue, cs.get(key));
+
+            final int expectedColHValue = expectedColFValue + 3;
+            cs = table.getColumnSource("H");
+            Assert.assertFalse("Col H is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "H=F + 3", Formula using prev constant column as dependent variable
+            Assert.assertEquals("Col H expected value is a constant value", expectedColHValue, cs.get(key));
+
+            cs = table.getColumnSource("I");
+            Assert.assertFalse("Col I is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "I=C * D", Formula using two prev columns as dependent variable
+            Assert.assertEquals("Col I expected value is an increasing int values",
+                    expectedIntValue * expectedColDValue, cs.get(key));
+
+            final int expectedColJValue = 2 * 4;
+            cs = table.getColumnSource("J");
+            Assert.assertTrue("Col J is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "J=2*4", constant integer value of 8
+            Assert.assertEquals("Col J expected value is a constant value", expectedColJValue, cs.get(key));
+
+            cs = table.getColumnSource("K");
+            Assert.assertFalse("Col K is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "K=atomicValue.getAndIncrement()" , atomicValue initial value set at 0
+            Assert.assertEquals("Col K expected value is an increasing int value", expectedIntValue, cs.get(key));
+
+            cs = table.getColumnSource("L");
+            Assert.assertFalse("Col L is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "L=K*G", Formula using two prev columns as dependent variable
+            Assert.assertEquals("Col L expected value is an increasing int values",
+                    expectedIntValue * expectedColGValue, cs.get(key));
+
+            cs = table.getColumnSource("M");
+            Assert.assertFalse("Col M is not a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "M=K*H", Formula using two prev columns as dependent variable
+            Assert.assertEquals("Col M expected value is an increasing int values",
+                    expectedIntValue * expectedColHValue, cs.get(key));
+
+            final boolean expectedColExistsValue = true;
+            cs = table.getColumnSource("Exists");
+            Assert.assertTrue("Col Exists is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "Exists=true", constant boolean value of true
+            Assert.assertEquals("Col Exists expected value is a constant value", expectedColExistsValue, cs.get(key));
+
+            final String expectedColFooValue = "Bar";
+            cs = table.getColumnSource("Foo");
+            Assert.assertTrue("Col Foo is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "Foo=Bar", constant String value of Bar
+            Assert.assertEquals("Col Foo expected value is a constant value", expectedColFooValue, cs.get(key));
+
+            final Integer expectedZValue = expectedIntValue == 0 ? null : expectedIntValue - 1;
+            cs = table.getColumnSource("Z");
+            Assert.assertFalse("Col Z is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            // "Z=K_[i-1]" arrayAccess
+            Assert.assertEquals("Col Z expected value is a constant value", expectedZValue, cs.get(key));
+        });
+    }
+
+    @Test
+    public void constantBooleanValueTest() {
+        singleColumnConstantValueFormulaTest("Exists=true", Boolean.class, true, 7, "constantBooleanValueTest");
+    }
+
+    @Test
+    public void constantStringValueTest() {
+        singleColumnConstantValueFormulaTest("Foo=\"Bar\"", String.class, "Bar", 5, "constantStringValueTest");
+    }
+
+    @Test
+    public void constantIntValueTest() {
+        singleColumnConstantValueFormulaTest("X=7", int.class, 7, 5, "constantIntValueTest");
+        singleColumnConstantValueFormulaTest("X=4 + 3", int.class, 7, 7, "constantIntValueTest");
+        singleColumnConstantValueFormulaTest("X=(4 - 3) * 7", int.class, 7, 7, "constantIntValueTest");
+        singleColumnConstantValueFormulaTest("X=(4 + 3) * 4", int.class, 28, 7, "constantIntValueTest");
+    }
+
+    @Test
+    public void constantDoubleValueTest() {
+        singleColumnConstantValueFormulaTest("X=((4 + 4) / 4) + 5", double.class, 7.0d, 7, "constantDoubleValueTest");
+    }
+
+    @Test
+    public void constantLongValueTest() {
+        singleColumnConstantValueFormulaTest("X=7L", long.class, 7L, 7, "constantDoubleValueTest");
+    }
+
+    private <T> void singleColumnConstantValueFormulaTest(final String formula, final Class<T> columnType,
+            final T columnRowValue, final int tableLength, final String description) {
+        final QueryPerformanceNugget nugget = QueryPerformanceRecorder.getInstance().getNugget(description);
+        try {
+            final Table source = TableTools.emptyTable(tableLength).update(formula);
+            String[] columns = source.getDefinition().getColumnNamesArray();
+            Assert.assertEquals("length of columns = 1", 1, columns.length);
+            ColumnSource<?> cs = source.getColumnSource(columns[0]);
+
+            Assert.assertTrue("ColumnSource is a SingleValueColumnSource", cs instanceof SingleValueColumnSource);
+            source.getRowSet().forAllRowKeys(key -> {
+                Assert.assertEquals(columnType, source.getColumnSource(columns[0]).getType());
+                Assert.assertEquals(columnRowValue, source.getColumnSource(columns[0]).get(key));
+            });
+        } finally {
+            nugget.done();
+        }
+    }
+
+    @Test
+    public void threeColumnConstantValueFormulaTest() {
+        String[] formulas = new String[] {"X=i", "Y=7", "Z=X*Y"};
+        threeColumnConstantValueFormulaTest(formulas, int.class, 7, TestConstantFormulaEvaluation::calculate, 5,
+                "productOfFirstTwoColsTest");
+
+        formulas = new String[] {"X=i", "Y=7", "Z=X+Y"};
+        threeColumnConstantValueFormulaTest(formulas, int.class, 7, Integer::sum, 7, "sumOfFirstTwoColsTest");
+
+        formulas = new String[] {"X=ii", "Y=7L", "Z=X+Y"};
+        threeColumnConstantValueFormulaTest(formulas, long.class, 7L, Long::sum, 8, "sumOfFirstTwoColsTest");
+
+        formulas = new String[] {"X=\"\" + k", "Y=\"TestConcat\"", "Z=X+Y"};
+        threeColumnConstantValueFormulaTest(formulas, String.class, "TestConcat", (x, y) -> x + y, 8,
+                "sumOfFirstTwoColsTest");
+
+        formulas = new String[] {"X=\"Foo\"", "Y=\"Bar\"", "Z=X+Y"};
+        threeColumnConstantValueFormulaTest(formulas, String.class, "Bar", (x, y) -> x + y, 8, "sumOfFirstTwoColsTest");
+    }
+
+    private <T> void threeColumnConstantValueFormulaTest(final String[] formulas, final Class<T> calculatedColType,
+            final T expectedConstValue, final ColumnFormula<T> columnFormula, final int tableLength,
+            final String description) {
+        final QueryPerformanceNugget nugget = QueryPerformanceRecorder.getInstance().getNugget(description);
+        try {
+            final Table source = TableTools.emptyTable(tableLength).update(formulas);
+            String[] columns = source.getDefinition().getColumnNamesArray();
+            boolean constantValueColFound = false;
+            Assert.assertEquals("length of columns = " + formulas.length, columns.length, formulas.length);
+            for (int i = 0; i < formulas.length; i++) {
+                ColumnSource<?> cs = source.getColumnSource(columns[i]);
+                if (isConstantExpression(formulas[i])) {
+                    constantValueColFound = true;
+                    System.out.printf("%s is a Constant value formula, ColumnSource for Column [%s] is %s%n",
+                            formulas[i], columns[i], cs);
+                    Assert.assertTrue("ColumnSource is a SingleValueColumnSource ",
+                            cs instanceof SingleValueColumnSource);
+                } else {
+                    Assert.assertFalse("ColumnSource is NOT a SingleValueColumnSource ",
+                            cs instanceof SingleValueColumnSource);
+                }
+            }
+
+            Assert.assertTrue("ConstantValue Column was found", constantValueColFound);
+
+            source.getRowSet().forAllRowKeys(key -> {
+                Assert.assertEquals(source.getColumnSource(columns[2]).getType(), calculatedColType);
+                Assert.assertEquals("ConstantValue verification", expectedConstValue,
+                        source.getColumnSource(columns[1]).get(key));
+                // noinspection unchecked
+                final T expected = columnFormula.calculate(
+                        (T) source.getColumnSource(columns[0]).get(key),
+                        (T) source.getColumnSource(columns[1]).get(key));
+                Assert.assertEquals(expected, source.getColumnSource(columns[2]).get(key));
+            });
+        } finally {
+            nugget.done();
+        }
+    }
+
+    @Test
+    public void queryScopeForAtomicIntPlusConstantFormulaTest() {
+        final QueryPerformanceNugget nugget = QueryPerformanceRecorder.getInstance()
+                .getNugget("queryScopeForAtomicInt");
+        try {
+            final AtomicInteger atomicValue = new AtomicInteger(1);
+            QueryScope.addParam("atomicValue", atomicValue);
+            String[] formulas = new String[] {
+                    "X=10", // constant integer value of 10
+                    "Y=atomicValue.getAndIncrement()", // Predictable QueryScope Usage in Formula
+                    "Z=Y*X" // Formula using two prev columns as dependent variable
+            };
+            final Table source = TableTools.emptyTable(7).update(formulas);
+            String[] columns = source.getDefinition().getColumnNamesArray();
+            boolean constantValueColFound = false;
+            Assert.assertEquals("length of columns = " + formulas.length, columns.length, formulas.length);
+            for (int i = 0; i < formulas.length; i++) {
+                ColumnSource<?> cs = source.getColumnSource(columns[i]);
+                if (isConstantExpression(formulas[i])) {
+                    constantValueColFound = true;
+                    System.out.printf("%s is a Constant value formula, ColumnSource for Column [%s] is %s%n",
+                            formulas[i], columns[i], cs);
+                    Assert.assertTrue("ColumnSource is a SingleValueColumnSource ",
+                            cs instanceof SingleValueColumnSource);
+                } else {
+                    Assert.assertFalse("ColumnSource is NOT a SingleValueColumnSource ",
+                            cs instanceof SingleValueColumnSource);
+                }
+            }
+
+            Assert.assertTrue("ConstantValue Column was found", constantValueColFound);
+
+            AtomicInteger atomicInteger = new AtomicInteger(1);
+            source.getRowSet().forAllRowKeys(key -> {
+                final int expectedAtomicIntColValue = atomicInteger.getAndIncrement();
+                final int expectedCalculatedColValue = 10 * expectedAtomicIntColValue;
+                Assert.assertEquals("ConstantValue verification", 10, source.getColumnSource(columns[0]).get(key));
+                Assert.assertEquals("AtomicInteger verification", expectedAtomicIntColValue,
+                        source.getColumnSource(columns[1]).get(key));
+                Assert.assertEquals("Calculate Col verification", expectedCalculatedColValue,
+                        source.getColumnSource(columns[2]).get(key));
+            });
+        } finally {
+            nugget.done();
+        }
+    }
+
+    private interface ColumnFormula<T> {
+        T calculate(T col1, T col2);
+    }
+
+    @Test
+    public void constantExpressionTest() {
+        Assert.assertTrue("\"Exists=true\" is a Constant Value Expression", isConstantExpression("Exists=true"));
+        Assert.assertTrue("\"Foo=\"Bar\"\" is a Constant Value Expression", isConstantExpression("Foo=\"Bar\""));
+        Assert.assertTrue("\"X=7\" is a Constant Value Expression", isConstantExpression("X=7"));
+        Assert.assertTrue("\"U=4 + 3\" is a Constant Value Expression", isConstantExpression("U=4 + 3"));
+        Assert.assertTrue("\"A=4 + 3 + 3\" is a Constant Value Expression", isConstantExpression("A=4 + 3 + 3"));
+        Assert.assertTrue("\"B=4 / (3 + 3)\" is a Constant Value Expression", isConstantExpression("B=4 / (3 + 3)"));
+        Assert.assertTrue("\"C=(4 + 3) + (3 * (5 + (8 - 6)))\" is a Constant Value Expression",
+                isConstantExpression("C=(4 + 3) + (3 * (5 + (8 - 6)))"));
+        Assert.assertTrue("\"D=((4 + 3) - (7 -95) + (3 * (5 + (8 - 6))))\" is a Constant Value Expression",
+                isConstantExpression("D=((4 + 3) - (7 -95) + (3 * (5 + (8 - 6))))"));
+    }
+
+    @Test
+    public void notConstantExpressionTest() {
+        Assert.assertFalse("\"W=k\" is not a Constant Value Expression", isConstantExpression("W=k"));
+        Assert.assertFalse("\"M=ii\" is not a Constant Value Expression", isConstantExpression("M=ii"));
+        Assert.assertFalse("\"N=i\" is not a Constant Value Expression", isConstantExpression("N=i"));
+        Assert.assertFalse("\"N=i\" is not a Constant Value Expression", isConstantExpression("P=4 + a"));
+        Assert.assertFalse("\"Z=Y_[i-1]\" is not a Constant Value Expression", isConstantExpression("Z=Y_[i-1]"));
+        Assert.assertFalse("\"Y=random.nextInt(1000000)\" is not a Constant Value Expression",
+                isConstantExpression("Y=random.nextInt(1000000)"));
+        Assert.assertFalse("\"e=((4 + 3) - (7 -95) + (3 * (5 + (g - 8))))\" is not a Constant Value Expression",
+                isConstantExpression("e=((4 + 3) - (7 -95) + (3 * (5 + (g - 8))))"));
+        Assert.assertFalse("\"f=((4 + 3) - (7 -95) + (3 * (5 + (8 - g))))\" is not a Constant Value Expression",
+                isConstantExpression("f=((4 + 3) - (7 -95) + (3 * (5 + (8 - g))))"));
+    }
+
+    private boolean isConstantExpression(String expression) {
+        if (expression == null || expression.trim().length() == 0) {
+            return false;
+        }
+        Expression expr = JavaExpressionParser.parseExpression(expression);
+        return JavaExpressionParser.isConstantValueExpression(expr);
+    }
+
+    @Test
+    public void testRefreshingTableForConstantFormulaColumnSource() {
+        final QueryTable table = TstUtils.testRefreshingTable(i(2, 4, 6).toTracking(),
+                col("x", 1, 2, 3), col("y", 'a', 'b', 'c'));
+        final String[] formulas = new String[] {"x = x * 2", "z = y", "u=7"};
+        QueryTable table2 = UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(
+                () -> (QueryTable) table.select(formulas));
+        Set<String> expectedConstValueColumns = Collections.singleton("u");
+        Integer[] expectedConstValues = new Integer[] {7};
+        checkConstantFormula(table2, expectedConstValueColumns, expectedConstValues, int.class);
+
+        final String[] formulas2 = new String[] {"x = x * 2", "z1 = z", "u1=u", "u2=u1 * 2"};
+        QueryTable table3 =
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> (QueryTable) table2.select(formulas2));
+        Set<String> expectedConstValueColumns2 = Collections.singleton("u1");
+        Integer[] expectedConstValues2 = new Integer[] {7};
+        // verify parent constant value ColumnSource is same when inherited as is
+        Assert.assertSame(table3.getColumnSource("u1"), table2.getColumnSource("u"));
+        checkConstantFormula(table3, expectedConstValueColumns2, expectedConstValues2, int.class);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private <T> void checkConstantFormula(final Table source, final Set<String> expectedConstValueColumns,
+            final T[] expectedConstValues, final Class<T> calculatedColType) {
+        final QueryPerformanceNugget nugget =
+                QueryPerformanceRecorder.getInstance().getNugget("queryScopeForAtomicInt");
+        try {
+            int count = 0;
+            int[] constantColIndex = new int[expectedConstValues.length];
+            String[] columns = source.getDefinition().getColumnNamesArray();
+
+            for (int ii = 0; ii < columns.length; ii++) {
+                final ColumnSource<?> cs = source.getColumnSource(columns[ii]);
+                if (expectedConstValueColumns.contains(columns[ii])) {
+                    constantColIndex[count++] = ii;
+                    Assert.assertTrue("ColumnSource is a SingleValueColumnSource ",
+                            cs instanceof SingleValueColumnSource);
+                    Assert.assertEquals("ColumnType ", calculatedColType, cs.getType());
+                } else {
+                    Assert.assertFalse("ColumnSource is NOT a SingleValueColumnSource ",
+                            cs instanceof SingleValueColumnSource);
+                }
+            }
+
+            Assert.assertEquals("ConstantValue Columns found, count matches expectedConstValues count", count,
+                    expectedConstValues.length);
+
+            if (expectedConstValues.length == 0) {
+                return;
+            }
+
+            source.getRowSet().forAllRowKeys(key -> {
+                for (int i = 0; i < constantColIndex.length; i++) {
+                    Assert.assertEquals("ConstantValue verification", expectedConstValues[i],
+                            source.getColumnSource(columns[constantColIndex[i]]).get(key));
+                }
+            });
+        } finally {
+            nugget.done();
+        }
+    }
+}


### PR DESCRIPTION
I used a little creative freedom to keep code style more consistent with DHC. There were some incorrect generic parameters in DHE that are fixed here. In DHC, SelectColumns are aggressively initialized before they reach the analyzer. Some comments were updated/removed to reflect this. I also inlined the helper method added to SelectColumn as it only applies to a very specific subset of DhFormulaColumn and only needs to be invoked by the FormulaAnalyzer.

The internal JIRA Ticket: [DH-11933](https://deephaven.atlassian.net/browse/DH-11933)
The internal [commit](https://github.com/deephaven-ent/iris/commit/e28e80c6134376a321e2180018b142dde8802a72).

I opted to not run nightlies on this change.