### PR TITLE
Fix test code for Python 3.10

### DIFF
--- a/py/server/tests/test_column.py
+++ b/py/server/tests/test_column.py
@@ -73,7 +73,7 @@ class ColumnTestCase(BaseTestCase):
         self.assertEqual(test_table.columns[1].component_type, dtypes.double)
 
     def test_numeric_columns(self):
-        x = [MAX_BYTE, MAX_SHORT, MAX_INT, MAX_LONG, 0.98888, 999999.888888]
+        x = [MAX_BYTE, MAX_SHORT, MAX_INT, MAX_LONG, 1, 999999]
         n = len(x)
 
         def get_x(i) -> int:

--- a/py/server/tests/test_dtypes.py
+++ b/py/server/tests/test_dtypes.py
@@ -92,20 +92,20 @@ class DTypesTestCase(BaseTestCase):
         self.assertTrue(np.array_equal(np_array, expected))
 
     def test_integer_array(self):
-        np_array = np.array([float('nan'), NULL_DOUBLE, 1.123, np.inf], dtype=np.float64)
+        np_array = np.array([float('nan'), NULL_DOUBLE, np.inf], dtype=np.float64)
 
         nulls = {dtypes.int64: NULL_LONG, dtypes.int32: NULL_INT, dtypes.short: NULL_SHORT, dtypes.byte: NULL_BYTE}
         for dt, nv in nulls.items():
             map_fn = functools.partial(remap_double, null_value=nv)
             with self.subTest(f"numpy double array to {dt}"):
-                expected = [nv, nv, 1, nv]
+                expected = [nv, nv, nv]
                 j_array = dtypes.array(dt, np_array, remap=map_fn)
                 py_array = [x for x in j_array]
                 self.assertEqual(expected, py_array)
 
         with self.subTest("int array from Python list"):
             expected = [1, 2, 3]
-            j_array = dtypes.array(dtypes.int32, [1.1, 2.2, 3.3])
+            j_array = dtypes.array(dtypes.int32, [1, 2, 3])
             self.assertIn("[I", str(type(j_array)))
             py_array = [x for x in j_array]
             self.assertEqual(expected, py_array)


### PR DESCRIPTION
Fixes #3325 

Python 3.10 no longer implicitly converts floating numbers to integers in the C API. Tests that rely on the old behavior are  rewritten to be more type explicit and precise.

