### PR TITLE
Fix infinite loop caused by integer overflow in ParquetTools.writeTable()

### DIFF
--- a/Base/src/main/java/io/deephaven/base/ArrayUtil.java
+++ b/Base/src/main/java/io/deephaven/base/ArrayUtil.java
@@ -9,6 +9,13 @@ import java.util.*;
 
 public class ArrayUtil {
 
+    /**
+     * The maximum array size is determined by the JVM and in practice is less than Integer.MAX_VALUE. (See note at
+     * {@link jdk.internal.util.ArraysSupport#SOFT_MAX_ARRAY_LENGTH}.)
+     */
+    // We would like to use jdk.internal.util.ArraysSupport.MAX_ARRAY_LENGTH, but it is not exported
+    public static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
     public static int[] pushArray(int e, int[] a) {
         if (a == null) {
             a = new int[] {e};

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/InMemoryColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/InMemoryColumnSource.java
@@ -3,9 +3,9 @@
  */
 package io.deephaven.engine.table.impl.sources;
 
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.WritableColumnSource;
-import io.deephaven.engine.table.impl.ImmutableColumnSource;
 import io.deephaven.engine.table.impl.sources.immutable.*;
 import io.deephaven.engine.table.impl.sources.immutable.Immutable2DCharArraySource;
 import io.deephaven.engine.table.impl.sources.immutable.ImmutableCharArraySource;
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface InMemoryColumnSource {
     // We would like to use jdk.internal.util.ArraysSupport.MAX_ARRAY_LENGTH, but it is not exported
-    int TWO_DIMENSIONAL_COLUMN_SOURCE_THRESHOLD = Integer.MAX_VALUE - 8;
+    int TWO_DIMENSIONAL_COLUMN_SOURCE_THRESHOLD = ArrayUtil.MAX_ARRAY_SIZE;
 
     /**
      * Create an immutable in-memory column source that is capable of holding longSize elements.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionRedirection.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionRedirection.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.engine.table.impl.sources;
 
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.base.MathUtil;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.util.annotations.VisibleForTesting;
@@ -32,7 +33,7 @@ public class UnionRedirection {
             Configuration.getInstance().getLongWithDefault("UnionRedirection.allocationUnit", 1 << 16);
 
     // We would like to use jdk.internal.util.ArraysSupport.MAX_ARRAY_LENGTH, but it is not exported
-    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    private static final int MAX_ARRAY_SIZE = ArrayUtil.MAX_ARRAY_SIZE;
 
     /**
      * Number of table slots to allocate initially.

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
@@ -12,6 +12,7 @@ import io.deephaven.barrage.flatbuf.BarrageMessageType;
 import io.deephaven.barrage.flatbuf.BarrageMessageWrapper;
 import io.deephaven.barrage.flatbuf.BarrageModColumnMetadata;
 import io.deephaven.barrage.flatbuf.BarrageUpdateMetadata;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
@@ -42,7 +43,7 @@ public class BarrageStreamReader implements StreamReader {
     private static final Logger log = LoggerFactory.getLogger(BarrageStreamReader.class);
 
     // We would like to use jdk.internal.util.ArraysSupport.MAX_ARRAY_LENGTH, but it is not exported
-    private static final int MAX_CHUNK_SIZE = Integer.MAX_VALUE - 8;
+    private static final int MAX_CHUNK_SIZE = ArrayUtil.MAX_ARRAY_SIZE;
 
     private final LongConsumer deserializeTmConsumer;
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainBinaryChunkedWriter.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainBinaryChunkedWriter.java
@@ -20,6 +20,12 @@ import java.nio.IntBuffer;
  * Plain encoding except for binary values
  */
 public class PlainBinaryChunkedWriter extends AbstractBulkValuesWriter<Binary[]> {
+
+    /**
+     * The maximum array size is determined by the JVM and in practice is less than Integer.MAX_VALUE. (See note at {@link jdk.internal.util.ArraysSupport#SOFT_MAX_ARRAY_LENGTH}.)
+     */
+    private static final int MAXIMUM_TOTAL_CAPACITY = Integer.MAX_VALUE - 8;
+
     private final ByteBufferAllocator allocator;
 
     ByteBuffer innerBuffer;
@@ -126,13 +132,13 @@ public class PlainBinaryChunkedWriter extends AbstractBulkValuesWriter<Binary[]>
         final int currentCapacity = innerBuffer.capacity();
         final int currentPosition = innerBuffer.position();
         final long requiredCapacity = (long)currentPosition + v.length() + Integer.BYTES;
-        if(requiredCapacity > Integer.MAX_VALUE) {
-            throw new IllegalStateException("Unable to write " + requiredCapacity + " values");
+        if(requiredCapacity > MAXIMUM_TOTAL_CAPACITY) {
+            throw new IllegalStateException("Unable to write " + requiredCapacity + " values. (Maximum capacity: " + MAXIMUM_TOTAL_CAPACITY + ".)");
         }
 
         int newCapacity = currentCapacity;
         while(newCapacity < requiredCapacity) {
-            newCapacity = Math.min(Integer.MAX_VALUE, newCapacity * 2);
+            newCapacity = (int) Math.min(MAXIMUM_TOTAL_CAPACITY, newCapacity * 2L);
         }
 
         final ByteBuffer newBuf = allocator.allocate(newCapacity);

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainBinaryChunkedWriter.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainBinaryChunkedWriter.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.parquet.base;
 
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.parquet.base.util.Helpers;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
@@ -21,10 +22,7 @@ import java.nio.IntBuffer;
  */
 public class PlainBinaryChunkedWriter extends AbstractBulkValuesWriter<Binary[]> {
 
-    /**
-     * The maximum array size is determined by the JVM and in practice is less than Integer.MAX_VALUE. (See note at {@link jdk.internal.util.ArraysSupport#SOFT_MAX_ARRAY_LENGTH}.)
-     */
-    private static final int MAXIMUM_TOTAL_CAPACITY = Integer.MAX_VALUE - 8;
+    private static final int MAXIMUM_TOTAL_CAPACITY = ArrayUtil.MAX_ARRAY_SIZE;
 
     private final ByteBufferAllocator allocator;
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainDoubleChunkedWriter.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainDoubleChunkedWriter.java
@@ -139,17 +139,18 @@ public class PlainDoubleChunkedWriter extends AbstractBulkValuesWriter<DoubleBuf
 
         final int currentCapacity = targetBuffer.capacity();
         final int currentPosition = targetBuffer.position();
-        final int requiredCapacity = currentPosition + valuesToAdd.remaining();
+        final long requiredCapacity = (long) currentPosition + valuesToAdd.remaining();
         if(requiredCapacity < currentCapacity) {
             return;
         }
 
         if(requiredCapacity > MAXIMUM_TOTAL_CAPACITY) {
-            throw new IllegalStateException("Unable to write " + requiredCapacity + " values");
+            throw new IllegalStateException("Unable to write " + requiredCapacity + " values. (Maximum capacity: " + MAXIMUM_TOTAL_CAPACITY + ".)");
         }
 
         int newCapacity = currentCapacity;
         while(newCapacity < requiredCapacity) {
+            // note: since MAXIMUM_TOTAL_CAPACITY <= Integer.MAX_VALUE / 2, doubling 'newCapacity' will never overflow
             newCapacity = Math.min(MAXIMUM_TOTAL_CAPACITY, newCapacity * 2);
         }
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainFloatChunkedWriter.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainFloatChunkedWriter.java
@@ -139,17 +139,18 @@ public class PlainFloatChunkedWriter extends AbstractBulkValuesWriter<FloatBuffe
 
         final int currentCapacity = targetBuffer.capacity();
         final int currentPosition = targetBuffer.position();
-        final int requiredCapacity = currentPosition + valuesToAdd.remaining();
+        final long requiredCapacity = (long) currentPosition + valuesToAdd.remaining();
         if(requiredCapacity < currentCapacity) {
             return;
         }
 
         if(requiredCapacity > MAXIMUM_TOTAL_CAPACITY) {
-            throw new IllegalStateException("Unable to write " + requiredCapacity + " values");
+            throw new IllegalStateException("Unable to write " + requiredCapacity + " values. (Maximum capacity: " + MAXIMUM_TOTAL_CAPACITY + ".)");
         }
 
         int newCapacity = currentCapacity;
         while(newCapacity < requiredCapacity) {
+            // note: since MAXIMUM_TOTAL_CAPACITY <= Integer.MAX_VALUE / 2, doubling 'newCapacity' will never overflow
             newCapacity = Math.min(MAXIMUM_TOTAL_CAPACITY, newCapacity * 2);
         }
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainIntChunkedWriter.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainIntChunkedWriter.java
@@ -132,17 +132,18 @@ public class PlainIntChunkedWriter extends AbstractBulkValuesWriter<IntBuffer> {
 
         final int currentCapacity = targetBuffer.capacity();
         final int currentPosition = targetBuffer.position();
-        final int requiredCapacity = currentPosition + valuesToAdd.remaining();
+        final long requiredCapacity = (long) currentPosition + valuesToAdd.remaining();
         if(requiredCapacity < currentCapacity) {
             return;
         }
 
         if(requiredCapacity > MAXIMUM_TOTAL_CAPACITY) {
-            throw new IllegalStateException("Unable to write " + requiredCapacity + " values");
+            throw new IllegalStateException("Unable to write " + requiredCapacity + " values. (Maximum capacity: " + MAXIMUM_TOTAL_CAPACITY + ".)");
         }
 
         int newCapacity = currentCapacity;
         while(newCapacity < requiredCapacity) {
+            // note: since MAXIMUM_TOTAL_CAPACITY <= Integer.MAX_VALUE / 2, doubling 'newCapacity' will never overflow
             newCapacity = Math.min(MAXIMUM_TOTAL_CAPACITY, newCapacity * 2);
         }
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainLongChunkedWriter.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/PlainLongChunkedWriter.java
@@ -139,17 +139,18 @@ public class PlainLongChunkedWriter extends AbstractBulkValuesWriter<LongBuffer>
 
         final int currentCapacity = targetBuffer.capacity();
         final int currentPosition = targetBuffer.position();
-        final int requiredCapacity = currentPosition + valuesToAdd.remaining();
+        final long requiredCapacity = (long) currentPosition + valuesToAdd.remaining();
         if(requiredCapacity < currentCapacity) {
             return;
         }
 
         if(requiredCapacity > MAXIMUM_TOTAL_CAPACITY) {
-            throw new IllegalStateException("Unable to write " + requiredCapacity + " values");
+            throw new IllegalStateException("Unable to write " + requiredCapacity + " values. (Maximum capacity: " + MAXIMUM_TOTAL_CAPACITY + ".)");
         }
 
         int newCapacity = currentCapacity;
         while(newCapacity < requiredCapacity) {
+            // note: since MAXIMUM_TOTAL_CAPACITY <= Integer.MAX_VALUE / 2, doubling 'newCapacity' will never overflow
             newCapacity = Math.min(MAXIMUM_TOTAL_CAPACITY, newCapacity * 2);
         }
 

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateParquetChunkedWriters.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateParquetChunkedWriters.java
@@ -39,8 +39,8 @@ public class ReplicateParquetChunkedWriters {
                 "final int currentCapacity",
                 "final int currentPosition",
                 "final int targetPageSize",
-                "int requiredCapacity",
                 "int newCapacity",
+                "MAXIMUM_TOTAL_CAPACITY <= Integer.MAX_VALUE / 2",
                 "int MAXIMUM_TOTAL_CAPACITY = Integer.MAX_VALUE")
                 .forEach(ReplicateParquetChunkedWriters::injectIntBuffer);
     }


### PR DESCRIPTION
Fix infinite loop in `PlainBinaryChunkedWriter.ensureCapacityFor()` triggered by integer overflow while calculating `newCapacity`. Introduce a global constant for `MAX_ARRAY_SIZE` (since it's more explicit than writing `Integer.MAX_VALUE - 8` in multiple places).