### PR TITLE
Session expiration should be known to clients

### DIFF
--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -45,6 +45,8 @@ default.processEnvironmentFactory=io.deephaven.util.process.DefaultProcessEnviro
 
 OperationInitializationThreadPool.threads=1
 
+# Default session duration is 5 minutes
+http.session.durationMs=300000
 
 AuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler
 
@@ -53,7 +55,7 @@ AuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler
 authentication.client.configuration.list=AuthHandlers
 
 # List of configuration properties to provide to authenticated clients, so they can interact with the server.
-client.configuration.list=java.version,deephaven.version,barrage.version,
+client.configuration.list=java.version,deephaven.version,barrage.version,http.session.durationMs
 # Version list to add to the configuration property list. Each `=`-delimited pair denotes a short name for a versioned
 # jar, and a class that is found in that jar. Any such keys will be made available to the client.configuration.list
 # as <key>.version.

--- a/props/test-configs/src/main/resources/dh-tests.prop
+++ b/props/test-configs/src/main/resources/dh-tests.prop
@@ -94,6 +94,7 @@ BarrageMessageProducer.minSnapshotCellCount=50
 BarrageMessageProducer.maxSnapshotCellCount=50
 BarrageStreamGenerator.batchSize=4
 
+http.session.durationMs=300000
 AuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler
 authentication.client.configuration.list=
 client.version.list=

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyConfig.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyConfig.java
@@ -62,9 +62,8 @@ public abstract class JettyConfig implements ServerConfig {
     /**
      * The default configuration is suitable for local development purposes. It inherits all of the defaults, which are
      * documented on each individual method. In brief, the default server starts up on all interfaces with plaintext
-     * port {@value DEFAULT_PLAINTEXT_PORT}, a token expiration duration of {@value DEFAULT_TOKEN_EXPIRE_MIN} minutes, a
-     * scheduler pool size of {@value DEFAULT_SCHEDULER_POOL_SIZE}, and a max inbound message size of
-     * {@value DEFAULT_MAX_INBOUND_MESSAGE_SIZE_MiB} MiB.
+     * port {@value DEFAULT_PLAINTEXT_PORT}, a scheduler pool size of {@value DEFAULT_SCHEDULER_POOL_SIZE}, and a max
+     * inbound message size of {@value DEFAULT_MAX_INBOUND_MESSAGE_SIZE_MiB} MiB.
      */
     public static JettyConfig defaultConfig() {
         return builder().build();

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
@@ -16,6 +16,8 @@ import io.deephaven.server.test.TestAuthModule;
 import io.deephaven.server.test.FlightMessageRoundTripTest;
 
 import javax.inject.Singleton;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 public class JettyFlightRoundTripTest extends FlightMessageRoundTripTest {
 
@@ -23,7 +25,10 @@ public class JettyFlightRoundTripTest extends FlightMessageRoundTripTest {
     public interface JettyTestConfig {
         @Provides
         static JettyConfig providesJettyConfig() {
-            return JettyConfig.defaultConfig();
+            return JettyConfig.builder()
+                    .port(0)
+                    .tokenExpire(Duration.of(5, ChronoUnit.MINUTES))
+                    .build();
         }
     }
 

--- a/server/netty/src/main/java/io/deephaven/server/netty/NettyConfig.java
+++ b/server/netty/src/main/java/io/deephaven/server/netty/NettyConfig.java
@@ -26,9 +26,8 @@ public abstract class NettyConfig implements ServerConfig {
     /**
      * The default configuration is suitable for local development purposes. It inherits all of the defaults, which are
      * documented on each individual method. In brief, the default server starts up on all interfaces with plaintext
-     * port {@value DEFAULT_PLAINTEXT_PORT}, a token expiration duration of {@value DEFAULT_TOKEN_EXPIRE_MIN} minutes, a
-     * scheduler pool size of {@value DEFAULT_SCHEDULER_POOL_SIZE}, and a max inbound message size of
-     * {@value DEFAULT_MAX_INBOUND_MESSAGE_SIZE_MiB} MiB.
+     * port {@value DEFAULT_PLAINTEXT_PORT}, a scheduler pool size of {@value DEFAULT_SCHEDULER_POOL_SIZE}, and a max
+     * inbound message size of {@value DEFAULT_MAX_INBOUND_MESSAGE_SIZE_MiB} MiB.
      */
     public static NettyConfig defaultConfig() {
         return builder().build();

--- a/server/netty/src/test/java/io/deephaven/server/netty/NettyFlightRoundTripTest.java
+++ b/server/netty/src/test/java/io/deephaven/server/netty/NettyFlightRoundTripTest.java
@@ -16,6 +16,8 @@ import io.deephaven.server.test.TestAuthModule;
 import io.deephaven.server.test.FlightMessageRoundTripTest;
 
 import javax.inject.Singleton;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 public class NettyFlightRoundTripTest extends FlightMessageRoundTripTest {
 
@@ -25,6 +27,7 @@ public class NettyFlightRoundTripTest extends FlightMessageRoundTripTest {
         static NettyConfig providesNettyConfig() {
             return NettyConfig.builder()
                     .port(0)
+                    .tokenExpire(Duration.of(5, ChronoUnit.MINUTES))
                     .build();
         }
     }

--- a/server/src/main/java/io/deephaven/server/config/ServerConfig.java
+++ b/server/src/main/java/io/deephaven/server/config/ServerConfig.java
@@ -17,8 +17,6 @@ import java.util.Optional;
  */
 public interface ServerConfig {
 
-    int DEFAULT_TOKEN_EXPIRE_MIN = 5;
-
     int DEFAULT_SCHEDULER_POOL_SIZE = 4;
 
     int DEFAULT_MAX_INBOUND_MESSAGE_SIZE_MiB = 100;
@@ -145,12 +143,9 @@ public interface ServerConfig {
     Optional<SSLConfig> outboundSsl();
 
     /**
-     * The token expiration. Defaults to {@value DEFAULT_TOKEN_EXPIRE_MIN} minutes.
+     * The token expiration.
      */
-    @Default
-    default Duration tokenExpire() {
-        return Duration.ofMinutes(DEFAULT_TOKEN_EXPIRE_MIN);
-    }
+    Duration tokenExpire();
 
     /**
      * The scheduler pool size. Defaults to {@value DEFAULT_SCHEDULER_POOL_SIZE}.


### PR DESCRIPTION
By moving the default value from Configuration invocations to the config file, it is visible to more than just that one callsite, so we can permit clients to see this value and re-auth accordingly.