### PR TITLE
Port DH-12148: Formula Array Access

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -123,6 +123,7 @@ public interface Table extends
     String FILTERABLE_COLUMNS_ATTRIBUTE = "FilterableColumns";
     String TOTALS_TABLE_ATTRIBUTE = "TotalsTable";
     String ADD_ONLY_TABLE_ATTRIBUTE = "AddOnly";
+    String APPEND_ONLY_TABLE_ATTRIBUTE = "AppendOnly";
     /**
      * <p>
      * If this attribute is present with value {@code true}, this Table is a "stream table".

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -124,6 +124,7 @@ public interface Table extends
     String TOTALS_TABLE_ATTRIBUTE = "TotalsTable";
     String ADD_ONLY_TABLE_ATTRIBUTE = "AddOnly";
     String APPEND_ONLY_TABLE_ATTRIBUTE = "AppendOnly";
+    String TEST_SOURCE_TABLE_ATTRIBUTE = "TestSource";
     /**
      * <p>
      * If this attribute is present with value {@code true}, this Table is a "stream table".

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/RowSetShiftData.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/RowSetShiftData.java
@@ -305,10 +305,12 @@ public final class RowSetShiftData implements Serializable, LogOutputAppendable 
                     break;
                 }
 
-                // TODO: This loop is unfortunate, we will iterate the entire Index shift data; even if we have an input
-                // index that is only a small subset. For the ending condition we solve that with the advance breaking
-                // out of the loop, but for the starting condition, we can do better by binary searching the shift data
-                // for the beginning of the index if the end of that range is less than the data.
+                // TODO #3341: This loop is unfortunate, we will iterate the entire RowSetShiftData; even if we have an
+                // input rowSet that is only a small subset. For the ending condition we solve that with the advance
+                // breaking out of the loop, but for the starting condition, we can do better by binary searching the
+                // shift data for the beginning of the index if the end of that range is less than the data. We can
+                // binary search for the next relevant shifted range anytime we attempt a shift that does not effect the
+                // rowSet.
                 if (endRange < rsIt.peekNextKey()) {
                     continue;
                 }

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/WritableRowSetImpl.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/WritableRowSetImpl.java
@@ -43,7 +43,8 @@ public class WritableRowSetImpl extends RowSequenceAsChunkImpl implements Writab
         this.innerSet = Objects.requireNonNull(innerSet);
     }
 
-    protected final OrderedLongSet getInnerSet() {
+    @VisibleForTesting
+    public final OrderedLongSet getInnerSet() {
         return innerSet;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AggAllByCopyAttributes.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AggAllByCopyAttributes.java
@@ -4,7 +4,6 @@
 package io.deephaven.engine.table.impl;
 
 import io.deephaven.api.agg.spec.*;
-import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.BaseTable.CopyAttributeOperation;
 
 import java.util.Objects;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -271,8 +271,14 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
         tempMap.put(ADD_ONLY_TABLE_ATTRIBUTE, EnumSet.of(
                 CopyAttributeOperation.DropColumns,
-                CopyAttributeOperation.UpdateView,
-                CopyAttributeOperation.View,
+                CopyAttributeOperation.PartitionBy,
+                CopyAttributeOperation.Coalesce));
+
+
+        tempMap.put(APPEND_ONLY_TABLE_ATTRIBUTE, EnumSet.of(
+                CopyAttributeOperation.DropColumns,
+                CopyAttributeOperation.FirstBy,
+                CopyAttributeOperation.Flatten,
                 CopyAttributeOperation.PartitionBy,
                 CopyAttributeOperation.Coalesce));
 
@@ -367,7 +373,24 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         if (!isRefreshing()) {
             return true;
         }
-        return Boolean.TRUE.equals(getAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE));
+        boolean addOnly = Boolean.TRUE.equals(getAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE));
+        boolean appendOnly = Boolean.TRUE.equals(getAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE));
+        return addOnly || appendOnly;
+    }
+
+    /**
+     * Returns true if this table is append-only, or has an attribute asserting that no modifies, shifts, or removals
+     * are generated and that all new rows are added to the end of the table.
+     *
+     * @return true if this table may only append rows at the end of the table
+     */
+    public boolean isAppendOnly() {
+        if (!isRefreshing()) {
+            return true;
+        }
+        boolean addOnly = Boolean.TRUE.equals(getAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE));
+        boolean appendOnly = Boolean.TRUE.equals(getAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE));
+        return appendOnly || (addOnly && isFlat());
     }
 
     /**
@@ -594,10 +617,14 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         if (isFlat()) {
             Assert.assertion(getRowSet().isFlat(), "build().isFlat()", getRowSet(), "build()");
         }
-        if (isAddOnly()) {
+        if (isAppendOnly() || isAddOnly()) {
             Assert.assertion(update.removed().isEmpty(), "update.removed.empty()");
             Assert.assertion(update.modified().isEmpty(), "update.modified.empty()");
             Assert.assertion(update.shifted().empty(), "update.shifted.empty()");
+        }
+        if (isAppendOnly()) {
+            Assert.assertion(getRowSet().lastRowKeyPrev() < update.added().firstRowKey(),
+                    "getRowSet().lastRowKeyPrev() < update.added().firstRowKey()");
         }
 
         // First validate that each rowSet is in a sane state.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -623,7 +623,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
             Assert.assertion(update.shifted().empty(), "update.shifted.empty()");
         }
         if (isAppendOnly()) {
-            Assert.assertion(getRowSet().lastRowKeyPrev() < update.added().firstRowKey(),
+            Assert.assertion(getRowSet().sizePrev() == 0 || getRowSet().lastRowKeyPrev() < update.added().firstRowKey(),
                     "getRowSet().lastRowKeyPrev() < update.added().firstRowKey()");
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
@@ -39,7 +39,12 @@ class NaturalJoinHelper {
                 naturalJoinInternal(leftTable, rightTable, columnsToMatch, columnsToAdd, exactMatch, control);
         leftTable.maybeCopyColumnDescriptions(result, rightTable, columnsToMatch, columnsToAdd);
         leftTable.copyAttributes(result, BaseTable.CopyAttributeOperation.Join);
-        if (exactMatch && leftTable.isAppendOnly() && rightTable.isAppendOnly()) {
+        // note in exact match we require that the right table can match as soon as a row is added to the left
+        boolean rightDoesNotGenerateModifies = !rightTable.isRefreshing() || (exactMatch && rightTable.isAddOnly());
+        if (leftTable.isAddOnly() && rightDoesNotGenerateModifies) {
+            result.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+        }
+        if (leftTable.isAppendOnly() && rightDoesNotGenerateModifies) {
             result.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
         }
         return result;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
@@ -39,6 +39,9 @@ class NaturalJoinHelper {
                 naturalJoinInternal(leftTable, rightTable, columnsToMatch, columnsToAdd, exactMatch, control);
         leftTable.maybeCopyColumnDescriptions(result, rightTable, columnsToMatch, columnsToAdd);
         leftTable.copyAttributes(result, BaseTable.CopyAttributeOperation.Join);
+        if (exactMatch && leftTable.isAppendOnly() && rightTable.isAppendOnly()) {
+            result.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
+        }
         return result;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1492,7 +1492,8 @@ public class QueryTable extends BaseTable<QueryTable> {
                     checkInitiateOperation();
 
                     final SelectAndViewAnalyzerWrapper analyzerWrapper = SelectAndViewAnalyzer.create(
-                            this, SelectAndViewAnalyzer.Mode.VIEW_LAZY, columns, rowSet, getModifiedColumnSetForUpdates(),
+                            this, SelectAndViewAnalyzer.Mode.VIEW_LAZY, columns, rowSet,
+                            getModifiedColumnSetForUpdates(),
                             true, false, selectColumns);
                     final SelectColumn[] processedColumns = analyzerWrapper.getProcessedColumns()
                             .toArray(SelectColumn[]::new);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1188,7 +1188,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     public SelectValidationResult validateSelect(final SelectColumn... selectColumns) {
         final SelectColumn[] clones = SelectColumn.copyFrom(selectColumns);
         SelectAndViewAnalyzerWrapper analyzerWrapper = SelectAndViewAnalyzer.create(
-                SelectAndViewAnalyzer.Mode.SELECT_STATIC, columns, rowSet, getModifiedColumnSetForUpdates(), true,
+                this, SelectAndViewAnalyzer.Mode.SELECT_STATIC, columns, rowSet, getModifiedColumnSetForUpdates(), true,
                 false, clones);
         return new SelectValidationResult(analyzerWrapper.getAnalyzer(), clones);
     }
@@ -1216,7 +1216,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                     }
                     final boolean publishTheseSources = flavor == Flavor.Update;
                     final SelectAndViewAnalyzerWrapper analyzerWrapper = SelectAndViewAnalyzer.create(
-                            mode, columns, rowSet, getModifiedColumnSetForUpdates(), publishTheseSources, true,
+                            this, mode, columns, rowSet, getModifiedColumnSetForUpdates(), publishTheseSources, true,
                             selectColumns);
 
                     final SelectAndViewAnalyzer analyzer = analyzerWrapper.getAnalyzer();
@@ -1404,7 +1404,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                             initializeWithSnapshot(humanReadablePrefix, swapListener, (usePrev, beforeClockValue) -> {
                                 final boolean publishTheseSources = flavor == Flavor.UpdateView;
                                 final SelectAndViewAnalyzerWrapper analyzerWrapper = SelectAndViewAnalyzer.create(
-                                        SelectAndViewAnalyzer.Mode.VIEW_EAGER, columns, rowSet,
+                                        this, SelectAndViewAnalyzer.Mode.VIEW_EAGER, columns, rowSet,
                                         getModifiedColumnSetForUpdates(), publishTheseSources, true, viewColumns);
                                 final SelectColumn[] processedViewColumns = analyzerWrapper.getProcessedColumns()
                                         .toArray(SelectColumn[]::new);
@@ -1492,7 +1492,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                     checkInitiateOperation();
 
                     final SelectAndViewAnalyzerWrapper analyzerWrapper = SelectAndViewAnalyzer.create(
-                            SelectAndViewAnalyzer.Mode.VIEW_LAZY, columns, rowSet, getModifiedColumnSetForUpdates(),
+                            this, SelectAndViewAnalyzer.Mode.VIEW_LAZY, columns, rowSet, getModifiedColumnSetForUpdates(),
                             true, false, selectColumns);
                     final SelectColumn[] processedColumns = analyzerWrapper.getProcessedColumns()
                             .toArray(SelectColumn[]::new);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1013,6 +1013,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                                     }
 
                                     for (final WhereFilter filter : filters) {
+                                        filter.validateSafeForRefresh(this);
                                         filter.setRecomputeListener(filteredTable);
                                     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnOperation.java
@@ -3,10 +3,10 @@
  */
 package io.deephaven.engine.table.impl;
 
+import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderRandom;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
 import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.TrackingRowSet;
 import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.MatchPair;
@@ -16,6 +16,7 @@ import io.deephaven.engine.table.TableUpdate;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.select.MatchPairFactory;
 import io.deephaven.engine.table.impl.sources.ShiftedColumnSource;
+import org.apache.commons.lang3.mutable.MutableLong;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -82,21 +83,23 @@ public class ShiftedColumnOperation {
      * additional shifted column(s) that is based on the given source column(s) and the shift.
      *
      * @param source the source table, used to create new table with the shifted column
-     * @param shift the constant shift value
+     * @param shift the constant shift value, must be non-zero
      * @param pairs the source and shifted column pair(s) as shifted=source match pairs
      * @return a new Table that has all columns from input table plus additional shifted column(s) that are created
      *         using the shift from their source column(s)
      */
     @NotNull
     private static Table getShiftedColumns(@NotNull Table source, long shift, @NotNull MatchPair... pairs) {
+        Assert.neqZero(shift, "shift");
+
         final Map<String, ColumnSource<?>> columnSourceMap = new LinkedHashMap<>(source.getColumnSourceMap());
         final Map<String, Set<String>> sourceToShiftModColSetMap = new LinkedHashMap<>();
         final Set<String> sourceColumns = new LinkedHashSet<>();
         final Set<String> shiftedColumns = new LinkedHashSet<>();
 
         Arrays.stream(pairs).forEach(pair -> {
-            columnSourceMap.put(pair.leftColumn,
-                    new ShiftedColumnSource<>(source.getRowSet(), source.getColumnSource(pair.rightColumn), shift));
+            columnSourceMap.put(pair.leftColumn, new ShiftedColumnSource<>(
+                    source.getRowSet(), source.getColumnSource(pair.rightColumn), shift));
             Set<String> set = sourceToShiftModColSetMap.computeIfAbsent(pair.rightColumn, s -> new LinkedHashSet<>());
             set.add(pair.rightColumn);
             set.add(pair.leftColumn);
@@ -109,18 +112,19 @@ public class ShiftedColumnOperation {
 
         Arrays.stream(source.getDefinition().getColumnNamesArray()).forEach(colName -> {
             if (sourceToShiftModColSetMap.containsKey(colName)) {
-                resultTableMCSs.add(
-                        result.newModifiedColumnSet(sourceToShiftModColSetMap.get(colName).toArray(new String[0])));
+                resultTableMCSs.add(result.newModifiedColumnSet(
+                        sourceToShiftModColSetMap.get(colName).toArray(String[]::new)));
             } else {
+                // add identity mapping for all other columns
                 resultTableMCSs.add(result.newModifiedColumnSet(colName));
             }
         });
 
         final QueryTable sourceAsQueryTable = (QueryTable) source;
         final ModifiedColumnSet sourceColumnSet =
-                sourceAsQueryTable.newModifiedColumnSet(sourceColumns.toArray(new String[0]));
-        final ModifiedColumnSet resultColumnSet = result.newModifiedColumnSet(shiftedColumns.toArray(new String[0]));
-        final ModifiedColumnSet columnSetForDownstream = result.getModifiedColumnSetForUpdates();
+                sourceAsQueryTable.newModifiedColumnSet(sourceColumns.toArray(String[]::new));
+        final ModifiedColumnSet dirtyColumnSet = result.newModifiedColumnSet(shiftedColumns.toArray(String[]::new));
+        final ModifiedColumnSet downstreamColumnSet = result.getModifiedColumnSetForUpdates();
         final ModifiedColumnSet.Transformer mcsTransformer = sourceAsQueryTable.newModifiedColumnSetTransformer(
                 source.getDefinition().getColumnNamesArray(), resultTableMCSs.toArray(ModifiedColumnSet[]::new));
 
@@ -129,49 +133,82 @@ public class ShiftedColumnOperation {
                 @Override
                 public void onUpdate(TableUpdate upstream) {
                     final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-                    downstream.modifiedColumnSet = columnSetForDownstream;
+                    downstream.modifiedColumnSet = downstreamColumnSet;
                     mcsTransformer.clearAndTransform(
                             upstream.modifiedColumnSet(), downstream.modifiedColumnSet);
 
-                    boolean updateColSetDownStream = upstream.modifiedColumnSet().containsAll(sourceColumnSet);
+                    WritableRowSet modifiedRows = null;
+                    boolean dirtyModifiedColumnSet = false;
 
-                    final RowSetBuilderRandom redirectedKeysBuilder = RowSetFactory.builderRandom();
-                    final RowSetBuilderRandom previousRedirectedKeysBuilder = RowSetFactory.builderRandom();
-                    final TrackingRowSet index = source.getRowSet();
+                    if (upstream.removed().isNonempty()) {
+                        try (final RowSet prevRowSet = source.getRowSet().copyPrev();
+                                final WritableRowSet dirtyRowSet = computeDirtyModifiedRowSetInPositionSpace(
+                                        prevRowSet, upstream.removed(), shift)) {
+                            if (dirtyRowSet.isNonempty()) {
+                                modifiedRows = prevRowSet.subSetForPositions(dirtyRowSet);
+                                dirtyModifiedColumnSet = true;
 
-                    try (final RowSet prevIndex = index.copyPrev()) {
-                        if (upstream.removed().isNonempty()) {
-                            updateColSetDownStream = true;
-                            updateRedirectedKeys(prevIndex, upstream.removed(), shift, previousRedirectedKeysBuilder);
-                        }
-
-                        if (upstream.modified().isNonempty()
-                                && upstream.modifiedColumnSet().containsAny(sourceColumnSet)) {
-                            if (upstream.modifiedColumnSet().containsAll(sourceColumnSet)) {
-                                updateColSetDownStream = true;
+                                // move the dirty rows into current keyspace
+                                if (upstream.shifted().nonempty()) {
+                                    upstream.shifted().apply(modifiedRows);
+                                }
                             }
-                            updateRedirectedKeys(index, upstream.modified(), shift, redirectedKeysBuilder);
-                        }
-
-                        if (upstream.added().isNonempty()) {
-                            updateColSetDownStream = true;
-                            updateRedirectedKeys(index, upstream.added(), shift, redirectedKeysBuilder);
-                        }
-
-                        if (updateColSetDownStream) {
-                            columnSetForDownstream.setAll(resultColumnSet);
                         }
                     }
 
-                    WritableRowSet modified = redirectedKeysBuilder.build();
-                    downstream.modified = modified;
-                    modified.insert(upstream.modified());
-                    try (final WritableRowSet prevModified = previousRedirectedKeysBuilder.build()) {
-                        prevModified.remove(upstream.removed());
-                        upstream.shifted().apply(prevModified);
-                        modified.insert(prevModified);
+                    final boolean haveAdds = upstream.added().isNonempty();
+                    final boolean haveMods = upstream.modified().isNonempty()
+                            && upstream.modifiedColumnSet().containsAny(sourceColumnSet);
+
+                    // we'll combine adds and mods to coalesce ranges prior to subSetForPositions
+                    if (haveAdds || haveMods) {
+                        try (final WritableRowSet dirtyFromAdds = haveAdds ? computeDirtyModifiedRowSetInPositionSpace(
+                                source.getRowSet(), upstream.added(), shift) : null;
+                                final WritableRowSet dirtyFromMods =
+                                        haveMods ? computeDirtyModifiedRowSetInPositionSpace(
+                                                source.getRowSet(), upstream.modified(), shift) : null) {
+
+                            if (haveAdds && dirtyFromAdds.isNonempty()) {
+                                dirtyModifiedColumnSet = true;
+                            }
+                            // note dirtyFromMods is propagated by the mcsTransformer
+
+                            final RowSet dirtyPositions = haveAdds ? dirtyFromAdds : dirtyFromMods;
+                            if (haveAdds && haveMods) {
+                                dirtyFromAdds.insert(dirtyFromMods);
+                            }
+
+                            if (dirtyPositions.isNonempty()) {
+                                final WritableRowSet dirtyRowSet =
+                                        source.getRowSet().subSetForPositions(dirtyPositions);
+
+                                if (haveAdds && haveMods) {
+                                    // modifications might dirty added rows
+                                    dirtyRowSet.remove(upstream.added());
+                                }
+
+                                if (dirtyRowSet.isEmpty()) {
+                                    dirtyRowSet.close();
+                                } else if (modifiedRows == null) {
+                                    modifiedRows = dirtyRowSet;
+                                } else {
+                                    modifiedRows.insert(dirtyRowSet);
+                                    dirtyRowSet.close();
+                                }
+                            }
+                        }
                     }
-                    modified.remove(upstream.added());
+
+                    if (dirtyModifiedColumnSet) {
+                        downstreamColumnSet.setAll(dirtyColumnSet);
+                    }
+
+                    if (modifiedRows != null) {
+                        // close the copied upstream set
+                        downstream.modified.close();
+                        modifiedRows.insert(upstream.modified());
+                        downstream.modified = modifiedRows;
+                    } // else we can use the existing upstream modified row set
 
                     result.notifyListeners(downstream);
                 }
@@ -182,43 +219,56 @@ public class ShiftedColumnOperation {
     }
 
     /**
-     * The method invokes an inPlaceShift of 1 or -1 repeatedly until all redirected keys are collected in to the passed
-     * in builder.
+     * Computes the modified rowSet based on the sourceRowSet and the updatedRowSet. The provided rowSets must be in the
+     * same keyspace (previous, or current). The resulting rowSet is in position space and will not include any rows
+     * that are in the updatedRowSet.
      *
-     * @param rowSet Index to compute modified keys, prevIndex expected in case of removed and currentIndex otherwise
-     * @param upstreamIndex the upstream rowSet (one of upstream.removed, upstream.modified or upstream.added depending
-     *        on call)
-     * @param shift the constant shift value
-     * @param redirectedKeysBuilder the builder used to collect redirected keys
+     * @param sourceRowSet the source's row set
+     * @param updatedRowSet the updated row set (removed, updated, or modified)
+     * @param shift the shift value
+     * @return the effective modified row set in position space of the same keyspace (previous, or current)
      */
-    private static void updateRedirectedKeys(
-            @NotNull RowSet rowSet,
-            @NotNull RowSet upstreamIndex,
-            long shift,
-            @NotNull RowSetBuilderRandom redirectedKeysBuilder) {
-        final WritableRowSet posRowSet = rowSet.invert(upstreamIndex);
-        final long lastKeyPos = rowSet.size() - 1;
-        for (long i = 0; i < Math.abs(shift); ++i) {
-            if (shift < 0) {
-                // the last position rowSet is removed to avoid any overflow errors.
-                // In this case the shiftInPlace as of now handles the overflow without any errors
-                // however, having the check eliminates this implicit dependency
-                if (posRowSet.lastRowKey() == lastKeyPos) {
-                    posRowSet.remove(lastKeyPos);
+    private static WritableRowSet computeDirtyModifiedRowSetInPositionSpace(
+            @NotNull RowSet sourceRowSet, @NotNull RowSet updatedRowSet, long shift) {
+        final MutableLong minKeyAllowed = new MutableLong(0);
+        final RowSetBuilderSequential rowSetBuilder = RowSetFactory.builderSequential();
+
+        // when shift < 0, we need to look-ahead to avoid including rows that are part of the updatedRowSet
+        final MutableLong prevRangeEnd = new MutableLong(-1);
+        try (final WritableRowSet posRowSet = sourceRowSet.invert(updatedRowSet)) {
+            posRowSet.forAllRowKeyRanges((s, e) -> {
+                final long dirtyStart;
+                final long dirtyEnd;
+
+                if (shift > 0) {
+                    dirtyStart = Math.max(minKeyAllowed.longValue(), s - shift);
+                    dirtyEnd = s - 1;
+                    minKeyAllowed.setValue(e + 1);
+                } else {
+                    final long pEnd = prevRangeEnd.longValue();
+                    prevRangeEnd.setValue(e);
+                    if (pEnd == -1) {
+                        return;
+                    }
+
+                    dirtyStart = pEnd + 1;
+                    dirtyEnd = Math.min(s - 1, pEnd - shift);
                 }
-                posRowSet.shiftInPlace(1);
-            } else {
-                // inPlaceShift of -1 is not allowed on key 0
-                if (posRowSet.firstRowKey() == 0) {
-                    posRowSet.remove(0);
+
+                if (dirtyStart <= dirtyEnd) {
+                    rowSetBuilder.appendRange(dirtyStart, dirtyEnd);
                 }
-                posRowSet.shiftInPlace(-1);
-            }
-            if (posRowSet.isNonempty()) {
-                try (final RowSet keysModified = rowSet.subSetForPositions(posRowSet)) {
-                    redirectedKeysBuilder.addRowSet(keysModified);
-                }
-            }
+            });
         }
+
+        // if we were looking ahead, we need to process the last range
+        final long pEnd = prevRangeEnd.longValue();
+        if (shift < 0 && pEnd != -1 && pEnd + 1 < sourceRowSet.size()) {
+            final long dirtyStart = pEnd + 1;
+            final long dirtyEnd = pEnd - shift;
+            rowSetBuilder.appendRange(dirtyStart, dirtyEnd);
+        }
+
+        return rowSetBuilder.build();
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnOperation.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderRandom;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.TrackingRowSet;
+import io.deephaven.engine.rowset.WritableRowSet;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.MatchPair;
+import io.deephaven.engine.table.ModifiedColumnSet;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.TableUpdate;
+import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
+import io.deephaven.engine.table.impl.select.MatchPairFactory;
+import io.deephaven.engine.table.impl.sources.ShiftedColumnSource;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tools for creating a new ShiftedColumn(s) for a given input table and a source column(s)
+ */
+public class ShiftedColumnOperation {
+
+    // static use only
+    private ShiftedColumnOperation() {}
+
+    /**
+     * Creates a new table that has all the columns of the source table plus includes the new shifted column(s).
+     *
+     * @param source source table
+     * @param shift the positive or negative shift value
+     * @param matchColumns the source and shifted column pair(s) as shifted=source for example "X1=X", "Y1=Y"...
+     * @return a new Table that includes the shifted column
+     */
+    public static Table addShiftedColumns(@NotNull Table source, long shift, @NotNull String... matchColumns) {
+        String nuggetName = "addShiftedColumns ( " + shift + " , " + String.join(",", matchColumns) + ") ";
+        return getShiftedColumnsUsingNugget(nuggetName, source, shift, MatchPairFactory.getExpressions(matchColumns));
+    }
+
+    /**
+     * Creates a new table that has all the columns of the source table plus includes the new shifted column(s).
+     *
+     * @param source the source table, used to create new table with the shifted column
+     * @param shift the constant shift value
+     * @param matchPairs the source and shifted column pair(s) as shifted=source match pairs
+     * @return a new Table that has all columns from source table plus additional shifted column(s) that are created
+     *         using the shift from their source column(s)
+     */
+    public static Table addShiftedColumns(@NotNull Table source, long shift,
+            @NotNull MatchPair... matchPairs) {
+        String nuggetName = "addShiftedColumns ( shift , matchPairs )";
+        return getShiftedColumnsUsingNugget(nuggetName, source, shift, matchPairs);
+    }
+
+    /**
+     * Delegates to {@link ShiftedColumnOperation#getShiftedColumns(Table, long, MatchPair...)} using
+     * QueryPerformanceRecorder.
+     *
+     * @param source the source table, used to create new table with the shifted column
+     * @param shift the constant shift value
+     * @param pairs the source and shifted column pair(s) as shifted=source match pairs
+     * @return a new Table that has all columns from source table plus additional shifted column(s) that are created
+     *         using the shift from their source column(s)
+     */
+    @NotNull
+    private static Table getShiftedColumnsUsingNugget(
+            @NotNull String nuggetName, @NotNull Table source, long shift, @NotNull MatchPair... pairs) {
+        return QueryPerformanceRecorder.withNugget(nuggetName, source.sizeForInstrumentation(),
+                () -> getShiftedColumns(source, shift, pairs));
+    }
+
+    /**
+     * Encapsulates the logic to create and return a new Table that has all the columns from input table plus an
+     * additional shifted column(s) that is based on the given source column(s) and the shift.
+     *
+     * @param source the source table, used to create new table with the shifted column
+     * @param shift the constant shift value
+     * @param pairs the source and shifted column pair(s) as shifted=source match pairs
+     * @return a new Table that has all columns from input table plus additional shifted column(s) that are created
+     *         using the shift from their source column(s)
+     */
+    @NotNull
+    private static Table getShiftedColumns(@NotNull Table source, long shift, @NotNull MatchPair... pairs) {
+        final Map<String, ColumnSource<?>> columnSourceMap = new LinkedHashMap<>(source.getColumnSourceMap());
+        final Map<String, Set<String>> sourceToShiftModColSetMap = new LinkedHashMap<>();
+        final Set<String> sourceColumns = new LinkedHashSet<>();
+        final Set<String> shiftedColumns = new LinkedHashSet<>();
+
+        Arrays.stream(pairs).forEach(pair -> {
+            columnSourceMap.put(pair.leftColumn,
+                    new ShiftedColumnSource<>(source.getRowSet(), source.getColumnSource(pair.rightColumn), shift));
+            Set<String> set = sourceToShiftModColSetMap.computeIfAbsent(pair.rightColumn, s -> new LinkedHashSet<>());
+            set.add(pair.rightColumn);
+            set.add(pair.leftColumn);
+            sourceColumns.add(pair.rightColumn);
+            shiftedColumns.add(pair.leftColumn);
+        });
+
+        final QueryTable result = new QueryTable(source.getRowSet(), columnSourceMap);
+        final Set<ModifiedColumnSet> resultTableMCSs = new LinkedHashSet<>();
+
+        Arrays.stream(source.getDefinition().getColumnNamesArray()).forEach(colName -> {
+            if (sourceToShiftModColSetMap.containsKey(colName)) {
+                resultTableMCSs.add(
+                        result.newModifiedColumnSet(sourceToShiftModColSetMap.get(colName).toArray(new String[0])));
+            } else {
+                resultTableMCSs.add(result.newModifiedColumnSet(colName));
+            }
+        });
+
+        final QueryTable sourceAsQueryTable = (QueryTable) source;
+        final ModifiedColumnSet sourceColumnSet =
+                sourceAsQueryTable.newModifiedColumnSet(sourceColumns.toArray(new String[0]));
+        final ModifiedColumnSet resultColumnSet = result.newModifiedColumnSet(shiftedColumns.toArray(new String[0]));
+        final ModifiedColumnSet columnSetForDownstream = result.getModifiedColumnSetForUpdates();
+        final ModifiedColumnSet.Transformer mcsTransformer = sourceAsQueryTable.newModifiedColumnSetTransformer(
+                source.getDefinition().getColumnNamesArray(), resultTableMCSs.toArray(ModifiedColumnSet[]::new));
+
+        if (source.isRefreshing()) {
+            final BaseTable.ListenerImpl listener = new BaseTable.ListenerImpl("propagateUpdates", source, result) {
+                @Override
+                public void onUpdate(TableUpdate upstream) {
+                    final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
+                    downstream.modifiedColumnSet = columnSetForDownstream;
+                    mcsTransformer.clearAndTransform(
+                            upstream.modifiedColumnSet(), downstream.modifiedColumnSet);
+
+                    boolean updateColSetDownStream = upstream.modifiedColumnSet().containsAll(sourceColumnSet);
+
+                    final RowSetBuilderRandom redirectedKeysBuilder = RowSetFactory.builderRandom();
+                    final RowSetBuilderRandom previousRedirectedKeysBuilder = RowSetFactory.builderRandom();
+                    final TrackingRowSet index = source.getRowSet();
+
+                    try (final RowSet prevIndex = index.copyPrev()) {
+                        if (upstream.removed().isNonempty()) {
+                            updateColSetDownStream = true;
+                            updateRedirectedKeys(prevIndex, upstream.removed(), shift, previousRedirectedKeysBuilder);
+                        }
+
+                        if (upstream.modified().isNonempty()
+                                && upstream.modifiedColumnSet().containsAny(sourceColumnSet)) {
+                            if (upstream.modifiedColumnSet().containsAll(sourceColumnSet)) {
+                                updateColSetDownStream = true;
+                            }
+                            updateRedirectedKeys(index, upstream.modified(), shift, redirectedKeysBuilder);
+                        }
+
+                        if (upstream.added().isNonempty()) {
+                            updateColSetDownStream = true;
+                            updateRedirectedKeys(index, upstream.added(), shift, redirectedKeysBuilder);
+                        }
+
+                        if (updateColSetDownStream) {
+                            columnSetForDownstream.setAll(resultColumnSet);
+                        }
+                    }
+
+                    WritableRowSet modified = redirectedKeysBuilder.build();
+                    downstream.modified = modified;
+                    modified.insert(upstream.modified());
+                    try (final WritableRowSet prevModified = previousRedirectedKeysBuilder.build()) {
+                        prevModified.remove(upstream.removed());
+                        upstream.shifted().apply(prevModified);
+                        modified.insert(prevModified);
+                    }
+                    modified.remove(upstream.added());
+
+                    result.notifyListeners(downstream);
+                }
+            };
+            source.addUpdateListener(listener);
+        }
+        return result;
+    }
+
+    /**
+     * The method invokes an inPlaceShift of 1 or -1 repeatedly until all redirected keys are collected in to the passed
+     * in builder.
+     *
+     * @param rowSet Index to compute modified keys, prevIndex expected in case of removed and currentIndex otherwise
+     * @param upstreamIndex the upstream rowSet (one of upstream.removed, upstream.modified or upstream.added depending
+     *        on call)
+     * @param shift the constant shift value
+     * @param redirectedKeysBuilder the builder used to collect redirected keys
+     */
+    private static void updateRedirectedKeys(
+            @NotNull RowSet rowSet,
+            @NotNull RowSet upstreamIndex,
+            long shift,
+            @NotNull RowSetBuilderRandom redirectedKeysBuilder) {
+        final WritableRowSet posRowSet = rowSet.invert(upstreamIndex);
+        final long lastKeyPos = rowSet.size() - 1;
+        for (long i = 0; i < Math.abs(shift); ++i) {
+            if (shift < 0) {
+                // the last position rowSet is removed to avoid any overflow errors.
+                // In this case the shiftInPlace as of now handles the overflow without any errors
+                // however, having the check eliminates this implicit dependency
+                if (posRowSet.lastRowKey() == lastKeyPos) {
+                    posRowSet.remove(lastKeyPos);
+                }
+                posRowSet.shiftInPlace(1);
+            } else {
+                // inPlaceShift of -1 is not allowed on key 0
+                if (posRowSet.firstRowKey() == 0) {
+                    posRowSet.remove(0);
+                }
+                posRowSet.shiftInPlace(-1);
+            }
+            if (posRowSet.isNonempty()) {
+                try (final RowSet keysModified = rowSet.subSetForPositions(posRowSet)) {
+                    redirectedKeysBuilder.addRowSet(keysModified);
+                }
+            }
+        }
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnsFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnsFactory.java
@@ -220,15 +220,19 @@ public class ShiftedColumnsFactory extends VoidVisitorAdapter<ShiftedColumnsFact
             @NotNull List<Pair<String, Map<Long, List<MatchPair>>>> shiftColPairs) {
         List<String> filterFormulas = new LinkedList<>();
         Map<Long, Set<MatchPair>> allShiftToColPairs = new LinkedHashMap<>();
-        for (Pair<String, Map<Long, List<MatchPair>>> pair : shiftColPairs) {
-            String updatedFormula = pair.first;
-            for (Map.Entry<Long, List<MatchPair>> entry : pair.getSecond().entrySet()) {
+        for (Pair<String, Map<Long, List<MatchPair>>> formulaMapPair : shiftColPairs) {
+            String updatedFormula = formulaMapPair.first;
+            for (Map.Entry<Long, List<MatchPair>> entry : formulaMapPair.getSecond().entrySet()) {
                 for (MatchPair matchPair : entry.getValue()) {
-                    String shift = entry.getKey() < 0 ? MINUS + -entry.getKey() : PLUS + entry.getKey();
-                    String shiftedColName = matchPair.rightColumn + shift + matchPair.leftColumn;
-                    updatedFormula = updatedFormula.replaceAll(matchPair.leftColumn, shiftedColName);
-                    allShiftToColPairs.computeIfAbsent(entry.getKey(), dummy -> new LinkedHashSet<>())
-                            .add(new MatchPair(shiftedColName, matchPair.rightColumn));
+                    if (entry.getKey() == 0) {
+                        updatedFormula = updatedFormula.replaceAll(matchPair.leftColumn, matchPair.rightColumn);
+                    } else {
+                        String shift = entry.getKey() < 0 ? MINUS + -entry.getKey() : PLUS + entry.getKey();
+                        String shiftedColName = matchPair.rightColumn + shift + matchPair.leftColumn;
+                        updatedFormula = updatedFormula.replaceAll(matchPair.leftColumn, shiftedColName);
+                        allShiftToColPairs.computeIfAbsent(entry.getKey(), dummy -> new LinkedHashSet<>())
+                                .add(new MatchPair(shiftedColName, matchPair.rightColumn));
+                    }
                 }
             }
             filterFormulas.add(updatedFormula);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnsFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnsFactory.java
@@ -1,0 +1,879 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl;
+
+import com.github.javaparser.ast.ArrayCreationLevel;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.CompactConstructorDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.InitializerDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.ReceiverParameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.comments.BlockComment;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.expr.ArrayAccessExpr;
+import com.github.javaparser.ast.expr.ArrayCreationExpr;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.CastExpr;
+import com.github.javaparser.ast.expr.CharLiteralExpr;
+import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.ConditionalExpr;
+import com.github.javaparser.ast.expr.DoubleLiteralExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.InstanceOfExpr;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.LongLiteralExpr;
+import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
+import com.github.javaparser.ast.expr.MemberValuePair;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.PatternExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.SuperExpr;
+import com.github.javaparser.ast.expr.SwitchExpr;
+import com.github.javaparser.ast.expr.TextBlockLiteralExpr;
+import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.expr.TypeExpr;
+import com.github.javaparser.ast.expr.UnaryExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.modules.ModuleDeclaration;
+import com.github.javaparser.ast.modules.ModuleExportsDirective;
+import com.github.javaparser.ast.modules.ModuleOpensDirective;
+import com.github.javaparser.ast.modules.ModuleProvidesDirective;
+import com.github.javaparser.ast.modules.ModuleRequiresDirective;
+import com.github.javaparser.ast.modules.ModuleUsesDirective;
+import com.github.javaparser.ast.stmt.AssertStmt;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.BreakStmt;
+import com.github.javaparser.ast.stmt.CatchClause;
+import com.github.javaparser.ast.stmt.ContinueStmt;
+import com.github.javaparser.ast.stmt.DoStmt;
+import com.github.javaparser.ast.stmt.EmptyStmt;
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.ForEachStmt;
+import com.github.javaparser.ast.stmt.ForStmt;
+import com.github.javaparser.ast.stmt.IfStmt;
+import com.github.javaparser.ast.stmt.LabeledStmt;
+import com.github.javaparser.ast.stmt.LocalClassDeclarationStmt;
+import com.github.javaparser.ast.stmt.LocalRecordDeclarationStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.stmt.SwitchEntry;
+import com.github.javaparser.ast.stmt.SwitchStmt;
+import com.github.javaparser.ast.stmt.SynchronizedStmt;
+import com.github.javaparser.ast.stmt.ThrowStmt;
+import com.github.javaparser.ast.stmt.TryStmt;
+import com.github.javaparser.ast.stmt.UnparsableStmt;
+import com.github.javaparser.ast.stmt.WhileStmt;
+import com.github.javaparser.ast.stmt.YieldStmt;
+import com.github.javaparser.ast.type.ArrayType;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.IntersectionType;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.ast.type.UnionType;
+import com.github.javaparser.ast.type.UnknownType;
+import com.github.javaparser.ast.type.VarType;
+import com.github.javaparser.ast.type.VoidType;
+import com.github.javaparser.ast.type.WildcardType;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.google.common.collect.Streams;
+import io.deephaven.api.Selectable;
+import io.deephaven.api.filter.Filter;
+import io.deephaven.base.Pair;
+import io.deephaven.engine.table.MatchPair;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.lang.JavaExpressionParser;
+import io.deephaven.engine.table.impl.lang.QueryLanguageParser;
+import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
+import io.deephaven.engine.table.impl.select.FormulaColumn;
+import io.deephaven.engine.table.impl.select.WhereFilter;
+import io.deephaven.engine.table.impl.select.WhereFilterFactory;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ShiftedColumnsFactory extends VoidVisitorAdapter<ShiftedColumnsFactory.ShiftedColumnAttributes> {
+
+    public static final String SHIFTED_COL_PREFIX = "_Shifted";
+    private static final String MINUS = "_Minus_";
+    private static final String PLUS = "_Plus_";
+
+    /**
+     * Returns a Pair object consisting of final formula string and shift to column MatchPairs. If the formula /
+     * expression has Array Access that conforms to "i +/- &lt;constant&gt;" or "ii +/- &lt;constant&gt;".
+     *
+     * @param expression column expression.
+     * @return Pair of final formula string and shift to column MatchPairs.
+     */
+    public static Pair<String, Map<Long, List<MatchPair>>> getShiftToColPairsMap(@NotNull Expression expression) {
+        ShiftedColumnAttributes formulaAttributes = new ShiftedColumnAttributes();
+        final ShiftedColumnsFactory visitor = new ShiftedColumnsFactory();
+        expression.accept(visitor, formulaAttributes);
+
+        Map<Long, List<MatchPair>> shiftToColPairMap = new LinkedHashMap<>();
+        for (Pair<Long, MatchPair> pair : formulaAttributes.shiftedColsMap.values()) {
+            List<MatchPair> colPairs = shiftToColPairMap.computeIfAbsent(pair.getFirst(), list -> new LinkedList<>());
+            colPairs.add(pair.getSecond());
+        }
+
+        return shiftToColPairMap.isEmpty() ? null
+                : new Pair<>(formulaAttributes.formulaBuilder.toString(), shiftToColPairMap);
+    }
+
+    /**
+     * Returns the array access expressions in the formula with appropriate shifted column suffixes.
+     *
+     * @param formula to convert
+     * @return returns the array access expressions in the formula with appropriate shifted column suffixes
+     */
+    public static String convertToShiftedFormula(@NotNull String formula) {
+        // Convert backticks *before* converting single equals!
+        // Backticks must be converted first in order to properly identify single-equals signs within
+        // String and char literals, which should *not* be converted.
+        formula = QueryLanguageParser.convertBackticks(formula);
+        formula = QueryLanguageParser.convertSingleEquals(formula);
+
+        Expression expression = JavaExpressionParser.parseExpression(formula);
+        ShiftedColumnAttributes formulaAttributes = new ShiftedColumnAttributes();
+        final ShiftedColumnsFactory visitor = new ShiftedColumnsFactory();
+        expression.accept(visitor, formulaAttributes);
+        return formulaAttributes.formulaBuilder.toString();
+    }
+
+    /**
+     * Performs {@link Table#where(Filter...)} operation on interim table built using shifted columns. Returns result
+     * table with only the original display columns.
+     *
+     * @param source input table
+     * @param shiftColPairs list of formula to shift column pairs
+     * @param currFilters filters list
+     * @return result table of expected where operation
+     */
+    public static Table where(
+            @NotNull Table source,
+            @NotNull List<Pair<String, Map<Long, List<MatchPair>>>> shiftColPairs,
+            @NotNull List<WhereFilter> currFilters) {
+        String nuggetName = "where(" +
+                currFilters.stream().map(Object::toString).collect(Collectors.joining(", ")) +
+                "; " +
+                shiftColPairs.stream().map(pair -> pair.first).collect(Collectors.joining(", ")) +
+                ')';
+
+        return QueryPerformanceRecorder.withNugget(nuggetName, source.sizeForInstrumentation(), () -> {
+            String[] displayColumns = source.getDefinition().getColumnNamesArray();
+            Pair<Table, Filter[]> resultPair = getShiftedTableFilterPair(source, shiftColPairs);
+            Table result = resultPair.getFirst().where(Streams.concat(
+                    currFilters.stream(), Arrays.stream(resultPair.second)).collect(Collectors.toList()));
+            return result.view(Selectable.from(displayColumns));
+        });
+    }
+
+    /**
+     * Returns Pair with table that includes all shifted columns used in filters, and the list of filter formulas
+     * updated with appropriate shifted column names.
+     *
+     * @param source input table
+     * @param shiftColPairs list of formula to shift column pairs
+     * @return Pair with shifted table and list of SelectFilters using Shifted Formulas
+     */
+    private static Pair<Table, Filter[]> getShiftedTableFilterPair(
+            @NotNull Table source,
+            @NotNull List<Pair<String, Map<Long, List<MatchPair>>>> shiftColPairs) {
+        List<String> filterFormulas = new LinkedList<>();
+        Map<Long, Set<MatchPair>> allShiftToColPairs = new LinkedHashMap<>();
+        for (Pair<String, Map<Long, List<MatchPair>>> pair : shiftColPairs) {
+            String updatedFormula = pair.first;
+            for (Map.Entry<Long, List<MatchPair>> entry : pair.getSecond().entrySet()) {
+                for (MatchPair matchPair : entry.getValue()) {
+                    String shift = entry.getKey() < 0 ? MINUS + -entry.getKey() : PLUS + entry.getKey();
+                    String shiftedColName = matchPair.rightColumn + shift + matchPair.leftColumn;
+                    updatedFormula = updatedFormula.replaceAll(matchPair.leftColumn, shiftedColName);
+                    allShiftToColPairs.computeIfAbsent(entry.getKey(), dummy -> new LinkedHashSet<>())
+                            .add(new MatchPair(shiftedColName, matchPair.rightColumn));
+                }
+            }
+            filterFormulas.add(updatedFormula);
+        }
+        Table tableSoFar = source;
+        for (Map.Entry<Long, Set<MatchPair>> entry : allShiftToColPairs.entrySet()) {
+            tableSoFar = ShiftedColumnOperation.addShiftedColumns(tableSoFar, entry.getKey(),
+                    entry.getValue().toArray(MatchPair[]::new));
+        }
+        Filter[] shiftedFilters = WhereFilterFactory.getExpressions(filterFormulas);
+        return new Pair<>(tableSoFar, shiftedFilters);
+    }
+
+    /**
+     * Returns new table that includes the columns from the source table plus additional column
+     * resultColumnName=expression built using ShiftedColumnOperation.
+     *
+     * @param source the source table to use build the new ShiftedColumns table.
+     * @param formulaColumn should be of type FormulaColumn
+     * @return new table that includes the columns from the source table plus additional column
+     *         "resultColumnName=expression" built using ShiftedColumnOperation.
+     */
+    public static Table getShiftedColumnsTable(@NotNull final Table source, @NotNull FormulaColumn formulaColumn) {
+        String nuggetName = "getShiftedColumnsTable ( " + formulaColumn + ") ";
+        return QueryPerformanceRecorder.withNugget(nuggetName, source.sizeForInstrumentation(), () -> {
+            Table tableSoFar = source;
+            Pair<String, Map<Long, List<MatchPair>>> formulaMapPair = formulaColumn.getFormulaShiftColPair();
+            // hold the current columns to be displayed in table
+            List<String> currColumns = source.getDefinition().getColumnNames();
+            for (Map.Entry<Long, List<MatchPair>> entry : formulaMapPair.getSecond().entrySet()) {
+                // Add formulaColName as prefix to ShiftedCols
+                MatchPair[] colPairs = entry.getValue().stream()
+                        .map(matchPair -> new MatchPair(formulaColumn.getName() + matchPair.leftColumn,
+                                matchPair.rightColumn))
+                        .toArray(MatchPair[]::new);
+
+                tableSoFar = ShiftedColumnOperation.addShiftedColumns(tableSoFar, entry.getKey(), colPairs);
+            }
+            String resultColFormula = formulaColumn.getName() + " = " + formulaMapPair.getFirst()
+                    .replaceAll(SHIFTED_COL_PREFIX, formulaColumn.getName() + SHIFTED_COL_PREFIX);
+            currColumns.add(resultColFormula);
+            return tableSoFar.view(currColumns.toArray(new String[0]));
+        });
+    }
+
+    /**
+     * Returns null if the ArrayAccessExpression is NOT of type "i +/- &lt;constant&gt;" or "ii +/- &lt;constant&gt;"
+     * Otherwise builds a Pair containing shift and sourceColumn.
+     *
+     * @param expression is a ArrayAccessExpr
+     * @return null or Pair containing shift value and sourceColumn.
+     */
+    private static Pair<Long, String> parseForConstantArrayAccessAttributes(@NotNull ArrayAccessExpr expression) {
+        if (!(expression.getIndex() instanceof BinaryExpr)) {
+            return null;
+        }
+
+        BinaryExpr binaryExpr = (BinaryExpr) expression.getIndex();
+        final String[] validLeftValues = new String[] {"i", "ii"};
+
+        boolean isExpectedLeftExpr = false;
+        if (binaryExpr.getLeft() instanceof NameExpr) {
+            final String leftName = ((NameExpr) binaryExpr.getLeft()).getNameAsString();
+            isExpectedLeftExpr = Arrays.asList(validLeftValues).contains(leftName);
+        }
+
+        boolean isExpectedOperator =
+                binaryExpr.getOperator() == BinaryExpr.Operator.PLUS ||
+                        binaryExpr.getOperator() == BinaryExpr.Operator.MINUS;
+
+        boolean isExpectedRightExpr = binaryExpr.getRight() instanceof IntegerLiteralExpr;
+
+        if (!isExpectedLeftExpr || !isExpectedOperator || !isExpectedRightExpr) {
+            return null;
+        }
+
+        String sourceCol = expression.getName().toString();
+        sourceCol = sourceCol.substring(0, sourceCol.length() - 1);
+
+        long rightValue = Long.parseLong(((IntegerLiteralExpr) (binaryExpr.getRight())).getValue());
+        Long shift = binaryExpr.getOperator() == BinaryExpr.Operator.MINUS ? -rightValue : rightValue;
+
+        return new Pair<>(shift, sourceCol);
+    }
+
+    // GenericVisitor overrides below
+    // ----------------------------------------------------------------------------------------------------------------
+    @Override
+    public void visit(ArrayAccessExpr expr, ShiftedColumnAttributes attributes) {
+
+        Pair<Long, MatchPair> shiftAndMatchPair = attributes.shiftedColsMap.get(expr.toString());
+        if (shiftAndMatchPair != null) {
+            attributes.formulaBuilder.append(shiftAndMatchPair.getSecond().leftColumn);
+            return;
+        }
+
+        Pair<Long, String> attributePair = parseForConstantArrayAccessAttributes(expr);
+        if (attributePair != null) {
+            final String shiftedColName = SHIFTED_COL_PREFIX + attributes.index.getAndIncrement();
+            MatchPair matchPair = new MatchPair(shiftedColName, attributePair.getSecond());
+            attributes.formulaBuilder.append(shiftedColName);
+            attributes.shiftedColsMap.put(expr.toString(), new Pair<>(attributePair.getFirst(), matchPair));
+            return;
+        }
+
+        attributes.formulaBuilder.append(expr);
+    }
+
+    @Override
+    public void visit(EnclosedExpr currExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append("(");
+        currExpr.getInner().accept(this, attributes);
+        attributes.formulaBuilder.append(")");
+    }
+
+    @Override
+    public void visit(BinaryExpr currExpr, ShiftedColumnAttributes attributes) {
+        currExpr.getLeft().accept(this, attributes);
+        attributes.formulaBuilder.append(' ');
+        attributes.formulaBuilder.append(QueryLanguageParser.getOperatorSymbol(currExpr.getOperator())).append(' ');
+        currExpr.getRight().accept(this, attributes);
+    }
+
+    @Override
+    public void visit(ArrayCreationExpr arrayCreationExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(arrayCreationExpr);
+    }
+
+    @Override
+    public void visit(ArrayInitializerExpr initializerExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append('{');
+        if (initializerExpr.getValues() != null) {
+            attributes.formulaBuilder.append(' ');
+            for (Iterator<Expression> i = initializerExpr.getValues().iterator(); i.hasNext();) {
+                Expression expr = i.next();
+                expr.accept(this, attributes);
+                if (i.hasNext()) {
+                    attributes.formulaBuilder.append(", ");
+                }
+            }
+            attributes.formulaBuilder.append(' ');
+        }
+        attributes.formulaBuilder.append('}');
+    }
+
+    @Override
+    public void visit(FieldAccessExpr fieldAccessExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(fieldAccessExpr);
+    }
+
+    @Override
+    public void visit(StringLiteralExpr literalExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append('"');
+        attributes.formulaBuilder.append(literalExpr.getValue());
+        attributes.formulaBuilder.append('"');
+    }
+
+    @Override
+    public void visit(IntegerLiteralExpr literalExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(literalExpr.getValue());
+    }
+
+    @Override
+    public void visit(LongLiteralExpr literalExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(literalExpr.getValue());
+    }
+
+    @Override
+    public void visit(CharLiteralExpr literalExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append('\'');
+        attributes.formulaBuilder.append(literalExpr.getValue());
+        attributes.formulaBuilder.append('\'');
+    }
+
+    @Override
+    public void visit(DoubleLiteralExpr literalExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(literalExpr.getValue());
+    }
+
+    @Override
+    public void visit(BooleanLiteralExpr literalExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(literalExpr.getValue());
+    }
+
+    @Override
+    public void visit(NullLiteralExpr literalExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append("null");
+    }
+
+    @Override
+    public void visit(MethodCallExpr methodCallExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(methodCallExpr);
+    }
+
+    @Override
+    public void visit(NameExpr nameExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(nameExpr);
+    }
+
+    @Override
+    public void visit(ObjectCreationExpr objectCreationExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(objectCreationExpr);
+    }
+
+    @Override
+    public void visit(UnaryExpr unaryExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(unaryExpr);
+    }
+
+    @Override
+    public void visit(CastExpr castExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(castExpr);
+    }
+
+    @Override
+    public void visit(ClassExpr classExpr, ShiftedColumnAttributes attributes) {
+        attributes.formulaBuilder.append(classExpr);
+    }
+
+    @Override
+    public void visit(ConditionalExpr conditionalExpr, ShiftedColumnAttributes attributes) {
+        conditionalExpr.getCondition().accept(this, attributes);
+        attributes.formulaBuilder.append(" ? ");
+        conditionalExpr.getThenExpr().accept(this, attributes);
+        attributes.formulaBuilder.append(" : ");
+        conditionalExpr.getElseExpr().accept(this, attributes);
+    }
+
+    @Override
+    public void visit(AssignExpr assignExpr, ShiftedColumnAttributes attributes) {
+        assignExpr.getTarget().accept(this, attributes);
+        attributes.formulaBuilder
+                .append(' ')
+                .append(assignExpr.getOperator().asString())
+                .append(' ');
+        assignExpr.getValue().accept(this, attributes);
+    }
+
+    // ---------- UNSUPPORTED: ----------------------------------------------------------------------------------------
+
+    @Override
+    public void visit(AnnotationDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("AnnotationDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(AnnotationMemberDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("AnnotationMemberDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(AssertStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("AssertStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(BlockComment n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("BlockComment Operation not supported");
+    }
+
+    @Override
+    public void visit(BlockStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("BlockStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(BreakStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("BreakStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(CatchClause n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("CatchClause Operation not supported");
+    }
+
+    @Override
+    public void visit(ClassOrInterfaceDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ClassOrInterfaceDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(CompilationUnit n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("CompilationUnit Operation not supported");
+    }
+
+    @Override
+    public void visit(ConstructorDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ConstructorDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(ContinueStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ContinueStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(DoStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("DoStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(EmptyStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("EmptyStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(EnumConstantDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("EnumConstantDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(EnumDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("EnumDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(ExplicitConstructorInvocationStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ExplicitConstructorInvocationStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(FieldDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("FieldDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(IfStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("IfStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(ImportDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ImportDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(InitializerDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("InitializerDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(InstanceOfExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("InstanceOfExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(JavadocComment n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("JavadocComment Operation not supported");
+    }
+
+    @Override
+    public void visit(LabeledStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("LabeledStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(LambdaExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("LambdaExpr Operation not supported!");
+    }
+
+    @Override
+    public void visit(LineComment n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("LineComment Operation not supported");
+    }
+
+    @Override
+    public void visit(MarkerAnnotationExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("MarkerAnnotationExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(MemberValuePair n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("MemberValuePair Operation not supported");
+    }
+
+    @Override
+    public void visit(MethodDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("MethodDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(MethodReferenceExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("MethodReferenceExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(PackageDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("PackageDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(Parameter n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("Parameter Operation not supported");
+    }
+
+    @Override
+    public void visit(ReturnStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ReturnStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(SingleMemberAnnotationExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("SingleMemberAnnotationExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(SuperExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("SuperExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(SwitchStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("SwitchStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(SynchronizedStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("SynchronizedStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(ThisExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ThisExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(ThrowStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ThrowStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(TryStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("TryStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(TypeExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("TypeExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(TypeParameter n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("TypeParameter Operation not supported");
+    }
+
+    @Override
+    public void visit(VariableDeclarationExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("VariableDeclarationExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(VariableDeclarator n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("VariableDeclarator Operation not supported");
+    }
+
+    @Override
+    public void visit(VoidType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("VoidType Operation not supported");
+    }
+
+    @Override
+    public void visit(WhileStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("WhileStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(WildcardType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("WildcardType Operation not supported");
+    }
+
+    @Override
+    public void visit(ClassOrInterfaceType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ClassOrInterfaceType Operation not supported");
+    }
+
+    @Override
+    public void visit(ExpressionStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ExpressionStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(ForEachStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ForEachStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(ForStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ForStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(NormalAnnotationExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("NormalAnnotationExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(PrimitiveType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("PrimitiveType Operation not supported");
+    }
+
+    @Override
+    public void visit(Name n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("Name Operation not supported");
+    }
+
+    @Override
+    public void visit(SimpleName n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("SimpleName Operation not supported");
+    }
+
+    @Override
+    public void visit(ArrayType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ArrayType Operation not supported");
+    }
+
+    @Override
+    public void visit(ArrayCreationLevel n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ArrayCreationLevel Operation not supported");
+    }
+
+    @Override
+    public void visit(IntersectionType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("IntersectionType Operation not supported");
+    }
+
+    @Override
+    public void visit(UnionType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("UnionType Operation not supported");
+    }
+
+    @Override
+    public void visit(SwitchEntry n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("SwitchEntry Operation not supported");
+    }
+
+    @Override
+    public void visit(LocalClassDeclarationStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("LocalClassDeclarationStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(LocalRecordDeclarationStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("LocalRecordDeclarationStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(UnknownType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("UnknownType Operation not supported");
+    }
+
+    @Override
+    public void visit(NodeList n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("NodeList Operation not supported");
+    }
+
+    @Override
+    public void visit(ModuleDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ModuleDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(ModuleRequiresDirective n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ModuleRequiresDirective Operation not supported");
+    }
+
+    @Override
+    public void visit(ModuleExportsDirective n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ModuleExportsDirective Operation not supported");
+    }
+
+    @Override
+    public void visit(ModuleProvidesDirective n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ModuleProvidesDirective Operation not supported");
+    }
+
+    @Override
+    public void visit(ModuleUsesDirective n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ModuleUsesDirective Operation not supported");
+    }
+
+    @Override
+    public void visit(ModuleOpensDirective n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ModuleOpensDirective Operation not supported");
+    }
+
+    @Override
+    public void visit(UnparsableStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("UnparsableStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(ReceiverParameter n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("ReceiverParameter Operation not supported");
+    }
+
+    @Override
+    public void visit(VarType n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("VarType Operation not supported");
+    }
+
+    @Override
+    public void visit(Modifier n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("Modifier Operation not supported");
+    }
+
+    @Override
+    public void visit(SwitchExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("SwitchExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(TextBlockLiteralExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("TextBlockLiteralExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(YieldStmt n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("YieldStmt Operation not supported");
+    }
+
+    @Override
+    public void visit(PatternExpr n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("PatternExpr Operation not supported");
+    }
+
+    @Override
+    public void visit(RecordDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("RecordDeclaration Operation not supported");
+    }
+
+    @Override
+    public void visit(CompactConstructorDeclaration n, ShiftedColumnAttributes arg) {
+        throw new UnsupportedOperationException("CompactConstructorDeclaration Operation not supported");
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+
+    public static class ShiftedColumnAttributes {
+        final MutableInt index;
+        final StringBuilder formulaBuilder;
+        final Map<String, Pair<Long, MatchPair>> shiftedColsMap;
+
+        public ShiftedColumnAttributes() {
+            this.index = new MutableInt(1);
+            this.formulaBuilder = new StringBuilder();
+            this.shiftedColsMap = new LinkedHashMap<>();
+        }
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnsFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnsFactory.java
@@ -325,7 +325,7 @@ public class ShiftedColumnsFactory extends VoidVisitorAdapter<ShiftedColumnsFact
         }
 
         Pair<Long, String> attributePair = parseForConstantArrayAccessAttributes(expr);
-        if (attributePair != null) {
+        if (attributePair != null && attributePair.getFirst() != 0) {
             final String shiftedColName = SHIFTED_COL_PREFIX + attributes.index.getAndIncrement();
             MatchPair matchPair = new MatchPair(shiftedColName, attributePair.getSecond());
             attributes.formulaBuilder.append(shiftedColName);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/StreamTableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/StreamTableTools.java
@@ -91,6 +91,7 @@ public class StreamTableTools {
                         final QueryTable result = new QueryTable(rowSet, columns);
                         result.setRefreshing(true);
                         result.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+                        result.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
                         result.setFlat();
                         resultHolder.setValue(result);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
@@ -423,6 +423,7 @@ public class TableUpdateValidator implements QueryTable.Operation {
             final Chunk<? extends Values> expected =
                     expectedSource.getChunk(expectedGetContext(), toValidate);
             final Chunk<? extends Values> actual = getSourceChunk(toValidate, usePrev);
+            Assert.eq(expected.size(), "expected.size()", actual.size(), "actual.size()");
             chunkEquals.equal(expected, actual, equalValuesDest());
             MutableInt off = new MutableInt();
             toValidate.forAllRowKeys((i) -> {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TimeTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TimeTable.java
@@ -117,6 +117,7 @@ public class TimeTable extends QueryTable implements Runnable {
             setAttribute(Table.STREAM_TABLE_ATTRIBUTE, Boolean.TRUE);
         } else {
             setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, Boolean.TRUE);
+            setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, Boolean.TRUE);
             setFlat();
         }
         if (startTime != null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/BaseTableTransformationColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/BaseTableTransformationColumn.java
@@ -67,11 +67,6 @@ abstract class BaseTableTransformationColumn implements SelectColumn {
     }
 
     @Override
-    public final boolean disallowRefresh() {
-        return false;
-    }
-
-    @Override
     public final boolean isStateless() {
         return true;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
@@ -111,11 +111,6 @@ class LongConstantColumn implements SelectColumn {
     }
 
     @Override
-    public final boolean disallowRefresh() {
-        return false;
-    }
-
-    @Override
     public final boolean isStateless() {
         return true;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -30,7 +30,7 @@ import java.util.function.Consumer;
 public abstract class AbstractFormulaColumn implements FormulaColumn {
     private static final Logger log = LoggerFactory.getLogger(AbstractFormulaColumn.class);
 
-    private static final boolean ALLOW_UNSAFE_REFRESHING_FORMULAS = Configuration.getInstance()
+    public static final boolean ALLOW_UNSAFE_REFRESHING_FORMULAS = Configuration.getInstance()
             .getBooleanForClassWithDefault(AbstractFormulaColumn.class, "allowUnsafeRefreshingFormulas", false);
 
 
@@ -100,7 +100,7 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
             isUnsafe |= !sourceTable.isAddOnly() && usesK;
             isUnsafe |= !usedColumnArrays.isEmpty();
             if (isUnsafe) {
-                throw new IllegalArgumentException("Formula " + formulaString + " uses i, ii, k, or column array " +
+                throw new IllegalArgumentException("Formula '" + formulaString + "' uses i, ii, k, or column array " +
                         "variables, and is not safe to refresh. Note that some usages, such as on an append-only " +
                         "table are safe. To allow unsafe refreshing formulas, set the system property " +
                         "io.deephaven.engine.table.impl.select.AbstractFormulaColumn.allowUnsafeRefreshingFormulas.");

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -66,6 +66,13 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
 
     @Override
     public List<String> initInputs(Table table) {
+//        if (!ALLOW_UNSAFE_REFRESHING_FORMULAS) {
+//            if (table.isAppendOnly() && !disallowRefresh(
+//            !usesI && !usesII && !usesK && usedColumnArrays.isEmpty();
+//        }
+//        if (disallowRefresh()) {
+//
+//        }
         return initInputs(table.getRowSet(), table.getColumnSourceMap());
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -90,6 +90,10 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
 
     @Override
     public void validateSafeForRefresh(BaseTable<?> sourceTable) {
+        if (sourceTable.hasAttribute(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE)) {
+            // allow any tests to use i, ii, and k without throwing an exception; we're probably using it safely
+            return;
+        }
         if (sourceTable.isRefreshing() && !ALLOW_UNSAFE_REFRESHING_FORMULAS) {
             // note that constant offset array accesss does not use i/ii or end up in usedColumnArrays
             boolean isUnsafe = !sourceTable.isAppendOnly() && (usesI || usesII);
@@ -98,7 +102,7 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
             if (isUnsafe) {
                 throw new IllegalArgumentException("Formula " + formulaString + " uses i, ii, k, or column array " +
                         "variables, and is not safe to refresh. Note that some usages, such as on an append-only " +
-                        "table are safe. To allow unsafe refreshing formulas, set the system property" +
+                        "table are safe. To allow unsafe refreshing formulas, set the system property " +
                         "io.deephaven.engine.table.impl.select.AbstractFormulaColumn.allowUnsafeRefreshingFormulas.");
             }
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.engine.table.impl.select;
 
+import io.deephaven.base.Pair;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.context.ExecutionContext;
@@ -10,6 +11,7 @@ import io.deephaven.engine.context.QueryCompiler;
 import io.deephaven.engine.context.QueryScopeParam;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.lang.QueryLanguageParser;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
@@ -65,6 +67,7 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
 
     private FormulaAnalyzer.Result analyzedFormula;
     private boolean hasConstantValue;
+    private Pair<String, Map<Long, List<MatchPair>>> formulaShiftColPair;
 
     public FormulaColumnPython getFormulaColumnPython() {
         return formulaColumnPython;
@@ -193,6 +196,7 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
             analyzedFormula = FormulaAnalyzer.analyze(formulaString, columnDefinitionMap,
                     timeConversionResult, result);
             hasConstantValue = result.isConstantValueExpression();
+            formulaShiftColPair = result.getFormulaShiftColPair();
 
             log.debug().append("Expression (after language conversion) : ").append(analyzedFormula.cookedFormulaString)
                     .endl();
@@ -735,6 +739,7 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
             copy.hasConstantValue = hasConstantValue;
             copy.returnedType = returnedType;
             copy.formulaColumnPython = formulaColumnPython;
+            copy.formulaShiftColPair = formulaShiftColPair;
             onCopy(copy);
         }
         return copy;
@@ -743,6 +748,11 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
     @Override
     public boolean hasConstantValue() {
         return hasConstantValue;
+    }
+
+    @Override
+    public Pair<String, Map<Long, List<MatchPair>>> getFormulaShiftColPair() {
+        return formulaShiftColPair;
     }
 
     private FormulaFactory createFormulaFactory() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FormulaColumn.java
@@ -3,6 +3,12 @@
  */
 package io.deephaven.engine.table.impl.select;
 
+import io.deephaven.base.Pair;
+import io.deephaven.engine.table.MatchPair;
+
+import java.util.List;
+import java.util.Map;
+
 public interface FormulaColumn extends SelectColumn {
 
     static FormulaColumn createFormulaColumn(String columnName, String formulaString,
@@ -26,5 +32,26 @@ public interface FormulaColumn extends SelectColumn {
      */
     default boolean hasConstantValue() {
         return false;
+    }
+
+    /**
+     * Returns true if the formula expression of the column has Array Access that conforms to "i +/- <constant>" or "ii
+     * +/- <constant>" </>.
+     *
+     * @return true or false
+     */
+    default boolean hasConstantArrayAccess() {
+        return getFormulaShiftColPair() != null;
+    }
+
+    /**
+     * Returns a Pair object consisting of formula string and shift to column MatchPairs. If the column formula or
+     * expression has Array Access that conforms to "i +/- <constant>" or "ii +/- <constant>" </>. If there is a parsing
+     * error for the expression null is returned.
+     *
+     * @return Pair of final formula string and shift to column MatchPairs.
+     */
+    default Pair<String, Map<Long, List<MatchPair>>> getFormulaShiftColPair() {
+        return null;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumn.java
@@ -221,11 +221,6 @@ public class FunctionalColumn<S, D> implements SelectColumn {
     }
 
     @Override
-    public boolean disallowRefresh() {
-        return false;
-    }
-
-    @Override
     public boolean isStateless() {
         return false;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
@@ -217,11 +217,6 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
     }
 
     @Override
-    public boolean disallowRefresh() {
-        return false;
-    }
-
-    @Override
     public boolean isStateless() {
         return false;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
@@ -93,11 +93,6 @@ public class NullSelectColumn<T> implements SelectColumn {
     }
 
     @Override
-    public boolean disallowRefresh() {
-        return false;
-    }
-
-    @Override
     public boolean isStateless() {
         return true;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ReinterpretedColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ReinterpretedColumn.java
@@ -330,11 +330,6 @@ public class ReinterpretedColumn<S, D> implements SelectColumn {
     }
 
     @Override
-    public boolean disallowRefresh() {
-        return false;
-    }
-
-    @Override
     public boolean isStateless() {
         return sourceColumnSource.isStateless();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
@@ -12,6 +12,7 @@ import io.deephaven.engine.context.QueryCompiler;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.rowset.TrackingRowSet;
+import io.deephaven.engine.table.impl.BaseTable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -156,12 +157,13 @@ public interface SelectColumn extends Selectable {
     boolean isRetain();
 
     /**
-     * Should we disallow use of this column for refreshing tables?
+     * Validate that this SelectColumn is safe to use in the context of the provided sourceTable.
      *
-     * Some formulas can not be reliably computed with a refreshing table, therefore we will refuse to compute those
-     * values.
+     * @param sourceTable the source table
      */
-    boolean disallowRefresh();
+    default void validateSafeForRefresh(final BaseTable<?> sourceTable) {
+        // nothing to validate by default
+    }
 
     /**
      * Returns true if this column is stateless (i.e. one row does not depend on the order of evaluation for another

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
@@ -157,7 +157,7 @@ public interface SelectColumn extends Selectable {
     boolean isRetain();
 
     /**
-     * Validate that this SelectColumn is safe to use in the context of the provided sourceTable.
+     * Validate that this {@code SelectColumn} is safe to use in the context of the provided sourceTable.
      *
      * @param sourceTable the source table
      */

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SourceColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SourceColumn.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.select;
 import io.deephaven.api.JoinAddition;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.*;
+import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.sources.InMemoryColumnSource;
 import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.table.impl.NoSuchColumnException;
@@ -165,12 +166,6 @@ public class SourceColumn implements SelectColumn {
         int result = sourceName.hashCode();
         result = 31 * result + destName.hashCode();
         return result;
-    }
-
-
-    @Override
-    public boolean disallowRefresh() {
-        return false;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SwitchColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SwitchColumn.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.select;
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.table.*;
 import io.deephaven.api.util.NameValidator;
+import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.select.python.FormulaColumnPython;
 import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.rowset.TrackingRowSet;
@@ -124,6 +125,11 @@ public class SwitchColumn implements SelectColumn {
     }
 
     @Override
+    public void validateSafeForRefresh(BaseTable<?> sourceTable) {
+        getRealColumn().validateSafeForRefresh(sourceTable);
+    }
+
+    @Override
     public String toString() {
         return columnName + "=" + expression;
     }
@@ -134,11 +140,6 @@ public class SwitchColumn implements SelectColumn {
                     "getRealColumn() is not available until this SwitchColumn is initialized; ensure that initInputs or initDef has been called first");
         }
         return realColumn;
-    }
-
-    @Override
-    public boolean disallowRefresh() {
-        return getRealColumn().disallowRefresh();
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilter.java
@@ -12,6 +12,7 @@ import io.deephaven.engine.context.QueryCompiler;
 import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.remote.ConstructSnapshot;
 import io.deephaven.engine.table.impl.select.MatchFilter.MatchType;
@@ -111,6 +112,15 @@ public interface WhereFilter extends Filter {
      *          {@link QueryCompiler} usage needs to be resolved within init. Implementations must be idempotent.
      */
     void init(TableDefinition tableDefinition);
+
+    /**
+     * Validate that this {@code WhereFilter} is safe to use in the context of the provided sourceTable.
+     *
+     * @param sourceTable the source table
+     */
+    default void validateSafeForRefresh(final BaseTable<?> sourceTable) {
+        // nothing to validate by default
+    }
 
     /**
      * Filter selection to only matching rows.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/BaseLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/BaseLayer.java
@@ -77,9 +77,9 @@ public class BaseLayer extends SelectAndViewAnalyzer {
     }
 
     @Override
-    final Map<String, Set<String>> calcDependsOnRecurse() {
+    final Map<String, Set<String>> calcDependsOnRecurse(boolean forcePublishAllSources) {
         final Map<String, Set<String>> result = new HashMap<>();
-        if (publishTheseSources) {
+        if (publishTheseSources || forcePublishAllSources) {
             for (final String col : sources.keySet()) {
                 result.computeIfAbsent(col, dummy -> new HashSet<>()).add(col);
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/DependencyLayerBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/DependencyLayerBase.java
@@ -56,8 +56,8 @@ public abstract class DependencyLayerBase extends SelectAndViewAnalyzer {
     }
 
     @Override
-    final Map<String, Set<String>> calcDependsOnRecurse() {
-        final Map<String, Set<String>> result = inner.calcDependsOnRecurse();
+    final Map<String, Set<String>> calcDependsOnRecurse(boolean forcePublishAllResources) {
+        final Map<String, Set<String>> result = inner.calcDependsOnRecurse(forcePublishAllResources);
         final Set<String> thisResult = new HashSet<>();
         for (final String dep : dependencies) {
             final Set<String> innerDependencies = result.get(dep);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/RedirectionLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/RedirectionLayer.java
@@ -155,8 +155,8 @@ public final class RedirectionLayer extends SelectAndViewAnalyzer {
     }
 
     @Override
-    public Map<String, Set<String>> calcDependsOnRecurse() {
-        return inner.calcDependsOnRecurse();
+    public Map<String, Set<String>> calcDependsOnRecurse(boolean forcePublishAllResources) {
+        return inner.calcDependsOnRecurse(forcePublishAllResources);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
@@ -272,7 +272,8 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
             return false;
         }
         final ColumnSource<?> sccs = sc.getDataView();
-        return sccs instanceof InMemoryColumnSource && !Vector.class.isAssignableFrom(sc.getReturnedType());
+        return sccs instanceof InMemoryColumnSource && ((InMemoryColumnSource) sccs).isInMemory()
+                && !Vector.class.isAssignableFrom(sc.getReturnedType());
     }
 
     static final int BASE_LAYER_INDEX = 0;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
@@ -133,7 +133,8 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
                 continue;
             }
 
-            // shifted columns appear to not be safe for refresh, so we do not validate them
+            // shifted columns appear to not be safe for refresh, so we do not validate them until they are rewritten
+            // using the intermediary shifted column
             if (sourceTable.isRefreshing()) {
                 sc.validateSafeForRefresh(sourceTable);
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzerWrapper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzerWrapper.java
@@ -63,7 +63,8 @@ public class SelectAndViewAnalyzerWrapper {
     public QueryTable applyShiftsAndRemainingColumns(
             @NotNull QueryTable sourceTable, @NotNull QueryTable queryTable, UpdateFlavor updateFlavor) {
         if (shiftColumn != null) {
-            queryTable = (QueryTable) ShiftedColumnsFactory.getShiftedColumnsTable(queryTable, shiftColumn);
+            queryTable = (QueryTable) ShiftedColumnsFactory.getShiftedColumnsTable(
+                    queryTable, shiftColumn, updateFlavor);
         }
 
         // shift columns may introduce modifies that are not present in the original table; set these before using

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzerWrapper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzerWrapper.java
@@ -67,16 +67,18 @@ public class SelectAndViewAnalyzerWrapper {
         }
 
         // shift columns may introduce modifies that are not present in the original table; set these before using
-        if (shiftColumn == null && sourceTable.isAddOnly()) {
-            queryTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
-        }
-        if ((shiftColumn == null || !shiftColumnHasPositiveOffset) && sourceTable.isAppendOnly()) {
-            // note if the shift offset is non-positive, then this result is still append-only
-            queryTable.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
-        }
-        if (sourceTable.hasAttribute(Table.TEST_SOURCE_TABLE_ATTRIBUTE)) {
-            // be convenient for test authors by propagating the test source table attribute
-            queryTable.setAttribute(Table.TEST_SOURCE_TABLE_ATTRIBUTE, true);
+        if (sourceTable.isRefreshing()) {
+            if (shiftColumn == null && sourceTable.isAddOnly()) {
+                queryTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+            }
+            if ((shiftColumn == null || !shiftColumnHasPositiveOffset) && sourceTable.isAppendOnly()) {
+                // note if the shift offset is non-positive, then this result is still append-only
+                queryTable.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
+            }
+            if (sourceTable.hasAttribute(Table.TEST_SOURCE_TABLE_ATTRIBUTE)) {
+                // be convenient for test authors by propagating the test source table attribute
+                queryTable.setAttribute(Table.TEST_SOURCE_TABLE_ATTRIBUTE, true);
+            }
         }
 
         boolean isMultiStateSelect = shiftColumn != null || remainingCols != null;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzerWrapper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzerWrapper.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl.select.analyzers;
+
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.impl.QueryTable;
+import io.deephaven.engine.table.impl.ShiftedColumnsFactory;
+import io.deephaven.engine.table.impl.select.FormulaColumn;
+import io.deephaven.engine.table.impl.select.SelectColumn;
+import io.deephaven.engine.table.impl.select.SourceColumn;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class SelectAndViewAnalyzerWrapper {
+    public enum UpdateFlavor {
+        Update, UpdateView, LazyUpdate, View
+    }
+
+    private final SelectAndViewAnalyzer analyzer;
+    private final FormulaColumn shiftColumn;
+    private final List<SelectColumn> remainingCols;
+    private final List<SelectColumn> processedColumns;
+
+    SelectAndViewAnalyzerWrapper(
+            SelectAndViewAnalyzer analyzer,
+            FormulaColumn shiftColumn,
+            List<SelectColumn> remainingCols,
+            List<SelectColumn> processedColumns) {
+        this.analyzer = analyzer;
+        this.shiftColumn = shiftColumn;
+        this.remainingCols = remainingCols;
+        this.processedColumns = processedColumns;
+    }
+
+    public final Map<String, ColumnSource<?>> getPublishedColumnResources() {
+        if (shiftColumn == null) {
+            return analyzer.getPublishedColumnSources();
+        } else {
+            return analyzer.getAllColumnSources();
+        }
+    }
+
+    public final Map<String, String[]> calcEffects() {
+        return analyzer.calcEffects(shiftColumn != null);
+    }
+
+    public SelectAndViewAnalyzer getAnalyzer() {
+        return analyzer;
+    }
+
+    public List<SelectColumn> getProcessedColumns() {
+        return processedColumns;
+    }
+
+    public QueryTable applyShiftsAndRemainingColumns(@NotNull QueryTable queryTable, UpdateFlavor updateFlavor) {
+        if (shiftColumn != null) {
+            queryTable = (QueryTable) ShiftedColumnsFactory.getShiftedColumnsTable(queryTable, shiftColumn);
+        }
+
+        if (remainingCols != null) {
+            switch (updateFlavor) {
+                case Update: {
+                    queryTable = (QueryTable) queryTable.update(remainingCols);
+                    break;
+                }
+                case UpdateView: {
+                    queryTable = (QueryTable) queryTable.updateView(remainingCols);
+                    break;
+                }
+                case LazyUpdate: {
+                    queryTable = (QueryTable) queryTable.lazyUpdate(remainingCols);
+                    break;
+                }
+                case View: {
+                    List<SelectColumn> newResultColumns = new LinkedList<>();
+                    for (SelectColumn processed : processedColumns) {
+                        newResultColumns.add(new SourceColumn(processed.getName()));
+                    }
+                    if (shiftColumn != null) {
+                        newResultColumns.add(new SourceColumn(shiftColumn.getName()));
+                    }
+                    newResultColumns.addAll(remainingCols);
+                    queryTable = (QueryTable) queryTable.view(newResultColumns);
+                    break;
+                }
+            }
+        }
+
+        return queryTable;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/StaticFlattenLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/StaticFlattenLayer.java
@@ -100,8 +100,8 @@ final public class StaticFlattenLayer extends SelectAndViewAnalyzer {
     }
 
     @Override
-    Map<String, Set<String>> calcDependsOnRecurse() {
-        return inner.calcDependsOnRecurse();
+    Map<String, Set<String>> calcDependsOnRecurse(boolean forcePublishAllResources) {
+        return inner.calcDependsOnRecurse(forcePublishAllResources);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/InMemoryColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/InMemoryColumnSource.java
@@ -20,10 +20,18 @@ import org.jetbrains.annotations.Nullable;
 import java.time.Instant;
 
 /**
- * This is a marker interface for a column source that is entirely within memory; therefore select operations should not
- * try to copy it into memory a second time.
+ * This is a marker interface for a column source that might be entirely within memory; therefore select operations
+ * should not try to copy it into memory a second time.
  */
 public interface InMemoryColumnSource {
+
+    /**
+     * @return true if this column source is entirely in memory.
+     */
+    default boolean isInMemory() {
+        return true;
+    }
+
     // We would like to use jdk.internal.util.ArraysSupport.MAX_ARRAY_LENGTH, but it is not exported
     int TWO_DIMENSIONAL_COLUMN_SOURCE_THRESHOLD = ArrayUtil.MAX_ARRAY_SIZE;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShiftedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShiftedColumnSource.java
@@ -34,7 +34,7 @@ import java.time.*;
  * @param <T>
  */
 public class ShiftedColumnSource<T> extends AbstractColumnSource<T>
-        implements UngroupableColumnSource, ConvertableTimeSource {
+        implements UngroupableColumnSource, ConvertableTimeSource, InMemoryColumnSource {
     protected final ColumnSource<T> innerSource;
     protected final TrackingRowSet rowSet;
     protected final long shift;
@@ -45,6 +45,11 @@ public class ShiftedColumnSource<T> extends AbstractColumnSource<T>
         this.innerSource = innerSource;
         this.rowSet = rowSet;
         this.shift = shift;
+    }
+
+    @Override
+    public boolean isInMemory() {
+        return innerSource instanceof InMemoryColumnSource && ((InMemoryColumnSource) innerSource).isInMemory();
     }
 
     long getColumnIndex(long outerKey) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShiftedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShiftedColumnSource.java
@@ -1,0 +1,723 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl.sources;
+
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSequence;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.TrackingRowSet;
+import io.deephaven.engine.rowset.WritableRowSet;
+import io.deephaven.engine.table.ChunkSource;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.SharedContext;
+import io.deephaven.engine.table.impl.AbstractColumnSource;
+import io.deephaven.engine.table.impl.DefaultGetContext;
+import io.deephaven.engine.table.impl.ShiftedColumnOperation;
+import io.deephaven.time.DateTime;
+import io.deephaven.util.BooleanUtils;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.util.type.TypeUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.*;
+
+/**
+ * A {@link ColumnSource} that provides internal shifted redirectionIndex logic to access into an underlying wrapped
+ * {@link ColumnSource}. This is used, in a {@link ShiftedColumnOperation}.
+ *
+ * @param <T>
+ */
+public class ShiftedColumnSource<T> extends AbstractColumnSource<T>
+        implements UngroupableColumnSource, ConvertableTimeSource {
+    protected final ColumnSource<T> innerSource;
+    protected final TrackingRowSet rowSet;
+    protected final long shift;
+
+    public ShiftedColumnSource(
+            @NotNull TrackingRowSet rowSet, @NotNull final ColumnSource<T> innerSource, final long shift) {
+        super(innerSource.getType());
+        this.innerSource = innerSource;
+        this.rowSet = rowSet;
+        this.shift = shift;
+    }
+
+    long getColumnIndex(long outerKey) {
+        long outerPosition = rowSet.find(outerKey);
+        long shiftedPosition = outerPosition + shift;
+        if (outerPosition < 0 || outerPosition >= rowSet.size()) {
+            return RowSequence.NULL_ROW_KEY;
+        }
+        return rowSet.get(shiftedPosition);
+    }
+
+    long getPrevColumnIndex(long outerKey) {
+        long outerPosition = rowSet.findPrev(outerKey);
+        long shiftedPosition = outerPosition + shift;
+        if (outerPosition < 0 || outerPosition >= rowSet.sizePrev()) {
+            return RowSequence.NULL_ROW_KEY;
+        }
+        return rowSet.getPrev(shiftedPosition);
+    }
+
+    /**
+     * Returns the appropriate Redirected Index for the passed in ordered keys based on current or prev Index.
+     *
+     * @param usePrev indicates if redirection is needed in pre-shift or post-shift space
+     * @param toRedirect keys to Redirect
+     * @param nullAtBeginningOrEnd holds the calculated count of null at beginning or end when processing is complete
+     * @return returns the appropriate Redirected Index for the passed in ordered keys
+     */
+    @NotNull
+    public RowSet buildRedirectedKeys(
+            boolean usePrev,
+            final @NotNull RowSequence toRedirect,
+            final @NotNull MutableInt nullAtBeginningOrEnd) {
+        final RowSet useRowSet = usePrev ? rowSet.copyPrev() : rowSet;
+        try (final RowSet ignored = useRowSet != rowSet ? useRowSet : null;
+                final RowSet toRedirectKeys = toRedirect.asRowSet();
+                final WritableRowSet posIndex = useRowSet.invert(toRedirectKeys)) {
+            final long origSize = posIndex.size();
+            if (shift < 0) {
+                posIndex.removeRange(0, -shift - 1);
+                int sz = (int) (origSize - posIndex.size());
+                nullAtBeginningOrEnd.setValue(sz);
+            } else if (shift > 0) {
+                posIndex.removeRange(useRowSet.size() - shift, useRowSet.size());
+                int sz = (int) (origSize - posIndex.size());
+                nullAtBeginningOrEnd.setValue(-(sz));
+            }
+            posIndex.shiftInPlace(shift);
+            return useRowSet.subSetForPositions(posIndex);
+        }
+    }
+
+    @Override
+    public boolean isImmutable() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public T get(long index) {
+        if (index < 0) {
+            return null;
+        }
+        return innerSource.get(getColumnIndex(index));
+    }
+
+    @Nullable
+    @Override
+    public Boolean getBoolean(long index) {
+        if (index < 0) {
+            return null;
+        }
+        return innerSource.getBoolean(getColumnIndex(index));
+    }
+
+    @Override
+    public byte getByte(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_BYTE;
+        }
+        return innerSource.getByte(getColumnIndex(index));
+    }
+
+    @Override
+    public char getChar(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_CHAR;
+        }
+        return innerSource.getChar(getColumnIndex(index));
+    }
+
+    @Override
+    public double getDouble(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_DOUBLE;
+        }
+        return innerSource.getDouble(getColumnIndex(index));
+    }
+
+    @Override
+    public float getFloat(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_FLOAT;
+        }
+        return innerSource.getFloat(getColumnIndex(index));
+    }
+
+    @Override
+    public int getInt(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_INT;
+        }
+        return innerSource.getInt(getColumnIndex(index));
+    }
+
+    @Override
+    public long getLong(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_LONG;
+        }
+        return innerSource.getLong(getColumnIndex(index));
+    }
+
+    @Override
+    public short getShort(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_SHORT;
+        }
+        return innerSource.getShort(getColumnIndex(index));
+    }
+
+    @Nullable
+    @Override
+    public T getPrev(long index) {
+        if (index < 0) {
+            return null;
+        }
+        return innerSource.getPrev(getPrevColumnIndex(index));
+    }
+
+    @Nullable
+    @Override
+    public Boolean getPrevBoolean(long index) {
+        if (index < 0) {
+            return null;
+        }
+        return innerSource.getPrevBoolean(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public byte getPrevByte(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_BYTE;
+        }
+        return innerSource.getPrevByte(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public char getPrevChar(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_CHAR;
+        }
+        return innerSource.getPrevChar(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public double getPrevDouble(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_DOUBLE;
+        }
+        return innerSource.getPrevDouble(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public float getPrevFloat(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_FLOAT;
+        }
+        return innerSource.getPrevFloat(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public int getPrevInt(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_INT;
+        }
+        return innerSource.getPrevInt(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public long getPrevLong(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_LONG;
+        }
+        return innerSource.getPrevLong(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public short getPrevShort(long index) {
+        if (index < 0) {
+            return QueryConstants.NULL_SHORT;
+        }
+        return innerSource.getPrevShort(getPrevColumnIndex(index));
+    }
+
+    @Override
+    public boolean isUngroupable() {
+        return innerSource instanceof UngroupableColumnSource && asUngroupableSource().isUngroupable();
+    }
+
+    @Override
+    public long getUngroupedSize(long columnIndex) {
+        return asUngroupableSource().getUngroupedSize(getColumnIndex(columnIndex));
+    }
+
+    @Override
+    public long getUngroupedPrevSize(long columnIndex) {
+        return asUngroupableSource().getUngroupedPrevSize(getPrevColumnIndex(columnIndex));
+    }
+
+    @Override
+    public T getUngrouped(long columnIndex, int arrayIndex) {
+        // noinspection unchecked
+        return (T) asUngroupableSource().getUngrouped(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public T getUngroupedPrev(long columnIndex, int arrayIndex) {
+        // noinspection unchecked
+        return (T) asUngroupableSource().getUngroupedPrev(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public Boolean getUngroupedBoolean(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedBoolean(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public Boolean getUngroupedPrevBoolean(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevBoolean(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public double getUngroupedDouble(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedDouble(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public double getUngroupedPrevDouble(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevDouble(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public float getUngroupedFloat(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedFloat(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public float getUngroupedPrevFloat(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevFloat(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public byte getUngroupedByte(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedByte(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public byte getUngroupedPrevByte(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevByte(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public char getUngroupedChar(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedChar(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public char getUngroupedPrevChar(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevChar(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public short getUngroupedShort(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedShort(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public short getUngroupedPrevShort(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevShort(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public int getUngroupedInt(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedInt(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public int getUngroupedPrevInt(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevInt(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public long getUngroupedLong(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedLong(getColumnIndex(columnIndex), arrayIndex);
+    }
+
+    @Override
+    public long getUngroupedPrevLong(long columnIndex, int arrayIndex) {
+        return asUngroupableSource().getUngroupedPrevLong(getPrevColumnIndex(columnIndex), arrayIndex);
+    }
+
+    private UngroupableColumnSource asUngroupableSource() {
+        return (UngroupableColumnSource) innerSource;
+    }
+
+    @Override
+    public void releaseCachedResources() {
+        super.releaseCachedResources();
+        innerSource.releaseCachedResources();
+    }
+
+    @Override
+    public ColumnSource<ZonedDateTime> toZonedDateTime(ZoneId zone) {
+        return new ShiftedColumnSource<>(rowSet, ((ConvertableTimeSource) innerSource).toZonedDateTime(zone), shift);
+    }
+
+    @Override
+    public ColumnSource<LocalDate> toLocalDate(ZoneId zone) {
+        return new ShiftedColumnSource<>(rowSet, ((ConvertableTimeSource) innerSource).toLocalDate(zone), shift);
+    }
+
+    @Override
+    public ColumnSource<LocalTime> toLocalTime(ZoneId zone) {
+        return new ShiftedColumnSource<>(rowSet, ((ConvertableTimeSource) innerSource).toLocalTime(zone), shift);
+    }
+
+    @Override
+    public ColumnSource<Instant> toInstant() {
+        return new ShiftedColumnSource<>(rowSet, ((ConvertableTimeSource) innerSource).toInstant(), shift);
+    }
+
+    @Override
+    public ColumnSource<DateTime> toDateTime() {
+        return new ShiftedColumnSource<>(rowSet, ((ConvertableTimeSource) innerSource).toDateTime(), shift);
+    }
+
+    @Override
+    public ColumnSource<Long> toEpochNano() {
+        return new ShiftedColumnSource<>(rowSet, ((ConvertableTimeSource) innerSource).toEpochNano(), shift);
+    }
+
+    @Override
+    public boolean supportsTimeConversion() {
+        return innerSource instanceof ConvertableTimeSource
+                && ((ConvertableTimeSource) innerSource).supportsTimeConversion();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <ALTERNATE_DATA_TYPE> ColumnSource<ALTERNATE_DATA_TYPE> doReinterpret(
+            @NotNull Class<ALTERNATE_DATA_TYPE> alternateDataType) {
+        if (TypeUtils.getUnboxedTypeIfBoxed(alternateDataType) == byte.class && getType() == Boolean.class) {
+            return new ReinterpretToOriginalForBoolean<>(alternateDataType);
+        }
+
+        if (innerSource instanceof ConvertableTimeSource
+                && ((ConvertableTimeSource) innerSource).supportsTimeConversion()) {
+            if (alternateDataType == long.class || alternateDataType == Long.class) {
+                return (ColumnSource<ALTERNATE_DATA_TYPE>) toEpochNano();
+            } else if (alternateDataType == DateTime.class) {
+                return (ColumnSource<ALTERNATE_DATA_TYPE>) toDateTime();
+            } else if (alternateDataType == Instant.class) {
+                return (ColumnSource<ALTERNATE_DATA_TYPE>) toInstant();
+            }
+        }
+
+        // noinspection unchecked,rawtypes
+        return new ReinterpretToOriginal(alternateDataType);
+    }
+
+    private class ReinterpretToOriginal<ALTERNATE_DATA_TYPE> extends ShiftedColumnSource<ALTERNATE_DATA_TYPE> {
+        private ReinterpretToOriginal(Class<ALTERNATE_DATA_TYPE> alternateDataType) {
+            super(ShiftedColumnSource.this.rowSet,
+                    ShiftedColumnSource.this.innerSource.reinterpret(alternateDataType),
+                    ShiftedColumnSource.this.shift);
+        }
+
+        @Override
+        public boolean allowsReinterpret(@SuppressWarnings("rawtypes") @NotNull Class alternateDataType) {
+            return alternateDataType == ShiftedColumnSource.this.getType();
+        }
+
+        @Override
+        protected <ORIGINAL_TYPE> ColumnSource<ORIGINAL_TYPE> doReinterpret(
+                @NotNull Class<ORIGINAL_TYPE> alternateDataType) {
+            // noinspection unchecked
+            return (ColumnSource<ORIGINAL_TYPE>) ShiftedColumnSource.this;
+        }
+    }
+
+    private class ReinterpretToOriginalForBoolean<ALTERNATE_DATA_TYPE>
+            extends ReinterpretToOriginal<ALTERNATE_DATA_TYPE> {
+        private ReinterpretToOriginalForBoolean(Class<ALTERNATE_DATA_TYPE> alternateDataType) {
+            super(alternateDataType);
+        }
+
+        @Override
+        public byte getByte(long index) {
+            if (index < 0) {
+                return BooleanUtils.NULL_BOOLEAN_AS_BYTE;
+            }
+            return super.getByte(index);
+        }
+
+        @Override
+        public byte getPrevByte(long index) {
+            if (index < 0) {
+                return BooleanUtils.NULL_BOOLEAN_AS_BYTE;
+            }
+            return super.getPrevByte(index);
+        }
+
+        @Override
+        public FillContext makeFillContext(int chunkCapacity, SharedContext sharedContext) {
+            return new FillContext(this, chunkCapacity, sharedContext);
+        }
+    }
+
+    @Override
+    public ShiftedColumnSource.FillContext makeFillContext(final int chunkCapacity, final SharedContext sharedContext) {
+        return new ShiftedColumnSource.FillContext(this, chunkCapacity, sharedContext);
+    }
+
+    @Override
+    public void fillChunk(
+            @NotNull final ColumnSource.FillContext context,
+            @NotNull final WritableChunk<? super Values> destination,
+            @NotNull final RowSequence rowSequence) {
+        doFillChunk(context, destination, rowSequence, false);
+    }
+
+    @Override
+    public void fillPrevChunk(
+            @NotNull final ColumnSource.FillContext context,
+            @NotNull final WritableChunk<? super Values> destination,
+            @NotNull final RowSequence rowSequence) {
+        doFillChunk(context, destination, rowSequence, true);
+    }
+
+    private void doFillChunk(
+            @NotNull final ColumnSource.FillContext context,
+            @NotNull final WritableChunk<? super Values> destination,
+            @NotNull final RowSequence rowSequence,
+            final boolean usePrev) {
+        final int size = rowSequence.intSize();
+        destination.setSize(size);
+        if (size <= 0) {
+            return;
+        }
+        final ShiftedColumnSource.FillContext effectiveContext = (ShiftedColumnSource.FillContext) context;
+
+        effectiveContext.shareable.ensureMappedKeysInitialized(this, usePrev, rowSequence);
+        effectiveContext.doOrderedFillAscending(innerSource, usePrev, destination);
+        destination.setSize(size);
+    }
+
+    @Override
+    public Chunk<? extends Values> getChunk(@NotNull ChunkSource.GetContext context, @NotNull RowSequence rowSequence) {
+        // noinspection unchecked
+        return getChunk((GetContext) context, false, rowSequence);
+    }
+
+    @Override
+    public Chunk<? extends Values> getPrevChunk(@NotNull ChunkSource.GetContext context,
+            @NotNull RowSequence rowSequence) {
+        // noinspection unchecked
+        return getChunk((GetContext) context, true, rowSequence);
+    }
+
+    /**
+     * returns the Chunk filled with redirected keys, passes inner getChunk/getPrevChunk if no nulls are present at the
+     * beginning or end.
+     *
+     * @param context the passed in GetContext
+     * @param usePrev boolean to indicate is invoked from getPrevChunk or getChunk
+     * @param rowSequence the passed in rowSequence
+     * @return returns the Chunk filled with redirected keys
+     */
+    private Chunk<? extends Values> getChunk(
+            @NotNull GetContext context, boolean usePrev, @NotNull RowSequence rowSequence) {
+        final int size = rowSequence.intSize();
+
+        final FillContext effectiveContext = (FillContext) DefaultGetContext.getFillContext(context);
+        effectiveContext.shareable.ensureMappedKeysInitialized(this, usePrev, rowSequence);
+        if (effectiveContext.shareable.beginningNullCount == 0 && effectiveContext.shareable.endingNullCount == 0) {
+            if (usePrev) {
+                return innerSource.getPrevChunk(context.innerGetContext, effectiveContext.shareable.innerRowSequence);
+            } else {
+                return innerSource.getChunk(context.innerGetContext, effectiveContext.shareable.innerRowSequence);
+            }
+        }
+
+        final WritableChunk<Values> destination = DefaultGetContext.getWritableChunk(context);
+        destination.setSize(size);
+        if (size <= 0) {
+            return destination;
+        }
+
+        effectiveContext.doOrderedFillAscending(innerSource, usePrev, destination);
+        destination.setSize(size);
+
+        return destination;
+    }
+
+    @Override
+    public GetContext makeGetContext(int chunkCapacity, SharedContext sharedContext) {
+        return new GetContext(chunkCapacity, sharedContext);
+    }
+
+    private class GetContext extends DefaultGetContext<Values> {
+        private final ColumnSource.GetContext innerGetContext;
+
+        GetContext(int chunkCapacity, SharedContext sharedContext) {
+            super(ShiftedColumnSource.this, chunkCapacity, sharedContext);
+            // we cannot share the inner context as this shifted column maps to a different set of rows than others
+            this.innerGetContext = innerSource.makeGetContext(chunkCapacity, null);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            innerGetContext.close();
+        }
+    }
+
+    private static class FillContext implements ChunkSource.FillContext {
+        private final ShiftedColumnSource.FillContext.Shareable shareable;
+        private final ColumnSource.FillContext innerFillContext;
+        private final ResettableWritableChunk<? super Values> destinationSlice;
+
+        FillContext(final ShiftedColumnSource<?> cs, final int chunkCapacity, final SharedContext sharedContext) {
+            shareable = sharedContext == null
+                    ? new ShiftedColumnSource.FillContext.Shareable(false)
+                    : sharedContext.getOrCreate(new ShiftedColumnSource.FillContext.SharingKey(cs.rowSet, cs.shift),
+                            () -> new ShiftedColumnSource.FillContext.Shareable(true));
+            innerFillContext = cs.innerSource.makeFillContext(chunkCapacity, shareable);
+            destinationSlice = cs.innerSource.getChunkType().makeResettableWritableChunk();
+        }
+
+        @Override
+        public void close() {
+            innerFillContext.close();
+            if (destinationSlice != null) {
+                destinationSlice.close();
+            }
+            if (!shareable.shared) {
+                shareable.close();
+            }
+        }
+
+        private static final class SharingKey implements SharedContext.Key<ShiftedColumnSource.FillContext.Shareable> {
+            final RowSet rowSet;
+            final long shift;
+
+            private SharingKey(@NotNull final RowSet rowSet, final long shift) {
+                this.rowSet = rowSet;
+                this.shift = shift;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o)
+                    return true;
+                if (o == null || getClass() != o.getClass())
+                    return false;
+                SharingKey that = (SharingKey) o;
+                return shift == that.shift && rowSet == that.rowSet;
+            }
+
+            @Override
+            public int hashCode() {
+                return System.identityHashCode(rowSet) + (int) shift;
+            }
+        }
+
+        private static final class Shareable extends SharedContext {
+            private boolean mappedKeysReusable = false;
+            private final boolean shared;
+            private int beginningNullCount = 0;
+            private int endingNullCount = 0;
+            private RowSequence innerRowSequence;
+
+            private Shareable(final boolean shared) {
+                this.shared = shared;
+            }
+
+            private void ensureMappedKeysInitialized(
+                    ShiftedColumnSource<?> cs,
+                    final boolean usePrev,
+                    @NotNull final RowSequence rowSequence) {
+                if (mappedKeysReusable) {
+                    return;
+                }
+                if (!shared) {
+                    reset();
+                }
+
+                final MutableInt nullCountAtBeginningOrEnd = new MutableInt(0);
+                innerRowSequence = cs.buildRedirectedKeys(usePrev, rowSequence, nullCountAtBeginningOrEnd);
+                if (nullCountAtBeginningOrEnd.intValue() < 0) {
+                    beginningNullCount = 0;
+                    endingNullCount = -nullCountAtBeginningOrEnd.intValue();
+                } else {
+                    beginningNullCount = nullCountAtBeginningOrEnd.intValue();
+                    endingNullCount = 0;
+                }
+
+                mappedKeysReusable = shared;
+            }
+
+            @Override
+            public void reset() {
+                mappedKeysReusable = false;
+                beginningNullCount = 0;
+                endingNullCount = 0;
+                if (innerRowSequence != null) {
+                    innerRowSequence.close();
+                    innerRowSequence = null;
+                }
+                super.reset();
+            }
+
+            @Override
+            public void close() {
+                if (innerRowSequence != null) {
+                    innerRowSequence.close();
+                    innerRowSequence = null;
+                }
+                super.close();
+            }
+        }
+
+        private void doOrderedFillAscending(
+                @NotNull final ColumnSource<?> innerSource,
+                final boolean usePrev,
+                @NotNull final WritableChunk<? super Values> destination) {
+            final RowSequence innerOk = shareable.innerRowSequence;
+            if (shareable.beginningNullCount > 0) {
+                destination.fillWithNullValue(0, shareable.beginningNullCount);
+                // noinspection unchecked,rawtypes
+                destinationSlice.resetFromChunk((WritableChunk) destination, shareable.beginningNullCount,
+                        innerOk.intSize());
+                if (usePrev) {
+                    // noinspection unchecked
+                    innerSource.fillPrevChunk(innerFillContext, destinationSlice, innerOk);
+                } else {
+                    // noinspection unchecked
+                    innerSource.fillChunk(innerFillContext, destinationSlice, innerOk);
+                }
+            } else {
+                if (usePrev) {
+                    innerSource.fillPrevChunk(innerFillContext, destination, innerOk);
+                } else {
+                    innerSource.fillChunk(innerFillContext, destination, innerOk);
+                }
+            }
+            if (shareable.endingNullCount > 0) {
+                final int startOff = destination.size();
+                final int finalSize = startOff + shareable.endingNullCount;
+                destination.setSize(finalSize);
+                destination.fillWithNullValue(startOff, shareable.endingNullCount);
+            }
+        }
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/DynamicTableWriter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/DynamicTableWriter.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.util;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.WritableColumnSource;
+import io.deephaven.engine.table.Table;
 import io.deephaven.qst.column.header.ColumnHeader;
 import io.deephaven.qst.table.TableHeader;
 import io.deephaven.qst.type.Type;
@@ -384,8 +385,12 @@ public class DynamicTableWriter implements TableWriter {
 
     private DynamicTableWriter(final Map<String, ColumnSource<?>> sources, final Map<String, Object> constantValues,
             final int allocatedSize) {
-        this.allocatedSize = 256;
-        this.table = new UpdateSourceQueryTable(RowSetFactory.fromKeys().toTracking(), sources);
+        this.allocatedSize = allocatedSize;
+        table = new UpdateSourceQueryTable(RowSetFactory.fromKeys().toTracking(), sources);
+        table.setFlat();
+        table.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+        table.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
+
         final int nCols = sources.size();;
         this.columnNames = new String[nCols];
         this.arrayColumnSources = new WritableColumnSource[nCols];

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
@@ -475,7 +475,8 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
         final PartitionedTable result2 =
                 sourceTable2.update("SlowItDown=pauseHelper.pauseValue(k)").partitionBy("USym2").transform(
                         executionContext, t -> t.withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, "true"))
-                                .update("SlowItDown2=pauseHelper2.pauseValue(2 * k)"), true);
+                                .update("SlowItDown2=pauseHelper2.pauseValue(2 * k)"),
+                        true);
 
         // pauseHelper.pause();
         pauseHelper2.pause();
@@ -562,7 +563,8 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                 .build();
         final PartitionedTable result2 = sourceTable2.partitionBy("USym2").transform(executionContext,
                 t -> t.withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, "true"))
-                        .update("SlowItDown2=pauseHelper.pauseValue(2 * k)"), true);
+                        .update("SlowItDown2=pauseHelper.pauseValue(2 * k)"),
+                true);
 
         final PartitionedTable joined = result.partitionedTransform(result2, (l, r) -> {
             System.out.println("Doing naturalJoin");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/PartitionedTableTest.java
@@ -473,8 +473,9 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                 .captureQueryCompiler()
                 .build();
         final PartitionedTable result2 =
-                sourceTable2.update("SlowItDown=pauseHelper.pauseValue(k)").partitionBy("USym2")
-                        .transform(executionContext, t -> t.update("SlowItDown2=pauseHelper2.pauseValue(2 * k)"), true);
+                sourceTable2.update("SlowItDown=pauseHelper.pauseValue(k)").partitionBy("USym2").transform(
+                        executionContext, t -> t.withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, "true"))
+                                .update("SlowItDown2=pauseHelper2.pauseValue(2 * k)"), true);
 
         // pauseHelper.pause();
         pauseHelper2.pause();
@@ -559,8 +560,9 @@ public class PartitionedTableTest extends RefreshingTableTestCase {
                 .captureQueryLibrary()
                 .captureQueryCompiler()
                 .build();
-        final PartitionedTable result2 = sourceTable2.partitionBy("USym2")
-                .transform(executionContext, t -> t.update("SlowItDown2=pauseHelper.pauseValue(2 * k)"), true);
+        final PartitionedTable result2 = sourceTable2.partitionBy("USym2").transform(executionContext,
+                t -> t.withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, "true"))
+                        .update("SlowItDown2=pauseHelper.pauseValue(2 * k)"), true);
 
         final PartitionedTable joined = result.partitionedTransform(result2, (l, r) -> {
             System.out.println("Doing naturalJoin");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -284,6 +284,7 @@ public class QueryTableAggregationTest {
         final QueryTable[] inputs = IntStream.range(0, 5).mapToObj((final int tableIndex) -> {
             // noinspection AutoBoxing
             QueryScope.addParam(tableIndexName, tableIndex);
+            parents[tableIndex].setAttribute(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, true);
             final QueryTable result = (QueryTable) parents[tableIndex].update(
                     "StrCol = Long.toString((long) (ii / 5))",
                     "IntCol = " + tableIndexName + " * 1_000_000 + i",
@@ -3109,7 +3110,8 @@ public class QueryTableAggregationTest {
     @Test
     public void testSelectDistinctUpdates() {
         final QueryTable table = testRefreshingTable(i(2, 4, 6, 8).toTracking(), col("x", 1, 2, 3, 2));
-        final QueryTable result = (QueryTable) (table.selectDistinct("x"));
+        final QueryTable result = (QueryTable) (table.selectDistinct("x"))
+                .withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, true));
         final QueryTableTestBase.ListenerWithGlobals listener;
         result.addUpdateListener(listener = base.newListenerWithGlobals(result));
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAjTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAjTest.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -1203,6 +1204,8 @@ public class QueryTableAjTest {
     }
 
     private void checkAjResult(Table leftTable, Table rightTable, Table result, boolean reverse, boolean noexact) {
+        leftTable = leftTable.withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, true));
+
         final TIntArrayList expectedStamp = new TIntArrayList();
         final TIntArrayList expectedSentinel = new TIntArrayList();
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableCrossJoinTestBase.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableCrossJoinTestBase.java
@@ -460,12 +460,8 @@ public abstract class QueryTableCrossJoinTestBase extends QueryTableTestBase {
     public void testStaticVsNaturalJoin2() {
         final int size = 10000;
 
-        final QueryTable xqt = new QueryTable(RowSetFactory.flat(size).toTracking(),
-                Collections.emptyMap());
-        xqt.setRefreshing(true);
-        final QueryTable yqt = new QueryTable(RowSetFactory.flat(size).toTracking(),
-                Collections.emptyMap());
-        yqt.setRefreshing(true);
+        final QueryTable xqt = TstUtils.testRefreshingTable(RowSetFactory.flat(size).toTracking());
+        final QueryTable yqt = TstUtils.testRefreshingTable(RowSetFactory.flat(size).toTracking());
 
         final Table x = xqt.update("Col1=i");
         final Table y = yqt.update("Col2=i*2");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableLeftOuterJoinTestBase.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableLeftOuterJoinTestBase.java
@@ -1285,10 +1285,8 @@ public abstract class QueryTableLeftOuterJoinTestBase extends QueryTableTestBase
     public void testStaticVsNaturalJoin2() {
         final int size = 10000;
 
-        final QueryTable xqt = new QueryTable(RowSetFactory.flat(size).toTracking(), Collections.emptyMap());
-        xqt.setRefreshing(true);
-        final QueryTable yqt = new QueryTable(RowSetFactory.flat(size).toTracking(), Collections.emptyMap());
-        yqt.setRefreshing(true);
+        final QueryTable xqt = TstUtils.testRefreshingTable(RowSetFactory.flat(size).toTracking());
+        final QueryTable yqt = TstUtils.testRefreshingTable(RowSetFactory.flat(size).toTracking());
 
         final Table x = xqt.update("Col1=i");
         final Table y = yqt.update("Col2=i*2");

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
@@ -360,7 +360,11 @@ public class QueryTableSelectUpdateTest {
             if (indexPositionChangesAllowed) {
                 // we should make sure that our added + removed is equal to the source added + removed size
                 long sourceSizeChange = listener1.added.size() - listener1.removed.size();
-                long resultSizeChange = listener2.added.size() - listener2.removed.size();
+                long resultSizeChange = 0;
+                // if the update was determined to be irrelevant, listener2 may not receive any event
+                if (listener2.added != null && listener2.removed != null) {
+                    resultSizeChange = listener2.added.size() - listener2.removed.size();
+                }
                 if (sourceSizeChange != resultSizeChange) {
                     issues.add("Source changed size by " + sourceSizeChange + ", but result changed size by "
                             + resultSizeChange);
@@ -574,7 +578,7 @@ public class QueryTableSelectUpdateTest {
 
     private void testUpdateIncremental(final int seed, MutableInt numSteps) {
         final Random random = new Random(seed);
-        final ColumnInfo[] columnInfo;
+        final ColumnInfo<?, ?>[] columnInfo;
         final int size = 25;
         final QueryTable queryTable = getTable(size, random,
                 columnInfo = initColumnInfos(new String[] {"Sym", "intCol", "doubleCol"},
@@ -872,9 +876,12 @@ public class QueryTableSelectUpdateTest {
         TestCase.assertEquals(Arrays.asList(0, 1), Arrays.asList(table2.getColumn("Position").get(0, table2.size())));
         // assertEquals(Arrays.asList("7", "9"), Arrays.asList(table2.getColumn("Key").get(0, table2.size())));
         TestCase.assertEquals(Arrays.asList(null, 0), Arrays.asList(table2.getColumn("PrevI").get(0, table2.size())));
-        TestCase.assertEquals(i(), base.added);
+
+        // note this modification is not reported to table2 since `update` is smart enough to notice that no columns
+        // are actually modified in the result table
+        TestCase.assertEquals(i(7, 9), base.added);
         TestCase.assertEquals(i(), base.removed);
-        TestCase.assertEquals(i(9), base.modified);
+        TestCase.assertEquals(i(), base.modified);
     }
 
     @Test

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -214,129 +214,47 @@ public class QueryTableTest extends QueryTableTestBase {
         final Table sortedTable = queryTable.sort("intCol");
 
         final EvalNugget[] en = new EvalNugget[] {
-                new EvalNugget() {
-                    public Table e() {
-                        return queryTable.updateView("intCol=intCol * 2");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return queryTable.updateView("intCol=intCol + doubleCol");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return queryTable.updateView("newCol=intCol / 2", "newCol2=newCol * 4");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return queryTable.updateView("newCol=intCol / 2").updateView("newCol2=newCol * 4");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return queryTable.view("intCol=intCol * 2");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return queryTable.view("intCol=intCol + doubleCol");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return queryTable.view("newCol=intCol / 2").updateView("newCol2=newCol * 4");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return sortedTable.updateView("intCol=intCol * 2");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return sortedTable.updateView("intCol=intCol + doubleCol");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol * 4");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return sortedTable.updateView("newCol=intCol / 2").updateView("newCol2=newCol * 4");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return sortedTable.view("intCol=intCol * 2");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return sortedTable.view("intCol=intCol + doubleCol");
-                    }
-                },
-                new EvalNugget() {
-                    public Table e() {
-                        return sortedTable.view("newCol=intCol / 2").updateView("newCol2=newCol * 4");
-                    }
-                },
-                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget
-                        .from(() -> queryTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
-                                "repeatedCol=newCol_[i-1] * repeatedCol"))
-                        .hasUnstableColumns("repeatedCol"),
-                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> queryTable.updateView("newCol=intCol_[i-1]"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget
-                        .from(() -> sortedTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
-                                "repeatedCol=newCol_[i-1] * repeatedCol"))
-                        .hasUnstableColumns("repeatedCol"),
-                EvalNugget.from(() -> sortedTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol_[i-1]"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> queryTable.view("newCol=intCol_[i-1]"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget
-                        .from(() -> queryTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
-                                "repeatedCol=newCol_[i-1] * repeatedCol"))
-                        .hasUnstableColumns("repeatedCol"),
-                EvalNugget.from(() -> queryTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> sortedTable.view("newCol=intCol_[i-1]"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol"))
-                        .hasUnstableColumns("newCol2"),
-                EvalNugget
-                        .from(() -> sortedTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
-                                "repeatedCol=newCol_[i-1] * repeatedCol"))
-                        .hasUnstableColumns("repeatedCol"),
-                EvalNugget.from(() -> sortedTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(
-                        () -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2", "newCol=newCol_[i-1] + 7"))
-                        .hasUnstableColumns("newCol"),
-                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol=newCol_[i-1] + 7"))
-                        .hasUnstableColumns("newCol"),
+                EvalNugget.from(() -> queryTable.updateView("intCol=intCol * 2")),
+                EvalNugget.from(() -> queryTable.updateView("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                EvalNugget.from(() -> queryTable.view("intCol=intCol * 2")),
+                EvalNugget.from(() -> queryTable.view("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("intCol=intCol * 2")),
+                EvalNugget.from(() -> sortedTable.updateView("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                EvalNugget.from(() -> sortedTable.view("intCol=intCol * 2")),
+                EvalNugget.from(() -> sortedTable.view("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> queryTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> sortedTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> queryTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> sortedTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2",
+                        "newCol=newCol_[i-1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol=newCol_[i-1] + 7")),
         };
 
         for (int i = 0; i < 10; i++) {
@@ -2705,11 +2623,7 @@ public class QueryTableTest extends QueryTableTestBase {
                     table.groupBy("Sym").sort("Sym").update("MyBoolean=boolArray", "MyDouble=doubleArray");
 
             final EvalNugget[] en = new EvalNugget[] {
-                    new EvalNugget() {
-                        public Table e() {
-                            return mismatch.ungroup(nullFill);
-                        }
-                    },
+                    EvalNugget.from(() -> mismatch.ungroup(nullFill)),
             };
 
             for (int i = 0; i < 10; i++) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -2653,6 +2653,7 @@ public class QueryTableTest extends QueryTableTestBase {
         final Table rightBy = right.groupBy("Letter");
 
         final Table joined = leftBy.naturalJoin(rightBy, "Letter")
+                .withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, true))
                 .updateView("BValue = ((i%2) == 0) ? null : BValue");
 
         QueryTable expected = testRefreshingTable(col("Letter", 'a', 'b', 'c', 'd'),
@@ -3157,7 +3158,10 @@ public class QueryTableTest extends QueryTableTestBase {
         final Table t0 = newTable(byteCol("Q", (byte) 0));
         final QueryTable t1 = testRefreshingTable(i().toTracking(), intCol("T"));
         final Table t2 = t1.view("Q=(byte)(i%2)");
-        final Table result = merge(t0, t2).tail(1).view("Q=Q*i").sumBy();
+        final Table result = merge(t0, t2).tail(1)
+                .withAttributes(Map.of(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, true))
+                .view("Q=Q*i")
+                .sumBy();
         int i = 1;
         for (int step = 0; step < 2; ++step) {
             final int key = i++;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ShiftedColumnOperationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ShiftedColumnOperationTest.java
@@ -1,0 +1,2707 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.chunk.LongChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.hashing.LongChunkEquals;
+import io.deephaven.engine.rowset.RowSequence;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.RowSetShiftData;
+import io.deephaven.engine.rowset.TrackingRowSet;
+import io.deephaven.engine.rowset.WritableRowSet;
+import io.deephaven.engine.rowset.chunkattributes.RowKeys;
+import io.deephaven.engine.rowset.impl.TrackingWritableRowSetImpl;
+import io.deephaven.engine.rowset.impl.WritableRowSetImpl;
+import io.deephaven.engine.table.ChunkSource;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.ModifiedColumnSet;
+import io.deephaven.engine.table.SharedContext;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.util.ChunkUtils;
+import io.deephaven.engine.testutil.ColumnInfo;
+import io.deephaven.engine.testutil.EvalNugget;
+import io.deephaven.engine.testutil.TstUtils;
+import io.deephaven.engine.testutil.generator.IntGenerator;
+import io.deephaven.engine.testutil.generator.SetGenerator;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
+import io.deephaven.engine.updategraph.UpdateGraphProcessor;
+import io.deephaven.engine.util.PrintListener;
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.test.types.OutOfBandTest;
+import io.deephaven.util.QueryConstants;
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.mutable.MutableLong;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Collections;
+import java.util.Random;
+
+import static io.deephaven.engine.testutil.TstUtils.*;
+import static io.deephaven.engine.testutil.testcase.RefreshingTableTestCase.simulateShiftAwareStep;
+import static io.deephaven.engine.util.TableTools.*;
+
+@Category(OutOfBandTest.class)
+public class ShiftedColumnOperationTest {
+    @Rule
+    public EngineCleanup cleanup = new EngineCleanup();
+
+    @Test
+    public void testSimpleMatchPair() {
+        for (int shift = 1; shift < 5; shift++) {
+            testSimpleMatchPair(shift);
+        }
+    }
+
+    private void testSimpleMatchPair(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30),
+                intCol("Value2", 202, 222, 242, 262, 282, 302));
+
+        final Table shiftMinusConst =
+                ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value", "CV32=Value2");
+        final Table shiftPlusConst =
+                ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value", "CV22=Value2");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(6, 8, 22, 24), intCol("Sentinel", 4, 5, 12, 13), intCol("Value", 16, 18, 32, 34),
+                    intCol("Value2", 162, 182, 322, 342));
+            table.notifyListeners(i(6, 8, 22, 24), i(), i());
+
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        String[] minusConstCols =
+                new String[] {"CV3=Value_[i-" + shiftConst + "]", "CV32=Value2_[i-" + shiftConst + "]"};
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(minusConstCols)),
+                shiftMinusConst);
+
+        String[] plusConstCols =
+                new String[] {"CV2=Value_[i+" + shiftConst + "]", "CV22=Value2_[i+" + shiftConst + "]"};
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(plusConstCols)),
+                shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2, 4, 26, 28), intCol("Sentinel", 2, 3, 14, 15), intCol("Value", 12, 14, 36, 38),
+                    intCol("Value2", 122, 142, 362, 382));
+            removeRows(table, i(6, 24));
+            table.notifyListeners(i(2, 4, 26, 28), i(6, 24), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(minusConstCols)),
+                shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(plusConstCols)),
+                shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testSimpleFillChunkSingleColumnChanges() {
+        for (int shift = 1; shift < 5; shift++) {
+            testSimpleFillChunkSingleColumnChanges(shift);
+        }
+    }
+
+    private void testSimpleFillChunkSingleColumnChanges(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 10, 12, 14, 16, 18));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(0, 1, 12, 14), intCol("Sentinel", -1, 0, 6, 7), intCol("Value", 6, 8, 20, 22));
+            addToTable(table, i(8), intCol("Sentinel", 18), intCol("Value", 25));
+            table.notifyListeners(i(0, 1, 12, 14), i(), i(8));
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testModifiedColSet() {
+        for (int shift = 1; shift < 5; shift++) {
+            testModifiedColSet(shift);
+        }
+    }
+
+    private void testModifiedColSet(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30),
+                intCol("Value2", 202, 222, 242, 262, 282, 302),
+                intCol("Value3", 2020, 2220, 2420, 2620, 2820, 3020));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value",
+                "CV32=Value2", "CV33=Value3");
+        final Table shiftPlusConst =
+                ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value", "CV22=Value2", "CV23=Value3");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table,
+                    i(10, 12, 18),
+                    intCol("Sentinel", 6, 7, 10),
+                    intCol("Value", 420, 422, 428),
+                    intCol("Value2", 202, 222, 282),
+                    intCol("Value3", 2020, 2220, 2820));
+
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update = new TableUpdateImpl(i(), i(), i(10, 12, 18), shiftData,
+                    table.newModifiedColumnSet("Value"));
+            table.notifyListeners(update);
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        String[] minusConstCols = new String[] {"CV3=Value_[i-" + shiftConst + "]",
+                "CV32=Value2_[i-" + shiftConst + "]", "CV33=Value3_[i-" + shiftConst + "]"};
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(minusConstCols)),
+                shiftMinusConst);
+
+        String[] plusConstCols = new String[] {"CV2=Value_[i+" + shiftConst + "]", "CV22=Value2_[i+" + shiftConst + "]",
+                "CV23=Value3_[i+" + shiftConst + "]"};
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(plusConstCols)),
+                shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(14, 16, 20),
+                    intCol("Sentinel", 8, 9, 11),
+                    intCol("Value", 24, 26, 30),
+                    intCol("Value2", 3242, 3262, 3302),
+                    intCol("Value3", 2420, 2620, 3020));
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update = new TableUpdateImpl(i(), i(), i(14, 16, 20), shiftData,
+                    table.newModifiedColumnSet("Value2"));
+            table.notifyListeners(update);
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(minusConstCols)),
+                shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(plusConstCols)),
+                shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testModifiedColSetMultiColMapping() {
+        for (int shift = 1; shift < 5; shift++) {
+            testModifiedColSetMultiColMapping(shift);
+        }
+    }
+
+    private void testModifiedColSetMultiColMapping(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30),
+                intCol("Value2", 202, 222, 242, 262, 282, 302),
+                intCol("Value3", 2020, 2220, 2420, 2620, 2820, 3020));
+
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst),
+                "CV3=Value", "C2V3=Value", "CV32=Value2", "C2V32=Value2", "CV33=Value3", "C2V33=Value3");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst,
+                "CV2=Value", "C2V2=Value", "CV22=Value2", "C2V22=Value2", "CV23=Value3", "C2V23=Value3");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table,
+                    i(10, 12, 18),
+                    intCol("Sentinel", 6, 7, 10),
+                    intCol("Value", 420, 422, 428),
+                    intCol("Value2", 202, 222, 282),
+                    intCol("Value3", 2020, 2220, 2820));
+
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update = new TableUpdateImpl(i(), i(), i(10, 12, 18), shiftData,
+                    table.newModifiedColumnSet("Value"));
+            table.notifyListeners(update);
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        String[] minusConstCols = new String[] {
+                "CV3=Value_[i-" + shiftConst + "]", "C2V3=Value_[i-" + shiftConst + "]",
+                "CV32=Value2_[i-" + shiftConst + "]", "C2V32=Value2_[i-" + shiftConst + "]",
+                "CV33=Value3_[i-" + shiftConst + "]", "C2V33=Value3_[i-" + shiftConst + "]"};
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(minusConstCols)),
+                shiftMinusConst);
+
+        String[] plusConstCols = new String[] {
+                "CV2=Value_[i+" + shiftConst + "]", "C2V2=Value_[i+" + shiftConst + "]",
+                "CV22=Value2_[i+" + shiftConst + "]", "C2V22=Value2_[i+" + shiftConst + "]",
+                "CV23=Value3_[i+" + shiftConst + "]", "C2V23=Value3_[i+" + shiftConst + "]"};
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(plusConstCols)),
+                shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(14, 16, 20),
+                    intCol("Sentinel", 8, 9, 11),
+                    intCol("Value", 24, 26, 30),
+                    intCol("Value2", 3242, 3262, 3302),
+                    intCol("Value3", 2420, 2620, 3020));
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update = new TableUpdateImpl(i(), i(), i(14, 16, 20), shiftData,
+                    table.newModifiedColumnSet("Value2"));
+            table.notifyListeners(update);
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(minusConstCols)),
+                shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update(plusConstCols)),
+                shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testSimple5() {
+        for (int shift = 1; shift < 5; shift++) {
+            testSimple5(shift);
+        }
+    }
+
+    private void testSimple5(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(6, 8, 22, 24), intCol("Sentinel", 4, 5, 12, 13), intCol("Value", 16, 18, 32, 34));
+            table.notifyListeners(i(6, 8, 22, 24), i(), i());
+
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2, 4, 26, 28), intCol("Sentinel", 2, 3, 14, 15), intCol("Value", 12, 14, 36, 38));
+            removeRows(table, i(6, 24));
+            table.notifyListeners(i(2, 4, 26, 28), i(6, 24), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddRemoveAtTheEnd() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddRemoveAtTheEnd(shift);
+        }
+    }
+
+    private void testAddRemoveAtTheEnd(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(6, 8, 22, 24), intCol("Sentinel", 4, 5, 12, 13), intCol("Value", 16, 18, 32, 34));
+            table.notifyListeners(i(6, 8, 22, 24), i(), i());
+
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2, 4, 26, 28), intCol("Sentinel", 2, 3, 14, 15), intCol("Value", 12, 14, 36, 38));
+            removeRows(table, i(6, 24));
+            table.notifyListeners(i(2, 4, 26, 28), i(6, 24), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddRemoveOverlap() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddRemoveOverlap(shift);
+        }
+    }
+
+    private void testAddRemoveOverlap(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(6, 14, 18, 24), intCol("Sentinel", 4, 5, 12, 13), intCol("Value", 16, 18, 32, 34));
+            removeRows(table, i(10, 14, 18, 20));
+            table.notifyListeners(i(6, 24), i(10, 14, 18, 20), i());
+
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddRemove() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30));
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final Table shiftMinusOne = ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value");
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+
+        final TableUpdateValidator tuvMinusOne = TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusOneFailureListener = new FailureListener();
+        tuvMinusOne.getResultTable().addUpdateListener(tuvMinusOneFailureListener);
+
+        final Table shiftPlusOne = ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value");
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+
+        final TableUpdateValidator tuvPlusOne = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusOneFailureListener = new FailureListener();
+        tuvPlusOne.getResultTable().addUpdateListener(tuvPlusOneFailureListener);
+
+        final int shiftConst = 2;
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(6, 8, 22, 24), intCol("Sentinel", 4, 5, 12, 13), intCol("Value", 16, 18, 32, 34));
+            table.notifyListeners(i(6, 8, 22, 24), i(), i());
+
+        });
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2, 4, 26, 28), intCol("Sentinel", 2, 3, 14, 15), intCol("Value", 12, 14, 36, 38));
+            removeRows(table, i(6, 24));
+            table.notifyListeners(i(2, 4, 26, 28), i(6, 24), i());
+        });
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+    }
+
+    @Test
+    public void testContiguousAddUpdateRemove() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(10, 12, 20, 28, 30).toTracking(),
+                intCol("Sentinel", 4, 5, 9, 13, 14),
+                intCol("Value", 18, 20, 28, 36, 38));
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final Table shiftMinusOne = ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value");
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+
+        final TableUpdateValidator tuvMinusOne = TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusOneFailureListener = new FailureListener();
+        tuvMinusOne.getResultTable().addUpdateListener(tuvMinusOneFailureListener);
+
+        final Table shiftPlusOne = ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value");
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+
+        final TableUpdateValidator tuvPlusOne = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusOneFailureListener = new FailureListener();
+        tuvPlusOne.getResultTable().addUpdateListener(tuvPlusOneFailureListener);
+
+        final int shiftConst = 2;
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(4, 6, 8, 14, 16, 18, 22, 24, 26, 32, 34, 36),
+                    intCol("Sentinel", 1, 2, 3, 6, 7, 8, 10, 11, 12, 15, 16, 17),
+                    intCol("Value", 12, 14, 16, 22, 24, 26, 30, 32, 34, 40, 42, 44));
+            table.notifyListeners(i(4, 6, 8, 14, 16, 18, 22, 24, 26, 32, 34, 36), i(), i());
+
+        });
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(4, 6, 8, 14, 16, 18, 22, 24, 26, 32, 34, 36),
+                    intCol("Sentinel", 101, 102, 103, 106, 107, 108, 110, 111, 112, 115, 116, 117),
+                    intCol("Value", 112, 114, 116, 122, 124, 126, 130, 132, 134, 140, 142, 144));
+            table.notifyListeners(i(), i(), i(4, 6, 8, 14, 16, 18, 22, 24, 26, 32, 34, 36));
+
+        });
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(4, 6, 8, 14, 16, 18, 22, 24, 26, 32, 34, 36));
+            table.notifyListeners(i(), i(4, 6, 8, 14, 16, 18, 22, 24, 26, 32, 34, 36), i());
+        });
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+    }
+
+    @Test
+    public void testSimpleRemoveRangeApproach() {
+        for (int shift = 1; shift < 5; shift++) {
+            testSimpleRemoveRangeApproach(shift);
+        }
+    }
+
+    private void testSimpleRemoveRangeApproach(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(0, 2, 4, 6, 8, 10, 12, 14, 16, 18).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+                intCol("Value", 8, 10, 12, 14, 16, 18, 20, 22, 24, 26));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(6, 10));
+            table.notifyListeners(i(), i(6, 10), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testSimpleRemoveChanges() {
+        for (int shift = 1; shift < 5; shift++) {
+            testSimpleRemoveChanges(shift);
+        }
+    }
+
+    private void testSimpleRemoveChanges(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 10, 12, 14, 16, 18));
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(6));
+            table.notifyListeners(i(), i(6), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testSimpleModifyChanges() {
+        for (int shift = 1; shift < 5; shift++) {
+            testSimpleModifyChanges(shift);
+        }
+    }
+
+    private void testSimpleModifyChanges(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(0, 2, 4, 6, 8, 10, 12, 14, 16, 18).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+                intCol("Value", 8, 10, 12, 14, 16, 18, 20, 22, 24, 26));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(0, 2, 4, 8, 12, 14, 18), intCol("Sentinel", 11, 12, 13, 15, 17, 18, 20),
+                    intCol("Value", 9, 11, 13, 17, 21, 23, 27));
+            table.notifyListeners(i(), i(), i(0, 2, 4, 8, 12, 14, 18));
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(0, 2, 4, 8, 12, 14, 18), intCol("Sentinel", 21, 22, 23, 25, 27, 28, 30),
+                    intCol("Value", 109, 111, 113, 117, 121, 123, 127));
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update = new TableUpdateImpl(i(), i(), i(0, 2, 4, 8, 12, 14, 18),
+                    shiftData, table.newModifiedColumnSet(table.getDefinition().getColumnNamesArray()));
+            table.notifyListeners(update);
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testSimpleAddSingleColumnChanges() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 100, 101, 102, 103, 104));
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final Table shiftMinusOne = ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value");
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+
+        final TableUpdateValidator tuvMinusOne = TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusOneFailureListener = new FailureListener();
+        tuvMinusOne.getResultTable().addUpdateListener(tuvMinusOneFailureListener);
+
+        final Table shiftPlusOne = ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value");
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+
+        final TableUpdateValidator tuvPlusOne = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusOneFailureListener = new FailureListener();
+        tuvPlusOne.getResultTable().addUpdateListener(tuvPlusOneFailureListener);
+
+        final int shiftConst = 4;
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+
+        ColumnSource<?> shiftedSource = shiftMinusConst.getColumnSource("CV3");
+        try (final WritableIntChunk<Values> chunk = WritableIntChunk.makeWritableChunk(shiftMinusConst.intSize());
+                final ChunkSource.FillContext fc = shiftedSource.makeFillContext(chunk.capacity())) {
+            shiftedSource.fillChunk(fc, chunk, shiftMinusConst.getRowSet());
+            System.out.println("Chunked Read:");
+            System.out.println(ChunkUtils.dumpChunk(chunk));
+            Assert.assertEquals(shiftMinusConst.intSize(), chunk.size());
+        }
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        ColumnSource<?> shiftedSourcePlus = shiftPlusConst.getColumnSource("CV2");
+        try (final WritableIntChunk<Values> chunk = WritableIntChunk.makeWritableChunk(shiftPlusConst.intSize());
+                final ChunkSource.FillContext fc = shiftedSourcePlus.makeFillContext(chunk.capacity())) {
+            shiftedSourcePlus.fillChunk(fc, chunk, shiftPlusConst.getRowSet());
+            System.out.println("Chunked Read:");
+            System.out.println(ChunkUtils.dumpChunk(chunk));
+            Assert.assertEquals(shiftPlusConst.intSize(), chunk.size());
+        }
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener printListenerOrig = new PrintListener("original table", table, 10);
+        final PrintListener printListener = new PrintListener("shiftMinus4", shiftMinusConst, 10);
+        final PrintListener printListenerPlusConst = new PrintListener("shiftPlus4", shiftPlusConst, 10);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(0, 1, 12, 14), intCol("Sentinel", -1, 0, 6, 7), intCol("Value", 98, 99, 105, 106));
+            table.notifyListeners(i(0, 1, 12, 14), i(), i());
+        });
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        printListenerOrig.stop();
+        printListener.stop();
+        printListenerPlusConst.stop();
+    }
+
+    @Test
+    public void testSimpleAddMultipleColumnChanges() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 100, 101, 102, 103, 104),
+                intCol("Value2", 1000, 1010, 1020, 1030, 1040),
+                intCol("Value3", 2000, 2010, 2020, 2030, 2040));
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final Table shiftMinusOne =
+                ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value", "V32=Value2", "V33=Value3");
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+
+        final TableUpdateValidator tuvMinusOne = TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusOneFailureListener = new FailureListener();
+        tuvMinusOne.getResultTable().addUpdateListener(tuvMinusOneFailureListener);
+
+        final Table shiftPlusOne =
+                ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value", "V22=Value2", "V23=Value3");
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+
+        final TableUpdateValidator tuvPlusOne = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusOneFailureListener = new FailureListener();
+        tuvPlusOne.getResultTable().addUpdateListener(tuvPlusOneFailureListener);
+
+        final int shiftConst = 4;
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value",
+                "CV32=Value2", "CV33=Value3");
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+
+        ColumnSource<?> shiftedSource = shiftMinusConst.getColumnSource("CV3");
+        try (final WritableIntChunk<Values> chunk = WritableIntChunk.makeWritableChunk(shiftMinusConst.intSize());
+                final ChunkSource.FillContext fc = shiftedSource.makeFillContext(chunk.capacity())) {
+            shiftedSource.fillChunk(fc, chunk, shiftMinusConst.getRowSet());
+            System.out.println("Chunked Read:");
+            System.out.println(ChunkUtils.dumpChunk(chunk));
+            Assert.assertEquals(shiftMinusConst.intSize(), chunk.size());
+        }
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final Table shiftPlusConst =
+                ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value", "CV22=Value2", "CV23=Value3");
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        ColumnSource<?> shiftedSourcePlus = shiftPlusConst.getColumnSource("CV2");
+        try (final WritableIntChunk<Values> chunk = WritableIntChunk.makeWritableChunk(shiftPlusConst.intSize());
+                final ChunkSource.FillContext fc = shiftedSourcePlus.makeFillContext(chunk.capacity())) {
+            shiftedSourcePlus.fillChunk(fc, chunk, shiftPlusConst.getRowSet());
+            System.out.println("Chunked Read:");
+            System.out.println(ChunkUtils.dumpChunk(chunk));
+            Assert.assertEquals(shiftPlusConst.intSize(), chunk.size());
+        }
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener printListenerOrig = new PrintListener("original table", table, 10);
+        final PrintListener printListenerMinusOne =
+                new PrintListener("original table", shiftMinusOne, 10);
+        final PrintListener printListener = new PrintListener("shiftMinus4", shiftMinusConst, 10);
+        final PrintListener printListenerPlusConst = new PrintListener("shiftPlus4", shiftPlusConst, 10);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(0, 1, 12, 14), intCol("Sentinel", -1, 0, 6, 7), intCol("Value", 98, 99, 105, 106),
+                    intCol("Value2", 980, 990, 1050, 1060), intCol("Value3", 1980, 1990, 2050, 2060));
+            table.notifyListeners(i(0, 1, 12, 14), i(), i());
+        });
+        System.out.println("---table---");
+        TableTools.showWithRowSet(table);
+        System.out.println("---shiftMinusOne---");
+        TableTools.showWithRowSet(shiftMinusOne);
+        System.out.println("---shiftPlusOne---");
+        TableTools.showWithRowSet(shiftPlusOne);
+        System.out.println("---shiftMinusConst---");
+        TableTools.showWithRowSet(shiftMinusConst);
+        System.out.println("---shiftPlusConst---");
+        TableTools.showWithRowSet(shiftPlusConst);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(
+                        () -> table.update("V3 = Value_[i - 1]", "V32 = Value2_[i - 1]", "V33 = Value3_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(
+                        () -> table.update("V2 = Value_[i + 1]", "V22 = Value2_[i + 1]", "V23 = Value3_[i + 1]")),
+                shiftPlusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock()
+                        .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]",
+                                "CV32 = Value2_[i - " + shiftConst + "]", "CV33 = Value3_[i - " + shiftConst + "]")),
+                shiftMinusConst);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock()
+                        .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]",
+                                "CV22 = Value2_[i + " + shiftConst + "]", "CV23 = Value3_[i + " + shiftConst + "]")),
+                shiftPlusConst);
+
+        printListenerOrig.stop();
+        printListenerMinusOne.stop();
+        printListener.stop();
+        printListenerPlusConst.stop();
+    }
+
+
+    @Test
+    public void testRemoveWithTUV() {
+        for (int i = 1; i < 5; i++) {
+            testRemoveWithTUV(i);
+        }
+    }
+
+    private void testRemoveWithTUV(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14, 16, 18).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7, 8, 9),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22, 24, 26));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(8));
+            table.notifyListeners(i(), i(8), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddSingleNewRowToBeginning() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddSingleNewRowToBeginning(shift);
+        }
+    }
+
+    private void testAddSingleNewRowToBeginning(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 2, 3, 4, 5),
+                intCol("Value", 12, 14, 16, 18));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2), intCol("Sentinel", 1), intCol("Value", 10));
+            table.notifyListeners(i(2), i(), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddMultipleNewRowToBeginning() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddMultipleNewRowToBeginning(shift);
+        }
+    }
+
+    private void testAddMultipleNewRowToBeginning(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(6, 8, 10).toTracking(),
+                intCol("Sentinel", 3, 4, 5),
+                intCol("Value", 14, 16, 18));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2, 4), intCol("Sentinel", 1, 2), intCol("Value", 10, 12));
+            table.notifyListeners(i(2, 4), i(), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddSingleNewRowToEnd() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddSingleNewRowToEnd(shift);
+        }
+    }
+
+    private void testAddSingleNewRowToEnd(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 10, 12, 14, 16, 18));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(12), intCol("Sentinel", 6), intCol("Value", 20));
+            table.notifyListeners(i(12), i(), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddMultipleNewRowsToEnd() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddMultipleNewRowsToEnd(shift);
+        }
+    }
+
+    private void testAddMultipleNewRowsToEnd(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 10, 12, 14, 16, 18));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(12, 14, 16), intCol("Sentinel", 6, 7, 8), intCol("Value", 20, 22, 24));
+            table.notifyListeners(i(12, 14, 16), i(), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddMultipleNonContiguousRows() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddMultipleNonContiguousRows(shift);
+        }
+    }
+
+    private void testAddMultipleNonContiguousRows(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 3, 5, 7, 9),
+                intCol("Value", 10, 12, 14, 16, 18));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(3, 5, 7), intCol("Sentinel", 2, 4, 6), intCol("Value", 11, 13, 15));
+            table.notifyListeners(i(7, 5, 3), i(), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddMultipleContiguousNewRows() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddMultipleContiguousNewRows(shift);
+        }
+    }
+
+    private void testAddMultipleContiguousNewRows(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 8, 14, 20).toTracking(),
+                intCol("Sentinel", 1, 7, 13, 19),
+                intCol("Value", 10, 16, 22, 28));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(3, 5, 7, 9, 11, 13), intCol("Sentinel", 2, 4, 6, 8, 10, 12),
+                    intCol("Value", 11, 13, 15, 17, 19, 21));
+            table.notifyListeners(i(7, 5, 3, 9, 11, 13), i(), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddRowsToBeginningMiddle() {
+        for (int shift = 1; shift < 3; shift++) {
+            testAddRowsToBeginningMiddle(shift);
+        }
+    }
+
+    private void testAddRowsToBeginningMiddle(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(6, 12, 14).toTracking(),
+                intCol("Sentinel", 3, 6, 7),
+                intCol("Value", 14, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2, 4, 8, 10), intCol("Sentinel", 1, 2, 4, 5), intCol("Value", 10, 12, 16, 18));
+            table.notifyListeners(i(2, 4, 8, 10), i(), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddRowsToBeginningMiddleAndEnd() {
+        for (int shift = 1; shift < 3; shift++) {
+            testAddRowsToBeginningMiddleAndEnd(shift);
+        }
+    }
+
+    private void testAddRowsToBeginningMiddleAndEnd(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(6, 12, 14).toTracking(),
+                intCol("Sentinel", 3, 6, 7),
+                intCol("Value", 14, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(2, 4, 8, 10, 16, 18), intCol("Sentinel", 1, 2, 4, 5, 8, 9),
+                    intCol("Value", 10, 12, 16, 18, 24, 26));
+            table.notifyListeners(i(2, 4, 8, 10, 16, 18), i(), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testModificationNoShift() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 10, 12, 14, 16, 18));
+        final Table shiftMinusOne = ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value");
+        final Table shiftPlusOne = ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value");
+
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "pre-update", 1);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusOne = new PrintListener("Minus One", shiftMinusOne);
+        final PrintListener plPlusOne = new PrintListener("Plus One", shiftPlusOne);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(6), intCol("Sentinel", 6), intCol("Value", 20));
+            table.notifyListeners(i(), i(), i(6));
+        });
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "post-update", 1);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+
+        plTable.stop();
+        plMinusOne.stop();
+        plPlusOne.stop();
+    }
+
+    @Test
+    public void testShiftOnly() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5),
+                intCol("Value", 10, 12, 14, 16, 18));
+
+        final Table shiftMinusOne = ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value");
+        final Table shiftPlusOne = ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value");
+
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "pre-update", 1);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusOne = new PrintListener("Minus One", shiftMinusOne);
+        final PrintListener plPlusOne = new PrintListener("Plus One", shiftPlusOne);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(6));
+            addToTable(table, i(7), intCol("Sentinel", 3), intCol("Value", 14));
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            shiftDataBuilder.shiftRange(6, 6, 1);
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update =
+                    new TableUpdateImpl(i(), i(), i(), shiftData, ModifiedColumnSet.EMPTY);
+            table.notifyListeners(update);
+        });
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "post-update", 1);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+
+        plTable.stop();
+        plMinusOne.stop();
+        plPlusOne.stop();
+    }
+
+    @Test
+    public void testShiftAndModify() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6),
+                intCol("Value", 10, 12, 14, 16, 18, 20));
+
+        final Table shiftMinusOne = ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value");
+        final Table shiftPlusOne = ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value");
+
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "pre-update", 1);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusOne = new PrintListener("Minus One", shiftMinusOne);
+        final PrintListener plPlusOne = new PrintListener("Plus One", shiftPlusOne);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(6, 10));
+            addToTable(table, i(7), intCol("Sentinel", 3), intCol("Value", 16));
+            addToTable(table, i(9), intCol("Sentinel", 5), intCol("Value", 19));
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            shiftDataBuilder.shiftRange(6, 6, 1);
+            shiftDataBuilder.shiftRange(10, 10, -1);
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update =
+                    new TableUpdateImpl(i(), i(), i(7, 9), shiftData, table.newModifiedColumnSet("Value"));
+            table.notifyListeners(update);
+        });
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "post-update", 1);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+
+        plTable.stop();
+        plMinusOne.stop();
+        plPlusOne.stop();
+    }
+
+    @Test
+    public void testAddAndShift() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(0, 4, 8).toTracking(),
+                intCol("Sentinel", 1, 5, 9),
+                intCol("Value", 10, 14, 18));
+
+        final Table shiftMinusOne = ShiftedColumnOperation.addShiftedColumns(table, -1, "V3=Value");
+        final Table shiftPlusOne = ShiftedColumnOperation.addShiftedColumns(table, 1, "V2=Value");
+
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "pre-update", 1);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusOne", (QueryTable) shiftMinusOne);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst = TableUpdateValidator.make("shiftPlusOne", (QueryTable) shiftPlusOne);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusOne = new PrintListener("Minus One", shiftMinusOne);
+        final PrintListener plPlusOne = new PrintListener("Plus One", shiftPlusOne);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(4));
+            addToTable(table, i(3), intCol("Sentinel", 3), intCol("Value", 11));
+            addToTable(table, i(5), intCol("Sentinel", 5), intCol("Value", 14));
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            shiftDataBuilder.shiftRange(4, 4, 1);
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update =
+                    new TableUpdateImpl(i(3), i(), i(), shiftData, ModifiedColumnSet.EMPTY);
+            table.notifyListeners(update);
+        });
+
+        printTableUpdates(table, shiftMinusOne, shiftPlusOne, "post-update", 1);
+
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V3 = Value_[i - 1]")),
+                shiftMinusOne);
+        assertTableEquals(
+                UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("V2 = Value_[i + 1]")),
+                shiftPlusOne);
+
+        plTable.stop();
+        plMinusOne.stop();
+        plPlusOne.stop();
+    }
+
+    @Test
+    public void testAddAndUpdateWithShift() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddAndUpdateWithShift(shift);
+        }
+    }
+
+    private void testAddAndUpdateWithShift(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(3, 6, 9, 12, 15, 18, 21, 24).toTracking(),
+                intCol("Sentinel", 1, 3, 5, 7, 9, 11, 13, 15),
+                intCol("Value", 10, 14, 18, 22, 26, 30, 34, 38));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(9, 18));
+            addToTable(table, i(8), intCol("Sentinel", 4), intCol("Value", 17));
+            addToTable(table, i(10), intCol("Sentinel", 5), intCol("Value", 18));
+            addToTable(table, i(17), intCol("Sentinel", 11), intCol("Value", 30));
+            addToTable(table, i(20), intCol("Sentinel", 12), intCol("Value", 32));
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            shiftDataBuilder.shiftRange(9, 9, 1);
+            shiftDataBuilder.shiftRange(18, 18, -1);
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update =
+                    new TableUpdateImpl(i(8, 20), i(), i(), shiftData, ModifiedColumnSet.ALL);
+            table.notifyListeners(update);
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testAddAndUpdateWithOutShift() {
+        for (int shift = 1; shift < 5; shift++) {
+            testAddAndUpdateWithOutShift(shift);
+        }
+    }
+
+    private void testAddAndUpdateWithOutShift(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(3, 6, 9, 12, 15, 18, 21, 24).toTracking(),
+                intCol("Sentinel", 1, 3, 5, 7, 9, 11, 13, 15),
+                intCol("Value", 10, 14, 18, 22, 26, 30, 34, 38));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(8), intCol("Sentinel", 4), intCol("Value", 17));
+            addToTable(table, i(9), intCol("Sentinel", 6), intCol("Value", 19));
+            addToTable(table, i(18), intCol("Sentinel", 10), intCol("Value", 29));
+            addToTable(table, i(20), intCol("Sentinel", 12), intCol("Value", 32));
+            table.notifyListeners(i(8, 20), i(), i(9, 18));
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveSingleMiddleRow() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveSingleMiddleRow(shift);
+        }
+    }
+
+    private void testRemoveSingleMiddleRow(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(6));
+            table.notifyListeners(i(), i(6), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveFirstRow() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveFirstRow(shift);
+        }
+    }
+
+    private void testRemoveFirstRow(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(2));
+            table.notifyListeners(i(), i(2), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveFirstTwoRows() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveFirstTwoRows(shift);
+        }
+    }
+
+    private void testRemoveFirstTwoRows(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(2, 4));
+            table.notifyListeners(i(), i(2, 4), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveLastRow() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveLastRow(shift);
+        }
+    }
+
+    private void testRemoveLastRow(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(14));
+            table.notifyListeners(i(), i(14), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveLastTwoRows() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveLastTwoRows(shift);
+        }
+    }
+
+    private void testRemoveLastTwoRows(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(12, 14));
+            table.notifyListeners(i(), i(12, 14), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveRandomNonFirstAndLastRows() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveRandomNonFirstAndLastRows(shift);
+        }
+    }
+
+    private void testRemoveRandomNonFirstAndLastRows(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(4, 8, 12));
+            table.notifyListeners(i(), i(4, 8, 12), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveFirstLastAndRandomRows() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveFirstLastAndRandomRows(shift);
+        }
+    }
+
+    private void testRemoveFirstLastAndRandomRows(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(2, 4, 8, 12, 14));
+            table.notifyListeners(i(), i(2, 4, 8, 12, 14), i());
+        });
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveFirstLastAndRandomRowsWithMoreData() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveFirstLastAndRandomRowsWithMoreData(shift);
+        }
+    }
+
+    private void testRemoveFirstLastAndRandomRowsWithMoreData(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14, 16, 18).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7, 8, 9),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22, 24, 26));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(2, 4, 8, 12, 14));
+            table.notifyListeners(i(), i(2, 4, 8, 12, 14), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void testRemoveAllRows() {
+        for (int shift = 1; shift < 5; shift++) {
+            testRemoveAllRows(shift);
+        }
+    }
+
+    private void testRemoveAllRows(final int shiftConst) {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8, 10, 12, 14).toTracking(),
+                intCol("Sentinel", 1, 2, 3, 4, 5, 6, 7),
+                intCol("Value", 10, 12, 14, 16, 18, 20, 22));
+
+        final Table shiftMinusConst = ShiftedColumnOperation.addShiftedColumns(table, (-1 * shiftConst), "CV3=Value");
+        final Table shiftPlusConst = ShiftedColumnOperation.addShiftedColumns(table, shiftConst, "CV2=Value");
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "pre-update", shiftConst);
+
+        final TableUpdateValidator tuv = TableUpdateValidator.make("table", table);
+        FailureListener tuvFailureListener = new FailureListener();
+        tuv.getResultTable().addUpdateListener(tuvFailureListener);
+
+        final TableUpdateValidator tuvMinusConst =
+                TableUpdateValidator.make("shiftMinusConst", (QueryTable) shiftMinusConst);
+        FailureListener tuvMinusConstFailureListener = new FailureListener();
+        tuvMinusConst.getResultTable().addUpdateListener(tuvMinusConstFailureListener);
+
+        final TableUpdateValidator tuvMPlusConst =
+                TableUpdateValidator.make("shiftPlusConst", (QueryTable) shiftPlusConst);
+        FailureListener tuvPlusConstFailureListener = new FailureListener();
+        tuvMPlusConst.getResultTable().addUpdateListener(tuvPlusConstFailureListener);
+
+        final PrintListener plTable = new PrintListener("Table", table);
+        final PrintListener plMinusConst = new PrintListener("Minus Const", shiftMinusConst);
+        final PrintListener plPlusConst = new PrintListener("Plus Const", shiftPlusConst);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(2, 4, 6, 8, 10, 12, 14));
+            table.notifyListeners(i(), i(2, 4, 6, 8, 10, 12, 14), i());
+        });
+
+        printTableUpdates(table, shiftMinusConst, shiftPlusConst, "post-update", shiftConst);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV3 = Value_[i - " + shiftConst + "]")), shiftMinusConst);
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> table.update("CV2 = Value_[i + " + shiftConst + "]")), shiftPlusConst);
+
+        plTable.stop();
+        plMinusConst.stop();
+        plPlusConst.stop();
+    }
+
+    @Test
+    public void orderedKeysExample() {
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        builder.appendRange(0, 100);
+        builder.appendRange(400, 600);
+        builder.appendRange(10000, 11000);
+        builder.appendKey(20000);
+        builder.appendKey(20001);
+        final RowSet rowSet = builder.build();
+
+        System.out.println("Whole RowSet: " + rowSet);
+
+        try (final RowSequence.Iterator okIt = rowSet.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final RowSequence chunkOk = okIt.getNextRowSequenceWithLength(50);
+                System.out.println("Chunk of 50:" + okString(chunkOk));
+            }
+        }
+
+        try (final RowSequence.Iterator okIt = rowSet.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long nextKey = okIt.peekNextKey();
+                final RowSequence chunkOk = okIt.getNextRowSequenceThrough(nextKey | 0xff);
+                System.out.println("256 Masked Chunk: " + okString(chunkOk));
+            }
+        }
+    }
+
+    @Test
+    public void testBigShift() {
+        final QueryTable table = TstUtils.testRefreshingTable(
+                i(2, 4, 6, 8).toTracking(),
+                intCol("Sentinel", 100, 101, 102, 103),
+                intCol("Value", 201, 202, 203, 204));
+        final Table shifted = UpdateGraphProcessor.DEFAULT.sharedLock()
+                .computeLocked(() -> ShiftedColumnOperation.addShiftedColumns(table, -1, "VS=Value"));
+        TableTools.showWithRowSet(shifted);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("VS=Value_[i-1]")),
+                shifted);
+
+        final PrintListener pl = new PrintListener("Shifted Result", shifted, 10);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            removeRows(table, i(2, 4, 6, 8));
+            addToTable(table, i(1002, 1003, 1004, 1008), intCol("Sentinel", 100, 104, 101, 103),
+                    intCol("Value", 201, 205, 202, 204));
+
+            final TableUpdateImpl update = new TableUpdateImpl();
+            final RowSetShiftData.Builder builder = new RowSetShiftData.Builder();
+            builder.shiftRange(0, 100, +1000);
+            update.shifted = builder.build();
+            update.added = i(1003);
+            update.removed = i(6);
+            update.modified = i(1002);
+            update.modifiedColumnSet = table.newModifiedColumnSet("Value");
+            table.notifyListeners(update);
+        });
+        TableTools.showWithRowSet(shifted);
+
+        assertTableEquals(UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> table.update("VS=Value_[i-1]")),
+                shifted);
+        pl.stop();
+    }
+
+    @Test
+    public void testFillChunk() {
+        final Table dummy = TableTools.emptyTable(10_000_000L).update("X=ii");
+
+        final MutableLong sum = new MutableLong();
+        final ColumnSource<Long> xcs = dummy.getColumnSource("X", long.class);
+        final long start = System.nanoTime();
+        dummy.getRowSet().forAllRowKeys(idx -> sum.add(xcs.getLong(idx)));
+        final long end = System.nanoTime();
+        System.out.println("Sum: " + sum.longValue() + ", duration=" + (end - start));
+
+        final long startCk = System.nanoTime();
+        sum.setValue(0);
+        try (final RowSequence.Iterator okIt = dummy.getRowSet().getRowSequenceIterator();
+                final ChunkSource.GetContext gc = xcs.makeGetContext(2048)) {
+            while (okIt.hasMore()) {
+                final RowSequence chunkOk = okIt.getNextRowSequenceWithLength(2048);
+                final LongChunk<? extends Values> longChunk = xcs.getChunk(gc, chunkOk).asLongChunk();
+                long smallSum = 0;
+                for (int ii = 0; ii < longChunk.size(); ++ii) {
+                    smallSum += longChunk.get(ii);
+                }
+                sum.add(smallSum);
+            }
+        }
+        final long endCk = System.nanoTime();
+        System.out.println("Sum: " + sum.longValue() + ", duration=" + (endCk - startCk));
+
+    }
+
+    @Test
+    public void testSharedContext() {
+        final RowSet rowSet = RowSetFactory.flat(10000);
+
+        final MutableInt invertCount = new MutableInt();
+        final TrackingRowSet proxyRowSet =
+                new TrackingWritableRowSetImpl(((WritableRowSetImpl) rowSet).getInnerSet()) {
+                    @Override
+                    public WritableRowSet invert(RowSet keys) {
+                        invertCount.increment();
+                        return super.invert(keys);
+                    }
+                };
+
+        final Table dummy = new QueryTable(proxyRowSet, Collections.emptyMap()).update("X=ii", "X2=ii*2");
+
+        final Table shifted = ShiftedColumnOperation.addShiftedColumns(dummy, -1, "S=X");
+        final Table shifted2 = ShiftedColumnOperation.addShiftedColumns(shifted, -1, "S2=X2");
+
+        final ColumnSource<Long> scs = shifted2.getColumnSource("S", long.class);
+        final ColumnSource<Long> s2cs = shifted2.getColumnSource("S2", long.class);
+
+        final int chunkSize = 2048;
+        try (final RowSequence.Iterator okIt = shifted2.getRowSet().getRowSequenceIterator();
+                final SharedContext sharedContext = SharedContext.makeSharedContext();
+                final ChunkSource.GetContext gc = scs.makeGetContext(chunkSize, sharedContext);
+                final ChunkSource.GetContext gc2 = s2cs.makeGetContext(chunkSize, sharedContext);
+                final WritableLongChunk<RowKeys> expect =
+                        WritableLongChunk.makeWritableChunk(chunkSize)) {
+            while (okIt.hasMore()) {
+                sharedContext.reset();
+                final RowSequence chunkOk = okIt.getNextRowSequenceWithLength(chunkSize);
+                final long invertStart = invertCount.longValue();
+                final LongChunk<? extends Values> ck1 = scs.getChunk(gc, chunkOk).asLongChunk();
+                final LongChunk<? extends Values> ck2 = s2cs.getChunk(gc2, chunkOk).asLongChunk();
+                final long invertEnd = invertCount.longValue();
+                Assert.assertEquals(1, invertEnd - invertStart);
+                chunkOk.fillRowKeyChunk(expect);
+                for (int ii = 0; ii < expect.size(); ++ii) {
+                    final long vv = expect.get(ii);
+                    if (vv == 0) {
+                        expect.set(ii, QueryConstants.NULL_LONG);
+                    } else {
+                        expect.set(ii, vv - 1);
+                    }
+                }
+                Assert.assertTrue(LongChunkEquals.equalReduce(expect, ck1));
+                chunkOk.fillRowKeyChunk(expect);
+                for (int ii = 0; ii < expect.size(); ++ii) {
+                    final long vv = expect.get(ii);
+                    if (vv == 0) {
+                        expect.set(ii, QueryConstants.NULL_LONG);
+                    } else {
+                        expect.set(ii, (vv - 1) * 2);
+                    }
+                }
+                Assert.assertTrue(LongChunkEquals.equalReduce(expect, ck2));
+            }
+        }
+    }
+
+    @Test
+    public void testRandomizedUpdates() {
+        for (int size = 10; size <= 1000; size *= 10) {
+            for (int seed = 0; seed < 1; ++seed) {
+                System.out.println("Size = " + size + ", seed=" + seed);
+                testRandomizedUpdates(seed, size, 4, 50);
+            }
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void testRandomizedUpdates(final int seed, final int tableSize, final int maxShiftConst,
+            final int simulationSize) {
+
+        final Random random = new Random(seed);
+        final ColumnInfo<?, ?>[] columnInfo;
+        final QueryTable queryTable = getTable(tableSize, random,
+                columnInfo = initColumnInfos(new String[] {"Sym", "intCol", "doubleCol"},
+                        new SetGenerator<>("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+                        new IntGenerator(10, 100),
+                        new SetGenerator<>(10.1, 20.1, 30.1, 40.1, 50.1, 60.1, 70.1, 80.1, 90.1)));
+
+        if (RefreshingTableTestCase.printTableUpdates) {
+            System.out.println("Original Table");
+            TableTools.showWithRowSet(queryTable);
+        }
+
+        final EvalNugget[] en = new EvalNugget[maxShiftConst * 2];
+        String[] matchColumns = new String[] {"Sym2=Sym", "intCol2=intCol", "doubleCol2=doubleCol"};
+
+        for (int i = 0; i < maxShiftConst; i++) {
+            long shift = i + 1;
+            en[i * 2] =
+                    EvalNugget.from(() -> ShiftedColumnOperation.addShiftedColumns(queryTable, -shift, matchColumns));
+            en[i * 2 + 1] =
+                    EvalNugget.from(() -> ShiftedColumnOperation.addShiftedColumns(queryTable, shift, matchColumns));
+        }
+
+        for (int step = 0; step < simulationSize; step++) {
+            simulateShiftAwareStep(tableSize, random, queryTable, columnInfo, en);
+        }
+    }
+
+    @NotNull
+    private String okString(RowSequence chunkOk) {
+        final StringBuilder strBuilder = new StringBuilder();
+        final MutableBoolean first = new MutableBoolean(true);
+        chunkOk.forAllRowKeyRanges((s, e) -> {
+            if (!first.getValue()) {
+                strBuilder.append(", ");
+            } else {
+                first.setFalse();
+            }
+            if (s == e) {
+                strBuilder.append(s);
+            } else {
+                strBuilder.append(s).append("-").append(e);
+            }
+        });
+
+        return strBuilder.toString();
+    }
+
+    private void printTableUpdates(@NotNull Table table, @NotNull Table shiftMinusConst, @NotNull Table shiftPlusConst,
+            String location, final int shiftConst) {
+        if (RefreshingTableTestCase.printTableUpdates) {
+            System.out.printf("----------------------------%s  ShiftConst +/- %d----------------------------%n",
+                    location, shiftConst);
+            System.out.println("---table---");
+            TableTools.showWithRowSet(table);
+            System.out.println("---shiftMinusConst---");
+            TableTools.showWithRowSet(shiftMinusConst);
+            System.out.println("---shiftPlusConst---");
+            TableTools.showWithRowSet(shiftPlusConst);
+        }
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
@@ -1,0 +1,1373 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.ConditionalExpr;
+import com.github.javaparser.ast.expr.Expression;
+import io.deephaven.base.Pair;
+import io.deephaven.engine.context.QueryScope;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetShiftData;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.MatchPair;
+import io.deephaven.engine.table.ModifiedColumnSet;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.lang.JavaExpressionParser;
+import io.deephaven.engine.table.impl.sources.ShiftedColumnSource;
+import io.deephaven.engine.table.impl.sources.SingleValueColumnSource;
+import io.deephaven.engine.table.impl.sources.ViewColumnSource;
+import io.deephaven.engine.testutil.ColumnInfo;
+import io.deephaven.engine.testutil.EvalNugget;
+import io.deephaven.engine.testutil.TstUtils;
+import io.deephaven.engine.testutil.generator.IntGenerator;
+import io.deephaven.engine.testutil.generator.SetGenerator;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
+import io.deephaven.engine.updategraph.UpdateGraphProcessor;
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.test.types.OutOfBandTest;
+import io.deephaven.time.DateTimeUtils;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.deephaven.engine.table.impl.MemoizedOperationKey.SelectUpdateViewOrUpdateView.*;
+import static io.deephaven.engine.testutil.TstUtils.*;
+import static io.deephaven.engine.testutil.testcase.RefreshingTableTestCase.simulateShiftAwareStep;
+import static io.deephaven.engine.util.TableTools.*;
+
+@Category(OutOfBandTest.class)
+public class TestFormulaArrayEvaluation {
+    @Rule
+    public EngineCleanup cleanup = new EngineCleanup();
+
+    @Test
+    public void testViewIncrementalSimpleTest() {
+
+        final QueryTable queryTable = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30),
+                intCol("Value2", 202, 222, 242, 262, 282, 302),
+                intCol("Value3", 2020, 2220, 2420, 2620, 2820, 3020));
+
+
+        final EvalNugget[] en = new EvalNugget[] {
+                EvalNugget.from(() -> queryTable.view("newCol=Value / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=Value / 2", "newCol2=newCol_[i+1] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=Value / 2", "newCol2=newCol_[i-2] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=Value / 2", "newCol2=newCol_[i+2] * 4")),
+        };
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(queryTable,
+                    i(10, 12, 18),
+                    intCol("Sentinel", 56, 57, 510),
+                    intCol("Value", 420, 422, 428),
+                    intCol("Value2", 302, 322, 382),
+                    intCol("Value3", 4020, 4220, 4820));
+
+            final RowSetShiftData.Builder shiftDataBuilder = new RowSetShiftData.Builder();
+            final RowSetShiftData shiftData = shiftDataBuilder.build();
+            final TableUpdateImpl update = new TableUpdateImpl(i(), i(), i(10, 12, 18), shiftData,
+                    queryTable.newModifiedColumnSet("Sentinel", "Value", "Value2", "Value3"));
+            System.out.println("published update in Test: " + update);
+            queryTable.notifyListeners(update);
+        });
+        TstUtils.validate("", en);
+    }
+
+    @Test
+    public void testViewIncrementalRandomizedTest() {
+        final Random random = new Random(0);
+        final ColumnInfo<?, ?>[] columnInfo;
+        final int size = 50;
+        final QueryTable queryTable = getTable(size, random,
+                columnInfo = initColumnInfos(new String[] {"Sym", "intCol", "doubleCol"},
+                        new SetGenerator<>("a", "b", "c", "d", "e"),
+                        new IntGenerator(10, 100),
+                        new SetGenerator<>(10.1, 20.1, 30.1)));
+
+        final Table sortedTable = queryTable.sort("intCol");
+
+        final EvalNugget[] en = new EvalNugget[] {
+                EvalNugget.from(() -> queryTable.updateView("intCol=intCol * 2")),
+                EvalNugget.from(() -> queryTable.updateView("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                EvalNugget.from(() -> queryTable.view("intCol=intCol * 2")),
+                EvalNugget.from(() -> queryTable.view("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("intCol=intCol * 2")),
+                EvalNugget.from(() -> sortedTable.updateView("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                EvalNugget.from(() -> sortedTable.view("intCol=intCol * 2")),
+                EvalNugget.from(() -> sortedTable.view("intCol=intCol + doubleCol")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2").updateView("newCol2=newCol * 4")),
+                // i-1
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> queryTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> sortedTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> queryTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol_[i-1]")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * 4")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-1] * newCol")),
+                EvalNugget.from(() -> sortedTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-1] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2",
+                        "newCol=newCol_[i-1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol=newCol_[i-1] + 7")),
+                // i+1
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+1] * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+1] * newCol")),
+                EvalNugget.from(() -> queryTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+1] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i+1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol_[i+1]")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+1] * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+1] * newCol")),
+                EvalNugget.from(() -> sortedTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+1] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i+1] + 7")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol_[i+1]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol_[i+1]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i+1] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i+1] * newCol")),
+                EvalNugget.from(() -> queryTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+1] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.view("newCol2=intCol / 2", "newCol=newCol2_[i+1] + 7")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol_[i+1]")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i+1] * 4")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i+1] * newCol")),
+                EvalNugget.from(() -> sortedTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+1] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.view("newCol2=intCol / 2", "newCol=newCol2_[i+1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2",
+                        "newCol=newCol_[i+1] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol=newCol_[i+1] + 7")),
+                // i-2
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-2] * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-2] * newCol")),
+                EvalNugget.from(() -> queryTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-2] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-2] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol_[i-2]")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-2] * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-2] * newCol")),
+                EvalNugget.from(() -> sortedTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-2] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i-2] + 7")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol_[i-2]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol_[i-2]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-2] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i-2] * newCol")),
+                EvalNugget.from(() -> queryTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-2] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-2] + 7")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol_[i-2]")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-2] * 4")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i-2] * newCol")),
+                EvalNugget.from(() -> sortedTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i-2] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.view("newCol2=intCol / 2", "newCol=newCol2_[i-2] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2",
+                        "newCol=newCol_[i-2] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol=newCol_[i-2] + 7")),
+                // i+2
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+2] * 4")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+2] * newCol")),
+                EvalNugget.from(() -> queryTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+2] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i+2] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol_[i+2]")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+2] * 4")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+2] * newCol")),
+                EvalNugget.from(() -> sortedTable.updateView("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+2] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol2=intCol / 2", "newCol=newCol2_[i+2] + 7")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol_[i+2]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol_[i+2]")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i+2] * 4")),
+                EvalNugget.from(() -> queryTable.view("newCol=intCol / 2", "newCol2=newCol_[i+2] * newCol")),
+                EvalNugget.from(() -> queryTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+2] * repeatedCol")),
+                EvalNugget.from(() -> queryTable.view("newCol2=intCol / 2", "newCol=newCol2_[i+2] + 7")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol_[i+2]")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i+2] * 4")),
+                EvalNugget.from(() -> sortedTable.view("newCol=intCol / 2", "newCol2=newCol_[i+2] * newCol")),
+                EvalNugget.from(() -> sortedTable.view("repeatedCol=doubleCol - 0.5", "newCol=intCol / 2",
+                        "repeatedCol=newCol_[i+2] * repeatedCol")),
+                EvalNugget.from(() -> sortedTable.view("newCol2=intCol / 2", "newCol=newCol2_[i+2] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol2=intCol / 2", "newCol=newCol2",
+                        "newCol=newCol_[i+2] + 7")),
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol=newCol_[i+2] + 7")),
+        };
+
+        for (int i = 0; i < 10; i++) {
+            simulateShiftAwareStep(size, random, queryTable, columnInfo, en);
+        }
+    }
+
+    @Test
+    public void testViewIncrementalRandomizedPerformanceTest() {
+        final Random random = new Random(0);
+        final ColumnInfo<?, ?>[] columnInfo;
+        final int size = 50000;
+        final QueryTable queryTable = getTable(size, random,
+                columnInfo = initColumnInfos(new String[] {"Sym", "intCol", "doubleCol"},
+                        new SetGenerator<>("a", "b", "c", "d", "e"),
+                        new IntGenerator(10, 100),
+                        new SetGenerator<>(10.1, 20.1, 30.1)));
+
+        final Table sortedTable = queryTable.sort("intCol");
+
+        final EvalNugget[] en = new EvalNugget[] {
+                // i-500
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-500] * newCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i-500] * newCol")),
+                // i+500
+                EvalNugget.from(() -> queryTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+500] * newCol")),
+                EvalNugget.from(() -> sortedTable.updateView("newCol=intCol / 2", "newCol2=newCol_[i+500] * newCol")),
+        };
+
+        // original implementation of ShiftedColumnOperation took ~30s; current impl takes ~8s
+        final long startTm = System.currentTimeMillis();
+        for (int i = 0; i < 5; i++) {
+            simulateShiftAwareStep(size, random, queryTable, columnInfo, en);
+        }
+        final long duration = System.currentTimeMillis() - startTm;
+        Assert.assertTrue("test finishes in less than 15 seconds", duration < 15_000);
+    }
+
+    @Test
+    public void updateTableStableMultiShiftedColValuesTest() {
+        stableMultiShiftedColValuesTest(Flavor.Update, 7, 20);
+    }
+
+    @Test
+    public void selectTableStableMultiShiftedColValuesTest() {
+        stableMultiShiftedColValuesTest(Flavor.Select, 7, 20);
+    }
+
+    @Test
+    public void viewTableStableMultiShiftedColValuesTest() {
+        stableMultiShiftedColValuesTest(Flavor.View, 7, 20);
+    }
+
+    @Test
+    public void updateViewTableStableMultiShiftedColValuesTest() {
+        stableMultiShiftedColValuesTest(Flavor.UpdateView, 7, 20);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void stableMultiShiftedColValuesTest(Flavor flavor, final int tableSize, final int displayTableSize) {
+        String[] formulas = new String[] {
+                "A=k * 10",
+                "B=i * 2",
+                "Z=A_[i-1]",
+                "D=A_[i + 1] * B_[ii -2]",
+                "C=true"
+        };
+
+        Table source = emptyTable(tableSize);
+        Table shiftedTable = emptyTable(tableSize);
+
+        switch (flavor) {
+            case Update: {
+                source = source.update(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.update("A=k * 10", "B=i * 2"), -1, "Z=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, 1, "DS1=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, -2, "DS2=B")
+                        .view("A", "B", "Z", "D=DS1 * DS2", "C=true");
+                break;
+            }
+            case UpdateView: {
+                source = source.updateView(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.updateView("A=k * 10", "B=i * 2"), -1, "Z=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, 1, "DS1=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, -2, "DS2=B")
+                        .view("A", "B", "Z", "D=DS1 * DS2", "C=true");
+                break;
+            }
+            case Select: {
+                source = source.select(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.updateView("A=k * 10", "B=i * 2"), -1, "Z=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, 1, "DS1=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, -2, "DS2=B")
+                        .view("A", "B", "Z", "D=DS1 * DS2", "C=true");
+                break;
+            }
+            case View: {
+                source = source.view(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.view("A=k * 10", "B=i * 2"), -1, "Z=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, 1, "DS1=A");
+                shiftedTable = ShiftedColumnOperation.addShiftedColumns(shiftedTable, -2, "DS2=B")
+                        .view("A", "B", "Z", "D=DS1 * DS2", "C=true");
+                break;
+            }
+        }
+
+        showTableWithRowSet(source, Math.min(tableSize, displayTableSize));
+        showTableWithRowSet(shiftedTable, Math.min(tableSize, displayTableSize));
+
+        String[] columns = source.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("length of columns = " + formulas.length, formulas.length, columns.length);
+
+        String[] shiftedColumns = shiftedTable.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("length of columns = " + formulas.length, formulas.length, shiftedColumns.length);
+
+        for (int i = 0; i < formulas.length; i++) {
+            ColumnSource<?> cs = source.getColumnSource(columns[i]);
+            ColumnSource<?> scs = shiftedTable.getColumnSource(shiftedColumns[i]);
+            Assert.assertEquals("ColumnSources' names are equal", columns[i], shiftedColumns[i]);
+
+            if (columns[i].equals("Z")) {
+                Assert.assertTrue("ColumnSource is a ShiftedColumnSource ", cs instanceof ShiftedColumnSource);
+                Assert.assertTrue("ColumnSource is a ShiftedColumnSource ", scs instanceof ShiftedColumnSource);
+            } else {
+                Assert.assertFalse("ColumnSource is NOT a ShiftedColumnSource ", cs instanceof ShiftedColumnSource);
+                Assert.assertFalse("ColumnSource is NOT a ShiftedColumnSource ", scs instanceof ShiftedColumnSource);
+            }
+        }
+
+        AtomicLong atomicLong = new AtomicLong(0);
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        final RowSet index = source.getRowSet();
+        final int aMultiplier = 10;
+        final int bMultiplier = 2;
+        Long prevAValue = null;
+        for (final RowSet.Iterator indexIterator = index.iterator(); indexIterator.hasNext();) {
+            final long key = indexIterator.nextLong();
+            final int currIntValue = atomicInteger.getAndIncrement();
+            final long currLongValue = atomicLong.getAndIncrement();
+            final long expectedColAValue = currLongValue * aMultiplier;
+            final int expectedColBValue = currIntValue * bMultiplier;
+            final Long arrayAccessValue = prevAValue;
+            prevAValue = expectedColAValue;
+            final Long expectedColDS1Value = key >= tableSize - 1 ? null : (currLongValue + 1) * aMultiplier;
+            final Integer expectedColDS2Value = key < 2 ? null : (currIntValue - 2) * bMultiplier;
+            final Long expectedColDValue = (expectedColDS1Value == null || expectedColDS2Value == null) ? null
+                    : expectedColDS1Value * expectedColDS2Value.longValue();
+
+            Assert.assertEquals("A=k * 10 verification", expectedColAValue,
+                    source.getColumnSource(columns[0]).get(key));
+            Assert.assertEquals("B=i * 2 verification", expectedColBValue, source.getColumnSource(columns[1]).get(key));
+            Assert.assertEquals("Z=A_[i-1] verification", arrayAccessValue,
+                    source.getColumnSource(columns[2]).get(key));
+            Assert.assertEquals("D=A_[i + 1] * B_[ii -2] verification", expectedColDValue,
+                    source.getColumnSource(columns[3]).get(key));
+            Assert.assertEquals("C=true verification", true, source.getColumnSource(columns[4]).get(key));
+
+            Assert.assertEquals("A=k * 10 verification", expectedColAValue,
+                    shiftedTable.getColumnSource(columns[0]).get(key));
+            Assert.assertEquals("B=i * 2 verification", expectedColBValue,
+                    shiftedTable.getColumnSource(columns[1]).get(key));
+            Assert.assertEquals("Z=A_[i-1] verification", arrayAccessValue,
+                    shiftedTable.getColumnSource(columns[2]).get(key));
+            Assert.assertEquals("D=A_[i + 1] * B_[ii -2] verification", expectedColDValue,
+                    shiftedTable.getColumnSource(columns[3]).get(key));
+            Assert.assertEquals("C=true verification", true, shiftedTable.getColumnSource(columns[4]).get(key));
+        }
+    }
+
+    @Test
+    public void updateTableStableColValuesTest() {
+        stableColValuesTest(Flavor.Update, 7, 20);
+    }
+
+    @Test
+    public void selectTableStableColValuesTest() {
+        stableColValuesTest(Flavor.Select, 7, 20);
+    }
+
+    @Test
+    public void viewTableStableColValuesTest() {
+        stableColValuesTest(Flavor.View, 7, 20);
+    }
+
+    @Test
+    public void updateViewTableStableColValuesTest() {
+        stableColValuesTest(Flavor.UpdateView, 7, 20);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void stableColValuesTest(Flavor flavor, final int tableSize, final int displayTableSize) {
+        String[] formulas = new String[] {
+                "A=k * 10",
+                "B=i * 2",
+                "Z=A_[i-1]",
+                "D=i",
+                "C=true"
+        };
+
+        Table source = emptyTable(tableSize);
+        Table shiftedTable = emptyTable(tableSize);
+
+        switch (flavor) {
+            case Update: {
+                source = source.update(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.update("A=k * 10", "B=i * 2"), -1, "Z=A")
+                        .update("D=i", "C=true");
+                break;
+            }
+            case UpdateView: {
+                source = source.updateView(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.updateView("A=k * 10", "B=i * 2"), -1, "Z=A")
+                        .updateView("D=i", "C=true");
+                break;
+            }
+            case Select: {
+                source = source.select(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.select("A=k * 10", "B=i * 2"), -1, "Z=A")
+                        .view("A", "B", "Z", "D=i", "C=true");
+                break;
+            }
+            case View: {
+                source = source.view(formulas);
+                shiftedTable = ShiftedColumnOperation
+                        .addShiftedColumns(shiftedTable.view("A=k * 10", "B=i * 2"), -1, "Z=A")
+                        .view("A", "B", "Z", "D=i", "C=true");
+                break;
+            }
+        }
+
+        showTableWithRowSet(source, Math.min(tableSize, displayTableSize));
+        showTableWithRowSet(shiftedTable, Math.min(tableSize, displayTableSize));
+
+        String[] columns = source.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("length of columns = " + formulas.length, formulas.length, columns.length);
+
+        String[] shiftedColumns = shiftedTable.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("length of columns = " + formulas.length, formulas.length, shiftedColumns.length);
+
+        for (int i = 0; i < formulas.length; i++) {
+            ColumnSource<?> cs = source.getColumnSource(columns[i]);
+            ColumnSource<?> scs = shiftedTable.getColumnSource(shiftedColumns[i]);
+            Assert.assertEquals("ColumnSources' names are equal", columns[i], shiftedColumns[i]);
+
+            if (columns[i].equals("Z")) {
+                Assert.assertTrue("ColumnSource is a ShiftedColumnSource ", cs instanceof ShiftedColumnSource);
+                Assert.assertTrue("ColumnSource is a ShiftedColumnSource ", scs instanceof ShiftedColumnSource);
+            } else {
+                Assert.assertFalse("ColumnSource is NOT a ShiftedColumnSource ", cs instanceof ShiftedColumnSource);
+                Assert.assertFalse("ColumnSource is NOT a ShiftedColumnSource ", scs instanceof ShiftedColumnSource);
+            }
+        }
+
+        AtomicLong atomicLong = new AtomicLong(0);
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        final RowSet index = source.getRowSet();
+        final int aMultiplier = 10;
+        final int bMultiplier = 2;
+        Long prevAValue = null;
+        for (final RowSet.Iterator indexIterator = index.iterator(); indexIterator.hasNext();) {
+            final long key = indexIterator.nextLong();
+            final int currIntValue = atomicInteger.getAndIncrement();
+            final long currLongValue = atomicLong.getAndIncrement();
+            final long expectedColAValue = currLongValue * aMultiplier;
+            final int expectedColBValue = currIntValue * bMultiplier;
+            final Long arrayAccessValue = prevAValue;
+            prevAValue = expectedColAValue;
+
+            Assert.assertEquals("A=k * 10 verification", expectedColAValue,
+                    source.getColumnSource(columns[0]).get(key));
+            Assert.assertEquals("B=i * 2 verification", expectedColBValue, source.getColumnSource(columns[1]).get(key));
+            Assert.assertEquals("Z=A_[i-1] verification", arrayAccessValue,
+                    source.getColumnSource(columns[2]).get(key));
+            Assert.assertEquals("D=i verification", currIntValue, source.getColumnSource(columns[3]).get(key));
+            Assert.assertEquals("C=true verification", true, source.getColumnSource(columns[4]).get(key));
+
+            Assert.assertEquals("A=k * 10 verification", expectedColAValue,
+                    shiftedTable.getColumnSource(columns[0]).get(key));
+            Assert.assertEquals("B=i * 2 verification", expectedColBValue,
+                    shiftedTable.getColumnSource(columns[1]).get(key));
+            Assert.assertEquals("Z=A_[i-1] verification", arrayAccessValue,
+                    shiftedTable.getColumnSource(columns[2]).get(key));
+            Assert.assertEquals("D=i verification", currIntValue, shiftedTable.getColumnSource(columns[3]).get(key));
+            Assert.assertEquals("C=true verification", true, shiftedTable.getColumnSource(columns[4]).get(key));
+        }
+    }
+
+    @Test
+    public void updateTableTest() {
+        validateColSourceAndEntriesTest(Flavor.Update, 7, 20);
+    }
+
+    @Test
+    public void selectTableTest() {
+        validateColSourceAndEntriesTest(Flavor.Select, 7, 20);
+    }
+
+    @Test
+    public void viewTableTest() {
+        validateColSourceAndEntriesTest(Flavor.View, 7, 20);
+    }
+
+    @Test
+    public void updateViewTableTest() {
+        validateColSourceAndEntriesTest(Flavor.UpdateView, 7, 20);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void validateColSourceAndEntriesTest(Flavor flavor, final int tableSize, final int displayTableSize) {
+
+        final AtomicInteger atomicValue = new AtomicInteger(1);
+        QueryScope.addParam("atomicValue", atomicValue);
+        String[] formulas = new String[] {
+                "X=10", // constant integer value of 10
+                "Y=atomicValue.getAndIncrement()", // Predictable QueryScope Usage in Formula
+                "Z=Y_[i - 1] * X", // Formula using two prev columns as dependent variable
+                "D=(Z_[i+1]) * (Y_[i-1])", // Formula using two prev columns as dependent variable
+                "E=(Z_[i+1]) = (Y_[i-1])", // Test single equals operator as equality
+                "C=true" // constant bool value
+        };
+
+        Table source = emptyTable(tableSize);
+
+        switch (flavor) {
+            case Update: {
+                source = source.update(formulas);
+                break;
+            }
+            case UpdateView: {
+                source = source.updateView(formulas);
+                break;
+            }
+            case Select: {
+                source = source.select(formulas);
+                break;
+            }
+            case View: {
+                source = source.view(formulas);
+                break;
+            }
+        }
+
+        showTableWithRowSet(source, Math.min(tableSize, displayTableSize));
+
+        String[] columns = source.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("length of columns = " + formulas.length, formulas.length, columns.length);
+
+        for (int i = 0; i < formulas.length; i++) {
+            ColumnSource<?> cs = source.getColumnSource(columns[i]);
+
+            if (columns[i].equals("Z") || columns[i].equals("D") || columns[i].equals("E")
+                    || (columns[i].equals("Y") && (flavor == Flavor.UpdateView || flavor == Flavor.View))) {
+                Assert.assertTrue(columns[i] + " ColumnSource is a ViewColumnSource ", cs instanceof ViewColumnSource);
+            } else if (columns[i].equals("X") || columns[i].equals("C")) {
+                Assert.assertTrue(columns[i] + " ColumnSource is a SingleValueColumnSource ",
+                        cs instanceof SingleValueColumnSource);
+            } else {
+                Assert.assertFalse(columns[i] + " ColumnSource is NOT a ViewColumnSource ",
+                        cs instanceof ViewColumnSource);
+            }
+        }
+
+        if (flavor == Flavor.UpdateView || flavor == Flavor.View) {
+            return;
+        }
+
+        AtomicInteger atomicInteger = new AtomicInteger(1);
+        final RowSet index = source.getRowSet();
+        final int constantXValue = 10;
+        Integer yPrevValue = null;
+        Integer zForwardValue = 10;
+        for (final RowSet.Iterator indexIterator = index.iterator(); indexIterator.hasNext();) {
+            final long key = indexIterator.nextLong();
+            final int expectedAtomicIntColValue = atomicInteger.getAndIncrement();
+            final Integer expectedCalculatedColValue =
+                    expectedAtomicIntColValue == 1 ? null : constantXValue * (expectedAtomicIntColValue - 1);
+            final Integer dCurrValue = yPrevValue == null || zForwardValue == null ? null : zForwardValue * yPrevValue;
+            final Boolean eCurrValue = zForwardValue != null && zForwardValue.equals(yPrevValue);
+            yPrevValue = expectedAtomicIntColValue;
+            zForwardValue = expectedAtomicIntColValue == (tableSize - 1) ? null
+                    : constantXValue * (expectedAtomicIntColValue + 1);
+            Assert.assertEquals("X=10 verification", constantXValue, source.getColumnSource(columns[0]).get(key));
+            Assert.assertEquals("Y=atomicValue.getAndIncrement() verification", expectedAtomicIntColValue,
+                    source.getColumnSource(columns[1]).get(key));
+            Assert.assertEquals("Z=Y_[i - 1] * X verification", expectedCalculatedColValue,
+                    source.getColumnSource(columns[2]).get(key));
+            Assert.assertEquals("D=(Z_[i+1]) * (Y_[i-1]) verification", dCurrValue,
+                    source.getColumnSource(columns[3]).get(key));
+            Assert.assertEquals("E=(Z_[i+1]) == (Y_[i-1]) verification", eCurrValue,
+                    source.getColumnSource(columns[4]).get(key));
+            Assert.assertEquals("C=true verification", true, source.getColumnSource(columns[5]).get(key));
+        }
+
+    }
+
+    @Test
+    public void parseForConstantArrayAccessTest() {
+
+        String shiftedPrefix = ShiftedColumnsFactory.SHIFTED_COL_PREFIX;
+        // singleResultColumnTest
+        String[] expressions = new String[] {"Y_[i-1]", "Y_[ii-1]", "Y_[i - 1]", "Y_[ii - 1]", "Y_[ i - 1 ]",
+                "Y_[ ii - 1 ]"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1");
+
+        expressions = new String[] {"(Y_[i-1]) * B", "(Y_[ii-1]) * B", "(Y_[i - 1]) * B", "(Y_[ii - 1]) * B",
+                "(Y_[ i - 1]) * B", "(Y_[ ii - 1 ]) * B"};
+        singleResultColumnTest(expressions, -1L, "Y", "(" + shiftedPrefix + "1) * B");
+
+        expressions = new String[] {"Y_[i+1]", "Y_[ii+1]", "Y_[i + 1]", "Y_[ii + 1]", "Y_[ i + 1 ]", "Y_[ ii + 1 ]"};
+        singleResultColumnTest(expressions, 1L, "Y", shiftedPrefix + "1");
+
+        expressions = new String[] {"(Y_[i+1]) * B", "(Y_[ii+1]) * B", "(Y_[i + 1]) * B", "(Y_[ii + 1]) * B",
+                "(Y_[ i + 1]) * B", "(Y_[ ii + 1 ]) * B"};
+        singleResultColumnTest(expressions, 1L, "Y", "(" + shiftedPrefix + "1) * B");
+
+        expressions = new String[] {"Y_[i-2]", "Y_[ii-2]", "Y_[i - 2]", "Y_[ii - 2]", "Y_[ i - 2 ]", "Y_[ ii - 2 ]"};
+        singleResultColumnTest(expressions, -2L, "Y", shiftedPrefix + "1");
+
+        expressions = new String[] {"(Y_[i-2]) * B", "(Y_[ii-2]) * B", "(Y_[i - 2]) * B", "(Y_[ii - 2]) * B",
+                "(Y_[ i - 2]) * B", "(Y_[ ii - 2 ]) * B"};
+        singleResultColumnTest(expressions, -2L, "Y", "(" + shiftedPrefix + "1) * B");
+
+        expressions = new String[] {"Y_[i+2]", "Y_[ii+2]", "Y_[i + 2]", "Y_[ii + 2]", "Y_[ i + 2 ]", "Y_[ ii + 2 ]"};
+        singleResultColumnTest(expressions, 2L, "Y", shiftedPrefix + "1");
+
+        expressions = new String[] {"(Y_[i+2]) * B", "(Y_[ii+2]) * B", "(Y_[i + 2]) * B", "(Y_[ii + 2]) * B",
+                "(Y_[ i + 2]) * B", "(Y_[ ii + 2 ]) * B"};
+        singleResultColumnTest(expressions, 2L, "Y", "(" + shiftedPrefix + "1) * B");
+
+        // singleShiftMultiColumnTest
+        String[] sourceColumns = new String[] {"Y", "B"};
+        expressions = new String[] {"(Y_[i-1]) * (B_[i-1])", "(Y_[ii-1]) * (B_[ii-1])", "(Y_[i - 1]) * (B_[i - 1])",
+                "(Y_[ii - 1]) * (B_[ii - 1])", "(Y_[ i - 1]) * (B_[ i - 1 ])", "(Y_[ ii - 1 ]) * (B_[ ii - 1 ])"};
+        singleShiftMultiColumnTest(expressions, -1L, sourceColumns,
+                "(" + shiftedPrefix + "1) * (" + shiftedPrefix + "2)");
+
+        expressions = new String[] {"Y_[i-1] * B_[i-1]", "Y_[ii-1] * B_[ii-1]", "Y_[i - 1] * B_[i - 1]",
+                "Y_[ii - 1] * B_[ii - 1]", "Y_[ i - 1] * B_[ i - 1 ]", "Y_[ ii - 1 ] * B_[ ii - 1 ]"};
+        singleShiftMultiColumnTest(expressions, -1L, sourceColumns, shiftedPrefix + "1 * " + shiftedPrefix + "2");
+
+        expressions = new String[] {"(Y_[i+1]) * (B_[i+1])", "(Y_[ii+1]) * (B_[ii+1])", "(Y_[i + 1]) * (B_[i + 1])",
+                "(Y_[ii + 1]) * (B_[ii + 1])", "(Y_[ i + 1]) * (B_[ i + 1 ])", "(Y_[ ii + 1 ]) * (B_[ ii + 1 ])"};
+        singleShiftMultiColumnTest(expressions, 1L, sourceColumns,
+                "(" + shiftedPrefix + "1) * (" + shiftedPrefix + "2)");
+
+        expressions = new String[] {"Y_[i+1] * B_[i+1]", "Y_[ii+1] * B_[ii+1]", "Y_[i + 1] * B_[i + 1]",
+                "Y_[ii + 1] * B_[ii + 1]", "Y_[ i + 1] * B_[ i + 1 ]", "Y_[ ii + 1 ] * B_[ ii + 1 ]"};
+        singleShiftMultiColumnTest(expressions, 1L, sourceColumns, shiftedPrefix + "1 * " + shiftedPrefix + "2");
+
+        expressions = new String[] {"(Y_[i-2]) * (B_[i-2])", "(Y_[ii-2]) * (B_[ii-2])", "(Y_[i - 2]) * (B_[i - 2])",
+                "(Y_[ii - 2]) * (B_[ii - 2])", "(Y_[ i - 2]) * (B_[ i - 2 ])", "(Y_[ ii - 2 ]) * (B_[ ii - 2 ])"};
+        singleShiftMultiColumnTest(expressions, -2L, sourceColumns,
+                "(" + shiftedPrefix + "1) * (" + shiftedPrefix + "2)");
+
+        expressions = new String[] {"Y_[i-2] * B_[i-2]", "Y_[ii-2] * B_[ii-2]", "Y_[i - 2] * B_[i - 2]",
+                "Y_[ii - 2] * B_[ii - 2]", "Y_[ i - 2] * B_[ i - 2 ]", "Y_[ ii - 2 ] * B_[ ii - 2 ]"};
+        singleShiftMultiColumnTest(expressions, -2L, sourceColumns, shiftedPrefix + "1 * " + shiftedPrefix + "2");
+
+        expressions = new String[] {"(Y_[i+2]) * (B_[i+2])", "(Y_[ii+2]) * (B_[ii+2])", "(Y_[i + 2]) * (B_[i + 2])",
+                "(Y_[ii + 2]) * (B_[ii + 2])", "(Y_[ i + 2]) * (B_[ i + 2 ])", "(Y_[ ii + 2 ]) * (B_[ ii + 2 ])"};
+        singleShiftMultiColumnTest(expressions, 2L, sourceColumns,
+                "(" + shiftedPrefix + "1) * (" + shiftedPrefix + "2)");
+
+        expressions = new String[] {"Y_[i+2] * B_[i+2]", "Y_[ii+2] * B_[ii+2]", "Y_[i + 2] * B_[i + 2]",
+                "Y_[ii + 2] * B_[ii + 2]", "Y_[ i + 2] * B_[ i + 2 ]", "Y_[ ii + 2 ] * B_[ ii + 2 ]"};
+        singleShiftMultiColumnTest(expressions, 2L, sourceColumns, shiftedPrefix + "1 * " + shiftedPrefix + "2");
+
+        // multiShiftSingleColumnTest
+        long[] shift = new long[] {-1L, 1L};
+        expressions = new String[] {"(Y_[i-1]) * (Y_[i+1])", "(Y_[ii-1]) * (Y_[ii+1])", "(Y_[i - 1]) * (Y_[i + 1])",
+                "(Y_[ii - 1]) * (Y_[ii + 1])", "(Y_[ i - 1]) * (Y_[ i + 1 ])", "(Y_[ ii - 1 ]) * (Y_[ ii + 1 ])"};
+        multiShiftSingleColumnTest(expressions, shift, "Y", "(" + shiftedPrefix + "1) * (" + shiftedPrefix + "2)");
+
+        shift = new long[] {2L, -2L};
+        expressions = new String[] {"(Y_[i+2]) * (Y_[i-2])", "(Y_[ii+2]) * (Y_[ii-2])", "(Y_[i + 2]) * (Y_[i - 2])",
+                "(Y_[ii + 2]) * (Y_[ii - 2])", "(Y_[ i + 2]) * (Y_[ i - 2 ])", "(Y_[ ii + 2 ]) * (Y_[ ii - 2 ])"};
+        multiShiftSingleColumnTest(expressions, shift, "Y", "(" + shiftedPrefix + "1) * (" + shiftedPrefix + "2)");
+
+        shift = new long[] {1L, -2L};
+        expressions = new String[] {"Y_[i+1] * Y_[i-2]", "Y_[ii+1] * Y_[ii-2]", "Y_[i + 1] * Y_[i - 2]",
+                "Y_[ii + 1] * Y_[ii - 2]", "Y_[ i + 1] * Y_[ i - 2 ]", "Y_[ ii + 1 ] * Y_[ ii - 2 ]"};
+        multiShiftSingleColumnTest(expressions, shift, "Y", shiftedPrefix + "1 * " + shiftedPrefix + "2");
+
+        // multiShiftMultiColumnTest
+        shift = new long[] {-1L, 1L, -2L, 2L};
+        MatchPair[] expectedColPairs = new MatchPair[] {
+                new MatchPair(shiftedPrefix + "1", "Y"),
+                new MatchPair(shiftedPrefix + "2", "B"),
+                new MatchPair(shiftedPrefix + "3", "Y"),
+                new MatchPair(shiftedPrefix + "4", "B")};
+        expressions = new String[] {"(Y_[i+1] * B_[ i - 2] ) + (Y_[ii - 1] * B_[ii + 2]) + (Y_[i + 1] * B_[i - 2])"};
+        multiShiftMultiColumnTest(expressions, shift, expectedColPairs,
+                "(" + shiftedPrefix + "1 * " + shiftedPrefix + "2) + (" + shiftedPrefix + "3 * " + shiftedPrefix
+                        + "4) + (" + shiftedPrefix + "1 * " + shiftedPrefix + "2)");
+
+        // singleResultColumnTest - different expressions
+        expressions = new String[] {"Y_[i-1] * true"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 * true");
+
+        expressions = new String[] {"Y_[i-1] * 0.5f"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 * 0.5f");
+
+        expressions = new String[] {"Y_[i-1] + \"test\""};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + \"test\"");
+
+        expressions = new String[] {"Y_[i-1] + 10"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + 10");
+
+        expressions = new String[] {"Y_[i-1] + 10L"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + 10L");
+
+        expressions = new String[] {"Y_[i-1] + 'C'"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + 'C'");
+
+        expressions = new String[] {"Y_[i-1] + " + null};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + null");
+
+        expressions = new String[] {"Y_[i-1] + " + Integer.MIN_VALUE};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + " + Integer.MIN_VALUE);
+
+        // tests UnaryExpr
+        expressions = new String[] {"Y_[ii-1] + " + Long.MIN_VALUE};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + " + Long.MIN_VALUE);
+
+        // tests LongLiteralMinValueExpr
+        expressions = new String[] {"Y_[ii-1] + " + Long.MIN_VALUE + "L"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + " + Long.MIN_VALUE + "L");
+
+        // tests MethodReferenceExpr
+        expressions = new String[] {"Y_[ii-1] + random.nextInt(1000000)"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + random.nextInt(1000000)");
+
+        // tests FieldAccessExpression
+        expressions = new String[] {"Y_[ii-1] + expectedColPairs.length"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + expectedColPairs.length");
+
+        // tests CastExpr
+        expressions = new String[] {"Y_[ii-1] + ((long)random.nextInt(1000000))"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + ((long) random.nextInt(1000000))");
+
+        // tests ArrayCreationExpr
+        expressions = new String[] {"Y_[ii-1] + new long[] { 1L, 2L}"};
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + new long[] { 1L, 2L }");
+
+        // tests ObjectCreationExpr
+        expressions = new String[] {"Y_[ii-1] + new Boolean(true)"};
+        // ObjectCreationExpression toString has two spaces between new and expression
+        singleResultColumnTest(expressions, -1L, "Y", shiftedPrefix + "1 + new Boolean(true)");
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void singleResultColumnTest(String[] singleResultColumn, long shift, String sourceCol,
+            String expectedFormula) {
+        try {
+            MatchPair expectedColPair = new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1, sourceCol);
+            for (String expression : singleResultColumn) {
+                Expression expr = JavaExpressionParser.parseExpression(expression);
+                Pair<String, Map<Long, List<MatchPair>>> pair = ShiftedColumnsFactory.getShiftToColPairsMap(expr);
+
+                Assert.assertNotNull(pair);
+                Assert.assertEquals(expectedFormula, pair.getFirst());
+                Map<Long, List<MatchPair>> map = pair.getSecond();
+                Assert.assertNotNull(map);
+                Assert.assertEquals(1, map.size());
+                List<MatchPair> colPairs = map.get(shift);
+                Assert.assertNotNull(colPairs);
+                Assert.assertEquals(1, colPairs.size());
+                Assert.assertEquals(expectedColPair, colPairs.get(0));
+            }
+
+        } catch (Exception exception) {
+            Assert.fail(exception.getMessage());
+            exception.printStackTrace();
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void singleShiftMultiColumnTest(String[] expressions, long shift, String[] sourceCol,
+            String expectedFormula) {
+        try {
+            for (String expression : expressions) {
+                Expression expr = JavaExpressionParser.parseExpression(expression);
+                Pair<String, Map<Long, List<MatchPair>>> pair = ShiftedColumnsFactory.getShiftToColPairsMap(expr);
+                Assert.assertNotNull(pair);
+                Assert.assertEquals(expectedFormula, pair.getFirst());
+                Assert.assertEquals(1, pair.getSecond().size());
+                Assert.assertNotNull(pair.getSecond().get(shift));
+                Assert.assertEquals(sourceCol.length, pair.getSecond().get(shift).size());
+                for (int i = 1; i <= sourceCol.length; i++) {
+                    MatchPair matchPair = pair.getSecond().get(shift).get(i - 1);
+                    Assert.assertEquals("verify shifted column name suffix",
+                            ShiftedColumnsFactory.SHIFTED_COL_PREFIX + i, matchPair.leftColumn);
+                    Assert.assertEquals("verify source column name", sourceCol[i - 1], matchPair.rightColumn);
+                }
+            }
+        } catch (Exception exception) {
+            Assert.fail(exception.getMessage());
+            exception.printStackTrace();
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void multiShiftSingleColumnTest(String[] expressions, long[] shift, String sourceCol,
+            String expectedFormula) {
+        try {
+            for (String expression : expressions) {
+                Expression expr = JavaExpressionParser.parseExpression(expression);
+                Pair<String, Map<Long, List<MatchPair>>> pair = ShiftedColumnsFactory.getShiftToColPairsMap(expr);
+                Assert.assertNotNull(pair);
+                Assert.assertEquals(expectedFormula, pair.getFirst());
+                Assert.assertNotNull(pair.getSecond());
+                Assert.assertEquals(shift.length, pair.getSecond().size());
+                for (int i = 0; i < shift.length; i++) {
+                    Assert.assertNotNull(pair.getSecond().get(shift[i]));
+                    Assert.assertEquals(1, pair.getSecond().get(shift[i]).size());
+                    MatchPair matchPair = pair.getSecond().get(shift[i]).get(0);
+                    Assert.assertEquals("verify shifted column name suffix",
+                            ShiftedColumnsFactory.SHIFTED_COL_PREFIX + (i + 1), matchPair.leftColumn);
+                    Assert.assertEquals("verify source column name", sourceCol, matchPair.rightColumn);
+                }
+            }
+        } catch (Exception exception) {
+            Assert.fail(exception.getMessage());
+            exception.printStackTrace();
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void multiShiftMultiColumnTest(String[] expressions, long[] shift, MatchPair[] expectedColPairs,
+            String expectedFormula) {
+        try {
+            for (String expression : expressions) {
+                Expression expr = JavaExpressionParser.parseExpression(expression);
+                Pair<String, Map<Long, List<MatchPair>>> pair = ShiftedColumnsFactory.getShiftToColPairsMap(expr);
+                Assert.assertNotNull(pair);
+                Assert.assertEquals(expectedFormula, pair.getFirst());
+                Assert.assertEquals(shift.length, pair.getSecond().size());
+                Set<MatchPair> allResultColumns = new HashSet<>();
+                for (long l : shift) {
+                    Assert.assertNotNull(pair.getSecond().get(l));
+                    allResultColumns.addAll(pair.getSecond().get(l));
+                }
+                Assert.assertEquals(expectedColPairs.length, allResultColumns.size());
+                for (MatchPair expectedCol : expectedColPairs) {
+                    Assert.assertTrue(allResultColumns.contains(expectedCol));
+                }
+            }
+        } catch (Exception exception) {
+            Assert.fail(exception.getMessage());
+            exception.printStackTrace();
+        }
+    }
+
+    @Test
+    public void arrayInitializerTest() {
+        String[] expressions = new String[] {
+                "Y_[i-1]", "Y_[i-2]", "Y_[i+1]", "Y_[i+2]",
+                "random.nextInt(1000000)", "((4 + 3) - (7 -95) + (3 * (5 + (g - 8))))",
+                "((4 + 3) - (7 -95) + (3 * (5 + (8 - g))))"
+        };
+
+        String[] resultFormulaArray = new String[] {
+                ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1,
+                ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2,
+                ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 3,
+                ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 4,
+                "random.nextInt(1000000)", "((4 + 3) - (7 - 95) + (3 * (5 + (g - 8))))",
+                "((4 + 3) - (7 - 95) + (3 * (5 + (8 - g))))"
+        };
+
+        long[] expectedShift = new long[] {-1L, -2L, 1L, 2L};
+        MatchPair[] expectedColPairs = new MatchPair[] {
+                new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1, "Y"),
+                new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2, "Y"),
+                new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 3, "Y"),
+                new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 4, "Y"),
+        };
+
+        evaluateArrayInitializer(expressions, resultFormulaArray, expectedShift, expectedColPairs);
+
+        evaluateArrayInitializer(new String[0], new String[0], new long[0], MatchPair.ZERO_LENGTH_MATCH_PAIR_ARRAY);
+    }
+
+    private void evaluateArrayInitializer(
+            final String[] expressions,
+            final String[] resultFormulaArray,
+            final long[] expectedShift,
+            final MatchPair[] expectedColPairs) {
+        String expectedResult = buildArrayInitializerResult(resultFormulaArray);
+        NodeList<Expression> expressionList = new NodeList<>();
+        for (String expression : expressions) {
+            Expression expr = JavaExpressionParser.parseExpression(expression);
+            expressionList.add(expr);
+        }
+        ArrayInitializerExpr arrayInitializerExpr = new ArrayInitializerExpr(expressionList);
+
+        Pair<String, Map<Long, List<MatchPair>>> pair =
+                ShiftedColumnsFactory.getShiftToColPairsMap(arrayInitializerExpr);
+        if (expectedShift.length > 0) {
+            Assert.assertNotNull(pair);
+            Assert.assertEquals("formula comparison", expectedResult, pair.getFirst());
+            Assert.assertEquals("compare number of shifts", expectedShift.length, pair.getSecond().size());
+            for (int i = 0; i < expectedShift.length; i++) {
+                Assert.assertNotNull(pair.getSecond().get(expectedShift[i]));
+                Assert.assertEquals("verify expected col pair size", 1,
+                        pair.getSecond().get(expectedShift[i]).size());
+                Assert.assertEquals("compare expected col pair", expectedColPairs[i],
+                        pair.getSecond().get(expectedShift[i]).get(0));
+            }
+        } else {
+            Assert.assertNull(pair);
+        }
+    }
+
+    private String buildArrayInitializerResult(String[] resultFormulaArray) {
+        if (resultFormulaArray == null || resultFormulaArray.length == 0) {
+            return "{ }";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (String str : resultFormulaArray) {
+            if (builder.length() == 0) {
+                builder.append('{');
+            } else {
+                builder.append(',');
+            }
+            builder.append(' ').append(str);
+        }
+        builder.append(' ').append('}');
+        return builder.toString();
+    }
+
+    @Test
+    public void conditionExprTest() {
+        // noinspection unchecked
+        Triple<String, String, String>[] conditionalTriples = new Triple[] {
+                new ImmutableTriple<>("A == D", "B_[i-1]", "C_[i-2]"),
+                new ImmutableTriple<>("A == D", "B", "C_[i-2]"),
+                new ImmutableTriple<>("A == D", "B * Y", "C_[2-i]")
+        };
+
+        // noinspection unchecked
+        Pair<String, Boolean>[] expectedFormulas = new Pair[] {
+                new Pair<>("A == D ? " + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1 + " : "
+                        + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2, true),
+                new Pair<>("A == D ? B : " + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1, true),
+                new Pair<>("A == D ? B * Y : ", false)
+        };
+
+        Map<Long, List<MatchPair>> shiftToMatchPair = new LinkedHashMap<>();
+        List<MatchPair> matchPairList = new LinkedList<>();
+        matchPairList.add(new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1, "B"));
+        shiftToMatchPair.put(-1L, matchPairList);
+
+        List<MatchPair> matchPairList2 = new LinkedList<>();
+        matchPairList2.add(new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2, "C"));
+        shiftToMatchPair.put(-2L, matchPairList2);
+
+        evaluateConditionExpressions(conditionalTriples[0], expectedFormulas[0], shiftToMatchPair);
+
+        shiftToMatchPair = new LinkedHashMap<>();
+        matchPairList = new LinkedList<>();
+        matchPairList.add(new MatchPair(ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1, "C"));
+        shiftToMatchPair.put(-2L, matchPairList);
+        evaluateConditionExpressions(conditionalTriples[1], expectedFormulas[1], shiftToMatchPair);
+
+        evaluateConditionExpressions(conditionalTriples[2], expectedFormulas[2], null);
+    }
+
+    private void evaluateConditionExpressions(Triple<String, String, String> conditionalTriple,
+            Pair<String, Boolean> expectedFormula, Map<Long, List<MatchPair>> shiftToMatchPair) {
+        Expression condition = JavaExpressionParser.parseExpression(conditionalTriple.getLeft());
+        Expression then = JavaExpressionParser.parseExpression(conditionalTriple.getMiddle());
+        Expression elseExpr = JavaExpressionParser.parseExpression(conditionalTriple.getRight());
+        ConditionalExpr conditionalExpr = new ConditionalExpr(condition, then, elseExpr);
+        Pair<String, Map<Long, List<MatchPair>>> pair = ShiftedColumnsFactory.getShiftToColPairsMap(conditionalExpr);
+        if (expectedFormula.getSecond()) {
+            Assert.assertNotNull(pair);
+            Assert.assertEquals("compare formula", expectedFormula.getFirst(), pair.getFirst());
+            Assert.assertNotNull(pair.getSecond());
+            Assert.assertEquals("compare map sizes", shiftToMatchPair.size(), pair.getSecond().size());
+            for (Map.Entry<Long, List<MatchPair>> entry : shiftToMatchPair.entrySet()) {
+                Assert.assertNotNull(pair.getSecond().get(entry.getKey()));
+                Assert.assertEquals("compare expected shifted cols for same shift", entry.getValue().size(),
+                        pair.getSecond().get(entry.getKey()).size());
+                ListIterator<MatchPair> expectedIt = entry.getValue().listIterator();
+                ListIterator<MatchPair> actualIt = pair.getSecond().get(entry.getKey()).listIterator();
+                while (expectedIt.hasNext() && actualIt.hasNext()) {
+                    MatchPair expectedMp = expectedIt.next();
+                    MatchPair actualMp = actualIt.next();
+                    Assert.assertEquals("compare match pairs left column", expectedMp.leftColumn, actualMp.leftColumn);
+                    Assert.assertEquals("compare match pairs right column", expectedMp.rightColumn,
+                            actualMp.rightColumn);
+                }
+                if (expectedIt.hasNext()) {
+                    Assert.fail("expected match pair list still has elements");
+                }
+                if (actualIt.hasNext()) {
+                    Assert.fail("actual match pair list still has elements");
+                }
+            }
+        } else {
+            Assert.assertNull(pair);
+        }
+    }
+
+    @Test
+    public void validConstantArrayAccessTest() {
+        String[] expressions = new String[] {
+                "Z=Y_[i-1]", "Z=Y_[i-2]", "Z=Y_[i+1]", "Z=Y_[i+2]",
+                "Z=(Y_[i-1]) * B", "Z=(Y_[i-2]) * B", "Z=(Y_[i+1]) * B", "Z=(Y_[i+2]) * B",
+                "Z=(Y_[i-1]) * (B_[i-1])", "Z=(Y_[i-2]) * (B_[i-2])", "Z=(Y_[i+1]) * (B_[i+1])",
+                "Z=(Y_[i+2]) * (B_[i+2])",
+                "Z=(Y_[i-1]) * (B_[i * 1])", "Z=(Y_[i-2]) * (B_[i / 2])", "Z=(Y_[i+1]) * (B_[1 - i])",
+                "Z=(Y_[i+2]) * (B_[i + x])",
+
+                "Z=Y_[ii-1]", "Z=Y_[ii-2]", "Z=Y_[ii+1]", "Z=Y_[ii+2]",
+                "Z=(Y_[ii-1]) * B", "Z=(Y_[ii-2]) * B", "Z=(Y_[ii+1]) * B", "Z=(Y_[ii+2]) * B",
+                "Z=(Y_[ii-1]) * (B_[ii-1])", "Z=(Y_[ii-2]) * (B_[ii-2])", "Z=(Y_[ii+1]) * (B_[ii+1])",
+                "Z=(Y_[ii+2]) * (B_[ii+2])",
+                "Z=(Y_[ii-1]) * (B_[ii * 1])", "Z=(Y_[ii-2]) * (B_[ii / 2])", "Z=(Y_[ii+1]) * (B_[1 - ii])",
+                "Z=(Y_[ii+2]) * (B_[ii + x])",
+                "X.getClass() == Long.class ? Y_[ii-1] : B_[i - 1]"
+        };
+
+        constantArrayAccessTest(expressions, true);
+    }
+
+    @Test
+    public void inValidConstantArrayAccessTest() {
+        String[] expressions = new String[] {
+                "W=k", "M=ii", "N=i", "P=4 + a", "Y=random.nextInt(1000000)",
+                "e=((4 + 3) - (7 -95) + (3 * (5 + (g - 8))))", "f=((4 + 3) - (7 -95) + (3 * (5 + (8 - g))))",
+                "Z=Y_[i-x]", "Z=Y_[i+x]", "Z=Y_[i * 1]", "Z=Y_[i / 2]",
+                "Z=Y_[2+2]", "Z=Y_[2+i]", "Z=Y_[2+ii]", "Z=Y_[2-i]", "Z=Y_[2-ii]",
+                "X.getClass() == String.class"
+        };
+
+        constantArrayAccessTest(expressions, false);
+    }
+
+    @Test
+    public void allAssignExprTest() {
+        String[] assignExprValues = new String[] {
+                "Y_[i-x]", "Y_[i+x]", "Y_[i * 1]", "Y_[i / 2]",
+                "Y_[2+2]", "Y_[2+i]", "Y_[2+ii]", "Y_[2-i]", "Y_[2-ii]"
+        };
+        Random random = new Random(0);
+        List<String> expressions = new LinkedList<>();
+        for (AssignExpr.Operator op : AssignExpr.Operator.values()) {
+            String expression = "Z " + op.asString() + " "
+                    + assignExprValues[random.nextInt(assignExprValues.length - 1)];
+            expressions.add(expression);
+        }
+        constantArrayAccessTest(expressions.toArray(new String[0]), false);
+    }
+
+    private void constantArrayAccessTest(String[] expressions, boolean assertTrue) {
+        for (String expression : expressions) {
+            final Expression expr = JavaExpressionParser.parseExpression(expression);
+            final Pair<String, Map<Long, List<MatchPair>>> pair = ShiftedColumnsFactory.getShiftToColPairsMap(expr);
+            final boolean hasConstantArrayAccess = pair != null;
+
+            if (assertTrue) {
+                Assert.assertTrue("\"" + expression + "\" has Constant ArrayAccess Expression",
+                        hasConstantArrayAccess);
+            } else {
+                Assert.assertFalse("\"" + expression + "\" is not a Constant ArrayAccess Expression",
+                        hasConstantArrayAccess);
+            }
+        }
+    }
+
+    private void showTableWithRowSet(Table table, int tableSize) {
+        if (RefreshingTableTestCase.printTableUpdates) {
+            TableTools.showWithRowSet(table, tableSize);
+        }
+    }
+
+    // tests for Where Clause
+
+    @Test
+    public void dh12273_convertToShiftedFormula() {
+
+        String[][] formulas = new String[][] {
+                {"Y=Y_[i-1] && A=A_[i-1]",
+                        "Y == " + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1 + " && A == "
+                                + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2},
+                {"Y_[i-1]==A_[i-1]",
+                        ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1 + " == "
+                                + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2},
+                {"Y_[1-i]==A_[i-1]", "Y_[1 - i] == " + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1},
+                {"Y=Y_[i-1] && A=A_[ii-1]",
+                        "Y == " + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1 + " && A == "
+                                + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2},
+                {"(Y==Y_[i-1]) && (A==A_[ii-1])",
+                        "(Y == " + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1 + ") && (A == "
+                                + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 2 + ")"},
+                {"(Y==Y_[i-k]) && (A==A_[2-ii])", "(Y == Y_[i - k]) && (A == A_[2 - ii])"},
+                {"(1 <= Y_[i - 1] && Y_[i - 1] > 10)",
+                        "(1 <= " + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1 + " && "
+                                + ShiftedColumnsFactory.SHIFTED_COL_PREFIX + 1 + " > 10)"}
+        };
+
+
+        for (String[] formulaPair : formulas) {
+            try {
+                final DateTimeUtils.Result timeConversionResult = DateTimeUtils.convertExpression(formulaPair[0]);
+                final String convertedFilterFormula = timeConversionResult.getConvertedFormula();
+                final String shiftedFilterFormula = ShiftedColumnsFactory.convertToShiftedFormula(formulaPair[0]);
+
+                Assert.assertEquals("Verifying ShiftConverted Formulas", formulaPair[1], shiftedFilterFormula);
+                Assert.assertNotEquals("Verifying time conversion formula not equal to ShiftConvertedFormula ",
+                        convertedFilterFormula, shiftedFilterFormula);
+            } catch (Exception e) {
+                Assert.fail(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void dh12273_verifyFilterTypesTestCase() {
+        String[] formulas = new String[] {"A=atomicInteger.getAndIncrement()", "B=2", "C=20", "D=true"};
+
+        String[] filters = new String[] {"(1 <= A_[i - 1] && A_[i - 1] <= 10)"};
+        verifyFilterTypes(formulas, filters, 20, 10);
+
+        filters = new String[] {"1 <= A_[i - 1] ", "A_[i - 1] <= 10"};
+        verifyFilterTypes(formulas, filters, 20, 10);
+
+        // TODO add different types of filters currently this is only conditional filter
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void verifyFilterTypes(String[] formulas, String[] filters, int sourceTableSize, int expectedRowCount) {
+        final AtomicInteger atomicInteger = new AtomicInteger(0);
+        QueryScope.addParam("atomicInteger", atomicInteger);
+
+        final Table et = emptyTable(sourceTableSize).update(formulas);
+        final Table arrayAccess = et.where(filters);
+
+        Assert.assertEquals("verify expected filter table size", expectedRowCount, arrayAccess.size());
+    }
+
+    @Test
+    public void dh12273SimpleConstantWhereTestCase() {
+        String[] filters = new String[] {"Y=Y_[i-1] && A=A_[i-1]", "Y_[i-1]==A_[i-1]"};
+        verifySimpleConstantTableWhere(filters, 7);
+
+        filters = new String[] {"Y=Y_[i-1]", "A=A_[i-1]"};
+        verifySimpleConstantTableWhere(filters, 7);
+
+        filters = new String[] {"Y=Y_[i-1]", "A=A_[i-1]", "Y_[i-1]==A_[i-1]"};
+        verifySimpleConstantTableWhere(filters, 7);
+
+        filters = new String[] {"Y=Y_[i-1]", "A=A_[i-1]", "D==(Y_[i-1]==A_[i-1])"};
+        verifySimpleConstantTableWhere(filters, 7);
+
+        filters = new String[] {"Y==Y_[i-1] && A==A_[i-1]", "D==(Y_[i-1]==A_[i-1])"};
+        verifySimpleConstantTableWhere(filters, 7);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void verifySimpleConstantTableWhere(String[] filterExpressions, int tableSize) {
+        String[] colFormulas = new String[] {"Y=10", "A=10", "B=20", "D=true"};
+        final Table source = emptyTable(tableSize).update(colFormulas);
+        final Table arrayAccess = source.where(filterExpressions);
+
+        final String[] columns = arrayAccess.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("source table and arrayAccess table columns are equal / same", colFormulas.length,
+                columns.length);
+
+        final RowSet index = arrayAccess.getRowSet();
+        final int constantYColValue = 10;
+        final int constantAColValue = 10;
+        final int constantBColValue = 20;
+        final boolean constantDColValue = true;
+
+        for (final RowSet.Iterator indexIterator = index.iterator(); indexIterator.hasNext();) {
+            final long key = indexIterator.nextLong();
+            Assert.assertEquals("Y=10 verification", constantYColValue,
+                    arrayAccess.getColumnSource(columns[0]).get(key));
+            Assert.assertEquals("A=10 verification", constantAColValue,
+                    arrayAccess.getColumnSource(columns[1]).get(key));
+            Assert.assertEquals("B=20 verification", constantBColValue,
+                    arrayAccess.getColumnSource(columns[2]).get(key));
+            Assert.assertEquals("D=true verification", constantDColValue,
+                    arrayAccess.getColumnSource(columns[3]).get(key));
+        }
+    }
+
+    @Test
+    public void dh12273_whereForNegativeShiftTestCase() {
+        String[] formulas = new String[] {"Y=i", "YMod2=Y%2", "A=i", "AMod4=A%4"};
+
+        String[] filters = new String[] {"YMod2=YMod2_[i-2] && AMod4=AMod4_[i-4]"};
+        verifyWhereForNegativeShifts(filters, formulas, 8, -2, -4, 0, 0);
+
+        filters = new String[] {"YMod2=YMod2_[i-2]", "AMod4=AMod4_[i-4]"};
+        verifyWhereForNegativeShifts(filters, formulas, 8, -2, -4, 0, 0);
+
+        formulas = new String[] {"Y=i", "YMod2=Y%2", "A=i", "AMod3=A%3"};
+        filters = new String[] {"YMod2=YMod2_[i-2] && AMod3=AMod3_[i-3]"};
+        verifyWhereForNegativeShifts(filters, formulas, 9, -2, -3, 1, 0);
+
+        filters = new String[] {"YMod2=YMod2_[i-2]", "AMod3=AMod3_[i-3]"};
+        verifyWhereForNegativeShifts(filters, formulas, 9, -2, -3, 1, 0);
+
+        formulas = new String[] {"Y=i", "YMod1=Y%1", "A=i", "AMod3=A%3"};
+        filters = new String[] {"YMod1=YMod1_[i-1] && AMod3=AMod3_[i-3]"};
+        verifyWhereForNegativeShifts(filters, formulas, 9, -1, -3, 0, 0);
+
+        filters = new String[] {"YMod1=YMod1_[i-1]", "AMod3=AMod3_[i-3]"};
+        verifyWhereForNegativeShifts(filters, formulas, 9, -1, -3, 0, 0);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void verifyWhereForNegativeShifts(String[] filterExpressions, String[] formulas, int tableSize, long yShift,
+            long aShift, int expectedYShiftStartValue, int expectedAShiftStartValue) {
+        final Table source = emptyTable(tableSize).update(formulas);
+        final Table arrayAccess = source.where(filterExpressions);
+        long absMaxShift = Math.max(Math.abs(yShift), Math.abs(aShift));
+
+        final String[] columns = arrayAccess.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("verify expected filtered table row count tableSize[" + tableSize + "], absMaxShift["
+                + absMaxShift + "]", (tableSize - absMaxShift), arrayAccess.intSize());
+
+        final RowSet index = arrayAccess.getRowSet();
+
+        int yModColValue = expectedYShiftStartValue;
+        int aModColValue = expectedAShiftStartValue;
+        int minStartCounterValue = 0;
+        for (final RowSet.Iterator indexIterator = index.iterator(); indexIterator.hasNext();) {
+            final long key = indexIterator.nextLong();
+            Assert.assertEquals(columns[1] + " verification", yModColValue,
+                    arrayAccess.getColumnSource(columns[1]).get(key));
+            Assert.assertEquals(columns[3] + " verification", aModColValue,
+                    arrayAccess.getColumnSource(columns[3]).get(key));
+
+            minStartCounterValue++;
+            yModColValue = (int) ((minStartCounterValue + expectedYShiftStartValue) % yShift);
+            aModColValue = (int) ((minStartCounterValue + expectedAShiftStartValue) % aShift);
+        }
+    }
+
+    @Test
+    public void dh12273_whereWithPositiveShiftsTestCase() {
+
+        String[] formulas = new String[] {"Y=i", "A=ii", "YMod=Y_[i+1]", "AMod=A_[i + 2]"};
+        String[] filters = new String[] {"Y_[i+1] % 2 == 0", "(A_[i + 2] + 1) % 2 == 0"};
+        verifyWhereForPositiveShifts(filters, formulas, 10, 1, 2, 2, 3);
+
+        formulas = new String[] {"Y=i", "A=ii", "YMod=Y_[i+2]", "AMod=A_[i + 3]"};
+        filters = new String[] {"Y_[i+2] % 2 == 0", "(A_[i + 3] + 1) % 2 == 0"};
+        verifyWhereForPositiveShifts(filters, formulas, 10, 2, 3, 2, 3);
+
+        formulas = new String[] {"Y=i", "A=ii", "YMod=Y_[i+3]", "AMod=A_[i + 4]"};
+        filters = new String[] {"Y_[i+3] % 2 == 0", "(A_[i + 4] + 1) % 2 == 0"};
+        verifyWhereForPositiveShifts(filters, formulas, 10, 3, 4, 4, 5);
+
+        formulas = new String[] {"Y=i", "A=ii", "YMod=Y_[i+2]", "AMod=A_[i + 3]"};
+        filters = new String[] {"Y_[i+2] % 2 == 0", "(A_[i + 3] + 3) % 2 == 0"};
+        verifyWhereForPositiveShifts(filters, formulas, 10, 2, 3, 2, 3);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void verifyWhereForPositiveShifts(String[] filterExpressions, String[] formulas, int tableSize, long yShift,
+            long aShift, int expectedYShiftStartValue, long expectedAShiftStartValue) {
+        final Table source = emptyTable(tableSize).update(formulas);
+        final Table arrayAccess = source.where(filterExpressions);
+        long absMaxShift = Math.max(yShift, aShift);
+
+        final String[] columns = arrayAccess.getDefinition().getColumnNamesArray();
+        Assert.assertEquals("verify expected filtered table row count tableSize[" + tableSize + "], absMaxShift["
+                + absMaxShift + "]", Math.round((double) (tableSize - absMaxShift) / 2), arrayAccess.intSize());
+
+        final RowSet index = arrayAccess.getRowSet();
+
+        int yModColValue = expectedYShiftStartValue;
+        long aModColValue = expectedAShiftStartValue;
+        for (final RowSet.Iterator indexIterator = index.iterator(); indexIterator.hasNext();) {
+            final long key = indexIterator.nextLong();
+            Assert.assertEquals(columns[2] + " verification", yModColValue,
+                    arrayAccess.getColumnSource(columns[2]).get(key));
+            Assert.assertEquals(columns[3] + " verification", aModColValue,
+                    arrayAccess.getColumnSource(columns[3]).get(key));
+
+            yModColValue = yModColValue + 2;
+            aModColValue = aModColValue + 2;
+        }
+    }
+
+    @Test
+    public void dh12273_simpleIncrementalRefreshingTableWhereTest() {
+        final QueryTable queryTable = TstUtils.testRefreshingTable(
+                i(10, 12, 14, 16, 18, 20).toTracking(),
+                intCol("Sentinel", 6, 7, 8, 9, 10, 11),
+                intCol("Value", 20, 22, 24, 26, 28, 30),
+                intCol("Value2", 202, 222, 242, 262, 282, 302),
+                intCol("Value3", 2020, 2220, 2420, 2620, 2820, 3020),
+                intCol("Value4", 2020, 2020, 2420, 2420, 2820, 2820));
+
+
+        final EvalNugget[] en = new EvalNugget[] {
+                EvalNugget.from(() -> queryTable.where("Value % 2 == 0", "Sentinel % 2 != 0")),
+                EvalNugget.from(() -> queryTable.where("Value % 2 == 0", "Value4==Value4_[i-1]", "Sentinel % 2 != 0"))
+        };
+
+        TstUtils.validate("", en);
+
+        UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            addToTable(queryTable,
+                    i(10, 12, 18),
+                    intCol("Sentinel", 56, 57, 510),
+                    intCol("Value", 421, 422, 425),
+                    intCol("Value2", 302, 322, 382),
+                    intCol("Value3", 4020, 4220, 4820),
+                    intCol("Value4", 4020, 4020, 4820));
+
+            final ModifiedColumnSet queryTableColSetForUpdate = queryTable.getModifiedColumnSetForUpdates();
+            queryTableColSetForUpdate.clear();
+            queryTableColSetForUpdate.setAll("Sentinel", "Value", "Value2", "Value3", "Value4");
+            final TableUpdateImpl update = new TableUpdateImpl(i(), i(), i(10, 12, 18), RowSetShiftData.EMPTY,
+                    queryTableColSetForUpdate /* ModifiedColumnSet.ALL */);
+            System.out.println("published update in Test: " + update);
+            queryTable.notifyListeners(update);
+        });
+
+        TstUtils.validate("", en);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
@@ -591,8 +591,8 @@ public class TestFormulaArrayEvaluation {
         for (int i = 0; i < formulas.length; i++) {
             ColumnSource<?> cs = source.getColumnSource(columns[i]);
 
-            if (columns[i].equals("Z") || columns[i].equals("D") || columns[i].equals("E")
-                    || (columns[i].equals("Y") && (flavor == Flavor.UpdateView || flavor == Flavor.View))) {
+            if ((columns[i].equals("Z") || columns[i].equals("D") || columns[i].equals("E")
+                    || columns[i].equals("Y")) && (flavor == Flavor.UpdateView || flavor == Flavor.View)) {
                 Assert.assertTrue(columns[i] + " ColumnSource is a ViewColumnSource ", cs instanceof ViewColumnSource);
             } else if (columns[i].equals("X") || columns[i].equals("C")) {
                 Assert.assertTrue(columns[i] + " ColumnSource is a SingleValueColumnSource ",

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterTest.java
@@ -8,10 +8,6 @@ import io.deephaven.api.RawString;
 import io.deephaven.api.filter.Filter;
 import io.deephaven.api.filter.FilterCondition;
 import io.deephaven.api.value.Value;
-import io.deephaven.engine.table.impl.select.ConditionFilter;
-import io.deephaven.engine.table.impl.select.LongRangeFilter;
-import io.deephaven.engine.table.impl.select.MatchFilter;
-import io.deephaven.engine.table.impl.select.WhereFilter;
 import junit.framework.TestCase;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestIncrementalReleaseFilter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestIncrementalReleaseFilter.java
@@ -95,7 +95,7 @@ public class TestIncrementalReleaseFilter extends RefreshingTableTestCase {
         incrementalReleaseFilter.start();
         final Table filtered = source.where(incrementalReleaseFilter);
 
-        final Table updated = UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> filtered.update("I=ii"));
+        final Table updated = UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> filtered.update("I=0"));
 
         int steps = 0;
 
@@ -117,10 +117,10 @@ public class TestIncrementalReleaseFilter extends RefreshingTableTestCase {
         final AutoTuningIncrementalReleaseFilter incrementalReleaseFilter =
                 new AutoTuningIncrementalReleaseFilter(0, 100, 1.1, true);
         incrementalReleaseFilter.start();
-        final Table filtered = source.where(incrementalReleaseFilter);
+        final Table filtered = source.updateView("I = ii").where(incrementalReleaseFilter);
 
         final Table updated = UpdateGraphProcessor.DEFAULT.sharedLock().computeLocked(() -> filtered
-                .update("I=io.deephaven.engine.table.impl.util.TestIncrementalReleaseFilter.sleepValue(100000, ii)"));
+                .update("I=io.deephaven.engine.table.impl.util.TestIncrementalReleaseFilter.sleepValue(100000, I)"));
 
         int cycles = 0;
         while (filtered.size() < source.size()) {

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
@@ -16,10 +16,12 @@ import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.ElementSource;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.AbstractColumnSource;
+import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.PrevColumnSource;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.util.ColumnHolder;
 import io.deephaven.engine.testutil.generator.TestDataGenerator;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.engine.testutil.rowset.RowSetTstUtils;
 import io.deephaven.engine.testutil.sources.ByteTestSource;
 import io.deephaven.engine.testutil.sources.DateTimeTestSource;
@@ -559,7 +561,9 @@ public class TstUtils {
 
     public static QueryTable testTable(TrackingRowSet rowSet, ColumnHolder<?>... columnHolders) {
         final Map<String, ColumnSource<?>> columns = getColumnSourcesFromHolders(rowSet, columnHolders);
-        return new QueryTable(rowSet, columns);
+        QueryTable queryTable = new QueryTable(rowSet, columns);
+        queryTable.setAttribute(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, true);
+        return queryTable;
     }
 
     @NotNull
@@ -575,6 +579,7 @@ public class TstUtils {
     public static QueryTable testRefreshingTable(TrackingRowSet rowSet, ColumnHolder<?>... columnHolders) {
         final QueryTable queryTable = testTable(rowSet, columnHolders);
         queryTable.setRefreshing(true);
+        queryTable.setAttribute(BaseTable.TEST_SOURCE_TABLE_ATTRIBUTE, true);
         return queryTable;
     }
 

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
@@ -276,7 +276,7 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
         refreshThread.setDaemon(true);
 
         final int updateThreads =
-                Configuration.getInstance().getIntegerWithDefault("UpdateGraphProcessor.updateThreads", 1);
+                Configuration.getInstance().getIntegerWithDefault("UpdateGraphProcessor.updateThreads", -1);
         if (updateThreads <= 0) {
             this.updateThreads = Runtime.getRuntime().availableProcessors();
         } else {

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
@@ -276,7 +276,7 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
         refreshThread.setDaemon(true);
 
         final int updateThreads =
-                Configuration.getInstance().getIntegerWithDefault("UpdateGraphProcessor.updateThreads", -1);
+                Configuration.getInstance().getIntegerWithDefault("UpdateGraphProcessor.updateThreads", 1);
         if (updateThreads <= 0) {
             this.updateThreads = Runtime.getRuntime().availableProcessors();
         } else {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -13,7 +13,6 @@ import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.rowset.*;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.QueryTable;
-import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.perf.PerformanceEntry;
 import io.deephaven.engine.table.impl.perf.UpdatePerformanceTracker;
 import io.deephaven.engine.table.impl.sources.ArrayBackedColumnSource;
@@ -36,7 +35,6 @@ import io.deephaven.io.logger.Logger;
 import io.deephaven.time.DateTime;
 import io.deephaven.util.annotations.InternalUseOnly;
 import org.HdrHistogram.Histogram;
-import org.apache.commons.lang3.mutable.MutableLong;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -100,11 +98,6 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
     protected boolean serverReverseViewport;
     protected BitSet serverColumns;
 
-    /** the size of the initial viewport requested from the server (-1 implies full subscription) */
-    private long initialSnapshotViewportRowCount;
-    /** have we completed the initial snapshot */
-    private boolean initialSnapshotReceived;
-
     /** synchronize access to pendingUpdates */
     private final Object pendingUpdatesLock = new Object();
 
@@ -156,7 +149,6 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
         } else {
             serverViewport = RowSetFactory.empty();
         }
-        this.initialSnapshotViewportRowCount = initialViewPortRows;
 
         this.destSources = new WritableColumnSource<?>[writableSources.length];
         for (int ii = 0; ii < writableSources.length; ++ii) {
@@ -208,10 +200,6 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
     @VisibleForTesting
     public BitSet getServerColumns() {
         return serverColumns;
-    }
-
-    public void setInitialSnapshotViewportRowCount(long rowCount) {
-        initialSnapshotViewportRowCount = rowCount;
     }
 
     /**

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
@@ -12,6 +12,7 @@ import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.rowset.RowSetShiftData;
+import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.util.BarrageMessage;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
@@ -161,6 +162,10 @@ public class ArrowToTableConverter {
 
         final BarrageUtil.ConvertedArrowSchema result = BarrageUtil.convertArrowSchema(header);
         resultTable = BarrageTable.make(null, result.tableDef, result.attributes, -1);
+        resultTable.setFlat();
+        resultTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+        resultTable.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
+
         columnConversionFactors = result.conversionFactors;
         columnChunkTypes = resultTable.getWireChunkTypes();
         columnTypes = resultTable.getWireTypes();

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
@@ -161,10 +161,10 @@ public class ArrowToTableConverter {
         }
 
         final BarrageUtil.ConvertedArrowSchema result = BarrageUtil.convertArrowSchema(header);
+        result.attributes.put(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+        result.attributes.put(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
         resultTable = BarrageTable.make(null, result.tableDef, result.attributes, -1);
         resultTable.setFlat();
-        resultTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
-        resultTable.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
 
         columnConversionFactors = result.conversionFactors;
         columnChunkTypes = resultTable.getWireChunkTypes();

--- a/go/pkg/client/example_import_table_test.go
+++ b/go/pkg/client/example_import_table_test.go
@@ -71,31 +71,31 @@ func Example_importTable() {
 	fmt.Println(filteredRecord)
 
 	// Output:
-	// Data Before:
-	// record:
-	//   schema:
-	//   fields: 3
-	//     - Ticker: type=utf8
-	//     - Close: type=float32
-	//     - Volume: type=int32
-	//   rows: 7
-	//   col[0][Ticker]: ["XRX" "XYZZY" "IBM" "GME" "AAPL" "ZNGA" "T"]
-	//   col[1][Close]: [53.8 88.5 38.7 453 26.7 544.9 13.4]
-	//   col[2][Volume]: [87000 6060842 138000 138000000 19000 48300 1500]
-	//
-	// Data After:
-	// record:
-	//   schema:
-	//   fields: 3
-	//     - Ticker: type=utf8, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String", "deephaven:isDateFormat": "false"]
-	//     - Close: type=float32, nullable
-	//        metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "float", "deephaven:isDateFormat": "false"]
-	//     - Volume: type=int32, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "int", "deephaven:isDateFormat": "false"]
-	//   metadata: ["deephaven:attribute.SortedColumns": "Close=Ascending", "deephaven:attribute_type.SortedColumns": "java.lang.String", "deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute.AddOnly": "true"]
-	//   rows: 5
-	//   col[0][Ticker]: ["IBM" "XRX" "XYZZY" "GME" "ZNGA"]
-	//   col[1][Close]: [38.7 53.8 88.5 453 544.9]
-	//   col[2][Volume]: [138000 87000 6060842 138000000 48300]
+    // Data Before:
+    // record:
+    //   schema:
+    //   fields: 3
+    //     - Ticker: type=utf8
+    //     - Close: type=float32
+    //     - Volume: type=int32
+    //   rows: 7
+    //   col[0][Ticker]: ["XRX" "XYZZY" "IBM" "GME" "AAPL" "ZNGA" "T"]
+    //   col[1][Close]: [53.8 88.5 38.7 453 26.7 544.9 13.4]
+    //   col[2][Volume]: [87000 6060842 138000 138000000 19000 48300 1500]
+    //
+    // Data After:
+    // record:
+    //   schema:
+    //   fields: 3
+    //     - Ticker: type=utf8, nullable
+    //         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String", "deephaven:isDateFormat": "false"]
+    //     - Close: type=float32, nullable
+    //        metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "float", "deephaven:isDateFormat": "false"]
+    //     - Volume: type=int32, nullable
+    //         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "int", "deephaven:isDateFormat": "false"]
+    //   metadata: ["deephaven:attribute.SortedColumns": "Close=Ascending", "deephaven:attribute_type.SortedColumns": "java.lang.String", "deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute.AddOnly": "true", "deephaven:attribute_type.AppendOnly": "java.lang.Boolean", "deephaven:attribute.AppendOnly": "true"]
+    //   rows: 5
+    //   col[0][Ticker]: ["IBM" "XRX" "XYZZY" "GME" "ZNGA"]
+    //   col[1][Close]: [38.7 53.8 88.5 453 544.9]
+    //   col[2][Volume]: [138000 87000 6060842 138000000 48300]
 }

--- a/go/pkg/client/example_table_ops_test.go
+++ b/go/pkg/client/example_table_ops_test.go
@@ -34,7 +34,6 @@ func Example_tableOps() {
 
 	fmt.Println(queryResult)
 
-	// Output:
     // Data Before:
     // record:
     //   schema:
@@ -57,7 +56,7 @@ func Example_tableOps() {
     //        metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "float", "deephaven:isDateFormat": "false"]
     //     - Volume: type=int32, nullable
     //         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "int", "deephaven:isDateFormat": "false"]
-    //   metadata: ["deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute.AddOnly": "true"]
+    //   metadata: ["deephaven:attribute_type.AppendOnly": "java.lang.Boolean", "deephaven:attribute.AppendOnly": "true", "deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute.AddOnly": "true"]
     //   rows: 5
     //   col[0][Ticker]: ["XRX" "IBM" "GME" "AAPL" "ZNGA"]
     //   col[1][Close]: [53.8 38.7 453 26.7 544.9]

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
@@ -198,9 +198,6 @@ public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements
         // store this for streamreader parser
         expectedColumns = columns;
 
-        // update the viewport size for initial snapshot completion
-        resultTable.setInitialSnapshotViewportRowCount(viewport == null ? -1 : viewport.size());
-
         // Send the snapshot request:
         observer.onNext(FlightData.newBuilder()
                 .setAppMetadata(ByteStringAccess.wrap(makeRequestInternal(viewport, columns, reverseViewport, options)))

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -203,9 +203,6 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
                 completedCondition = UpdateGraphProcessor.DEFAULT.exclusiveLock().newCondition();
             }
 
-            // update the viewport size for initial snapshot completion
-            resultTable.setInitialSnapshotViewportRowCount(viewport == null ? -1 : viewport.size());
-
             // Send the initial subscription:
             observer.onNext(FlightData.newBuilder()
                     .setAppMetadata(

--- a/java-client/session-dagger/src/test/java/io/deephaven/client/UpdateOrSelectSessionTest.java
+++ b/java-client/session-dagger/src/test/java/io/deephaven/client/UpdateOrSelectSessionTest.java
@@ -88,16 +88,6 @@ public class UpdateOrSelectSessionTest extends DeephavenSessionTestBase {
     }
 
     @Test
-    public void allowTickingI() throws InterruptedException, TableHandle.TableHandleException {
-        allow(TimeTable.of(Duration.ofSeconds(1)).tail(1), "Y = i");
-    }
-
-    @Test
-    public void allowTickingII() throws InterruptedException, TableHandle.TableHandleException {
-        allow(TimeTable.of(Duration.ofSeconds(1)).tail(1), "Y = ii");
-    }
-
-    @Test
     public void allowSpecificFunctions() throws TableHandle.TableHandleException, InterruptedException {
         // This test isn't meant to be exhaustive
         allow(TableSpec.empty(1).view("Seconds=(long)1659095381"), "Nanos = secondsToNanos(Seconds)");

--- a/java-client/session-dagger/src/test/java/io/deephaven/client/WhereSessionTest.java
+++ b/java-client/session-dagger/src/test/java/io/deephaven/client/WhereSessionTest.java
@@ -4,13 +4,8 @@ import io.deephaven.client.impl.TableHandle;
 import io.deephaven.qst.table.TableSpec;
 import io.deephaven.qst.table.TimeTable;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.function.BiFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
@@ -39,16 +34,6 @@ public class WhereSessionTest extends DeephavenSessionTestBase {
     @Test
     public void allowTimeTableII() throws InterruptedException, TableHandle.TableHandleException {
         allow(TimeTable.of(Duration.ofSeconds(1)), "ii % 2 == 0");
-    }
-
-    @Test
-    public void allowTickingI() throws InterruptedException, TableHandle.TableHandleException {
-        allow(TimeTable.of(Duration.ofSeconds(1)).tail(1), "i % 2 == 0");
-    }
-
-    @Test
-    public void allowTickingII() throws InterruptedException, TableHandle.TableHandleException {
-        allow(TimeTable.of(Duration.ofSeconds(1)).tail(1), "ii % 2 == 0");
     }
 
     @Test

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -228,7 +228,6 @@ public class ArrowFlightUtil {
                 final SessionState.ExportBuilder<Table> localExportBuilder = resultExportBuilder;
                 resultExportBuilder = null;
 
-
                 // gRPC is about to remove its hard reference to this observer. We must keep the result table hard
                 // referenced until the export is complete, so that the export can properly be satisfied. ExportObject's
                 // LivenessManager enforces strong reachability.


### PR DESCRIPTION
I had to pull together several PR's to completely port this feature. There was a lot more work than I anticipated lurking beneath the façade of DH-12148.

I felt that ShiftColumnOperation could be improved on from a performance point of view. I've included a test that arbitrarily takes ~30s on the original implementation, and ~8s on the replacement implementation. This is +70% improvement for that arbitrary, but hand picked, case using random updates. There are degenerate scenarios of the original implementation that the new implementation avoids. I dropped the replacement in a separate commit should one want to review the port vs the rewrite.

An interesting bonus of supporting formula array access is that we can drop most usages of `EvalNugget#hasUnstableColumns` as array offset access is now guaranteed to propagate downstream. This helped me identify a bug or two.

There were a couple of snippets/scenarios in the DHE port that just did not work in DHC. I reached out to @cpwright offline to highlight concerns.

[DH-12148](https://deephaven.atlassian.net/browse/DH-12148): Formula Array Access changes [commit](https://github.com/deephaven-ent/iris/commit/7e701a77e6ed26d852755c2886b19e6441bc85fd)
[DH-12030](https://deephaven.atlassian.net/browse/DH-12030) Implement ShiftColumnOperation [commit](https://github.com/deephaven-ent/iris/commit/f7826a675240d08dabf39eaa839aeb9d8a93d112)
[DH-12199](https://deephaven.atlassian.net/browse/DH-12199): ShiftedColumnOperation's ModifiedColumnSet should include all Source Column + Shifted Columns [commit](https://github.com/deephaven-ent/iris/commit/718a502862802610ecf9ed5db09cace635150295)
[DH-12273](https://deephaven.atlassian.net/browse/DH-12273): FormulaArrayAccess changes for where clause [commit](https://github.com/deephaven-ent/iris/commit/30dffe3f6bb3a6727a553c348c7ca8c1ec07da51)

Nightlies are running [here](https://github.com/nbauernfeind/deephaven-core/actions/runs/4348490143).
