### PR TITLE
Port DH-11656: More efficiently null sparse array sources

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AsOfJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AsOfJoinHelper.java
@@ -309,13 +309,13 @@ public class AsOfJoinHelper {
             public void onUpdate(TableUpdate upstream) {
                 final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
 
-                upstream.removed().forAllRowKeys(rowRedirection::removeVoid);
+                rowRedirection.removeAll(upstream.removed());
 
                 final boolean keysModified = upstream.modifiedColumnSet().containsAny(leftKeysOrStamps);
 
                 final RowSet restampKeys;
                 if (keysModified) {
-                    upstream.getModifiedPreShift().forAllRowKeys(rowRedirection::removeVoid);
+                    rowRedirection.removeAll(upstream.getModifiedPreShift());
                     restampKeys = upstream.modified().union(upstream.added());
                 } else {
                     restampKeys = upstream.added();
@@ -333,7 +333,7 @@ public class AsOfJoinHelper {
 
                     try (final RowSet foundKeys = foundBuilder.build();
                             final RowSet notFound = restampKeys.minus(foundKeys)) {
-                        notFound.forAllRowKeys(rowRedirection::removeVoid);
+                        rowRedirection.removeAll(notFound);
                     }
 
                     try (final AsOfStampContext stampContext = new AsOfStampContext(order, disallowExactMatch,
@@ -1473,14 +1473,14 @@ public class AsOfJoinHelper {
                                 public void onUpdate(TableUpdate upstream) {
                                     final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
 
-                                    upstream.removed().forAllRowKeys(rowRedirection::removeVoid);
+                                    rowRedirection.removeAll(upstream.removed());
 
                                     final boolean stampModified = upstream.modified().isNonempty()
                                             && upstream.modifiedColumnSet().containsAny(leftStampColumn);
 
                                     final RowSet restampKeys;
                                     if (stampModified) {
-                                        upstream.getModifiedPreShift().forAllRowKeys(rowRedirection::removeVoid);
+                                        rowRedirection.removeAll(upstream.getModifiedPreShift());
                                         restampKeys = upstream.modified().union(upstream.added());
                                     } else {
                                         restampKeys = upstream.added();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
@@ -553,7 +553,7 @@ class NaturalJoinHelper {
         @Override
         public void onUpdate(final TableUpdate upstream) {
             final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-            upstream.removed().forAllRowKeys(rowRedirection::removeVoid);
+            rowRedirection.removeAll(upstream.removed());
 
             try (final RowSet prevRowSet = leftTable.getRowSet().copyPrev()) {
                 rowRedirection.applyShift(prevRowSet, upstream.shifted());
@@ -773,7 +773,7 @@ class NaturalJoinHelper {
 
             if (rightIndex == RowSequence.NULL_ROW_KEY) {
                 jsm.checkExactMatch(exactMatch, leftIndices.firstRowKey(), rightIndex);
-                leftIndices.forAllRowKeys(rowRedirection::removeVoid);
+                rowRedirection.removeAll(leftIndices);
             } else {
                 leftIndices.forAllRowKeys((long key) -> rowRedirection.putVoid(key, rightIndex));
             }
@@ -939,7 +939,7 @@ class NaturalJoinHelper {
                         probeSize == 0 ? null : jsm.makeProbeContext(leftSources, probeSize);
                         final Context bc =
                                 buildSize == 0 ? null : jsm.makeBuildContext(leftSources, buildSize)) {
-                    leftRemoved.forAllRowKeys(rowRedirection::removeVoid);
+                    rowRedirection.removeAll(leftRemoved);
                     jsm.removeLeft(pc, leftRemoved, leftSources);
 
                     final RowSet leftModifiedPreShift;
@@ -952,7 +952,7 @@ class NaturalJoinHelper {
 
                         // remove pre-shift modified
                         jsm.removeLeft(pc, leftModifiedPreShift, leftSources);
-                        leftModifiedPreShift.forAllRowKeys(rowRedirection::removeVoid);
+                        rowRedirection.removeAll(leftModifiedPreShift);
                     } else {
                         leftModifiedPreShift = null;
                     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/RightIncrementalChunkedCrossJoinStateManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/RightIncrementalChunkedCrossJoinStateManager.java
@@ -688,7 +688,7 @@ class RightIncrementalChunkedCrossJoinStateManager
 
     public void updateLeftRowRedirection(RowSet leftAdded, long slotLocation) {
         if (slotLocation == RowSequence.NULL_ROW_KEY) {
-            leftAdded.forAllRowKeys(leftRowToSlot::removeVoid);
+            leftRowToSlot.removeAll(leftAdded);
         } else {
             leftAdded.forAllRowKeys(ii -> leftRowToSlot.putVoid(ii, slotLocation));
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SparseSelect.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SparseSelect.java
@@ -195,7 +195,7 @@ public class SparseSelect {
                                 if (sparseObjectSources.length > 0) {
                                     try (final RowSet removedOnly = upstream.removed().minus(upstream.added())) {
                                         for (final ObjectSparseArraySource<?> objectSparseArraySource : sparseObjectSources) {
-                                            objectSparseArraySource.remove(removedOnly);
+                                            objectSparseArraySource.setNull(removedOnly);
                                         }
                                     }
                                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
@@ -388,7 +388,7 @@ public class TableUpdateValidator implements QueryTable.Operation {
         }
 
         public void remove(final RowSet toRemove) {
-            expectedSource.remove(toRemove);
+            expectedSource.setNull(toRemove);
         }
 
         private void updateValues(final RowSequence toUpdate, final boolean usePrev) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/BucketedChunkedAjMergedListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/BucketedChunkedAjMergedListener.java
@@ -179,7 +179,7 @@ public class BucketedChunkedAjMergedListener extends MergedListener {
             slots.ensureCapacity(leftRestampRemovals.size());
 
             if (leftRestampRemovals.isNonempty()) {
-                leftRestampRemovals.forAllRowKeys(rowRedirection::removeVoid);
+                rowRedirection.removeAll(leftRestampRemovals);
 
                 // We first do a probe pass, adding all of the removals to a builder in the as of join state manager
                 final int removedSlotCount = asOfJoinStateManager.markForRemoval(leftRestampRemovals, leftKeySources,
@@ -191,8 +191,7 @@ public class BucketedChunkedAjMergedListener extends MergedListener {
                     final int slot = slots.getInt(slotIndex);
                     final RowSet leftRemoved = indexFromBuilder(slotIndex);
 
-                    leftRemoved.forAllRowKeys(rowRedirection::removeVoid);
-
+                    rowRedirection.removeAll(leftRemoved);
 
                     final SegmentedSortedArray leftSsa = asOfJoinStateManager.getLeftSsaOrIndex(slot, leftIndexOutput);
                     if (leftSsa == null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/ZeroKeyChunkedAjMergedListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/ZeroKeyChunkedAjMergedListener.java
@@ -145,7 +145,7 @@ public class ZeroKeyChunkedAjMergedListener extends MergedListener {
                 }
 
                 if (leftRestampRemovals.isNonempty()) {
-                    leftRestampRemovals.forAllRowKeys(rowRedirection::removeVoid);
+                    rowRedirection.removeAll(leftRestampRemovals);
 
                     try (final RowSequence.Iterator leftRsIt = leftRestampRemovals.getRowSequenceIterator()) {
                         assert leftFillContext != null;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/AbstractLongArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/AbstractLongArraySource.java
@@ -58,6 +58,11 @@ public abstract class AbstractLongArraySource<T> extends ArraySourceHelper<T, lo
     }
 
     @Override
+    public void setNull(long key) {
+        set(key, NULL_LONG);
+    }
+
+    @Override
     public final long getLong(long rowKey) {
         if (rowKey < 0 || rowKey > maxIndex) {
             return NULL_LONG;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/AbstractSparseLongArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/AbstractSparseLongArraySource.java
@@ -23,6 +23,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -130,14 +131,9 @@ abstract public class AbstractSparseLongArraySource<T> extends SparseArrayColumn
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getLong(i));
-            set(i, NULL_LONG);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_LONG); return true; });
     }
 
     // region boxed methods
@@ -270,6 +266,11 @@ abstract public class AbstractSparseLongArraySource<T> extends SparseArrayColumn
 
         final LongOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -606,7 +607,7 @@ abstract public class AbstractSparseLongArraySource<T> extends SparseArrayColumn
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final LongChunk<? extends Values> chunk = src.asLongChunk();
@@ -675,7 +676,7 @@ abstract public class AbstractSparseLongArraySource<T> extends SparseArrayColumn
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final LongChunk<? extends Values> chunk = src.asLongChunk();
@@ -729,6 +730,137 @@ abstract public class AbstractSparseLongArraySource<T> extends SparseArrayColumn
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final long [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_LONG) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final long[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_LONG);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_LONG);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final long[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<long[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final long oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_LONG) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_LONG;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -796,7 +928,7 @@ abstract public class AbstractSparseLongArraySource<T> extends SparseArrayColumn
     // region getChunk
     @Override
     public Chunk<Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return LongChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BooleanSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BooleanSingleValueSource.java
@@ -70,13 +70,6 @@ public class BooleanSingleValueSource extends SingleValueColumnSource<Boolean> i
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_BOOLEAN);
-        // endregion null set
-    }
-
-    @Override
     public final Boolean get(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_BOOLEAN;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BooleanSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/BooleanSparseArraySource.java
@@ -29,6 +29,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -136,14 +137,9 @@ public class BooleanSparseArraySource extends SparseArrayColumnSource<Boolean> i
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getBoolean(i));
-            set(i, NULL_BOOLEAN);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_BOOLEAN); return true; });
     }
 
     // region boxed methods
@@ -290,6 +286,11 @@ public class BooleanSparseArraySource extends SparseArrayColumnSource<Boolean> i
 
         final ByteOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -628,7 +629,7 @@ public class BooleanSparseArraySource extends SparseArrayColumnSource<Boolean> i
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ObjectChunk<Boolean, ? extends Values> chunk = src.asObjectChunk();
@@ -699,7 +700,7 @@ public class BooleanSparseArraySource extends SparseArrayColumnSource<Boolean> i
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ObjectChunk<Boolean, ? extends Values> chunk = src.asObjectChunk();
@@ -753,6 +754,137 @@ public class BooleanSparseArraySource extends SparseArrayColumnSource<Boolean> i
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final byte [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_BOOLEAN_AS_BYTE) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final byte[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_BOOLEAN_AS_BYTE);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_BOOLEAN_AS_BYTE);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final byte[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<byte[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final byte oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_BOOLEAN_AS_BYTE) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_BOOLEAN_AS_BYTE;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteSingleValueSource.java
@@ -81,13 +81,6 @@ public class ByteSingleValueSource extends SingleValueColumnSource<Byte> impleme
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_BYTE);
-        // endregion null set
-    }
-
-    @Override
     public final byte getByte(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_BYTE;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteSparseArraySource.java
@@ -24,6 +24,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -131,14 +132,9 @@ public class ByteSparseArraySource extends SparseArrayColumnSource<Byte> impleme
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getByte(i));
-            set(i, NULL_BYTE);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_BYTE); return true; });
     }
 
     // region boxed methods
@@ -285,6 +281,11 @@ public class ByteSparseArraySource extends SparseArrayColumnSource<Byte> impleme
 
         final ByteOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -621,7 +622,7 @@ public class ByteSparseArraySource extends SparseArrayColumnSource<Byte> impleme
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ByteChunk<? extends Values> chunk = src.asByteChunk();
@@ -690,7 +691,7 @@ public class ByteSparseArraySource extends SparseArrayColumnSource<Byte> impleme
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ByteChunk<? extends Values> chunk = src.asByteChunk();
@@ -744,6 +745,137 @@ public class ByteSparseArraySource extends SparseArrayColumnSource<Byte> impleme
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final byte [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_BYTE) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final byte[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_BYTE);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_BYTE);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final byte[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<byte[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final byte oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_BYTE) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_BYTE;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -811,7 +943,7 @@ public class ByteSparseArraySource extends SparseArrayColumnSource<Byte> impleme
     // region getChunk
     @Override
     public ByteChunk<Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return ByteChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/CharacterSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/CharacterSingleValueSource.java
@@ -76,13 +76,6 @@ public class CharacterSingleValueSource extends SingleValueColumnSource<Characte
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_CHAR);
-        // endregion null set
-    }
-
-    @Override
     public final char getChar(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_CHAR;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/CharacterSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/CharacterSparseArraySource.java
@@ -19,6 +19,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -126,14 +127,9 @@ public class CharacterSparseArraySource extends SparseArrayColumnSource<Characte
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getChar(i));
-            set(i, NULL_CHAR);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_CHAR); return true; });
     }
 
     // region boxed methods
@@ -280,6 +276,11 @@ public class CharacterSparseArraySource extends SparseArrayColumnSource<Characte
 
         final CharOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -616,7 +617,7 @@ public class CharacterSparseArraySource extends SparseArrayColumnSource<Characte
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final CharChunk<? extends Values> chunk = src.asCharChunk();
@@ -685,7 +686,7 @@ public class CharacterSparseArraySource extends SparseArrayColumnSource<Characte
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final CharChunk<? extends Values> chunk = src.asCharChunk();
@@ -739,6 +740,137 @@ public class CharacterSparseArraySource extends SparseArrayColumnSource<Characte
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final char [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_CHAR) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final char[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_CHAR);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_CHAR);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final char[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<char[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final char oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_CHAR) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_CHAR;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -806,7 +938,7 @@ public class CharacterSparseArraySource extends SparseArrayColumnSource<Characte
     // region getChunk
     @Override
     public CharChunk<Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return CharChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DateTimeArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DateTimeArraySource.java
@@ -220,7 +220,7 @@ public class DateTimeArraySource extends AbstractLongArraySource<DateTime> {
 
         @Override
         public void setNull(long key) {
-            set(key, NULL_LONG);
+            DateTimeArraySource.super.setNull(key);
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DoubleSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DoubleSingleValueSource.java
@@ -81,13 +81,6 @@ public class DoubleSingleValueSource extends SingleValueColumnSource<Double> imp
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_DOUBLE);
-        // endregion null set
-    }
-
-    @Override
     public final double getDouble(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_DOUBLE;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DoubleSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/DoubleSparseArraySource.java
@@ -24,6 +24,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -131,14 +132,9 @@ public class DoubleSparseArraySource extends SparseArrayColumnSource<Double> imp
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getDouble(i));
-            set(i, NULL_DOUBLE);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_DOUBLE); return true; });
     }
 
     // region boxed methods
@@ -285,6 +281,11 @@ public class DoubleSparseArraySource extends SparseArrayColumnSource<Double> imp
 
         final DoubleOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -621,7 +622,7 @@ public class DoubleSparseArraySource extends SparseArrayColumnSource<Double> imp
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final DoubleChunk<? extends Values> chunk = src.asDoubleChunk();
@@ -690,7 +691,7 @@ public class DoubleSparseArraySource extends SparseArrayColumnSource<Double> imp
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final DoubleChunk<? extends Values> chunk = src.asDoubleChunk();
@@ -744,6 +745,137 @@ public class DoubleSparseArraySource extends SparseArrayColumnSource<Double> imp
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final double [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_DOUBLE) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final double[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_DOUBLE);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_DOUBLE);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final double[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<double[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final double oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_DOUBLE) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_DOUBLE;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -811,7 +943,7 @@ public class DoubleSparseArraySource extends SparseArrayColumnSource<Double> imp
     // region getChunk
     @Override
     public DoubleChunk<Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return DoubleChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/FloatSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/FloatSingleValueSource.java
@@ -81,13 +81,6 @@ public class FloatSingleValueSource extends SingleValueColumnSource<Float> imple
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_FLOAT);
-        // endregion null set
-    }
-
-    @Override
     public final float getFloat(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_FLOAT;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/FloatSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/FloatSparseArraySource.java
@@ -24,6 +24,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -131,14 +132,9 @@ public class FloatSparseArraySource extends SparseArrayColumnSource<Float> imple
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getFloat(i));
-            set(i, NULL_FLOAT);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_FLOAT); return true; });
     }
 
     // region boxed methods
@@ -285,6 +281,11 @@ public class FloatSparseArraySource extends SparseArrayColumnSource<Float> imple
 
         final FloatOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -621,7 +622,7 @@ public class FloatSparseArraySource extends SparseArrayColumnSource<Float> imple
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final FloatChunk<? extends Values> chunk = src.asFloatChunk();
@@ -690,7 +691,7 @@ public class FloatSparseArraySource extends SparseArrayColumnSource<Float> imple
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final FloatChunk<? extends Values> chunk = src.asFloatChunk();
@@ -744,6 +745,137 @@ public class FloatSparseArraySource extends SparseArrayColumnSource<Float> imple
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final float [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_FLOAT) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final float[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_FLOAT);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_FLOAT);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final float[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<float[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final float oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_FLOAT) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_FLOAT;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -811,7 +943,7 @@ public class FloatSparseArraySource extends SparseArrayColumnSource<Float> imple
     // region getChunk
     @Override
     public FloatChunk<Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return FloatChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/IntegerSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/IntegerSingleValueSource.java
@@ -81,13 +81,6 @@ public class IntegerSingleValueSource extends SingleValueColumnSource<Integer> i
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_INT);
-        // endregion null set
-    }
-
-    @Override
     public final int getInt(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_INT;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/IntegerSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/IntegerSparseArraySource.java
@@ -24,6 +24,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -131,14 +132,9 @@ public class IntegerSparseArraySource extends SparseArrayColumnSource<Integer> i
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getInt(i));
-            set(i, NULL_INT);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_INT); return true; });
     }
 
     // region boxed methods
@@ -285,6 +281,11 @@ public class IntegerSparseArraySource extends SparseArrayColumnSource<Integer> i
 
         final IntOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -621,7 +622,7 @@ public class IntegerSparseArraySource extends SparseArrayColumnSource<Integer> i
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final IntChunk<? extends Values> chunk = src.asIntChunk();
@@ -690,7 +691,7 @@ public class IntegerSparseArraySource extends SparseArrayColumnSource<Integer> i
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final IntChunk<? extends Values> chunk = src.asIntChunk();
@@ -744,6 +745,137 @@ public class IntegerSparseArraySource extends SparseArrayColumnSource<Integer> i
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final int [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_INT) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final int[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_INT);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_INT);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final int[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<int[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final int oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_INT) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_INT;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -811,7 +943,7 @@ public class IntegerSparseArraySource extends SparseArrayColumnSource<Integer> i
     // region getChunk
     @Override
     public IntChunk<Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return IntChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/LongSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/LongSingleValueSource.java
@@ -81,13 +81,6 @@ public class LongSingleValueSource extends SingleValueColumnSource<Long> impleme
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_LONG);
-        // endregion null set
-    }
-
-    @Override
     public final long getLong(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_LONG;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ObjectSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ObjectSingleValueSource.java
@@ -69,13 +69,6 @@ public class ObjectSingleValueSource<T> extends SingleValueColumnSource<T> imple
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(null);
-        // endregion null set
-    }
-
-    @Override
     public final T get(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return null;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ObjectSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ObjectSparseArraySource.java
@@ -24,6 +24,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -134,14 +135,9 @@ public class ObjectSparseArraySource<T> extends SparseArrayColumnSource<T> imple
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, get(i));
-            set(i, null);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, null); return true; });
     }
 
     // region boxed methods
@@ -272,6 +268,11 @@ public class ObjectSparseArraySource<T> extends SparseArrayColumnSource<T> imple
 
         final ObjectOneOrN.Block0<T> localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -608,7 +609,7 @@ public class ObjectSparseArraySource<T> extends SparseArrayColumnSource<T> imple
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ObjectChunk<T, ? extends Values> chunk = src.asObjectChunk();
@@ -677,7 +678,7 @@ public class ObjectSparseArraySource<T> extends SparseArrayColumnSource<T> imple
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ObjectChunk<T, ? extends Values> chunk = src.asObjectChunk();
@@ -731,6 +732,137 @@ public class ObjectSparseArraySource<T> extends SparseArrayColumnSource<T> imple
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final T [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != null) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final T [] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, null);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, null);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final T [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<T []> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final T oldValue = block[indexWithinBlock];
+                        if (oldValue != null) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = null;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -798,7 +930,7 @@ public class ObjectSparseArraySource<T> extends SparseArrayColumnSource<T> imple
     // region getChunk
     @Override
     public ObjectChunk<T, Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return ObjectChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShortSingleValueSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShortSingleValueSource.java
@@ -81,13 +81,6 @@ public class ShortSingleValueSource extends SingleValueColumnSource<Short> imple
     }
 
     @Override
-    public final void setNull(long key) {
-        // region null set
-        set(NULL_SHORT);
-        // endregion null set
-    }
-
-    @Override
     public final short getShort(long rowKey) {
         if (rowKey == RowSequence.NULL_ROW_KEY) {
             return NULL_SHORT;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShortSparseArraySource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ShortSparseArraySource.java
@@ -24,6 +24,7 @@ import io.deephaven.engine.table.impl.sources.sparse.LongOneOrN;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.util.SoftRecycler;
 import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -131,14 +132,9 @@ public class ShortSparseArraySource extends SparseArrayColumnSource<Short> imple
         final RowSet.SearchIterator it = (shiftDelta > 0) ? keysToShift.reverseIterator() : keysToShift.searchIterator();
         it.forEachLong((i) -> {
             set(i + shiftDelta, getShort(i));
-            set(i, NULL_SHORT);
+            setNull(i);
             return true;
         });
-    }
-
-    @Override
-    public void remove(RowSet toRemove) {
-        toRemove.forEachRowKey((i) -> { set(i, NULL_SHORT); return true; });
     }
 
     // region boxed methods
@@ -285,6 +281,11 @@ public class ShortSparseArraySource extends SparseArrayColumnSource<Short> imple
 
         final ShortOneOrN.Block0 localPrevBlocks = prevBlocks;
         final LongOneOrN.Block0 localPrevInUse = prevInUse;
+
+        if (localPrevBlocks == null) {
+            assert prevInUse == null;
+            return;
+        }
 
         // there is no reason to allow these to be used anymore; instead we just null them out so that any
         // getPrev calls will immediately return get().
@@ -621,7 +622,7 @@ public class ShortSparseArraySource extends SparseArrayColumnSource<Short> imple
     // region fillFromChunkByRanges
     @Override
     void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ShortChunk<? extends Values> chunk = src.asShortChunk();
@@ -690,7 +691,7 @@ public class ShortSparseArraySource extends SparseArrayColumnSource<Short> imple
     // region fillFromChunkByKeys
     @Override
     void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return;
         }
         final ShortChunk<? extends Values> chunk = src.asShortChunk();
@@ -744,6 +745,137 @@ public class ShortSparseArraySource extends SparseArrayColumnSource<Short> imple
         }
     }
     // endregion fillFromChunkByKeys
+
+    // region nullByRanges
+    @Override
+    void nullByRanges(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final short [] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+
+                if (block == null) {
+                    continue;
+                }
+
+                blockOk.forAllRowKeyRanges((s, e) -> {
+                    final int length = (int)((e - s) + 1);
+
+                    final int sIndexWithinBlock = (int) (s & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+                        boolean prevRequired = false;
+                        for (int jj = 0; jj < length; ++jj) {
+                            final int indexWithinBlock = sIndexWithinBlock + jj;
+                            if (block[indexWithinBlock] != NULL_SHORT) {
+                                prevRequired = true;
+                                break;
+                            }
+                        }
+
+                        if (prevRequired) {
+                            final short[] prevBlock = ensurePrevBlock(firstKey, block0, block1, block2);
+                            final long[] inUse = prevInUse.get(block0).get(block1).get(block2);
+
+                            assert inUse != null;
+                            assert prevBlock != null;
+
+                            for (int jj = 0; jj < length; ++jj) {
+                                final int indexWithinBlock = sIndexWithinBlock + jj;
+                                final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                                final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                                if ((inUse[indexWithinInUse] & maskWithinInUse) == 0) {
+                                    prevBlock[indexWithinBlock] = block[indexWithinBlock];
+                                    inUse[indexWithinInUse] |= maskWithinInUse;
+                                }
+                            }
+
+                            Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_SHORT);
+                        }
+                    } else {
+                        Arrays.fill(block, sIndexWithinBlock, sIndexWithinBlock + length, NULL_SHORT);
+                    }
+                });
+            }
+        }
+    }
+    // endregion nullByRanges
+
+    // region nullByKeys
+    @Override
+    void nullByKeys(@NotNull RowSequence rowSequence) {
+        if (rowSequence.isEmpty()) {
+            return;
+        }
+
+        final boolean hasPrev = prevFlusher != null;
+
+        if (hasPrev) {
+            prevFlusher.maybeActivate();
+        }
+
+        try (RowSequence.Iterator okIt = rowSequence.getRowSequenceIterator()) {
+            while (okIt.hasMore()) {
+                final long firstKey = okIt.peekNextKey();
+                final long maxKeyInCurrentBlock = firstKey | INDEX_MASK;
+                final RowSequence blockOk = okIt.getNextRowSequenceThrough(maxKeyInCurrentBlock);
+
+                final int block0 = (int) (firstKey >> BLOCK0_SHIFT) & BLOCK0_MASK;
+                final int block1 = (int) (firstKey >> BLOCK1_SHIFT) & BLOCK1_MASK;
+                final int block2 = (int) (firstKey >> BLOCK2_SHIFT) & BLOCK2_MASK;
+                final short[] block = blocks.getInnermostBlockByKeyOrNull(firstKey);
+                if (block == null) {
+                    continue;
+                }
+
+                MutableObject<short[]> prevBlock = new MutableObject<>();
+                MutableObject<long[]> inUse = new MutableObject<>();
+
+                blockOk.forAllRowKeys(key -> {
+
+                    final int indexWithinBlock = (int) (key & INDEX_MASK);
+                    // This 'if' with its constant condition should be very friendly to the branch predictor.
+                    if (hasPrev) {
+
+                        final short oldValue = block[indexWithinBlock];
+                        if (oldValue != NULL_SHORT) {
+                            if (prevBlock.getValue() == null) {
+                                prevBlock.setValue(ensurePrevBlock(firstKey, block0, block1, block2));
+                                inUse.setValue(prevInUse.get(block0).get(block1).get(block2));
+                            }
+
+                            final int indexWithinInUse = indexWithinBlock >> LOG_INUSE_BITSET_SIZE;
+                            final long maskWithinInUse = 1L << (indexWithinBlock & IN_USE_MASK);
+
+                            if ((inUse.getValue()[indexWithinInUse] & maskWithinInUse) == 0) {
+                                prevBlock.getValue()[indexWithinBlock] = oldValue;
+                                inUse.getValue()[indexWithinInUse] |= maskWithinInUse;
+                            }
+                        }
+                    }
+                    block[indexWithinBlock] = NULL_SHORT;
+                });
+            }
+        }
+    }
+    // endregion nullByKeys
 
     // region fillFromChunkUnordered
     @Override
@@ -811,7 +943,7 @@ public class ShortSparseArraySource extends SparseArrayColumnSource<Short> imple
     // region getChunk
     @Override
     public ShortChunk<Values> getChunk(@NotNull GetContext context, @NotNull RowSequence rowSequence) {
-        if (rowSequence.size() == 0) {
+        if (rowSequence.isEmpty()) {
             return ShortChunk.getEmptyChunk();
         }
         final long firstKey = rowSequence.firstRowKey();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SingleValueColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SingleValueColumnSource.java
@@ -10,6 +10,8 @@ import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.table.impl.AbstractColumnSource;
 import io.deephaven.engine.table.impl.util.ShiftData;
 
+import static io.deephaven.util.QueryConstants.NULL_BYTE;
+
 public abstract class SingleValueColumnSource<T> extends AbstractColumnSource<T>
         implements WritableColumnSource<T>, ChunkSink<Values>, ShiftData.ShiftCallback, InMemoryColumnSource,
         RowKeyAgnosticChunkSource<Values> {
@@ -96,8 +98,13 @@ public abstract class SingleValueColumnSource<T> extends AbstractColumnSource<T>
     }
 
     @Override
-    public final void setNull(RowSequence orderedKeys) {
-        if (!orderedKeys.isEmpty()) {
+    public final void setNull(long key) {
+        setNull();
+    }
+
+    @Override
+    public final void setNull(RowSequence rowSequence) {
+        if (!rowSequence.isEmpty()) {
             setNull();
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SparseArrayColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/SparseArrayColumnSource.java
@@ -195,7 +195,7 @@ public abstract class SparseArrayColumnSource<T>
     }
 
     public void remove(RowSet toRemove) {
-        throw new UnsupportedOperationException();
+        setNull(toRemove);
     }
 
     public static <T> SparseArrayColumnSource<T> getSparseMemoryColumnSource(Collection<T> data, Class<T> type) {
@@ -404,6 +404,15 @@ public abstract class SparseArrayColumnSource<T>
     // endregion fillChunk
 
     @Override
+    public void setNull(RowSequence rowSequence) {
+        if (rowSequence.getAverageRunLengthEstimate() < USE_RANGES_AVERAGE_RUN_LENGTH) {
+            nullByKeys(rowSequence);
+        } else {
+            nullByRanges(rowSequence);
+        }
+    }
+
+    @Override
     public void fillChunkUnordered(
             @NotNull final FillContext context,
             @NotNull final WritableChunk<? super Values> dest,
@@ -447,6 +456,10 @@ public abstract class SparseArrayColumnSource<T>
     abstract void fillFromChunkByRanges(@NotNull RowSequence rowSequence, Chunk<? extends Values> src);
 
     abstract void fillFromChunkByKeys(@NotNull RowSequence rowSequence, Chunk<? extends Values> src);
+
+    abstract void nullByRanges(@NotNull RowSequence rowSequence);
+
+    abstract void nullByKeys(@NotNull RowSequence rowSequence);
 
     @Override
     public boolean isImmutable() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/IntColumnSourceWritableRowRedirection.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/IntColumnSourceWritableRowRedirection.java
@@ -116,13 +116,18 @@ public final class IntColumnSourceWritableRowRedirection implements WritableRowR
         if (previous == QueryConstants.NULL_INT) {
             return RowSequence.NULL_ROW_KEY;
         }
-        columnSource.set(outerRowKey, QueryConstants.NULL_INT);
+        columnSource.setNull(outerRowKey);
         return previous;
     }
 
     @Override
     public void removeVoid(long outerRowKey) {
-        columnSource.set(outerRowKey, QueryConstants.NULL_INT);
+        columnSource.setNull(outerRowKey);
+    }
+
+    @Override
+    public void removeAll(RowSequence rowSequence) {
+        columnSource.setNull(rowSequence);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/LongColumnSourceWritableRowRedirection.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/LongColumnSourceWritableRowRedirection.java
@@ -8,9 +8,7 @@ import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.table.ChunkSink;
 import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.rowset.chunkattributes.RowKeys;
-import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.util.QueryConstants;
 import org.jetbrains.annotations.NotNull;
 
@@ -45,23 +43,18 @@ public final class LongColumnSourceWritableRowRedirection
         if (previous == QueryConstants.NULL_LONG) {
             return RowSequence.NULL_ROW_KEY;
         }
-        columnSource.set(outerRowKey, QueryConstants.NULL_LONG);
+        columnSource.setNull(outerRowKey);
         return previous;
     }
 
     @Override
     public void removeVoid(long outerRowKey) {
-        columnSource.set(outerRowKey, QueryConstants.NULL_LONG);
+        columnSource.setNull(outerRowKey);
     }
 
     @Override
-    public void removeAll(final RowSequence outerRowKeys) {
-        final int numKeys = outerRowKeys.intSize();
-        try (final ChunkSink.FillFromContext fillFromContext = columnSource.makeFillFromContext(numKeys);
-             final WritableLongChunk<Values> values = WritableLongChunk.makeWritableChunk(numKeys)) {
-            values.fillWithNullValue(0, numKeys);
-            columnSource.fillFromChunk(fillFromContext, values, outerRowKeys);
-        }
+    public void removeAll(final RowSequence rowSequence) {
+        columnSource.setNull(rowSequence);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/WritableRowRedirection.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/WritableRowRedirection.java
@@ -81,12 +81,12 @@ public interface WritableRowRedirection extends RowRedirection, ChunkSink<RowKey
     }
 
     /**
-     * Remove the specified {@code outerRowKeys}.
+     * Remove the specified {@code rowSequence}.
      *
-     * @param outerRowKeys The outer row keys to remove
+     * @param rowSequence The outer row keys to remove
      */
-    default void removeAll(final RowSequence outerRowKeys) {
-        outerRowKeys.forAllRowKeys(this::remove);
+    default void removeAll(final RowSequence rowSequence) {
+        rowSequence.forAllRowKeys(this::remove);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/WritableRowRedirectionLockFree.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/WritableRowRedirectionLockFree.java
@@ -219,12 +219,12 @@ public class WritableRowRedirectionLockFree implements WritableRowRedirection {
     }
 
     @Override
-    public void removeAll(final RowSequence outerRowKeys) {
+    public void removeAll(final RowSequence rowSequence) {
         if (updateCommitter != null) {
             updateCommitter.maybeActivate();
         }
 
-        outerRowKeys.forAllRowKeys(key -> updates.put(key, BASELINE_KEY_NOT_FOUND));
+        rowSequence.forAllRowKeys(key -> updates.put(key, BASELINE_KEY_NOT_FOUND));
     }
 
     @Override

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
@@ -714,6 +714,8 @@ public class ReplicateSourcesAndChunks {
                 "ObjectChunk<[?] super Values>", "ObjectChunk<Boolean, ? super Values>");
         lines = simpleFixup(lines, "primitive get", "NULL_BOOLEAN", "NULL_BOOLEAN_AS_BYTE", "getBoolean", "getByte",
                 "getPrevBoolean", "getPrevByte");
+        lines = simpleFixup(lines, "nullByKeys", "NULL_BOOLEAN", "NULL_BOOLEAN_AS_BYTE");
+        lines = simpleFixup(lines, "nullByRanges", "NULL_BOOLEAN", "NULL_BOOLEAN_AS_BYTE");
         lines = simpleFixup(lines, "setNull", "NULL_BOOLEAN", "NULL_BOOLEAN_AS_BYTE");
 
         lines = replaceRegion(lines, "copyFromTypedArray", Arrays.asList(
@@ -1057,7 +1059,8 @@ public class ReplicateSourcesAndChunks {
                 "recycler2.borrowItem\\(\\)", "(T[][])recycler2.borrowItem()",
                 "recycler1.borrowItem\\(\\)", "(T[][][])recycler1.borrowItem()",
                 "recycler0.borrowItem\\(\\)", "(T[][][][])recycler0.borrowItem()",
-                "public final void set\\(long key, Object value\\) \\{", "public final void set(long key, T value) {");
+                "public final void set\\(long key, Object value\\) \\{", "public final void set(long key, T value) {",
+                "Object oldValue", "T oldValue");
 
         lines = replaceRegion(lines, "recyclers", Arrays.asList(
                 "    private static final SoftRecycler recycler = new SoftRecycler<>(DEFAULT_RECYCLER_CAPACITY,",


### PR DESCRIPTION
Some of the `setNull` port was completed in some of Larry's work this past summer.

I dropped `setNull(long key)` from the implementations of `SingleValueSource`s in favor of a final impl in the abstract base class that redirects to `setNull()`.

Internal JIRA [DH-11656](https://deephaven.atlassian.net/browse/DH-11656)
Internal Commit: [b4ce7833096c56ae0ae166d252ebf952ef167a8e](https://github.com/deephaven-ent/iris/commit/b4ce7833096c56ae0ae166d252ebf952ef167a8e)
Nightlies are [here](https://github.com/nbauernfeind/deephaven-core/actions/runs/3991605260).