### PR TITLE
Fix array copy function for booleans

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
@@ -404,8 +404,7 @@ public class WebBarrageUtils {
                         boolArray[i] = wireValues.get(i);
                     }
                 }
-                return new ByteArrayColumnData(Js.uncheckedCast(boolArray));
-
+                return new BooleanArrayColumnData(boolArray);
             case "byte":
                 assert positions.length().toFloat64() >= size;
                 Int8Array byteArray =

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/SubscriptionTableData.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/SubscriptionTableData.java
@@ -270,7 +270,7 @@ public class SubscriptionTableData {
         switch (type) {
             case "long":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    long value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asLong();
+                    final long value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asLong();
                     if (value == QueryConstants.NULL_LONG) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
                     } else {
@@ -324,18 +324,19 @@ public class SubscriptionTableData {
                 };
             case "java.lang.Boolean":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    int value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asInt();
-                    if (value == 1) {
-                        Js.asArrayLike(destArray).setAt((int) destPos, true);
-                    } else if (value == 0) {
-                        Js.asArrayLike(destArray).setAt((int) destPos, false);
-                    } else {
+                    final Any value = Js.asArrayLike(srcArray).getAtAsAny(srcPos);
+
+                    if (value == null) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
+                    } else if (value.asBoolean()) {
+                        Js.asArrayLike(destArray).setAt((int) destPos, true);
+                    } else {
+                        Js.asArrayLike(destArray).setAt((int) destPos, false);
                     }
                 };
             case "int":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    int value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asInt();
+                    final int value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asInt();
                     if (value == QueryConstants.NULL_INT) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
                     } else {
@@ -344,7 +345,7 @@ public class SubscriptionTableData {
                 };
             case "byte":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    byte value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asByte();
+                    final byte value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asByte();
                     if (value == QueryConstants.NULL_BYTE) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
                     } else {
@@ -353,7 +354,7 @@ public class SubscriptionTableData {
                 };
             case "short":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    short value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asShort();
+                    final short value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asShort();
                     if (value == QueryConstants.NULL_SHORT) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
                     } else {
@@ -362,7 +363,7 @@ public class SubscriptionTableData {
                 };
             case "double":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    double value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asDouble();
+                    final double value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asDouble();
                     if (value == QueryConstants.NULL_DOUBLE) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
                     } else {
@@ -371,7 +372,7 @@ public class SubscriptionTableData {
                 };
             case "float":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    float value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asFloat();
+                    final float value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asFloat();
                     if (value == QueryConstants.NULL_FLOAT) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
                     } else {
@@ -380,7 +381,7 @@ public class SubscriptionTableData {
                 };
             case "char":
                 return (destArray, destPos, srcArray, srcPos) -> {
-                    char value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asChar();
+                    final char value = Js.asArrayLike(srcArray).getAtAsAny(srcPos).asChar();
                     if (value == QueryConstants.NULL_CHAR) {
                         Js.asArrayLike(destArray).setAt((int) destPos, null);
                     } else {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/FigureSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/FigureSubscription.java
@@ -251,7 +251,8 @@ public final class FigureSubscription {
                 return (Promise<TableSubscription>) (Promise) Promise.reject("Already closed");
             }
 
-            TableSubscription sub = table.subscribe(table.getColumns());
+            TableSubscription sub = table.subscribe(
+                    table.getColumns().filter((c, index, all) -> this.requiredColumns.contains(c.getName())));
             // TODO, technically we can probably unsubscribe to the table at this point, since we're listening to the
             // subscription itself
 


### PR DESCRIPTION
- Boolean was encoded as a ByteArrayColumnData in WebBarrageUtils. Converting to an Int was causing a class cast exception
- Use a BooleanArrayColumnData for encoding boolean data instead (BooleanArrayColumnData wasn't being used anywhere)
- Just check for null values, then check the boolean value
- Only subscribe to columns necessary for the current plot instead of all the columns in the table
- Fixes #3356

Tested with the snippets from the ticket, and building plots with the tables. All worked fine.
Also tested with a ticking table with true, false, and null:
```
from deephaven import time_table
tt = time_table("00:00:01").update(["y=Math.sin(i)", "MyBoolean=i%5==0 ? true : i%2 == 0 ? false : null"])
```
Worked as expected without errors.