### PR TITLE
Always set offset of null string in barrage/flight payloads

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarBinaryChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarBinaryChunkInputStreamGenerator.java
@@ -6,6 +6,7 @@ package io.deephaven.extensions.barrage.chunk;
 import com.google.common.io.LittleEndianDataOutputStream;
 import gnu.trove.iterator.TLongIterator;
 import io.deephaven.UncheckedDeephavenException;
+import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.ChunkPositions;
 import io.deephaven.chunk.attributes.Values;
@@ -472,12 +473,14 @@ public class VarBinaryChunkInputStreamGenerator<T> extends BaseChunkInputStreamG
                         }
                         final int offset = offsets.get(ei);
                         final int length = offsets.get(ei + 1) - offset;
+                        Assert.geq(length, "length", 0);
                         if (offset + length > serializedData.length) {
                             throw new IllegalStateException("not enough data was serialized to parse this element: " +
                                     "elementIndex=" + ei + " offset=" + offset + " length=" + length +
                                     " serializedLen=" + serializedData.length);
                         }
-                        chunk.set(outOffset + ei++, mapper.constructFrom(serializedData, offset, length));                        validityWord >>= 1;
+                        chunk.set(outOffset + ei++, mapper.constructFrom(serializedData, offset, length));
+                        validityWord >>= 1;
                         bitsLeftInThisWord--;
                     } else {
                         final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
@@ -73,6 +73,7 @@ public enum JsDataHandler {
             for (int i = 0; i < data.length; i++) {
                 if (data[i] == null) {
                     nullCount++;
+                    positions.setAt(i, (double) lastOffset);
                     continue;
                 }
                 validity.set(i);


### PR DESCRIPTION
Null values must still have an offset assigned, so that the previous entry in the buffer has an ending position declared.

Also fixed whitespace and added an assert in the server's code to read these uploaded columns.

Fixes #3389