### PR TITLE
Update web version to v0.29.0

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,9 +2,9 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.28.0
-ARG GRID_VERSION=0.28.0
-ARG CHART_VERSION=0.28.0
+ARG WEB_VERSION=0.29.0
+ARG GRID_VERSION=0.29.0
+ARG CHART_VERSION=0.29.0
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
- Release notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.29.0
- Expandable rows show tooltip
