### PR TITLE
Add extraHeaders support for java-client

### DIFF
--- a/java-client/example-utilities/src/main/java/io/deephaven/client/examples/ConnectOptions.java
+++ b/java-client/example-utilities/src/main/java/io/deephaven/client/examples/ConnectOptions.java
@@ -12,6 +12,8 @@ import io.deephaven.uri.DeephavenUri;
 import io.grpc.ManagedChannel;
 import picocli.CommandLine.Option;
 
+import java.util.Map;
+
 public class ConnectOptions {
 
     public static final String DEFAULT_HOST = "localhost";
@@ -46,6 +48,9 @@ public class ConnectOptions {
     @Option(names = {"--ssl"}, description = "The optional ssl config file.", converter = SSLConverter.class)
     SSLConfig ssl;
 
+    @Option(names = {"--header"})
+    Map<String, String> headers;
+
     private ClientConfig config() {
         final Builder builder = ClientConfig.builder().target(target);
         if (userAgent != null) {
@@ -56,6 +61,9 @@ public class ConnectOptions {
         }
         if (ssl != null) {
             builder.ssl(ssl);
+        }
+        if (headers != null) {
+            builder.putAllExtraHeaders(headers);
         }
         return builder.build();
     }

--- a/java-client/session/src/main/java/io/deephaven/client/impl/ChannelHelper.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/ChannelHelper.java
@@ -7,14 +7,17 @@ import io.deephaven.ssl.config.SSLConfig;
 import io.deephaven.ssl.config.TrustJdk;
 import io.deephaven.ssl.config.impl.KickstartUtils;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.MetadataUtils;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import nl.altindag.ssl.SSLFactory;
 import nl.altindag.ssl.util.NettySslUtils;
 
 import javax.net.ssl.SSLException;
+import java.util.Map;
 
 public final class ChannelHelper {
 
@@ -62,6 +65,15 @@ public final class ChannelHelper {
             channelBuilder.usePlaintext();
         }
         clientConfig.userAgent().ifPresent(channelBuilder::userAgent);
+        if (!clientConfig.extraHeaders().isEmpty()) {
+            channelBuilder.intercept(MetadataUtils.newAttachHeadersInterceptor(of(clientConfig.extraHeaders())));
+        }
         return channelBuilder.build();
+    }
+
+    private static Metadata of(Map<String, String> map) {
+        final Metadata metadata = new Metadata();
+        map.forEach((k, v) -> metadata.put(Metadata.Key.of(k, Metadata.ASCII_STRING_MARSHALLER), v));
+        return metadata;
     }
 }

--- a/java-client/session/src/main/java/io/deephaven/client/impl/ClientConfig.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/ClientConfig.java
@@ -6,10 +6,10 @@ package io.deephaven.client.impl;
 import io.deephaven.annotations.BuildableStyle;
 import io.deephaven.ssl.config.SSLConfig;
 import io.deephaven.uri.DeephavenTarget;
-import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -41,6 +41,11 @@ public abstract class ClientConfig {
     public abstract Optional<String> userAgent();
 
     /**
+     * The extra headers.
+     */
+    public abstract Map<String, String> extraHeaders();
+
+    /**
      * The maximum inbound message size. Defaults to 100MiB.
      */
     @Default
@@ -55,6 +60,10 @@ public abstract class ClientConfig {
         Builder ssl(SSLConfig ssl);
 
         Builder userAgent(String userAgent);
+
+        Builder putExtraHeaders(String key, String value);
+
+        Builder putAllExtraHeaders(Map<String, ? extends String> entries);
 
         Builder maxInboundMessageSize(int maxInboundMessageSize);
 


### PR DESCRIPTION
This adds the ability for construction of a java-client with extra headers set on every request. This is potentially useful for cases where a proxy needs additional information to be able to route a request. It has been plumbed through the java client example utilities. In the future, we may wish to more formally support these use cases through DeephavenTarget / DH URIs.