### PR TITLE
Compute `UpdateBy` results correctly for in-memory columns

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -201,6 +201,7 @@ public abstract class UpdateBy {
                 .toArray();
         inputCacheNeeded = cacheableSourceIndices.length > 0;
 
+        // noinspection unchecked
         inputSourceCaches = new SoftReference[inputSources.length];
 
         buckets =

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByBucketHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByBucketHelper.java
@@ -319,7 +319,7 @@ class UpdateByBucketHelper extends IntrusiveDoublyLinkedNode.Impl<UpdateByBucket
             // compute the affected/influenced operators and rowsets within this window
             windows[winIdx].computeAffectedRowsAndOperators(windowContexts[winIdx], upstream);
 
-            isDirty |= windows[winIdx].isWindowDirty(windowContexts[winIdx]);
+            isDirty |= windows[winIdx].isWindowBucketDirty(windowContexts[winIdx]);
         }
 
         if (!isDirty) {
@@ -354,7 +354,7 @@ class UpdateByBucketHelper extends IntrusiveDoublyLinkedNode.Impl<UpdateByBucket
      * @param initialStep indicates whether this is part of the creation phase
      */
     public void processWindow(final int winIdx, final boolean initialStep) {
-        if (!windows[winIdx].isWindowDirty(windowContexts[winIdx])) {
+        if (!windows[winIdx].isWindowBucketDirty(windowContexts[winIdx])) {
             return; // no work to do for this bucket window
         }
         windows[winIdx].processRows(windowContexts[winIdx], initialStep);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindow.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindow.java
@@ -2,7 +2,6 @@ package io.deephaven.engine.table.impl.updateby;
 
 import gnu.trove.set.hash.TIntHashSet;
 import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
@@ -267,7 +266,7 @@ abstract class UpdateByWindow {
      *
      * @param context the window context that will manage the results.
      */
-    boolean isWindowDirty(final UpdateByWindowBucketContext context) {
+    boolean isWindowBucketDirty(final UpdateByWindowBucketContext context) {
         return context.isDirty;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindow.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindow.java
@@ -231,7 +231,7 @@ abstract class UpdateByWindow {
     void assignInputSources(final UpdateByWindowBucketContext context, final ColumnSource<?>[] inputSources) {
         context.inputSources = inputSources;
         context.inputSourceGetContexts = new ChunkSource.GetContext[inputSources.length];
-        context.inputSourceChunks = new WritableChunk[inputSources.length];
+        context.inputSourceChunks = new Chunk[inputSources.length];
 
         for (int srcIdx : context.dirtySourceIndices) {
             context.inputSourceGetContexts[srcIdx] =

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
@@ -16,6 +16,7 @@ import io.deephaven.engine.testutil.generator.TestDataGenerator;
 import io.deephaven.engine.testutil.generator.SortedDateTimeGenerator;
 import io.deephaven.engine.updategraph.TerminalNotification;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
+import io.deephaven.engine.util.TableDiff;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.test.types.OutOfBandTest;
 import io.deephaven.util.ExceptionDetails;
@@ -206,6 +207,55 @@ public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateError
 
         TableTools.show(result);
     }
+
+    @Test
+    public void testInMemoryColumn() {
+        final CreateResult result = createTestTable(1000, true, false, false, 0xFEEDFACE,
+                new String[] {"ts"}, new TestDataGenerator[] {new SortedDateTimeGenerator(
+                        convertDateTime("2022-03-09T09:00:00.000 NY"),
+                        convertDateTime("2022-03-09T16:30:00.000 NY"))});
+
+        final OperationControl skipControl = OperationControl.builder()
+                .onNullValue(BadDataBehavior.SKIP)
+                .onNanValue(BadDataBehavior.SKIP).build();
+
+        final String[] columnNamesArray = result.t.getDefinition().getColumnNamesArray();
+        final Collection<? extends UpdateByOperation> clauses = List.of(
+                UpdateByOperation.Fill(),
+                UpdateByOperation.RollingSum(100, 0,
+                        makeOpColNames(columnNamesArray, "_rollsumticksrev", "Sym", "ts", "boolCol")),
+                UpdateByOperation.RollingSum("ts", Duration.ofMinutes(15), Duration.ofMinutes(0),
+                        makeOpColNames(columnNamesArray, "_rollsumtimerev", "Sym", "ts", "boolCol")),
+                UpdateByOperation.RollingSum(0, 100,
+                        makeOpColNames(columnNamesArray, "_rollsumticksfwd", "Sym", "ts", "boolCol")),
+                UpdateByOperation.RollingSum(-50, 100,
+                        makeOpColNames(columnNamesArray, "_rollsumticksfwdex", "Sym", "ts", "boolCol")),
+                UpdateByOperation.RollingSum("ts", Duration.ofMinutes(0), Duration.ofMinutes(15),
+                        makeOpColNames(columnNamesArray, "_rollsumtimefwd", "Sym", "ts", "boolCol")),
+                UpdateByOperation.RollingSum("ts", Duration.ofMinutes(-10), Duration.ofMinutes(15),
+                        makeOpColNames(columnNamesArray, "_rollsumtimefwdex", "Sym", "ts", "boolCol")),
+                UpdateByOperation.RollingSum(50, 50,
+                        makeOpColNames(columnNamesArray, "_rollsumticksfwdrev", "Sym", "ts",
+                                "boolCol")),
+                UpdateByOperation.RollingSum("ts", Duration.ofMinutes(5), Duration.ofMinutes(5),
+                        makeOpColNames(columnNamesArray, "_rollsumtimebothfwdrev", "Sym", "ts",
+                                "boolCol")),
+
+                UpdateByOperation.Ema(skipControl, "ts", 10 * MINUTE,
+                        makeOpColNames(columnNamesArray, "_ema", "Sym", "ts", "boolCol")),
+                UpdateByOperation.CumSum(makeOpColNames(columnNamesArray, "_sum", "Sym", "ts")),
+                UpdateByOperation.CumMin(makeOpColNames(columnNamesArray, "_min", "boolCol")),
+                UpdateByOperation.CumMax(makeOpColNames(columnNamesArray, "_max", "boolCol")),
+                UpdateByOperation
+                        .CumProd(makeOpColNames(columnNamesArray, "_prod", "Sym", "ts", "boolCol")));
+        final UpdateByControl control = UpdateByControl.builder().useRedirection(false).build();
+
+        final Table table = result.t.updateBy(control, clauses, ColumnName.from("Sym"));
+        final Table memoryTable = result.t.select().updateBy(control, clauses, ColumnName.from("Sym"));
+
+        TstUtils.assertTableEquals("msg", table, memoryTable, TableDiff.DiffItems.DoublesExact);
+    }
+
 
     @Override
     public void reportUpdateError(Throwable t) {


### PR DESCRIPTION
@pete-petey uncovered a bug when attempting to compute output values for in-memory sources.  The reproducing python code is the following:
```
import os
import deephaven.pandas as dhpd
os.system('pip install Nasdaq-Data-Link')

import nasdaqdatalink
mydata = dhpd.to_table(nasdaqdatalink.get("WIKI/MSFT")).update("Sym = `MSFT`")

from deephaven.updateby import rolling_sum_tick
rev_ticks = 10
fwd_ticks = 0

rolling_volume = mydata.update_by([
    rolling_sum_tick(cols="Rolling_Volume = Adj_Volume", rev_ticks=10, fwd_ticks=0)], by="Sym")
```

The error is that the output columns from UpdateBy are not computed but remain `null`. 

This fix addresses the root problem and provides a test case to ensure that the in-memory input source columns are computed correctly.