### PR TITLE
Fixed `seekRow` Error on Char Column

### DIFF
--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -319,7 +319,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
             if (BigInteger.class.isAssignableFrom(dataType)) {
                 return new BigInteger(literal.getStringValue());
             }
-            if (!String.class.isAssignableFrom(dataType)) {
+            if (!String.class.isAssignableFrom(dataType) && dataType != char.class) {
                 throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "Invalid String type for seek: " + dataType);
             }


### PR DESCRIPTION
Previously, calling `seekRow` with a `Char` Column would throw an error. This is now fixed.