### PR TITLE
Explicitly set platform for amd64-only images

### DIFF
--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -564,6 +564,7 @@ class Docker {
 
         String imageName = project.property('deephaven.registry.imageName')
         String imageId = project.property('deephaven.registry.imageId')
+        String platform = project.findProperty('deephaven.registry.platform')
         boolean ignoreOutOfDate = project.hasProperty('deephaven.registry.ignoreOutOfDate') ?
                 'true' == project.property('deephaven.registry.ignoreOutOfDate') :
                 false
@@ -578,6 +579,9 @@ class Docker {
             pull.group = 'Docker Registry'
             pull.description = "Release management task: Pulls '${imageName}'"
             pull.image.set imageName
+            if (platform != null) {
+                pull.platform.set platform
+            }
         }
 
         def bumpImage = project.tasks.register('bumpImage', DockerInspectImage) {inspect ->

--- a/buildSrc/src/main/groovy/Docker.groovy
+++ b/buildSrc/src/main/groovy/Docker.groovy
@@ -579,9 +579,6 @@ class Docker {
             pull.group = 'Docker Registry'
             pull.description = "Release management task: Pulls '${imageName}'"
             pull.image.set imageName
-            if (platform != null) {
-                pull.platform.set platform
-            }
         }
 
         def bumpImage = project.tasks.register('bumpImage', DockerInspectImage) {inspect ->
@@ -677,6 +674,9 @@ class Docker {
             build.inputs.files dockerFileTask.outputs.files
             build.dockerFile.set dockerFileTask.outputs.files.singleFile
             build.images.add("deephaven/${project.projectDir.name}:local-build".toString())
+            if (platform != null) {
+                build.platform.set platform
+            }
         }
     }
 

--- a/docker/registry/cpp-client-base/gradle.properties
+++ b/docker/registry/cpp-client-base/gradle.properties
@@ -1,4 +1,5 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/cpp-client-base:latest
 deephaven.registry.imageId=ghcr.io/deephaven/cpp-client-base@sha256:5b6e1749437170c0b0a3ebe5755c38fdbe3645b7c409cf8a72bc6a6acf50eebe
+# TODO(deephaven-base-images#54): arm64 native image for cpp-client-base
 deephaven.registry.platform=linux/amd64

--- a/docker/registry/cpp-client-base/gradle.properties
+++ b/docker/registry/cpp-client-base/gradle.properties
@@ -1,3 +1,4 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/cpp-client-base:latest
 deephaven.registry.imageId=ghcr.io/deephaven/cpp-client-base@sha256:5b6e1749437170c0b0a3ebe5755c38fdbe3645b7c409cf8a72bc6a6acf50eebe
+deephaven.registry.platform=linux/amd64

--- a/docker/registry/protoc-base/gradle.properties
+++ b/docker/registry/protoc-base/gradle.properties
@@ -1,4 +1,5 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/protoc-base:latest
 deephaven.registry.imageId=ghcr.io/deephaven/protoc-base@sha256:dcbde68539a04be744963d1f3c90c30be1c7f75d291635d2f1efc3ee0c0167ed
+# TODO(deephaven-base-images#55): arm64 native image for protoc-base
 deephaven.registry.platform=linux/amd64

--- a/docker/registry/protoc-base/gradle.properties
+++ b/docker/registry/protoc-base/gradle.properties
@@ -1,3 +1,4 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/protoc-base:latest
 deephaven.registry.imageId=ghcr.io/deephaven/protoc-base@sha256:dcbde68539a04be744963d1f3c90c30be1c7f75d291635d2f1efc3ee0c0167ed
+deephaven.registry.platform=linux/amd64


### PR DESCRIPTION
This adds in a specific platform modifier for images that only support amd64.

This allows the update command `./docker/registry/scripts/update-requirements.sh` to work without extra intervention (that Colin had to take previously when we were updating protoc-base).

https://github.com/deephaven/deephaven-base-images/issues/54
https://github.com/deephaven/deephaven-base-images/issues/55
