### PR TITLE
Add read_sql in the dbc package

### DIFF
--- a/py/server/deephaven/dbc/__init__.py
+++ b/py/server/deephaven/dbc/__init__.py
@@ -1,5 +1,35 @@
 #
 #     Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
 #
+"""The dbc package includes the modules and functions for using external databases with Deephaven."""
 
-"""The dbc package includes the modules for using external databases with Deephaven."""
+from deephaven import DHError
+from deephaven.table import Table
+import deephaven.arrow as dharrow
+
+
+def read_sql(conn: str, query: str) -> Table:
+    """Executes the provided SQL query via ConnectorX and returns a Deephaven table.
+
+    Args:
+        conn (str): a connection string URI, please refer to https://sfu-db.github.io/connector-x/databases.html for
+            database specific format
+        query (str): SQL query statement
+
+    Returns:
+        a new Table
+
+    Raises:
+        DHError
+    """
+    try:
+        import connectorx as cx
+    except ImportError:
+        raise DHError(message="import ConnectorX failed, please install it first.")
+
+    try:
+        pa_table = cx.read_sql(conn=conn, query=query, return_type="arrow")
+    except Exception as e:
+        raise DHError(e, message="failed to get a Arrow table from ConnectorX.") from e
+
+    return dharrow.to_table(pa_table)

--- a/py/server/deephaven/dbc/adbc.py
+++ b/py/server/deephaven/dbc/adbc.py
@@ -9,11 +9,9 @@ ADBC defines a standard API to fetch data in Arrow format from databases that su
 from databases that only support ODBC/JDBC. By relying on ADBC, Deephaven is able to ingest data efficiently from a
 wide variety of data sources. """
 
-from typing import Any
-
-from deephaven.table import Table
-from deephaven import arrow as dharrow
 from deephaven import DHError
+from deephaven import arrow as dharrow
+from deephaven.table import Table
 
 try:
     import adbc_driver_manager.dbapi
@@ -26,8 +24,8 @@ def read_cursor(cursor: adbc_driver_manager.dbapi.Cursor) -> Table:
     """Converts the result set of the provided cursor into a Deephaven table.
 
     Args:
-        cursor (Any): an ADBC DB-API cursor. Prior to it being passed in, its execute() method must be called to
-            run a query operation that produces an Arrow table
+        cursor (adbc_driver_manager.dbapi.Cursor): an ADBC DB-API cursor. Prior to it being passed in, its execute()
+            method must be called to run a query operation that produces an Arrow table
 
     Returns:
         a new Table

--- a/py/server/deephaven/dbc/odbc.py
+++ b/py/server/deephaven/dbc/odbc.py
@@ -8,8 +8,6 @@ Turbodbc is DB-API 2.0 compliant, provides access to relational databases via th
 importantly it has optimized, built-in Apache Arrow support when fetching ODBC result sets. This enables Deephaven to
 achieve maximum efficiency when ingesting relational data. """
 
-from typing import Any
-
 from deephaven import DHError
 from deephaven import arrow as dharrow
 from deephaven.table import Table
@@ -25,8 +23,8 @@ def read_cursor(cursor: turbodbc.cursor.Cursor) -> Table:
     """Converts the result set of the provided cursor into a Deephaven table.
 
     Args:
-        cursor (Any): a Turbodbc cursor. Prior to it being passed in, its execute() method must be called to run a query
-            operation that produces a result set
+        cursor (turbodbc.cursor.Cursor): a Turbodbc cursor. Prior to it being passed in, its execute() method must be
+            called to run a query operation that produces a result set
 
     Returns:
         a new Table

--- a/py/server/tests/test_dbc.py
+++ b/py/server/tests/test_dbc.py
@@ -5,7 +5,8 @@ import unittest
 
 import turbodbc
 
-from deephaven.dbc import odbc as dhodbc, adbc as dhadbc
+from deephaven import DHError
+from deephaven.dbc import odbc as dhodbc, adbc as dhadbc, read_sql
 from tests.testbase import BaseTestCase
 
 
@@ -31,6 +32,13 @@ class DbcTestCase(BaseTestCase):
                 # This is not ideal but ADBC might have a bug regarding cursor.rowcount it currently returns -1
                 # instead of the actual size
                 self.assertEqual(table.size, 10)
+
+    def test_read_sql(self):
+        postgres_url = "postgresql://test:test@postgres:5432/test"
+        query = "SELECT t_ts, t_id, t_instrument, t_exchange, t_price, t_size FROM CRYPTO_TRADES LIMIT 10"
+        dh_table = read_sql(conn=postgres_url, query=query)
+        self.assertEqual(len(dh_table.columns), 6)
+        self.assertEqual(dh_table.size, 10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #3430

1. add the read_sql() function. ***Note that it is a package-level function so the handling of the optional dependency on ConnectorX is different from the adbc/odbc modules***
2. clean up existing code a bit