### PR TITLE
Avoid creating a Java array when we can simply use the existing instance

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -124,7 +124,7 @@ public class TableViewportSubscription extends HasEventHandling {
                     batcher.setFlat(true);
                 });
                 // TODO handle updateInterval core#188
-                Column[] columnsToSub = table.isStreamTable() ? table.getColumns().asArray(new Column[0]) : columns;
+                Column[] columnsToSub = table.isStreamTable() ? Js.uncheckedCast(table.getColumns()) : columns;
                 table.setInternalViewport(firstRow, lastRow, columnsToSub);
 
                 // Listen for events and refire them on ourselves, optionally on the original table


### PR DESCRIPTION
This sidesteps the issue where copying an array was attempting to write type information to a frozen object.

Fixes #3437