### PR TITLE
Fix automcomplete suggestions overwriting existing text

### DIFF
--- a/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
+++ b/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
@@ -37,7 +37,7 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
     private final Provider<ScriptSession> scriptSession;
 
     public PythonAutoCompleteObserver(StreamObserver<AutoCompleteResponse> responseObserver,
-                                      Provider<ScriptSession> scriptSession, final SessionState session) {
+            Provider<ScriptSession> scriptSession, final SessionState session) {
         super(session, responseObserver);
         this.scriptSession = scriptSession;
     }
@@ -98,8 +98,8 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
     }
 
     private void getCompletionItems(GetCompletionItemsRequest request,
-                                    SessionState.ExportObject<ScriptSession> exportedConsole,
-                                    StreamObserver<AutoCompleteResponse> responseObserver) {
+            SessionState.ExportObject<ScriptSession> exportedConsole,
+            StreamObserver<AutoCompleteResponse> responseObserver) {
         final ScriptSession scriptSession = exportedConsole.get();
         try (final SafeCloseable ignored = scriptSession.getExecutionContext().open()) {
 

--- a/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
+++ b/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
@@ -37,7 +37,7 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
     private final Provider<ScriptSession> scriptSession;
 
     public PythonAutoCompleteObserver(StreamObserver<AutoCompleteResponse> responseObserver,
-            Provider<ScriptSession> scriptSession, final SessionState session) {
+                                      Provider<ScriptSession> scriptSession, final SessionState session) {
         super(session, responseObserver);
         this.scriptSession = scriptSession;
     }
@@ -98,8 +98,8 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
     }
 
     private void getCompletionItems(GetCompletionItemsRequest request,
-            SessionState.ExportObject<ScriptSession> exportedConsole,
-            StreamObserver<AutoCompleteResponse> responseObserver) {
+                                    SessionState.ExportObject<ScriptSession> exportedConsole,
+                                    StreamObserver<AutoCompleteResponse> responseObserver) {
         final ScriptSession scriptSession = exportedConsole.get();
         try (final SafeCloseable ignored = scriptSession.getExecutionContext().open()) {
 
@@ -157,7 +157,7 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
                 item.setLabel(completionName);
                 item.setLength(completionName.length());
                 range.getStartBuilder().setLine(pos.getLine()).setCharacter(start);
-                range.getEndBuilder().setLine(pos.getLine()).setCharacter(start + completionName.length());
+                range.getEndBuilder().setLine(pos.getLine()).setCharacter(pos.getCharacter());
                 item.setInsertTextFormat(2);
                 item.setSortText(ChunkerCompleter.sortable(finalItems.size()));
                 finalItems.add(item.build());


### PR DESCRIPTION
Fixes #3363 

`TextEdit.range` should be the range of characters to be replaced, not the range of the inserted characters. For completions that should just be the original range

We should maybe change our returned `TextEdit` to use `newText` instead of `text` to match the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit). That would require a 1 line change in the web UI, and it probably needs to support both options since the monaco component is re-used in enterprise