### PR TITLE
Add dropColumns as TableOperations / TableSpec

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -304,12 +304,6 @@ public interface Table extends
     Table updateView(Selectable... newColumns);
 
     @ConcurrentMethod
-    Table dropColumns(Collection<String> columnNames);
-
-    @ConcurrentMethod
-    Table dropColumns(String... columnNames);
-
-    @ConcurrentMethod
     Table dropColumnFormats();
 
     Table renameColumns(MatchPair... pairs);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1106,10 +1106,7 @@ public class QueryTable extends BaseTable<QueryTable> {
         }
 
         if (isFlat()) {
-            if (isRefreshing()) {
-                manageWithCurrentScope();
-            }
-            return this;
+            return prepareReturnThis();
         }
 
         return getResult(new FlattenOperation(this));
@@ -1342,10 +1339,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     @Override
     public Table view(final Collection<? extends Selectable> viewColumns) {
         if (viewColumns == null || viewColumns.isEmpty()) {
-            if (isRefreshing()) {
-                manageWithCurrentScope();
-            }
-            return this;
+            return prepareReturnThis();
         }
         return viewOrUpdateView(Flavor.View, SelectColumn.from(viewColumns));
     }
@@ -1357,10 +1351,7 @@ public class QueryTable extends BaseTable<QueryTable> {
 
     private Table viewOrUpdateView(Flavor flavor, final SelectColumn... viewColumns) {
         if (viewColumns == null || viewColumns.length == 0) {
-            if (isRefreshing()) {
-                manageWithCurrentScope();
-            }
-            return this;
+            return prepareReturnThis();
         }
 
         final String humanReadablePrefix = flavor.toString();
@@ -1477,6 +1468,9 @@ public class QueryTable extends BaseTable<QueryTable> {
 
     @Override
     public Table dropColumns(String... columnNames) {
+        if (columnNames == null || columnNames.length == 0) {
+            return prepareReturnThis();
+        }
         return memoizeResult(MemoizedOperationKey.dropColumns(columnNames), () -> QueryPerformanceRecorder
                 .withNugget("dropColumns(" + Arrays.toString(columnNames) + ")", sizeForInstrumentation(), () -> {
                     final Mutable<Table> result = new MutableObject<>();
@@ -1547,10 +1541,7 @@ public class QueryTable extends BaseTable<QueryTable> {
         return QueryPerformanceRecorder.withNugget("renameColumns(" + matchString(pairs) + ")",
                 sizeForInstrumentation(), () -> {
                     if (pairs == null || pairs.length == 0) {
-                        if (isRefreshing()) {
-                            manageWithCurrentScope();
-                        }
-                        return this;
+                        return prepareReturnThis();
                     }
 
                     checkInitiateOperation();
@@ -2199,18 +2190,12 @@ public class QueryTable extends BaseTable<QueryTable> {
     public Table sort(Collection<SortColumn> columnsToSortBy) {
         final SortPair[] sortPairs = SortPair.from(columnsToSortBy);
         if (sortPairs.length == 0) {
-            if (isRefreshing()) {
-                manageWithCurrentScope();
-            }
-            return this;
+            return prepareReturnThis();
         } else if (sortPairs.length == 1) {
             final String columnName = sortPairs[0].getColumn();
             final SortingOrder order = sortPairs[0].getOrder();
             if (SortedColumnsAttribute.isSortedBy(this, columnName, order)) {
-                if (isRefreshing()) {
-                    manageWithCurrentScope();
-                }
-                return this;
+                return prepareReturnThis();
             }
         }
 
@@ -2263,10 +2248,7 @@ public class QueryTable extends BaseTable<QueryTable> {
         return QueryPerformanceRecorder.withNugget("ungroup(" + Arrays.toString(columnsToUngroupBy) + ")",
                 sizeForInstrumentation(), () -> {
                     if (columnsToUngroupBy.length == 0) {
-                        if (isRefreshing()) {
-                            manageWithCurrentScope();
-                        }
-                        return this;
+                        return prepareReturnThis();
                     }
 
                     checkInitiateOperation();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
@@ -266,13 +266,6 @@ public interface TableDefaults extends Table, TableOperationsDefaults<Table, Tab
     @Override
     @ConcurrentMethod
     @FinalDefault
-    default Table dropColumns(Collection<String> columnNames) {
-        return dropColumns(columnNames.toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
-    }
-
-    @Override
-    @ConcurrentMethod
-    @FinalDefault
     default Table dropColumnFormats() {
         String[] columnAry = getDefinition().getColumnStream()
                 .map(ColumnDefinition::getName)

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/PartitionedTableProxyImpl.java
@@ -15,6 +15,7 @@ import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.LivenessArtifact;
 import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.PartitionedTable;
+import io.deephaven.engine.table.PartitionedTable.Proxy;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.TableUpdate;
@@ -569,6 +570,11 @@ class PartitionedTableProxyImpl extends LivenessArtifact implements PartitionedT
     @Override
     public PartitionedTable.Proxy ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup) {
         return basicTransform(ct -> ct.ungroup(nullFill, columnsToUngroup));
+    }
+
+    @Override
+    public PartitionedTable.Proxy dropColumns(String... columnNames) {
+        return basicTransform(ct -> ct.dropColumns(columnNames));
     }
 
     // endregion TableOperations Implementation

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -553,18 +553,21 @@ public class QueryTableTest extends QueryTableTestBase {
         final List<ColumnSource<?>> colSources =
                 Arrays.asList(TableTools.objColSource("c", "e", "g"), colSource(2, 4, 6), colSource(1.0, 2.0, 3.0));
         final Table table = newTable(3, colNames, colSources);
-        assertEquals(3, table.dropColumns().getColumnSources().size());
+        assertEquals(3, table.dropColumns(Collections.emptyList()).getColumnSources().size());
         Collection<? extends ColumnSource<?>> columnSourcesAfterDrop = table.getColumnSources();
         ColumnSource<?>[] columnsAfterDrop =
                 columnSourcesAfterDrop.toArray(ColumnSource.ZERO_LENGTH_COLUMN_SOURCE_ARRAY);
-        Collection<? extends ColumnSource<?>> columnSources = table.dropColumns().getColumnSources();
+        Collection<? extends ColumnSource<?>> columnSources =
+                table.dropColumns(Collections.emptyList()).getColumnSources();
         ColumnSource<?>[] columns = columnSources.toArray(ColumnSource.ZERO_LENGTH_COLUMN_SOURCE_ARRAY);
         assertSame(columns[0], columnsAfterDrop[0]);
         assertSame(columns[1], columnsAfterDrop[1]);
         assertSame(columns[2], columnsAfterDrop[2]);
-        assertSame(table.getColumnSource("String"), table.dropColumns().getColumnSource("String"));
-        assertSame(table.getColumnSource("Int"), table.dropColumns().getColumnSource("Int"));
-        assertSame(table.getColumnSource("Double"), table.dropColumns().getColumnSource("Double"));
+        assertSame(table.getColumnSource("String"),
+                table.dropColumns(Collections.emptyList()).getColumnSource("String"));
+        assertSame(table.getColumnSource("Int"), table.dropColumns(Collections.emptyList()).getColumnSource("Int"));
+        assertSame(table.getColumnSource("Double"),
+                table.dropColumns(Collections.emptyList()).getColumnSource("Double"));
 
         assertEquals(2, table.dropColumns("Int").getColumnSources().size());
         columnSourcesAfterDrop = table.dropColumns("Int").getColumnSources();

--- a/java-client/session/src/main/java/io/deephaven/client/impl/BatchTableRequestBuilder.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/BatchTableRequestBuilder.java
@@ -41,6 +41,7 @@ import io.deephaven.proto.backplane.grpc.CreateInputTableRequest.InputTableKind;
 import io.deephaven.proto.backplane.grpc.CreateInputTableRequest.InputTableKind.InMemoryAppendOnly;
 import io.deephaven.proto.backplane.grpc.CreateInputTableRequest.InputTableKind.InMemoryKeyBacked;
 import io.deephaven.proto.backplane.grpc.CrossJoinTablesRequest;
+import io.deephaven.proto.backplane.grpc.DropColumnsRequest;
 import io.deephaven.proto.backplane.grpc.EmptyTableRequest;
 import io.deephaven.proto.backplane.grpc.ExactJoinTablesRequest;
 import io.deephaven.proto.backplane.grpc.FetchTableRequest;
@@ -73,6 +74,7 @@ import io.deephaven.qst.table.AggregateTable;
 import io.deephaven.qst.table.AsOfJoinTable;
 import io.deephaven.qst.table.Clock.Visitor;
 import io.deephaven.qst.table.ClockSystem;
+import io.deephaven.qst.table.DropColumnsTable;
 import io.deephaven.qst.table.EmptyTable;
 import io.deephaven.qst.table.ExactJoinTable;
 import io.deephaven.qst.table.HeadTable;
@@ -503,6 +505,17 @@ class BatchTableRequestBuilder {
                 request.addColumnsToUngroup(ungroupColumn.name());
             }
             out = op(Builder::setUngroup, request);
+        }
+
+        @Override
+        public void visit(DropColumnsTable dropColumnsTable) {
+            final DropColumnsRequest.Builder request = DropColumnsRequest.newBuilder()
+                    .setResultId(ticket)
+                    .setSourceId(ref(dropColumnsTable.parent()));
+            for (ColumnName dropColumn : dropColumnsTable.dropColumns()) {
+                request.addColumnNames(dropColumn.name());
+            }
+            out = op(Builder::setDropColumns, request);
         }
 
         private SelectOrUpdateRequest selectOrUpdate(SingleParentTable x,

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -440,7 +440,7 @@ class Table(JObjectWrapper):
         """
         try:
             cols = to_sequence(cols)
-            return Table(j_table=self.j_table.dropColumns(j_array_list(cols)))
+            return Table(j_table=self.j_table.dropColumns(*cols))
         except Exception as e:
             raise DHError(e, "table drop_columns operation failed.") from e
 

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -440,7 +440,7 @@ class Table(JObjectWrapper):
         """
         try:
             cols = to_sequence(cols)
-            return Table(j_table=self.j_table.dropColumns(*cols))
+            return Table(j_table=self.j_table.dropColumns(j_array_list(cols)))
         except Exception as e:
             raise DHError(e, "table drop_columns operation failed.") from e
 

--- a/qst/graphviz/src/main/java/io/deephaven/graphviz/LabelBuilder.java
+++ b/qst/graphviz/src/main/java/io/deephaven/graphviz/LabelBuilder.java
@@ -7,6 +7,7 @@ import io.deephaven.api.Strings;
 import io.deephaven.qst.table.AggregateAllTable;
 import io.deephaven.qst.table.AggregateTable;
 import io.deephaven.qst.table.AsOfJoinTable;
+import io.deephaven.qst.table.DropColumnsTable;
 import io.deephaven.qst.table.EmptyTable;
 import io.deephaven.qst.table.ExactJoinTable;
 import io.deephaven.qst.table.HeadTable;
@@ -195,6 +196,13 @@ public class LabelBuilder extends TableVisitorGeneric {
     public void visit(UngroupTable ungroupTable) {
         sb.append("ungroup(").append(ungroupTable.nullFill()).append(",[");
         append(Strings::of, ungroupTable.ungroupColumns(), sb);
+        sb.append("])");
+    }
+
+    @Override
+    public void visit(DropColumnsTable dropColumnsTable) {
+        sb.append("dropColumns([");
+        append(Strings::of, dropColumnsTable.dropColumns(), sb);
         sb.append("])");
     }
 

--- a/qst/src/main/java/io/deephaven/qst/TableAdapterImpl.java
+++ b/qst/src/main/java/io/deephaven/qst/TableAdapterImpl.java
@@ -10,6 +10,7 @@ import io.deephaven.qst.TableAdapterResults.Output;
 import io.deephaven.qst.table.AggregateAllTable;
 import io.deephaven.qst.table.AggregateTable;
 import io.deephaven.qst.table.AsOfJoinTable;
+import io.deephaven.qst.table.DropColumnsTable;
 import io.deephaven.qst.table.EmptyTable;
 import io.deephaven.qst.table.ExactJoinTable;
 import io.deephaven.qst.table.HeadTable;
@@ -307,6 +308,12 @@ class TableAdapterImpl<TOPS extends TableOperations<TOPS, TABLE>, TABLE> impleme
     public void visit(UngroupTable ungroupTable) {
         addOp(ungroupTable, parentOps(ungroupTable)
                 .ungroup(ungroupTable.nullFill(), ungroupTable.ungroupColumns()));
+    }
+
+    @Override
+    public void visit(DropColumnsTable dropColumnsTable) {
+        addOp(dropColumnsTable,
+                parentOps(dropColumnsTable).dropColumns(dropColumnsTable.dropColumns().toArray(new ColumnName[0])));
     }
 
     private final class OutputTable implements Output<TOPS, TABLE> {

--- a/qst/src/main/java/io/deephaven/qst/table/DropColumnsTable.java
+++ b/qst/src/main/java/io/deephaven/qst/table/DropColumnsTable.java
@@ -29,13 +29,6 @@ public abstract class DropColumnsTable extends TableBase implements SingleParent
         return visitor;
     }
 
-    @Check
-    final void checkNonEmpty() {
-        if (dropColumns().isEmpty()) {
-            throw new IllegalArgumentException("Expected dropColumns() to be non-empty");
-        }
-    }
-
     public interface Builder {
         Builder parent(TableSpec parent);
 

--- a/qst/src/main/java/io/deephaven/qst/table/DropColumnsTable.java
+++ b/qst/src/main/java/io/deephaven/qst/table/DropColumnsTable.java
@@ -36,7 +36,7 @@ public abstract class DropColumnsTable extends TableBase implements SingleParent
         }
     }
 
-    interface Builder {
+    public interface Builder {
         Builder parent(TableSpec parent);
 
         Builder addDropColumns(ColumnName element);

--- a/qst/src/main/java/io/deephaven/qst/table/DropColumnsTable.java
+++ b/qst/src/main/java/io/deephaven/qst/table/DropColumnsTable.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.qst.table;
+
+import io.deephaven.annotations.NodeStyle;
+import io.deephaven.api.ColumnName;
+import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import java.util.List;
+
+@Immutable
+@NodeStyle
+public abstract class DropColumnsTable extends TableBase implements SingleParentTable {
+
+    public static Builder builder() {
+        return ImmutableDropColumnsTable.builder();
+    }
+
+    public abstract TableSpec parent();
+
+    public abstract List<ColumnName> dropColumns();
+
+    @Override
+    public final <V extends Visitor> V walk(V visitor) {
+        visitor.visit(this);
+        return visitor;
+    }
+
+    @Check
+    final void checkNonEmpty() {
+        if (dropColumns().isEmpty()) {
+            throw new IllegalArgumentException("Expected dropColumns() to be non-empty");
+        }
+    }
+
+    interface Builder {
+        Builder parent(TableSpec parent);
+
+        Builder addDropColumns(ColumnName element);
+
+        Builder addDropColumns(ColumnName... elements);
+
+        Builder addAllDropColumns(Iterable<? extends ColumnName> elements);
+
+        DropColumnsTable build();
+    }
+}

--- a/qst/src/main/java/io/deephaven/qst/table/ParentsVisitor.java
+++ b/qst/src/main/java/io/deephaven/qst/table/ParentsVisitor.java
@@ -296,6 +296,11 @@ public class ParentsVisitor implements Visitor {
         out = single(ungroupTable);
     }
 
+    @Override
+    public void visit(DropColumnsTable dropColumnsTable) {
+        out = single(dropColumnsTable);
+    }
+
     private static class Search {
 
         private final Predicate<TableSpec> excludePaths;

--- a/qst/src/main/java/io/deephaven/qst/table/TableBase.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableBase.java
@@ -933,6 +933,31 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
+    public final DropColumnsTable dropColumns(String... columnNames) {
+        final DropColumnsTable.Builder builder = DropColumnsTable.builder()
+                .parent(this);
+        for (String columnName : columnNames) {
+            builder.addDropColumns(ColumnName.of(columnName));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public final DropColumnsTable dropColumns(Collection<String> columnNames) {
+        final DropColumnsTable.Builder builder = DropColumnsTable.builder()
+                .parent(this);
+        for (String columnName : columnNames) {
+            builder.addDropColumns(ColumnName.of(columnName));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public final DropColumnsTable dropColumns(ColumnName[] columnNames) {
+        return DropColumnsTable.builder().parent(this).addDropColumns(columnNames).build();
+    }
+
+    @Override
     public final <V extends TableSchema.Visitor> V walk(V visitor) {
         visitor.visit(this);
         return visitor;

--- a/qst/src/main/java/io/deephaven/qst/table/TableBase.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableBase.java
@@ -953,7 +953,7 @@ public abstract class TableBase implements TableSpec {
     }
 
     @Override
-    public final DropColumnsTable dropColumns(ColumnName[] columnNames) {
+    public final DropColumnsTable dropColumns(ColumnName... columnNames) {
         return DropColumnsTable.builder().parent(this).addDropColumns(columnNames).build();
     }
 

--- a/qst/src/main/java/io/deephaven/qst/table/TableSpec.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableSpec.java
@@ -157,5 +157,7 @@ public interface TableSpec extends TableOperations<TableSpec, TableSpec>, TableS
         void visit(UpdateByTable updateByTable);
 
         void visit(UngroupTable ungroupTable);
+
+        void visit(DropColumnsTable dropColumnsTable);
     }
 }

--- a/qst/src/main/java/io/deephaven/qst/table/TableVisitorGeneric.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TableVisitorGeneric.java
@@ -151,4 +151,9 @@ public abstract class TableVisitorGeneric implements TableSpec.Visitor {
     public void visit(UngroupTable ungroupTable) {
         accept(ungroupTable);
     }
+
+    @Override
+    public void visit(DropColumnsTable dropColumnsTable) {
+        accept(dropColumnsTable);
+    }
 }

--- a/qst/src/main/java/io/deephaven/qst/table/TimeTable.java
+++ b/qst/src/main/java/io/deephaven/qst/table/TimeTable.java
@@ -79,7 +79,7 @@ public abstract class TimeTable extends TableBase {
         }
     }
 
-    interface Builder {
+    public interface Builder {
         Builder clock(Clock clock);
 
         Builder interval(Duration interval);

--- a/qst/src/main/java/io/deephaven/qst/table/UngroupTable.java
+++ b/qst/src/main/java/io/deephaven/qst/table/UngroupTable.java
@@ -33,7 +33,7 @@ public abstract class UngroupTable extends TableBase implements SingleParentTabl
         return visitor;
     }
 
-    interface Builder {
+    public interface Builder {
         Builder parent(TableSpec parent);
 
         Builder addUngroupColumns(ColumnName element);

--- a/table-api/src/main/java/io/deephaven/api/TableOperations.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperations.java
@@ -1302,27 +1302,30 @@ public interface TableOperations<TOPS extends TableOperations<TOPS, TABLE>, TABL
     // -------------------------------------------------------------------------------------------
 
     /**
-     * Drop the {@code columnNames} from {@code this} table.
+     * Creates a new table without the {@code columnNames} from {@code this}.
      *
      * @param columnNames the columns to drop
      * @return the table
      */
+    @ConcurrentMethod
     TOPS dropColumns(String... columnNames);
 
     /**
-     * Drop the {@code columnNames} from {@code this} table.
+     * Creates a new table without the {@code columnNames} from {@code this}.
      *
      * @param columnNames the columns to drop
      * @return the table
      */
+    @ConcurrentMethod
     TOPS dropColumns(Collection<String> columnNames);
 
     /**
-     * Drop the {@code columnNames} from {@code this} table.
+     * Creates a new table without the {@code columnNames} from {@code this}.
      *
      * @param columnNames the columns to drop
      * @return the table
      */
+    @ConcurrentMethod
     TOPS dropColumns(ColumnName... columnNames);
 
     // -------------------------------------------------------------------------------------------

--- a/table-api/src/main/java/io/deephaven/api/TableOperations.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperations.java
@@ -1300,4 +1300,31 @@ public interface TableOperations<TOPS extends TableOperations<TOPS, TABLE>, TABL
     TOPS ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup);
 
     // -------------------------------------------------------------------------------------------
+
+    /**
+     * Drop the {@code columnNames} from {@code this} table.
+     *
+     * @param columnNames the columns to drop
+     * @return the table
+     */
+    TOPS dropColumns(String... columnNames);
+
+    /**
+     * Drop the {@code columnNames} from {@code this} table.
+     *
+     * @param columnNames the columns to drop
+     * @return the table
+     */
+    TOPS dropColumns(Collection<String> columnNames);
+
+    /**
+     * Drop the {@code columnNames} from {@code this} table.
+     *
+     * @param columnNames the columns to drop
+     * @return the table
+     */
+    TOPS dropColumns(ColumnName[] columnNames);
+
+    // -------------------------------------------------------------------------------------------
+
 }

--- a/table-api/src/main/java/io/deephaven/api/TableOperations.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperations.java
@@ -1323,7 +1323,7 @@ public interface TableOperations<TOPS extends TableOperations<TOPS, TABLE>, TABL
      * @param columnNames the columns to drop
      * @return the table
      */
-    TOPS dropColumns(ColumnName[] columnNames);
+    TOPS dropColumns(ColumnName... columnNames);
 
     // -------------------------------------------------------------------------------------------
 

--- a/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
@@ -685,4 +685,19 @@ public abstract class TableOperationsAdapter<TOPS_1 extends TableOperations<TOPS
     public final TOPS_1 ungroup(boolean nullFill, Collection<? extends ColumnName> columnsToUngroup) {
         return adapt(delegate.ungroup(nullFill, columnsToUngroup));
     }
+
+    @Override
+    public final TOPS_1 dropColumns(String... columnNames) {
+        return adapt(delegate.dropColumns(columnNames));
+    }
+
+    @Override
+    public final TOPS_1 dropColumns(Collection<String> columnNames) {
+        return adapt(delegate.dropColumns(columnNames));
+    }
+
+    @Override
+    public final TOPS_1 dropColumns(ColumnName[] columnNames) {
+        return adapt(delegate.dropColumns(columnNames));
+    }
 }

--- a/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperationsAdapter.java
@@ -697,7 +697,7 @@ public abstract class TableOperationsAdapter<TOPS_1 extends TableOperations<TOPS
     }
 
     @Override
-    public final TOPS_1 dropColumns(ColumnName[] columnNames) {
+    public final TOPS_1 dropColumns(ColumnName... columnNames) {
         return adapt(delegate.dropColumns(columnNames));
     }
 }

--- a/table-api/src/main/java/io/deephaven/api/TableOperationsDefaults.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperationsDefaults.java
@@ -698,7 +698,7 @@ public interface TableOperationsDefaults<TOPS extends TableOperations<TOPS, TABL
 
     @Override
     @ConcurrentMethod
-    default TOPS dropColumns(ColumnName[] columnNames) {
+    default TOPS dropColumns(ColumnName... columnNames) {
         return dropColumns(Arrays.stream(columnNames).map(ColumnName::name).toArray(String[]::new));
     }
 

--- a/table-api/src/main/java/io/deephaven/api/TableOperationsDefaults.java
+++ b/table-api/src/main/java/io/deephaven/api/TableOperationsDefaults.java
@@ -690,6 +690,20 @@ public interface TableOperationsDefaults<TOPS extends TableOperations<TOPS, TABL
 
     // -------------------------------------------------------------------------------------------
 
+    @Override
+    @ConcurrentMethod
+    default TOPS dropColumns(Collection<String> columnNames) {
+        return dropColumns(columnNames.toArray(new String[0]));
+    }
+
+    @Override
+    @ConcurrentMethod
+    default TOPS dropColumns(ColumnName[] columnNames) {
+        return dropColumns(Arrays.stream(columnNames).map(ColumnName::name).toArray(String[]::new));
+    }
+
+    // -------------------------------------------------------------------------------------------
+
     static Collection<String> splitToCollection(String string) {
         return string.trim().isEmpty() ? Collections.emptyList()
                 : Arrays.stream(string.split(",")).map(String::trim).filter(s -> !s.isEmpty())


### PR DESCRIPTION
This is in support of #3473, where for adapting implementation purposes, it's cleaner and easier to use dropColumns.