### PR TITLE
JS API should only show non-constituent columns in groupedColumns array

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -358,7 +358,7 @@ public class JsTreeTable extends HasEventHandling {
             if (definition.isVisible()) {
                 columns[columns.length] = column;
             }
-            if (definition.isRollupGroupByColumn()) {
+            if (definition.isRollupGroupByColumn() && !definition.isRollupConstituentNodeColumn()) {
                 groupedColumns.push(column);
 
                 if (hasConstituentColumns) {


### PR DESCRIPTION
Fixes #3477