### PR TITLE
Remove 0.0.1 release number from client pydocs

### DIFF
--- a/py/client/docs/source/conf.py
+++ b/py/client/docs/source/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, Deephaven Data Labs'
 author = 'Deephaven Data Labs'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+#release = '0.0.1'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Matches what we are doing with the server pydocs at sphinx/source/conf.py