### PR TITLE
GitHub action to update the web version

### DIFF
--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -52,7 +52,7 @@ jobs:
           GRID_VERSION: ${{steps.web_versions.outputs.GRID_VERSION}}
           CHART_VERSION: ${{steps.web_versions.outputs.CHART_VERSION}}
         with:
-          # TODO: We need to add a PAT so that we can push to my fork probably
+          # TODO: We need to add a PAT so that we can push to my fork probably... or do we?
 #          path: ./deephaven-core
           base: main
           title: Update web version ${{ env.WEB_VERSION }}

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -21,7 +21,7 @@ jobs:
         id: web_versions
         run: |
           echo "npm version is $(npm --version)"
-          echo "WEB_VERSION=0.34.0" >> $GITHUB_OUTPUT
+          echo "WEB_VERSION=0.29.0" >> $GITHUB_OUTPUT
           echo "GRID_VERSION=$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
           echo "CHART_VERSION=$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
       - name: Update deephaven-core

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -1,16 +1,15 @@
 # This workflow will automatically create a PR in deephaven-core to update the WEB_VERSION
 name: Update web version
 
-on:
-  workflow_dispatch:
-  repository_dispatch:
-    types: [update_web]
+on: workflow_dispatch
 jobs:
   update-web:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout latest deephaven-core
+      - name: Checkout latest
         uses: actions/checkout@v3
+        with:
+          ref: main
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -38,5 +37,5 @@ jobs:
           base: main
           title: Update web version ${{ env.WEB_VERSION }}
           body: Release notes https://github.com/deephaven/web-client-ui/releases/tag/v${{ env.WEB_VERSION }}
-          branch: update-web-test-${{ env.WEB_VERSION }}
+          branch: deephaven-bot/update-web-${{ env.WEB_VERSION }}
           delete-branch: true

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -1,12 +1,10 @@
-# This workflow will automatically create a PR in deephaven-core to update the WEB_VERSION when a new web version is published
+# This workflow will automatically create a PR in deephaven-core to update the WEB_VERSION
 name: Update web version
 
 on:
   workflow_dispatch:
   repository_dispatch:
     types: [update_web]
-  # TODO: Remove `pull_request`, just used for debugging right now
-  pull_request:
 jobs:
   update-web:
     runs-on: ubuntu-22.04
@@ -20,8 +18,7 @@ jobs:
       - name: Get web versions
         id: web_versions
         run: |
-          echo "npm version is $(npm --version)"
-          echo "WEB_VERSION=0.29.0" >> $GITHUB_OUTPUT
+          echo "WEB_VERSION=$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
           echo "GRID_VERSION=$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
           echo "CHART_VERSION=$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
       - name: Update deephaven-core

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -1,0 +1,64 @@
+# This workflow will automatically create a PR in deephaven-core to update the WEB_VERSION when a new web version is published
+name: Update deephaven-core web version
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [update_web]
+  # TODO: Remove `pull_request`, just used for debugging right now
+  pull_request:
+jobs:
+  update-web:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout latest deephaven-core
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - name: Get web versions
+        id: web_versions
+        run: |
+          echo "WEB_VERSION<<$(npm info @deephaven/code-studio@latest version" >> $GITHUB_OUTPUT
+          echo "GRID_VERSION<<$(npm info @deephaven/embed-grid@latest version" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION<<$(npm info @deephaven/embed-chart@latest version" >> $GITHUB_OUTPUT
+      - name: Update deephaven-core
+        env:
+          WEB_VERSION: ${{steps.web_versions.outputs.WEB_VERSION}}
+          GRID_VERSION: ${{steps.web_versions.outputs.GRID_VERSION}}
+          CHART_VERSION: ${{steps.web_versions.outputs.CHART_VERSION}}
+        run: |
+          echo "`pwd`"
+          echo "code-studio version is $WEB_VERSION, $GRID_VERSION, $CHART_VERSION"
+          git status
+          # git log
+          # git checkout -b update-web-$WEB_VERSION
+          sed -i "s/^ARG WEB_VERSION=.*/ARG WEB_VERSION=$WEB_VERSION/" ./web/client-ui/Dockerfile
+          sed -i "s/^ARG GRID_VERSION=.*/ARG GRID_VERSION=$GRID_VERSION/" ./web/client-ui/Dockerfile
+          sed -i "s/^ARG CHART_VERSION=.*/ARG CHART_VERSION=$CHART_VERSION/" ./web/client-ui/Dockerfile
+          # if [ -z "$(git status --porcelain)" ]; then
+          #   echo "No changes, versions up to date. Exiting"
+          #   exit 0
+          # fi
+          git status
+          git diff
+          # git commit --all --message="Update web version v$WEB_VERSION"
+          # git log
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        env:
+          WEB_VERSION: ${{steps.web_versions.outputs.WEB_VERSION}}
+          GRID_VERSION: ${{steps.web_versions.outputs.GRID_VERSION}}
+          CHART_VERSION: ${{steps.web_versions.outputs.CHART_VERSION}}
+        with:
+          # TODO: We need to add a PAT so that we can push to my fork probably
+#          path: ./deephaven-core
+          base: main
+          title: Update web version ${{ env.WEB_VERSION }}
+          body: Release notes https://github.com/deephaven/web-client-ui/releases/tag/${{ env.WEB_VERSION }}
+          branch: update-web-test-${{ env.WEB_VERSION }}
+          delete-branch: true
+#          token: ${{ secrets.CORE_PR_TOKEN }}
+          # push-to-fork: mofojed/deephaven-core
+          draft: true

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [update_web]
+  pull_request:
 jobs:
   update-web:
     runs-on: ubuntu-22.04
@@ -18,7 +19,7 @@ jobs:
       - name: Get web versions
         id: web_versions
         run: |
-          echo "WEB_VERSION=$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
+          echo "WEB_VERSION=0.30.0" >> $GITHUB_OUTPUT
           echo "GRID_VERSION=$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
           echo "CHART_VERSION=$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
       - name: Update deephaven-core
@@ -36,6 +37,6 @@ jobs:
           WEB_VERSION: ${{steps.web_versions.outputs.WEB_VERSION}}
         with:
           title: Update web version ${{ env.WEB_VERSION }}
-          body: Release notes https://github.com/deephaven/web-client-ui/releases/tag/${{ env.WEB_VERSION }}
+          body: Release notes https://github.com/deephaven/web-client-ui/releases/tag/v${{ env.WEB_VERSION }}
           branch: update-web-test-${{ env.WEB_VERSION }}
           delete-branch: true

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types: [update_web]
-  pull_request:
 jobs:
   update-web:
     runs-on: ubuntu-22.04
@@ -19,7 +18,7 @@ jobs:
       - name: Get web versions
         id: web_versions
         run: |
-          echo "WEB_VERSION=0.30.0" >> $GITHUB_OUTPUT
+          echo "WEB_VERSION=$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
           echo "GRID_VERSION=$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
           echo "CHART_VERSION=$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
       - name: Update deephaven-core

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -21,8 +21,6 @@ jobs:
         id: web_versions
         run: |
           echo "npm version is $(npm --version)"
-#               TODO: Revert this back
-#          echo "WEB_VERSION=$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
           echo "WEB_VERSION=0.34.0" >> $GITHUB_OUTPUT
           echo "GRID_VERSION=$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
           echo "CHART_VERSION=$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -21,7 +21,9 @@ jobs:
         id: web_versions
         run: |
           echo "npm version is $(npm --version)"
-          echo "WEB_VERSION=$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
+#               TODO: Revert this back
+#          echo "WEB_VERSION=$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
+          echo "WEB_VERSION=0.34.0" >> $GITHUB_OUTPUT
           echo "GRID_VERSION=$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
           echo "CHART_VERSION=$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
       - name: Update deephaven-core

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -1,5 +1,5 @@
 # This workflow will automatically create a PR in deephaven-core to update the WEB_VERSION when a new web version is published
-name: Update deephaven-core web version
+name: Update web version
 
 on:
   workflow_dispatch:
@@ -20,9 +20,9 @@ jobs:
       - name: Get web versions
         id: web_versions
         run: |
-          echo "WEB_VERSION<<$(npm info @deephaven/code-studio@latest version" >> $GITHUB_OUTPUT
-          echo "GRID_VERSION<<$(npm info @deephaven/embed-grid@latest version" >> $GITHUB_OUTPUT
-          echo "CHART_VERSION<<$(npm info @deephaven/embed-chart@latest version" >> $GITHUB_OUTPUT
+          echo "WEB_VERSION<<$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
+          echo "GRID_VERSION<<$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION<<$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
       - name: Update deephaven-core
         env:
           WEB_VERSION: ${{steps.web_versions.outputs.WEB_VERSION}}

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           WEB_VERSION: ${{steps.web_versions.outputs.WEB_VERSION}}
         with:
+          base: main
           title: Update web version ${{ env.WEB_VERSION }}
           body: Release notes https://github.com/deephaven/web-client-ui/releases/tag/v${{ env.WEB_VERSION }}
           branch: update-web-test-${{ env.WEB_VERSION }}

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: Checkout latest deephaven-core
         uses: actions/checkout@v3
-      - name: Setup Node
+      - name: Get web versions
+        id: web_versions
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-      - name: Get web versions
-        id: web_versions
         run: |
+          echo "npm version is $(npm --version)"
           echo "WEB_VERSION<<$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
           echo "GRID_VERSION<<$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
           echo "CHART_VERSION<<$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -13,11 +13,12 @@ jobs:
     steps:
       - name: Checkout latest deephaven-core
         uses: actions/checkout@v3
-      - name: Get web versions
-        id: web_versions
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
+      - name: Get web versions
+        id: web_versions
         run: |
           echo "npm version is $(npm --version)"
           echo "WEB_VERSION<<$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -30,36 +30,15 @@ jobs:
           GRID_VERSION: ${{steps.web_versions.outputs.GRID_VERSION}}
           CHART_VERSION: ${{steps.web_versions.outputs.CHART_VERSION}}
         run: |
-          echo "`pwd`"
-          echo "code-studio version is $WEB_VERSION, $GRID_VERSION, $CHART_VERSION"
-          git status
-          # git log
-          # git checkout -b update-web-$WEB_VERSION
           sed -i "s/^ARG WEB_VERSION=.*/ARG WEB_VERSION=$WEB_VERSION/" ./web/client-ui/Dockerfile
           sed -i "s/^ARG GRID_VERSION=.*/ARG GRID_VERSION=$GRID_VERSION/" ./web/client-ui/Dockerfile
           sed -i "s/^ARG CHART_VERSION=.*/ARG CHART_VERSION=$CHART_VERSION/" ./web/client-ui/Dockerfile
-          # if [ -z "$(git status --porcelain)" ]; then
-          #   echo "No changes, versions up to date. Exiting"
-          #   exit 0
-          # fi
-          git status
-          git diff
-          # git commit --all --message="Update web version v$WEB_VERSION"
-          # git log
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         env:
           WEB_VERSION: ${{steps.web_versions.outputs.WEB_VERSION}}
-          GRID_VERSION: ${{steps.web_versions.outputs.GRID_VERSION}}
-          CHART_VERSION: ${{steps.web_versions.outputs.CHART_VERSION}}
         with:
-          # TODO: We need to add a PAT so that we can push to my fork probably... or do we?
-#          path: ./deephaven-core
-          base: main
           title: Update web version ${{ env.WEB_VERSION }}
           body: Release notes https://github.com/deephaven/web-client-ui/releases/tag/${{ env.WEB_VERSION }}
           branch: update-web-test-${{ env.WEB_VERSION }}
           delete-branch: true
-#          token: ${{ secrets.CORE_PR_TOKEN }}
-          # push-to-fork: mofojed/deephaven-core
-          draft: true

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -21,9 +21,9 @@ jobs:
         id: web_versions
         run: |
           echo "npm version is $(npm --version)"
-          echo "WEB_VERSION<<$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
-          echo "GRID_VERSION<<$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
-          echo "CHART_VERSION<<$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
+          echo "WEB_VERSION=$(npm info @deephaven/code-studio@latest version)" >> $GITHUB_OUTPUT
+          echo "GRID_VERSION=$(npm info @deephaven/embed-grid@latest version)" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION=$(npm info @deephaven/embed-chart@latest version)" >> $GITHUB_OUTPUT
       - name: Update deephaven-core
         env:
           WEB_VERSION: ${{steps.web_versions.outputs.WEB_VERSION}}


### PR DESCRIPTION
- GitHub action that automatically updates the web versions to the latest and create a Pull Request for it
- Can be triggered manually through `workflow_dispatch`, or eventually will trigger it automatically from `web-client-ui` repo when publishing web packages action is completed
- Tested against my own repository. Example PR that was created there: https://github.com/mofojed/deephaven-core/pull/7
- If already at the latest version, then action exits successfully