### PR TITLE
Move rpcWrapper to gRPC Interceptor; Open Session's ExecutionContext

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
@@ -19,6 +19,7 @@ import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
 import io.deephaven.extensions.barrage.chunk.ChunkInputStreamGenerator;
 import io.deephaven.extensions.barrage.table.BarrageTable;
 import io.deephaven.io.streams.ByteBufferInputStream;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import org.apache.arrow.flatbuf.Message;
 import org.apache.arrow.flatbuf.MessageHeader;
@@ -157,7 +158,7 @@ public class ArrowToTableConverter {
 
     protected void parseSchema(final Schema header) {
         if (resultTable != null) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Schema evolution not supported");
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Schema evolution not supported");
         }
 
         final BarrageUtil.ConvertedArrowSchema result = BarrageUtil.convertArrowSchema(header);
@@ -218,7 +219,7 @@ public class ArrowToTableConverter {
             }
 
             if (acd.data.get(0).size() != numRowsAdded) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "Inconsistent num records per column: " + numRowsAdded + " != " + acd.data.get(0).size());
             }
             acd.type = columnTypes[ci];

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -32,6 +32,7 @@ import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.flight.util.MessageHelper;
 import io.deephaven.proto.flight.util.SchemaHelper;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.time.DateTime;
 import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.util.ColumnFormatting;
@@ -293,7 +294,7 @@ public class BarrageUtil {
                             return long.class;
                     }
                 }
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
                         " of intType(signed=" + intType.getIsSigned() + ", bitWidth=" + intType.getBitWidth() + ")");
             case Bool:
                 return boolean.class;
@@ -303,7 +304,7 @@ public class BarrageUtil {
                 if (maybeConvertForTimeUnit(durationUnit, result, i)) {
                     return long.class;
                 }
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
                         " of durationType(unit=" + durationUnit.toString() + ")");
             case Timestamp:
                 final ArrowType.Timestamp timestampType = (ArrowType.Timestamp) arrowType;
@@ -314,7 +315,7 @@ public class BarrageUtil {
                         return DateTime.class;
                     }
                 }
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
                         " of timestampType(Timezone=" + tz +
                         ", Unit=" + timestampUnit.toString() + ")");
             case FloatingPoint:
@@ -326,13 +327,13 @@ public class BarrageUtil {
                         return double.class;
                     case HALF:
                     default:
-                        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
                                 " of floatingPointType(Precision=" + floatingPointType.getPrecision().toString() + ")");
                 }
             case Utf8:
                 return java.lang.String.class;
             default:
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
                         " of type " + arrowType.getTypeID().toString());
         }
     }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
@@ -5,75 +5,16 @@ package io.deephaven.extensions.barrage.util;
 
 import io.deephaven.io.logger.Logger;
 import com.google.rpc.Code;
-import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.proto.util.Exceptions;
 import io.deephaven.util.FunctionalInterfaces;
-import io.deephaven.util.SafeCloseable;
 import io.deephaven.internal.log.LoggerFactory;
-import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
-import java.io.IOException;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 
 public class GrpcUtil {
     private static final Logger log = LoggerFactory.getLogger(GrpcUtil.class);
-
-    /**
-     * Utility to avoid errors escaping to the stream, to make sure the server log and client both see the message if
-     * there is an error, and if the error was not meant to propagate to a gRPC client, obfuscates it.
-     *
-     * @param log the current class's logger
-     * @param response the responseStream used to send messages to the client
-     * @param lambda the code to safely execute
-     * @param <T> some IOException type, so that we can handle IO errors as well as runtime exceptions.
-     */
-    public static <T extends IOException> void rpcWrapper(final Logger log, final StreamObserver<?> response,
-            final FunctionalInterfaces.ThrowingRunnable<T> lambda) {
-        try (final SafeCloseable ignored = LivenessScopeStack.open()) {
-            lambda.run();
-        } catch (final StatusRuntimeException err) {
-            if (err.getStatus().equals(Status.UNAUTHENTICATED)) {
-                log.info().append("ignoring unauthenticated request").endl();
-            } else {
-                log.error().append(err).endl();
-            }
-            safelyError(response, err);
-        } catch (final RuntimeException | IOException err) {
-            safelyError(response, securelyWrapError(log, err));
-        }
-    }
-
-    /**
-     * Utility to avoid errors escaping to the stream, to make sure the server log and client both see the message if
-     * there is an error, and if the error was not meant to propagate to a gRPC client, obfuscates it.
-     *
-     * @param log the current class's logger
-     * @param response the responseStream used to send messages to the client
-     * @param lambda the code to safely execute
-     * @param <T> the type of the value to be returned
-     * @return the result of the lambda
-     */
-    public static <T> T rpcWrapper(final Logger log, final StreamObserver<?> response, final Callable<T> lambda) {
-        try (final SafeCloseable ignored = LivenessScopeStack.open()) {
-            return lambda.call();
-        } catch (final StatusRuntimeException err) {
-            if (err.getStatus().equals(Status.UNAUTHENTICATED)) {
-                log.info().append("ignoring unauthenticated request").endl();
-            } else {
-                log.error().append(err).endl();
-            }
-            safelyError(response, err);
-        } catch (final InterruptedException err) {
-            Thread.currentThread().interrupt();
-            safelyError(response, securelyWrapError(log, err, Code.UNAVAILABLE));
-        } catch (final Throwable err) {
-            safelyError(response, securelyWrapError(log, err));
-        }
-        return null;
-    }
 
     public static StatusRuntimeException securelyWrapError(final Logger log, final Throwable err) {
         return securelyWrapError(log, err, Code.INVALID_ARGUMENT);
@@ -87,11 +28,7 @@ public class GrpcUtil {
 
         final UUID errorId = UUID.randomUUID();
         log.error().append("Internal Error '").append(errorId.toString()).append("' ").append(err).endl();
-        return statusRuntimeException(statusCode, "Details Logged w/ID '" + errorId + "'");
-    }
-
-    public static StatusRuntimeException statusRuntimeException(final Code statusCode, final String details) {
-        return Exceptions.statusRuntimeException(statusCode, details);
+        return Exceptions.statusRuntimeException(statusCode, "Details Logged w/ID '" + errorId + "'");
     }
 
     /**
@@ -155,7 +92,7 @@ public class GrpcUtil {
      * stream.
      */
     public static void safelyError(final StreamObserver<?> observer, final Code statusCode, final String msg) {
-        safelyError(observer, statusRuntimeException(statusCode, msg));
+        safelyError(observer, Exceptions.statusRuntimeException(statusCode, msg));
     }
 
     /**

--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationFactory.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationFactory.java
@@ -13,8 +13,8 @@ import io.deephaven.appmode.ScriptApplication;
 import io.deephaven.appmode.StaticClassApplication;
 import io.deephaven.engine.util.GroovyDeephavenSession;
 import io.deephaven.engine.util.ScriptSession;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.integrations.python.PythonDeephavenSession;
+import io.deephaven.proto.util.Exceptions;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -77,7 +77,7 @@ public class ApplicationFactory implements ApplicationConfig.Visitor {
 
     @Override
     public void visit(QSTApplication qst) {
-        throw GrpcUtil.statusRuntimeException(Code.UNIMPLEMENTED, "See deephaven-core#1080; support qst application");
+        throw Exceptions.statusRuntimeException(Code.UNIMPLEMENTED, "See deephaven-core#1080; support qst application");
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
@@ -22,6 +22,7 @@ import io.deephaven.server.session.SessionState;
 import io.deephaven.server.util.Scheduler;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -125,22 +126,21 @@ public class ApplicationServiceGrpcImpl extends ApplicationServiceGrpc.Applicati
     }
 
     @Override
-    public synchronized void listFields(ListFieldsRequest request,
-            StreamObserver<FieldsChangeUpdate> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
-            final Subscription subscription = new Subscription(session, responseObserver);
+    public synchronized void listFields(
+            @NotNull final ListFieldsRequest request,
+            @NotNull final StreamObserver<FieldsChangeUpdate> responseObserver) {
+        final SessionState session = sessionService.getCurrentSession();
+        final Subscription subscription = new Subscription(session, responseObserver);
 
-            final FieldsChangeUpdate.Builder responseBuilder = FieldsChangeUpdate.newBuilder();
-            for (FieldInfo fieldInfo : known.values()) {
-                responseBuilder.addCreated(fieldInfo);
-            }
-            if (subscription.send(responseBuilder.build())) {
-                subscriptions.add(subscription);
-            } else {
-                subscription.onCancel();
-            }
-        });
+        final FieldsChangeUpdate.Builder responseBuilder = FieldsChangeUpdate.newBuilder();
+        for (FieldInfo fieldInfo : known.values()) {
+            responseBuilder.addCreated(fieldInfo);
+        }
+        if (subscription.send(responseBuilder.build())) {
+            subscriptions.add(subscription);
+        } else {
+            subscription.onCancel();
+        }
     }
 
     synchronized void remove(Subscription sub) {

--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationTicketResolver.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationTicketResolver.java
@@ -9,7 +9,6 @@ import io.deephaven.appmode.ApplicationState;
 import io.deephaven.appmode.Field;
 import io.deephaven.base.string.EncodingInfo;
 import io.deephaven.engine.table.Table;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.Ticket;
 import io.deephaven.proto.flight.util.TicketRouterHelper;
 import io.deephaven.proto.util.ApplicationTicketHelper;
@@ -74,13 +73,13 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
 
     private <T> SessionState.ExportObject<T> resolve(final AppFieldId id, final String logId) {
         if (id.app == null) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': field '" + getLogNameFor(id)
                             + "' does not belong to an application");
         }
         final Field<Object> field = id.app.getField(id.fieldName);
         if (field == null) {
-            throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+            throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                     "Could not resolve '" + logId + "': field '" + getLogNameFor(id) + "' not found");
         }
         Object value = authTransformation.transform(field.value());
@@ -93,7 +92,7 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
             final @Nullable SessionState session, final Flight.FlightDescriptor descriptor, final String logId) {
         final AppFieldId id = appFieldIdFor(descriptor, logId);
         if (id.app == null) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': field does not belong to an application");
         }
 
@@ -101,7 +100,7 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
         synchronized (id.app) {
             Field<?> field = id.app.getField(id.fieldName);
             if (field == null) {
-                throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+                throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                         "Could not resolve '" + logId + "': field '" + getLogNameFor(id) + "' not found");
             }
             Object value = field.value();
@@ -109,7 +108,7 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
                 value = authTransformation.transform(value);
                 info = TicketRouter.getFlightInfo((Table) value, descriptor, flightTicketForName(id.app, id.fieldName));
             } else {
-                throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+                throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                         "Could not resolve '" + logId + "': field '" + getLogNameFor(id) + "' is not a flight");
             }
         }
@@ -120,14 +119,14 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
     @Override
     public <T> SessionState.ExportBuilder<T> publish(
             SessionState session, ByteBuffer ticket, final String logId) {
-        throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+        throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                 "Could not publish '" + logId + "': application tickets cannot be published to");
     }
 
     @Override
     public <T> SessionState.ExportBuilder<T> publish(
             final SessionState session, final Flight.FlightDescriptor descriptor, final String logId) {
-        throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+        throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                 "Could not publish '" + logId + "': application flight descriptors cannot be published to");
     }
 
@@ -210,7 +209,7 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
         try {
             ticketAsString = decoder.decode(ticket).toString();
         } catch (CharacterCodingException e) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': failed to decode: " + e.getMessage());
         } finally {
             ticket.position(initialPosition);
@@ -221,7 +220,7 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
         final int endOfAppId = ticketAsString.indexOf('/', endOfRoute + 1);
         final int endOfFieldSegment = ticketAsString.indexOf('/', endOfAppId + 1);
         if (endOfAppId == -1 || endOfFieldSegment == -1) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': ticket does conform to expected format");
         }
         final String appId = ticketAsString.substring(endOfRoute + 1, endOfAppId);
@@ -229,7 +228,7 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
 
         final ApplicationState app = applicationMap.get(appId);
         if (app == null) {
-            throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+            throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                     "Could not resolve '" + logId + "': no application exists with the identifier: " + appId);
         }
 
@@ -243,13 +242,13 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
         }
 
         if (descriptor.getType() != Flight.FlightDescriptor.DescriptorType.PATH) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': only flight paths are supported");
         }
 
         // current structure: a/app_id/f/field_name
         if (descriptor.getPathCount() != 4) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': unexpected path length (found: "
                             + TicketRouterHelper.getLogNameFor(descriptor) + ", expected: 4)");
         }
@@ -257,12 +256,12 @@ public class ApplicationTicketResolver extends TicketResolverBase implements App
         final String appId = descriptor.getPath(1);
         final ApplicationState app = applicationMap.get(appId);
         if (app == null) {
-            throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+            throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                     "Could not resolve '" + logId + "': no application exists with the identifier: " + appId);
         }
 
         if (!descriptor.getPath(2).equals(ApplicationTicketHelper.FIELD_PATH_SEGMENT)) {
-            throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+            throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                     "Could not resolve '" + logId + "': path is not an application field");
         }
 

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -133,9 +133,10 @@ public class ArrowFlightUtil {
             final MessageInfo mi;
             try {
                 mi = BarrageProtoUtil.parseProtoMessage(request);
-            } catch (IOException err) {
-                throw new UncheckedDeephavenException("Failed to parse barrage proto message", err);
+            } catch (final IOException err) {
+                throw GrpcUtil.securelyWrapError(log, err);
             }
+
             if (mi.descriptor != null) {
                 if (flightDescriptor != null) {
                     if (!flightDescriptor.equals(mi.descriptor)) {
@@ -334,8 +335,8 @@ public class ArrowFlightUtil {
             MessageInfo message;
             try {
                 message = BarrageProtoUtil.parseProtoMessage(request);
-            } catch (IOException err) {
-                throw new UncheckedDeephavenException("Unable to parse barrage proto message request", err);
+            } catch (final IOException err) {
+                throw GrpcUtil.securelyWrapError(log, err);
             }
             synchronized (this) {
 
@@ -428,8 +429,8 @@ public class ArrowFlightUtil {
                 if (requestHandler != null) {
                     requestHandler.close();
                 }
-            } catch (IOException ioException) {
-                throw new UncheckedDeephavenException("IOException closing handler", ioException);
+            } catch (final IOException err) {
+                throw GrpcUtil.securelyWrapError(log, err);
             }
 
             release();

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -31,6 +31,7 @@ import io.deephaven.extensions.barrage.util.BarrageUtil;
 import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.proto.util.ExportTicketHelper;
 import io.deephaven.server.barrage.BarrageMessageProducer;
 import io.deephaven.extensions.barrage.BarrageStreamGeneratorImpl;
@@ -129,53 +130,56 @@ public class ArrowFlightUtil {
         // this is the entry point for client-streams
         @Override
         public void onNext(final InputStream request) {
-            GrpcUtil.rpcWrapper(log, observer, () -> {
-                final MessageInfo mi = BarrageProtoUtil.parseProtoMessage(request);
-                if (mi.descriptor != null) {
-                    if (flightDescriptor != null) {
-                        if (!flightDescriptor.equals(mi.descriptor)) {
-                            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                                    "additional flight descriptor sent does not match original descriptor");
-                        }
-                    } else {
-                        flightDescriptor = mi.descriptor;
-                        resultExportBuilder = ticketRouter
-                                .<Table>publish(session, mi.descriptor, "Flight.Descriptor")
-                                .onError(observer);
+            final MessageInfo mi;
+            try {
+                mi = BarrageProtoUtil.parseProtoMessage(request);
+            } catch (IOException err) {
+                throw new UncheckedDeephavenException("Failed to parse barrage proto message", err);
+            }
+            if (mi.descriptor != null) {
+                if (flightDescriptor != null) {
+                    if (!flightDescriptor.equals(mi.descriptor)) {
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                                "additional flight descriptor sent does not match original descriptor");
                     }
+                } else {
+                    flightDescriptor = mi.descriptor;
+                    resultExportBuilder = ticketRouter
+                            .<Table>publish(session, mi.descriptor, "Flight.Descriptor")
+                            .onError(observer);
                 }
+            }
 
-                if (mi.app_metadata != null
-                        && mi.app_metadata.msgType() == BarrageMessageType.BarrageSerializationOptions) {
-                    options = BarrageSubscriptionOptions.of(BarrageSubscriptionRequest
-                            .getRootAsBarrageSubscriptionRequest(mi.app_metadata.msgPayloadAsByteBuffer()));
-                }
+            if (mi.app_metadata != null
+                    && mi.app_metadata.msgType() == BarrageMessageType.BarrageSerializationOptions) {
+                options = BarrageSubscriptionOptions.of(BarrageSubscriptionRequest
+                        .getRootAsBarrageSubscriptionRequest(mi.app_metadata.msgPayloadAsByteBuffer()));
+            }
 
-                if (mi.header == null) {
-                    return; // nothing to do!
-                }
+            if (mi.header == null) {
+                return; // nothing to do!
+            }
 
-                if (mi.header.headerType() == MessageHeader.Schema) {
-                    parseSchema((Schema) mi.header.header(new Schema()));
-                    return;
-                }
+            if (mi.header.headerType() == MessageHeader.Schema) {
+                parseSchema((Schema) mi.header.header(new Schema()));
+                return;
+            }
 
-                if (mi.header.headerType() != MessageHeader.RecordBatch) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                            "Only schema/record-batch messages supported");
-                }
+            if (mi.header.headerType() != MessageHeader.RecordBatch) {
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        "Only schema/record-batch messages supported");
+            }
 
-                final int numColumns = resultTable.getColumnSources().size();
-                final BarrageMessage msg = createBarrageMessage(mi, numColumns);
-                msg.rowsAdded = RowSetFactory.fromRange(totalRowsRead, totalRowsRead + msg.length - 1);
-                msg.rowsIncluded = msg.rowsAdded.copy();
-                msg.modColumnData = BarrageMessage.ZERO_MOD_COLUMNS;
-                totalRowsRead += msg.length;
-                resultTable.handleBarrageMessage(msg);
+            final int numColumns = resultTable.getColumnSources().size();
+            final BarrageMessage msg = createBarrageMessage(mi, numColumns);
+            msg.rowsAdded = RowSetFactory.fromRange(totalRowsRead, totalRowsRead + msg.length - 1);
+            msg.rowsIncluded = msg.rowsAdded.copy();
+            msg.modColumnData = BarrageMessage.ZERO_MOD_COLUMNS;
+            totalRowsRead += msg.length;
+            resultTable.handleBarrageMessage(msg);
 
-                // no app_metadata to report; but ack the processing
-                GrpcUtil.safelyOnNext(observer, Flight.PutResult.getDefaultInstance());
-            });
+            // no app_metadata to report; but ack the processing
+            GrpcUtil.safelyOnNext(observer, Flight.PutResult.getDefaultInstance());
         }
 
         private void onCancel() {
@@ -186,7 +190,7 @@ public class ArrowFlightUtil {
             if (resultExportBuilder != null) {
                 // this thrown error propagates to observer
                 resultExportBuilder.submit(() -> {
-                    throw GrpcUtil.statusRuntimeException(Code.CANCELLED, "cancelled");
+                    throw Exceptions.statusRuntimeException(Code.CANCELLED, "cancelled");
                 });
                 resultExportBuilder = null;
             }
@@ -214,40 +218,39 @@ public class ArrowFlightUtil {
 
         @Override
         public void onCompleted() {
-            GrpcUtil.rpcWrapper(log, observer, () -> {
-                if (resultExportBuilder == null) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                            "Result flight descriptor never provided");
-                }
-                if (resultTable == null) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Result flight schema never provided");
-                }
+            if (resultExportBuilder == null) {
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        "Result flight descriptor never provided");
+            }
+            if (resultTable == null) {
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        "Result flight schema never provided");
+            }
 
-                final BarrageTable localResultTable = resultTable;
-                resultTable = null;
-                final SessionState.ExportBuilder<Table> localExportBuilder = resultExportBuilder;
-                resultExportBuilder = null;
+            final BarrageTable localResultTable = resultTable;
+            resultTable = null;
+            final SessionState.ExportBuilder<Table> localExportBuilder = resultExportBuilder;
+            resultExportBuilder = null;
 
-                // gRPC is about to remove its hard reference to this observer. We must keep the result table hard
-                // referenced until the export is complete, so that the export can properly be satisfied. ExportObject's
-                // LivenessManager enforces strong reachability.
-                if (!localExportBuilder.getExport().tryManage(localResultTable)) {
-                    GrpcUtil.safelyError(observer, Code.DATA_LOSS, "Result export already destroyed");
-                    localResultTable.dropReference();
-                    session.removeOnCloseCallback(this);
-                    return;
-                }
+            // gRPC is about to remove its hard reference to this observer. We must keep the result table hard
+            // referenced until the export is complete, so that the export can properly be satisfied. ExportObject's
+            // LivenessManager enforces strong reachability.
+            if (!localExportBuilder.getExport().tryManage(localResultTable)) {
+                GrpcUtil.safelyError(observer, Code.DATA_LOSS, "Result export already destroyed");
                 localResultTable.dropReference();
+                session.removeOnCloseCallback(this);
+                return;
+            }
+            localResultTable.dropReference();
 
-                // no more changes allowed; this is officially static content
-                localResultTable.sealTable(() -> localExportBuilder.submit(() -> {
-                    GrpcUtil.safelyComplete(observer);
-                    session.removeOnCloseCallback(this);
-                    return localResultTable;
-                }), () -> {
-                    GrpcUtil.safelyError(observer, Code.DATA_LOSS, "Do put could not be sealed");
-                    session.removeOnCloseCallback(this);
-                });
+            // no more changes allowed; this is officially static content
+            localResultTable.sealTable(() -> localExportBuilder.submit(() -> {
+                GrpcUtil.safelyComplete(observer);
+                session.removeOnCloseCallback(this);
+                return localResultTable;
+            }), () -> {
+                GrpcUtil.safelyError(observer, Code.DATA_LOSS, "Do put could not be sealed");
+                session.removeOnCloseCallback(this);
             });
         }
 
@@ -328,67 +331,70 @@ public class ArrowFlightUtil {
         // this entry is used for client-streaming requests
         @Override
         public void onNext(final InputStream request) {
-            GrpcUtil.rpcWrapper(log, listener, () -> {
-                MessageInfo message = BarrageProtoUtil.parseProtoMessage(request);
-                synchronized (this) {
+            MessageInfo message;
+            try {
+                message = BarrageProtoUtil.parseProtoMessage(request);
+            } catch (IOException err) {
+                throw new UncheckedDeephavenException("Unable to parse barrage proto message request", err);
+            }
+            synchronized (this) {
 
-                    // `FlightData` messages from Barrage clients will provide app_metadata describing the request but
-                    // official Flight implementations may force a NULL metadata field in the first message. In that
-                    // case, identify a valid Barrage connection by verifying the `FlightDescriptor.CMD` field contains
-                    // the `Barrage` magic bytes
+                // `FlightData` messages from Barrage clients will provide app_metadata describing the request but
+                // official Flight implementations may force a NULL metadata field in the first message. In that
+                // case, identify a valid Barrage connection by verifying the `FlightDescriptor.CMD` field contains
+                // the `Barrage` magic bytes
 
-                    if (requestHandler != null) {
-                        // rely on the handler to verify message type
-                        requestHandler.handleMessage(message);
-                        return;
+                if (requestHandler != null) {
+                    // rely on the handler to verify message type
+                    requestHandler.handleMessage(message);
+                    return;
+                }
+
+                if (message.app_metadata != null) {
+                    // handle the different message types that can come over DoExchange
+                    switch (message.app_metadata.msgType()) {
+                        case BarrageMessageType.BarrageSubscriptionRequest:
+                            requestHandler = new SubscriptionRequestHandler();
+                            break;
+                        case BarrageMessageType.BarrageSnapshotRequest:
+                            requestHandler = new SnapshotRequestHandler();
+                            break;
+                        default:
+                            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                                    myPrefix + "received a message with unhandled BarrageMessageType");
                     }
+                    requestHandler.handleMessage(message);
+                    return;
+                }
 
-                    if (message.app_metadata != null) {
-                        // handle the different message types that can come over DoExchange
-                        switch (message.app_metadata.msgType()) {
-                            case BarrageMessageType.BarrageSubscriptionRequest:
-                                requestHandler = new SubscriptionRequestHandler();
-                                break;
-                            case BarrageMessageType.BarrageSnapshotRequest:
-                                requestHandler = new SnapshotRequestHandler();
-                                break;
-                            default:
-                                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                                        myPrefix + "received a message with unhandled BarrageMessageType");
-                        }
-                        requestHandler.handleMessage(message);
-                        return;
-                    }
+                // handle the possible error cases
+                if (!isFirstMsg) {
+                    // only the first messages is allowed to have null metadata
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                            myPrefix + "failed to receive Barrage request metadata");
+                }
 
-                    // handle the possible error cases
-                    if (!isFirstMsg) {
-                        // only the first messages is allowed to have null metadata
-                        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                                myPrefix + "failed to receive Barrage request metadata");
-                    }
+                isFirstMsg = false;
 
-                    isFirstMsg = false;
+                // The magic value is '0x6E687064'. It is the numerical representation of the ASCII "dphn".
+                int size = message.descriptor.getCmd().size();
+                if (size == 4) {
+                    ByteBuffer bb = message.descriptor.getCmd().asReadOnlyByteBuffer();
 
-                    // The magic value is '0x6E687064'. It is the numerical representation of the ASCII "dphn".
-                    int size = message.descriptor.getCmd().size();
-                    if (size == 4) {
-                        ByteBuffer bb = message.descriptor.getCmd().asReadOnlyByteBuffer();
+                    // set the order to little-endian (FlatBuffers default)
+                    bb.order(ByteOrder.LITTLE_ENDIAN);
 
-                        // set the order to little-endian (FlatBuffers default)
-                        bb.order(ByteOrder.LITTLE_ENDIAN);
-
-                        // read and compare the value to the "magic" bytes
-                        long value = (long) bb.getInt(0) & 0xFFFFFFFFL;
-                        if (value != BarrageUtil.FLATBUFFER_MAGIC) {
-                            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                                    myPrefix + "expected BarrageMessageWrapper magic bytes in FlightDescriptor.cmd");
-                        }
-                    } else {
-                        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    // read and compare the value to the "magic" bytes
+                    long value = (long) bb.getInt(0) & 0xFFFFFFFFL;
+                    if (value != BarrageUtil.FLATBUFFER_MAGIC) {
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                                 myPrefix + "expected BarrageMessageWrapper magic bytes in FlightDescriptor.cmd");
                     }
+                } else {
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                            myPrefix + "expected BarrageMessageWrapper magic bytes in FlightDescriptor.cmd");
                 }
-            });
+            }
         }
 
         public void onCancel() {
@@ -447,7 +453,7 @@ public class ArrowFlightUtil {
             public void handleMessage(@NotNull final BarrageProtoUtil.MessageInfo message) {
                 // verify this is the correct type of message for this handler
                 if (message.app_metadata.msgType() != BarrageMessageType.BarrageSnapshotRequest) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "Request type cannot be changed after initialization, expected BarrageSnapshotRequest metadata");
                 }
 
@@ -522,13 +528,12 @@ public class ArrowFlightUtil {
             public void handleMessage(@NotNull final MessageInfo message) {
                 // verify this is the correct type of message for this handler
                 if (message.app_metadata.msgType() != BarrageMessageType.BarrageSubscriptionRequest) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "Request type cannot be changed after initialization, expected BarrageSubscriptionRequest metadata");
                 }
 
                 if (message.app_metadata.msgPayloadVector() == null) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                            "Subscription request not supplied");
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Subscription request not supplied");
                 }
 
                 // ensure synchronization with parent class functions
@@ -667,7 +672,7 @@ public class ArrowFlightUtil {
                 }
 
                 if (!subscriptionFound) {
-                    throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND, "Subscription was not found.");
+                    throw Exceptions.statusRuntimeException(Code.NOT_FOUND, "Subscription was not found.");
                 }
             }
 

--- a/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
@@ -17,6 +17,7 @@ import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.ExportNotification;
 import io.deephaven.proto.backplane.grpc.WrappedAuthenticationRequest;
 import io.deephaven.extensions.barrage.BarrageStreamGeneratorImpl;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionService;
 import io.deephaven.server.session.SessionState;
 import io.deephaven.server.session.TicketRouter;
@@ -24,6 +25,7 @@ import io.deephaven.auth.AuthContext;
 import io.grpc.stub.StreamObserver;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.FlightServiceGrpc;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -63,8 +65,8 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
 
     @Override
     public StreamObserver<Flight.HandshakeRequest> handshake(
-            StreamObserver<Flight.HandshakeResponse> responseObserver) {
-        return GrpcUtil.rpcWrapper(log, responseObserver, () -> new HandshakeObserver(responseObserver));
+            @NotNull final StreamObserver<Flight.HandshakeResponse> responseObserver) {
+        return new HandshakeObserver(responseObserver);
     }
 
     private final class HandshakeObserver implements StreamObserver<Flight.HandshakeRequest> {
@@ -108,8 +110,8 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
             }
 
             if (auth.isEmpty()) {
-                responseObserver.onError(GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED,
-                        "Authentication details invalid"));
+                responseObserver.onError(
+                        Exceptions.statusRuntimeException(Code.UNAUTHENTICATED, "Authentication details invalid"));
                 return;
             }
 
@@ -147,95 +149,93 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                 return;
             }
             responseObserver.onError(
-                    GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED, "no authentication details provided"));
+                    Exceptions.statusRuntimeException(Code.UNAUTHENTICATED, "no authentication details provided"));
         }
     }
 
     @Override
-    public void listFlights(final Flight.Criteria request, final StreamObserver<Flight.FlightInfo> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            ticketRouter.visitFlightInfo(sessionService.getOptionalSession(), responseObserver::onNext);
-            responseObserver.onCompleted();
-        });
+    public void listFlights(
+            @NotNull final Flight.Criteria request,
+            @NotNull final StreamObserver<Flight.FlightInfo> responseObserver) {
+        ticketRouter.visitFlightInfo(sessionService.getOptionalSession(), responseObserver::onNext);
+        responseObserver.onCompleted();
     }
 
     @Override
-    public void getFlightInfo(final Flight.FlightDescriptor request,
-            final StreamObserver<Flight.FlightInfo> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getOptionalSession();
+    public void getFlightInfo(
+            @NotNull final Flight.FlightDescriptor request,
+            @NotNull final StreamObserver<Flight.FlightInfo> responseObserver) {
+        final SessionState session = sessionService.getOptionalSession();
 
-            final SessionState.ExportObject<Flight.FlightInfo> export =
-                    ticketRouter.flightInfoFor(session, request, "request");
+        final SessionState.ExportObject<Flight.FlightInfo> export =
+                ticketRouter.flightInfoFor(session, request, "request");
 
-            if (session != null) {
-                session.nonExport()
-                        .require(export)
-                        .onError(responseObserver)
-                        .submit(() -> {
-                            responseObserver.onNext(export.get());
-                            responseObserver.onCompleted();
-                        });
-            } else {
-                if (export.tryRetainReference()) {
-                    try {
-                        if (export.getState() == ExportNotification.State.EXPORTED) {
-                            responseObserver.onNext(export.get());
-                            responseObserver.onCompleted();
-                        }
-                    } finally {
-                        export.dropReference();
+        if (session != null) {
+            session.nonExport()
+                    .require(export)
+                    .onError(responseObserver)
+                    .submit(() -> {
+                        responseObserver.onNext(export.get());
+                        responseObserver.onCompleted();
+                    });
+        } else {
+            if (export.tryRetainReference()) {
+                try {
+                    if (export.getState() == ExportNotification.State.EXPORTED) {
+                        responseObserver.onNext(export.get());
+                        responseObserver.onCompleted();
                     }
-                } else {
-                    responseObserver.onError(
-                            GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "Could not find flight info"));
+                } finally {
+                    export.dropReference();
                 }
+            } else {
+                responseObserver.onError(
+                        Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION, "Could not find flight info"));
             }
-        });
+        }
     }
 
     @Override
-    public void getSchema(final Flight.FlightDescriptor request,
-            final StreamObserver<Flight.SchemaResult> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getOptionalSession();
+    public void getSchema(
+            @NotNull final Flight.FlightDescriptor request,
+            @NotNull final StreamObserver<Flight.SchemaResult> responseObserver) {
+        final SessionState session = sessionService.getOptionalSession();
 
-            final SessionState.ExportObject<Flight.FlightInfo> export =
-                    ticketRouter.flightInfoFor(session, request, "request");
+        final SessionState.ExportObject<Flight.FlightInfo> export =
+                ticketRouter.flightInfoFor(session, request, "request");
 
-            if (session != null) {
-                session.nonExport()
-                        .require(export)
-                        .onError(responseObserver)
-                        .submit(() -> {
-                            responseObserver.onNext(Flight.SchemaResult.newBuilder()
-                                    .setSchema(export.get().getSchema())
-                                    .build());
-                            responseObserver.onCompleted();
-                        });
-            } else {
-                if (export.tryRetainReference()) {
-                    try {
-                        if (export.getState() == ExportNotification.State.EXPORTED) {
-                            responseObserver.onNext(Flight.SchemaResult.newBuilder()
-                                    .setSchema(export.get().getSchema())
-                                    .build());
-                            responseObserver.onCompleted();
-                        }
-                    } finally {
-                        export.dropReference();
-                    }
-                } else {
-                    responseObserver.onError(
-                            GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "Could not find flight info"));
+        if (session != null) {
+            session.nonExport()
+                    .require(export)
+                    .onError(responseObserver)
+                    .submit(() -> {
+                        responseObserver.onNext(Flight.SchemaResult.newBuilder()
+                                .setSchema(export.get().getSchema())
+                                .build());
+                        responseObserver.onCompleted();
+                    });
+        } else if (export.tryRetainReference()) {
+            try {
+                if (export.getState() == ExportNotification.State.EXPORTED) {
+                    responseObserver.onNext(Flight.SchemaResult.newBuilder()
+                            .setSchema(export.get().getSchema())
+                            .build());
+                    responseObserver.onCompleted();
                 }
+            } finally {
+                export.dropReference();
             }
-        });
+        } else {
+            responseObserver.onError(
+                    Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION, "Could not find flight info"));
+        }
     }
 
-    public void doGetCustom(final Flight.Ticket request, final StreamObserver<InputStream> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> ArrowFlightUtil.DoGetCustom(
-                streamGeneratorFactory, sessionService.getCurrentSession(), ticketRouter, request, responseObserver));
+    public void doGetCustom(
+            final Flight.Ticket request,
+            final StreamObserver<InputStream> responseObserver) {
+        ArrowFlightUtil.DoGetCustom(
+                streamGeneratorFactory, sessionService.getCurrentSession(), ticketRouter, request, responseObserver);
     }
 
     /**
@@ -245,8 +245,7 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
      * @return the observer that grpc can delegate received messages to
      */
     public StreamObserver<InputStream> doPutCustom(final StreamObserver<Flight.PutResult> responseObserver) {
-        return GrpcUtil.rpcWrapper(log, responseObserver, () -> new ArrowFlightUtil.DoPutObserver(
-                sessionService.getCurrentSession(), ticketRouter, responseObserver));
+        return new ArrowFlightUtil.DoPutObserver(sessionService.getCurrentSession(), ticketRouter, responseObserver);
     }
 
     /**
@@ -256,7 +255,6 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
      * @return the observer that grpc can delegate received messages to
      */
     public StreamObserver<InputStream> doExchangeCustom(final StreamObserver<InputStream> responseObserver) {
-        return GrpcUtil.rpcWrapper(log, responseObserver,
-                () -> doExchangeFactory.openExchange(sessionService.getCurrentSession(), responseObserver));
+        return doExchangeFactory.openExchange(sessionService.getCurrentSession(), responseObserver);
     }
 }

--- a/server/src/main/java/io/deephaven/server/browserstreaming/BrowserStream.java
+++ b/server/src/main/java/io/deephaven/server/browserstreaming/BrowserStream.java
@@ -7,6 +7,7 @@ import com.google.rpc.Code;
 import io.deephaven.base.RAPriQueue;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.extensions.barrage.util.GrpcUtil;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.deephaven.server.util.GrpcServiceOverrideBuilder;
 import io.deephaven.internal.log.LoggerFactory;
@@ -81,7 +82,7 @@ public class BrowserStream<T> implements Closeable {
             @Override
             public void onCancel() {
                 StatusRuntimeException canceled =
-                        GrpcUtil.statusRuntimeException(Code.CANCELLED, "Stream canceled on the server");
+                        Exceptions.statusRuntimeException(Code.CANCELLED, "Stream canceled on the server");
                 GrpcUtil.safelyError(responseObserver, canceled);
 
                 GrpcUtil.safelyError(requestObserver, canceled);
@@ -130,13 +131,13 @@ public class BrowserStream<T> implements Closeable {
     public void onMessageReceived(T message, StreamData streamData) {
         synchronized (this) {
             if (halfClosedSeq != -1 && streamData.getSequence() > halfClosedSeq) {
-                throw GrpcUtil.statusRuntimeException(Code.ABORTED, "Sequence sent after half close: closed seq="
+                throw Exceptions.statusRuntimeException(Code.ABORTED, "Sequence sent after half close: closed seq="
                         + halfClosedSeq + " recv seq=" + streamData.getSequence());
             }
 
             if (streamData.isHalfClose()) {
                 if (halfClosedSeq != -1) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Already half closed: closed seq="
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Already half closed: closed seq="
                             + halfClosedSeq + " recv seq=" + streamData.getSequence());
                 }
                 halfClosedSeq = streamData.getSequence();
@@ -144,7 +145,7 @@ public class BrowserStream<T> implements Closeable {
 
             if (mode == Mode.IN_ORDER) {
                 if (streamData.getSequence() < nextSeq) {
-                    throw GrpcUtil.statusRuntimeException(Code.OUT_OF_RANGE,
+                    throw Exceptions.statusRuntimeException(Code.OUT_OF_RANGE,
                             "Duplicate sequence sent: next seq=" + nextSeq + " recv seq=" + streamData.getSequence());
                 }
                 boolean queueMsg = false;

--- a/server/src/main/java/io/deephaven/server/browserstreaming/BrowserStreamInterceptor.java
+++ b/server/src/main/java/io/deephaven/server/browserstreaming/BrowserStreamInterceptor.java
@@ -4,8 +4,8 @@
 package io.deephaven.server.browserstreaming;
 
 import com.google.rpc.Code;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.proto.util.ExportTicketHelper;
 import io.grpc.Context;
 import io.grpc.Contexts;
@@ -45,7 +45,7 @@ public class BrowserStreamInterceptor implements ServerInterceptor {
         boolean hasTicket = ticketInt != null;
         boolean hasSeqString = sequenceString != null;
         if (hasTicket != hasSeqString) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Either both " + TICKET_HEADER_NAME + " and "
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Either both " + TICKET_HEADER_NAME + " and "
                     + SEQUENCE_HEADER_NAME + " must be provided, or neither");
         }
 

--- a/server/src/main/java/io/deephaven/server/config/ConfigServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/config/ConfigServiceGrpcImpl.java
@@ -1,7 +1,9 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.server.config;
 
 import io.deephaven.configuration.Configuration;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.AuthenticationConstantsRequest;
@@ -12,6 +14,7 @@ import io.deephaven.proto.backplane.grpc.ConfigurationConstantsRequest;
 import io.deephaven.proto.backplane.grpc.ConfigurationConstantsResponse;
 import io.deephaven.server.session.SessionService;
 import io.grpc.stub.StreamObserver;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -62,28 +65,26 @@ public class ConfigServiceGrpcImpl extends ConfigServiceGrpc.ConfigServiceImplBa
     }
 
     @Override
-    public void getAuthenticationConstants(AuthenticationConstantsRequest request,
-            StreamObserver<AuthenticationConstantsResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            AuthenticationConstantsResponse.Builder builder = AuthenticationConstantsResponse.newBuilder();
-            builder.putAllConfigValues(collectConfigs(AUTH_CLIENT_CONFIG_PROPERTY));
-            responseObserver.onNext(builder.build());
-            responseObserver.onCompleted();
-        });
+    public void getAuthenticationConstants(
+            @NotNull final AuthenticationConstantsRequest request,
+            @NotNull final StreamObserver<AuthenticationConstantsResponse> responseObserver) {
+        AuthenticationConstantsResponse.Builder builder = AuthenticationConstantsResponse.newBuilder();
+        builder.putAllConfigValues(collectConfigs(AUTH_CLIENT_CONFIG_PROPERTY));
+        responseObserver.onNext(builder.build());
+        responseObserver.onCompleted();
     }
 
     @Override
-    public void getConfigurationConstants(ConfigurationConstantsRequest request,
-            StreamObserver<ConfigurationConstantsResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            // Read the current session so we throw if not authenticated
-            sessionService.getCurrentSession();
+    public void getConfigurationConstants(
+            @NotNull final ConfigurationConstantsRequest request,
+            @NotNull final StreamObserver<ConfigurationConstantsResponse> responseObserver) {
+        // Read the current session so we throw if not authenticated
+        sessionService.getCurrentSession();
 
-            ConfigurationConstantsResponse.Builder builder = ConfigurationConstantsResponse.newBuilder();
-            builder.putAllConfigValues(collectConfigs(CLIENT_CONFIG_PROPERTY));
-            responseObserver.onNext(builder.build());
-            responseObserver.onCompleted();
-        });
+        ConfigurationConstantsResponse.Builder builder = ConfigurationConstantsResponse.newBuilder();
+        builder.putAllConfigValues(collectConfigs(CLIENT_CONFIG_PROPERTY));
+        responseObserver.onNext(builder.build());
+        responseObserver.onCompleted();
     }
 
     private Map<String, ConfigValue> collectConfigs(String clientConfigProperty) {

--- a/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
+++ b/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
@@ -12,10 +12,10 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.DynamicNode;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.util.ScriptSession;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.Ticket;
 import io.deephaven.proto.flight.util.TicketRouterHelper;
 import io.deephaven.proto.util.ByteHelper;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.proto.util.ScopeTicketHelper;
 import io.deephaven.server.auth.AuthorizationProvider;
 import io.deephaven.server.session.SessionState;
@@ -63,7 +63,7 @@ public class ScopeTicketResolver extends TicketResolverBase {
             final ScriptSession gss = scriptSessionProvider.get();
             Object scopeVar = gss.getVariable(scopeName, null);
             if (scopeVar == null) {
-                throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+                throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                         "Could not resolve '" + logId + ": no variable exists with name '" + scopeName + "'");
             }
             if (scopeVar instanceof Table) {
@@ -71,7 +71,7 @@ public class ScopeTicketResolver extends TicketResolverBase {
                 return TicketRouter.getFlightInfo((Table) scopeVar, descriptor, flightTicketForName(scopeName));
             }
 
-            throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+            throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                     "Could not resolve '" + logId + "': no variable exists with name '" + scopeName + "'");
         });
 
@@ -117,7 +117,7 @@ public class ScopeTicketResolver extends TicketResolverBase {
         export = authTransformation.transform(export);
 
         if (export == null) {
-            return SessionState.wrapAsFailedExport(GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            return SessionState.wrapAsFailedExport(Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': no variable exists with name '" + scopeName + "'"));
         }
 
@@ -205,12 +205,12 @@ public class ScopeTicketResolver extends TicketResolverBase {
      */
     public static String nameForTicket(final ByteBuffer ticket, final String logId) {
         if (ticket == null || ticket.remaining() == 0) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': no ticket supplied");
         }
         if (ticket.remaining() < 3 || ticket.get(ticket.position()) != TICKET_PREFIX
                 || ticket.get(ticket.position() + 1) != '/') {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': found 0x" + ByteHelper.byteBufToHex(ticket) + "' (hex)");
         }
 
@@ -221,7 +221,7 @@ public class ScopeTicketResolver extends TicketResolverBase {
             ticket.position(initialPosition + 2);
             return decoder.decode(ticket).toString();
         } catch (CharacterCodingException e) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': failed to decode: " + e.getMessage());
         } finally {
             ticket.position(initialPosition);
@@ -238,11 +238,11 @@ public class ScopeTicketResolver extends TicketResolverBase {
      */
     public static String nameForDescriptor(final Flight.FlightDescriptor descriptor, final String logId) {
         if (descriptor.getType() != Flight.FlightDescriptor.DescriptorType.PATH) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve descriptor '" + logId + "': only paths are supported");
         }
         if (descriptor.getPathCount() != 2) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve descriptor '" + logId + "': unexpected path length (found: "
                             + TicketRouterHelper.getLogNameFor(descriptor) + ", expected: 2)");
         }

--- a/server/src/main/java/io/deephaven/server/console/completer/JavaAutoCompleteObserver.java
+++ b/server/src/main/java/io/deephaven/server/console/completer/JavaAutoCompleteObserver.java
@@ -3,7 +3,6 @@ package io.deephaven.server.console.completer;
 import com.google.rpc.Code;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.engine.util.VariableProvider;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.lang.completion.ChunkerCompleter;
@@ -13,6 +12,7 @@ import io.deephaven.lang.parse.LspTools;
 import io.deephaven.lang.parse.ParsedDocument;
 import io.deephaven.lang.shared.lsp.CompletionCancelled;
 import io.deephaven.proto.backplane.script.grpc.*;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.console.ConsoleServiceGrpcImpl;
 import io.deephaven.server.session.SessionCloseableObserver;
 import io.deephaven.server.session.SessionState;
@@ -91,8 +91,7 @@ public class JavaAutoCompleteObserver extends SessionCloseableObserver<AutoCompl
                 break;
             }
             case REQUEST_NOT_SET: {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                        "Autocomplete command missing request");
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Autocomplete command missing request");
             }
         }
     }
@@ -101,7 +100,7 @@ public class JavaAutoCompleteObserver extends SessionCloseableObserver<AutoCompl
             SessionState.ExportObject<ScriptSession> exportedConsole, CompletionParser parser,
             StreamObserver<AutoCompleteResponse> responseObserver) {
         final ScriptSession scriptSession = exportedConsole.get();
-        try (final SafeCloseable ignored = scriptSession.getExecutionContext().open()) {
+        try {
             final VariableProvider vars = scriptSession.getVariableProvider();
             final VersionedTextDocumentIdentifier doc = request.getTextDocument();
             final CompletionLookups h = CompletionLookups.preload(scriptSession);

--- a/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
+++ b/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
@@ -2,12 +2,12 @@ package io.deephaven.server.console.completer;
 
 import com.google.rpc.Code;
 import io.deephaven.engine.util.ScriptSession;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.lang.completion.ChunkerCompleter;
 import io.deephaven.lang.parse.CompletionParser;
 import io.deephaven.proto.backplane.script.grpc.*;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.console.ConsoleServiceGrpcImpl;
 import io.deephaven.server.session.SessionCloseableObserver;
 import io.deephaven.server.session.SessionState;
@@ -91,8 +91,7 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
                 break;
             }
             case REQUEST_NOT_SET: {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                        "Autocomplete command missing request");
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Autocomplete command missing request");
             }
         }
     }
@@ -101,8 +100,7 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
             SessionState.ExportObject<ScriptSession> exportedConsole,
             StreamObserver<AutoCompleteResponse> responseObserver) {
         final ScriptSession scriptSession = exportedConsole.get();
-        try (final SafeCloseable ignored = scriptSession.getExecutionContext().open()) {
-
+        try {
             PyObject completer = (PyObject) scriptSession.getVariable("jedi_settings");
             boolean canJedi = completer.callMethod("is_enabled").getBooleanValue();
             if (!canJedi) {

--- a/server/src/main/java/io/deephaven/server/grpc/Common.java
+++ b/server/src/main/java/io/deephaven/server/grpc/Common.java
@@ -1,18 +1,17 @@
 package io.deephaven.server.grpc;
 
 import com.google.rpc.Code;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.TableReference;
 import io.deephaven.proto.backplane.grpc.TableReference.RefCase;
 import io.deephaven.proto.backplane.grpc.Ticket;
-import io.deephaven.server.grpc.GrpcErrorHelper;
+import io.deephaven.proto.util.Exceptions;
 
 public class Common {
 
     public static void validate(Ticket ticket) {
         GrpcErrorHelper.checkHasNoUnknownFields(ticket);
         if (ticket.getTicket().isEmpty()) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Ticket is empty");
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Ticket is empty");
         }
     }
 
@@ -32,7 +31,7 @@ public class Common {
                 break;
             case REF_NOT_SET:
             default:
-                throw GrpcUtil.statusRuntimeException(Code.INTERNAL,
+                throw Exceptions.statusRuntimeException(Code.INTERNAL,
                         String.format("Server missing TableReference type %s", ref));
         }
     }

--- a/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
+++ b/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
@@ -4,14 +4,12 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
 import com.google.protobuf.Message;
-import com.google.protobuf.MessageOrBuilder;
 import com.google.rpc.Code;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
+import io.deephaven.proto.util.Exceptions;
 import io.grpc.StatusRuntimeException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 
@@ -20,7 +18,7 @@ public class GrpcErrorHelper {
         final Descriptor descriptor = message.getDescriptorForType();
         final FieldDescriptor fieldDescriptor = descriptor.findFieldByNumber(fieldNumber);
         if (!message.hasField(fieldDescriptor)) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, String.format("%s must have field %s (%d)",
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format("%s must have field %s (%d)",
                     descriptor.getFullName(), fieldDescriptor.getName(), fieldNumber));
         }
     }
@@ -34,7 +32,7 @@ public class GrpcErrorHelper {
                     descriptor.getFullName(), fieldDescriptor.getName(), fieldNumber));
         }
         if (message.getRepeatedFieldCount(fieldDescriptor) <= 0) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     String.format("%s must have at least one %s (%d)", descriptor.getFullName(),
                             fieldDescriptor.getName(), fieldNumber));
         }
@@ -45,7 +43,7 @@ public class GrpcErrorHelper {
         final OneofDescriptor oneofDescriptor =
                 descriptor.getOneofs().stream().filter(o -> oneOfName.equals(o.getName())).findFirst().orElseThrow();
         if (!message.hasOneof(oneofDescriptor)) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
                     "%s must have oneof %s. Note: this may also indicate that the server is older than the client and doesn't know about this new oneof option.",
                     descriptor.getFullName(), oneOfName));
         }
@@ -53,7 +51,7 @@ public class GrpcErrorHelper {
 
     public static void checkHasNoUnknownFields(Message message) {
         if (!message.getUnknownFields().asMap().isEmpty()) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     String.format("%s has unknown field(s)", message.getDescriptorForType().getFullName()));
         }
     }

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableViewSubscription.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableViewSubscription.java
@@ -22,6 +22,7 @@ import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.extensions.barrage.util.HierarchicalTableSchemaUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.util.Scheduler;
 import io.deephaven.time.DateTime;
 import io.deephaven.util.SafeCloseable;
@@ -371,7 +372,7 @@ public class HierarchicalTableViewSubscription extends LivenessArtifact {
 
         if (viewportColumns != null) {
             if (viewportColumns.length() > view.getHierarchicalTable().getAvailableColumnDefinitions().size()) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
                         "Requested columns out of range: length=%d, available length=%d",
                         viewportColumns.length(),
                         view.getHierarchicalTable().getAvailableColumnDefinitions().size()));
@@ -379,17 +380,17 @@ public class HierarchicalTableViewSubscription extends LivenessArtifact {
         }
         if (viewportRows != null) {
             if (!viewportRows.isContiguous()) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "HierarchicalTableView subscriptions only support contiguous viewports");
             }
             if (viewportRows.size() > LARGEST_POOLED_CHUNK_CAPACITY) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
                         "HierarchicalTableView subscriptions only support viewport size up to %d rows, requested %d rows",
                         LARGEST_POOLED_CHUNK_CAPACITY, viewportRows.size()));
             }
         }
         if (reverseViewport) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     "HierarchicalTableView subscriptions do not support reverse viewports");
         }
 

--- a/server/src/main/java/io/deephaven/server/partitionedtable/PartitionedTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/partitionedtable/PartitionedTableServiceGrpcImpl.java
@@ -1,3 +1,6 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
 package io.deephaven.server.partitionedtable;
 
 import com.google.rpc.Code;
@@ -5,7 +8,6 @@ import io.deephaven.auth.codegen.impl.PartitionedTableServiceContextualAuthWirin
 import io.deephaven.engine.table.PartitionedTable;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
@@ -14,12 +16,14 @@ import io.deephaven.proto.backplane.grpc.MergeRequest;
 import io.deephaven.proto.backplane.grpc.PartitionByRequest;
 import io.deephaven.proto.backplane.grpc.PartitionByResponse;
 import io.deephaven.proto.backplane.grpc.PartitionedTableServiceGrpc;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.auth.AuthorizationProvider;
 import io.deephaven.server.session.SessionService;
 import io.deephaven.server.session.SessionState;
 import io.deephaven.server.session.TicketResolverBase;
 import io.deephaven.server.session.TicketRouter;
 import io.grpc.stub.StreamObserver;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 
@@ -53,120 +57,118 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
     }
 
     @Override
-    public void partitionBy(PartitionByRequest request, StreamObserver<PartitionByResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
+    public void partitionBy(
+            @NotNull final PartitionByRequest request,
+            @NotNull final StreamObserver<PartitionByResponse> responseObserver) {
+        final SessionState session = sessionService.getCurrentSession();
 
-            SessionState.ExportObject<Table> targetTable =
-                    ticketRouter.resolve(session, request.getTableId(), "tableId");
+        SessionState.ExportObject<Table> targetTable =
+                ticketRouter.resolve(session, request.getTableId(), "tableId");
 
-            session.newExport(request.getResultId(), "resultId")
-                    .require(targetTable)
-                    .onError(responseObserver)
-                    .submit(() -> {
-                        authWiring.checkPermissionPartitionBy(session.getAuthContext(), request,
-                                Collections.singletonList(targetTable.get()));
-                        PartitionedTable partitionedTable = targetTable.get().partitionBy(request.getDropKeys(),
-                                request.getKeyColumnNamesList().toArray(String[]::new));
-                        safelyComplete(responseObserver, PartitionByResponse.getDefaultInstance());
-                        return partitionedTable;
-                    });
-
-        });
+        session.newExport(request.getResultId(), "resultId")
+                .require(targetTable)
+                .onError(responseObserver)
+                .submit(() -> {
+                    authWiring.checkPermissionPartitionBy(session.getAuthContext(), request,
+                            Collections.singletonList(targetTable.get()));
+                    PartitionedTable partitionedTable = targetTable.get().partitionBy(request.getDropKeys(),
+                            request.getKeyColumnNamesList().toArray(String[]::new));
+                    safelyComplete(responseObserver, PartitionByResponse.getDefaultInstance());
+                    return partitionedTable;
+                });
     }
 
     @Override
-    public void merge(MergeRequest request, StreamObserver<ExportedTableCreationResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
+    public void merge(
+            @NotNull final MergeRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+        final SessionState session = sessionService.getCurrentSession();
 
-            SessionState.ExportObject<PartitionedTable> partitionedTable =
-                    ticketRouter.resolve(session, request.getPartitionedTable(), "partitionedTable");
+        SessionState.ExportObject<PartitionedTable> partitionedTable =
+                ticketRouter.resolve(session, request.getPartitionedTable(), "partitionedTable");
 
-            session.newExport(request.getResultId(), "resultId")
-                    .require(partitionedTable)
-                    .onError(responseObserver)
-                    .submit(() -> {
-                        authWiring.checkPermissionMerge(session.getAuthContext(), request,
-                                Collections.singletonList(partitionedTable.get().table()));
-                        Table merged;
-                        if (partitionedTable.get().table().isRefreshing()) {
-                            merged = updateGraphProcessor.sharedLock()
-                                    .computeLocked(partitionedTable.get()::merge);
-                        } else {
-                            merged = partitionedTable.get().merge();
+        session.newExport(request.getResultId(), "resultId")
+                .require(partitionedTable)
+                .onError(responseObserver)
+                .submit(() -> {
+                    authWiring.checkPermissionMerge(session.getAuthContext(), request,
+                            Collections.singletonList(partitionedTable.get().table()));
+                    Table merged;
+                    if (partitionedTable.get().table().isRefreshing()) {
+                        merged = updateGraphProcessor.sharedLock()
+                                .computeLocked(partitionedTable.get()::merge);
+                    } else {
+                        merged = partitionedTable.get().merge();
+                    }
+                    merged = authorizationTransformation.transform(merged);
+                    final ExportedTableCreationResponse response =
+                            buildTableCreationResponse(request.getResultId(), merged);
+                    safelyComplete(responseObserver, response);
+                    return merged;
+                });
+    }
+
+    @Override
+    public void getTable(
+            @NotNull final GetTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+        final SessionState session = sessionService.getCurrentSession();
+
+        SessionState.ExportObject<PartitionedTable> partitionedTable =
+                ticketRouter.resolve(session, request.getPartitionedTable(), "partitionedTable");
+        SessionState.ExportObject<Table> keys =
+                ticketRouter.resolve(session, request.getKeyTableTicket(), "keyTableTicket");
+
+        session.newExport(request.getResultId(), "resultId")
+                .require(partitionedTable, keys)
+                .onError(responseObserver)
+                .submit(() -> {
+                    Table table;
+                    Table keyTable = keys.get();
+                    authWiring.checkPermissionGetTable(session.getAuthContext(), request,
+                            List.of(partitionedTable.get().table(), keyTable));
+                    if (!keyTable.isRefreshing()) {
+                        long keyTableSize = keyTable.size();
+                        if (keyTableSize != 1) {
+                            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                                    "Provided key table does not have one row, instead has " + keyTableSize);
                         }
-                        merged = authorizationTransformation.transform(merged);
-                        final ExportedTableCreationResponse response =
-                                buildTableCreationResponse(request.getResultId(), merged);
-                        safelyComplete(responseObserver, response);
-                        return merged;
-                    });
-        });
-
-    }
-
-    @Override
-    public void getTable(GetTableRequest request, StreamObserver<ExportedTableCreationResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
-
-            SessionState.ExportObject<PartitionedTable> partitionedTable =
-                    ticketRouter.resolve(session, request.getPartitionedTable(), "partitionedTable");
-            SessionState.ExportObject<Table> keys =
-                    ticketRouter.resolve(session, request.getKeyTableTicket(), "keyTableTicket");
-
-            session.newExport(request.getResultId(), "resultId")
-                    .require(partitionedTable, keys)
-                    .onError(responseObserver)
-                    .submit(() -> {
-                        Table table;
-                        Table keyTable = keys.get();
-                        authWiring.checkPermissionGetTable(session.getAuthContext(), request,
-                                List.of(partitionedTable.get().table(), keyTable));
-                        if (!keyTable.isRefreshing()) {
+                        long row = keyTable.getRowSet().firstRowKey();
+                        Object[] values =
+                                partitionedTable.get().keyColumnNames().stream()
+                                        .map(keyTable::getColumnSource)
+                                        .map(cs -> cs.get(row))
+                                        .toArray();
+                        table = partitionedTable.get().constituentFor(values);
+                    } else {
+                        table = updateGraphProcessor.sharedLock().computeLocked(() -> {
                             long keyTableSize = keyTable.size();
                             if (keyTableSize != 1) {
-                                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                                         "Provided key table does not have one row, instead has " + keyTableSize);
                             }
-                            long row = keyTable.getRowSet().firstRowKey();
-                            Object[] values =
-                                    partitionedTable.get().keyColumnNames().stream()
-                                            .map(keyTable::getColumnSource)
-                                            .map(cs -> cs.get(row))
-                                            .toArray();
-                            table = partitionedTable.get().constituentFor(values);
-                        } else {
-                            table = updateGraphProcessor.sharedLock().computeLocked(() -> {
-                                long keyTableSize = keyTable.size();
-                                if (keyTableSize != 1) {
-                                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                                            "Provided key table does not have one row, instead has " + keyTableSize);
+                            Table requestedRow = partitionedTable.get().table().whereIn(keyTable,
+                                    partitionedTable.get().keyColumnNames().toArray(String[]::new));
+                            if (requestedRow.size() != 1) {
+                                if (requestedRow.isEmpty()) {
+                                    throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
+                                            "Key matches zero rows in the partitioned table");
+                                } else {
+                                    throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
+                                            "Key matches more than one entry in the partitioned table: "
+                                                    + requestedRow.size());
                                 }
-                                Table requestedRow = partitionedTable.get().table().whereIn(keyTable,
-                                        partitionedTable.get().keyColumnNames().toArray(String[]::new));
-                                if (requestedRow.size() != 1) {
-                                    if (requestedRow.isEmpty()) {
-                                        throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
-                                                "Key matches zero rows in the partitioned table");
-                                    } else {
-                                        throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
-                                                "Key matches more than one entry in the partitioned table: "
-                                                        + requestedRow.size());
-                                    }
-                                }
-                                return (Table) requestedRow
-                                        .getColumnSource(partitionedTable.get().constituentColumnName())
-                                        .get(requestedRow.getRowSet().firstRowKey());
-                            });
-                        }
-                        table = authorizationTransformation.transform(table);
-                        final ExportedTableCreationResponse response =
-                                buildTableCreationResponse(request.getResultId(), table);
-                        safelyComplete(responseObserver, response);
-                        return table;
-                    });
-        });
+                            }
+                            return (Table) requestedRow
+                                    .getColumnSource(partitionedTable.get().constituentColumnName())
+                                    .get(requestedRow.getRowSet().firstRowKey());
+                        });
+                    }
+                    table = authorizationTransformation.transform(table);
+                    final ExportedTableCreationResponse response =
+                            buildTableCreationResponse(request.getResultId(), table);
+                    safelyComplete(responseObserver, response);
+                    return table;
+                });
     }
 }

--- a/server/src/main/java/io/deephaven/server/session/ExportTicketResolver.java
+++ b/server/src/main/java/io/deephaven/server/session/ExportTicketResolver.java
@@ -5,8 +5,8 @@ package io.deephaven.server.session;
 
 import com.google.rpc.Code;
 import io.deephaven.engine.table.Table;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.flight.util.FlightExportTicketHelper;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.proto.util.ExportTicketHelper;
 import io.deephaven.server.auth.AuthorizationProvider;
 import org.apache.arrow.flight.impl.Flight;
@@ -41,7 +41,7 @@ public class ExportTicketResolver extends TicketResolverBase {
     public SessionState.ExportObject<Flight.FlightInfo> flightInfoFor(
             @Nullable final SessionState session, final Flight.FlightDescriptor descriptor, final String logId) {
         if (session == null) {
-            throw GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED,
+            throw Exceptions.statusRuntimeException(Code.UNAUTHENTICATED,
                     "Could not resolve '" + logId + "': no exports can exist without a session to search");
         }
 
@@ -54,7 +54,7 @@ public class ExportTicketResolver extends TicketResolverBase {
                                 FlightExportTicketHelper.descriptorToFlightTicket(descriptor, logId));
                     }
 
-                    throw GrpcUtil.statusRuntimeException(Code.NOT_FOUND,
+                    throw Exceptions.statusRuntimeException(Code.NOT_FOUND,
                             "Could not resolve '" + logId + "': flight '" + descriptor.toString() + " does not exist");
                 });
     }
@@ -68,7 +68,7 @@ public class ExportTicketResolver extends TicketResolverBase {
     public <T> SessionState.ExportObject<T> resolve(
             @Nullable final SessionState session, final ByteBuffer ticket, final String logId) {
         if (session == null) {
-            throw GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED,
+            throw Exceptions.statusRuntimeException(Code.UNAUTHENTICATED,
                     "Could not resolve '" + logId + "': no exports can exist without an active session");
         }
 
@@ -79,7 +79,7 @@ public class ExportTicketResolver extends TicketResolverBase {
     public <T> SessionState.ExportObject<T> resolve(
             @Nullable final SessionState session, final Flight.FlightDescriptor descriptor, final String logId) {
         if (session == null) {
-            throw GrpcUtil.statusRuntimeException(Code.UNAUTHENTICATED,
+            throw Exceptions.statusRuntimeException(Code.UNAUTHENTICATED,
                     "Could not resolve '" + logId + "': no exports can exist without a session to search");
         }
 

--- a/server/src/main/java/io/deephaven/server/session/SessionModule.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionModule.java
@@ -29,7 +29,7 @@ public interface SessionModule {
     @Binds
     @IntoSet
     ServerInterceptor bindSessionServiceInterceptor(
-            SessionServiceGrpcImpl.AuthServerInterceptor sessionServiceInterceptor);
+            SessionServiceGrpcImpl.SessionServiceInterceptor sessionServiceGrpcInterceptor);
 
     @Binds
     @IntoSet

--- a/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
@@ -7,6 +7,8 @@ import com.google.protobuf.ByteString;
 import com.google.rpc.Code;
 import io.deephaven.auth.AuthContext;
 import io.deephaven.auth.AuthenticationException;
+import io.deephaven.csv.util.MutableObject;
+import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
@@ -22,18 +24,23 @@ import io.deephaven.proto.backplane.grpc.ReleaseResponse;
 import io.deephaven.proto.backplane.grpc.SessionServiceGrpc;
 import io.deephaven.proto.backplane.grpc.TerminationNotificationRequest;
 import io.deephaven.proto.backplane.grpc.TerminationNotificationResponse;
+import io.deephaven.proto.util.Exceptions;
+import io.deephaven.util.FunctionalInterfaces;
+import io.deephaven.util.SafeCloseable;
 import io.grpc.Context;
-import io.grpc.Contexts;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.apache.arrow.flight.auth.AuthConstants;
 import org.apache.arrow.flight.auth2.Auth2Constants;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -65,137 +72,133 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
     }
 
     @Override
-    public void newSession(final HandshakeRequest request, final StreamObserver<HandshakeResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            // TODO: once jsapi is updated to use flight auth, then newSession can be deprecated or removed
-            final AuthContext authContext = new AuthContext.SuperUser();
+    public void newSession(
+            @NotNull final HandshakeRequest request,
+            @NotNull final StreamObserver<HandshakeResponse> responseObserver) {
+        // TODO: once jsapi is updated to use flight auth, then newSession can be deprecated or removed
+        final AuthContext authContext = new AuthContext.SuperUser();
 
-            final SessionState session = service.newSession(authContext);
-            responseObserver.onNext(HandshakeResponse.newBuilder()
-                    .setMetadataHeader(ByteString.copyFromUtf8(DEEPHAVEN_SESSION_ID))
-                    .setSessionToken(session.getExpiration().getBearerTokenAsByteString())
-                    .setTokenDeadlineTimeMillis(session.getExpiration().deadlineMillis)
-                    .setTokenExpirationDelayMillis(service.getExpirationDelayMs())
-                    .build());
+        final SessionState session = service.newSession(authContext);
+        responseObserver.onNext(HandshakeResponse.newBuilder()
+                .setMetadataHeader(ByteString.copyFromUtf8(DEEPHAVEN_SESSION_ID))
+                .setSessionToken(session.getExpiration().getBearerTokenAsByteString())
+                .setTokenDeadlineTimeMillis(session.getExpiration().deadlineMillis)
+                .setTokenExpirationDelayMillis(service.getExpirationDelayMs())
+                .build());
 
-            responseObserver.onCompleted();
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void refreshSessionToken(
+            @NotNull final HandshakeRequest request,
+            @NotNull final StreamObserver<HandshakeResponse> responseObserver) {
+        // TODO: once jsapi is updated to use flight auth, then newSession can be deprecated or removed
+        if (request.getAuthProtocol() != 0) {
+            responseObserver.onError(
+                    Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Protocol version not allowed."));
+            return;
+        }
+
+        final SessionState session = service.getCurrentSession();
+        final SessionService.TokenExpiration expiration = service.refreshToken(session);
+
+        responseObserver.onNext(HandshakeResponse.newBuilder()
+                .setMetadataHeader(ByteString.copyFromUtf8(DEEPHAVEN_SESSION_ID))
+                .setSessionToken(expiration.getBearerTokenAsByteString())
+                .setTokenDeadlineTimeMillis(expiration.deadlineMillis)
+                .setTokenExpirationDelayMillis(service.getExpirationDelayMs())
+                .build());
+
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void closeSession(
+            @NotNull final HandshakeRequest request,
+            @NotNull final StreamObserver<CloseSessionResponse> responseObserver) {
+        if (request.getAuthProtocol() != 0) {
+            responseObserver.onError(
+                    Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Protocol version not allowed."));
+            return;
+        }
+
+        final SessionState session = service.getCurrentSession();
+        service.closeSession(session);
+        responseObserver.onNext(CloseSessionResponse.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void release(
+            @NotNull final ReleaseRequest request,
+            @NotNull final StreamObserver<ReleaseResponse> responseObserver) {
+        final SessionState session = service.getCurrentSession();
+
+        if (!request.hasId()) {
+            responseObserver
+                    .onError(Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Release ticket not supplied"));
+            return;
+        }
+        final SessionState.ExportObject<?> export = session.getExportIfExists(request.getId(), "id");
+        if (export == null) {
+            responseObserver.onError(Exceptions.statusRuntimeException(Code.UNAVAILABLE, "Export not yet defined"));
+            return;
+        }
+
+        // If the export is already in a terminal state, the implementation quietly ignores the request as there
+        // are no additional resources to release.
+        export.cancel();
+        responseObserver.onNext(ReleaseResponse.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void exportFromTicket(
+            @NotNull final ExportRequest request,
+            @NotNull final StreamObserver<ExportResponse> responseObserver) {
+        final SessionState session = service.getCurrentSession();
+
+        if (!request.hasSourceId()) {
+            responseObserver
+                    .onError(Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Source ticket not supplied"));
+            return;
+        }
+        if (!request.hasResultId()) {
+            responseObserver
+                    .onError(Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Result ticket not supplied"));
+            return;
+        }
+
+        final SessionState.ExportObject<Object> source = ticketRouter.resolve(
+                session, request.getSourceId(), "sourceId");
+        session.newExport(request.getResultId(), "resultId")
+                .require(source)
+                .onError(responseObserver)
+                .submit(() -> {
+                    GrpcUtil.safelyComplete(responseObserver, ExportResponse.getDefaultInstance());
+                    return source.get();
+                });
+    }
+
+    @Override
+    public void exportNotifications(
+            @NotNull final ExportNotificationRequest request,
+            @NotNull final StreamObserver<ExportNotification> responseObserver) {
+        final SessionState session = service.getCurrentSession();
+
+        session.addExportListener(responseObserver);
+        ((ServerCallStreamObserver<ExportNotification>) responseObserver).setOnCancelHandler(() -> {
+            session.removeExportListener(responseObserver);
         });
     }
 
     @Override
-    public void refreshSessionToken(final HandshakeRequest request,
-            final StreamObserver<HandshakeResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            // TODO: once jsapi is updated to use flight auth, then newSession can be deprecated or removed
-            if (request.getAuthProtocol() != 0) {
-                responseObserver.onError(
-                        GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Protocol version not allowed."));
-                return;
-            }
-
-            final SessionState session = service.getCurrentSession();
-            final SessionService.TokenExpiration expiration = service.refreshToken(session);
-
-            responseObserver.onNext(HandshakeResponse.newBuilder()
-                    .setMetadataHeader(ByteString.copyFromUtf8(DEEPHAVEN_SESSION_ID))
-                    .setSessionToken(expiration.getBearerTokenAsByteString())
-                    .setTokenDeadlineTimeMillis(expiration.deadlineMillis)
-                    .setTokenExpirationDelayMillis(service.getExpirationDelayMs())
-                    .build());
-
-            responseObserver.onCompleted();
-        });
-    }
-
-    @Override
-    public void closeSession(final HandshakeRequest request,
-            final StreamObserver<CloseSessionResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            if (request.getAuthProtocol() != 0) {
-                responseObserver.onError(
-                        GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Protocol version not allowed."));
-                return;
-            }
-
-            final SessionState session = service.getCurrentSession();
-            service.closeSession(session);
-            responseObserver.onNext(CloseSessionResponse.getDefaultInstance());
-            responseObserver.onCompleted();
-        });
-    }
-
-    @Override
-    public void release(final ReleaseRequest request, final StreamObserver<ReleaseResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = service.getCurrentSession();
-
-            if (!request.hasId()) {
-                responseObserver
-                        .onError(GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Release ticket not supplied"));
-                return;
-            }
-            final SessionState.ExportObject<?> export = session.getExportIfExists(request.getId(), "id");
-            if (export == null) {
-                responseObserver.onError(GrpcUtil.statusRuntimeException(Code.UNAVAILABLE, "Export not yet defined"));
-                return;
-            }
-
-            // If the export is already in a terminal state, the implementation quietly ignores the request as there
-            // are no additional resources to release.
-            export.cancel();
-            responseObserver.onNext(ReleaseResponse.getDefaultInstance());
-            responseObserver.onCompleted();
-        });
-    }
-
-    @Override
-    public void exportFromTicket(ExportRequest request, StreamObserver<ExportResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = service.getCurrentSession();
-
-            if (!request.hasSourceId()) {
-                responseObserver
-                        .onError(GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Source ticket not supplied"));
-                return;
-            }
-            if (!request.hasResultId()) {
-                responseObserver
-                        .onError(GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Result ticket not supplied"));
-                return;
-            }
-
-            final SessionState.ExportObject<Object> source = ticketRouter.resolve(
-                    session, request.getSourceId(), "sourceId");
-            session.newExport(request.getResultId(), "resultId")
-                    .require(source)
-                    .onError(responseObserver)
-                    .submit(() -> {
-                        GrpcUtil.safelyComplete(responseObserver, ExportResponse.getDefaultInstance());
-                        return source.get();
-                    });
-        });
-    }
-
-    @Override
-    public void exportNotifications(final ExportNotificationRequest request,
-            final StreamObserver<ExportNotification> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = service.getCurrentSession();
-
-            session.addExportListener(responseObserver);
-            ((ServerCallStreamObserver<ExportNotification>) responseObserver).setOnCancelHandler(() -> {
-                session.removeExportListener(responseObserver);
-            });
-        });
-    }
-
-    @Override
-    public void terminationNotification(TerminationNotificationRequest request,
-            StreamObserver<TerminationNotificationResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = service.getCurrentSession();
-            service.addTerminationListener(session, responseObserver);
-        });
+    public void terminationNotification(
+            @NotNull final TerminationNotificationRequest request,
+            @NotNull final StreamObserver<TerminationNotificationResponse> responseObserver) {
+        final SessionState session = service.getCurrentSession();
+        service.addTerminationListener(session, responseObserver);
     }
 
     public static void insertCallHeader(String key, String value) {
@@ -264,13 +267,13 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
     }
 
     @Singleton
-    public static class AuthServerInterceptor implements ServerInterceptor {
+    public static class SessionServiceInterceptor implements ServerInterceptor {
         private final SessionService service;
         private static final Status authenticationDetailsInvalid =
                 Status.UNAUTHENTICATED.withDescription("Authentication details invalid");
 
         @Inject
-        public AuthServerInterceptor(final SessionService service) {
+        public SessionServiceInterceptor(final SessionService service) {
             this.service = service;
         }
 
@@ -309,7 +312,108 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
             final InterceptedCall<ReqT, RespT> serverCall = new InterceptedCall<>(service, call, session);
             final Context context = Context.current().withValues(
                     SESSION_CONTEXT_KEY, session, SESSION_CALL_KEY, serverCall);
-            return Contexts.interceptCall(context, serverCall, metadata, serverCallHandler);
+
+            final SessionState finalSession = session;
+
+            final MutableObject<SessionServiceCallListener<ReqT, RespT>> listener = new MutableObject<>();
+            rpcWrapper(serverCall, context, finalSession, () -> listener.setValue(new SessionServiceCallListener<>(
+                    serverCallHandler.startCall(serverCall, metadata), serverCall, context, finalSession)));
+            if (listener.getValue() == null) {
+                return new ServerCall.Listener<>() {};
+            }
+            return listener.getValue();
+        }
+    }
+
+    private static class SessionServiceCallListener<ReqT, RespT> extends
+            ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
+        private final ServerCall<ReqT, RespT> call;
+        private final Context context;
+        private final SessionState session;
+
+        public SessionServiceCallListener(
+                ServerCall.Listener<ReqT> delegate,
+                ServerCall<ReqT, RespT> call,
+                Context context,
+                SessionState session) {
+            super(delegate);
+            this.call = call;
+            this.context = context;
+            this.session = session;
+        }
+
+        @Override
+        public void onMessage(ReqT message) {
+            rpcWrapper(call, context, session, () -> super.onMessage(message));
+        }
+
+        @Override
+        public void onHalfClose() {
+            rpcWrapper(call, context, session, super::onHalfClose);
+        }
+
+        @Override
+        public void onCancel() {
+            rpcWrapper(call, context, session, super::onCancel);
+        }
+
+        @Override
+        public void onComplete() {
+            rpcWrapper(call, context, session, super::onComplete);
+        }
+
+        @Override
+        public void onReady() {
+            rpcWrapper(call, context, session, super::onReady);
+        }
+    }
+
+    /**
+     * Utility to avoid errors escaping to the stream, to make sure the server log and client both see the message if
+     * there is an error, and if the error was not meant to propagate to a gRPC client, obfuscates it.
+     *
+     * @param call the gRPC call
+     * @param context the gRPC context to attach
+     * @param session the session that this gRPC call is associated with
+     * @param lambda the code to safely execute
+     */
+    private static <ReqT, RespT> void rpcWrapper(
+            @NotNull final ServerCall<ReqT, RespT> call,
+            @NotNull final Context context,
+            @Nullable final SessionState session,
+            @NotNull final FunctionalInterfaces.ThrowingRunnable<InterruptedException> lambda) {
+        Context previous = context.attach();
+        try (final SafeCloseable ignored1 = LivenessScopeStack.open();
+                final SafeCloseable ignored2 = session == null ? null : session.getExecutionContext().open()) {
+            lambda.run();
+        } catch (final StatusRuntimeException err) {
+            if (err.getStatus().equals(Status.UNAUTHENTICATED)) {
+                log.info().append("ignoring unauthenticated request").endl();
+            } else {
+                log.error().append(err).endl();
+            }
+            closeWithError(call, err);
+        } catch (final InterruptedException err) {
+            Thread.currentThread().interrupt();
+            closeWithError(call, GrpcUtil.securelyWrapError(log, err, Code.UNAVAILABLE));
+        } catch (final Throwable err) {
+            closeWithError(call, GrpcUtil.securelyWrapError(log, err));
+        } finally {
+            context.detach(previous);
+        }
+    }
+
+    private static <ReqT, RespT> void closeWithError(
+            @NotNull final ServerCall<ReqT, RespT> call,
+            @NotNull final StatusRuntimeException err) {
+        try {
+            Metadata metadata = Status.trailersFromThrowable(err);
+            if (metadata == null) {
+                metadata = new Metadata();
+            }
+            call.close(Status.fromThrowable(err), metadata);
+        } catch (final Exception unexpectedErr) {
+            log.debug().append("Unanticipated gRPC Error: ").append(unexpectedErr).endl();
         }
     }
 }

--- a/server/src/main/java/io/deephaven/server/session/TicketRouter.java
+++ b/server/src/main/java/io/deephaven/server/session/TicketRouter.java
@@ -6,12 +6,12 @@ package io.deephaven.server.session;
 import com.google.rpc.Code;
 import io.deephaven.engine.table.Table;
 import io.deephaven.extensions.barrage.util.BarrageUtil;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.hash.KeyedIntObjectHashMap;
 import io.deephaven.hash.KeyedIntObjectKey;
 import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
 import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.util.Exceptions;
 import org.apache.arrow.flight.impl.Flight;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,7 +50,7 @@ public class TicketRouter {
             final ByteBuffer ticket,
             final String logId) {
         if (ticket.remaining() == 0) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "could not resolve '" + logId + "' it's an empty ticket");
         }
         return getResolver(ticket.get(ticket.position()), logId).resolve(session, ticket, logId);
@@ -235,7 +235,7 @@ public class TicketRouter {
     private TicketResolver getResolver(final byte route, final String logId) {
         final TicketResolver resolver = byteResolverMap.get(route);
         if (resolver == null) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': no resolver for route '" + route + "' (byte)");
         }
         return resolver;
@@ -243,18 +243,18 @@ public class TicketRouter {
 
     private TicketResolver getResolver(final Flight.FlightDescriptor descriptor, final String logId) {
         if (descriptor.getType() != Flight.FlightDescriptor.DescriptorType.PATH) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': flight descriptor is not a path");
         }
         if (descriptor.getPathCount() <= 0) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': flight descriptor does not have route path");
         }
 
         final String route = descriptor.getPath(0);
         final TicketResolver resolver = descriptorResolverMap.get(route);
         if (resolver == null) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "Could not resolve '" + logId + "': no resolver for route '" + route + "'");
         }
 

--- a/server/src/main/java/io/deephaven/server/table/ExportedTableUpdateListener.java
+++ b/server/src/main/java/io/deephaven/server/table/ExportedTableUpdateListener.java
@@ -10,7 +10,6 @@ import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.InstrumentedTableUpdateListener;
 import io.deephaven.engine.table.impl.NotificationStepReceiver;
 import io.deephaven.engine.table.impl.SwapListener;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.hash.KeyedLongObjectHashMap;
 import io.deephaven.hash.KeyedLongObjectKey;
 import io.deephaven.internal.log.LoggerFactory;
@@ -18,6 +17,7 @@ import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.ExportNotification;
 import io.deephaven.proto.backplane.grpc.ExportedTableUpdateMessage;
 import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.proto.util.ExportTicketHelper;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
@@ -61,7 +61,7 @@ public class ExportedTableUpdateListener implements StreamObserver<ExportNotific
      */
     public void onNext(final ExportNotification notification) {
         if (isDestroyed) {
-            throw GrpcUtil.statusRuntimeException(Code.CANCELLED, "client cancelled the stream");
+            throw Exceptions.statusRuntimeException(Code.CANCELLED, "client cancelled the stream");
         }
 
         final Ticket ticket = notification.getTicket();

--- a/server/src/main/java/io/deephaven/server/table/ops/AggSpecAdapter.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/AggSpecAdapter.java
@@ -12,7 +12,6 @@ import io.deephaven.api.agg.spec.AggSpecSortedLast;
 import io.deephaven.api.agg.spec.AggSpecWAvg;
 import io.deephaven.api.agg.spec.AggSpecWSum;
 import io.deephaven.api.object.UnionObject;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.AggSpec.AggSpecAbsSum;
 import io.deephaven.proto.backplane.grpc.AggSpec.AggSpecApproximatePercentile;
 import io.deephaven.proto.backplane.grpc.AggSpec.AggSpecAvg;
@@ -38,6 +37,7 @@ import io.deephaven.proto.backplane.grpc.AggSpec.AggSpecVar;
 import io.deephaven.proto.backplane.grpc.AggSpec.AggSpecWeighted;
 import io.deephaven.proto.backplane.grpc.AggSpec.TypeCase;
 import io.deephaven.proto.backplane.grpc.NullValue;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.grpc.GrpcErrorHelper;
 
 import java.lang.reflect.InvocationTargetException;
@@ -98,32 +98,32 @@ class AggSpecAdapter {
                 return;
             case NULL_VALUE:
                 if (nonUniqueSentinel.getNullValue() != NullValue.NULL_VALUE) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "AggSpecNonUniqueSentinel null_value out of range");
                 }
                 return;
             case BYTE_VALUE:
                 if (nonUniqueSentinel.getByteValue() != (byte) nonUniqueSentinel.getByteValue()) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "AggSpecNonUniqueSentinel byte_value out of range");
                 }
                 return;
             case SHORT_VALUE:
                 if (nonUniqueSentinel.getShortValue() != (short) nonUniqueSentinel.getShortValue()) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "AggSpecNonUniqueSentinel short_value out of range");
                 }
                 return;
             case CHAR_VALUE:
                 if (nonUniqueSentinel.getCharValue() != (char) nonUniqueSentinel.getCharValue()) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "AggSpecNonUniqueSentinel char_value out of range");
                 }
                 return;
             case TYPE_NOT_SET:
                 // Should be caught by checkHasOneOf, fall-through to internal error if not.
             default:
-                throw GrpcUtil.statusRuntimeException(Code.INTERNAL,
+                throw Exceptions.statusRuntimeException(Code.INTERNAL,
                         String.format("Server missing AggSpecNonUniqueSentinel type %s", type));
         }
     }
@@ -211,9 +211,9 @@ class AggSpecAdapter {
             case CHAR_VALUE:
                 return UnionObject.of((char) nonUniqueSentinel.getCharValue());
             case TYPE_NOT_SET:
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "AggSpecNonUniqueSentinel type not set");
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "AggSpecNonUniqueSentinel type not set");
             default:
-                throw GrpcUtil.statusRuntimeException(Code.INTERNAL, String
+                throw Exceptions.statusRuntimeException(Code.INTERNAL, String
                         .format("Server is missing AggSpecNonUniqueSentinel case %s", nonUniqueSentinel.getTypeCase()));
         }
     }
@@ -244,10 +244,10 @@ class AggSpecAdapter {
                 return adapter;
             }
             if (unimplemented.contains(type)) {
-                throw GrpcUtil.statusRuntimeException(Code.UNIMPLEMENTED,
+                throw Exceptions.statusRuntimeException(Code.UNIMPLEMENTED,
                         String.format("AggSpec type %s is unimplemented", type));
             }
-            throw GrpcUtil.statusRuntimeException(Code.INTERNAL,
+            throw Exceptions.statusRuntimeException(Code.INTERNAL,
                     String.format("Server is missing AggSpec type %s", type));
         }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/AggregationAdapter.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/AggregationAdapter.java
@@ -12,12 +12,12 @@ import io.deephaven.api.agg.FirstRowKey;
 import io.deephaven.api.agg.LastRowKey;
 import io.deephaven.api.agg.Partition;
 import io.deephaven.api.agg.spec.AggSpec;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.Aggregation.AggregationColumns;
 import io.deephaven.proto.backplane.grpc.Aggregation.AggregationCount;
 import io.deephaven.proto.backplane.grpc.Aggregation.AggregationPartition;
 import io.deephaven.proto.backplane.grpc.Aggregation.AggregationRowKey;
 import io.deephaven.proto.backplane.grpc.Aggregation.TypeCase;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.grpc.GrpcErrorHelper;
 
 import java.lang.reflect.InvocationTargetException;
@@ -107,10 +107,10 @@ public class AggregationAdapter {
                 return adapter;
             }
             if (unimplemented.contains(type)) {
-                throw GrpcUtil.statusRuntimeException(Code.UNIMPLEMENTED,
+                throw Exceptions.statusRuntimeException(Code.UNIMPLEMENTED,
                         String.format("Aggregation type %s is unimplemented", type));
             }
-            throw GrpcUtil.statusRuntimeException(Code.INTERNAL,
+            throw Exceptions.statusRuntimeException(Code.INTERNAL,
                     String.format("Server is missing Aggregation type %s", type));
         }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/ComboAggregateGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/ComboAggregateGrpcImpl.java
@@ -11,9 +11,9 @@ import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.ComboAggregateRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
 import org.jetbrains.annotations.NotNull;
@@ -41,13 +41,12 @@ public class ComboAggregateGrpcImpl extends GrpcTableOperation<ComboAggregateReq
     @Override
     public void validateRequest(ComboAggregateRequest request) throws StatusRuntimeException {
         if (request.getAggregatesCount() == 0) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     "ComboAggregateRequest incorrectly has zero aggregates provided");
         }
         for (String groupByColumn : request.getGroupByColumnsList()) {
             if (!NameValidator.isValidColumnName(groupByColumn)) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                        "ComboAggregateRequest group by");
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "ComboAggregateRequest group by");
             }
         }
         if (isSimpleAggregation(request)) {
@@ -55,21 +54,21 @@ public class ComboAggregateGrpcImpl extends GrpcTableOperation<ComboAggregateReq
             // which would suggest they meant to set force_combo=true
             ComboAggregateRequest.Aggregate aggregate = request.getAggregates(0);
             if (aggregate.getMatchPairsCount() != 0) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "force_combo is false and only one aggregate provided, but match_pairs is specified");
             }
             if (aggregate.getPercentile() != 0) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "force_combo is false and only one aggregate provided, but percentile is specified");
             }
             if (aggregate.getAvgMedian()) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "force_combo is false and only one aggregate provided, but avg_median is specified");
             }
             if (aggregate.getType() != ComboAggregateRequest.AggType.COUNT
                     && aggregate.getType() != ComboAggregateRequest.AggType.WEIGHTED_AVG) {
                 if (!aggregate.getColumnName().isEmpty()) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "force_combo is false and only one aggregate provided, but column_name is specified for type other than COUNT or WEIGHTED_AVG");
                 }
             }
@@ -77,24 +76,24 @@ public class ComboAggregateGrpcImpl extends GrpcTableOperation<ComboAggregateReq
             for (ComboAggregateRequest.Aggregate aggregate : request.getAggregatesList()) {
                 if (aggregate.getType() != ComboAggregateRequest.AggType.PERCENTILE) {
                     if (aggregate.getPercentile() != 0) {
-                        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                                 "percentile is specified for type " + aggregate.getType());
                     }
                     if (aggregate.getAvgMedian()) {
-                        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                                 "avg_median is specified for type " + aggregate.getType());
                     }
                 }
                 if (aggregate.getType() == ComboAggregateRequest.AggType.COUNT) {
                     if (aggregate.getMatchPairsCount() != 0) {
-                        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                                 "match_pairs is specified for type COUNT");
                     }
                 }
                 if (aggregate.getType() != ComboAggregateRequest.AggType.COUNT
                         && aggregate.getType() != ComboAggregateRequest.AggType.WEIGHTED_AVG) {
                     if (!aggregate.getColumnName().isEmpty()) {
-                        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                                 "column_name is specified for type " + aggregate.getType());
                     }
                 }

--- a/server/src/main/java/io/deephaven/server/table/ops/CreateInputTableGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/CreateInputTableGrpcImpl.java
@@ -11,10 +11,10 @@ import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.util.AppendOnlyArrayBackedMutableTable;
 import io.deephaven.engine.table.impl.util.KeyedArrayBackedMutableTable;
 import io.deephaven.extensions.barrage.util.BarrageUtil;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.CreateInputTableRequest;
 import io.deephaven.proto.flight.util.SchemaHelper;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
 import org.apache.arrow.flatbuf.Schema;
@@ -44,14 +44,13 @@ public class CreateInputTableGrpcImpl extends GrpcTableOperation<CreateInputTabl
     public void validateRequest(CreateInputTableRequest request) throws StatusRuntimeException {
         // ensure we have one of either schema or source table (protobuf will ensure we don't have both)
         if (!request.hasSchema() && !request.hasSourceTableId()) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     "Must specify one of schema and source_table_id");
         }
 
         if (request.getKind().getKindCase() == null ||
                 request.getKind().getKindCase() == KIND_NOT_SET) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
-                    "Unrecognized InputTableKind");
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Unrecognized InputTableKind");
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/EmptyTableGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/EmptyTableGrpcImpl.java
@@ -8,9 +8,9 @@ import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.util.TableTools;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.EmptyTableRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
 
@@ -30,7 +30,7 @@ public class EmptyTableGrpcImpl extends GrpcTableOperation<EmptyTableRequest> {
     @Override
     public void validateRequest(final EmptyTableRequest request) throws StatusRuntimeException {
         if (request.getSize() < 0) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Size must be greater than zero");
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Size must be greater than zero");
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/HeadOrTailByGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/HeadOrTailByGrpcImpl.java
@@ -11,9 +11,9 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.select.SelectColumn;
 import io.deephaven.engine.table.impl.select.SelectColumnFactory;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.HeadOrTailByRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.deephaven.server.table.validation.ColumnExpressionValidator;
 import io.grpc.StatusRuntimeException;
@@ -46,7 +46,8 @@ public abstract class HeadOrTailByGrpcImpl extends GrpcTableOperation<HeadOrTail
     public void validateRequest(final HeadOrTailByRequest request) throws StatusRuntimeException {
         final long nRows = request.getNumRows();
         if (nRows < 0) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "numRows must be >= 0 (found: " + nRows + ")");
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    "numRows must be >= 0 (found: " + nRows + ")");
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/HeadOrTailGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/HeadOrTailGrpcImpl.java
@@ -7,9 +7,9 @@ import com.google.rpc.Code;
 import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.HeadOrTailRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
 
@@ -38,7 +38,8 @@ public abstract class HeadOrTailGrpcImpl extends GrpcTableOperation<HeadOrTailRe
     public void validateRequest(final HeadOrTailRequest request) throws StatusRuntimeException {
         final long nRows = request.getNumRows();
         if (nRows < 0) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "numRows must be >= 0 (found: " + nRows + ")");
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    "numRows must be >= 0 (found: " + nRows + ")");
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/JoinTablesGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/JoinTablesGrpcImpl.java
@@ -11,7 +11,6 @@ import io.deephaven.engine.table.MatchPair;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.select.MatchPairFactory;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.AsOfJoinTablesRequest;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.CrossJoinTablesRequest;
@@ -19,6 +18,7 @@ import io.deephaven.proto.backplane.grpc.ExactJoinTablesRequest;
 import io.deephaven.proto.backplane.grpc.LeftJoinTablesRequest;
 import io.deephaven.proto.backplane.grpc.NaturalJoinTablesRequest;
 import io.deephaven.proto.backplane.grpc.Ticket;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
 
@@ -59,7 +59,7 @@ public abstract class JoinTablesGrpcImpl<T> extends GrpcTableOperation<T> {
             MatchPairFactory.getExpressions(getColMatchList.apply(request));
             MatchPairFactory.getExpressions(getColAddList.apply(request));
         } catch (final ExpressionException err) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     err.getMessage() + ": " + err.getProblemExpression());
         }
     }
@@ -75,7 +75,7 @@ public abstract class JoinTablesGrpcImpl<T> extends GrpcTableOperation<T> {
             columnsToMatch = MatchPairFactory.getExpressions(getColMatchList.apply(request));
             columnsToAdd = MatchPairFactory.getExpressions(getColAddList.apply(request));
         } catch (final ExpressionException err) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     err.getMessage() + ": " + err.getProblemExpression());
         }
 
@@ -114,7 +114,7 @@ public abstract class JoinTablesGrpcImpl<T> extends GrpcTableOperation<T> {
             super.validateRequest(request);
 
             if (request.getAsOfMatchRule() == AsOfJoinTablesRequest.MatchRule.UNRECOGNIZED) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Unrecognized as-of match rule");
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Unrecognized as-of match rule");
             }
         }
 
@@ -208,8 +208,7 @@ public abstract class JoinTablesGrpcImpl<T> extends GrpcTableOperation<T> {
         public static Table doJoin(final Table lhs, final Table rhs,
                 final MatchPair[] columnsToMatch, final MatchPair[] columnsToAdd,
                 final LeftJoinTablesRequest request) {
-            throw GrpcUtil.statusRuntimeException(Code.UNIMPLEMENTED,
-                    "LeftJoinTables is currently unimplemented");
+            throw Exceptions.statusRuntimeException(Code.UNIMPLEMENTED, "LeftJoinTables is currently unimplemented");
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/MergeTablesGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/MergeTablesGrpcImpl.java
@@ -9,9 +9,9 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.engine.util.TableTools;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.MergeTablesRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
 
@@ -37,7 +37,7 @@ public class MergeTablesGrpcImpl extends GrpcTableOperation<MergeTablesRequest> 
     @Override
     public void validateRequest(final MergeTablesRequest request) throws StatusRuntimeException {
         if (request.getSourceIdsList().isEmpty()) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Cannot merge zero source tables.");
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Cannot merge zero source tables.");
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/SelectDistinctGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/SelectDistinctGrpcImpl.java
@@ -7,9 +7,9 @@ import com.google.rpc.Code;
 import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.SelectDistinctRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 
 import javax.inject.Inject;
@@ -37,7 +37,7 @@ public class SelectDistinctGrpcImpl extends GrpcTableOperation<SelectDistinctReq
         final Set<String> requestedMissing = new HashSet<>(request.getColumnNamesList());
         requestedMissing.removeAll(parent.getDefinition().getColumnNameMap().keySet());
         if (!requestedMissing.isEmpty()) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "column(s) not found: " + String.join(", ", requestedMissing));
         }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/SnapshotWhenTableGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/SnapshotWhenTableGrpcImpl.java
@@ -12,10 +12,10 @@ import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest.Operation;
 import io.deephaven.proto.backplane.grpc.SnapshotWhenTableRequest;
 import io.deephaven.proto.backplane.grpc.TableReference;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.grpc.Common;
 import io.deephaven.server.grpc.GrpcErrorHelper;
 import io.deephaven.server.session.SessionState;
@@ -76,7 +76,7 @@ public final class SnapshotWhenTableGrpcImpl extends GrpcTableOperation<Snapshot
         try {
             options(request);
         } catch (UnsupportedOperationException e) {
-            throw GrpcUtil.statusRuntimeException(Code.UNIMPLEMENTED, e.getMessage());
+            throw Exceptions.statusRuntimeException(Code.UNIMPLEMENTED, e.getMessage());
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/SortTableGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/SortTableGrpcImpl.java
@@ -12,10 +12,10 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.AbsoluteSortColumnConventions;
 import io.deephaven.engine.table.impl.QueryTable;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.SortDescriptor;
 import io.deephaven.proto.backplane.grpc.SortTableRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 
 import javax.inject.Inject;
@@ -79,7 +79,7 @@ public class SortTableGrpcImpl extends GrpcTableOperation<SortTableRequest> {
                     direction = 1;
                     break;
                 default:
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                             "Unexpected sort direction: " + direction);
             }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -7,7 +7,6 @@ import com.google.rpc.Code;
 import io.deephaven.clientsupport.gotorow.SeekRow;
 import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
 import io.deephaven.engine.table.Table;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.extensions.barrage.util.ExportUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
@@ -52,6 +51,7 @@ import io.deephaven.proto.backplane.grpc.UngroupRequest;
 import io.deephaven.proto.backplane.grpc.UnstructuredFilterTableRequest;
 import io.deephaven.proto.backplane.grpc.UpdateByRequest;
 import io.deephaven.proto.backplane.grpc.WhereInRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.proto.util.ExportTicketHelper;
 import io.deephaven.server.grpc.GrpcErrorHelper;
 import io.deephaven.server.session.SessionService;
@@ -63,6 +63,7 @@ import io.deephaven.server.table.ExportedTableUpdateListener;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 import java.math.BigDecimal;
@@ -103,7 +104,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
         // noinspection unchecked
         final GrpcTableOperation<T> operation = (GrpcTableOperation<T>) operationMap.get(op);
         if (operation == null) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     "BatchTableRequest.Operation.OpCode is unset, incompatible, or not yet supported. (found: " + op
                             + ")");
         }
@@ -111,163 +112,191 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
     }
 
     @Override
-    public void emptyTable(final EmptyTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void emptyTable(
+            @NotNull final EmptyTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.EMPTY_TABLE, request, responseObserver);
     }
 
     @Override
-    public void timeTable(final TimeTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void timeTable(
+            @NotNull final TimeTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.TIME_TABLE, request, responseObserver);
     }
 
     @Override
-    public void mergeTables(final MergeTablesRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void mergeTables(
+            @NotNull final MergeTablesRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.MERGE, request, responseObserver);
     }
 
     @Override
-    public void selectDistinct(final SelectDistinctRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void selectDistinct(
+            @NotNull final SelectDistinctRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.SELECT_DISTINCT, request, responseObserver);
     }
 
     @Override
-    public void update(final SelectOrUpdateRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void update(
+            @NotNull final SelectOrUpdateRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.UPDATE, request, responseObserver);
     }
 
     @Override
-    public void lazyUpdate(final SelectOrUpdateRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void lazyUpdate(
+            @NotNull final SelectOrUpdateRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.LAZY_UPDATE, request, responseObserver);
     }
 
     @Override
-    public void view(final SelectOrUpdateRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void view(
+            @NotNull final SelectOrUpdateRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.VIEW, request, responseObserver);
     }
 
     @Override
-    public void updateView(final SelectOrUpdateRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void updateView(
+            @NotNull final SelectOrUpdateRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.UPDATE_VIEW, request, responseObserver);
     }
 
     @Override
-    public void select(final SelectOrUpdateRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void select(
+            @NotNull final SelectOrUpdateRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.SELECT, request, responseObserver);
     }
 
     @Override
-    public void headBy(final HeadOrTailByRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void headBy(
+            @NotNull final HeadOrTailByRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.HEAD_BY, request, responseObserver);
     }
 
     @Override
-    public void tailBy(final HeadOrTailByRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void tailBy(
+            @NotNull final HeadOrTailByRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.TAIL_BY, request, responseObserver);
     }
 
     @Override
-    public void head(final HeadOrTailRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void head(
+            @NotNull final HeadOrTailRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.HEAD, request, responseObserver);
     }
 
     @Override
-    public void tail(final HeadOrTailRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void tail(
+            @NotNull final HeadOrTailRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.TAIL, request, responseObserver);
     }
 
     @Override
-    public void ungroup(final UngroupRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void ungroup(
+            @NotNull final UngroupRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.UNGROUP, request, responseObserver);
     }
 
     @Override
-    public void comboAggregate(final ComboAggregateRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void comboAggregate(
+            @NotNull final ComboAggregateRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.COMBO_AGGREGATE, request, responseObserver);
     }
 
     @Override
-    public void aggregateAll(AggregateAllRequest request,
-            StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void aggregateAll(
+            @NotNull final AggregateAllRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(OpCase.AGGREGATE_ALL, request, responseObserver);
     }
 
     @Override
-    public void aggregate(AggregateRequest request, StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void aggregate(
+            @NotNull final AggregateRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.AGGREGATE, request, responseObserver);
     }
 
     @Override
-    public void snapshot(final SnapshotTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void snapshot(
+            @NotNull final SnapshotTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.SNAPSHOT, request, responseObserver);
     }
 
     @Override
-    public void snapshotWhen(final SnapshotWhenTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void snapshotWhen(
+            @NotNull final SnapshotWhenTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.SNAPSHOT_WHEN, request, responseObserver);
     }
 
     @Override
-    public void dropColumns(final DropColumnsRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void dropColumns(
+            @NotNull final DropColumnsRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.DROP_COLUMNS, request, responseObserver);
     }
 
     @Override
-    public void filter(final FilterTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void filter(
+            @NotNull final FilterTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.FILTER, request, responseObserver);
     }
 
     @Override
-    public void unstructuredFilter(final UnstructuredFilterTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void unstructuredFilter(
+            @NotNull final UnstructuredFilterTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.UNSTRUCTURED_FILTER, request, responseObserver);
     }
 
     @Override
-    public void sort(final SortTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void sort(
+            @NotNull final SortTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.SORT, request, responseObserver);
     }
 
     @Override
-    public void flatten(final FlattenRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void flatten(
+            @NotNull final FlattenRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.FLATTEN, request, responseObserver);
     }
 
     @Override
-    public void crossJoinTables(final CrossJoinTablesRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void crossJoinTables(
+            @NotNull final CrossJoinTablesRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.CROSS_JOIN, request, responseObserver);
     }
 
     @Override
-    public void naturalJoinTables(final NaturalJoinTablesRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void naturalJoinTables(
+            @NotNull final NaturalJoinTablesRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.NATURAL_JOIN, request, responseObserver);
     }
 
     @Override
-    public void exactJoinTables(final ExactJoinTablesRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void exactJoinTables(
+            @NotNull final ExactJoinTablesRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.EXACT_JOIN, request, responseObserver);
     }
 
@@ -320,13 +349,14 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                 return new BigInteger(literal.getStringValue());
             }
             if (!String.class.isAssignableFrom(dataType) && dataType != char.class) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT,
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "Invalid String type for seek: " + dataType);
             }
             return literal.getStringValue();
         } else if (literal.hasNanoTimeValue()) {
             if (!DateTime.class.isAssignableFrom(dataType)) {
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Invalid Date type for seek: " + dataType);
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                        "Invalid Date type for seek: " + dataType);
             }
             return new DateTime(literal.getNanoTimeValue());
         } else if (literal.hasLongValue()) {
@@ -372,166 +402,166 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
         } else if (literal.hasBoolValue()) {
             return literal.getBoolValue();
         }
-        throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "Invalid column type for seek: " + dataType);
+        throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "Invalid column type for seek: " + dataType);
     }
 
     @Override
-    public void whereIn(WhereInRequest request, StreamObserver<ExportedTableCreationResponse> responseObserver) {
+    public void whereIn(
+            @NotNull final WhereInRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
         oneShotOperationWrapper(BatchTableRequest.Operation.OpCase.WHERE_IN, request, responseObserver);
     }
 
     @Override
-    public void seekRow(SeekRowRequest request, StreamObserver<SeekRowResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
-            final Ticket sourceId = request.getSourceId();
-            if (sourceId.getTicket().isEmpty()) {
-                throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "No consoleId supplied");
-            }
-            SessionState.ExportObject<Table> exportedTable =
-                    ticketRouter.resolve(session, sourceId, "sourceId");
-            session.nonExport()
-                    .require(exportedTable)
-                    .onError(responseObserver)
-                    .submit(() -> {
-                        final Table table = exportedTable.get();
-                        authWiring.checkPermissionSeekRow(session.getAuthContext(), request,
-                                Collections.singletonList(table));
-                        final String columnName = request.getColumnName();
-                        final Class<?> dataType = table.getDefinition().getColumn(columnName).getDataType();
-                        final Object seekValue = getSeekValue(request.getSeekValue(), dataType);
-                        final Long result = table.apply(new SeekRow(
-                                request.getStartingRow(),
-                                columnName,
-                                seekValue,
-                                request.getInsensitive(),
-                                request.getContains(),
-                                request.getIsBackward()));
-                        SeekRowResponse.Builder rowResponse = SeekRowResponse.newBuilder();
-                        safelyComplete(responseObserver, rowResponse.setResultRow(result).build());
-                    });
-        });
-    }
-
-    @Override
-    public void batch(final BatchTableRequest request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            GrpcErrorHelper.checkRepeatedFieldNonEmpty(request, BatchTableRequest.OPS_FIELD_NUMBER);
-            GrpcErrorHelper.checkHasNoUnknownFields(request);
-            for (Operation operation : request.getOpsList()) {
-                GrpcErrorHelper.checkHasOneOf(operation, "op");
-                GrpcErrorHelper.checkHasNoUnknownFields(operation);
-            }
-            final SessionState session = sessionService.getCurrentSession();
-
-            // step 1: initialize exports
-            final List<BatchExportBuilder<?>> exportBuilders = request.getOpsList().stream()
-                    .map(op -> createBatchExportBuilder(session, op))
-                    .collect(Collectors.toList());
-
-            // step 2: resolve dependencies
-            exportBuilders.forEach(export -> export.resolveDependencies(session, exportBuilders));
-
-            // step 3: check for cyclical dependencies; this is our only opportunity to check non-export cycles
-            // TODO: check for cycles
-
-            // step 4: submit the batched operations
-            final AtomicInteger remaining = new AtomicInteger(exportBuilders.size());
-            final AtomicReference<StatusRuntimeException> firstFailure = new AtomicReference<>();
-
-            final Runnable onOneResolved = () -> {
-                if (remaining.decrementAndGet() == 0) {
-                    final StatusRuntimeException failure = firstFailure.get();
-                    if (failure != null) {
-                        safelyError(responseObserver, failure);
-                    } else {
-                        safelyComplete(responseObserver);
-                    }
-                }
-            };
-
-            for (int i = 0; i < exportBuilders.size(); ++i) {
-                final BatchExportBuilder<?> exportBuilder = exportBuilders.get(i);
-                final int exportId = exportBuilder.exportBuilder.getExportId();
-
-                final TableReference resultId;
-                if (exportId == SessionState.NON_EXPORT_ID) {
-                    resultId = TableReference.newBuilder().setBatchOffset(i).build();
-                } else {
-                    resultId = ExportTicketHelper.tableReference(exportId);
-                }
-
-                exportBuilder.exportBuilder.onError((result, errorContext, cause, dependentId) -> {
-                    String errorInfo = errorContext;
-                    if (dependentId != null) {
-                        errorInfo += " dependency: " + dependentId;
-                    }
-                    if (cause instanceof StatusRuntimeException) {
-                        errorInfo += " cause: " + cause.getMessage();
-                        firstFailure.compareAndSet(null, (StatusRuntimeException) cause);
-                    }
-                    final ExportedTableCreationResponse response = ExportedTableCreationResponse.newBuilder()
-                            .setResultId(resultId)
-                            .setSuccess(false)
-                            .setErrorInfo(errorInfo)
-                            .build();
-                    safelyOnNext(responseObserver, response);
-                    onOneResolved.run();
-                }).submit(() -> {
-                    final Table table = exportBuilder.doExport();
-                    final ExportedTableCreationResponse response =
-                            ExportUtil.buildTableCreationResponse(resultId, table);
-                    safelyOnNext(responseObserver, response);
-                    onOneResolved.run();
-                    return table;
+    public void seekRow(
+            @NotNull final SeekRowRequest request,
+            @NotNull final StreamObserver<SeekRowResponse> responseObserver) {
+        final SessionState session = sessionService.getCurrentSession();
+        final Ticket sourceId = request.getSourceId();
+        if (sourceId.getTicket().isEmpty()) {
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION, "No consoleId supplied");
+        }
+        SessionState.ExportObject<Table> exportedTable =
+                ticketRouter.resolve(session, sourceId, "sourceId");
+        session.nonExport()
+                .require(exportedTable)
+                .onError(responseObserver)
+                .submit(() -> {
+                    final Table table = exportedTable.get();
+                    authWiring.checkPermissionSeekRow(session.getAuthContext(), request,
+                            Collections.singletonList(table));
+                    final String columnName = request.getColumnName();
+                    final Class<?> dataType = table.getDefinition().getColumn(columnName).getDataType();
+                    final Object seekValue = getSeekValue(request.getSeekValue(), dataType);
+                    final Long result = table.apply(new SeekRow(
+                            request.getStartingRow(),
+                            columnName,
+                            seekValue,
+                            request.getInsensitive(),
+                            request.getContains(),
+                            request.getIsBackward()));
+                    SeekRowResponse.Builder rowResponse = SeekRowResponse.newBuilder();
+                    safelyComplete(responseObserver, rowResponse.setResultRow(result).build());
                 });
-            }
-        });
     }
 
     @Override
-    public void exportedTableUpdates(final ExportedTableUpdatesRequest request,
-            final StreamObserver<ExportedTableUpdateMessage> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
-            authWiring.checkPermissionExportedTableUpdates(session.getAuthContext(), request, Collections.emptyList());
-            final ExportedTableUpdateListener listener = new ExportedTableUpdateListener(session, responseObserver);
-            session.addExportListener(listener);
-            ((ServerCallStreamObserver<ExportedTableUpdateMessage>) responseObserver).setOnCancelHandler(
-                    () -> session.removeExportListener(listener));
-        });
+    public void batch(
+            @NotNull final BatchTableRequest request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+        GrpcErrorHelper.checkRepeatedFieldNonEmpty(request, BatchTableRequest.OPS_FIELD_NUMBER);
+        GrpcErrorHelper.checkHasNoUnknownFields(request);
+        for (Operation operation : request.getOpsList()) {
+            GrpcErrorHelper.checkHasOneOf(operation, "op");
+            GrpcErrorHelper.checkHasNoUnknownFields(operation);
+        }
+        final SessionState session = sessionService.getCurrentSession();
+
+        // step 1: initialize exports
+        final List<BatchExportBuilder<?>> exportBuilders = request.getOpsList().stream()
+                .map(op -> createBatchExportBuilder(session, op))
+                .collect(Collectors.toList());
+
+        // step 2: resolve dependencies
+        exportBuilders.forEach(export -> export.resolveDependencies(session, exportBuilders));
+
+        // step 3: check for cyclical dependencies; this is our only opportunity to check non-export cycles
+        // TODO: check for cycles
+
+        // step 4: submit the batched operations
+        final AtomicInteger remaining = new AtomicInteger(exportBuilders.size());
+        final AtomicReference<StatusRuntimeException> firstFailure = new AtomicReference<>();
+
+        final Runnable onOneResolved = () -> {
+            if (remaining.decrementAndGet() == 0) {
+                final StatusRuntimeException failure = firstFailure.get();
+                if (failure != null) {
+                    safelyError(responseObserver, failure);
+                } else {
+                    safelyComplete(responseObserver);
+                }
+            }
+        };
+
+        for (int i = 0; i < exportBuilders.size(); ++i) {
+            final BatchExportBuilder<?> exportBuilder = exportBuilders.get(i);
+            final int exportId = exportBuilder.exportBuilder.getExportId();
+
+            final TableReference resultId;
+            if (exportId == SessionState.NON_EXPORT_ID) {
+                resultId = TableReference.newBuilder().setBatchOffset(i).build();
+            } else {
+                resultId = ExportTicketHelper.tableReference(exportId);
+            }
+
+            exportBuilder.exportBuilder.onError((result, errorContext, cause, dependentId) -> {
+                String errorInfo = errorContext;
+                if (dependentId != null) {
+                    errorInfo += " dependency: " + dependentId;
+                }
+                if (cause instanceof StatusRuntimeException) {
+                    errorInfo += " cause: " + cause.getMessage();
+                    firstFailure.compareAndSet(null, (StatusRuntimeException) cause);
+                }
+                final ExportedTableCreationResponse response = ExportedTableCreationResponse.newBuilder()
+                        .setResultId(resultId)
+                        .setSuccess(false)
+                        .setErrorInfo(errorInfo)
+                        .build();
+                safelyOnNext(responseObserver, response);
+                onOneResolved.run();
+            }).submit(() -> {
+                final Table table = exportBuilder.doExport();
+                final ExportedTableCreationResponse response =
+                        ExportUtil.buildTableCreationResponse(resultId, table);
+                safelyOnNext(responseObserver, response);
+                onOneResolved.run();
+                return table;
+            });
+        }
     }
 
     @Override
-    public void getExportedTableCreationResponse(final Ticket request,
-            final StreamObserver<ExportedTableCreationResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
+    public void exportedTableUpdates(
+            @NotNull final ExportedTableUpdatesRequest request,
+            @NotNull final StreamObserver<ExportedTableUpdateMessage> responseObserver) {
+        final SessionState session = sessionService.getCurrentSession();
+        authWiring.checkPermissionExportedTableUpdates(session.getAuthContext(), request, Collections.emptyList());
+        final ExportedTableUpdateListener listener = new ExportedTableUpdateListener(session, responseObserver);
+        session.addExportListener(listener);
+        ((ServerCallStreamObserver<ExportedTableUpdateMessage>) responseObserver).setOnCancelHandler(
+                () -> session.removeExportListener(listener));
+    }
 
-            if (request.getTicket().isEmpty()) {
-                throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "No request ticket supplied");
-            }
+    @Override
+    public void getExportedTableCreationResponse(
+            @NotNull final Ticket request,
+            @NotNull final StreamObserver<ExportedTableCreationResponse> responseObserver) {
+        final SessionState session = sessionService.getCurrentSession();
 
-            final SessionState.ExportObject<Object> export = ticketRouter.resolve(session, request, "request");
+        if (request.getTicket().isEmpty()) {
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION, "No request ticket supplied");
+        }
 
-            session.nonExport()
-                    .require(export)
-                    .onError(responseObserver)
-                    .submit(() -> {
-                        final Object obj = export.get();
-                        if (!(obj instanceof Table)) {
-                            responseObserver.onError(
-                                    GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "Ticket is not a table"));
-                            return;
-                        }
-                        authWiring.checkPermissionGetExportedTableCreationResponse(
-                                session.getAuthContext(), request, Collections.singletonList((Table) obj));
-                        final ExportedTableCreationResponse response =
-                                ExportUtil.buildTableCreationResponse(request, (Table) obj);
-                        safelyComplete(responseObserver, response);
-                    });
-        });
+        final SessionState.ExportObject<Object> export = ticketRouter.resolve(session, request, "request");
+
+        session.nonExport()
+                .require(export)
+                .onError(responseObserver)
+                .submit(() -> {
+                    final Object obj = export.get();
+                    if (!(obj instanceof Table)) {
+                        responseObserver.onError(
+                                Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
+                                        "Ticket is not a table"));
+                        return;
+                    }
+                    authWiring.checkPermissionGetExportedTableCreationResponse(
+                            session.getAuthContext(), request, Collections.singletonList((Table) obj));
+                    final ExportedTableCreationResponse response =
+                            ExportUtil.buildTableCreationResponse(request, (Table) obj);
+                    safelyComplete(responseObserver, response);
+                });
     }
 
     /**
@@ -546,37 +576,35 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
             final BatchTableRequest.Operation.OpCase op,
             final T request,
             final StreamObserver<ExportedTableCreationResponse> responseObserver) {
-        GrpcUtil.rpcWrapper(log, responseObserver, () -> {
-            final SessionState session = sessionService.getCurrentSession();
-            final GrpcTableOperation<T> operation = getOp(op);
-            operation.validateRequest(request);
+        final SessionState session = sessionService.getCurrentSession();
+        final GrpcTableOperation<T> operation = getOp(op);
+        operation.validateRequest(request);
 
-            final Ticket resultId = operation.getResultTicket(request);
-            if (resultId.getTicket().isEmpty()) {
-                throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION, "No result ticket supplied");
-            }
+        final Ticket resultId = operation.getResultTicket(request);
+        if (resultId.getTicket().isEmpty()) {
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION, "No result ticket supplied");
+        }
 
-            final List<SessionState.ExportObject<Table>> dependencies = operation.getTableReferences(request).stream()
-                    .map(ref -> resolveOneShotReference(session, ref))
-                    .collect(Collectors.toList());
+        final List<SessionState.ExportObject<Table>> dependencies = operation.getTableReferences(request).stream()
+                .map(ref -> resolveOneShotReference(session, ref))
+                .collect(Collectors.toList());
 
-            session.newExport(resultId, "resultId")
-                    .require(dependencies)
-                    .onError(responseObserver)
-                    .submit(() -> {
-                        operation.checkPermission(request, dependencies);
-                        final Table result = operation.create(request, dependencies);
-                        final ExportedTableCreationResponse response =
-                                ExportUtil.buildTableCreationResponse(resultId, result);
-                        safelyComplete(responseObserver, response);
-                        return result;
-                    });
-        });
+        session.newExport(resultId, "resultId")
+                .require(dependencies)
+                .onError(responseObserver)
+                .submit(() -> {
+                    operation.checkPermission(request, dependencies);
+                    final Table result = operation.create(request, dependencies);
+                    final ExportedTableCreationResponse response =
+                            ExportUtil.buildTableCreationResponse(resultId, result);
+                    safelyComplete(responseObserver, response);
+                    return result;
+                });
     }
 
     private SessionState.ExportObject<Table> resolveOneShotReference(SessionState session, TableReference ref) {
         if (!ref.hasTicket()) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "One-shot operations must use ticket references");
         }
         return ticketRouter.resolve(session, ref.getTicket(), "sourceId");
@@ -590,11 +618,11 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
             case BATCH_OFFSET:
                 final int offset = ref.getBatchOffset();
                 if (offset < 0 || offset >= exportBuilders.size()) {
-                    throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "invalid table reference: " + ref);
+                    throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "invalid table reference: " + ref);
                 }
                 return exportBuilders.get(offset).exportBuilder.getExport();
             default:
-                throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, "invalid table reference: " + ref);
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, "invalid table reference: " + ref);
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/table/ops/TimeTableGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TimeTableGrpcImpl.java
@@ -9,9 +9,9 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.TimeTable;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.TimeTableRequest;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.deephaven.server.util.Scheduler;
 import io.deephaven.time.DateTimeUtils;
@@ -42,7 +42,7 @@ public class TimeTableGrpcImpl extends GrpcTableOperation<TimeTableRequest> {
     public void validateRequest(final TimeTableRequest request) throws StatusRuntimeException {
         final long periodNanos = request.getPeriodNanos();
         if (periodNanos <= 0) {
-            throw GrpcUtil.statusRuntimeException(Code.FAILED_PRECONDITION,
+            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                     "periodNanos must be >= 0 (found: " + periodNanos + ")");
         }
     }

--- a/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/UpdateByGrpcImpl.java
@@ -13,7 +13,6 @@ import io.deephaven.api.updateby.spec.WindowScale;
 import io.deephaven.auth.codegen.impl.TableServiceContextualAuthWiring;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.Table;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.backplane.grpc.BatchTableRequest;
 import io.deephaven.proto.backplane.grpc.UpdateByRequest;
 import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation.UpdateByColumn;
@@ -25,6 +24,7 @@ import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation.Updat
 import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation.UpdateByColumn.UpdateBySpec.UpdateByEma.UpdateByEmaOptions;
 import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOperation.UpdateByColumn.UpdateBySpec.UpdateByFill;
 import io.deephaven.proto.backplane.grpc.UpdateByRequest.UpdateByOptions;
+import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.session.SessionState;
 import io.grpc.StatusRuntimeException;
 
@@ -60,7 +60,7 @@ public final class UpdateByGrpcImpl extends GrpcTableOperation<UpdateByRequest> 
                 ColumnName.of(columnName);
             }
         } catch (IllegalArgumentException e) {
-            throw GrpcUtil.statusRuntimeException(Code.INVALID_ARGUMENT, e.getMessage());
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, e.getMessage());
         }
 
     }


### PR DESCRIPTION
I've cleaned up the `rpcWrapper` by moving it into the session object injection itself.
I've also opened the session's ExecutionContext in the context of all gRPC requests. 

DHE can now fetch the AuthContext during Ticket resolution as originally intended.

Nightlies are running here: https://github.com/nbauernfeind/deephaven-core/actions/runs/4370246882