### PR TITLE
Add SearchDisplayMode layout hints

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/LayoutHintBuilder.java
@@ -33,6 +33,27 @@ public class LayoutHintBuilder {
     private Map<String, ColumnGroup> columnGroups;
 
     /**
+     * The display mode for the search bar.
+     */
+    public enum SearchDisplayModes {
+        /**
+         * Use the system default
+         */
+        Default,
+        /**
+         * Permit the search bar to be displayed, regardless of system settings
+         */
+        Show,
+        /**
+         * Hide the search bar, regardless of system settings.
+         */
+        Hide
+    }
+
+    private SearchDisplayModes searchDisplayMode = SearchDisplayModes.Default;
+
+
+    /**
      * Helper class to maintain sub-properties for auto filter columns
      */
     private static class AutoFilterData {
@@ -229,6 +250,11 @@ public class LayoutHintBuilder {
         if (groupableStr != null && !groupableStr.isEmpty()) {
             final String[] groupableColumns = groupableStr.split(",");
             lhb.groupableColumns(groupableColumns);
+        }
+
+        final String searchableStr = options.get("searchable");
+        if (searchableStr != null && !searchableStr.isEmpty()) {
+            lhb.setSearchBarAccess(SearchDisplayModes.valueOf(searchableStr));
         }
 
         final String columnGroupsStr = options.get("columnGroups");
@@ -555,6 +581,30 @@ public class LayoutHintBuilder {
         return this;
     }
 
+    /**
+     * Set the search bar to explicitly be accessible or inaccessible, or use system default.
+     *
+     * @param searchable The display mode to use
+     * @return This LayoutHintBuilder
+     */
+    @ScriptApi
+    public LayoutHintBuilder setSearchBarAccess(final SearchDisplayModes searchable) {
+        searchDisplayMode = searchable;
+        return this;
+    }
+
+    /**
+     * Set the search bar to explicitly be accessible or inaccessible, or use system default.
+     *
+     * @param searchable The display mode to use
+     * @return This LayoutHintBuilder
+     */
+    @ScriptApi
+    public LayoutHintBuilder setSearchBarAccess(final String searchable) {
+        searchDisplayMode = SearchDisplayModes.valueOf(searchable);
+        return this;
+    }
+
     // endregion
 
     /**
@@ -599,6 +649,10 @@ public class LayoutHintBuilder {
 
         if (groupableColumns != null && !groupableColumns.isEmpty()) {
             sb.append("groupable=").append(String.join(",", groupableColumns)).append(';');
+        }
+
+        if (searchDisplayMode != SearchDisplayModes.Default) {
+            sb.append("searchable=").append(searchDisplayMode.toString()).append(';');
         }
 
         if (columnGroups != null && !columnGroups.isEmpty()) {
@@ -710,6 +764,13 @@ public class LayoutHintBuilder {
      */
     public @NotNull Set<String> getGroupableColumns() {
         return groupableColumns == null ? Collections.emptySet() : Collections.unmodifiableSet(groupableColumns);
+    }
+
+    public @NotNull SearchDisplayModes getSearchDisplayMode() {
+        if (searchDisplayMode == null) {
+            searchDisplayMode = SearchDisplayModes.Default;
+        }
+        return searchDisplayMode;
     }
 
     /**

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1852,7 +1852,7 @@ class Table(JObjectWrapper):
 
     def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
                      freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None,
-                     column_groups: List[dict] = None) -> Table:
+                     column_groups: List[dict] = None, search_display_mode: str = None) -> Table:
         """ Sets layout hints on the Table
 
         Args:
@@ -1867,6 +1867,8 @@ class Table(JObjectWrapper):
                 name (str): The group name
                 children (List[str]): The
                 color (Optional[str]): The hex color string or Deephaven color name
+            search_display_mode (str): set the search bar to explicitly be accessible or inaccessible, or use the system default.
+                Values can be one of `Show`, `Hide`, and `Default`
 
         Returns:
             a new table with the layout hints set
@@ -1893,6 +1895,10 @@ class Table(JObjectWrapper):
                 for group in column_groups:
                     _j_layout_hint_builder.columnGroup(group.get("name"), j_array_list(group.get("children")),
                                                        group.get("color", ""))
+
+            if search_display_mode is not None:
+                _j_layout_hint_builder.setSearchBarAccess(search_display_mode)
+
         except Exception as e:
             raise DHError(e, "failed to create layout hints") from e
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsLayoutHints.java
@@ -47,6 +47,8 @@ public class JsLayoutHints {
     }
 
     private boolean savedLayoutsAllowed = true;
+
+    private String searchDisplayMode = JsLayoutHints.SEARCH_DISPLAY_DEFAULT;
     private String[] frontColumns;
     private String[] backColumns;
     private String[] hiddenColumns;
@@ -88,6 +90,11 @@ public class JsLayoutHints {
             frozenColumns = JsObject.freeze(freezeStr.split(","));
         }
 
+        final String searchableStr = options.get("searchable");
+        if (searchableStr != null && !searchableStr.isEmpty()) {
+            searchDisplayMode = searchableStr;
+        }
+
         final String groupsStr = options.get("columnGroups");
         if (groupsStr != null && !groupsStr.isEmpty()) {
             ColumnGroup[] groups =
@@ -100,9 +107,19 @@ public class JsLayoutHints {
         return this;
     }
 
+    @JsProperty(namespace = "dh.SearchDisplayMode")
+    public static final String  SEARCH_DISPLAY_DEFAULT = "Default",
+            SEARCH_DISPLAY_HIDE = "Hide",
+            SEARCH_DISPLAY_SHOW = "Show";
+
     @JsProperty
     public boolean getAreSavedLayoutsAllowed() {
         return savedLayoutsAllowed;
+    }
+
+    @JsProperty
+    public String getSearchDisplayMode() {
+        return searchDisplayMode;
     }
 
     @JsProperty


### PR DESCRIPTION
- Ported over from Enterprise, where these are already implemented
- Not sure how best to handle the enum from the Python API, just using a String right now. Will get Jianfeng/Chip to review.
- Tested in Python and Groovy, ensuring you could bring up the Search Bar (from the side menu) in table `canSearch`, and it was not available in `cannotSearch`.
Python:
```python
from deephaven import empty_table
t = empty_table(100).update(["a=`abc`"])
canSearch = t.layout_hints(search_display_mode="Show")
cannotSearch = t.layout_hints(search_display_mode="Hide")
```
Groovy:
```groovy
import io.deephaven.engine.util.LayoutHintBuilder
import io.deephaven.engine.util.LayoutHintBuilder.SearchDisplayModes

t = emptyTable(5).updateView("a=`abc`")
canSearch = t.setLayoutHints(LayoutHintBuilder.get().setSearchBarAccess(SearchDisplayModes.Show).build())
cannotSearch = t.setLayoutHints(LayoutHintBuilder.get().setSearchBarAccess(SearchDisplayModes.Hide).build())
```
