### PR TITLE
Stop UGP NotificationProcessor From Silently Swallowing Errors

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/UpdateGraphProcessorJobScheduler.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/UpdateGraphProcessorJobScheduler.java
@@ -4,7 +4,6 @@ import io.deephaven.base.log.LogOutput;
 import io.deephaven.base.log.LogOutputAppendable;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.impl.perf.BasePerformanceEntry;
-import io.deephaven.engine.table.impl.util.JobScheduler;
 import io.deephaven.engine.updategraph.AbstractNotification;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
 import io.deephaven.io.log.impl.LogOutputStringImpl;

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphProcessor.java
@@ -1392,6 +1392,10 @@ public enum UpdateGraphProcessor implements UpdateSourceRegistrar, NotificationQ
             while (outstandingNotificationsCount() > 0) {
                 doWork();
             }
+            // A successful and a failed notification may race the release of pendingNormalNotificationsCheckNeeded,
+            // causing this thread to miss a false isHealthy. Since isHealthy is set prior to decrementing
+            // outstandingNotificationsCount, we're guaranteed to read the correct value after exiting the while loop.
+            Assert.eqTrue(isHealthy, "isHealthy");
         }
 
         @Override


### PR DESCRIPTION
In the Array Column Access PR nightly `testSerial` was timing out. After isolating the issue to a specific FuzzerTest, I was able to observe unwanted behavior when running from IJ.

In particular, `RefreshingTableTestCase` throws an `AssertionError` via `TestCase.fail()` if a table propagates a bad update. I've added an additional check to validate `APPEND_ONLY` tables. This error was causing the notification processing threads to exit, eventually starving the notification queue of threads to process them. The UGP was waiting for Godot, causing CI's `testSerial` to be forced to exit after 6 hrs.

This did not occur in my testing because the error was not common enough to starve my executor from processing threads. The machine I was using has 8 cores, but I suspect CI is at 2.

I've come up with a fix that should catch losing notification threads in non-test scenarios, too.

This is a new issue caused by enabling multi-threaded processing by default.
Running nightlies in case there were any tests silently failing: https://github.com/nbauernfeind/deephaven-core/actions/runs/4379371283