### PR TITLE
Make Classes Final That Publish `this` to UGP in Constructor

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TimeTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TimeTable.java
@@ -41,8 +41,10 @@ import static io.deephaven.util.type.TypeUtils.box;
  * A TimeTable adds rows at a fixed interval with a single column named "Timestamp".
  *
  * To create a TimeTable, you should use the {@link TableTools#timeTable} family of methods.
+ *
+ * @implNote The constructor publishes {@code this} to the {@link UpdateGraphProcessor} and thus cannot be subclassed.
  */
-public class TimeTable extends QueryTable implements Runnable {
+public final class TimeTable extends QueryTable implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(TimeTable.class);
 
     public static class Builder {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/DynamicTableWriter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/DynamicTableWriter.java
@@ -34,8 +34,10 @@ import java.util.stream.Collectors;
  * <p>
  * This class is not thread safe, you must synchronize externally. However, multiple setters may safely log
  * concurrently.
+ *
+ * @implNote The constructor publishes {@code this} to the {@link UpdateGraphProcessor} and thus cannot be subclassed.
  */
-public class DynamicTableWriter implements TableWriter {
+public final class DynamicTableWriter implements TableWriter {
     private final UpdateSourceQueryTable table;
     private final WritableColumnSource[] arrayColumnSources;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/FunctionGeneratedTableFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/FunctionGeneratedTableFactory.java
@@ -129,7 +129,10 @@ public class FunctionGeneratedTableFactory {
                 false);
     }
 
-    private class FunctionBackedTable extends QueryTable implements Runnable {
+    /**
+     * @implNote The constructor publishes {@code this} to the {@link UpdateGraphProcessor} and cannot be subclassed.
+     */
+    private final class FunctionBackedTable extends QueryTable implements Runnable {
         FunctionBackedTable(TrackingRowSet rowSet, Map<String, ColumnSource<?>> columns) {
             super(rowSet, columns);
             if (refreshIntervalMs >= 0) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/HashSetBackedTableFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/HashSetBackedTableFactory.java
@@ -145,7 +145,10 @@ public class HashSetBackedTableFactory {
         }
     }
 
-    private class HashSetBackedTable extends QueryTable implements Runnable {
+    /**
+     * @implNote The constructor publishes {@code this} to the {@link UpdateGraphProcessor} and cannot be subclassed.
+     */
+    private final class HashSetBackedTable extends QueryTable implements Runnable {
         HashSetBackedTable(TrackingRowSet rowSet, Map<String, ColumnSource<?>> columns) {
             super(rowSet, columns);
             if (refreshIntervalMs >= 0) {

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -122,7 +122,7 @@ public class KafkaTools {
 
     /**
      * Create an Avro schema object for a String containing a JSON encoded Avro schema definition.
-     * 
+     *
      * @param avroSchemaAsJsonString The JSON Avro schema definition
      * @return an Avro schema object
      */
@@ -1706,7 +1706,10 @@ public class KafkaTools {
                         "and can't automatically set it for type " + dataType);
     }
 
-    private static class StreamPartitionedTable extends PartitionedTableImpl implements Runnable {
+    /**
+     * @implNote The constructor publishes {@code this} to the {@link UpdateGraphProcessor} and cannot be subclassed.
+     */
+    private static final class StreamPartitionedTable extends PartitionedTableImpl implements Runnable {
 
         private static final String PARTITION_COLUMN_NAME = "Partition";
         private static final String CONSTITUENT_COLUMN_NAME = "Table";


### PR DESCRIPTION
The UGP may immediately refresh such tables. We cannot allow them to be refreshed before being fully constructed.