### PR TITLE
Fix headPct / tailPct Attribute Propagation

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -101,8 +101,15 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
             resultTable.setFlat();
         }
 
-        // if the first row is fixed (not negative), then we can propagate add-only/append-only properties
-        if (getFirstPositionInclusive() >= 0) {
+        if (operation.equals("headPct")) {
+            // headPct has a floating tail, so we can only propagate if append-only
+            if (parent.isAppendOnly()) {
+                resultTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+                resultTable.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
+            }
+        } else if (!operation.equals("tailPct") && getFirstPositionInclusive() >= 0) {
+            // tailPct has a floating head, so we can't propagate either property
+            // otherwise, if the first row is fixed (not negative), then we can propagate add-only/append-only
             if (parent.isAddOnly()) {
                 resultTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
             }


### PR DESCRIPTION
I forgot that headPct/tailPct have a floating tail / head (respectively).

In the head-pct add-only case adds at the front of the table will push existing rows out of the window. The head-pct append-only case implies that the tail's row-key can only increase enabling property propagation.

In both of the tail-pct cases the head row-key can increase leading to removals.

I saw this error show up as a FuzzerTest failure. (Yay for fixing that UGP thread loss issue!)
