### PR TITLE
Deephaven-in-docker gradle wiring support for env vars

### DIFF
--- a/buildSrc/src/main/groovy/io/deephaven/tools/docker/DeephavenInDockerExtension.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/tools/docker/DeephavenInDockerExtension.groovy
@@ -9,6 +9,7 @@ import com.bmuschko.gradle.docker.tasks.network.DockerRemoveNetwork
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskProvider
 
@@ -37,6 +38,8 @@ public abstract class DeephavenInDockerExtension {
     abstract Property<Integer> getAwaitStatusTimeout()
     abstract Property<Integer> getCheckInterval()
 
+    abstract MapProperty<String, String> getEnvVars();
+
     @Inject
     DeephavenInDockerExtension(Project project) {
         awaitStatusTimeout.set 20
@@ -62,6 +65,7 @@ public abstract class DeephavenInDockerExtension {
             task.targetImageId grpcApiImage.getImageId()
             task.containerName.set containerName.get()
             task.hostConfig.network.set networkName.get()
+            task.envVars.set(this.getEnvVars())
         }
 
         startTask = project.tasks.register('startDeephaven', DockerStartContainer) { task ->

--- a/cpp-client/build.gradle
+++ b/cpp-client/build.gradle
@@ -50,6 +50,9 @@ project.tasks.getByName('quick').dependsOn project.tasks.getByName('license')
 // start a grpc-api server
 String randomSuffix = UUID.randomUUID().toString();
 deephavenDocker {
+    envVars.set([
+            'START_OPTS':'-Xmx512m'
+    ])
     containerName.set "dh-server-for-cpp-${randomSuffix}"
     networkName.set "cpp-test-network-${randomSuffix}"
 }

--- a/go/build.gradle
+++ b/go/build.gradle
@@ -44,6 +44,9 @@ tasks.register('updateProtobuf', Sync) {
 // start a grpc-api server
 String randomSuffix = UUID.randomUUID().toString();
 deephavenDocker {
+    envVars.set([
+            'START_OPTS':'-Xmx512m'
+    ])
     containerName.set "dh-server-for-go-${randomSuffix}"
     networkName.set "go-test-network-${randomSuffix}"
 }

--- a/py/client/build.gradle
+++ b/py/client/build.gradle
@@ -74,6 +74,9 @@ tasks.register('updateProtobuf', Sync) {
 // Start up a docker container for the grpc server, then run pydeephaven test
 String randomSuffix = UUID.randomUUID().toString();
 deephavenDocker {
+    envVars.set([
+        'START_OPTS':'-Xmx512m'
+    ])
     containerName.set "pydeephaven-test-container-${randomSuffix}"
     networkName.set "pydeephaven-network-${randomSuffix}"
 }


### PR DESCRIPTION
Enables tests to control the environment variables of a running deephaven server in docker, to configure the jvm or deephaven itself.

This patch also modifies py/go/cpp tests to only ask for a max of 512mb of heap, to avoid issues running in docker desktop.

Fixes #3535