### PR TITLE
Apply spotless after quick-check failures

### DIFF
--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -2,9 +2,7 @@ name: Quick CI
 
 on:
   pull_request:
-    branches: [ main ]
   push:
-    branches: [ 'main', 'check/**', 'release/v*' ]
 
 jobs:
   quick:

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -55,5 +55,6 @@ jobs:
           gradle-version: wrapper
       - name: suggester / shellcheck
         uses: reviewdog/action-suggester@v1
+        if: failure()
         with:
           tool_name: spotless

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -48,3 +48,14 @@ jobs:
           name: quick-ci-jvm-err
           path: '**/*_pid*.log'
           if-no-files-found: ignore
+      - name: On failure, try to reformat and propose fixes
+        uses: burrunan/gradle-cache-action@v1
+        if: failure()
+        with:
+          job-id: spotless-formatting
+          arguments: spotlessJavaApply
+          gradle-version: wrapper
+      - name: suggester / shellcheck
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: spotless

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -55,7 +55,7 @@ jobs:
           job-id: spotless-formatting
           arguments: spotlessJavaApply
           gradle-version: wrapper
-      - name: suggester / shellcheck
+      - name: suggester / spotless
         uses: reviewdog/action-suggester@v1
         if: failure()
         with:

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -2,7 +2,9 @@ name: Quick CI
 
 on:
   pull_request:
+    branches: [ main ]
   push:
+    branches: [ 'main', 'check/**', 'release/v*' ]
 
 jobs:
   quick:


### PR DESCRIPTION
Automatically applies spotless after a quick check fails, and presents the diff as github PR comment suggestions for the author to fix.

Example pull request showing this in action (with the suggestion manually "unresolved" so that it is visible when looking at the changes): https://github.com/niloc132/deephaven-core/pull/4

![image](https://user-images.githubusercontent.com/241630/225495540-612906f2-2aa9-44f7-9916-caa3616835b1.png)
