### PR TITLE
Bump jetty to 11.0.14

### DIFF
--- a/buildSrc/src/main/groovy/Classpaths.groovy
+++ b/buildSrc/src/main/groovy/Classpaths.groovy
@@ -119,7 +119,7 @@ class Classpaths {
 
     static final String JETTY11_GROUP = 'org.eclipse.jetty'
     static final String JETTY11_NAME = 'jetty-bom'
-    static final String JETTY11_VERSION = '11.0.13'
+    static final String JETTY11_VERSION = '11.0.14'
 
     static final String GUAVA_GROUP = 'com.google.guava'
     static final String GUAVA_NAME = 'guava'


### PR DESCRIPTION
Release https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.14