### PR TITLE
QueryLanguageParser: Explicitly Create VarArgs for Primitives and Boxed Primitives

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -3,6 +3,8 @@
  */
 package io.deephaven.engine.table.impl.lang;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.ArrayCreationLevel;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -1102,8 +1104,8 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
                 }
             }
 
-            if (varArgType.isPrimitive() && allExpressionTypesArePrimitive) {
-                // there are ambiguous oddities with primitive varargs, so if its primitive lets just box it ourselves
+            if ((TypeUtils.isBoxedType(varArgType) || varArgType.isPrimitive()) && allExpressionTypesArePrimitive) {
+                // method invocation is ambiguous when both boxed and primitive versions of the method exist
                 Expression[] temp = new Expression[nArgs];
                 Expression[] varArgExpressions = new Expression[nArgExpressions - nArgs + 1];
                 System.arraycopy(expressions, 0, temp, 0, temp.length - 1);
@@ -1111,10 +1113,15 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
                         varArgExpressions.length);
 
                 NodeList<ArrayCreationLevel> levels = new NodeList<>(new ArrayCreationLevel());
+                com.github.javaparser.ast.type.Type elementType;
+                if (varArgType.isPrimitive()) {
+                    elementType = new PrimitiveType(PrimitiveType.Primitive.valueOf(
+                            varArgType.getSimpleName().toUpperCase()));
+                } else {
+                    elementType = StaticJavaParser.parseClassOrInterfaceType(varArgType.getSimpleName());
+                }
                 temp[temp.length - 1] = new ArrayCreationExpr(
-                        new PrimitiveType(
-                                PrimitiveType.Primitive.valueOf(varArgType.getSimpleName().toUpperCase())),
-                        levels, new ArrayInitializerExpr(new NodeList<>(varArgExpressions)));
+                        elementType, levels, new ArrayInitializerExpr(new NodeList<>(varArgExpressions)));
 
                 expressions = temp;
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -3,7 +3,6 @@
  */
 package io.deephaven.engine.table.impl.lang;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.ArrayCreationLevel;
 import com.github.javaparser.ast.CompilationUnit;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSelectUpdateTest.java
@@ -1079,4 +1079,16 @@ public class QueryTableSelectUpdateTest {
         Assert.assertEquals(4L, updated.getColumnSource("D").get(updated.getRowSet().get(1)));
         Assert.assertEquals(8L, updated.getColumnSource("D").getPrev(updated.getRowSet().copyPrev().get(2)));
     }
+
+    @Test
+    public void testRegressionGH3562() {
+        final Table src = TableTools.emptyTable(3).update("A = true", "B = ii != 1", "C = ii != 2");
+        final Table result = src.select("And = and(A, B, C)", "Or = or(A, B, C)");
+
+        final Table expected = TableTools.newTable(
+                TableTools.col("And", true, false, false),
+                TableTools.col("Or", true, true, true));
+
+        assertTableEquals(expected, result);
+    }
 }


### PR DESCRIPTION
Fixes #3562.