### PR TITLE
Fix a bug in EMA tests

### DIFF
--- a/py/client/tests/test_updateby.py
+++ b/py/client/tests/test_updateby.py
@@ -49,9 +49,9 @@ class UpdateByTestCase(BaseTestCase):
                     self.assertTrue(rt.is_refreshing is t.is_refreshing)
                     self.assertEqual(len(rt.schema), 1 + len(t.schema))
                     if rt.is_refreshing:
-                        self.assertEqual(rt.size, t.size)
-                    else:
                         self.assertGreaterEqual(rt.size, t.size)
+                    else:
+                        self.assertEqual(rt.size, t.size)
 
 
 if __name__ == '__main__':

--- a/py/client/tests/test_updateby.py
+++ b/py/client/tests/test_updateby.py
@@ -48,9 +48,7 @@ class UpdateByTestCase(BaseTestCase):
                     rt = t.update_by(ops=[op], by=["b"])
                     self.assertTrue(rt.is_refreshing is t.is_refreshing)
                     self.assertEqual(len(rt.schema), 1 + len(t.schema))
-                    if rt.is_refreshing:
-                        self.assertGreaterEqual(rt.size, t.size)
-                    else:
+                    if not rt.is_refreshing:
                         self.assertEqual(rt.size, t.size)
 
 


### PR DESCRIPTION
Not sure how it happened - the flip of the 'if' branches, could be a mistake caused by distraction. 