### PR TITLE
Ensures the avro `map` type maps to `java.util.Map` type.

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -396,7 +396,7 @@ public class KafkaTools {
                 break;
             }
             case MAP:
-                columnsOut.add(ColumnDefinition.fromGenericType(mappedNameForColumn, GenericRecord.class));
+                columnsOut.add(ColumnDefinition.fromGenericType(mappedNameForColumn, Map.class));
                 break;
             case NULL:
             default:


### PR DESCRIPTION
Fixes #3602