### PR TITLE
Stronger record checking

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/GenericRecordChunkAdapter.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/GenericRecordChunkAdapter.java
@@ -162,7 +162,7 @@ public class GenericRecordChunkAdapter extends MultiFieldChunkAdapter {
                 }
                 // The GenericContainer.class.isAssignableFrom(dataType) case is also covered by the generic object
                 // field copier.
-                return new GenericRecordObjectFieldCopier(fieldPathStr, separator, schema);
+                return new GenericRecordObjectFieldCopier(fieldPathStr, separator, schema, dataType);
         }
         throw new IllegalArgumentException("Can not convert field of type " + dataType);
     }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/GenericRecordObjectFieldCopier.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/GenericRecordObjectFieldCopier.java
@@ -33,10 +33,7 @@ public class GenericRecordObjectFieldCopier extends GenericRecordFieldCopier {
         for (int ii = 0; ii < length; ++ii) {
             final GenericRecord record = (GenericRecord) inputChunk.get(ii + sourceOffset);
             final Object value = GenericRecordUtil.getPath(record, fieldPath);
-            if (value != null && !dataType.isInstance(value)) {
-                throw new IllegalStateException(String.format("Unexpected value type %s, expected instance of %s", value.getClass(), dataType));
-            }
-            output.set(ii + destOffset, value);
+            output.set(ii + destOffset, dataType.cast(value));
         }
     }
 }


### PR DESCRIPTION
We should prefer to error out sooner rather than later when we know that the published objects are not compatible with the column definition.

Related to #3602 