### PR TITLE
UnionSourceManager: Do Not Generate Shifts on Empty Constituents

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -630,6 +630,9 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
             Assert.assertion(getRowSet().sizePrev() == 0 || getRowSet().lastRowKeyPrev() < update.added().firstRowKey(),
                     "getRowSet().lastRowKeyPrev() < update.added().firstRowKey()");
         }
+        if (isStream()) {
+            Assert.assertion(update.shifted().empty(), "update.shifted.empty()");
+        }
 
         // First validate that each rowSet is in a sane state.
         if (VALIDATE_UPDATE_INDICES) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -631,6 +631,9 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
                     "getRowSet().lastRowKeyPrev() < update.added().firstRowKey()");
         }
         if (isStream()) {
+            Assert.eq(update.added().size(), "added size", getRowSet().size(), "current table size");
+            Assert.eq(update.removed().size(), "removed size", getRowSet().sizePrev(), "previous table size");
+            Assert.assertion(update.modified().isEmpty(), "update.modified.isEmpty()");
             Assert.assertion(update.shifted().empty(), "update.shifted.empty()");
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -619,7 +619,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         Assert.neqNull(update.shifted(), "shifted");
 
         if (isFlat()) {
-            Assert.assertion(getRowSet().isFlat(), "build().isFlat()", getRowSet(), "build()");
+            Assert.assertion(getRowSet().isFlat(), "getRowSet().isFlat()", getRowSet(), "getRowSet()");
         }
         if (isAppendOnly() || isAddOnly()) {
             Assert.assertion(update.removed().isEmpty(), "update.removed.empty()");

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
@@ -499,7 +499,7 @@ public class UnionSourceManager {
             }
 
             if (changes == null || changes.empty()) {
-                // constituent is either static or did not change this cycle
+                // Constituent is either static or did not change this cycle
                 if (slotAllocationChanged) {
                     currFirstRowKeys[nextCurrentSlot + 1] = checkOverflow(nextSlotPrevFirstRowKey + shiftDelta);
                     resultRows.insertWithShift(currFirstRowKey, constituent.getRowSet());

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
@@ -534,7 +534,7 @@ public class UnionSourceManager {
             // Ignore shifts if the constituent was empty or became empty
             final boolean needToProcessShifts = changes.shifted().nonempty()
                     && constituent.getRowSet().isNonempty()
-                    && constituent.getRowSet().sizePrev() != 0;
+                    && constituent.getRowSet().sizePrev() != changes.removed().size();
 
             if (slotAllocationChanged) {
                 resultRows.insertWithShift(currFirstRowKey, constituent.getRowSet());

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
@@ -503,7 +503,7 @@ public class UnionSourceManager {
                 if (slotAllocationChanged) {
                     currFirstRowKeys[nextCurrentSlot + 1] = checkOverflow(nextSlotPrevFirstRowKey + shiftDelta);
                     resultRows.insertWithShift(currFirstRowKey, constituent.getRowSet());
-                    // don't bother shifting if the constituent is empty
+                    // Don't bother shifting or re-inserting if the constituent is empty
                     if (shiftDelta != 0 && constituent.size() > 0) {
                         downstreamShiftBuilder.shiftRange(prevFirstRowKey, prevLastRowKey, shiftDelta);
                     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
@@ -533,7 +533,6 @@ public class UnionSourceManager {
 
             // Ignore shifts if the constituent was empty or became empty
             final boolean needToProcessShifts = changes.shifted().nonempty()
-                    && constituent.getRowSet().isNonempty()
                     && constituent.getRowSet().sizePrev() != changes.removed().size();
 
             if (slotAllocationChanged) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestStreamTableTools.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestStreamTableTools.java
@@ -3,6 +3,8 @@
  */
 package io.deephaven.engine.table.impl;
 
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.testutil.TstUtils;
 import io.deephaven.time.DateTimeUtils;
@@ -47,18 +49,22 @@ public class TestStreamTableTools {
         TestCase.assertTrue(appendOnly.isFlat());
 
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            RowSet removed = streamTable.getRowSet().copyPrev();
+            ((WritableRowSet) streamTable.getRowSet()).clear();
             TstUtils.addToTable(streamTable, i(7), intCol("I", 1), doubleCol("D", Math.PI), dateTimeCol("DT", dt2),
                     col("B", true));
-            streamTable.notifyListeners(i(7), i(), i());
+            streamTable.notifyListeners(i(7), removed, i());
         });
 
         assertTableEquals(TableTools.newTable(intCol("I", 7, 1), doubleCol("D", Double.NEGATIVE_INFINITY, Math.PI),
                 dateTimeCol("DT", dt1, dt2), col("B", true, true)), appendOnly);
 
         UpdateGraphProcessor.DEFAULT.runWithinUnitTestCycle(() -> {
+            RowSet removed = streamTable.getRowSet().copyPrev();
+            ((WritableRowSet) streamTable.getRowSet()).clear();
             TstUtils.addToTable(streamTable, i(7), intCol("I", 2), doubleCol("D", Math.E), dateTimeCol("DT", dt3),
                     col("B", false));
-            streamTable.notifyListeners(i(7), i(), i());
+            streamTable.notifyListeners(i(7), removed, i());
         });
         assertTableEquals(
                 TableTools.newTable(intCol("I", 7, 1, 2), doubleCol("D", Double.NEGATIVE_INFINITY, Math.PI, Math.E),


### PR DESCRIPTION
Fixes #3594.

Nightlies are running at: https://github.com/nbauernfeind/deephaven-core/actions/runs/4545546046