### PR TITLE
Go client 2 param auth

### DIFF
--- a/go/internal/test_tools/test_tools.go
+++ b/go/internal/test_tools/test_tools.go
@@ -89,12 +89,23 @@ func GetPort() string {
 	}
 }
 
-// GetAuth returns the auth string to connect to for the tests.
-// By default it is Anonymous, but can be overridden by setting the DH_AUTH environment variable.
-func GetAuth() string {
-	auth := os.Getenv("DH_AUTH")
+// GetAuthType returns the auth type to use for the tests.
+// By default it is Anonymous but can be overridden by setting the DH_AUTH_TYPE environment variable.
+func GetAuthType() string {
+	auth := os.Getenv("DH_AUTH_TYPE")
 	if auth == "" {
 		return "Anonymous"
+	} else {
+		return auth
+	}
+}
+
+// GetAuthToken returns the auth token to use for the tests.
+// By default it is "" but can be overridden by setting the DH_AUTH_TOKEN environment variable.
+func GetAuthToken() string {
+	auth := os.Getenv("DH_AUTH_TOKEN")
+	if auth == "" {
+		return ""
 	} else {
 		return auth
 	}

--- a/go/pkg/client/client_test.go
+++ b/go/pkg/client/client_test.go
@@ -12,7 +12,7 @@ import (
 func TestConnectError(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := client.NewClient(ctx, "foobar", "1234", test_tools.GetAuth())
+	_, err := client.NewClient(ctx, "foobar", "1234", test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err == nil {
 		t.Fatalf("client did not fail to connect")
 	}
@@ -21,7 +21,7 @@ func TestConnectError(t *testing.T) {
 func TestAuthError(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), "garbage in")
+	_, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), "garbage in", "badtoken")
 	if err == nil {
 		t.Fatalf("client did not fail to connect")
 	}
@@ -30,7 +30,7 @@ func TestAuthError(t *testing.T) {
 func TestClosedClient(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient err %s", err.Error())
 	}
@@ -49,7 +49,7 @@ func TestClosedClient(t *testing.T) {
 func TestMismatchedScript(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth(), client.WithConsole("groovy"))
+	_, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken(), client.WithConsole("groovy"))
 	if err == nil {
 		t.Fatalf("client did not fail to connect")
 	}
@@ -61,7 +61,7 @@ func TestEmptyTable(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient err %s", err.Error())
 	}
@@ -92,7 +92,7 @@ func TestEmptyTable(t *testing.T) {
 func TestTimeTable(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient err %s", err.Error())
 	}
@@ -119,7 +119,7 @@ func TestTableUpload(t *testing.T) {
 	defer r.Release()
 
 	ctx := context.Background()
-	s, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	s, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient err %s", err.Error())
 		return
@@ -205,7 +205,7 @@ func waitForTable(ctx context.Context, cl *client.Client, names []string, timeou
 func TestFieldSync(t *testing.T) {
 	ctx := context.Background()
 
-	client1, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth(), client.WithConsole("python"))
+	client1, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken(), client.WithConsole("python"))
 	test_tools.CheckError(t, "NewClient", err)
 	defer client1.Close()
 
@@ -215,7 +215,7 @@ gotesttable1 = None
 `)
 	test_tools.CheckError(t, "RunScript", err)
 
-	client2, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth(), client.WithConsole("python"))
+	client2, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken(), client.WithConsole("python"))
 	test_tools.CheckError(t, "NewClient", err)
 	defer client2.Close()
 

--- a/go/pkg/client/console_test.go
+++ b/go/pkg/client/console_test.go
@@ -11,7 +11,7 @@ import (
 func TestOpenTable(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth(), client.WithConsole("python"))
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken(), client.WithConsole("python"))
 	test_tools.CheckError(t, "NewClient", err)
 
 	err = c.RunScript(ctx,
@@ -38,7 +38,7 @@ gotesttable = empty_table(42)
 func TestNoConsole(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 

--- a/go/pkg/client/example_fetch_table_test.go
+++ b/go/pkg/client/example_fetch_table_test.go
@@ -19,7 +19,7 @@ func Example_fetchTable() {
 
 	// Let's start a client connection using python as the script language ("groovy" is the other option).
 	// Note that the client language must match the language the server was started with.
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth(), client.WithConsole("python"))
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken(), client.WithConsole("python"))
 	if err != nil {
 		fmt.Println("error when connecting to server:", err.Error())
 		return
@@ -44,7 +44,7 @@ func Example_fetchTable() {
 	cl.Close()
 
 	// Now let's make a new connection, completely unrelated to the old one.
-	cl, err = client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err = client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		fmt.Println("error when connecting to localhost port 10000:", err.Error())
 		return

--- a/go/pkg/client/example_import_table_test.go
+++ b/go/pkg/client/example_import_table_test.go
@@ -18,7 +18,7 @@ func Example_importTable() {
 	// If you don't have any specific requirements, context.Background() is a good default.
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		fmt.Println("error when connecting to server:", err.Error())
 		return

--- a/go/pkg/client/example_input_table_test.go
+++ b/go/pkg/client/example_input_table_test.go
@@ -20,7 +20,7 @@ func Example_inputTable() {
 	// If you don't have any specific requirements, context.Background() is a good default.
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		fmt.Println("error when connecting to server:", err.Error())
 		return

--- a/go/pkg/client/example_run_script_test.go
+++ b/go/pkg/client/example_run_script_test.go
@@ -20,7 +20,7 @@ func Example_runScript() {
 
 	// Let's start a client connection using python as the script language ("groovy" is the other option).
 	// Note that the client language must match the language the server was started with.
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth(), client.WithConsole("python"))
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken(), client.WithConsole("python"))
 	if err != nil {
 		fmt.Println("error when connecting to server:", err.Error())
 		return

--- a/go/pkg/client/example_table_ops_test.go
+++ b/go/pkg/client/example_table_ops_test.go
@@ -89,7 +89,7 @@ func doImmediateOps() (string, error) {
 	// If you don't have any specific requirements, context.Background() is a good default.
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		fmt.Println("error when connecting to server:", err.Error())
 		return "", err
@@ -172,7 +172,7 @@ func doQueryOps() (string, error) {
 	// If you don't have any specific requirements, context.Background() is a good default.
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		fmt.Println("error when connecting to server:", err.Error())
 		return "", err

--- a/go/pkg/client/inputtable_test.go
+++ b/go/pkg/client/inputtable_test.go
@@ -174,7 +174,7 @@ func addNewDataToAppend(
 func TestAppendOnlyFromSchema(t *testing.T) {
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer cl.Close()
 
@@ -210,7 +210,7 @@ func TestAppendOnlyFromSchema(t *testing.T) {
 func TestAppendOnlyFromTable(t *testing.T) {
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer cl.Close()
 
@@ -250,7 +250,7 @@ func TestAppendOnlyFromTable(t *testing.T) {
 func TestKeyBackedTable(t *testing.T) {
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer cl.Close()
 
@@ -316,7 +316,7 @@ func TestKeyBackedTable(t *testing.T) {
 func TestInvalidInputTable(t *testing.T) {
 	ctx := context.Background()
 
-	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	cl, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer cl.Close()
 

--- a/go/pkg/client/query_test.go
+++ b/go/pkg/client/query_test.go
@@ -27,7 +27,7 @@ func TestDagQuerySerial(t *testing.T) {
 func dagQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -108,7 +108,7 @@ func TestMergeQuerySerial(t *testing.T) {
 func mergeQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -148,7 +148,7 @@ func TestNullMergeQuerySerial(t *testing.T) {
 func nullMergeQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -186,7 +186,7 @@ func TestExportNullTableQuerySerial(t *testing.T) {
 func exportNullTableQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -210,7 +210,7 @@ func TestNullTableArgQuerySerial(t *testing.T) {
 func nullTableArgQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -236,7 +236,7 @@ func TestEmptyMergeSerial(t *testing.T) {
 func emptyMerge(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -260,7 +260,7 @@ func TestTableNotReleasedSerial(t *testing.T) {
 func tableNotReleasedQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -298,7 +298,7 @@ func TestSeparateQueriesSerial(t *testing.T) {
 func separateQueries(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -350,7 +350,7 @@ func TestEmptyTableQuerySerial(t *testing.T) {
 func emptyTableQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 	}
@@ -409,7 +409,7 @@ func TestUpdateDropQuerySerial(t *testing.T) {
 func updateDropQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 	}
@@ -481,7 +481,7 @@ func TestDuplicateQuerySerial(t *testing.T) {
 func duplicateQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 		return
@@ -534,7 +534,7 @@ func TestInvalidTableQuerySerial(t *testing.T) {
 func invalidTableQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 		return
@@ -566,7 +566,7 @@ func doQueryTest(inputRec arrow.Record, t *testing.T, exec execBatchOrSerial, op
 
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 	}
@@ -885,7 +885,7 @@ func crossJoinQuery(t *testing.T, exec execBatchOrSerial) {
 func TestAsOfJoinQuery(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 	}
@@ -1105,11 +1105,11 @@ func TestDifferentClientsSerial(t *testing.T) {
 func differentClientsQuery(t *testing.T, exec execBatchOrSerial) {
 	ctx := context.Background()
 
-	client1, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	client1, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer client1.Close()
 
-	client2, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	client2, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer client2.Close()
 

--- a/go/pkg/client/tablehandle_test.go
+++ b/go/pkg/client/tablehandle_test.go
@@ -18,7 +18,7 @@ type unaryTableOp func(context.Context, *client.TableHandle) (*client.TableHandl
 func applyTableOp(input arrow.Record, t *testing.T, op unaryTableOp) arrow.Record {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 	}
@@ -210,7 +210,7 @@ func TestEmptyMerge(t *testing.T) {
 func TestExactJoin(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -258,7 +258,7 @@ func TestExactJoin(t *testing.T) {
 func TestNaturalJoin(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -306,7 +306,7 @@ func TestNaturalJoin(t *testing.T) {
 func TestCrossJoin(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -363,7 +363,7 @@ func TestCrossJoin(t *testing.T) {
 func TestAsOfJoin(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	if err != nil {
 		t.Fatalf("NewClient %s", err.Error())
 	}
@@ -534,7 +534,7 @@ func TestDedicatedAgg(t *testing.T) {
 func TestZeroTable(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -558,7 +558,7 @@ func TestZeroTable(t *testing.T) {
 func TestReleasedTable(t *testing.T) {
 	ctx := context.Background()
 
-	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	c, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer c.Close()
 
@@ -587,11 +587,11 @@ func TestReleasedTable(t *testing.T) {
 func TestDifferentClients(t *testing.T) {
 	ctx := context.Background()
 
-	client1, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	client1, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer client1.Close()
 
-	client2, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuth())
+	client2, err := client.NewClient(ctx, test_tools.GetHost(), test_tools.GetPort(), test_tools.GetAuthType(), test_tools.GetAuthToken())
 	test_tools.CheckError(t, "NewClient", err)
 	defer client2.Close()
 

--- a/go/pkg/client/tokens.go
+++ b/go/pkg/client/tokens.go
@@ -15,14 +15,13 @@ import (
 )
 
 // makeAuthString creates an authentication string from an authentication type and an authentication token.
-func makeAuthString(authType string, authToken string) {
+func makeAuthString(authType string, authToken string) string {
 	if authType == "Anonymous" {
 		return authType
 	} else if authType == "Basic" {
-		authTokenBase64 = base64.StdEncoding.EncodeToString([]byte(authToken))
-		return "Basic " + authTokenBase64
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte(authToken))
 	} else {
-		return str(authType) + " " + authToken
+		return authType + " " + authToken
 	}
 }
 
@@ -123,7 +122,7 @@ func (tr *tokenManager) Close() error {
 // "user:password"; when auth_type is DefaultAuth, it will be ignored; when auth_type is a custom-built
 // authenticator, it must conform to the specific requirement of the authenticator.
 func newTokenManager(ctx context.Context, fs *flightStub, cfg configpb2.ConfigServiceClient, authType string, authToken string) (*tokenManager, error) {
-	authString = makeAuthString(authType, authToken)
+	authString := makeAuthString(authType, authToken)
 
 	handshakeClient, err := fs.handshake(withAuth(ctx, authString))
 

--- a/go/pkg/client/tokens.go
+++ b/go/pkg/client/tokens.go
@@ -11,7 +11,20 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"encoding/base64"
 )
+
+// makeAuthString creates an authentication string from an authentication type and an authentication token.
+func makeAuthString(authType string, authToken string) {
+	if authType == "Anonymous" {
+		return authType
+	} else if authType == "Basic" {
+		authTokenBase64 = base64.StdEncoding.EncodeToString([]byte(authToken))
+		return "Basic " + authTokenBase64
+	} else {
+		return str(authType) + " " + authToken
+	}
+}
 
 // withAuth returns a context decorated with authentication data.
 func withAuth(ctx context.Context, authString string) context.Context {
@@ -102,10 +115,16 @@ func (tr *tokenManager) Close() error {
 // newTokenManager creates a tokenManager that begins a background goroutine that continually refreshes
 // the token so that it does not time out.
 //
-// authString is the authorization string used to get the first token.  Examples:
-//   - "Anonymous" is used for anonymous authentication.
-//   - "io.deephaven.authentication.psk.PskAuthenticationHandler <password>" is used for PSK authentication
-func newTokenManager(ctx context.Context, fs *flightStub, cfg configpb2.ConfigServiceClient, authString string) (*tokenManager, error) {
+// authType is the type of authentication to use.  This can be 'Anonymous', 'Basic', or any custom-built
+// authenticator in the server, such as "io.deephaven.authentication.psk.PskAuthenticationHandler",  The default is 'Anonymous'.
+// To see what authentication methods are available on the Deephaven server, navigate to: http://<host>:<port>/jsapi/authentication/.
+//
+// authToken is the authentication token string. When authType is 'Basic', it must be
+// "user:password"; when auth_type is DefaultAuth, it will be ignored; when auth_type is a custom-built
+// authenticator, it must conform to the specific requirement of the authenticator.
+func newTokenManager(ctx context.Context, fs *flightStub, cfg configpb2.ConfigServiceClient, authType string, authToken string) (*tokenManager, error) {
+	authString = makeAuthString(authType, authToken)
+
 	handshakeClient, err := fs.handshake(withAuth(ctx, authString))
 
 	if err != nil {

--- a/go/pkg/client/tokens.go
+++ b/go/pkg/client/tokens.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"github.com/apache/arrow/go/v8/arrow/flight"
@@ -11,7 +12,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"encoding/base64"
 )
 
 // makeAuthString creates an authentication string from an authentication type and an authentication token.


### PR DESCRIPTION
Make the Go client use 2 auth parameters, like the python client.