### PR TITLE
Provide reconnect wiring for other JS API types

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -24,7 +24,6 @@ import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.Seek
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.SelectDistinctRequest;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.SnapshotTableRequest;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.SnapshotWhenTableRequest;
-import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.comboaggregaterequest.Aggregate;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.runchartdownsamplerequest.ZoomRange;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.Ticket;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.TypedTicket;
@@ -75,7 +74,7 @@ import static io.deephaven.web.client.fu.LazyPromise.logError;
  * TODO provide hooks into the event handlers so we can see if no one is listening any more and release the table
  * handle/viewport.
  */
-public class JsTable extends HasEventHandling implements HasTableBinding, HasLifecycle {
+public class JsTable extends HasLifecycle implements HasTableBinding {
     @JsProperty(namespace = "dh.Table")
     public static final String EVENT_SIZECHANGED = "sizechanged",
             EVENT_UPDATED = "updated",
@@ -1113,7 +1112,6 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
         }
     }
 
-    @Override
     public void revive(ClientTableState state) {
         JsLog.debug("Revive!", (state == state()), this);
         if (state == state()) {
@@ -1123,10 +1121,6 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
                 getBinding().maybeReviveSubscription();
             });
         }
-    }
-
-    public void die(Object error) {
-        notifyDeath(this, error);
     }
 
     public Promise<JsTable> downsample(LongWrapper[] zoomRange, int pixelCount, String xCol, String[] yCols) {
@@ -1662,11 +1656,6 @@ public class JsTable extends HasEventHandling implements HasTableBinding, HasLif
     @Override
     public void rollback() {
         getBinding().rollback();
-    }
-
-    @Override
-    public void disconnected() {
-        notifyDisconnect(this);
     }
 
     public void setSize(double s) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -201,7 +201,7 @@ public class WorkerConnection {
     private final Map<ClientTableState, BiDiStream<FlightData, FlightData>> subscriptionStreams = new HashMap<>();
     private ResponseStreamWrapper<ExportedTableUpdateMessage> exportNotifications;
 
-    private JsSet<JsFigure> figures = new JsSet<>();
+    private JsSet<HasLifecycle> simpleReconnectableInstances = new JsSet<>();
 
     private List<LogItem> pastLogs = new ArrayList<>();
     private JsConsumer<LogItem> recordLog = pastLogs::add;
@@ -325,15 +325,20 @@ public class WorkerConnection {
 
                         reviver.revive(metadata, hasActiveSubs);
 
-                        figures.forEach((p0, p1, p2) -> p0.refetch());
+                        simpleReconnectableInstances.forEach((item, index, arr) -> item.refetch());
                     } else {
+                        // wire up figures to attempt to reconnect when ready
+                        simpleReconnectableInstances.forEach((item, index, arr) -> {
+                            item.reconnect();
+                            return null;
+                        });
+
                         // only notify that we're back, no need to re-create or re-fetch anything
                         ClientTableState[] hasActiveSubs = cache.getAllStates().stream()
                                 .filter(cts -> !cts.isEmpty())
                                 .toArray(ClientTableState[]::new);
 
                         reviver.revive(metadata, hasActiveSubs);
-
                     }
 
                     info.connected();
@@ -590,11 +595,11 @@ public class WorkerConnection {
     // @Override
 
     public void connectionLost() {
-        // notify all active tables and figures that the connection is closed
-        figures.forEach((p0, p1, p2) -> {
+        // notify all active tables and widgets that the connection is closed
+        // TODO(deephaven-core#3604) when a new session is created, refetch all widgets and use that to drive reconnect
+        simpleReconnectableInstances.forEach((item, index, array) -> {
             try {
-                p0.fireEvent(JsFigure.EVENT_DISCONNECT);
-                p0.suppressEvents();
+                item.disconnected();
             } catch (Exception e) {
                 JsLog.warn("Error in firing Figure.EVENT_DISCONNECT event", e);
             }
@@ -604,6 +609,7 @@ public class WorkerConnection {
         for (ClientTableState cts : cache.getAllStates()) {
             cts.forActiveLifecycles(HasLifecycle::disconnected);
         }
+
 
         if (state == State.Disconnected) {
             // deliberately closed, don't try to reopen at this time
@@ -891,12 +897,12 @@ public class WorkerConnection {
                 .then(response -> new JsWidget(this, c -> fetchObject(varDef, c)).refetch());
     }
 
-    public void registerFigure(JsFigure figure) {
-        this.figures.add(figure);
+    public void registerSimpleReconnectable(HasLifecycle figure) {
+        this.simpleReconnectableInstances.add(figure);
     }
 
-    public void releaseFigure(JsFigure figure) {
-        this.figures.delete(figure);
+    public void unregisterSimpleReconnectable(HasLifecycle figure) {
+        this.simpleReconnectableInstances.delete(figure);
     }
 
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/lifecycle/HasLifecycle.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/lifecycle/HasLifecycle.java
@@ -3,54 +3,86 @@
  */
 package io.deephaven.web.client.api.lifecycle;
 
+import elemental2.dom.CustomEvent;
 import elemental2.dom.CustomEventInit;
+import elemental2.promise.Promise;
 import io.deephaven.web.client.api.HasEventHandling;
 import io.deephaven.web.client.api.JsTable;
 import io.deephaven.web.client.fu.JsLog;
+import io.deephaven.web.client.fu.LazyPromise;
 import io.deephaven.web.client.state.ClientTableState;
 
 import static io.deephaven.web.client.api.JsTable.EVENT_RECONNECTFAILED;
 
 /**
- * An abstraction over the lifecycle methods used to reconnect JsTable, so we can have non-JsTable bound states get the
- * same revivification treatment.
+ * An abstraction over simple lifecycle methods, to see if objects are currently connected to their server-side
+ * counterparts.
  */
-public interface HasLifecycle {
-
-    // extend HasEventHandling to get these three provided for you.
-    void suppressEvents();
-
-    void unsuppressEvents();
-
-    boolean isSuppress();
-
-    void revive(ClientTableState state);
+public abstract class HasLifecycle extends HasEventHandling {
+    /**
+     * Simple flag to see if already connected - that is, if true, will not fire a reconnect event unless disconnected
+     * again.
+     */
+    private boolean connected = true;
 
     /**
-     * You should probably just call notifyDeath(this, failure), assuming you implement in an object that
-     * HasEventHandlers.
+     * Signal that reconnect was attempted and failed due to differences between client and server state.
      */
-    void die(Object failure);
-
-    default void notifyDeath(HasEventHandling handler, Object error) {
+    public void die(Object error) {
         JsLog.debug("Die!", this, error);
         final CustomEventInit init = CustomEventInit.create();
         init.setDetail(error);
         unsuppressEvents();
-        handler.fireEvent(EVENT_RECONNECTFAILED, init);
+        fireEvent(EVENT_RECONNECTFAILED, init);
         suppressEvents();
     }
 
-    default void maybeRevive(ClientTableState state) {
-        if (isSuppress()) {
-            revive(state);
+    /**
+     * Mark the object as being connected to its corresponding server-side object.
+     */
+    public void reconnect() {
+        connected = true;
+        unsuppressEvents();
+        fireEvent(JsTable.EVENT_RECONNECT);
+    }
+
+    /**
+     * Indicate that a new session has been created on the server, and this object should re-create its corresponding
+     * server-side object if possible. Override this to implement custom behavior, being sure to call reconnect() when
+     * finished.
+     *
+     * @return a promise that will resolve when this object is reconnected
+     */
+    public Promise<?> refetch() {
+        reconnect();
+        return Promise.resolve(this);
+    }
+
+    /**
+     * Mark the object as (still) disconnected from its corresponding server-side object, but reconnect will be
+     * attempted in the future.
+     */
+    public void disconnected() {
+        connected = false;
+        fireEvent(JsTable.EVENT_DISCONNECT);
+        suppressEvents();
+    }
+
+    /**
+     * Resolves immediately if connected, otherwise will resolve the next time this object is marked as connected, or
+     * reject if it can't connect.
+     */
+    public Promise<Void> nextReconnect() {
+        if (connected) {
+            return Promise.resolve((Void) null);
         }
-    }
-
-    void disconnected();
-
-    default void notifyDisconnect(HasEventHandling handler) {
-        handler.fireEvent(JsTable.EVENT_DISCONNECT);
-        suppressEvents();
+        return new Promise<>((resolve, reject) -> {
+            addEventListenerOneShot(
+                    HasEventHandling.EventPair.of(JsTable.EVENT_RECONNECT, event -> resolve.onInvoke((Void) null)),
+                    HasEventHandling.EventPair.of(JsTable.EVENT_DISCONNECT,
+                            event -> reject.onInvoke(((CustomEvent<Object>) event).detail)),
+                    HasEventHandling.EventPair.of(EVENT_RECONNECTFAILED,
+                            event -> reject.onInvoke(((CustomEvent<Object>) event).detail)));
+        });
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -36,6 +36,7 @@ import io.deephaven.web.client.api.barrage.def.ColumnDefinition;
 import io.deephaven.web.client.api.barrage.def.InitialTableDefinition;
 import io.deephaven.web.client.api.barrage.stream.BiDiStream;
 import io.deephaven.web.client.api.filter.FilterCondition;
+import io.deephaven.web.client.api.lifecycle.HasLifecycle;
 import io.deephaven.web.client.api.subscription.ViewportData;
 import io.deephaven.web.client.api.subscription.ViewportRow;
 import io.deephaven.web.client.api.tree.JsTreeTable.TreeViewportData.TreeRow;
@@ -70,7 +71,7 @@ import static io.deephaven.web.client.api.subscription.ViewportData.NO_ROW_FORMA
  *
  * The table size will be -1 until a viewport has been fetched.
  */
-public class JsTreeTable extends HasEventHandling {
+public class JsTreeTable extends HasLifecycle {
     @JsProperty(namespace = "dh.TreeTable")
     public static final String EVENT_UPDATED = "updated",
             EVENT_DISCONNECT = "disconnect",
@@ -319,6 +320,11 @@ public class JsTreeTable extends HasEventHandling {
     public JsTreeTable(WorkerConnection workerConnection, JsWidget widget) {
         this.connection = workerConnection;
         this.widget = widget;
+
+        // register for same-session disconnect/reconnect callbacks
+        this.connection.registerSimpleReconnectable(this);
+
+        // TODO(deephaven-core#3604) factor most of the rest of this out for a refetch, in case of new session
         HierarchicalTableDescriptor treeDescriptor =
                 HierarchicalTableDescriptor.deserializeBinary(widget.getDataAsU8());
 
@@ -834,6 +840,8 @@ public class JsTreeTable extends HasEventHandling {
     public void close() {
         JsLog.debug("Closing tree table", this);
 
+        connection.unregisterSimpleReconnectable(this);
+
         // Presently it is never necessary to release widget tickets, since they can't be export tickets.
         // connection.releaseTicket(widget.getTicket());
 
@@ -856,6 +864,13 @@ public class JsTreeTable extends HasEventHandling {
                 return null;
             });
             stream = null;
+        }
+
+        if (sourceTable.isAvailable()) {
+            sourceTable.get().then(table -> {
+                table.close();
+                return null;
+            });
         }
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
@@ -18,6 +18,8 @@ import io.deephaven.web.client.api.HasEventHandling;
 import io.deephaven.web.client.api.JsPartitionedTable;
 import io.deephaven.web.client.api.JsTable;
 import io.deephaven.web.client.api.WorkerConnection;
+import io.deephaven.web.client.api.console.JsVariableChanges;
+import io.deephaven.web.client.api.lifecycle.HasLifecycle;
 import io.deephaven.web.client.api.widget.JsWidget;
 import io.deephaven.web.client.fu.JsLog;
 import io.deephaven.web.client.fu.LazyPromise;
@@ -40,7 +42,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @JsType(name = "Figure", namespace = "dh.plot")
-public class JsFigure extends HasEventHandling {
+public class JsFigure extends HasLifecycle {
 
     @JsProperty(namespace = "dh.plot.Figure")
     public static final String EVENT_UPDATED = "updated",
@@ -181,6 +183,38 @@ public class JsFigure extends HasEventHandling {
             return (Promise<JsFigure>) (Promise) Promise.reject(fetchError);
         });
     }
+
+    /**
+     * Asks the figure to fire a reconnect event after its tables are ready.
+     */
+    @JsIgnore
+    public void reconnect() {
+        // For each table and partitioned table, listen for reconnect events - when all have reconnected,
+        // signal that the figure itself has disconnected. If any one table disconnects, this will be canceled.
+        Promise.all(
+                Stream.concat(
+                        Arrays.stream(tables),
+                        Arrays.stream(partitionedTables))
+                        .map(HasLifecycle::nextReconnect)
+                        .toArray(Promise[]::new))
+                .then(ignore -> {
+                    verifyTables();
+                    return null;
+                }).then(ignore -> {
+                    unsuppressEvents();
+                    fireEvent(EVENT_RECONNECT);
+                    enqueueSubscriptionCheck();
+                    return null;
+                }, failure -> {
+                    CustomEventInit<Object> init = CustomEventInit.create();
+                    init.setDetail(failure);
+                    unsuppressEvents();
+                    fireEvent(EVENT_RECONNECTFAILED, init);
+                    suppressEvents();
+                    return null;
+                });
+    }
+
 
     @JsProperty
     public String getTitle() {
@@ -655,7 +689,7 @@ public class JsFigure extends HasEventHandling {
             int nextPartitionedTableIndex = 0;
             for (int i = 0; i < response.getTypedExportIdList().length; i++) {
                 TypedTicket ticket = response.getTypedExportIdList().getAt(i);
-                if (ticket.getType().equals("Table")) {
+                if (ticket.getType().equals(JsVariableChanges.TABLE)) {
                     // Note that creating a CTS like this means we can't actually refetch it, but that's okay, we can't
                     // reconnect in this way without refetching the entire figure anyway.
                     int tableIndex = nextTableIndex++;
@@ -666,13 +700,13 @@ public class JsFigure extends HasEventHandling {
                     }).then(etcr -> {
                         ClientTableState cts = connection.newStateFromUnsolicitedTable(etcr, "table for figure");
                         JsTable table = new JsTable(connection, cts);
-                        // never attempt a reconnect, since we might have a different figure schema entirely
-                        table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
+                        // TODO(deephaven-core#3604) if using a new session don't attempt a reconnect, since we might
+                        // have a different figure schema entirely
+                        // table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
                         tables[tableIndex] = table;
                         return Promise.resolve(table);
                     });
-                } else if (ticket.getType().equals("PartitionedTable")) {
-
+                } else if (ticket.getType().equals(JsVariableChanges.PARTITIONEDTABLE)) {
                     int partitionedTableIndex = nextPartitionedTableIndex++;
                     promises[i] = Callbacks.<FetchObjectResponse, Object>grpcUnaryPromise(c -> {
                         FetchObjectRequest partitionedTableRequest = new FetchObjectRequest();
@@ -683,6 +717,10 @@ public class JsFigure extends HasEventHandling {
                         JsPartitionedTable partitionedTable =
                                 new JsPartitionedTable(connection, new JsWidget(connection,
                                         callback -> callback.handleResponse(null, object, ticket.getTicket())));
+                        // TODO(deephaven-core#3604) if using a new session don't attempt a reconnect, since we might
+                        // have a different figure schema entirely
+                        // partitionedTable.addEventListener(JsPartitionedTable.EVENT_DISCONNECT, ignore ->
+                        // partitionedTable.close());
                         partitionedTables[partitionedTableIndex] = partitionedTable;
                         return partitionedTable.refetch();
                     });
@@ -693,11 +731,11 @@ public class JsFigure extends HasEventHandling {
 
             return Promise.all(promises)
                     .then(ignore -> {
-                        connection.registerFigure(figure);
+                        connection.registerSimpleReconnectable(figure);
 
                         return Promise.resolve(
                                 new FigureTableFetchData(tables, partitionedTables,
-                                        f -> this.connection.releaseFigure(f)));
+                                        f -> this.connection.unregisterSimpleReconnectable(f)));
                     });
         }
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/state/TableReviver.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/state/TableReviver.java
@@ -79,7 +79,7 @@ public class TableReviver implements HasTableBinding {
             JsLog.debug("Attempting revive on ", state);
             state.maybeRevive(metadata).then(
                     success -> {
-                        state.forActiveLifecycles(t -> t.revive(state));
+                        state.forActiveLifecycles(t -> ((JsTable) t).revive(state));
                         return null;
                     }, failure -> {
                         state.forActiveLifecycles(t -> t.die(failure));
@@ -137,8 +137,7 @@ public class TableReviver implements HasTableBinding {
             } else {
                 ClientTableState succeeded = all.remove(new TableTicket(ticket.getTicket_asU8()));
                 succeeded.setResolution(ClientTableState.ResolutionState.RUNNING);
-                succeeded.forActiveLifecycles(t -> t.revive(succeeded));
-
+                succeeded.forActiveLifecycles(t -> ((JsTable) t).revive(succeeded));
             }
         });
         stream.onEnd(status -> {


### PR DESCRIPTION
Tested by creating a rollup, a plot with a table, and a plot with a partitioned table (i.e. "plot by"), taking the browser offline for up to a minute, and then going online again, and confirming that all widgets correctly connected and resumed ticking. Note that the current version of web-client-ui will make the page unusable if the old "HACK_CONNECTION_FAILURE" event is emitted - either test with a newer web UI or disable that event.

Fixes #3616