### PR TITLE
Specify Use of Java NIO for extensions-arrow

### DIFF
--- a/extensions/arrow/build.gradle
+++ b/extensions/arrow/build.gradle
@@ -33,3 +33,5 @@ spotless {
         )
     }
 }
+
+apply plugin: 'io.deephaven.java-open-nio'


### PR DESCRIPTION
Fixes java17/java18 issue not being able to initialize arrow memory utils. The issue was introduced in #3420.