### PR TITLE
Make Go example tests robust to metadata order

### DIFF
--- a/go/internal/test_tools/test_tools.go
+++ b/go/internal/test_tools/test_tools.go
@@ -112,11 +112,14 @@ func GetAuthToken() string {
 	}
 }
 
-type metadata arrow.Metadata
+type sortableMetadata arrow.Metadata
 
-func (m metadata) Len() int           { md := arrow.Metadata(m); return md.Len() }
-func (m metadata) Less(i, j int) bool { md := arrow.Metadata(m); return md.Keys()[i] < md.Keys()[j] }
-func (m metadata) Swap(i, j int) {
+func (m sortableMetadata) Len() int { md := arrow.Metadata(m); return md.Len() }
+func (m sortableMetadata) Less(i, j int) bool {
+	md := arrow.Metadata(m)
+	return md.Keys()[i] < md.Keys()[j]
+}
+func (m sortableMetadata) Swap(i, j int) {
 	md := arrow.Metadata(m)
 	k := md.Keys()
 	v := md.Values()
@@ -124,21 +127,21 @@ func (m metadata) Swap(i, j int) {
 	v[i], v[j] = v[j], v[i]
 }
 
-// StringRecord returns a string representation of a record in a deterministic way that is safe to use for diffs.
-func StringRecord(r arrow.Record) string {
+// RecordString returns a string representation of a record in a deterministic way that is safe to use for diffs.
+func RecordString(r arrow.Record) string {
 
 	if s := r.Schema(); s != nil {
-		sort.Sort(metadata(s.Metadata()))
+		sort.Sort(sortableMetadata(s.Metadata()))
 
 		for _, f := range s.Fields() {
-			sort.Sort(metadata(f.Metadata))
+			sort.Sort(sortableMetadata(f.Metadata))
 		}
 	}
 
 	return fmt.Sprintf("%v", r)
 }
 
-// PrintRecord prints a record in a deterministic way that is safe to use for diffs.
-func PrintRecord(r arrow.Record) {
-	fmt.Println(StringRecord(r))
+// RecordPrint prints a record in a deterministic way that is safe to use for diffs.
+func RecordPrint(r arrow.Record) {
+	fmt.Println(RecordString(r))
 }

--- a/go/pkg/client/example_import_table_test.go
+++ b/go/pkg/client/example_import_table_test.go
@@ -31,7 +31,7 @@ func Example_importTable() {
 	defer sampleRecord.Release()
 
 	fmt.Println("Data Before:")
-	fmt.Println(sampleRecord)
+	test_tools.PrintRecord(sampleRecord)
 
 	// Now we upload the record so that we can manipulate its data using the server.
 	// We get back a TableHandle, which is a reference to a table on the server.
@@ -68,7 +68,7 @@ func Example_importTable() {
 	defer filteredRecord.Release()
 
 	fmt.Println("Data After:")
-	fmt.Println(filteredRecord)
+	test_tools.PrintRecord(filteredRecord)
 
 	// Output:
 	// Data Before:
@@ -88,12 +88,12 @@ func Example_importTable() {
 	//   schema:
 	//   fields: 3
 	//     - Ticker: type=utf8, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String", "deephaven:isDateFormat": "false"]
+	//         metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String"]
 	//     - Close: type=float32, nullable
-	//        metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "float", "deephaven:isDateFormat": "false"]
+	//        metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "float"]
 	//     - Volume: type=int32, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "int", "deephaven:isDateFormat": "false"]
-	//   metadata: ["deephaven:attribute.SortedColumns": "Close=Ascending", "deephaven:attribute_type.SortedColumns": "java.lang.String", "deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute.AddOnly": "true", "deephaven:attribute_type.AppendOnly": "java.lang.Boolean", "deephaven:attribute.AppendOnly": "true"]
+	//         metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "int"]
+	//   metadata: ["deephaven:attribute.AddOnly": "true", "deephaven:attribute.AppendOnly": "true", "deephaven:attribute.SortedColumns": "Close=Ascending", "deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute_type.AppendOnly": "java.lang.Boolean", "deephaven:attribute_type.SortedColumns": "java.lang.String"]
 	//   rows: 5
 	//   col[0][Ticker]: ["IBM" "XRX" "XYZZY" "GME" "ZNGA"]
 	//   col[1][Close]: [38.7 53.8 88.5 453 544.9]

--- a/go/pkg/client/example_import_table_test.go
+++ b/go/pkg/client/example_import_table_test.go
@@ -31,7 +31,7 @@ func Example_importTable() {
 	defer sampleRecord.Release()
 
 	fmt.Println("Data Before:")
-	test_tools.PrintRecord(sampleRecord)
+	test_tools.RecordPrint(sampleRecord)
 
 	// Now we upload the record so that we can manipulate its data using the server.
 	// We get back a TableHandle, which is a reference to a table on the server.
@@ -68,7 +68,7 @@ func Example_importTable() {
 	defer filteredRecord.Release()
 
 	fmt.Println("Data After:")
-	test_tools.PrintRecord(filteredRecord)
+	test_tools.RecordPrint(filteredRecord)
 
 	// Output:
 	// Data Before:

--- a/go/pkg/client/example_input_table_test.go
+++ b/go/pkg/client/example_input_table_test.go
@@ -113,7 +113,7 @@ func Example_inputTable() {
 		}
 
 		fmt.Println("Got the output table!")
-		fmt.Println(outputRec)
+		test_tools.PrintRecord(outputRec)
 		outputRec.Release()
 		break
 	}
@@ -124,11 +124,11 @@ func Example_inputTable() {
 	//   schema:
 	//   fields: 3
 	//     - Ticker: type=utf8, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:type": "java.lang.String", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:inputtable.isKey": "true", "deephaven:isDateFormat": "false"]
+	//         metadata: ["deephaven:inputtable.isKey": "true", "deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String"]
 	//     - Close: type=float32, nullable
-	//        metadata: ["deephaven:isRowStyle": "false", "deephaven:type": "float", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:inputtable.isKey": "false", "deephaven:isDateFormat": "false"]
+	//        metadata: ["deephaven:inputtable.isKey": "false", "deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "float"]
 	//     - Volume: type=int32, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:type": "int", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:inputtable.isKey": "false", "deephaven:isDateFormat": "false"]
+	//         metadata: ["deephaven:inputtable.isKey": "false", "deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "int"]
 	//   metadata: ["deephaven:unsent.attribute.InputTable": ""]
 	//   rows: 4
 	//   col[0][Ticker]: ["XRX" "XYZZY" "GME" "ZNGA"]

--- a/go/pkg/client/example_input_table_test.go
+++ b/go/pkg/client/example_input_table_test.go
@@ -113,7 +113,7 @@ func Example_inputTable() {
 		}
 
 		fmt.Println("Got the output table!")
-		test_tools.PrintRecord(outputRec)
+		test_tools.RecordPrint(outputRec)
 		outputRec.Release()
 		break
 	}

--- a/go/pkg/client/example_table_ops_test.go
+++ b/go/pkg/client/example_table_ops_test.go
@@ -160,7 +160,7 @@ func doImmediateOps() (string, error) {
 	}
 	defer magRecord.Release()
 
-	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", test_tools.StringRecord(sampleRecord), test_tools.StringRecord(midRecord), test_tools.StringRecord(magRecord)), nil
+	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", test_tools.RecordString(sampleRecord), test_tools.RecordString(midRecord), test_tools.RecordString(magRecord)), nil
 }
 
 // This function demonstrates how to use query-graph table operations.
@@ -240,5 +240,5 @@ func doQueryOps() (string, error) {
 	}
 	defer magRecord.Release()
 
-	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", test_tools.StringRecord(sampleRecord), test_tools.StringRecord(midRecord), test_tools.StringRecord(magRecord)), nil
+	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", test_tools.RecordString(sampleRecord), test_tools.RecordString(midRecord), test_tools.RecordString(magRecord)), nil
 }

--- a/go/pkg/client/example_table_ops_test.go
+++ b/go/pkg/client/example_table_ops_test.go
@@ -34,6 +34,7 @@ func Example_tableOps() {
 
 	fmt.Println(queryResult)
 
+	// Output:
 	// Data Before:
 	// record:
 	//   schema:
@@ -51,12 +52,12 @@ func Example_tableOps() {
 	//   schema:
 	//   fields: 3
 	//     - Ticker: type=utf8, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String", "deephaven:isDateFormat": "false"]
+	//         metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String"]
 	//     - Close: type=float32, nullable
-	//        metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "float", "deephaven:isDateFormat": "false"]
+	//        metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "float"]
 	//     - Volume: type=int32, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "int", "deephaven:isDateFormat": "false"]
-	//   metadata: ["deephaven:attribute_type.AppendOnly": "java.lang.Boolean", "deephaven:attribute.AppendOnly": "true", "deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute.AddOnly": "true"]
+	//         metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "int"]
+	//   metadata: ["deephaven:attribute.AddOnly": "true", "deephaven:attribute.AppendOnly": "true", "deephaven:attribute_type.AddOnly": "java.lang.Boolean", "deephaven:attribute_type.AppendOnly": "java.lang.Boolean"]
 	//   rows: 5
 	//   col[0][Ticker]: ["XRX" "IBM" "GME" "AAPL" "ZNGA"]
 	//   col[1][Close]: [53.8 38.7 453 26.7 544.9]
@@ -66,13 +67,13 @@ func Example_tableOps() {
 	//   schema:
 	//   fields: 4
 	//     - Ticker: type=utf8, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String", "deephaven:isDateFormat": "false"]
+	//         metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "java.lang.String"]
 	//     - Close: type=float32, nullable
-	//        metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "float", "deephaven:isDateFormat": "false"]
+	//        metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "float"]
 	//     - Volume: type=int32, nullable
-	//         metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "int", "deephaven:isDateFormat": "false"]
+	//         metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "int"]
 	//     - Magnitude: type=int32, nullable
-	//            metadata: ["deephaven:isRowStyle": "false", "deephaven:isNumberFormat": "false", "deephaven:isStyle": "false", "deephaven:type": "int", "deephaven:isDateFormat": "false"]
+	//            metadata: ["deephaven:isDateFormat": "false", "deephaven:isNumberFormat": "false", "deephaven:isRowStyle": "false", "deephaven:isStyle": "false", "deephaven:type": "int"]
 	//   rows: 5
 	//   col[0][Ticker]: ["XRX" "IBM" "GME" "AAPL" "ZNGA"]
 	//   col[1][Close]: [53.8 38.7 453 26.7 544.9]
@@ -159,7 +160,7 @@ func doImmediateOps() (string, error) {
 	}
 	defer magRecord.Release()
 
-	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", sampleRecord, midRecord, magRecord), nil
+	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", test_tools.StringRecord(sampleRecord), test_tools.StringRecord(midRecord), test_tools.StringRecord(magRecord)), nil
 }
 
 // This function demonstrates how to use query-graph table operations.
@@ -239,5 +240,5 @@ func doQueryOps() (string, error) {
 	}
 	defer magRecord.Release()
 
-	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", sampleRecord, midRecord, magRecord), nil
+	return fmt.Sprintf("Data Before:\n%s\nNew data:\n%s\n%s", test_tools.StringRecord(sampleRecord), test_tools.StringRecord(midRecord), test_tools.StringRecord(magRecord)), nil
 }


### PR DESCRIPTION
Make Go tests tolerant to metadata reordering.

Resolves #3241