### PR TITLE
Correctly check Join result sizes in Go unit tests

### DIFF
--- a/go/pkg/client/query_test.go
+++ b/go/pkg/client/query_test.go
@@ -869,15 +869,25 @@ func crossJoinQuery(t *testing.T, exec execBatchOrSerial) {
 	defer results[2].Release()
 	defer results[3].Release()
 
-	left, _, result1, result2 := results[0], results[1], results[2], results[3]
+	left, right, result1, result2 := results[0], results[1], results[2], results[3]
 
-	if result1.NumRows() >= left.NumRows() {
-		t.Error("result1 was too large")
+	if left.NumRows() == 0 {
+		t.Error("left is empty")
 		return
 	}
 
-	if result2.NumRows() <= left.NumRows() {
-		t.Error("result2 was too small")
+	if right.NumRows() == 0 {
+		t.Error("right is empty")
+		return
+	}
+
+	if result1.NumRows() == 0 {
+		t.Error("result1 is empty")
+		return
+	}
+
+	if result2.NumRows() == 0 {
+		t.Error("result2 is empty")
 		return
 	}
 }

--- a/go/pkg/client/query_test.go
+++ b/go/pkg/client/query_test.go
@@ -871,23 +871,18 @@ func crossJoinQuery(t *testing.T, exec execBatchOrSerial) {
 
 	left, right, result1, result2 := results[0], results[1], results[2], results[3]
 
-	if left.NumRows() == 0 {
-		t.Error("left is empty")
-		return
-	}
-
-	if right.NumRows() == 0 {
-		t.Error("right is empty")
-		return
-	}
-
 	if result1.NumRows() == 0 {
 		t.Error("result1 is empty")
 		return
 	}
 
-	if result2.NumRows() == 0 {
-		t.Error("result2 is empty")
+	if result1.NumRows() >= left.NumRows()*right.NumRows() {
+		t.Errorf("result1 is the wrong size: %v >= %v", result1.NumRows(), left.NumRows()*right.NumRows())
+		return
+	}
+
+	if result2.NumRows() != left.NumRows()*right.NumRows() {
+		t.Errorf("result2 is the wrong size: %v != %v", result2.NumRows(), left.NumRows()*right.NumRows())
 		return
 	}
 }

--- a/go/pkg/client/tablehandle_test.go
+++ b/go/pkg/client/tablehandle_test.go
@@ -358,7 +358,7 @@ func TestCrossJoin(t *testing.T) {
 		return
 	}
 
-	if resultRec1.NumRows() > 0 && resultRec1.NumRows() >= leftRec.NumRows()*rightRec.NumRows() {
+	if resultRec1.NumRows() >= leftRec.NumRows()*rightRec.NumRows() {
 		t.Errorf("resultRec1 is the wrong size: %v >= %v", resultRec1.NumRows(), leftRec.NumRows()*rightRec.NumRows())
 		return
 	}

--- a/go/pkg/client/tablehandle_test.go
+++ b/go/pkg/client/tablehandle_test.go
@@ -341,6 +341,10 @@ func TestCrossJoin(t *testing.T) {
 	test_tools.CheckError(t, "Snapshot", err)
 	defer leftRec.Release()
 
+	rightRec, err := rightTbl.Snapshot(ctx)
+	test_tools.CheckError(t, "Snapshot", err)
+	defer rightRec.Release()
+
 	resultRec1, err := resultTbl1.Snapshot(ctx)
 	test_tools.CheckError(t, "Snapshot", err)
 	defer resultRec1.Release()
@@ -349,18 +353,18 @@ func TestCrossJoin(t *testing.T) {
 	test_tools.CheckError(t, "Snapshot", err)
 	defer resultRec2.Release()
 
-	if leftRec.NumRows() == 0 {
-		t.Error("left is empty")
-		return
-	}
-
 	if resultRec1.NumRows() == 0 {
 		t.Error("resultRec1 is empty")
 		return
 	}
 
-	if resultRec2.NumRows() == 0 {
-		t.Error("resultRec2 is empty")
+	if resultRec1.NumRows() > 0 && resultRec1.NumRows() >= leftRec.NumRows()*rightRec.NumRows() {
+		t.Errorf("resultRec1 is the wrong size: %v >= %v", resultRec1.NumRows(), leftRec.NumRows()*rightRec.NumRows())
+		return
+	}
+
+	if resultRec2.NumRows() != leftRec.NumRows()*rightRec.NumRows() {
+		t.Errorf("resultRec2 is the wrong size: %v != %v", resultRec2.NumRows(), leftRec.NumRows()*rightRec.NumRows())
 		return
 	}
 }

--- a/go/pkg/client/tablehandle_test.go
+++ b/go/pkg/client/tablehandle_test.go
@@ -349,13 +349,18 @@ func TestCrossJoin(t *testing.T) {
 	test_tools.CheckError(t, "Snapshot", err)
 	defer resultRec2.Release()
 
-	if resultRec1.NumRows() >= leftRec.NumRows() {
-		t.Error("resultRec1 was too large")
+	if leftRec.NumRows() == 0 {
+		t.Error("left is empty")
 		return
 	}
 
-	if resultRec2.NumRows() <= leftRec.NumRows() {
-		t.Error("resultRec2 was too small")
+	if resultRec1.NumRows() == 0 {
+		t.Error("resultRec1 is empty")
+		return
+	}
+
+	if resultRec2.NumRows() == 0 {
+		t.Error("resultRec2 is empty")
 		return
 	}
 }


### PR DESCRIPTION
Go unit tests use random input tables.  The checks for join results can be wrong.  Use correct Join checks to resolve the problem.

Resolves #3490