### PR TITLE
Ensure parquet compatible DECIMAL precision and scale

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
@@ -113,7 +113,19 @@ class TypeInfos {
         return (PrecisionAndScale) computedCache
                 .computeIfAbsent(columnName, unusedColumnName -> new HashMap<>())
                 .computeIfAbsent(ParquetTableWriter.CacheTags.DECIMAL_ARGS,
-                        unusedCacheTag -> computePrecisionAndScale(rowSet, columnSourceSupplier.get()));
+                        uct -> parquetCompatible(computePrecisionAndScale(rowSet, columnSourceSupplier.get())));
+    }
+
+    private static PrecisionAndScale parquetCompatible(PrecisionAndScale pas) {
+        // Parquet / SQL has a more limited range for DECIMAL(precision, scale).
+        // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal
+        // Scale must be zero or a positive integer less than the precision.
+        // Precision is required and must be a non-zero positive integer.
+        // https://github.com/deephaven/deephaven-core/issues/3650
+        if (pas.scale > pas.precision) {
+            return new PrecisionAndScale(pas.scale, pas.scale);
+        }
+        return pas;
     }
 
     static TypeInfo bigDecimalTypeInfo(

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
@@ -121,6 +121,7 @@ class TypeInfos {
         // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal
         // Scale must be zero or a positive integer less than the precision.
         // Precision is required and must be a non-zero positive integer.
+        // Ultimately, this just means that the on-disk format is not as small and tight as it otherwise could be.
         // https://github.com/deephaven/deephaven-core/issues/3650
         if (pas.scale > pas.precision) {
             return new PrecisionAndScale(pas.scale, pas.scale);

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/BigDecimalParquetBytesCodecTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/BigDecimalParquetBytesCodecTest.java
@@ -1,0 +1,130 @@
+package io.deephaven.parquet.table;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class BigDecimalParquetBytesCodecTest {
+
+    @Test
+    public void examples() {
+        // [.0000, .9999]
+        checkNoRounding(codec(4, 4), bd("0.0005"), bi(5));
+
+        // [0.0000, 9.9999]
+        checkNoRounding(codec(5, 4), bd("0.0005"), bi(5));
+
+        // [.000, .999]
+        check(codec(3, 3), bd("0.0005"), bi(1), bd("0.001"));
+
+        // [0.000, 9.999]
+        check(codec(4, 3), bd("0.0005"), bi(1), bd("0.001"));
+
+        // [.0000, .9999]
+        check(codec(4, 4), bd("0.00050"), bi(5), bd("0.0005"));
+
+        // [0.0000, 9.9999]
+        check(codec(5, 4), bd("0.00050"), bi(5), bd("0.0005"));
+
+        // [.00000, .99999]
+        check(codec(5, 5), bd("0.0005"), bi(50), bd("0.00050"));
+
+        // [0.00000, 9.99999]
+        check(codec(6, 5), bd("0.0005"), bi(50), bd("0.00050"));
+
+        // [00.000, 99.999]
+        checkNoRounding(codec(5, 3), bd("0.123"), bi(123));
+
+        // [00.000, 99.999]
+        checkNoRounding(codec(5, 3), bd("99.999"), bi(99999));
+    }
+
+    @Test
+    public void badEncodings() {
+        cantEncode(codec(3, 3), bd("1.0"));
+        cantEncode(codec(4, 3), bd("10.0"));
+    }
+
+    @Test
+    public void badDecodings() {
+        cantDecode(codec(3, 3), bi(1000));
+        cantDecode(codec(4, 3), bi(10000));
+    }
+
+    private static BigDecimal bd(String val) {
+        return new BigDecimal(val);
+    }
+
+    private static BigInteger bi(int val) {
+        return BigInteger.valueOf(val);
+    }
+
+    private static BigDecimalParquetBytesCodec codec(int precision, int scale) {
+        return new BigDecimalParquetBytesCodec(precision, scale, -1);
+    }
+
+    private static void checkNoRounding(BigDecimalParquetBytesCodec codec, BigDecimal input, BigInteger expectedEncoding) {
+        check(codec, input, expectedEncoding, input);
+    }
+
+    private static void check(BigDecimalParquetBytesCodec codec, BigDecimal input, BigInteger expectedEncoding, BigDecimal expectedDecoding) {
+        checkEncoding(codec, input, expectedEncoding);
+        checkDecoding(codec, expectedEncoding, expectedDecoding);
+        // Check negative
+        checkEncoding(codec, input.negate(), expectedEncoding.negate());
+        checkDecoding(codec, expectedEncoding.negate(), expectedDecoding.negate());
+    }
+
+    private static void checkEncoding(BigDecimalParquetBytesCodec codec, BigDecimal input, BigInteger expectedEncoding) {
+        final byte[] inputEncoded = codec.encode(input);
+        assertArrayEquals(expectedEncoding.toByteArray(), inputEncoded);
+    }
+
+    private static void checkDecoding(BigDecimalParquetBytesCodec codec, BigInteger encoding, BigDecimal expectedDecoding) {
+        if (expectedDecoding.precision() > codec.getPrecision()) {
+            throw new IllegalStateException();
+        }
+        if (expectedDecoding.scale() != codec.getScale()) {
+            throw new IllegalStateException();
+        }
+        final byte[] bytes = encoding.toByteArray();
+        final BigDecimal decoded = codec.decode(bytes, 0, bytes.length);
+        assertEquals(expectedDecoding, decoded);
+        // Anything value that is decodable should be exactly re-encodable
+        checkEncoding(codec, expectedDecoding, encoding);
+    }
+
+    private static void cantEncode(BigDecimalParquetBytesCodec codec, BigDecimal input) {
+        cantEncodeImpl(codec, input);
+        cantEncodeImpl(codec, input.negate());
+    }
+
+    private static void cantDecode(BigDecimalParquetBytesCodec codec, BigInteger encoding) {
+        cantDecodeImpl(codec, encoding);
+        cantDecodeImpl(codec, encoding.negate());
+    }
+
+    private static void cantEncodeImpl(BigDecimalParquetBytesCodec codec, BigDecimal input) {
+        try {
+            codec.encode(input);
+            fail("Expected ArithmeticException");
+        } catch (ArithmeticException e) {
+            // ignore
+        }
+    }
+
+    private static void cantDecodeImpl(BigDecimalParquetBytesCodec codec, BigInteger encoding) {
+        final byte[] bytes = encoding.toByteArray();
+        try {
+            codec.decode(bytes, 0, bytes.length);
+            fail("Expected ArithmeticException");
+        } catch (ArithmeticException e) {
+            // ignore
+        }
+    }
+}

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -7,6 +7,7 @@ import io.deephaven.api.Selectable;
 import io.deephaven.base.FileUtils;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.impl.util.ColumnHolder;
 import io.deephaven.engine.testutil.TstUtils;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.engine.util.BigDecimalUtils;
@@ -26,6 +27,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -329,6 +331,20 @@ public class ParquetTableReadWriteTest {
         // while Snappy is covered by other tests, this is a very fast test to quickly confirm that it works in the same
         // way as the other similar codec tests.
         compressionCodecTestHelper("SNAPPY");
+    }
+
+    @Test
+    public void testBigDecimalPrecisionScale() {
+        // https://github.com/deephaven/deephaven-core/issues/3650
+        final BigDecimal myBigDecimal = new BigDecimal("0.0005");
+        assertEquals(1, myBigDecimal.precision());
+        assertEquals(4, myBigDecimal.scale());
+        final Table table = TableTools
+                .newTable(new ColumnHolder<>("MyBigDecimal", BigDecimal.class, null, false, myBigDecimal));
+        final File dest = new File(rootFile, "ParquetTest_testBigDecimalPrecisionScale.parquet");
+        ParquetTools.writeTable(table, dest);
+        final Table fromDisk = ParquetTools.readTable(dest);
+        TstUtils.assertTableEquals(fromDisk, table);
     }
 
     /**


### PR DESCRIPTION
This PR ensures that even if Java can represent the BigDecimal more efficiently, we need to ensure we are sticking to the parquet (implementation) limitations.

Note: the specification is actually out of sync with the majority of implementations. See https://github.com/apache/parquet-format/pull/198
 
Fixes #3650