### PR TITLE
Simplify export listeners in the server

### DIFF
--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
@@ -76,7 +76,7 @@ public class MultiplexedWebsocketStreamImpl extends AbstractWebsocketStreamImpl 
             try {
                 websocketSession.getBasicRemote().sendBinary(message);
             } catch (IOException e) {
-                throw Status.fromThrowable(e).asRuntimeException();
+                cancel(Status.fromThrowable(e));
             }
         }
 

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -254,7 +254,7 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
                         if (isSnapshot) {
                             resultTable.sealTable(() -> {
                                 // signal that we are closing the connection
-                                GrpcUtil.safelyComplete(observer);
+                                observer.onCompleted();
                                 signalCompletion();
                             }, () -> {
                                 exceptionWhileCompleting = new Exception();

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -254,7 +254,7 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
                         if (isSnapshot) {
                             resultTable.sealTable(() -> {
                                 // signal that we are closing the connection
-                                observer.onCompleted();
+                                GrpcUtil.safelyComplete(observer);
                                 signalCompletion();
                             }, () -> {
                                 exceptionWhileCompleting = new Exception();

--- a/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
@@ -192,10 +192,7 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
             @NotNull final StreamObserver<ExportNotification> responseObserver) {
         final SessionState session = service.getCurrentSession();
 
-        session.addExportListener(responseObserver);
-        ((ServerCallStreamObserver<ExportNotification>) responseObserver).setOnCancelHandler(() -> {
-            session.removeExportListener(responseObserver);
-        });
+        session.addExportListener(SessionState.ExportNotificationObserver.of(responseObserver), responseObserver);
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -528,9 +528,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
         final SessionState session = sessionService.getCurrentSession();
         authWiring.checkPermissionExportedTableUpdates(session.getAuthContext(), request, Collections.emptyList());
         final ExportedTableUpdateListener listener = new ExportedTableUpdateListener(session, responseObserver);
-        session.addExportListener(listener);
-        ((ServerCallStreamObserver<ExportedTableUpdateMessage>) responseObserver).setOnCancelHandler(
-                () -> session.removeExportListener(listener));
+        session.addExportListener(listener, responseObserver);
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/util/GrpcServiceOverrideBuilder.java
+++ b/server/src/main/java/io/deephaven/server/util/GrpcServiceOverrideBuilder.java
@@ -4,6 +4,7 @@
 package io.deephaven.server.util;
 
 import com.google.rpc.Code;
+import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.browserstreaming.BrowserStream;
 import io.deephaven.server.browserstreaming.BrowserStreamInterceptor;
@@ -266,8 +267,7 @@ public class GrpcServiceOverrideBuilder {
                     .onError(responseObserver)
                     .submit(() -> {
                         browserStream.get().onMessageReceived(request, streamData);
-                        responseObserver.onNext(null);// TODO simple response payload
-                        responseObserver.onCompleted();
+                        GrpcUtil.safelyComplete(responseObserver, null);
                     });
         }
     }

--- a/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
+++ b/server/src/test/java/io/deephaven/server/session/SessionStateTest.java
@@ -1352,9 +1352,6 @@ public class SessionStateTest {
 
         @Override
         public void onNext(final ExportNotification value) {
-            if (isComplete) {
-                throw new IllegalStateException("illegal to invoke onNext after onComplete");
-            }
             notifications.add(value);
         }
 


### PR DESCRIPTION
Any code observing an export listener no longer is responsible to remove its own handler in case of the stream being canceled, and can use safelyComplete/safelyOnNext to signal clients.

Also fixes a websocket transport issue where errors were not correctly reported to the stream.

Fixes #3590

(temporarily left as draft to discuss a potential race condition)