### PR TITLE
Bump parquet-hadoop to 1.13.0

### DIFF
--- a/ParquetHadoop/build.gradle
+++ b/ParquetHadoop/build.gradle
@@ -18,8 +18,9 @@ tasks.withType(License) {
 
 dependencies {
     // TODO(deephaven-core#3148): LZ4_RAW parquet support
-    api('org.apache.parquet:parquet-hadoop:1.12.3')
+    api('org.apache.parquet:parquet-hadoop:1.13.0')
 
+    // TODO(deephaven-core#806): Remove dependency on hadoop-common
     api('org.apache.hadoop:hadoop-common:3.3.3') {
         // do not take any dependencies of this project,
         // we just want a few classes (Configuration, Path) for

--- a/ParquetHadoop/src/main/java/io/deephaven/parquet/base/tempfix/ParquetMetadataConverter.java
+++ b/ParquetHadoop/src/main/java/io/deephaven/parquet/base/tempfix/ParquetMetadataConverter.java
@@ -19,6 +19,7 @@
 package io.deephaven.parquet.base.tempfix;
 
 /*
+TODO(deephaven-core#901): Remove the hacked ParquetMetadataConverter.java and the need for the ParquetHadoop module.
 NOTE this only exists for this line, inside addRowGroup
 Without it the page offset is not being saved properly
             if (columnMetaData.getDictionaryPageOffset() >= 0) {


### PR DESCRIPTION
We should follow up asap with #901; and either port over the changes that have been made to that file in the meantime, remove it, or try and upstream our desired fix.