### PR TITLE
Bump to spotless-plugin-gradle 6.18.0

### DIFF
--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ShortConsumer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ShortConsumer.java
@@ -8,9 +8,9 @@ package io.deephaven.engine.rowset.impl.rsp.container;
  * <pre>
  * {@code
  * bitmap.forEach(new ShortConsumer() {
- *   public boolean accept(short value) {
- *     // do something here
- *   }
+ *     public boolean accept(short value) {
+ *         // do something here
+ *     }
  * });
  * }
  * </pre>

--- a/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ShortRangeConsumer.java
+++ b/Container/src/main/java/io/deephaven/engine/rowset/impl/rsp/container/ShortRangeConsumer.java
@@ -10,9 +10,9 @@ package io.deephaven.engine.rowset.impl.rsp.container;
  * <pre>
  * {@code
  * bitmap.forEach(new ShortConsumer() {
- *   public boolean accept(short value) {
- *     // do something here
- *   }
+ *     public boolean accept(short value) {
+ *         // do something here
+ *     }
  * });
  * }
  * </pre>

--- a/Plot/src/main/java/io/deephaven/plot/datasets/category/AbstractSwappableTableBasedCategoryDataSeries.java
+++ b/Plot/src/main/java/io/deephaven/plot/datasets/category/AbstractSwappableTableBasedCategoryDataSeries.java
@@ -45,14 +45,14 @@ public abstract class AbstractSwappableTableBasedCategoryDataSeries extends Abst
         chart().figure().registerFigureFunction(new FigureImplFunction(figImpl -> {
             ((AbstractSwappableTableBasedCategoryDataSeries) figImpl.getFigure().getCharts()
                     .getChart(chart().row(), chart().column()).axes(axes().id()).series(id()))
-                            .shapesSetSpecific(
-                                    new AssociativeDataSwappableTable<Comparable, Shape, String>(getSwappableTable(),
-                                            getCategoryCol(), colName, Comparable.class, String.class, getPlotInfo()) {
-                                        @Override
-                                        public Shape convert(String v) {
-                                            return NamedShape.getShape(v);
-                                        }
-                                    });
+                    .shapesSetSpecific(
+                            new AssociativeDataSwappableTable<Comparable, Shape, String>(getSwappableTable(),
+                                    getCategoryCol(), colName, Comparable.class, String.class, getPlotInfo()) {
+                                @Override
+                                public Shape convert(String v) {
+                                    return NamedShape.getShape(v);
+                                }
+                            });
             return figImpl;
         }, this));
         return this;
@@ -67,8 +67,8 @@ public abstract class AbstractSwappableTableBasedCategoryDataSeries extends Abst
         chart().figure().registerFigureFunction(new FigureImplFunction(figImpl -> {
             ((AbstractSwappableTableBasedCategoryDataSeries) figImpl.getFigure().getCharts()
                     .getChart(chart().row(), chart().column()).axes(axes().id()).series(id()))
-                            .sizesSetSpecific(new AssociativeDataSwappableTable<>(getSwappableTable(), getCategoryCol(),
-                                    colName, Comparable.class, Number.class, getPlotInfo()));
+                    .sizesSetSpecific(new AssociativeDataSwappableTable<>(getSwappableTable(), getCategoryCol(),
+                            colName, Comparable.class, Number.class, getPlotInfo()));
             return figImpl;
         }, this));
         return this;
@@ -83,8 +83,8 @@ public abstract class AbstractSwappableTableBasedCategoryDataSeries extends Abst
         chart().figure().registerFigureFunction(new FigureImplFunction(figImpl -> {
             ((AbstractSwappableTableBasedCategoryDataSeries) figImpl.getFigure().getCharts()
                     .getChart(chart().row(), chart().column()).axes(axes().id()).series(id()))
-                            .colorsSetSpecific(new AssociativeDataSwappableTable<>(getSwappableTable(),
-                                    getCategoryCol(), colName, Comparable.class, Paint.class, getPlotInfo()));
+                    .colorsSetSpecific(new AssociativeDataSwappableTable<>(getSwappableTable(),
+                            getCategoryCol(), colName, Comparable.class, Paint.class, getPlotInfo()));
             return figImpl;
         }, this));
         return this;
@@ -99,14 +99,14 @@ public abstract class AbstractSwappableTableBasedCategoryDataSeries extends Abst
         chart().figure().registerFigureFunction(new FigureImplFunction(figImpl -> {
             ((AbstractSwappableTableBasedCategoryDataSeries) figImpl.getFigure().getCharts()
                     .getChart(chart().row(), chart().column()).axes(axes().id()).series(id()))
-                            .colorsSetSpecific(
-                                    new AssociativeDataSwappableTable<Comparable, Paint, Integer>(getSwappableTable(),
-                                            getCategoryCol(), colName, Comparable.class, Integer.class, getPlotInfo()) {
-                                        @Override
-                                        public Paint convert(Integer v) {
-                                            return intToColor(chart(), v);
-                                        }
-                                    });
+                    .colorsSetSpecific(
+                            new AssociativeDataSwappableTable<Comparable, Paint, Integer>(getSwappableTable(),
+                                    getCategoryCol(), colName, Comparable.class, Integer.class, getPlotInfo()) {
+                                @Override
+                                public Paint convert(Integer v) {
+                                    return intToColor(chart(), v);
+                                }
+                            });
             return figImpl;
         }, this));
         return this;
@@ -121,14 +121,14 @@ public abstract class AbstractSwappableTableBasedCategoryDataSeries extends Abst
         chart().figure().registerFigureFunction(new FigureImplFunction(figImpl -> {
             ((AbstractSwappableTableBasedCategoryDataSeries) figImpl.getFigure().getCharts()
                     .getChart(chart().row(), chart().column()).axes(axes().id()).series(id()))
-                            .labelsSetSpecific(
-                                    new AssociativeDataSwappableTable<Comparable, String, Object>(getSwappableTable(),
-                                            getCategoryCol(), colName, Comparable.class, Object.class, getPlotInfo()) {
-                                        @Override
-                                        public String convert(final Object o) {
-                                            return Objects.toString(o);
-                                        }
-                                    });
+                    .labelsSetSpecific(
+                            new AssociativeDataSwappableTable<Comparable, String, Object>(getSwappableTable(),
+                                    getCategoryCol(), colName, Comparable.class, Object.class, getPlotInfo()) {
+                                @Override
+                                public String convert(final Object o) {
+                                    return Objects.toString(o);
+                                }
+                            });
             return figImpl;
         }, this));
         return this;

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -30,7 +30,7 @@ dependencies {
         because('needed by plugin com.avast.gradle.docker-compose')
     }
 
-    implementation('com.diffplug.spotless:spotless-plugin-gradle:6.12.0') {
+    implementation('com.diffplug.spotless:spotless-plugin-gradle:6.18.0') {
         because('needed by plugin java-coding-conventions')
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -2473,7 +2473,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                                 final WritableRowSet newRowSet = getUngroupIndex(
                                         computeSize(getRowSet(), arrayColumns, vectorColumns, nullFill),
                                         RowSetFactory.builderRandom(), newBase, getRowSet())
-                                                .build();
+                                        .build();
                                 final TrackingWritableRowSet rowSet = result.getRowSet().writableCast();
                                 final RowSet added = newRowSet.minus(rowSet);
                                 final RowSet removed = rowSet.minus(newRowSet);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/AggregationProcessor.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/AggregationProcessor.java
@@ -249,11 +249,11 @@ public class AggregationProcessor implements AggregationContextFactory {
         final String duplicationErrorMessage = (type.isRollup
                 ? RollupAggregationOutputs.of(aggregations)
                 : AggregationOutputs.of(aggregations))
-                        .collect(Collectors.groupingBy(ColumnName::name, Collectors.counting())).entrySet()
-                        .stream()
-                        .filter(kv -> kv.getValue() > 1)
-                        .map(kv -> kv.getKey() + " used " + kv.getValue() + " times")
-                        .collect(Collectors.joining(", "));
+                .collect(Collectors.groupingBy(ColumnName::name, Collectors.counting())).entrySet()
+                .stream()
+                .filter(kv -> kv.getValue() > 1)
+                .map(kv -> kv.getKey() + " used " + kv.getValue() + " times")
+                .collect(Collectors.joining(", "));
         if (!duplicationErrorMessage.isBlank()) {
             throw new IllegalArgumentException("Duplicate output columns found: " + duplicationErrorMessage);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/BaseNodeOperationsRecorder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/BaseNodeOperationsRecorder.java
@@ -78,7 +78,7 @@ abstract class BaseNodeOperationsRecorder<TYPE> {
             return (nodeOperations.getRecordedAbsoluteViews().isEmpty()
                     ? input
                     : input.updateView(nodeOperations.getRecordedAbsoluteViews()))
-                            .sort(nodeOperations.getRecordedSorts());
+                    .sort(nodeOperations.getRecordedSorts());
         }
         // NB: We don't bother to drop the absolute columns; nothing gets to consume the output node tables directly.
         return input;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
@@ -132,7 +132,7 @@ public class FormulaAnalyzer {
                 context.getQueryLibrary().getPackageImports(),
                 classImports, context.getQueryLibrary().getStaticImports(), possibleVariables,
                 possibleVariableParameterizedTypes)
-                        .getResult();
+                .getResult();
     }
 
     public static class Result {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestChunkedRegionedOperations.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestChunkedRegionedOperations.java
@@ -192,7 +192,7 @@ public class TestChunkedRegionedOperations {
                         "Ext  = II % 1024  == 0  ? null        : new SimpleExternalizable(II)",
                         "Fix  = Sym == null      ? null        : new BigInteger(Sym, 10)",
                         "Var  = Str == null      ? null        : new BigInteger(Str, 10)"))
-                                .withDefinitionUnsafe(definition);
+                .withDefinitionUnsafe(definition);
         // TODO: Add (Fixed|Variable)WidthObjectCodec columns
 
         final Table inputMissingData = ((QueryTable) TableTools.emptyTable(TABLE_SIZE)
@@ -215,7 +215,8 @@ public class TestChunkedRegionedOperations {
                         "Ser  = (SimpleSerializable) null",
                         "Ext  = (SimpleExternalizable) null",
                         "Fix  = (BigInteger) null",
-                        "Var  = (BigInteger) null")).withDefinitionUnsafe(definition);
+                        "Var  = (BigInteger) null"))
+                .withDefinitionUnsafe(definition);
 
         dataDirectory = Files.createTempDirectory(Paths.get(""), "TestChunkedRegionedOperations-").toFile();
         dataDirectory.deleteOnExit();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestDynamicTableWriter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/TestDynamicTableWriter.java
@@ -152,8 +152,8 @@ public class TestDynamicTableWriter {
                 longCol("LC", 4),
                 floatCol("FC", 5.5f),
                 doubleCol("DC", QueryConstants.NULL_DOUBLE))
-                        .updateView("StrC=(String)null", "BLC=(Boolean)null", "DTC=(DateTime)null",
-                                "BIC=(java.math.BigInteger)null");
+                .updateView("StrC=(String)null", "BLC=(Boolean)null", "DTC=(DateTime)null",
+                        "BIC=(java.math.BigInteger)null");
         TstUtils.assertTableEquals(expected1, result);
 
         final Row row = writer.getRowWriter();

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -148,7 +148,7 @@ public class BarrageUtil {
         final MutableInputTable inputTable = (MutableInputTable) attributes.get(Table.INPUT_TABLE_ATTRIBUTE);
         final List<Field> fields = columnDefinitionsToFields(
                 descriptions, inputTable, tableDefinition.getColumns(), ignored -> new HashMap<>())
-                        .collect(Collectors.toList());
+                .collect(Collectors.toList());
 
         return new Schema(fields, schemaMetadata).getSchema(builder);
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
@@ -212,7 +212,8 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
                             localPageCache.castAttr(), endPosReader,
                             ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK,
                             makeToPage(columnTypes.get(END_POS), ParquetInstructions.EMPTY, END_POS,
-                                    endPosReader, LAST_KEY_COL_DEF)).pageStore).get();
+                                    endPosReader, LAST_KEY_COL_DEF)).pageStore)
+                    .get();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -262,7 +262,7 @@ public class ParquetTableReadWriteTest {
         final Table testTable =
                 ((QueryTable) TableTools.emptyTable(10).select("someInt = i", "someString  = `foo`")
                         .where("i % 2 == 0").groupBy("someString").ungroup("someInt"))
-                                .withDefinitionUnsafe(definition);
+                        .withDefinitionUnsafe(definition);
         final File dest = new File(rootFile, "ParquetTest_groupByString_test.parquet");
         ParquetTools.writeTable(testTable, dest);
         final Table fromDisk = ParquetTools.readTable(dest);

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -670,19 +670,19 @@ public class SessionState {
          *
          * <pre>
          * {@code
-         *  <T> T getFromExport(ExportObject<T> export) {
-         *      if (export.tryRetainReference()) {
-         *          try {
-         *              if (export.getState() == ExportNotification.State.EXPORTED) {
-         *                  return export.get();
-         *              }
-         *          } finally {
-         *              export.dropReference();
-         *          }
-         *      }
-         *      return null;
-         *  }
-         *  }
+         * <T> T getFromExport(ExportObject<T> export) {
+         *     if (export.tryRetainReference()) {
+         *         try {
+         *             if (export.getState() == ExportNotification.State.EXPORTED) {
+         *                 return export.get();
+         *             }
+         *         } finally {
+         *             export.dropReference();
+         *         }
+         *     }
+         *     return null;
+         * }
+         * }
          * </pre>
          *
          * @return the result of the computed export


### PR DESCRIPTION
This updates some code formatting to remove some extra whitespace from preformatted javadoc code blocks, and updates the formatting in some fluent newline cases.