### PR TITLE
Fix array index error on stale hover request

### DIFF
--- a/py/server/deephaven_internal/auto_completer/_completer.py
+++ b/py/server/deephaven_internal/auto_completer/_completer.py
@@ -143,14 +143,25 @@ class Completer:
         # Might just be a client issue, but either way not useful right now
         completions = [c for c in completer.complete(line, col) if c.type != "path"]
 
+        # for now, a simple sorting based on number of preceding _
+        # we may want to apply additional sorting to each list before combining
         results: list = []
+        results_: list = []
+        results__: list = []
         for completion in completions:
             # keep checking the latest version as we run, so updated doc can cancel us
             if not self._versions[uri] == version:
                 return []
-            results.append(self.to_completion_result(completion, col))
+            result: list = self.to_completion_result(completion, col)
+            if result[0].startswith("__"):
+                results__.append(result)
+            elif result[0].startswith("_"):
+                results_.append(result)
+            else:
+                results.append(result)
 
-        return results
+        # put the results together in a better-than-nothing sorting
+        return results + results_ + results__
 
     @staticmethod
     def to_completion_result(completion: Completion, col: int) -> list[Any]:

--- a/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
+++ b/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
@@ -280,18 +280,15 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
                 // our java is 0-indexed lines and chars. jedi is 1-indexed lines and 0-indexed chars
                 // we'll keep that translation ugliness to the in-java result-processing.
                 pos.getLine() + 1, pos.getCharacter());
-        if (!result.isList()) {
+        if (!result.isString()) {
             throw new UnsupportedOperationException(
-                    "Expected list from jedi_settings.do_hover, got " + result.call("repr"));
+                    "Expected string from jedi_settings.do_hover, got " + result.call("repr"));
         }
 
-        // We expect [ contents ] as our result
         // We don't set the range b/c Jedi doesn't seem to give the word range under the cursor easily
         // Monaco in the web auto-detects the word range for the hover if not set
-        final List<PyObject> hover = result.asList();
-
         return GetHoverResponse.newBuilder()
-                .setContents(MarkupContent.newBuilder().setValue(hover.get(0).getStringValue()).setKind("markdown"))
+                .setContents(MarkupContent.newBuilder().setValue(result.getStringValue()).setKind("markdown"))
                 .build();
     }
 


### PR DESCRIPTION
Fixes #3695 

Doesn't need to modify the other autocomplete handlers since they expect a 2D array, and if the array is empty, it won't try to access any of the inner elements

Tested by hovering over a Python keyword and confirming no error is thrown. This was fine before as well, but I changed the Python hover function to return a string instead of a list containing 1 element that was a string