### PR TITLE
Use sessionTimeoutMs for fetching a variable timeout

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -688,7 +688,7 @@ public class WorkerConnection {
         Listener listener = new Listener();
 
         return promise
-                .timeout(10_000)
+                .timeout((int)sessionTimeoutMs)
                 .asPromise()
                 .then(Promise::resolve, fail -> {
                     listener.subscription.run();

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -688,7 +688,7 @@ public class WorkerConnection {
         Listener listener = new Listener();
 
         return promise
-                .timeout((int)sessionTimeoutMs)
+                .timeout((int) sessionTimeoutMs)
                 .asPromise()
                 .then(Promise::resolve, fail -> {
                     listener.subscription.run();


### PR DESCRIPTION
- Was hardcoded to 10s and not configurable
- Just re-use the session timeout prop
- @chipkent is running into the 10s timeout when testing on Jupyter (still investigating if there is another error, but should be able to configure this timeout regardless)