### PR TITLE
Use embedded pattern flags instead of exposing via python wrapper

### DIFF
--- a/py/server/deephaven/filters.py
+++ b/py/server/deephaven/filters.py
@@ -113,6 +113,9 @@ def pattern(
 ) -> Filter:
     """Creates a regular-expression pattern filter.
 
+    See https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html for documentation on
+    the regex pattern.
+
     Args:
         mode (PatternMode): the mode
         col (str): the column name

--- a/py/server/deephaven/filters.py
+++ b/py/server/deephaven/filters.py
@@ -105,119 +105,10 @@ class PatternMode(Enum):
     """Matches any subsequence of the input against the pattern"""
 
 
-class PatternFlag(Enum):
-    CASE_INSENSITIVE = _JPattern.CASE_INSENSITIVE
-    """Enables case-insensitive matching.
-
-    By default, case-insensitive matching assumes that only characters in the US-ASCII charset are being matched.
-    Unicode-aware case-insensitive matching can be enabled by specifying the UNICODE_CASE flag in conjunction with this
-    flag.
-
-    Case-insensitive matching can also be enabled via the embedded flag expression (?i).
-
-    Specifying this flag may impose a slight performance penalty.
-    """
-
-    MULTILINE = _JPattern.MULTILINE
-    """Enables multiline mode.
-
-    In multiline mode the expressions ^ and $ match just after or just before, respectively, a line terminator or the
-    end of the input sequence. By default these expressions only match at the beginning and the end of the entire input
-    sequence.
-
-    Multiline mode can also be enabled via the embedded flag expression (?m).
-    """
-
-    DOTALL = _JPattern.DOTALL
-    """Enables dotall mode.
-
-    In dotall mode, the expression . matches any character, including a line terminator. By default this expression does
-    not match line terminators.
-
-    Dotall mode can also be enabled via the embedded flag expression (?s). (The s is a mnemonic for "single-line" mode,
-    which is what this is called in Perl.)
-    """
-
-    UNICODE_CASE = _JPattern.UNICODE_CASE
-    """Enables Unicode-aware case folding.
-
-    When this flag is specified then case-insensitive matching, when enabled by the CASE_INSENSITIVE flag, is done in a
-    manner consistent with the Unicode Standard. By default, case-insensitive matching assumes that only characters in
-    the US-ASCII charset are being matched.
-
-    Unicode-aware case folding can also be enabled via the embedded flag expression (?u).
-
-    Specifying this flag may impose a performance penalty.
-    """
-
-    CANON_EQ = _JPattern.CANON_EQ
-    """Enables canonical equivalence.
-
-    When this flag is specified then two characters will be considered to match if, and only if, their full canonical
-    decompositions match. The expression "a\u030A", for example, will match the string "\u00E5" when this flag is
-    specified. By default, matching does not take canonical equivalence into account.
-
-    There is no embedded flag character for enabling canonical equivalence.
-
-    Specifying this flag may impose a performance penalty.
-    """
-
-    UNIX_LINES = _JPattern.UNIX_LINES
-    """Enables Unix lines mode.
-
-    In this mode, only the '\n' line terminator is recognized in the behavior of ., ^, and $.
-
-    Unix lines mode can also be enabled via the embedded flag expression (?d).
-    """
-
-    LITERAL = _JPattern.LITERAL
-    """Enables literal parsing of the pattern.
-
-    When this flag is specified then the input string that specifies the pattern is treated as a sequence of literal
-    characters. Metacharacters or escape sequences in the input sequence will be given no special meaning.
-
-    The flags CASE_INSENSITIVE and UNICODE_CASE retain their impact on matching when used in conjunction with this flag.
-    The other flags become superfluous.
-
-    There is no embedded flag character for enabling literal parsing.
-    """
-
-    UNICODE_CHARACTER_CLASS = _JPattern.UNICODE_CHARACTER_CLASS
-    """Enables the Unicode version of Predefined character classes and POSIX character classes.
-
-    When this flag is specified then the (US-ASCII only) Predefined character classes and POSIX character classes are in
-    conformance with Unicode Technical Standard #18: Unicode Regular Expression Annex C: Compatibility Properties.
-
-    The UNICODE_CHARACTER_CLASS mode can also be enabled via the embedded flag expression (?U).
-
-    The flag implies UNICODE_CASE, that is, it enables Unicode-aware case folding.
-
-    Specifying this flag may impose a performance penalty.
-    """
-
-    COMMENTS = _JPattern.COMMENTS
-    """Permits whitespace and comments in pattern.
-
-    In this mode, whitespace is ignored, and embedded comments starting with # are ignored until the end of a line.
-
-    Comments mode can also be enabled via the embedded flag expression (?x).
-    """
-
-    @staticmethod
-    def _bitwise_or(flags: Union[PatternFlag, List[PatternFlag]]) -> int:
-        return functools.reduce(
-            lambda x, y: x | y, [flag.value for flag in to_sequence(flags)]
-        )
-
-    def __repr__(self):
-        return self.name
-
-
 def pattern(
     mode: PatternMode,
     col: str,
     regex: str,
-    flags: Union[PatternFlag, List[PatternFlag]] = None,
     invert_pattern: bool = False,
 ) -> Filter:
     """Creates a regular-expression pattern filter.
@@ -226,7 +117,6 @@ def pattern(
         mode (PatternMode): the mode
         col (str): the column name
         regex (str): the regex pattern
-        flags (Union[PatternFlag, List[PatternFlag]]): the regex flags
         invert_pattern (bool): if the pattern match should be inverted
 
     Returns:
@@ -240,7 +130,7 @@ def pattern(
         return Filter(
             j_filter=_JPatternFilter(
                 _JColumnName.of(col),
-                _JPattern.compile(regex, PatternFlag._bitwise_or(flags)),
+                _JPattern.compile(regex),
                 mode.value,
                 invert_pattern,
             )

--- a/py/server/tests/test_filters.py
+++ b/py/server/tests/test_filters.py
@@ -5,7 +5,7 @@
 import unittest
 
 from deephaven import read_csv, DHError
-from deephaven.filters import Filter, PatternMode, PatternFlag, and_, or_, not_, pattern
+from deephaven.filters import Filter, PatternMode, and_, or_, not_, pattern
 from tests.testbase import BaseTestCase
 
 
@@ -20,7 +20,7 @@ class FilterTestCase(BaseTestCase):
 
     def test_pattern_filter(self):
         new_test_table = self.test_table.update("X = String.valueOf(d)")
-        regex_filter = pattern(PatternMode.MATCHES, "X", "...", flags=[PatternFlag.DOTALL])
+        regex_filter = pattern(PatternMode.MATCHES, "X", "(?s)...")
         with self.assertRaises(DHError):
             filtered_table = self.test_table.where(filters=regex_filter)
 
@@ -31,7 +31,7 @@ class FilterTestCase(BaseTestCase):
             filtered_table = new_test_table.where(filters=[regex_filter, "b < 100"])
 
         new_test_table = new_test_table.update("Y = String.valueOf(e)")
-        regex_filter1 = pattern(PatternMode.MATCHES, "Y", ".0.", flags=[PatternFlag.DOTALL])
+        regex_filter1 = pattern(PatternMode.MATCHES, "Y", "(?s).0.")
         filtered_table = new_test_table.where(filters=[regex_filter, regex_filter1])
         self.assertLessEqual(filtered_table.size, new_test_table.size)
 


### PR DESCRIPTION
Upon digging into how this filter might be exposed over gRPC, it seems like keeping things simpler and relying on the embedded flag expressions is a better choice as it allows the full pattern to be specified by a string. For motivation, some manually invoked filters that the web ui client is currently constructing is using embedded flags:

```ts
filter.invoke(
  'matches',
  dh.FilterValue.ofString(`(?s)(?i).*\\Q${value}\\E.*`)
)
```

This is an example of setting the flags `DOTALL` (?s) and `CASE_INSENSITIVE` (?i), and using literal wrappers `\Q` / `\E`, to search if the column contains `${value}`.

If we find there are certain patterns in the future that need explicit flags, we can add them back in at that time.

Follow-up to #3693