### PR TITLE
Correctly handle None input values for primitive type columns in new_table()

### DIFF
--- a/py/server/deephaven/column.py
+++ b/py/server/deephaven/column.py
@@ -66,7 +66,8 @@ class InputColumn(Column):
                 self.j_column = _JColumn.empty(self.j_column_header)
             else:
                 if self.data_type.is_primitive:
-                    self.j_column = _JColumn.ofUnsafe(self.name, dtypes.array(self.data_type, self.input_data))
+                    self.j_column = _JColumn.ofUnsafe(self.name, dtypes.array(self.data_type, self.input_data,
+                                                                              remap=dtypes.null_remap(self.data_type)))
                 else:
                     self.j_column = _JColumn.of(self.j_column_header, dtypes.array(self.data_type, self.input_data))
         except Exception as e:

--- a/py/server/deephaven/dtypes.py
+++ b/py/server/deephaven/dtypes.py
@@ -189,6 +189,7 @@ def array(dtype: DType, seq: Sequence, remap: Callable[[Any], Any] = None) -> jp
     """
     try:
         if isinstance(seq, str) and dtype == char:
+            # ord is the Python builtin function that takes a unicode character and returns an integer code point value
             remap = ord
 
         if remap:

--- a/py/server/tests/test_table_factory.py
+++ b/py/server/tests/test_table_factory.py
@@ -112,6 +112,22 @@ class TableFactoryTestCase(BaseTestCase):
         t = new_table(cols=cols)
         self.assertEqual(t.size, 2)
 
+    def test_new_table_nulls(self):
+        null_cols = [
+            datetime_col("datetime_col", [None]),
+            string_col("string_col", [None]),
+            char_col("char_col", [None]),
+            bool_col("bool_col", [None]),
+            int_col("int_col", [None]),
+            long_col("long_col", [None]),
+            float_col("float_col", [None]),
+            double_col("double_col", [None]),
+            byte_col("byte_col", [None]),
+            short_col("short_col", [None]),
+        ]
+        t = new_table(cols=null_cols)
+        self.assertEqual(t.to_string().count("null"), len(null_cols))
+
     def test_input_column_error(self):
         j_al = JArrayList()
 


### PR DESCRIPTION
Fixes #3688 