### PR TITLE
Don't print stack trace when autocomplete errors are suppressed

### DIFF
--- a/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
+++ b/server/src/main/java/io/deephaven/server/console/completer/PythonAutoCompleteObserver.java
@@ -153,7 +153,6 @@ public class PythonAutoCompleteObserver extends SessionCloseableObserver<AutoCom
 
         } catch (Throwable exception) {
             if (ConsoleServiceGrpcImpl.QUIET_AUTOCOMPLETE_ERRORS) {
-                exception.printStackTrace();
                 if (log.isTraceEnabled()) {
                     log.trace().append("Exception occurred during autocomplete").append(exception).endl();
                 }


### PR DESCRIPTION
Fixes #3766