### PR TITLE
To allow Dtype.qst_type to be None for some types (in particular Java ObjectVector)

### DIFF
--- a/py/server/deephaven/dtypes.py
+++ b/py/server/deephaven/dtypes.py
@@ -25,7 +25,10 @@ _j_name_type_map: Dict[str, DType] = {}
 
 
 def _qst_custom_type(cls_name: str):
-    return _JQstType.find(_JTableTools.typeFromName(cls_name))
+    try:
+        return _JQstType.find(_JTableTools.typeFromName(cls_name))
+    except:
+        return None
 
 
 class DType:

--- a/py/server/tests/test_column.py
+++ b/py/server/tests/test_column.py
@@ -72,6 +72,12 @@ class ColumnTestCase(BaseTestCase):
         self.assertIsNone(test_table.columns[0].component_type)
         self.assertEqual(test_table.columns[1].component_type, dtypes.double)
 
+    def test_vector_column(self):
+        t = empty_table(0).update_view("StringColumn=`abc`").group_by()
+        self.assertTrue(t.columns[0].data_type.j_name.endswith("ObjectVector"))
+        self.assertEqual(t.columns[0].component_type, dtypes.string)
+        self.assertIsNone(t.columns[0].data_type.qst_type)
+
     def test_numeric_columns(self):
         x = [MAX_BYTE, MAX_SHORT, MAX_INT, MAX_LONG, 1, 999999]
         n = len(x)


### PR DESCRIPTION
This is OK because practically such Java types won't be created from inside Python but the column info should still be inspectable.


Fixes #3777