### PR TITLE
ParallelWhere: Prevent Race Between Interrupt and Child Running

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InitialFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InitialFilterExecution.java
@@ -90,6 +90,9 @@ class InitialFilterExecution extends AbstractFilterExecution {
                 try {
                     if (!root.cancelled.get()) {
                         notification.run();
+                    } else {
+                        // we must ensure that we, the parent InitialFilterExecution, are notified of completion
+                        onChildCompleted();
                     }
                     if (Thread.interrupted()) {
                         // we would like to throw a query cancellation exception

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
@@ -801,6 +801,7 @@ public abstract class QueryTableWhereTest {
             try (final SafeCloseable ignored = executionContext.open()) {
                 tableToFilter.where("slowCounter.applyAsInt(X) % 2 == 0", "fastCounter.applyAsInt(X) % 3 == 0");
             } catch (Exception e) {
+                log.error().append("extra thread caught ").append(e).endl();
                 caught.setValue(e);
             }
             final long end1 = System.currentTimeMillis();
@@ -813,9 +814,10 @@ public abstract class QueryTableWhereTest {
         t.interrupt();
 
         try {
-            t.join(30000);
+            final long timeout_ms = 300_000; // 5 min
+            t.join(timeout_ms);
             if (t.isAlive()) {
-                throw new RuntimeException("Thread did not terminate within a reasonable time");
+                throw new RuntimeException("Thread did not terminate within " + timeout_ms + " ms");
             }
         } catch (InterruptedException e) {
             e.printStackTrace();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
@@ -813,7 +813,10 @@ public abstract class QueryTableWhereTest {
         t.interrupt();
 
         try {
-            t.join();
+            t.join(30000);
+            if (t.isAlive()) {
+                throw new RuntimeException("Thread did not terminate within a reasonable time");
+            }
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
I've also added a 5m timeout on the test; because why shouldn't we have some failsafe?

Here is a link to the final nightly run that targeted 18 attempts at reproducing: https://github.com/nbauernfeind/deephaven-core/actions/runs/4874961958

Statistically I was getting about 25% failures per run. This was 2 of 18 each without failures. I also caught the codepaths in use (with the child already cancelled).