### PR TITLE
Custom autocomplete API

### DIFF
--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
@@ -50,7 +50,7 @@ public class ChunkerCompleter implements CompletionHandler {
     private ParsedDocument doc;
 
     public ChunkerCompleter(final Logger log, VariableProvider variables) {
-        this(log, variables, new CompletionLookups(() -> new CustomCompletion() {}));
+        this(log, variables, new CompletionLookups(Collections.emptySet()));
     }
 
     public ChunkerCompleter(final Logger log, VariableProvider variables, CompletionLookups lookups) {

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
@@ -50,7 +50,7 @@ public class ChunkerCompleter implements CompletionHandler {
     private ParsedDocument doc;
 
     public ChunkerCompleter(final Logger log, VariableProvider variables) {
-        this(log, variables, new CompletionLookups());
+        this(log, variables, new CompletionLookups(() -> new CustomCompletion() {}));
     }
 
     public ChunkerCompleter(final Logger log, VariableProvider variables, CompletionLookups lookups) {
@@ -784,7 +784,7 @@ public class ChunkerCompleter implements CompletionHandler {
         // for now, this will be a naive replacement, but later we'll want to look at _where_
         // in the invoke the cursor is; when on the ending paren, we'd likely want to look at
         // whether we are the argument to something, and if so, do a type check, and suggest useful .coercions().
-        String name = node.getName().trim();
+        String name = node.getName();
 
         // Now, for our magic-named methods that we want to handle...
         boolean inArguments = node.isCursorInArguments(request.getCandidate());
@@ -984,6 +984,9 @@ public class ChunkerCompleter implements CompletionHandler {
                 maybeColumnComplete(results, node, replaceNode, request, direction);
                 break;
         }
+        // Try to delegate to another implementation
+        lookups.getCustomCompletions().methodArgumentCompletion(node, replaceNode, request, direction, results::add);
+
         if (node.getEndIndex() < request.getOffset()) {
             // user's cursor is actually past the end of our method...
             Class<?> scopeType;
@@ -1024,10 +1027,11 @@ public class ChunkerCompleter implements CompletionHandler {
         if (result.isPresent()) {
             return result;
         }
-        switch (o.getName()) {
-            // This used to be where we'd intercept certain well-known-service-variables, like "engine";
-            // leaving this here in case we have add and such service to the OSS completer.
+        Optional<Class<?>> customResult = lookups.getCustomCompletions().resolveScopeType(o);
+        if (customResult.isPresent()) {
+            return customResult;
         }
+
         // Ok, maybe the user hasn't run the query yet.
         // See if there's any named assign's that have a value of engine.i|t|etc
 
@@ -1352,10 +1356,17 @@ public class ChunkerCompleter implements CompletionHandler {
             }
             return definition;
         } else if (previous instanceof ChunkerInvoke) {
+            ChunkerInvoke invoke = (ChunkerInvoke) previous;
             // recurse into each scope node and use the result of our parent's type to compute our own.
             // This allows us to hack in special support for statically analyzing expressions which return tables.
+            TableDefinition attempt = findTableDefinition(invoke.getScope(), offset);
 
-            return findTableDefinition(((ChunkerInvoke) previous).getScope(), offset);
+            if (attempt != null) {
+                return attempt;
+            }
+
+            // If that fails, try a custom implementation
+            return lookups.getCustomCompletions().resolveTableDefinition(invoke, offset).orElse(null);
         }
         return null;
     }
@@ -1371,21 +1382,15 @@ public class ChunkerCompleter implements CompletionHandler {
         if (scope != null && scope.size() > 0) {
             IsScope root = scope.get(0);
             if (root instanceof ChunkerIdent) {
-                if ("engine".equals(root.getName())) {
-                    if (scope.size() > 1) {
-                        root = scope.get(1);
-                    }
-                } else {
-                    // look for the table in binding
-                    final TableDefinition def = offset.getTableDefinition(this, doc, variables, root.getName());
-                    if (def != null) {
-                        final ColumnDefinition col = def.getColumn(columnName);
-                        if (col == null) {
-                            // might happen if user did someTable.update("NewCol=123").update("NewCol=
-                            // we can handle this by inspecting the scope chain, but leaving edge case out for now.
-                        } else {
-                            return col.getDataType();
-                        }
+                // look for the table in binding
+                final TableDefinition def = offset.getTableDefinition(this, doc, variables, root.getName());
+                if (def != null) {
+                    final ColumnDefinition col = def.getColumn(columnName);
+                    if (col == null) {
+                        // might happen if user did someTable.update("NewCol=123").update("NewCol=
+                        // we can handle this by inspecting the scope chain, but leaving edge case out for now.
+                    } else {
+                        return col.getDataType();
                     }
                 }
             }

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CustomCompletion.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CustomCompletion.java
@@ -1,0 +1,50 @@
+package io.deephaven.lang.completion;
+
+import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.lang.api.IsScope;
+import io.deephaven.lang.generated.ChunkerInvoke;
+import io.deephaven.lang.generated.Node;
+import io.deephaven.proto.backplane.script.grpc.CompletionItem;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Allows applications to offer custom autocomplete suggestions. Methods are all default with no implementation, so that
+ * new operations can be added later.
+ */
+public interface CustomCompletion {
+
+
+    /**
+     * Factory interface for CustomCompletion instances, allowing the autocomplete internals to manage scope directly of
+     * CustomCompletion instances. By implementing the Factory interface, scope of dependencies can be managed, but any
+     * state should be left in the CustomCompletion itself (cached lookups, etc).
+     */
+    interface Factory {
+        CustomCompletion create();
+    }
+
+    /**
+     * User's cursor is within the method arguments.
+     */
+    default void methodArgumentCompletion(ChunkerInvoke node,
+            Node replaceNode,
+            CompletionRequest request,
+            ChunkerCompleter.SearchDirection direction,
+            Consumer<CompletionItem.Builder> results) {}
+
+    /**
+     * Return the type of the scoped value if known, otherwise null.
+     */
+    default Optional<Class<?>> resolveScopeType(IsScope scope) {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the definition of the table that would be created by the method call if known, otherwise null.
+     */
+    default Optional<TableDefinition> resolveTableDefinition(ChunkerInvoke invoke, CompletionRequest result) {
+        return Optional.empty();
+    }
+}

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CustomCompletion.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CustomCompletion.java
@@ -15,7 +15,6 @@ import java.util.function.Consumer;
  */
 public interface CustomCompletion {
 
-
     /**
      * Factory interface for CustomCompletion instances, allowing the autocomplete internals to manage scope directly of
      * CustomCompletion instances. By implementing the Factory interface, scope of dependencies can be managed, but any
@@ -26,7 +25,7 @@ public interface CustomCompletion {
     }
 
     /**
-     * User's cursor is within the method arguments.
+     * User's cursor is within the method arguments, provide autocomplete suggestions for cursor position.
      */
     default void methodArgumentCompletion(ChunkerInvoke node,
             Node replaceNode,
@@ -35,14 +34,14 @@ public interface CustomCompletion {
             Consumer<CompletionItem.Builder> results) {}
 
     /**
-     * Return the type of the scoped value if known, otherwise null.
+     * Return the type of the scoped value if known.
      */
     default Optional<Class<?>> resolveScopeType(IsScope scope) {
         return Optional.empty();
     }
 
     /**
-     * Returns the definition of the table that would be created by the method call if known, otherwise null.
+     * Returns the definition of the table that would be created by the method call if known.
      */
     default Optional<TableDefinition> resolveTableDefinition(ChunkerInvoke invoke, CompletionRequest result) {
         return Optional.empty();

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/DelegatingCustomCompletion.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/DelegatingCustomCompletion.java
@@ -12,6 +12,9 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+/**
+ * Creates all specified implementation, and sends all queries to each as necessary.
+ */
 public class DelegatingCustomCompletion implements CustomCompletion {
     private final List<CustomCompletion> delegates;
 

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/DelegatingCustomCompletion.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/DelegatingCustomCompletion.java
@@ -1,0 +1,51 @@
+package io.deephaven.lang.completion;
+
+import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.lang.api.IsScope;
+import io.deephaven.lang.generated.ChunkerInvoke;
+import io.deephaven.lang.generated.Node;
+import io.deephaven.proto.backplane.script.grpc.CompletionItem;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class DelegatingCustomCompletion implements CustomCompletion {
+    private final List<CustomCompletion> delegates;
+
+    public DelegatingCustomCompletion(Set<Factory> factories) {
+        delegates = factories.stream().map(Factory::create).collect(Collectors.toList());
+    }
+
+    @Override
+    public void methodArgumentCompletion(ChunkerInvoke node, Node replaceNode, CompletionRequest request,
+            ChunkerCompleter.SearchDirection direction, Consumer<CompletionItem.Builder> results) {
+        for (CustomCompletion delegate : delegates) {
+            delegate.methodArgumentCompletion(node, replaceNode, request, direction, results);
+        }
+    }
+
+    @Override
+    public Optional<Class<?>> resolveScopeType(IsScope scope) {
+        for (CustomCompletion delegate : delegates) {
+            Optional<Class<?>> result = delegate.resolveScopeType(scope);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TableDefinition> resolveTableDefinition(ChunkerInvoke invoke, CompletionRequest offset) {
+        for (CustomCompletion delegate : delegates) {
+            Optional<TableDefinition> result = delegate.resolveTableDefinition(invoke, offset);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,7 +27,9 @@ dependencies {
     implementation 'org.hdrhistogram:HdrHistogram:2.1.12'
 
     implementation project(':proto:proto-backplane-grpc-flight')
-    implementation project(':open-api-lang-tools')
+    api(project(':open-api-lang-tools')) {
+        because 'downstream dagger compile, see deephaven-core#1722'
+    }
     api(project(':log-factory')) {
         because 'downstream dagger compile, see deephaven-core#1722'
     }

--- a/server/src/main/java/io/deephaven/server/console/ConsoleModule.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleModule.java
@@ -5,9 +5,15 @@ package io.deephaven.server.console;
 
 import dagger.Binds;
 import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.ElementsIntoSet;
 import dagger.multibindings.IntoSet;
+import io.deephaven.lang.completion.CustomCompletion;
 import io.deephaven.server.session.TicketResolver;
 import io.grpc.BindableService;
+
+import java.util.Collections;
+import java.util.Set;
 
 @Module
 public interface ConsoleModule {
@@ -18,4 +24,10 @@ public interface ConsoleModule {
     @Binds
     @IntoSet
     TicketResolver bindConsoleTicketResolver(ScopeTicketResolver resolver);
+
+    @Provides
+    @ElementsIntoSet
+    static Set<CustomCompletion.Factory> primeCustomCompletions() {
+        return Collections.emptySet();
+    }
 }

--- a/server/src/main/java/io/deephaven/server/console/completer/JavaAutoCompleteObserver.java
+++ b/server/src/main/java/io/deephaven/server/console/completer/JavaAutoCompleteObserver.java
@@ -8,7 +8,6 @@ import io.deephaven.io.logger.Logger;
 import io.deephaven.lang.completion.ChunkerCompleter;
 import io.deephaven.lang.completion.CompletionLookups;
 import io.deephaven.lang.completion.CustomCompletion;
-import io.deephaven.lang.completion.DelegatingCustomCompletion;
 import io.deephaven.lang.parse.CompletionParser;
 import io.deephaven.lang.parse.LspTools;
 import io.deephaven.lang.parse.ParsedDocument;
@@ -18,9 +17,7 @@ import io.deephaven.proto.util.Exceptions;
 import io.deephaven.server.console.ConsoleServiceGrpcImpl;
 import io.deephaven.server.session.SessionCloseableObserver;
 import io.deephaven.server.session.SessionState;
-import io.deephaven.util.SafeCloseable;
 import io.grpc.stub.StreamObserver;
-import org.jpy.PyObject;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -177,8 +174,7 @@ public class JavaAutoCompleteObserver extends SessionCloseableObserver<AutoCompl
         final ScriptSession scriptSession = exportedConsole.get();
         final VariableProvider vars = scriptSession.getVariableProvider();
         final VersionedTextDocumentIdentifier doc = request.getTextDocument();
-        final CompletionLookups h =
-                CompletionLookups.preload(scriptSession, () -> new DelegatingCustomCompletion(customCompletionFactory));
+        final CompletionLookups h = CompletionLookups.preload(scriptSession, customCompletionFactory);
         // The only stateful part of a completer is the CompletionLookups, which are already
         // once-per-session-cached
         // so, we'll just create a new completer for each request. No need to hang onto these guys.

--- a/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
@@ -5,19 +5,15 @@ package io.deephaven.server.console.groovy;
 
 import dagger.Module;
 import dagger.Provides;
-import dagger.multibindings.ElementsIntoSet;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
 import io.deephaven.engine.util.GroovyDeephavenSession;
 import io.deephaven.engine.util.GroovyDeephavenSession.RunScripts;
 import io.deephaven.engine.util.ScriptSession;
-import io.deephaven.lang.completion.CustomCompletion;
 import io.deephaven.plugin.type.ObjectTypeLookup;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Collections;
-import java.util.Set;
 
 @Module(includes = InitScriptsModule.ServiceLoader.class)
 public class GroovyConsoleSessionModule {
@@ -36,11 +32,5 @@ public class GroovyConsoleSessionModule {
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    @Provides
-    @ElementsIntoSet
-    Set<CustomCompletion.Factory> primeCustomCompletions() {
-        return Collections.emptySet();
     }
 }

--- a/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
@@ -5,15 +5,19 @@ package io.deephaven.server.console.groovy;
 
 import dagger.Module;
 import dagger.Provides;
+import dagger.multibindings.ElementsIntoSet;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.StringKey;
 import io.deephaven.engine.util.GroovyDeephavenSession;
 import io.deephaven.engine.util.GroovyDeephavenSession.RunScripts;
 import io.deephaven.engine.util.ScriptSession;
+import io.deephaven.lang.completion.CustomCompletion;
 import io.deephaven.plugin.type.ObjectTypeLookup;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.Set;
 
 @Module(includes = InitScriptsModule.ServiceLoader.class)
 public class GroovyConsoleSessionModule {
@@ -32,5 +36,11 @@ public class GroovyConsoleSessionModule {
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Provides
+    @ElementsIntoSet
+    Set<CustomCompletion.Factory> primeCustomCompletions() {
+        return Collections.emptySet();
     }
 }


### PR DESCRIPTION
Permits downstream applications to add specific completions to Java autocomplete calls. This is an internal API at this time, and subject to change.