### PR TITLE
Custom autocomplete api follow-up

### DIFF
--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/ChunkerCompleter.java
@@ -985,7 +985,7 @@ public class ChunkerCompleter implements CompletionHandler {
                 break;
         }
         // Try to delegate to another implementation
-        lookups.getCustomCompletions().methodArgumentCompletion(node, replaceNode, request, direction, results::add);
+        lookups.getCustomCompletions().methodArgumentCompletion(this, node, replaceNode, request, direction, results);
 
         if (node.getEndIndex() < request.getOffset()) {
             // user's cursor is actually past the end of our method...

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CustomCompletion.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/CustomCompletion.java
@@ -6,6 +6,7 @@ import io.deephaven.lang.generated.ChunkerInvoke;
 import io.deephaven.lang.generated.Node;
 import io.deephaven.proto.backplane.script.grpc.CompletionItem;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -27,11 +28,12 @@ public interface CustomCompletion {
     /**
      * User's cursor is within the method arguments, provide autocomplete suggestions for cursor position.
      */
-    default void methodArgumentCompletion(ChunkerInvoke node,
+    default void methodArgumentCompletion(ChunkerCompleter completer,
+            ChunkerInvoke node,
             Node replaceNode,
             CompletionRequest request,
             ChunkerCompleter.SearchDirection direction,
-            Consumer<CompletionItem.Builder> results) {}
+            Collection<CompletionItem.Builder> results) {}
 
     /**
      * Return the type of the scoped value if known.

--- a/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/DelegatingCustomCompletion.java
+++ b/open-api/lang-tools/src/main/java/io/deephaven/lang/completion/DelegatingCustomCompletion.java
@@ -6,10 +6,10 @@ import io.deephaven.lang.generated.ChunkerInvoke;
 import io.deephaven.lang.generated.Node;
 import io.deephaven.proto.backplane.script.grpc.CompletionItem;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -23,10 +23,11 @@ public class DelegatingCustomCompletion implements CustomCompletion {
     }
 
     @Override
-    public void methodArgumentCompletion(ChunkerInvoke node, Node replaceNode, CompletionRequest request,
-            ChunkerCompleter.SearchDirection direction, Consumer<CompletionItem.Builder> results) {
+    public void methodArgumentCompletion(ChunkerCompleter completer, ChunkerInvoke node, Node replaceNode,
+            CompletionRequest request,
+            ChunkerCompleter.SearchDirection direction, Collection<CompletionItem.Builder> results) {
         for (CustomCompletion delegate : delegates) {
-            delegate.methodArgumentCompletion(node, replaceNode, request, direction, results);
+            delegate.methodArgumentCompletion(completer, node, replaceNode, request, direction, results);
         }
     }
 


### PR DESCRIPTION
Cleans up a few necessary pieces of the api to permit downstream use of CompletionBuilder and ChunkerCompleter.addMatch.