### PR TITLE
Use Jetty image for client integration tests, docs

### DIFF
--- a/Integrations/build.gradle
+++ b/Integrations/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.avast.gradle.docker-compose'
 }
 
-evaluationDependsOn ':docker-server'
+evaluationDependsOn ':docker-server-jetty'
 
 configurations {
     implementation.extendsFrom dhIntegrations
@@ -57,7 +57,7 @@ def runInDocker = { String name, String sourcePath, List<String> command, Closur
                 into 'python/configs'
             }
         }
-        parentContainers = [project(':docker-server').tasks.findByName('buildDocker-server-netty')] // deephaven/server-netty
+        parentContainers = [project(':docker-server-jetty').tasks.findByName('buildDocker-server-jetty')] // deephaven/server-jetty
 
         imageName = 'deephaven/py-integrations:local-build'
 
@@ -65,7 +65,7 @@ def runInDocker = { String name, String sourcePath, List<String> command, Closur
 
         dockerfile {
             // set up the container, env vars - things that aren't likely to change
-            from 'deephaven/server-netty:local-build'
+            from 'deephaven/server-jetty:local-build'
             runCommand '''set -eux; \\
                       pip3 install unittest-xml-reporting==3.0.4; \\
                       mkdir -p /out/report; \\

--- a/buildSrc/src/main/groovy/io/deephaven/tools/docker/DeephavenInDockerExtension.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/tools/docker/DeephavenInDockerExtension.groovy
@@ -44,6 +44,11 @@ public abstract class DeephavenInDockerExtension {
 
     abstract MapProperty<String, String> getEnvVars();
 
+    /**
+     * Makes the exposed port available to other docker tasks. Rather than hardcode a particular
+     * port, docker will select one (allowing for multiple parallel running instances), and expose
+     * it here after the "waitForPort" task is complete.
+     */
     abstract Property<Integer> getPort();
 
     @Inject
@@ -72,6 +77,8 @@ public abstract class DeephavenInDockerExtension {
             task.containerName.set containerName.get()
             task.hostConfig.network.set networkName.get()
             task.envVars.set(this.getEnvVars())
+
+            // In the jetty image, port 10000 is the http server
             task.exposePorts("tcp", [10000])
             task.hostConfig.portBindings.set(["10000"])
         }

--- a/cpp-client/build.gradle
+++ b/cpp-client/build.gradle
@@ -116,7 +116,7 @@ def testCppClient = Docker.registerDockerTask(project, 'testCppClient') {
         // Setup for test run.
         //
         environmentVariable 'DH_HOST', deephavenDocker.containerName.get()
-        environmentVariable 'DH_PORT', '8080'
+        environmentVariable 'DH_PORT', '10000'
     }
     containerDependencies.dependsOn = [deephavenDocker.healthyTask]
     containerDependencies.finalizedBy = deephavenDocker.endTask

--- a/go/build.gradle
+++ b/go/build.gradle
@@ -75,7 +75,7 @@ def testGoClient = Docker.registerDockerTask(project, 'testGoClient') {
                       ''')
         copyFile('.', '/project/')
         environmentVariable 'DH_HOST', deephavenDocker.containerName.get()
-        environmentVariable 'DH_PORT', '8080'
+        environmentVariable 'DH_PORT', '10000'
     }
     containerDependencies.dependsOn = [deephavenDocker.healthyTask]
     containerDependencies.finalizedBy = deephavenDocker.endTask

--- a/py/client/build.gradle
+++ b/py/client/build.gradle
@@ -105,7 +105,7 @@ tasks.getByName('check').dependsOn(Docker.registerDockerTask(project, 'testPyCli
                       pip3 install --upgrade pip; \\
                       pip3 install -r requirements-dev.txt'''
         environmentVariable 'DH_HOST', deephavenDocker.containerName.get()
-        environmentVariable 'DH_PORT', '8080'
+        environmentVariable 'DH_PORT', '10000'
     }
     parentContainers = [ Docker.registryTask(project, 'python') ]
     entrypoint = ['python', '-m', 'xmlrunner', 'discover', 'tests', '-v', '-o', '/out/report']

--- a/sphinx/sphinx.gradle
+++ b/sphinx/sphinx.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Generates docs for the python libraries provided in Deephaven Core'
 
-evaluationDependsOn ':docker-server'
+evaluationDependsOn ':docker-server-jetty'
 
 configurations {
     pythonWheel
@@ -29,7 +29,7 @@ def copySphinxLib = tasks.register('copySphinxLib', Sync) {
 def sphinxDockerfile = tasks.register('sphinxDockerfile', Dockerfile) {
     destFile.set layout.buildDirectory.file('sphinx-image/Dockerfile')
     // Deephaven server python API requires that the wheel be installed to build, so we share this image
-    from 'deephaven/server-netty:local-build'
+    from 'deephaven/server-jetty:local-build'
 
     copyFile "./wheel", "/wheel"
     copyFile "./lib", '${VIRTUAL_ENV}/lib/python3.10/site-packages/'
@@ -50,7 +50,7 @@ def sphinxImage = Docker.registerDockerImage(project, 'sphinx') {
     inputs.files copyPyClientWhl.get().outputs.files
     inputs.files copySphinxLib.get().outputs.files
     inputDir.set layout.buildDirectory.dir('sphinx-image')
-    inputs.files project(':docker-server').tasks.findByName('buildDocker-server-netty').outputs.files // deephaven/server-netty
+    inputs.files project(':docker-server-jetty').tasks.findByName('buildDocker-server-jetty').outputs.files // deephaven/server-jetty
     images.add('deephaven/sphinx:local-build')
 }
 
@@ -99,7 +99,7 @@ def cppClientDoxygenTask = Docker.registerDockerTask(project, 'cppClientDoxygen'
     }
     dockerfile {
         // share the common base image to keep it simple
-        from 'deephaven/server-netty:local-build'
+        from 'deephaven/server-jetty:local-build'
 
         runCommand('''set -eux; \\
                       apt-get update; \\
@@ -114,7 +114,7 @@ def cppClientDoxygenTask = Docker.registerDockerTask(project, 'cppClientDoxygen'
                       doxygen
                       ''')
     }
-    parentContainers = [project(':docker-server').tasks.findByName('buildDocker-server-netty')] // deephaven/server-netty
+    parentContainers = [project(':docker-server-jetty').tasks.findByName('buildDocker-server-jetty')] // deephaven/server-jetty
     containerOutPath = '/project/doc/doxygenoutput'
     copyOut {
         into "$buildDir/cppClientDoxygen"


### PR DESCRIPTION
Also optionally exposes port for dh-in-docker.

Fixes #2943