### PR TITLE
Update Web UI to v0.38.1

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,8 +2,8 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.38.0
-ARG GRID_VERSION=0.38.0
+ARG WEB_VERSION=0.38.1
+ARG GRID_VERSION=0.38.1
 ARG CHART_VERSION=0.38.0
 
 # Pull in the published code-studio package from npmjs and extract is


### PR DESCRIPTION
Embed-chart did not get a patch version bump because it did not change