### PR TITLE
Add HTTP compression support

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -216,6 +216,8 @@ public class JettyBackedGrpcServer implements GrpcServer {
             // The default of 32 bytes seems a bit small.
             gzipHandler.setMinGzipSize(1024);
             // The GzipHandler documentation says GET is the default, but the constructor shows both GET and POST.
+            // This should ensure our gRPC messages don't get compressed for now, but we may need to be more explicit in
+            // the future as gRPC can technically operate over GET.
             gzipHandler.setIncludedMethods(HttpMethod.GET.asString());
             // Otherwise, the other defaults seem reasonable.
             gzipHandler.setHandler(handlers);

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyConfig.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyConfig.java
@@ -27,6 +27,7 @@ public abstract class JettyConfig implements ServerConfig {
     public static final String HTTP_WEBSOCKETS = "http.websockets";
     public static final String HTTP_HTTP1 = "http.http1";
     public static final String HTTP_STREAM_TIMEOUT = "http2.stream.idleTimeoutMs";
+    public static final String HTTP_COMPRESSION = "http.compression";
 
     /**
      * Values to indicate what kind of websocket support should be offered.
@@ -40,7 +41,8 @@ public abstract class JettyConfig implements ServerConfig {
         NONE,
         /**
          * Establish one websocket per grpc stream (including unary calls). Compatible with the websocket client
-         * provided by https://github.com/improbable-eng/grpc-web/, but not recommended.
+         * provided by <a href="https://github.com/improbable-eng/grpc-web/">improbable-eng/grpc-web</a>, but not
+         * recommended.
          */
         GRPC_WEBSOCKET,
         /**
@@ -75,8 +77,10 @@ public abstract class JettyConfig implements ServerConfig {
      * {@link ServerConfig#buildFromConfig(ServerConfig.Builder, Configuration)}.
      *
      * <p>
-     * Additionally, parses the property {@value HTTP_WEBSOCKETS} into {@link Builder#websockets(WebsocketsSupport)} and
-     * {@value HTTP_HTTP1} into {@link Builder#http1(Boolean)}.
+     * Additionally, parses the property {@value HTTP_WEBSOCKETS} into {@link Builder#websockets(WebsocketsSupport)},
+     * {@value HTTP_HTTP1} into {@link Builder#http1(Boolean)}, {@value HTTP_STREAM_TIMEOUT} into
+     * {@link Builder#http2StreamIdleTimeout(long)}, and {@value HTTP_COMPRESSION} into
+     * {@link Builder#httpCompression(Boolean)}
      *
      * @param config the config
      * @return the builder
@@ -85,6 +89,7 @@ public abstract class JettyConfig implements ServerConfig {
         final Builder builder = ServerConfig.buildFromConfig(builder(), config);
         String httpWebsockets = config.getStringWithDefault(HTTP_WEBSOCKETS, null);
         String httpHttp1 = config.getStringWithDefault(HTTP_HTTP1, null);
+        String httpCompression = config.getStringWithDefault(HTTP_COMPRESSION, null);
         String h2StreamIdleTimeout = config.getStringWithDefault(HTTP_STREAM_TIMEOUT, null);
         if (httpWebsockets != null) {
             switch (httpWebsockets.toLowerCase()) {
@@ -108,6 +113,9 @@ public abstract class JettyConfig implements ServerConfig {
         }
         if (h2StreamIdleTimeout != null) {
             builder.http2StreamIdleTimeout(Long.parseLong(h2StreamIdleTimeout));
+        }
+        if (httpCompression != null) {
+            builder.httpCompression(Boolean.parseBoolean(httpCompression));
         }
         return builder;
     }
@@ -134,6 +142,12 @@ public abstract class JettyConfig implements ServerConfig {
     public abstract Boolean http1();
 
     public abstract OptionalLong http2StreamIdleTimeout();
+
+    /**
+     * Include HTTP compression.
+     */
+    @Nullable
+    public abstract Boolean httpCompression();
 
     /**
      * How long can a stream be idle in milliseconds before it should be shut down. Non-positive values disable this
@@ -177,11 +191,21 @@ public abstract class JettyConfig implements ServerConfig {
         return true;
     }
 
+    /**
+     * Returns {@link #httpCompression()} if explicitly set, otherwise returns {@code true}.
+     */
+    public final boolean httpCompressionOrDefault() {
+        final Boolean httpCompression = httpCompression();
+        return httpCompression == null || httpCompression;
+    }
+
     public interface Builder extends ServerConfig.Builder<JettyConfig, Builder> {
 
         Builder websockets(WebsocketsSupport websockets);
 
         Builder http1(Boolean http1);
+
+        Builder httpCompression(Boolean httpCompression);
 
         Builder http2StreamIdleTimeout(long timeoutInMillis);
     }


### PR DESCRIPTION
By default, enables HTTP compression. It can be explicitly disabled by setting the configuration property `http.compression` to `false`.

Partial #3827