### PR TITLE
Remove docs blog and conceptual ticket autogeneration

### DIFF
--- a/.github/workflows/create-docs-issues.js
+++ b/.github/workflows/create-docs-issues.js
@@ -1,6 +1,6 @@
 module.exports = async ({ github, context }) => {
   const ISSUE_REPO_NAME = "deephaven.io";
-  const ISSUE_TYPES = ["how-to", "conceptual", "reference", "blog"];
+  const ISSUE_TYPES = ["how-to", "conceptual", "reference"];
 
   const body =
     `_This issue was auto-generated_\n\n` +

--- a/.github/workflows/create-docs-issues.js
+++ b/.github/workflows/create-docs-issues.js
@@ -1,6 +1,6 @@
 module.exports = async ({ github, context }) => {
   const ISSUE_REPO_NAME = "deephaven.io";
-  const ISSUE_TYPES = ["how-to", "conceptual", "reference"];
+  const ISSUE_TYPES = ["how-to", "reference"];
 
   const body =
     `_This issue was auto-generated_\n\n` +


### PR DESCRIPTION
Per @margaretkennedy and the devrel team, reduce the auto generated docs tickets (when tagged `DocumentationNeeded`) to just how-to and reference