### PR TITLE
Check for overflows when calling jpy getIntValue

### DIFF
--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonValueGetter.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonValueGetter.java
@@ -49,21 +49,33 @@ class PythonValueGetter {
         if (valueIn == null) {
             return QueryConstants.NULL_INT;
         }
-        return valueIn.getIntValue();
+        long ll = valueIn.getLongValue();
+        if (ll > Integer.MAX_VALUE || ll < Integer.MIN_VALUE) {
+            throw new ArithmeticException("The PyObject value is outside Integer range.");
+        }
+        return (int) ll;
     }
 
     static short getShort(PyObject valueIn) {
         if (valueIn == null) {
-            return QueryConstants.NULL_SHORT;
+            return QueryConstants.NULL_SHORT; // NB: should there be a getShortValue() in jpy?
         }
-        return (short) valueIn.getIntValue(); // NB: should there be a getShortValue() in jpy?
+        long ll = valueIn.getLongValue();
+        if (ll > Short.MAX_VALUE || ll < Short.MIN_VALUE) {
+            throw new ArithmeticException("The PyObject value is outside Short range.");
+        }
+        return (short) ll;
     }
 
     static byte getByte(PyObject valueIn) {
         if (valueIn == null) {
             return QueryConstants.NULL_BYTE; // NB: should there be a getByteValue() in jpy?
         }
-        return (byte) valueIn.getIntValue();
+        long ll = valueIn.getLongValue();
+        if (ll > Byte.MAX_VALUE || ll < Byte.MIN_VALUE) {
+            throw new ArithmeticException("The PyObject value is outside Byte range.");
+        }
+        return (byte) ll;
     }
 
     static Boolean getBoolean(PyObject valueIn) {

--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonValueGetter.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonValueGetter.java
@@ -50,7 +50,7 @@ class PythonValueGetter {
             return QueryConstants.NULL_INT;
         }
         long ll = valueIn.getLongValue();
-        if (ll > Integer.MAX_VALUE || ll < Integer.MIN_VALUE) {
+        if ((int) ll != ll) {
             throw new ArithmeticException("The PyObject value is outside Integer range.");
         }
         return (int) ll;
@@ -61,7 +61,7 @@ class PythonValueGetter {
             return QueryConstants.NULL_SHORT; // NB: should there be a getShortValue() in jpy?
         }
         long ll = valueIn.getLongValue();
-        if (ll > Short.MAX_VALUE || ll < Short.MIN_VALUE) {
+        if ((short) ll != ll) {
             throw new ArithmeticException("The PyObject value is outside Short range.");
         }
         return (short) ll;
@@ -72,7 +72,7 @@ class PythonValueGetter {
             return QueryConstants.NULL_BYTE; // NB: should there be a getByteValue() in jpy?
         }
         long ll = valueIn.getLongValue();
-        if (ll > Byte.MAX_VALUE || ll < Byte.MIN_VALUE) {
+        if ((byte) ll != ll) {
             throw new ArithmeticException("The PyObject value is outside Byte range.");
         }
         return (byte) ll;


### PR DESCRIPTION
Fixes #3716

related to https://github.com/jpy-consortium/jpy/issues/98
linked to: #3598 

Note:
PyObject.getIntValue and family are also used in the generated formula code to cast a PyObject to a specified 'integer' type. Since casting in Java doesn't check for overflow, these use cases are not included as part of the change. 