### PR TITLE
Adds overrideAuthority, ClientChannelFactory, and channelBuilder

### DIFF
--- a/java-client/example-utilities/src/main/java/io/deephaven/client/examples/ConnectOptions.java
+++ b/java-client/example-utilities/src/main/java/io/deephaven/client/examples/ConnectOptions.java
@@ -41,6 +41,9 @@ public class ConnectOptions {
     @Option(names = {"-u", "--user-agent"}, description = "The user-agent.")
     String userAgent;
 
+    @Option(names = {"--override-authority"}, description = "The override authority.")
+    String overrideAuthority;
+
     @Option(names = {"--max-inbound-message-size"}, description = "The maximum inbound message size, " +
             "defaults to 100MB")
     Integer maxInboundMessageSize;
@@ -55,6 +58,9 @@ public class ConnectOptions {
         final Builder builder = ClientConfig.builder().target(target);
         if (userAgent != null) {
             builder.userAgent(userAgent);
+        }
+        if (overrideAuthority != null) {
+            builder.overrideAuthority(overrideAuthority);
         }
         if (maxInboundMessageSize != null) {
             builder.maxInboundMessageSize(maxInboundMessageSize);

--- a/java-client/session-dagger/src/main/java/io/deephaven/client/ClientDefaultsModule.java
+++ b/java-client/session-dagger/src/main/java/io/deephaven/client/ClientDefaultsModule.java
@@ -1,0 +1,21 @@
+package io.deephaven.client;
+
+import dagger.Module;
+import dagger.Provides;
+import io.deephaven.client.impl.ClientChannelFactory;
+
+/**
+ * Provides {@link ClientChannelFactory}.
+ */
+@Module
+public interface ClientDefaultsModule {
+
+
+    /**
+     * Equivalent to {@link ClientChannelFactory#defaultInstance()}.
+     */
+    @Provides
+    static ClientChannelFactory providesClientChannelFactory() {
+        return ClientChannelFactory.defaultInstance();
+    }
+}

--- a/java-client/session/src/main/java/io/deephaven/client/impl/ClientChannelFactory.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/ClientChannelFactory.java
@@ -1,0 +1,11 @@
+package io.deephaven.client.impl;
+
+import io.grpc.ManagedChannel;
+
+public interface ClientChannelFactory {
+    static ClientChannelFactory defaultInstance() {
+        return ChannelHelper::channel;
+    }
+
+    ManagedChannel create(ClientConfig clientConfig);
+}

--- a/java-client/session/src/main/java/io/deephaven/client/impl/ClientConfig.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/ClientConfig.java
@@ -41,6 +41,11 @@ public abstract class ClientConfig {
     public abstract Optional<String> userAgent();
 
     /**
+     * The overridden authority.
+     */
+    public abstract Optional<String> overrideAuthority();
+
+    /**
      * The extra headers.
      */
     public abstract Map<String, String> extraHeaders();
@@ -60,6 +65,8 @@ public abstract class ClientConfig {
         Builder ssl(SSLConfig ssl);
 
         Builder userAgent(String userAgent);
+
+        Builder overrideAuthority(String overrideAuthority);
 
         Builder putExtraHeaders(String key, String value);
 

--- a/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
+++ b/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
@@ -4,6 +4,7 @@
 package io.deephaven.python.server;
 
 import dagger.Component;
+import io.deephaven.client.ClientDefaultsModule;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.integrations.python.PyLogOutputStream;
@@ -54,6 +55,7 @@ public class EmbeddedServer {
             GroovyConsoleSessionModule.class,
             SessionToExecutionStateModule.class,
             CommunityAuthorizationModule.class,
+            ClientDefaultsModule.class,
     })
     public interface PythonServerComponent extends JettyServerComponent {
         @Component.Builder

--- a/server/src/main/java/io/deephaven/server/runner/CommunityDefaultsModule.java
+++ b/server/src/main/java/io/deephaven/server/runner/CommunityDefaultsModule.java
@@ -4,6 +4,7 @@
 package io.deephaven.server.runner;
 
 import dagger.Module;
+import io.deephaven.client.ClientDefaultsModule;
 import io.deephaven.server.console.SessionToExecutionStateModule;
 import io.deephaven.server.console.groovy.GroovyConsoleSessionModule;
 import io.deephaven.server.console.python.PythonConsoleSessionModule;
@@ -32,6 +33,7 @@ import io.deephaven.server.plugin.python.PythonPluginsRegistration;
  * @see PythonConsoleSessionModule
  * @see GroovyConsoleSessionModule
  * @see SessionToExecutionStateModule
+ * @see ClientDefaultsModule
  */
 @Module(includes = {
         DeephavenApiServerModule.class,
@@ -43,6 +45,7 @@ import io.deephaven.server.plugin.python.PythonPluginsRegistration;
         PythonConsoleSessionModule.class,
         GroovyConsoleSessionModule.class,
         SessionToExecutionStateModule.class,
+        ClientDefaultsModule.class,
 })
 public interface CommunityDefaultsModule {
 }

--- a/server/src/main/java/io/deephaven/server/uri/BarrageTableResolver.java
+++ b/server/src/main/java/io/deephaven/server/uri/BarrageTableResolver.java
@@ -68,23 +68,24 @@ public final class BarrageTableResolver implements UriResolver {
     }
 
     private final BarrageSessionFactoryBuilder builder;
-
     private final ScheduledExecutorService executor;
-
     private final BufferAllocator allocator;
-
     private final SSLConfig sslConfig;
-
+    private final ClientChannelFactory clientChannelFactory;
     private final Map<DeephavenTarget, BarrageSession> sessions;
 
     @Inject
     public BarrageTableResolver(
-            BarrageSessionFactoryBuilder builder, ScheduledExecutorService executor, BufferAllocator allocator,
-            @Named("client.sslConfig") SSLConfig sslConfig) {
+            BarrageSessionFactoryBuilder builder,
+            ScheduledExecutorService executor,
+            BufferAllocator allocator,
+            @Named("client.sslConfig") SSLConfig sslConfig,
+            ClientChannelFactory clientChannelFactory) {
         this.builder = Objects.requireNonNull(builder);
         this.executor = Objects.requireNonNull(executor);
         this.allocator = Objects.requireNonNull(allocator);
         this.sslConfig = Objects.requireNonNull(sslConfig);
+        this.clientChannelFactory = Objects.requireNonNull(clientChannelFactory);
         this.sessions = new ConcurrentHashMap<>();
     }
 
@@ -304,7 +305,7 @@ public final class BarrageTableResolver implements UriResolver {
     }
 
     private BarrageSession newSession(ClientConfig config) {
-        return newSession(ChannelHelper.channel(config));
+        return newSession(clientChannelFactory.create(config));
     }
 
     private BarrageSession newSession(ManagedChannel channel) {

--- a/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
+++ b/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
@@ -5,6 +5,7 @@ package io.deephaven.server.runner;
 
 import dagger.BindsInstance;
 import dagger.Component;
+import io.deephaven.client.ClientDefaultsModule;
 import io.deephaven.engine.liveness.LivenessScope;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.updategraph.UpdateGraphProcessor;
@@ -43,6 +44,7 @@ public abstract class DeephavenApiServerTestBase {
             NoConsoleSessionModule.class,
             ServerBuilderInProcessModule.class,
             ExecutionContextUnitTestModule.class,
+            ClientDefaultsModule.class,
     })
     public interface TestComponent {
 


### PR DESCRIPTION
`ClientConfig#overrideAuthority` adds an explicit configuration option to override the authority.

`ClientChannelFactory` gives the callers a lower level hook, in case they need it in the future to cover other gaps in `ManagedChannel` configure-ability.

`ChannelHelper#channelBuilder` allows lower level hooks to still take advantage of the ChannelHelper#channel defaults if they so wish.

Fixes #3834