### PR TITLE
Use gradle property to control signing.required

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: publish-local
-          arguments: server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build publishToMavenLocal -x signMavenJavaPublication -x signMyPlatformPublication
+          arguments: server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build publishToMavenLocal
           gradle-version: wrapper
 
       - name: Publish
@@ -61,6 +61,7 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CI_AT_DEEPHAVEN_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingRequired: true
 
       - name: Upload Applications
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}

--- a/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
@@ -10,7 +10,6 @@ import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.plugins.BasePluginConvention
 import org.gradle.api.publish.Publication
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.internal.DefaultPublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.plugins.signing.SigningExtension
@@ -122,13 +121,14 @@ class PublishingTools {
     }
 
     static void setupSigning(Project project, Publication publication) {
-        SigningExtension publishingExtension = project.extensions.getByType(SigningExtension)
-        publishingExtension.sign(publication)
+        SigningExtension signingExtension = project.extensions.getByType(SigningExtension)
+        signingExtension.required = "true" == project.findProperty('signingRequired')
+        signingExtension.sign(publication)
         String signingKey = project.findProperty('signingKey')
         String signingPassword = project.findProperty('signingPassword')
         if (signingKey != null && signingPassword != null) {
             // In CI, it's harder to pass a file; so if specified, we use the in-memory version.
-            publishingExtension.useInMemoryPgpKeys(signingKey, signingPassword)
+            signingExtension.useInMemoryPgpKeys(signingKey, signingPassword)
         }
     }
 


### PR DESCRIPTION
Adds gradle property `signingRequired`. This allows developers to use `./gradlew publishToMavenLocal` instead of `./gradlew publishToMavenLocal -x signMavenJavaPublication -x signMyPlatformPublication`. 

This is also a pre-requisite for gradle 8, see https://github.com/gradle/gradle/issues/24456. Extracted from #3715.