### PR TITLE
Add `UpdateBy` helper classes to groovy default imports.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -526,6 +526,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
                 "import static io.deephaven.engine.table.impl.lang.QueryLanguageFunctionUtils.*;\n" +
                 "import static io.deephaven.api.agg.Aggregation.*;\n" +
                 "import static io.deephaven.api.updateby.UpdateByOperation.*;\n" +
+                "import io.deephaven.api.updateby.*;\n" +
 
                 String.join("\n", scriptImports) + "\n";
         return new Pair<>(commandPrefix, commandPrefix + command

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -526,7 +526,10 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
                 "import static io.deephaven.engine.table.impl.lang.QueryLanguageFunctionUtils.*;\n" +
                 "import static io.deephaven.api.agg.Aggregation.*;\n" +
                 "import static io.deephaven.api.updateby.UpdateByOperation.*;\n" +
-                "import io.deephaven.api.updateby.*;\n" +
+                "import io.deephaven.api.updateby.UpdateByControl;\n" +
+                "import io.deephaven.api.updateby.OperationControl;\n" +
+                "import io.deephaven.api.updateby.DeltaControl;\n" +
+                "import io.deephaven.api.updateby.BadDataBehavior;\n" +
 
                 String.join("\n", scriptImports) + "\n";
         return new Pair<>(commandPrefix, commandPrefix + command


### PR DESCRIPTION
Closes #3795 

The documentation needed is updating existing demos / examples to remove previously required imports

Manually tested as follows:
```
baseTime = convertDateTime("2023-01-01T00:00:00 NY")
source = emptyTable(10).update("Timestamp = baseTime + i *  SECOND", "Letter = (i % 2 == 0) ? `A` : `B`", "X = randomInt(0,25)")

// use all the imported classes: UpdateByControl, OperationControl, DeltaControl, BadDataBehavior
ub_control = UpdateByControl.builder().useRedirection(true).build()
op_control = OperationControl.builder().onNullValue(BadDataBehavior.RESET).build()

result = source.updateBy(ub_control, [
    Ema(op_control, 5, "Ema_X = X"),
    Delta(DeltaControl.ZERO_DOMINATES, "Delta_X = X")
])
```

Tested locally and ran nightly: [5072832859](https://github.com/lbooker42/deephaven-core/actions/runs/5072832859)