### PR TITLE
Barrage: Fix BMP Failing OutOfBand BarrageBlinkTable Test by Respecting pre/post Snapshot Update Boundary

### DIFF
--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -1409,6 +1409,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
             for (final Delta delta : pendingDeltas) {
                 delta.close();
             }
+            blinkTableUpdateSize = 0;
             pendingDeltas.clear();
         }
 


### PR DESCRIPTION
I had forgotten about these great tests. It caught one issue due to how an update may be split by the creation of an empty snapshot.