### PR TITLE
Correctly pass errors from executed commands to gRPC clients

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
@@ -152,12 +152,6 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
             }
         }
 
-        // re-throw any captured exception now that our listener knows what query scope state had changed prior
-        // to the script session execution error
-        if (evaluateErr != null) {
-            throw evaluateErr;
-        }
-
         return diff;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -164,7 +164,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
         final String scriptName = script.substring(0, script.indexOf("."));
 
         log.info("Executing script: " + script);
-        evaluateScript(FileUtils.readTextFile(file), scriptName);
+        evaluateScript(FileUtils.readTextFile(file), scriptName).throwIfError();
     }
 
     private final Set<String> executedScripts = new HashSet<>();

--- a/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
@@ -74,6 +74,12 @@ public interface ScriptSession extends ReleasableLivenessManager, LivenessNode {
         public boolean isEmpty() {
             return error == null && created.isEmpty() && updated.isEmpty() && removed.isEmpty();
         }
+
+        public void throwIfError() {
+            if (error != null) {
+                throw error;
+            }
+        }
     }
 
     interface Listener {

--- a/engine/table/src/main/java/io/deephaven/engine/util/SourceClosure.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/SourceClosure.java
@@ -71,7 +71,7 @@ public class SourceClosure extends Closure<Object> {
             }
         }
 
-        groovyDeephavenSession.evaluateScript(scriptText, scriptName);
+        groovyDeephavenSession.evaluateScript(scriptText, scriptName).throwIfError();
         return null;
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/FuzzerTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/FuzzerTest.java
@@ -99,7 +99,7 @@ public class FuzzerTest {
 
         System.out.println(groovyString);
 
-        session.evaluateScript(groovyString);
+        session.evaluateScript(groovyString).throwIfError();
 
         final Map<String, Object> hardReferences = new ConcurrentHashMap<>();
 
@@ -142,9 +142,9 @@ public class FuzzerTest {
 
             System.out.println("Running test=======================\n TableSeed: " + fuzzDescriptor.tableSeed
                     + " QuerySeed: " + fuzzDescriptor.tableSeed);
-            System.out.println(query.toString());
+            System.out.println(query);
 
-            session.evaluateScript(query.toString());
+            session.evaluateScript(query.toString()).throwIfError();
 
             annotateBinding(session);
             final Map<String, Object> hardReferences = new ConcurrentHashMap<>();
@@ -220,7 +220,7 @@ public class FuzzerTest {
 
         System.out.println(tableQuery);
 
-        session.evaluateScript(tableQuery);
+        session.evaluateScript(tableQuery).throwIfError();
 
         for (int runNum = 0; runNum <= lastRun; ++runNum) {
             final long currentSeed = sourceRandom.nextLong();
@@ -231,8 +231,8 @@ public class FuzzerTest {
                 final StringBuilder sb = new StringBuilder("//========================================\n");
                 sb.append("// Seed: ").append(currentSeed).append("L\n\n");
                 sb.append(query).append("\n");
-                System.out.println(sb.toString());
-                session.evaluateScript(query);
+                System.out.println(sb);
+                session.evaluateScript(query).throwIfError();
             }
 
         }

--- a/engine/table/src/test/java/io/deephaven/engine/util/scripts/TestGroovyDeephavenSession.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/scripts/TestGroovyDeephavenSession.java
@@ -54,7 +54,7 @@ public class TestGroovyDeephavenSession {
 
     @Test
     public void testNullCast() {
-        session.evaluateScript("x = null; y = emptyTable(0).update(\"X = (java.util.List)x\")");
+        session.evaluateScript("x = null; y = emptyTable(0).update(\"X = (java.util.List)x\")").throwIfError();
         final Table y = fetchTable("y");
         final TableDefinition definition = y.getDefinition();
         final Class<?> colClass = definition.getColumn("X").getDataType();
@@ -70,7 +70,7 @@ public class TestGroovyDeephavenSession {
                 "    }\n" +
                 "}\n" +
                 "obj = new MyObj(1)\n" +
-                "result = emptyTable(1).select(\"A = obj.a\")");
+                "result = emptyTable(1).select(\"A = obj.a\")").throwIfError();
         Assert.assertNotNull(fetch("obj", Object.class));
         final Table result = fetchTable("result");
         Assert.assertFalse(result.isFailed());
@@ -82,6 +82,7 @@ public class TestGroovyDeephavenSession {
                 "z=emptyTable(10)\n" +
                 "y=emptyTable(10)\n" +
                 "u=emptyTable(10)");
+        changes.throwIfError();
         final String[] names = new String[] {"x", "z", "y", "u"};
         final MutableInt offset = new MutableInt();
         changes.created.forEach((name, type) -> {
@@ -97,7 +98,7 @@ public class TestGroovyDeephavenSession {
         if (this.getClass().getClassLoader().getDefinedPackage(packageString) != null) {
             Assert.fail("Package '" + packageString + "' is already loaded, test with a more obscure package.");
         }
-        session.evaluateScript("import " + packageString + ".*");
+        session.evaluateScript("import " + packageString + ".*").throwIfError();
     }
 }
 

--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationFactory.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationFactory.java
@@ -95,7 +95,7 @@ public class ApplicationFactory implements ApplicationConfig.Visitor {
 
     private void evaluateScripts(List<Path> files) {
         for (Path file : files) {
-            scriptSession.evaluateScript(absolutePath(file));
+            scriptSession.evaluateScript(absolutePath(file)).throwIfError();
         }
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsCommandResult.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsCommandResult.java
@@ -10,8 +10,8 @@ import jsinterop.annotations.JsProperty;
 @TsInterface
 @TsName(namespace = "dh.ide", name = "CommandResult")
 public class JsCommandResult {
-    private JsVariableChanges changes;
-    private String error;
+    private final JsVariableChanges changes;
+    private final String error;
 
     public JsCommandResult(JsVariableChanges changes, String error) {
         this.changes = changes;
@@ -26,5 +26,13 @@ public class JsCommandResult {
     @JsProperty
     public String getError() {
         return error;
+    }
+
+    @Override
+    public String toString() {
+        if (error != null && !error.isEmpty()) {
+            return error;
+        }
+        return super.toString();
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
@@ -171,10 +171,10 @@ public class IdeSession extends HasEventHandling {
         });
         runCodePromise.then(response -> {
             JsVariableChanges changes = JsVariableChanges.from(response.getChanges());
-            if (response.getErrorMessage().isEmpty()) {
-                promise.succeed(new JsCommandResult(changes, response.getErrorMessage()));
+            if (response.getErrorMessage() == null || response.getErrorMessage().isEmpty()) {
+                promise.succeed(new JsCommandResult(changes, null));
             } else {
-                promise.fail(new JsCommandResult(changes, response.getErrorMessage()));
+                promise.succeed(new JsCommandResult(changes, response.getErrorMessage()));
             }
             return null;
         }, err -> {

--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
@@ -170,11 +170,11 @@ public class IdeSession extends HasEventHandling {
             connection.consoleServiceClient().executeCommand(request, connection.metadata(), c::apply);
         });
         runCodePromise.then(response -> {
-            if (response.hasChanges()) {
-                JsVariableChanges changes = JsVariableChanges.from(response.getChanges());
+            JsVariableChanges changes = JsVariableChanges.from(response.getChanges());
+            if (response.getErrorMessage().isEmpty()) {
                 promise.succeed(new JsCommandResult(changes, response.getErrorMessage()));
             } else {
-
+                promise.fail(new JsCommandResult(changes, response.getErrorMessage()));
             }
             return null;
         }, err -> {

--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
@@ -170,8 +170,12 @@ public class IdeSession extends HasEventHandling {
             connection.consoleServiceClient().executeCommand(request, connection.metadata(), c::apply);
         });
         runCodePromise.then(response -> {
-            JsVariableChanges changes = JsVariableChanges.from(response.getChanges());
-            promise.succeed(new JsCommandResult(changes, response.getErrorMessage()));
+            if (response.hasChanges()) {
+                JsVariableChanges changes = JsVariableChanges.from(response.getChanges());
+                promise.succeed(new JsCommandResult(changes, response.getErrorMessage()));
+            } else {
+
+            }
             return null;
         }, err -> {
             promise.fail(err);

--- a/web/client-api/src/main/java/io/deephaven/web/public/console.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/console.html
@@ -63,6 +63,8 @@
                 commandField.removeAttribute('disabled');
                 if (result.error == null) {
                     commandField.value = '';
+                } else {
+                    document.getElementById('logs').append(result.error, document.createElement('br'))
                 }
             }, err => {
                 commandField.removeAttribute('disabled');


### PR DESCRIPTION
Changes script session to not throw when the invoked command has an
error, but instead returns a Changes instance which includes the error
object.

Also adjusts the JS IdeSession.runCode method to fail with a changes object, but the toString() method will continue to provide the error message.

Fixes #3876