### PR TITLE
Fix RowRedirectionLockFreeTest: Prevent Succeeding If Thread Fails

### DIFF
--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/RowRedirectionLockFreeTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/RowRedirectionLockFreeTest.java
@@ -47,7 +47,7 @@ public class RowRedirectionLockFreeTest extends RefreshingTableTestCase {
         for (int ii = 0; ii < threads.length; ++ii) {
             threads[ii].join();
             if (!participants[ii].cleanExit) {
-               fail("Thread " + participants[ii].name + " unexpectedly exited.");
+                fail("Thread " + participants[ii].name + " unexpectedly exited.");
             }
         }
         boolean failed = false;


### PR DESCRIPTION
This fixes one issue @devinrsmith pointed out in slack about the nightly failures.

Here is a nightly with this fix: https://github.com/nbauernfeind/deephaven-core/actions/runs/5178849528