### PR TITLE
Improve CI uploaded artifacts

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -51,19 +51,14 @@ jobs:
           name: check-ci-results
           path: |
             **/build/test-results/**
-            !**/build/test-results/**/binary/**
-
-      - name: Upload Test Reports
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: check-ci-reports
-          path: '**/build/reports/tests/**'
+            **/build/reports/tests/**
 
       - name: Upload JVM Error Logs
         uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: check-ci-jvm-err
-          path: '**/*_pid*.log'
+          path: |
+            **/*_pid*.log
+            **/core.*
           if-no-files-found: ignore

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -68,7 +68,6 @@ jobs:
           path: |
             **/build/test-results/**
             **/build/reports/tests/**
-            !**/build/test-results/**/binary/**
 
       - name: Upload JVM Error Logs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The binary logs may provide useful debugging information when CI appears to fail for no other apparent reason.

* Upload binary test-results as artifact for check-ci and nightly-check-ci
* Combines test-results and reports for check-ci (matches nightly-check-ci behavior)
* Adds core as artifact for check-ci-jvm-err (matches nightly-check-ci behavior)