### PR TITLE
Several JS API totals table fixes

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTotalsTableConfig.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTotalsTableConfig.java
@@ -246,7 +246,7 @@ public class JsTotalsTableConfig {
                     agg.setCount(count);
                     aggColumns.forEach((p0, p1, p2) -> {
                         String colName = p0.split("=")[0].trim();
-                        customColumns.push(colName + "__Count = Count");
+                        customColumns.push(colName + " = Count");
                         return null;
                     });
                     dropColumns.push("Count");

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/enums/JsAggregationOperation.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/enums/JsAggregationOperation.java
@@ -38,6 +38,7 @@ public class JsAggregationOperation {
         switch (aggregationType) {
             case COUNT:
             case COUNT_DISTINCT:
+            case DISTINCT:
             case FIRST:
             case LAST:
             case UNIQUE: {

--- a/web/client-api/src/main/java/io/deephaven/web/public/totals_tables.html
+++ b/web/client-api/src/main/java/io/deephaven/web/public/totals_tables.html
@@ -56,11 +56,11 @@
           ide = await connection.startSession("python");
           await ide.runCode(`
 from deephaven import time_table
-remoteTable = time_table("00:00:01").update_view(["I=i", "J=I*I", "K=I%100"]).last_by(by = ["K"])
+remoteTable = time_table("PT00:00:01").update_view(["I=i", "J=I*I", "K=I%100"]).last_by(by = ["K"])
 `)
       } else if (types.indexOf("groovy") !== -1) {
           ide = await connection.startSession("groovy");
-          await ide.runCode('remoteTable = timeTable("00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")')
+          await ide.runCode('remoteTable = timeTable("PT00:00:01").updateView("I=i", "J=I*I", "K=I%100").lastBy("K")')
       }
 
       openTable(await ide.getTable('remoteTable'));


### PR DESCRIPTION
Updates totals table samples to work in DHC.
Permits `Distinct` aggregation on any column type instead of none.
Correctly names `Count` columns to match DHE's JS API.
Correctly drops unused columns like `Count` before returning table to the UI.

Fixes #3921 