### PR TITLE
Minimal support for TLS connection and extra headers in python and C++ clients.

### DIFF
--- a/cpp-client/deephaven/client/CMakeLists.txt
+++ b/cpp-client/deephaven/client/CMakeLists.txt
@@ -54,12 +54,14 @@ set(ALL_FILES
 
     src/columns.cc
     src/expressions.cc
+    src/client_options.cc
     src/client.cc
     src/flight.cc
 
     include/public/deephaven/client/columns.h
     include/public/deephaven/client/expressions.h
     include/public/deephaven/client/client.h
+    include/public/deephaven/client/client_options.h
     include/public/deephaven/client/flight.h
     include/public/deephaven/client/utility/arrow_util.h
 

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -101,7 +101,8 @@ public:
       const std::string &target,
       const std::string &authorizationValue,
       bool use_tls = false,
-      const std::string &pem = "");
+      const std::string &pem = "",
+      const std::string &target_name_override = "");
   Server(const Server &other) = delete;
   Server &operator=(const Server &other) = delete;
   Server(Private,

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -363,9 +363,6 @@ public:
     }
   }
 
-  std::pair<std::string, std::string> getAuthHeader() const;
-  const ClientOptions::extra_headers_t &getExtraHeaders() const;
-
   // TODO: make this private
   void setExpirationInterval(std::chrono::milliseconds interval);
 

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -97,7 +97,11 @@ class Server : public std::enable_shared_from_this<Server> {
   typedef SFCallback<ExportedTableCreationResponse> EtcCallback;
 
 public:
-  static std::shared_ptr<Server> createFromTarget(const std::string &target, const std::string &authorizationValue, const std::string pem = "");
+  static std::shared_ptr<Server> createFromTarget(
+      const std::string &target,
+      const std::string &authorizationValue,
+      bool use_ssl = false,
+      const std::string &pem = "");
   Server(const Server &other) = delete;
   Server &operator=(const Server &other) = delete;
   Server(Private,

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -67,6 +67,7 @@ public:
   Response response_;
 };
 
+// Options for the creation of the underlying grpc channel.
 class ClientOptions {
 public:
   typedef std::vector<std::pair<std::string, int>> int_options_t;
@@ -81,16 +82,22 @@ public:
     return *this;
   }
 
-  ClientOptions &setPem(const std::string &pem) {
+  ClientOptions &setPem(const std::string &pem) {  // root certificate to use
     pem_ = pem;
     return *this;
   }
 
+  // See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for
+  // a list of available options.
   ClientOptions &setIntOption(const std::string &opt, const int val) {
     intOptions_.emplace_back(opt, val);
     return *this;
   }
 
+  // See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for
+  // a list of available options.
+  // Example:
+  //   copts.setStringOption("grpc.target_name_override", "idonthaveadnsforthishost");
   ClientOptions &setStringOption(const std::string &opt, const std::string &val) {
     stringOptions_.emplace_back(opt, val);
     return *this;

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <arrow/flight/client.h>
 
+#include "deephaven/client/client_options.h"
 #include "deephaven/client/utility/executor.h"
 #include "deephaven/dhcore/utility/callbacks.h"
 #include "deephaven/proto/ticket.pb.h"
@@ -67,133 +68,6 @@ public:
   Response response_;
 };
 
-// Options for the creation of the underlying grpc channel.
-class ClientOptions {
-public:
-  typedef std::vector<std::pair<std::string, int>> int_options_t;
-  typedef std::vector<std::pair<std::string, std::string>> string_options_t;
-  typedef std::vector<std::pair<std::string, std::string>> extra_headers_t;
-
-  ~ClientOptions();
-
-  /**
-   * Get ClientOptions object initialized with defaults.
-   *
-   * @return A ClientOptions object initialized with defaults.
-   */
-  static ClientOptions defaults() {
-    return ClientOptions();
-  }
-
-  /**
-   * Configure whether to set server connections as TLS
-   *
-   * @param useTls true if server connections should be TLS/SSL, false for insecure.
-   * @return *this, to be used for chaining
-   */
-  ClientOptions &setUseTls(const bool useTls) {
-    useTls_ = useTls;
-    return *this;
-  }
-
-  /**
-   * Sets a PEM-encoded certificate root for server connections.  The empty string
-   * means use system defaults.
-   *
-   * @param pem a PEM encoded certificate chain.
-   * @return *this, to be used for chaining
-   */
-  ClientOptions &setPem(const std::string pem) {  // root certificate to use
-    pem_ = std::move(pem);
-    return *this;
-  }
-
-  /**
-   * Addss an int-valued option.
-   * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
-   *
-   * @example copt.setIntOption("grpc.min_reconnect_backoff_ms", 2000)
-   * @param opt The option key.
-   * @param val The option valiue.
-   * @return *this, to be used for chaining
-   */
-  ClientOptions &addIntOption(const std::string opt, const int val) {
-    intOptions_.emplace_back(std::move(opt), val);
-    return *this;
-  }
-
-  /**
-   * Adds a string-valued option.
-   * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
-   *
-   * @example copt.setStringOption("grpc.target_name_override", "idonthaveadnsforthishost")
-   * @param opt The option key.
-   * @param val The option valiue.
-   * @return *this, to be used for chaining
-   */
-  ClientOptions &addStringOption(const std::string opt, const std::string val) {
-    stringOptions_.emplace_back(std::move(opt), std::move(val));
-    return *this;
-  }
-
-  /**
-   * Adds an extra header with a constant name and value to be sent with every outgoing request.
-   *
-   * @param header_name The header name
-   * @param header_value The header value
-   * @return *this, to be used for chaining
-   */
-  ClientOptions &addExtraHeader(const std::string &header_name, const std::string &header_value) {
-    extraHeaders_.emplace_back(header_name, header_value);
-    return *this;
-  }
-
-  /**
-   * Returns true if server connections should be configured for TLS/SSL.
-   *
-   * @return true if this connection should be TLS/SSL, false for insecure.
-   */
-  bool useTls() const { return useTls_; }
-
-  /**
-   * The PEM-encoded certificate root for server connections, or the empty string
-   * if using system defaults.
-   *
-   * @return A PEM-encoded certificate chain
-   */
-  const std::string &pem() const { return pem_; }
-
-  /**
-   * Integer-valued channel options set for server connections.
-   *
-   * @return A vector of pairs of string option name and integer option value.
-   */
-  const int_options_t &intOptions() const { return intOptions_; }
-
-  /**
-   * String-valued channel options set for server connections.
-   *
-   * @return A vector of pairs of string option name and string option value.
-   */
-  const string_options_t &stringOptions() const { return stringOptions_; }
-
-  /**
-   * Extra headers that should be sent with each outgoing server request.
-   *
-   * @return A vector of pairs of string header name and string header value.
-   */
-  const extra_headers_t &extraHeaders() const { return extraHeaders_; }
-
-private:
-  ClientOptions();
-
-  bool useTls_ = false;
-  std::string pem_;
-  int_options_t intOptions_;
-  string_options_t stringOptions_;
-  extra_headers_t extraHeaders_;
-};
-
 class Server : public std::enable_shared_from_this<Server> {
   struct Private {
   };
@@ -226,11 +100,7 @@ class Server : public std::enable_shared_from_this<Server> {
 public:
   static std::shared_ptr<Server> createFromTarget(
       const std::string &target,
-      const std::string &authorizationValue);
-  static std::shared_ptr<Server> createFromTarget(
-      const std::string &target,
-      const std::string &authorizationValue,
-      const ClientOptions &client_options);
+      const deephaven::client::ClientOptions &client_options);
   Server(const Server &other) = delete;
   Server &operator=(const Server &other) = delete;
   Server(Private,
@@ -240,7 +110,7 @@ public:
       std::unique_ptr<TableService::Stub> tableStub,
       std::unique_ptr<ConfigService::Stub> configStub,
       std::unique_ptr<arrow::flight::FlightClient> flightClient,
-      const ClientOptions::extra_headers_t &extraHeaders,
+      const deephaven::client::ClientOptions::extra_headers_t &extraHeaders,
       std::string sessionToken,
       std::chrono::milliseconds expirationInterval,
       std::chrono::system_clock::time_point nextHandshakeTime);
@@ -389,7 +259,7 @@ private:
   std::unique_ptr<TableService::Stub> tableStub_;
   std::unique_ptr<ConfigService::Stub> configStub_;
   std::unique_ptr<arrow::flight::FlightClient> flightClient_;
-  const ClientOptions::extra_headers_t extraHeaders_;
+  const deephaven::client::ClientOptions::extra_headers_t extraHeaders_;
   grpc::CompletionQueue completionQueue_;
 
   std::atomic<int32_t> nextFreeTicketId_;

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -74,47 +74,112 @@ public:
   typedef std::vector<std::pair<std::string, std::string>> string_options_t;
   typedef std::vector<std::pair<std::string, std::string>> extra_headers_t;
 
+  /**
+   * Get ClientOptions object initialized with defaults.
+   *
+   * @return A ClientOptions object initialized with defaults.
+   */
   static ClientOptions defaults() {
     return ClientOptions();
   }
 
+  /**
+   * Configure whether to set server connections as TLS
+   *
+   * @param useTls true if server connections should be TLS/SSL, false for insecure.
+   * @return *this, to be used for chaining
+   */
   ClientOptions &setUseTls(const bool useTls) {
     useTls_ = useTls;
     return *this;
   }
 
+  /**
+   * Sets a PEM-encoded certificate root for server connections.  The empty string
+   * means use system defaults.
+   *
+   * @param pem a PEM encoded certificate chain.
+   * @return *this, to be used for chaining
+   */
   ClientOptions &setPem(const std::string pem) {  // root certificate to use
     pem_ = std::move(pem);
     return *this;
   }
 
-  // See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for
-  // a list of available options.
-  // Example:
-  //   copts.setStringOption("grpc.min_reconnect_backoff_ms", 2000)
-  ClientOptions &addIntOption(const std::string &opt, const int val) {
-    intOptions_.emplace_back(opt, val);
+  /**
+   * Addss an int-valued option.
+   * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
+   *
+   * @example copt.setIntOption("grpc.min_reconnect_backoff_ms", 2000)
+   * @param opt The option key.
+   * @param val The option valiue.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &addIntOption(const std::string opt, const int val) {
+    intOptions_.emplace_back(std::move(opt), val);
     return *this;
   }
 
-  // See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for
-  // a list of available options.
-  // Example:
-  //   copts.setStringOption("grpc.target_name_override", "idonthaveadnsforthishost");
-  ClientOptions &addStringOption(const std::string &opt, const std::string &val) {
-    stringOptions_.emplace_back(opt, val);
+  /**
+   * Adds a string-valued option.
+   * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
+   *
+   * @example copt.setStringOption("grpc.target_name_override", "idonthaveadnsforthishost")
+   * @param opt The option key.
+   * @param val The option valiue.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &addStringOption(const std::string opt, const std::string val) {
+    stringOptions_.emplace_back(std::move(opt), std::move(val));
     return *this;
   }
 
+  /**
+   * Adds an extra header with a constant name and value to be sent with every outgoing request.
+   *
+   * @param header_name The header name
+   * @param header_value The header value
+   * @return *this, to be used for chaining
+   */
   ClientOptions &addExtraHeader(const std::string &header_name, const std::string &header_value) {
     extraHeaders_.emplace_back(header_name, header_value);
     return *this;
   }
 
+  /**
+   * Returns true if server connections should be configured for TLS/SSL.
+   *
+   * @return true if this connection should be TLS/SSL, false for insecure.
+   */
   bool useTls() const { return useTls_; }
+
+  /**
+   * The PEM-encoded certificate root for server connections, or the empty string
+   * if using system defaults.
+   *
+   * @return A PEM-encoded certificate chain
+   */
   const std::string &pem() const { return pem_; }
+
+  /**
+   * Integer-valued channel options set for server connections.
+   *
+   * @return A vector of pairs of string option name and integer option value.
+   */
   const int_options_t &intOptions() const { return intOptions_; }
+
+  /**
+   * String-valued channel options set for server connections.
+   *
+   * @return A vector of pairs of string option name and string option value.
+   */
   const string_options_t &stringOptions() const { return stringOptions_; }
+
+  /**
+   * Extra headers that should be sent with each outgoing server request.
+   *
+   * @return A vector of pairs of string header name and string header value.
+   */
   const extra_headers_t &extraHeaders() const { return extraHeaders_; }
 
 private:

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -73,7 +73,7 @@ public:
   typedef std::vector<std::pair<std::string, int>> int_options_t;
   typedef std::vector<std::pair<std::string, std::string>> string_options_t;
   typedef std::vector<std::pair<std::string, std::string>> extra_headers_t;
-public:
+
   static ClientOptions defaults() {
     return ClientOptions();
   }
@@ -83,8 +83,8 @@ public:
     return *this;
   }
 
-  ClientOptions &setPem(const std::string &pem) {  // root certificate to use
-    pem_ = pem;
+  ClientOptions &setPem(const std::string pem) {  // root certificate to use
+    pem_ = std::move(pem);
     return *this;
   }
 
@@ -116,17 +116,11 @@ public:
   const int_options_t &intOptions() const { return intOptions_; }
   const string_options_t &stringOptions() const { return stringOptions_; }
   const extra_headers_t &extraHeaders() const { return extraHeaders_; }
-private:
-  ClientOptions()
-    : useTls_(false)
-    , pem_("")
-    , intOptions_()
-    , stringOptions_()
-    , extraHeaders_()
-  {}
 
 private:
-  bool useTls_;
+  ClientOptions();
+
+  bool useTls_ = false;
   std::string pem_;
   int_options_t intOptions_;
   string_options_t stringOptions_;

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -74,6 +74,8 @@ public:
   typedef std::vector<std::pair<std::string, std::string>> string_options_t;
   typedef std::vector<std::pair<std::string, std::string>> extra_headers_t;
 
+  ~ClientOptions();
+
   /**
    * Get ClientOptions object initialized with defaults.
    *

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -67,6 +67,54 @@ public:
   Response response_;
 };
 
+class ClientOptions {
+public:
+  typedef std::vector<std::pair<std::string, int>> int_options_t;
+  typedef std::vector<std::pair<std::string, std::string>> string_options_t;
+public:
+  static ClientOptions defaults() {
+    return ClientOptions();
+  }
+
+  ClientOptions &setUseTls(const bool useTls) {
+    useTls_ = useTls;
+    return *this;
+  }
+
+  ClientOptions &setPem(const std::string &pem) {
+    pem_ = pem;
+    return *this;
+  }
+
+  ClientOptions &setIntOption(const std::string &opt, const int val) {
+    intOptions_.emplace_back(opt, val);
+    return *this;
+  }
+
+  ClientOptions &setStringOption(const std::string &opt, const std::string &val) {
+    stringOptions_.emplace_back(opt, val);
+    return *this;
+  }
+
+  bool useTls() const { return useTls_; }
+  const std::string &pem() const { return pem_; }
+  const int_options_t &intOptions() const { return intOptions_; }
+  const string_options_t &stringOptions() const { return stringOptions_; }
+private:
+  ClientOptions()
+    : useTls_(false)
+    , pem_("")
+    , intOptions_()
+    , stringOptions_()
+  {}
+
+private:
+  bool useTls_;
+  std::string pem_;
+  int_options_t intOptions_;
+  string_options_t stringOptions_;
+};
+
 class Server : public std::enable_shared_from_this<Server> {
   struct Private {
   };
@@ -99,10 +147,11 @@ class Server : public std::enable_shared_from_this<Server> {
 public:
   static std::shared_ptr<Server> createFromTarget(
       const std::string &target,
+      const std::string &authorizationValue);
+  static std::shared_ptr<Server> createFromTarget(
+      const std::string &target,
       const std::string &authorizationValue,
-      bool use_tls = false,
-      const std::string &pem = "",
-      const std::string &target_name_override = "");
+      const ClientOptions &client_options);
   Server(const Server &other) = delete;
   Server &operator=(const Server &other) = delete;
   Server(Private,

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -233,7 +233,7 @@ public:
   void setExpirationInterval(std::chrono::milliseconds interval);
 
 private:
-  static const char *authorizationKey;
+  static const char *const authorizationKey;
   typedef std::unique_ptr<::grpc::ClientAsyncResponseReader<ExportedTableCreationResponse>>
   (TableService::Stub::*selectOrUpdateMethod_t)(::grpc::ClientContext *context,
       const SelectOrUpdateRequest &request, ::grpc::CompletionQueue *cq);

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -89,6 +89,8 @@ public:
 
   // See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for
   // a list of available options.
+  // Example:
+  //   copts.setStringOption("grpc.min_reconnect_backoff_ms", 2000)
   ClientOptions &setIntOption(const std::string &opt, const int val) {
     intOptions_.emplace_back(opt, val);
     return *this;

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -100,7 +100,7 @@ public:
   static std::shared_ptr<Server> createFromTarget(
       const std::string &target,
       const std::string &authorizationValue,
-      bool use_ssl = false,
+      bool use_tls = false,
       const std::string &pem = "");
   Server(const Server &other) = delete;
   Server &operator=(const Server &other) = delete;

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -97,7 +97,7 @@ class Server : public std::enable_shared_from_this<Server> {
   typedef SFCallback<ExportedTableCreationResponse> EtcCallback;
 
 public:
-  static std::shared_ptr<Server> createFromTarget(const std::string &target, const std::string &authorizationValue);
+  static std::shared_ptr<Server> createFromTarget(const std::string &target, const std::string &authorizationValue, const std::string pem = "");
   Server(const Server &other) = delete;
   Server &operator=(const Server &other) = delete;
   Server(Private,

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string_view>
 #include "deephaven/client/columns.h"
+#include "deephaven/client/client_options.h"
 #include "deephaven/client/expressions.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 #include "deephaven/dhcore/utility/callbacks.h"
@@ -152,58 +153,6 @@ private:
   std::shared_ptr<impl::TableHandleManagerImpl> impl_;
 };
 
-/**
- * The ClientOptions object is intended to be passed to Client::connect(). For convenience, the mutating methods can be
- * chained. For example:
- * auto client = Client::connect("localhost:10000", ClientOptions().setBasicAuthentication("foo", "bar").setSessionType("groovy")
- */
-class ClientOptions {
-public:
-  /*
-   * Default constructor. Creates a default ClientOptions object with default authentication and Python scripting.
-   */
-  ClientOptions();
-  /**
-   * Move constructor
-   */
-  ClientOptions(ClientOptions &&other) noexcept;
-  /**
-   * Move assigment operator.
-   */
-  ClientOptions &operator=(ClientOptions &&other) noexcept;
-  /**
-   * Destructor
-   */
-  ~ClientOptions();
-
-  /**
-   * Modifies the ClientOptions object to set the default authentication scheme.
-   * @return *this, so that methods can be chained.
-   */
-  ClientOptions &setDefaultAuthentication();
-  /**
-   * Modifies the ClientOptions object to set the basic authentication scheme.
-   * @return *this, so that methods can be chained.
-   */
-  ClientOptions &setBasicAuthentication(const std::string &username, const std::string &password);
-  /**
-   * Modifies the ClientOptions object to set a custom authentication scheme.
-   * @return *this, so that methods can be chained.
-   */
-  ClientOptions &setCustomAuthentication(const std::string &authenticationKey, const std::string &authenticationValue);
-  /**
-   * Modifies the ClientOptions object to set the scripting language for the session.
-   * @param sessionType The scripting language for the session, such as "groovy" or "python".
-   * @return *this, so that methods can be chained.
-   */
-  ClientOptions &setSessionType(const std::string &sessionType);
-
-private:
-  std::string authorizationValue_;
-  std::string sessionType_;
-
-  friend class Client;
-};
 
 /**
  * The main class for interacting with Deephaven. Start here to connect with

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
@@ -13,8 +13,8 @@ class Client;
  
 /**
  * The ClientOptions object is intended to be passed to Client::connect(). For convenience, the mutating methods can be
- * chained. For example:
- * auto client = Client::connect("localhost:10000", ClientOptions().setBasicAuthentication("foo", "bar").setSessionType("groovy")
+ * chained.
+ * @example auto client = Client::connect("localhost:10000", ClientOptions().setBasicAuthentication("foo", "bar").setSessionType("groovy")
  */
 class ClientOptions {
 public:

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
@@ -104,7 +104,11 @@ public:
    */
   ClientOptions &addExtraHeader(std::string header_name, std::string header_value);
   /**
+   * Returns the value for the authorization header that will be sent to the server
+   * on the first request; this value is a function of the
+   * authentication method selected.
    *
+   * @return A string value for the authorization header
    *
    */
   const std::string &authorizationValue() const {

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <string>
+#include <utility>  // std::pair
+#include <vector>
 
 namespace deephaven::client {
 
@@ -16,6 +18,10 @@ class Client;
  */
 class ClientOptions {
 public:
+  typedef std::vector<std::pair<std::string, int>> int_options_t;
+  typedef std::vector<std::pair<std::string, std::string>> string_options_t;
+  typedef std::vector<std::pair<std::string, std::string>> extra_headers_t;
+
   /*
    * Default constructor. Creates a default ClientOptions object with default authentication and Python scripting.
    */
@@ -54,10 +60,97 @@ public:
    * @return *this, so that methods can be chained.
    */
   ClientOptions &setSessionType(const std::string &sessionType);
+  /**
+   * Configure whether to set server connections as TLS
+   *
+   * @param useTls true if server connections should be TLS/SSL, false for insecure.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &setUseTls(bool useTls);
+  /**
+   * Sets a PEM-encoded certificate root for server connections.  The empty string
+   * means use system defaults.
+   *
+   * @param pem a PEM encoded certificate chain.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &setPem(std::string pem);
+  /**
+   * Adds an int-valued option for the configuration of the underlying gRPC channels.
+   * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
+   *
+   * @example copt.setIntOption("grpc.min_reconnect_backoff_ms", 2000)
+   * @param opt The option key.
+   * @param val The option valiue.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &addIntOption(std::string opt, int val);
+  /**
+   * Adds a string-valued option for the configuration of the underlying gRPC channels.
+   * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
+   *
+   * @example copt.setStringOption("grpc.target_name_override", "idonthaveadnsforthishost")
+   * @param opt The option key.
+   * @param val The option valiue.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &addStringOption(std::string opt, std::string val);
+  /**
+   * Adds an extra header with a constant name and value to be sent with every outgoing server request.
+   *
+   * @param header_name The header name
+   * @param header_value The header value
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &addExtraHeader(std::string header_name, std::string header_value);
+  /**
+   *
+   *
+   */
+  const std::string &authorizationValue() const {
+    return authorizationValue_;
+  }
+    
+  /**
+   * Returns true if server connections should be configured for TLS/SSL.
+   *
+   * @return true if this connection should be TLS/SSL, false for insecure.
+   */
+  bool useTls() const { return useTls_; }
+  /**
+   * The PEM-encoded certificate root for server connections, or the empty string
+   * if using system defaults.
+   *
+   * @return A PEM-encoded certificate chain
+   */
+  const std::string &pem() const { return pem_; }
+  /**
+   * Integer-valued channel options set for server connections.
+   *
+   * @return A vector of pairs of string option name and integer option value.
+   */
+  const int_options_t &intOptions() const { return intOptions_; }
+  /**
+   * String-valued channel options set for server connections.
+   *
+   * @return A vector of pairs of string option name and string option value.
+   */
+  const string_options_t &stringOptions() const { return stringOptions_; }
+  /**
+   * Extra headers that should be sent with each outgoing server request.
+   *
+   * @return A vector of pairs of string header name and string header value.
+   */
+  const extra_headers_t &extraHeaders() const { return extraHeaders_; }
 
 private:
   std::string authorizationValue_;
   std::string sessionType_;
+  bool useTls_ = false;
+  std::string pem_;
+  int_options_t intOptions_;
+  string_options_t stringOptions_;
+  extra_headers_t extraHeaders_;
 
   friend class Client;
 };

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
@@ -109,7 +109,6 @@ public:
    * authentication method selected.
    *
    * @return A string value for the authorization header
-   *
    */
   const std::string &authorizationValue() const {
     return authorizationValue_;
@@ -131,19 +130,19 @@ public:
   /**
    * Integer-valued channel options set for server connections.
    *
-   * @return A vector of pairs of string option name and integer option value.
+   * @return A vector of pairs of string option name and integer option value
    */
   const int_options_t &intOptions() const { return intOptions_; }
   /**
    * String-valued channel options set for server connections.
    *
-   * @return A vector of pairs of string option name and string option value.
+   * @return A vector of pairs of string option name and string option value
    */
   const string_options_t &stringOptions() const { return stringOptions_; }
   /**
    * Extra headers that should be sent with each outgoing server request.
    *
-   * @return A vector of pairs of string header name and string header value.
+   * @return A vector of pairs of string header name and string header value
    */
   const extra_headers_t &extraHeaders() const { return extraHeaders_; }
 

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
@@ -74,7 +74,7 @@ public:
    * @param pem a PEM encoded certificate chain.
    * @return *this, to be used for chaining
    */
-  ClientOptions &setPem(std::string pem);
+  ClientOptions &setTlsRootCerts(std::string tlsRootCerts);
   /**
    * Adds an int-valued option for the configuration of the underlying gRPC channels.
    * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
@@ -84,6 +84,22 @@ public:
    * @param val The option valiue.
    * @return *this, to be used for chaining
    */
+  /**
+   * Sets a PEM-encoded certificate for the client and use mutual TLS.
+   * The empty string means don't use mutual TLS.
+   *
+   * @param pem a PEM encoded certificate chain, or empty for no mutual TLS.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &setClientCertChain(std::string clientCertChain);
+  /**
+   * Sets a PEM-encoded private key for the client certificate chain when using
+   * mutual TLS.
+   *
+   * @param pem a PEM encoded private key.
+   * @return *this, to be used for chaining
+   */
+  ClientOptions &setClientPrivateKey(std::string clientCertChain);
   ClientOptions &addIntOption(std::string opt, int val);
   /**
    * Adds a string-valued option for the configuration of the underlying gRPC channels.
@@ -124,9 +140,22 @@ public:
    * The PEM-encoded certificate root for server connections, or the empty string
    * if using system defaults.
    *
-   * @return A PEM-encoded certificate chain
+   * @return A PEM-encoded certificate chain, or empty.
    */
-  const std::string &pem() const { return pem_; }
+  const std::string &tlsRootCerts() const { return tlsRootCerts_; }
+  /**
+   * The PEM-encoded certificate chain to use for the client
+   * when using mutual TLS, or the empty string for no mutual TLS.
+   *
+   * @return A PEM-encoded certificate chain, or empty.
+   */
+  const std::string &clientCertChain() const { return clientCertChain_; }
+  /**
+   * The PEM-encoded client private key to use for mutual TLS.
+   *
+   * @return A PEM-encoded private key, or empty.
+   */
+  const std::string &clientPrivateKey() const { return clientPrivateKey_; }
   /**
    * Integer-valued channel options set for server connections.
    *
@@ -150,7 +179,9 @@ private:
   std::string authorizationValue_;
   std::string sessionType_;
   bool useTls_ = false;
-  std::string pem_;
+  std::string tlsRootCerts_;
+  std::string clientCertChain_;
+  std::string clientPrivateKey_;
   int_options_t intOptions_;
   string_options_t stringOptions_;
   extra_headers_t extraHeaders_;

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+#pragma once
+
+#include <string>
+
+namespace deephaven::client {
+
+class Client;
+ 
+/**
+ * The ClientOptions object is intended to be passed to Client::connect(). For convenience, the mutating methods can be
+ * chained. For example:
+ * auto client = Client::connect("localhost:10000", ClientOptions().setBasicAuthentication("foo", "bar").setSessionType("groovy")
+ */
+class ClientOptions {
+public:
+  /*
+   * Default constructor. Creates a default ClientOptions object with default authentication and Python scripting.
+   */
+  ClientOptions();
+  /**
+   * Move constructor
+   */
+  ClientOptions(ClientOptions &&other) noexcept;
+  /**
+   * Move assigment operator.
+   */
+  ClientOptions &operator=(ClientOptions &&other) noexcept;
+  /**
+   * Destructor
+   */
+  ~ClientOptions();
+
+  /**
+   * Modifies the ClientOptions object to set the default authentication scheme.
+   * @return *this, so that methods can be chained.
+   */
+  ClientOptions &setDefaultAuthentication();
+  /**
+   * Modifies the ClientOptions object to set the basic authentication scheme.
+   * @return *this, so that methods can be chained.
+   */
+  ClientOptions &setBasicAuthentication(const std::string &username, const std::string &password);
+  /**
+   * Modifies the ClientOptions object to set a custom authentication scheme.
+   * @return *this, so that methods can be chained.
+   */
+  ClientOptions &setCustomAuthentication(const std::string &authenticationKey, const std::string &authenticationValue);
+  /**
+   * Modifies the ClientOptions object to set the scripting language for the session.
+   * @param sessionType The scripting language for the session, such as "groovy" or "python".
+   * @return *this, so that methods can be chained.
+   */
+  ClientOptions &setSessionType(const std::string &sessionType);
+
+private:
+  std::string authorizationValue_;
+  std::string sessionType_;
+
+  friend class Client;
+};
+
+}  // namespace deephaven::client

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client_options.h
@@ -59,7 +59,7 @@ public:
    * @param sessionType The scripting language for the session, such as "groovy" or "python".
    * @return *this, so that methods can be chained.
    */
-  ClientOptions &setSessionType(const std::string &sessionType);
+  ClientOptions &setSessionType(std::string sessionType);
   /**
    * Configure whether to set server connections as TLS
    *

--- a/cpp-client/deephaven/client/include/public/deephaven/client/flight.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/flight.h
@@ -33,7 +33,9 @@ public:
       const TableHandle &table) const;
 
   /**
-   * Add Deephaven authentication headers to Arrow FlightCallOptions.
+   * Add Deephaven authentication headers, and any other extra headers
+   * request at session creation, to Arrow FlightCallOptions.
+   *
    * This is a bit of a hack, and is used in the scenario where the caller is rolling
    * their own Arrow Flight `DoPut` operation. Example code might look like this:
    * @code
@@ -44,14 +46,14 @@ public:
    *   // Empty FlightCallOptions
    *   arrow::flight::FlightCallOptions options;
    *   // add Deephaven auth headers to the FlightCallOptions
-   *   wrapper.addAuthHeaders(&options);
+   *   wrapper.addHeaders(&options);
    *   std::unique_ptr<arrow::flight::FlightStreamWriter> fsw;
    *   std::unique_ptr<arrow::flight::FlightMetadataReader> fmr;
    *   auto status = wrapper.flightClient()->DoPut(options, fd, schema, &fsw, &fmr);
    * @endcode
    * @param options Destination object where the authentication headers should be written.
    */
-  void addAuthHeaders(arrow::flight::FlightCallOptions *options) const;
+  void addHeaders(arrow::flight::FlightCallOptions *options) const;
 
   /**
    * Gets the underlying FlightClient

--- a/cpp-client/deephaven/client/src/client.cc
+++ b/cpp-client/deephaven/client/src/client.cc
@@ -50,7 +50,7 @@ void printTableData(std::ostream &s, const TableHandle &tableHandle, bool wantHe
 Client Client::connect(const std::string &target, const ClientOptions &options) {
   auto executor = Executor::create();
   auto flightExecutor = Executor::create();
-  auto server = Server::createFromTarget(target, options.authorizationValue_);
+  auto server = Server::createFromTarget(target, options);
   auto impl = ClientImpl::create(std::move(server), executor, flightExecutor, options.sessionType_);
   return Client(std::move(impl));
 }

--- a/cpp-client/deephaven/client/src/client.cc
+++ b/cpp-client/deephaven/client/src/client.cc
@@ -47,37 +47,6 @@ namespace {
 void printTableData(std::ostream &s, const TableHandle &tableHandle, bool wantHeaders);
 }  // namespace
 
-ClientOptions::ClientOptions() {
-  setDefaultAuthentication();
-  setSessionType("python");
-}
-
-ClientOptions::ClientOptions(ClientOptions &&other) noexcept = default;
-ClientOptions &ClientOptions::operator=(ClientOptions &&other) noexcept = default;
-ClientOptions::~ClientOptions() = default;
-
-ClientOptions &ClientOptions::setDefaultAuthentication() {
-  authorizationValue_ = "Anonymous";
-  return *this;
-}
-
-ClientOptions &ClientOptions::setBasicAuthentication(const std::string &username, const std::string &password) {
-  auto token = username + ':' + password;
-  authorizationValue_ = "Basic " + base64Encode(token);
-  return *this;
-}
-
-ClientOptions &ClientOptions::setCustomAuthentication(const std::string &authenticationType,
-    const std::string &authenticationToken) {
-  authorizationValue_ = authenticationType + " " + authenticationToken;
-  return *this;
-}
-
-ClientOptions &ClientOptions::setSessionType(const std::string &sessionType) {
-  this->sessionType_ = sessionType;
-  return *this;
-}
-
 Client Client::connect(const std::string &target, const ClientOptions &options) {
   auto executor = Executor::create();
   auto flightExecutor = Executor::create();

--- a/cpp-client/deephaven/client/src/client_options.cc
+++ b/cpp-client/deephaven/client/src/client_options.cc
@@ -39,4 +39,29 @@ ClientOptions &ClientOptions::setSessionType(const std::string &sessionType) {
   return *this;
 }
 
+ClientOptions &ClientOptions::setUseTls(const bool useTls) {
+  useTls_ = useTls;
+  return *this;
+}
+
+ClientOptions &ClientOptions::setPem(const std::string pem) {
+  pem_ = std::move(pem);
+  return *this;
+}
+
+ClientOptions &ClientOptions::addIntOption(const std::string opt, const int val) {
+  intOptions_.emplace_back(std::move(opt), val);
+  return *this;
+}
+
+ClientOptions &ClientOptions::addStringOption(const std::string opt, const std::string val) {
+  stringOptions_.emplace_back(std::move(opt), std::move(val));
+  return *this;
+}
+
+ClientOptions &ClientOptions::addExtraHeader(std::string header_name, std::string header_value) {
+  extraHeaders_.emplace_back(std::move(header_name), std::move(header_value));
+  return *this;
+}
+
 }  // namespace deephaven::client

--- a/cpp-client/deephaven/client/src/client_options.cc
+++ b/cpp-client/deephaven/client/src/client_options.cc
@@ -34,8 +34,8 @@ ClientOptions &ClientOptions::setCustomAuthentication(const std::string &authent
   return *this;
 }
 
-ClientOptions &ClientOptions::setSessionType(const std::string &sessionType) {
-  this->sessionType_ = sessionType;
+ClientOptions &ClientOptions::setSessionType(std::string sessionType) {
+  this->sessionType_ = std::move(sessionType);
   return *this;
 }
 
@@ -44,27 +44,27 @@ ClientOptions &ClientOptions::setUseTls(const bool useTls) {
   return *this;
 }
 
-ClientOptions &ClientOptions::setTlsRootCerts(const std::string tlsRootCerts) {
+ClientOptions &ClientOptions::setTlsRootCerts(std::string tlsRootCerts) {
   tlsRootCerts_ = std::move(tlsRootCerts);
   return *this;
 }
 
-ClientOptions &ClientOptions::setClientCertChain(const std::string clientCertChain) {
+ClientOptions &ClientOptions::setClientCertChain(std::string clientCertChain) {
   clientCertChain_ = std::move(clientCertChain);
   return *this;
 }
 
-ClientOptions &ClientOptions::setClientPrivateKey(const std::string clientPrivateKey) {
+ClientOptions &ClientOptions::setClientPrivateKey(std::string clientPrivateKey) {
   clientPrivateKey_ = std::move(clientPrivateKey);
   return *this;
 }
 
-ClientOptions &ClientOptions::addIntOption(const std::string opt, const int val) {
+ClientOptions &ClientOptions::addIntOption(std::string opt, const int val) {
   intOptions_.emplace_back(std::move(opt), val);
   return *this;
 }
 
-ClientOptions &ClientOptions::addStringOption(const std::string opt, const std::string val) {
+ClientOptions &ClientOptions::addStringOption(std::string opt, const std::string val) {
   stringOptions_.emplace_back(std::move(opt), std::move(val));
   return *this;
 }

--- a/cpp-client/deephaven/client/src/client_options.cc
+++ b/cpp-client/deephaven/client/src/client_options.cc
@@ -44,8 +44,18 @@ ClientOptions &ClientOptions::setUseTls(const bool useTls) {
   return *this;
 }
 
-ClientOptions &ClientOptions::setPem(const std::string pem) {
-  pem_ = std::move(pem);
+ClientOptions &ClientOptions::setTlsRootCerts(const std::string tlsRootCerts) {
+  tlsRootCerts_ = std::move(tlsRootCerts);
+  return *this;
+}
+
+ClientOptions &ClientOptions::setClientCertChain(const std::string clientCertChain) {
+  clientCertChain_ = std::move(clientCertChain);
+  return *this;
+}
+
+ClientOptions &ClientOptions::setClientPrivateKey(const std::string clientPrivateKey) {
+  clientPrivateKey_ = std::move(clientPrivateKey);
   return *this;
 }
 

--- a/cpp-client/deephaven/client/src/client_options.cc
+++ b/cpp-client/deephaven/client/src/client_options.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/client/client_options.h"
+#include "deephaven/dhcore/utility/utility.h"
+
+using deephaven::dhcore::utility::base64Encode;
+
+namespace deephaven::client {
+
+ClientOptions::ClientOptions() {
+  setDefaultAuthentication();
+  setSessionType("python");
+}
+
+ClientOptions::ClientOptions(ClientOptions &&other) noexcept = default;
+ClientOptions &ClientOptions::operator=(ClientOptions &&other) noexcept = default;
+ClientOptions::~ClientOptions() = default;
+
+ClientOptions &ClientOptions::setDefaultAuthentication() {
+  authorizationValue_ = "Anonymous";
+  return *this;
+}
+
+ClientOptions &ClientOptions::setBasicAuthentication(const std::string &username, const std::string &password) {
+  auto token = username + ':' + password;
+  authorizationValue_ = "Basic " + base64Encode(token);
+  return *this;
+}
+
+ClientOptions &ClientOptions::setCustomAuthentication(const std::string &authenticationType,
+    const std::string &authenticationToken) {
+  authorizationValue_ = authenticationType + " " + authenticationToken;
+  return *this;
+}
+
+ClientOptions &ClientOptions::setSessionType(const std::string &sessionType) {
+  this->sessionType_ = sessionType;
+  return *this;
+}
+
+}  // namespace deephaven::client

--- a/cpp-client/deephaven/client/src/flight.cc
+++ b/cpp-client/deephaven/client/src/flight.cc
@@ -30,10 +30,11 @@ std::shared_ptr<arrow::flight::FlightStreamReader> FlightWrapper::getFlightStrea
 }
 
 void FlightWrapper::addHeaders(arrow::flight::FlightCallOptions *options) const {
-  options->headers.push_back(impl_->server()->getAuthHeader());
-  for (auto const & header : impl_->server()->getExtraHeaders()) {
-    options->headers.push_back(header);
-  }
+  impl_->server()->forEachHeaderNameAndValue(
+    [&options](const std::string &name, const std::string &value) {
+      options->headers.push_back(std::make_pair(name, value));
+    }
+  );
 }
 
 arrow::flight::FlightClient *FlightWrapper::flightClient() const {

--- a/cpp-client/deephaven/client/src/flight.cc
+++ b/cpp-client/deephaven/client/src/flight.cc
@@ -19,7 +19,7 @@ FlightWrapper::~FlightWrapper() = default;
 std::shared_ptr<arrow::flight::FlightStreamReader> FlightWrapper::getFlightStreamReader(
     const TableHandle &table) const {
   arrow::flight::FlightCallOptions options;
-  addAuthHeaders(&options);
+  addHeaders(&options);
 
   std::unique_ptr<arrow::flight::FlightStreamReader> fsr;
   arrow::flight::Ticket tkt;
@@ -29,8 +29,11 @@ std::shared_ptr<arrow::flight::FlightStreamReader> FlightWrapper::getFlightStrea
   return fsr;
 }
 
-void FlightWrapper::addAuthHeaders(arrow::flight::FlightCallOptions *options) const {
+void FlightWrapper::addHeaders(arrow::flight::FlightCallOptions *options) const {
   options->headers.push_back(impl_->server()->getAuthHeader());
+  for (auto const & header : impl_->server()->getExtraHeaders()) {
+    options->headers.push_back(header);
+  }
 }
 
 arrow::flight::FlightClient *FlightWrapper::flightClient() const {

--- a/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
@@ -625,7 +625,7 @@ public:
   void invokeHelper() {
     arrow::flight::FlightCallOptions options;
     options.headers.push_back(server_->getAuthHeader());
-    for (auto const& header : server_->getExtraHeaders()) {
+    for (const auto &header : server_->getExtraHeaders()) {
       options.headers.push_back(header);
     }
 

--- a/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
@@ -624,10 +624,11 @@ public:
 
   void invokeHelper() {
     arrow::flight::FlightCallOptions options;
-    options.headers.push_back(server_->getAuthHeader());
-    for (const auto &header : server_->getExtraHeaders()) {
-      options.headers.push_back(header);
-    }
+    server_->forEachHeaderNameAndValue(
+      [&options](const std::string &name, const std::string &value) {
+        options.headers.push_back(std::make_pair(name, value));
+      }
+    );
 
     arrow::flight::FlightDescriptor fd;
     if (!ArrowUtil::tryConvertTicketToFlightDescriptor(ticket_.ticket(), &fd)) {

--- a/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
@@ -625,6 +625,9 @@ public:
   void invokeHelper() {
     arrow::flight::FlightCallOptions options;
     options.headers.push_back(server_->getAuthHeader());
+    for (auto const& header : server_->getExtraHeaders()) {
+      options.headers.push_back(header);
+    }
 
     arrow::flight::FlightDescriptor fd;
     if (!ArrowUtil::tryConvertTicketToFlightDescriptor(ticket_.ticket(), &fd)) {

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -27,6 +27,7 @@
 
 using namespace std;
 using arrow::flight::FlightClient;
+using deephaven::client::ClientOptions;
 using deephaven::dhcore::utility::SFCallback;
 using deephaven::dhcore::utility::bit_cast;
 using deephaven::dhcore::utility::streamf;
@@ -90,18 +91,8 @@ std::shared_ptr<grpc::ChannelCredentials> getCredentials(const bool useTls, cons
 }
 }  // namespace
 
-ClientOptions::ClientOptions() = default;
-ClientOptions::~ClientOptions() = default;
-
 std::shared_ptr<Server> Server::createFromTarget(
       const std::string &target,
-      const std::string &authorizationValue) {
-  return createFromTarget(target, authorizationValue, ClientOptions::defaults());
-}
-
-std::shared_ptr<Server> Server::createFromTarget(
-      const std::string &target,
-      const std::string &authorizationValue,
       const ClientOptions &copts) {
   if (!copts.useTls() && !copts.pem().empty()) {
     throw std::runtime_error(
@@ -154,7 +145,7 @@ std::shared_ptr<Server> Server::createFromTarget(
     ConfigurationConstantsRequest ccReq;
     ConfigurationConstantsResponse ccResp;
     grpc::ClientContext ctx;
-    ctx.AddMetadata(authorizationKey, authorizationValue);
+    ctx.AddMetadata(authorizationKey, copts.authorizationValue());
     for (const auto &header : copts.extraHeaders()) {
       ctx.AddMetadata(header.first, header.second);
     }

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -78,7 +78,8 @@ const size_t handshakeResendIntervalMillis = 5 * 1000;
 std::shared_ptr<Server> Server::createFromTarget(
       const std::string &target,
       const std::string &authorizationValue,
-      const std::string pem
+      const bool use_ssl,
+      const std::string &pem
 ) {
   auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
   auto as = ApplicationService::NewStub(channel);
@@ -88,7 +89,7 @@ std::shared_ptr<Server> Server::createFromTarget(
   auto cfs = ConfigService::NewStub(channel);
 
   // TODO(kosak): Warn about this string conversion or do something more general.
-  auto flightTarget = ((pem == "") ? "grpc://" : "grpc+tls://") + target;
+  auto flightTarget = ((use_ssl) ? "grpc+tls://" : "grpc://") + target;
   arrow::flight::Location location;
 
   auto rc1 = arrow::flight::Location::Parse(flightTarget, &location);

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -519,14 +519,6 @@ void Server::releaseAsync(Ticket ticket, std::shared_ptr<SFCallback<ReleaseRespo
   sendRpc(req, std::move(callback), sessionStub(), &SessionService::Stub::AsyncRelease);
 }
 
-std::pair<std::string, std::string> Server::getAuthHeader() const {
-  return std::make_pair(authorizationKey, sessionToken_);
-}
-
-const ClientOptions::extra_headers_t &Server::getExtraHeaders() const {
-  return extraHeaders_;
-}
-
 void Server::processCompletionQueueForever(const std::shared_ptr<Server> &self) {
   while (true) {
     if (!self->processNextCompletionQueueItem()) {

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -100,11 +100,14 @@ std::shared_ptr<Server> Server::createFromTarget(
   }
 
   grpc::ChannelArguments channel_args;
+  auto options = arrow::flight::FlightClientOptions::Defaults();
   for (const auto &opt : copts.intOptions()) {
     channel_args.SetInt(opt.first, opt.second);
+    options.generic_options.emplace_back(opt.first, opt.second);
   }
   for (const auto &opt : copts.stringOptions()) {
     channel_args.SetString(opt.first, opt.second);
+    options.generic_options.emplace_back(opt.first, opt.second);
   }
 
   auto channel = grpc::CreateCustomChannel(
@@ -126,7 +129,6 @@ std::shared_ptr<Server> Server::createFromTarget(
     throw std::runtime_error(DEEPHAVEN_DEBUG_MSG(message));
   }
 
-  auto options = arrow::flight::FlightClientOptions::Defaults();
   if (!copts.pem().empty()) {
     options.tls_root_certs = copts.pem();
   }

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -78,7 +78,7 @@ const size_t handshakeResendIntervalMillis = 5 * 1000;
 std::shared_ptr<Server> Server::createFromTarget(
       const std::string &target,
       const std::string &authorizationValue,
-      const bool use_ssl,
+      const bool use_tls,
       const std::string &pem
 ) {
   auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
@@ -88,12 +88,12 @@ std::shared_ptr<Server> Server::createFromTarget(
   auto ts = TableService::NewStub(channel);
   auto cfs = ConfigService::NewStub(channel);
 
-  if (!use_ssl && pem != "") {
-    throw std::runtime_error("Server::createFromTarget: use_ssl is false but pem provided");
+  if (!use_tls && pem != "") {
+    throw std::runtime_error("Server::createFromTarget: use_tls is false but pem provided");
   }
 
   // TODO(kosak): Warn about this string conversion or do something more general.
-  auto flightTarget = ((use_ssl) ? "grpc+tls://" : "grpc://") + target;
+  auto flightTarget = ((use_tls) ? "grpc+tls://" : "grpc://") + target;
   arrow::flight::Location location;
 
   auto rc1 = arrow::flight::Location::Parse(flightTarget, &location);

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -91,6 +91,7 @@ std::shared_ptr<grpc::ChannelCredentials> getCredentials(const bool useTls, cons
 }  // namespace
 
 ClientOptions::ClientOptions() = default;
+ClientOptions::~ClientOptions() = default;
 
 std::shared_ptr<Server> Server::createFromTarget(
       const std::string &target,

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -104,8 +104,8 @@ std::shared_ptr<Server> Server::createFromTarget(
       const std::string &target,
       const ClientOptions &copts) {
   if (!copts.useTls() && !copts.tlsRootCerts().empty()) {
-    throw std::runtime_error(
-        "Server::createFromTarget: ClientOptions: useTls is false but pem provided");
+    const char *message = "Server::createFromTarget: ClientOptions: useTls is false but pem provided";
+    throw std::runtime_error(DEEPHAVEN_DEBUG_MSG(message));
   }
 
   grpc::ChannelArguments channel_args;

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -60,7 +60,7 @@ using io::deephaven::proto::backplane::script::grpc::StartConsoleRequest;
 
 namespace deephaven::client::server {
 
-const char *Server::authorizationKey = "authorization";
+const char *const Server::authorizationKey = "authorization";
 
 namespace {
 Ticket makeScopeReference(std::string_view tableName);

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -88,6 +88,10 @@ std::shared_ptr<Server> Server::createFromTarget(
   auto ts = TableService::NewStub(channel);
   auto cfs = ConfigService::NewStub(channel);
 
+  if (!use_ssl && pem != "") {
+    throw std::runtime_error("Server::createFromTarget: use_ssl is false but pem provided");
+  }
+
   // TODO(kosak): Warn about this string conversion or do something more general.
   auto flightTarget = ((use_ssl) ? "grpc+tls://" : "grpc://") + target;
   arrow::flight::Location location;

--- a/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
@@ -130,6 +130,9 @@ void SubscribeState::invoke() {
 std::shared_ptr<SubscriptionHandle> SubscribeState::invokeHelper() {
   arrow::flight::FlightCallOptions fco;
   fco.headers.push_back(server_->getAuthHeader());
+  for (auto const& header : server_->getExtraHeaders()) {
+    fco.headers.push_back(header);
+  }
   auto *client = server_->flightClient();
 
   arrow::flight::FlightDescriptor descriptor;

--- a/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
@@ -130,7 +130,7 @@ void SubscribeState::invoke() {
 std::shared_ptr<SubscriptionHandle> SubscribeState::invokeHelper() {
   arrow::flight::FlightCallOptions fco;
   fco.headers.push_back(server_->getAuthHeader());
-  for (auto const& header : server_->getExtraHeaders()) {
+  for (const auto &header : server_->getExtraHeaders()) {
     fco.headers.push_back(header);
   }
   auto *client = server_->flightClient();

--- a/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
@@ -129,10 +129,11 @@ void SubscribeState::invoke() {
 
 std::shared_ptr<SubscriptionHandle> SubscribeState::invokeHelper() {
   arrow::flight::FlightCallOptions fco;
-  fco.headers.push_back(server_->getAuthHeader());
-  for (const auto &header : server_->getExtraHeaders()) {
-    fco.headers.push_back(header);
-  }
+  server_->forEachHeaderNameAndValue(
+    [&fco](const std::string &name, const std::string &value) {
+      fco.headers.push_back(std::make_pair(name, value));
+    }
+  );
   auto *client = server_->flightClient();
 
   arrow::flight::FlightDescriptor descriptor;

--- a/cpp-client/deephaven/client/src/utility/table_maker.cc
+++ b/cpp-client/deephaven/client/src/utility/table_maker.cc
@@ -44,7 +44,7 @@ TableHandle TableMaker::makeTable(const TableHandleManager &manager, int64_t num
   auto thfd = manager.newTableHandleAndFlightDescriptor(numRows, isStatic);
 
   arrow::flight::FlightCallOptions options;
-  wrapper.addAuthHeaders(&options);
+  wrapper.addHeaders(&options);
 
   std::unique_ptr<arrow::flight::FlightStreamWriter> fsw;
   std::unique_ptr<arrow::flight::FlightMetadataReader> fmr;

--- a/cpp-examples/create_table_with_arrow_flight/main.cc
+++ b/cpp-examples/create_table_with_arrow_flight/main.cc
@@ -110,7 +110,7 @@ void doit(const TableHandleManager &manager) {
   // 10. DoPut takes FlightCallOptions, which need to at least contain the Deephaven
   // authentication headers for this session.
   arrow::flight::FlightCallOptions options;
-  wrapper.addAuthHeaders(&options);
+  wrapper.addHeaders(&options);
 
   // 11. Perform the doPut
   std::unique_ptr<arrow::flight::FlightStreamWriter> fsw;

--- a/cpp-examples/create_table_with_arrow_flight/main.cc
+++ b/cpp-examples/create_table_with_arrow_flight/main.cc
@@ -79,7 +79,7 @@ void doit(const TableHandleManager &manager) {
   std::vector<int32_t> volumes{1000, 2000, 3000, 4000};
   auto numRows = static_cast<int64_t>(symbols.size());
   if (numRows != prices.size() || numRows != volumes.size()) {
-    throw std::runtime_error(DEEPHAVEN_DEBUG_MSG("sizes don't match"));
+    throw DEEPHAVEN_EXPR_MSG(std::runtime_error(DEEPHAVEN_DEBUG_MSG("sizes don't match")));
   }
 
   // 6. Move data to Arrow column builders

--- a/cpp-examples/read_csv/main.cc
+++ b/cpp-examples/read_csv/main.cc
@@ -70,7 +70,7 @@ arrow::Status doit(const TableHandleManager &manager, const std::string &csvfn) 
   auto [table_handle, fd] = manager.newTableHandleAndFlightDescriptor();
 
   arrow::flight::FlightCallOptions options;
-  wrapper.addAuthHeaders(&options);
+  wrapper.addHeaders(&options);
 
   std::unique_ptr<arrow::flight::FlightStreamWriter> fsw;
   std::unique_ptr<arrow::flight::FlightMetadataReader> fmr;

--- a/py/client/pydeephaven/_session_service.py
+++ b/py/client/pydeephaven/_session_service.py
@@ -21,7 +21,7 @@ class SessionService:
         else:
             options = (('grpc.ssl_target_name_override', self.session.target_name_override))
         if self.session.use_tls:
-            credentials = ssl_channel_credentials(root_certificates=self.session.pem)
+            credentials = grpc.ssl_channel_credentials(root_certificates=self.session.pem)
             grpc_channel = grpc.secure_channel(target, credentials, options) 
         else:
             grpc_channel = grpc.insecure_channel(target)

--- a/py/client/pydeephaven/_session_service.py
+++ b/py/client/pydeephaven/_session_service.py
@@ -17,7 +17,10 @@ class SessionService:
         """Connects to the server and returns a gRPC channel upon success."""
         target = ":".join([self.session.host, str(self.session.port)])
         if self.session._use_tls:
-            credentials = grpc.ssl_channel_credentials(root_certificates=self.session._pem)
+            credentials = grpc.ssl_channel_credentials(
+                root_certificates=self.session._tls_root_certs,
+                private_key=self.session._client_private_key,
+                certificate_chain=self.session._client_cert_chain)
             grpc_channel = grpc.secure_channel(target, credentials, self.session._client_opts) 
         else:
             grpc_channel = grpc.insecure_channel(target, self.session._client_opts)

--- a/py/client/pydeephaven/_session_service.py
+++ b/py/client/pydeephaven/_session_service.py
@@ -16,11 +16,11 @@ class SessionService:
     def connect(self) -> grpc.Channel:
         """Connects to the server and returns a gRPC channel upon success."""
         target = ":".join([self.session.host, str(self.session.port)])
-        if self.session.use_tls:
-            credentials = grpc.ssl_channel_credentials(root_certificates=self.session.pem)
-            grpc_channel = grpc.secure_channel(target, credentials, self.session.client_opts) 
+        if self.session._use_tls:
+            credentials = grpc.ssl_channel_credentials(root_certificates=self.session._pem)
+            grpc_channel = grpc.secure_channel(target, credentials, self.session._client_opts) 
         else:
-            grpc_channel = grpc.insecure_channel(target, self.session.client_opts)
+            grpc_channel = grpc.insecure_channel(target, self.session._client_opts)
         self._grpc_session_stub = session_pb2_grpc.SessionServiceStub(grpc_channel)
         return grpc_channel
 

--- a/py/client/pydeephaven/_session_service.py
+++ b/py/client/pydeephaven/_session_service.py
@@ -16,15 +16,11 @@ class SessionService:
     def connect(self) -> grpc.Channel:
         """Connects to the server and returns a gRPC channel upon success."""
         target = ":".join([self.session.host, str(self.session.port)])
-        if self.session.target_name_override is None:
-            options = None
-        else:
-            options = (('grpc.ssl_target_name_override', self.session.target_name_override))
         if self.session.use_tls:
             credentials = grpc.ssl_channel_credentials(root_certificates=self.session.pem)
-            grpc_channel = grpc.secure_channel(target, credentials, options) 
+            grpc_channel = grpc.secure_channel(target, credentials, self.session.client_opts) 
         else:
-            grpc_channel = grpc.insecure_channel(target)
+            grpc_channel = grpc.insecure_channel(target, self.session.client_opts)
         self._grpc_session_stub = session_pb2_grpc.SessionServiceStub(grpc_channel)
         return grpc_channel
 

--- a/py/client/pydeephaven/_session_service.py
+++ b/py/client/pydeephaven/_session_service.py
@@ -15,7 +15,16 @@ class SessionService:
 
     def connect(self) -> grpc.Channel:
         """Connects to the server and returns a gRPC channel upon success."""
-        grpc_channel = grpc.insecure_channel(":".join([self.session.host, str(self.session.port)]))
+        target = ":".join([self.session.host, str(self.session.port)])
+        if self.session.target_name_override is None:
+            options = None
+        else:
+            options = (('grpc.ssl_target_name_override', self.session.target_name_override))
+        if self.session.use_tls:
+            credentials = ssl_channel_credentials(root_certificates=self.session.pem)
+            grpc_channel = grpc.secure_channel(target, credentials, options) 
+        else:
+            grpc_channel = grpc.insecure_channel(target)
         self._grpc_session_stub = session_pb2_grpc.SessionServiceStub(grpc_channel)
         return grpc_channel
 

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -88,7 +88,8 @@ class Session:
     """
 
     def __init__(self, host: str = None, port: int = None, auth_type: str = "Anonymous", auth_token: str = "",
-                 never_timeout: bool = True, session_type: str = 'python', use_tls: bool = False, pem: bytes = None):
+                 never_timeout: bool = True, session_type: str = 'python',
+                 use_tls: bool = False, pem: bytes = None, target_name_override: str = None):
         """Initializes a Session object that connects to the Deephaven server
 
         Args:
@@ -100,11 +101,13 @@ class Session:
             auth_token (str): the authentication token string. When auth_type is 'Basic', it must be
                 "user:password"; when auth_type is "Anonymous', it will be ignored; when auth_type is a custom-built
                 authenticator, it must conform to the specific requirement of the authenticator
-            never_timeout (bool, optional): never allow the session to timeout, default is True
-            session_type (str, optional): the Deephaven session type. Defaults to 'python'
-            use_tls (bool, optional): if True, use a TLS connection.  Defaults to None
-            pem (bytes, optional): PEM encoded certificate to use for TLS connection. If not None implies use a TLS
+            never_timeout (bool): never allow the session to timeout, default is True
+            session_type (str): the Deephaven session type. Defaults to 'python'
+            use_tls (bool): if True, use a TLS connection.  Defaults to None
+            pem (bytes): PEM encoded certificate to use for TLS connection. If not None implies use a TLS
                  connection and the use_tls argument should have been passed as True. Defaults to None
+            target_name_override (str): set target name override for SSL host name checking; use with caution
+                 in production, this option has security implications in certificate handling.  Defaults to None
 
         Raises:
             DHError
@@ -125,7 +128,9 @@ class Session:
         self.pem = pem
         if self.pem is not None and not self.use_tls:
             raise DHError("use_tls is false but pem is not None")
-
+        self.target_name_override = target_name_override
+        if self.target_name_override is not None and not self.use_tls:
+            raise DHError("use_tls is false but target_name_override is not None")
 
         self.is_connected = False
 

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -88,7 +88,7 @@ class Session:
     """
 
     def __init__(self, host: str = None, port: int = None, auth_type: str = "Anonymous", auth_token: str = "",
-                 never_timeout: bool = True, session_type: str = 'python', use_ssl: bool = False, pem: bytes = None):
+                 never_timeout: bool = True, session_type: str = 'python', use_tls: bool = False, pem: bytes = None):
         """Initializes a Session object that connects to the Deephaven server
 
         Args:
@@ -102,9 +102,9 @@ class Session:
                 authenticator, it must conform to the specific requirement of the authenticator
             never_timeout (bool, optional): never allow the session to timeout, default is True
             session_type (str, optional): the Deephaven session type. Defaults to 'python'
-            use_ssl (bool, optional): if True, use an SSL connection.  Defaults to None
+            use_tls (bool, optional): if True, use a TLS connection.  Defaults to None
             pem (bytes, optional): PEM encoded certificate to use for TLS connection. If not None implies use a TLS
-                 connection and the use_ssl argument should have been passed as True. Defaults to None
+                 connection and the use_tls argument should have been passed as True. Defaults to None
 
         Raises:
             DHError
@@ -121,10 +121,10 @@ class Session:
         if not port:
             self.port = int(os.environ.get("DH_PORT", 10000))
 
-        self.use_ssl = use_ssl
+        self.use_tls = use_tls
         self.pem = pem
-        if self.pem is not None and not self.use_ssl:
-            raise DHError("use_ssl is false but pem is not None")
+        if self.pem is not None and not self.use_tls:
+            raise DHError("use_tls is false but pem is not None")
 
 
         self.is_connected = False
@@ -249,7 +249,7 @@ class Session:
     def _connect(self):
         with self._r_lock:
             try:
-                if self.use_ssl:
+                if self.use_tls:
                     self._flight_client = paflight.FlightClient(
                         location=f"grpc+tls://{self.host}:{self.port}",
                         middleware=[_DhClientAuthMiddlewareFactory(self)],

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -249,17 +249,12 @@ class Session:
     def _connect(self):
         with self._r_lock:
             try:
-                if self.use_tls:
-                    self._flight_client = paflight.FlightClient(
-                        location=f"grpc+tls://{self.host}:{self.port}",
-                        middleware=[_DhClientAuthMiddlewareFactory(self)],
-                        tls_root_certs = pem
-                    )
-                else:
-                    self._flight_client = paflight.FlightClient(
-                        location=(self.host, self.port),
-                        middleware=[_DhClientAuthMiddlewareFactory(self)]
-                    )
+                scheme = "grpc+tls" if use_tls else "grpc"
+                self._flight_client = paflight.FlightClient(
+                    location=f"{scheme}://{self.host}:{self.port}",
+                    middleware=[_DhClientAuthMiddlewareFactory(self)],
+                    tls_root_certs = pem
+                )
                 self._auth_handler = _DhClientAuthHandler(self)
                 self._flight_client.authenticate(self._auth_handler)
             except Exception as e:

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -200,7 +200,7 @@ class Session:
     def grpc_metadata(self):
         l =[(b'authorization', self._auth_token)]
         if self._extra_headers:
-            l.extend(list(tuple(self._extra_headers.items())))
+            l.extend(list(self._extra_headers.items()))
         return l
 
     @property

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -390,7 +390,7 @@ class Session:
 
         Args:
             period (int): the interval (in nano seconds) at which the time table ticks (adds a row)
-            start_time (int, optional): the start time for the time table in nano seconds, default is None (meaning now)
+            start_time (int): the start time for the time table in nano seconds, default is None (meaning now)
 
         Returns:
             a Table object

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -106,7 +106,9 @@ class Session:
             use_tls (bool): if True, use a TLS connection.  Defaults to None
             pem (bytes): PEM encoded certificate to use for TLS connection. If not None implies use a TLS
                  connection and the use_tls argument should have been passed as True. Defaults to None
-            client_opts: list of tuples for name and value of options to the underlying grpc channel creation.  Defaults to None
+            client_opts: list of tuples for name and value of options to the underlying grpc channel creation.
+                Defaults to None.  See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list
+                of valid options. 
 
         Raises:
             DHError

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -186,7 +186,7 @@ class Session:
     def grpc_metadata(self):
         l =[(b'authorization', self._auth_token)]
         if self._extra_headers:
-            l.append(list(tuple(self._extra_headers.items())))
+            l.extend(list(tuple(self._extra_headers.items())))
         return l
 
     @property

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -90,7 +90,7 @@ class Session:
     def __init__(self, host: str = None, port: int = None, auth_type: str = "Anonymous", auth_token: str = "",
                  never_timeout: bool = True, session_type: str = 'python',
                  use_tls: bool = False, pem: bytes = None,
-                 client_opts: List[Tuple[str,Union[int|str]]] = None):
+                 client_opts: List[Tuple[str,Union[int,str]]] = None):
         """Initializes a Session object that connects to the Deephaven server
 
         Args:

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -89,7 +89,8 @@ class Session:
 
     def __init__(self, host: str = None, port: int = None, auth_type: str = "Anonymous", auth_token: str = "",
                  never_timeout: bool = True, session_type: str = 'python',
-                 use_tls: bool = False, pem: bytes = None, client_opts: List[Tuple[str,Union[int|str]]] = None):
+                 use_tls: bool = False, pem: bytes = None,
+                 client_opts: List[Tuple[str,Union[int|str]]] = None):
         """Initializes a Session object that connects to the Deephaven server
 
         Args:
@@ -108,7 +109,10 @@ class Session:
                  connection and the use_tls argument should have been passed as True. Defaults to None
             client_opts: list of tuples for name and value of options to the underlying grpc channel creation.
                 Defaults to None.  See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list
-                of valid options. 
+                of valid options.
+                Example options:
+                  [ ('grpc.target_name_override', 'idonthaveadnsforthishost'),
+                    ('grpc.min_reconnect_backoff_ms', 2000) ]
 
         Raises:
             DHError

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -149,8 +149,6 @@ class Session:
         self._tls_root_certs = tls_root_certs
         self._client_cert_chain = client_cert_chain
         self._client_private_key = client_private_key
-        if self._tls_root_certs is not None and not self._use_tls:
-            raise DHError("use_tls is false but tsl_root_certs is not None")
         self._client_opts = client_opts
         self._extra_headers = extra_headers if extra_headers else {}
 

--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -254,11 +254,11 @@ class Session:
     def _connect(self):
         with self._r_lock:
             try:
-                scheme = "grpc+tls" if use_tls else "grpc"
+                scheme = "grpc+tls" if self.use_tls else "grpc"
                 self._flight_client = paflight.FlightClient(
                     location=f"{scheme}://{self.host}:{self.port}",
                     middleware=[_DhClientAuthMiddlewareFactory(self)],
-                    tls_root_certs = pem
+                    tls_root_certs = self.pem
                 )
                 self._auth_handler = _DhClientAuthHandler(self)
                 self._flight_client.authenticate(self._auth_handler)


### PR DESCRIPTION
Note the arrow flight client implementation itself is a very thin cython wrapper around the arrow flight C++ API, so the two changes in our clients in this PR, C++ and python, are functionally the same change being handled by the same underlying arrow flight C++ client API logic.

Resources:

* Python Arrow Flight cookbook for TLS
  https://arrow.apache.org/cookbook/py/flight.html#securing-connections-with-tls (Step 3)
* C++ Arrow Flight documentation for Connect
https://arrow.apache.org/docs/cpp/api/flight.html#_CPPv4N5arrow6flight12FlightClient7ConnectERK8LocationRK19FlightClientOptions
* C++ Arrow Flight documentation for Connect options:
https://arrow.apache.org/docs/cpp/api/flight.html#_CPPv4N5arrow6flight19FlightClientOptionsE
* Example of C++ TLS setup for client:
https://github.com/yasushi-saito/grpc-ssl-example/blob/master/cppclient/client.cc
* Python gRPC API
https://grpc.github.io/grpc/python/grpc.html#grpc.secure_channel
* DIscussion of target name override in the gRPC python repo:
https://github.com/grpc/grpc/issues/5697

Fixes #3228
Fixes #3943
