### PR TITLE
Create BarrageChunkAppendingMarshaller ideal for TableDataService Usage

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ReinterpretUtils.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ReinterpretUtils.java
@@ -237,6 +237,25 @@ public class ReinterpretUtils {
     }
 
     /**
+     * If {@code dataType} is something that we prefer to handle as a primitive, emit the appropriate {@link ChunkType},
+     * else the normal ChunkType for the data type.
+     *
+     * @param dataType The data type to convert to a {@link ChunkType}
+     * @return the appropriate {@link ChunkType} to use when writing primitives to the destination
+     */
+    @NotNull
+    public static ChunkType maybeConvertToWritablePrimitiveChunkType(@NotNull final Class<?> dataType) {
+        if (dataType == Boolean.class || dataType == boolean.class) {
+            return ChunkType.Byte;
+        }
+        if (dataType == Instant.class) {
+            // Note that storing ZonedDateTime as a primitive is lossy on the time zone.
+            return ChunkType.Long;
+        }
+        return ChunkType.fromElementType(dataType);
+    }
+
+    /**
      * If {@code dataType} is something that we prefer to handle as a primitive, emit the appropriate {@link Class data
      * type to use}, else return {@code dataType}.
      *

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/ArrowToTableConverter.java
@@ -170,9 +170,9 @@ public class ArrowToTableConverter {
         resultTable.setFlat();
 
         columnConversionFactors = result.conversionFactors;
-        columnChunkTypes = resultTable.getWireChunkTypes();
-        columnTypes = resultTable.getWireTypes();
-        componentTypes = resultTable.getWireComponentTypes();
+        columnChunkTypes = result.computeWireChunkTypes();
+        columnTypes = result.computeWireTypes();
+        componentTypes = result.computeWireComponentTypes();
 
         // retain reference until the resultTable can be sealed
         resultTable.retainReference();

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageChunkAppendingMarshaller.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageChunkAppendingMarshaller.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 
 /**
  * This class is used to append the results of a DoGet directly into destination {@link WritableChunk<Values>}.
- *
+ * <p>
  * It will append the results of a DoGet into the destination chunks, and notify the listener of the number of rows
  * appended to the record batch in total. The user will typically want to wait for OnCompletion to be called before
  * assuming they have received all the data.

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageMarshallingException.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageMarshallingException.java
@@ -1,0 +1,13 @@
+package io.deephaven.extensions.barrage.util;
+
+import io.deephaven.UncheckedDeephavenException;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This exception is thrown when Barrage encounters unexpected state while marshalling a gRPC message.
+ **/
+public final class BarrageMarshallingException extends UncheckedDeephavenException {
+    public BarrageMarshallingException(@NotNull final String details) {
+        super("Barrage encountered an error while parsing Flight data: " + details);
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
@@ -250,7 +250,8 @@ public class BarrageStreamReader implements StreamReader {
                         for (int ci = 0; ci < msg.modColumnData.length; ++ci) {
                             final BarrageMessage.ModColumnData mcd = msg.modColumnData[ci];
 
-                            long remaining = mcd.rowsModified.size() - numModRowsRead;
+                            // another column may be larger than this column
+                            long remaining = Math.max(0, mcd.rowsModified.size() - numModRowsRead);
 
                             // need to add the batch row data to the column chunks
                             int lastChunkIndex = mcd.data.size() - 1;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageStreamReader.java
@@ -51,8 +51,6 @@ public class BarrageStreamReader implements StreamReader {
     private long numModRowsRead = 0;
     private long numModRowsTotal = 0;
 
-    private long lastAddStartIndex = 0;
-    private long lastModStartIndex = 0;
     private BarrageMessage msg = null;
 
     public BarrageStreamReader(final LongConsumer deserializeTmConsumer) {
@@ -103,8 +101,6 @@ public class BarrageStreamReader implements StreamReader {
 
                         numAddRowsRead = 0;
                         numModRowsRead = 0;
-                        lastAddStartIndex = 0;
-                        lastModStartIndex = 0;
 
                         if (msg.isSnapshot) {
                             final ByteBuffer effectiveViewport = metadata.effectiveViewportAsByteBuffer();
@@ -134,7 +130,9 @@ public class BarrageStreamReader implements StreamReader {
 
                             // create an initial chunk of the correct size
                             final int chunkSize = (int) (Math.min(msg.rowsIncluded.size(), MAX_CHUNK_SIZE));
-                            msg.addColumnData[ci].data.add(columnChunkTypes[ci].makeWritableChunk(chunkSize));
+                            final WritableChunk<Values> chunk = columnChunkTypes[ci].makeWritableChunk(chunkSize);
+                            chunk.setSize(0);
+                            msg.addColumnData[ci].data.add(chunk);
                         }
                         numAddRowsTotal = msg.rowsIncluded.size();
 
@@ -153,7 +151,9 @@ public class BarrageStreamReader implements StreamReader {
                             // create an initial chunk of the correct size
                             final int chunkSize = (int) (Math.min(msg.modColumnData[ci].rowsModified.size(),
                                     MAX_CHUNK_SIZE));
-                            msg.modColumnData[ci].data.add(columnChunkTypes[ci].makeWritableChunk(chunkSize));
+                            final WritableChunk<Values> chunk = columnChunkTypes[ci].makeWritableChunk(chunkSize);
+                            chunk.setSize(0);
+                            msg.modColumnData[ci].data.add(chunk);
 
                             numModRowsTotal = Math.max(numModRowsTotal, msg.modColumnData[ci].rowsModified.size());
                         }
@@ -215,7 +215,6 @@ public class BarrageStreamReader implements StreamReader {
                     // add and mod rows are never combined in a batch. all added rows must be received before the first
                     // mod rows will be received.
                     if (numAddRowsRead < numAddRowsTotal) {
-                        final long currentChunkFirstRowOffset = lastAddStartIndex;
                         for (int ci = 0; ci < msg.addColumnData.length; ++ci) {
                             final BarrageMessage.AddColumnData acd = msg.addColumnData[ci];
 
@@ -228,38 +227,26 @@ public class BarrageStreamReader implements StreamReader {
                             // select the current chunk size and read the size
                             int lastChunkIndex = acd.data.size() - 1;
                             WritableChunk<Values> chunk = (WritableChunk<Values>) acd.data.get(lastChunkIndex);
-                            int chunkSize = acd.data.get(lastChunkIndex).size();
 
-                            final int chunkOffset;
-                            long rowOffset = numAddRowsRead - currentChunkFirstRowOffset;
-                            // reading the rows from this batch might overflow the existing chunk
-                            if (rowOffset + batch.length() > chunkSize) {
-                                if (lastAddStartIndex == currentChunkFirstRowOffset) {
-                                    // we only want to increment this once per loop
-                                    lastAddStartIndex += chunkSize;
-                                }
-
-                                // create a new chunk before trying to write again
-                                chunkSize = (int) (Math.min(remaining, MAX_CHUNK_SIZE));
-
+                            if (batch.length() > chunk.capacity() - chunk.size()) {
+                                // reading the rows from this batch will overflow the existing chunk; create a new one
+                                final int chunkSize = (int) (Math.min(remaining, MAX_CHUNK_SIZE));
                                 chunk = columnChunkTypes[ci].makeWritableChunk(chunkSize);
                                 acd.data.add(chunk);
 
-                                chunkOffset = 0;
+                                chunk.setSize(0);
                                 ++lastChunkIndex;
-                            } else {
-                                chunkOffset = (int) rowOffset;
                             }
 
                             // fill the chunk with data and assign back into the array
                             acd.data.set(lastChunkIndex,
                                     ChunkInputStreamGenerator.extractChunkFromInputStream(options, columnChunkTypes[ci],
                                             columnTypes[ci], componentTypes[ci], fieldNodeIter, bufferInfoIter, ois,
-                                            chunk, chunkOffset, chunkSize));
+                                            chunk, chunk.size(), (int) batch.length()));
+                            chunk.setSize(chunk.size() + (int) batch.length());
                         }
                         numAddRowsRead += batch.length();
                     } else {
-                        final long currentChunkFirstRowOffset = lastModStartIndex;
                         for (int ci = 0; ci < msg.modColumnData.length; ++ci) {
                             final BarrageMessage.ModColumnData mcd = msg.modColumnData[ci];
 
@@ -268,34 +255,25 @@ public class BarrageStreamReader implements StreamReader {
                             // need to add the batch row data to the column chunks
                             int lastChunkIndex = mcd.data.size() - 1;
                             WritableChunk<Values> chunk = (WritableChunk<Values>) mcd.data.get(lastChunkIndex);
-                            int chunkSize = chunk.size();
 
-                            final int chunkOffset;
-                            long rowOffset = numModRowsRead - currentChunkFirstRowOffset;
-                            // this batch might overflow the chunk
                             final int numRowsToRead = LongSizedDataStructure.intSize("BarrageStreamReader",
                                     Math.min(remaining, batch.length()));
-                            if (rowOffset + numRowsToRead > chunkSize) {
-                                if (lastModStartIndex == currentChunkFirstRowOffset) {
-                                    // we only want to increment this once per loop
-                                    lastModStartIndex += chunkSize;
-                                }
-                                // create a new chunk before trying to write again
-                                chunkSize = (int) (Math.min(remaining, MAX_CHUNK_SIZE));
+                            if (numRowsToRead > chunk.capacity() - chunk.size()) {
+                                // reading the rows from this batch will overflow the existing chunk; create a new one
+                                final int chunkSize = (int) (Math.min(remaining, MAX_CHUNK_SIZE));
                                 chunk = columnChunkTypes[ci].makeWritableChunk(chunkSize);
                                 mcd.data.add(chunk);
 
-                                chunkOffset = 0;
+                                chunk.setSize(0);
                                 ++lastChunkIndex;
-                            } else {
-                                chunkOffset = (int) rowOffset;
                             }
 
                             // fill the chunk with data and assign back into the array
                             mcd.data.set(lastChunkIndex,
                                     ChunkInputStreamGenerator.extractChunkFromInputStream(options, columnChunkTypes[ci],
                                             columnTypes[ci], componentTypes[ci], fieldNodeIter, bufferInfoIter, ois,
-                                            chunk, chunkOffset, numRowsToRead));
+                                            chunk, chunk.size(), numRowsToRead));
+                            chunk.setSize(chunk.size() + numRowsToRead);
                         }
                         numModRowsRead += batch.length();
                     }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -370,7 +370,6 @@ public class BarrageUtil {
         }
     }
 
-
     private static void setConversionFactor(final ConvertedArrowSchema result, final int i, final int factor) {
         if (result.conversionFactors == null) {
             result.conversionFactors = new int[result.nCols];

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -21,6 +21,7 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.remote.ConstructSnapshot;
+import io.deephaven.engine.table.impl.sources.ReinterpretUtils;
 import io.deephaven.engine.table.impl.util.BarrageMessage;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
 import io.deephaven.extensions.barrage.BarragePerformanceLog;
@@ -350,7 +351,25 @@ public class BarrageUtil {
         public ConvertedArrowSchema(final int nCols) {
             this.nCols = nCols;
         }
+
+        public ChunkType[] computeWireChunkTypes() {
+            return tableDef.getColumnStream()
+                    .map(ColumnDefinition::getDataType)
+                    .map(ReinterpretUtils::maybeConvertToPrimitiveDataType)
+                    .map(ChunkType::fromElementType)
+                    .toArray(ChunkType[]::new);
+        }
+
+        public Class<?>[] computeWireTypes() {
+            return tableDef.getColumnStream().map(ColumnDefinition::getDataType).toArray(Class[]::new);
+        }
+
+        public Class<?>[] computeWireComponentTypes() {
+            return tableDef.getColumnStream()
+                    .map(ColumnDefinition::getComponentType).toArray(Class[]::new);
+        }
     }
+
 
     private static void setConversionFactor(final ConvertedArrowSchema result, final int i, final int factor) {
         if (result.conversionFactors == null) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -355,8 +355,7 @@ public class BarrageUtil {
         public ChunkType[] computeWireChunkTypes() {
             return tableDef.getColumnStream()
                     .map(ColumnDefinition::getDataType)
-                    .map(ReinterpretUtils::maybeConvertToPrimitiveDataType)
-                    .map(ChunkType::fromElementType)
+                    .map(ReinterpretUtils::maybeConvertToWritablePrimitiveChunkType)
                     .toArray(ChunkType[]::new);
         }
 

--- a/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
@@ -24,7 +24,7 @@ import static io.deephaven.client.impl.Authentication.AUTHORIZATION_HEADER;
  * <p>
  * As a {@link CallCredentials}, this sets the (previously attained) bearer token on requests.
  */
-final public class BearerHandler extends CallCredentials implements ClientInterceptor {
+public final class BearerHandler extends CallCredentials implements ClientInterceptor {
 
     // this is really about "authentication" not "authorization"
     public static final String BEARER_PREFIX = "Bearer ";

--- a/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
@@ -24,7 +24,7 @@ import static io.deephaven.client.impl.Authentication.AUTHORIZATION_HEADER;
  * <p>
  * As a {@link CallCredentials}, this sets the (previously attained) bearer token on requests.
  */
-final class BearerHandler extends CallCredentials implements ClientInterceptor {
+final public class BearerHandler extends CallCredentials implements ClientInterceptor {
 
     // this is really about "authentication" not "authorization"
     public static final String BEARER_PREFIX = "Bearer ";
@@ -48,7 +48,7 @@ final class BearerHandler extends CallCredentials implements ClientInterceptor {
     }
 
     // exposed for flight
-    void setBearerToken(String bearerToken) {
+    public void setBearerToken(String bearerToken) {
         String localBearerToken = this.bearerToken;
         // Only follow through with the volatile write if it's a different value.
         if (!Objects.equals(localBearerToken, bearerToken)) {

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageBlinkTableTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageBlinkTableTest.java
@@ -189,8 +189,8 @@ public class BarrageBlinkTableTest extends RefreshingTableTestCase {
                     .useDeephavenNulls(useDeephavenNulls)
                     .build();
             final BarrageDataMarshaller marshaller = new BarrageDataMarshaller(
-                    options, barrageTable.getWireChunkTypes(), barrageTable.getWireTypes(),
-                    barrageTable.getWireComponentTypes(),
+                    options, schema.computeWireChunkTypes(), schema.computeWireTypes(),
+                    schema.computeWireComponentTypes(),
                     new BarrageStreamReader(barrageTable.getDeserializationTmConsumer()));
             BarrageMessageRoundTripTest.DummyObserver dummyObserver =
                     new BarrageMessageRoundTripTest.DummyObserver(marshaller, commandQueue);

--- a/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -19,13 +19,17 @@ import io.deephaven.barrage.flatbuf.BarrageSnapshotRequest;
 import io.deephaven.barrage.flatbuf.ColumnConversionMode;
 import io.deephaven.base.clock.Clock;
 import io.deephaven.base.verify.Assert;
-import io.deephaven.client.impl.DaggerDeephavenFlightRoot;
-import io.deephaven.client.impl.Export;
-import io.deephaven.client.impl.FlightSession;
-import io.deephaven.client.impl.FlightSessionFactory;
+import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.LongChunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.client.impl.*;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.LivenessScopeStack;
+import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.sources.ReinterpretUtils;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.engine.table.impl.DataAccessHelpers;
 import io.deephaven.engine.util.AbstractScriptSession;
@@ -33,6 +37,7 @@ import io.deephaven.engine.util.NoLanguageDeephavenSession;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.engine.util.TableDiff;
 import io.deephaven.engine.util.TableTools;
+import io.deephaven.extensions.barrage.util.BarrageChunkAppendingMarshaller;
 import io.deephaven.extensions.barrage.util.BarrageUtil;
 import io.deephaven.io.logger.LogBuffer;
 import io.deephaven.io.logger.LogBufferGlobal;
@@ -54,15 +59,16 @@ import io.deephaven.server.test.TestAuthModule.FakeBearer;
 import io.deephaven.server.util.Scheduler;
 import io.deephaven.util.SafeCloseable;
 import io.deephaven.auth.AuthContext;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
-import io.grpc.ServerInterceptor;
-import io.grpc.Status;
+import io.grpc.*;
+import io.grpc.CallOptions;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.stub.ClientCalls;
 import org.apache.arrow.flight.*;
 import org.apache.arrow.flight.auth.ClientAuthHandler;
 import org.apache.arrow.flight.auth2.Auth2Constants;
 import org.apache.arrow.flight.grpc.CredentialCallOption;
 import org.apache.arrow.flight.impl.Flight;
+import org.apache.arrow.flight.impl.FlightServiceGrpc;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -82,16 +88,8 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 
 import static org.junit.Assert.*;
 
@@ -215,6 +213,8 @@ public abstract class FlightMessageRoundTripTest {
         LogBufferGlobal.setInstance(logBuffer);
 
         component = component();
+        // open execution context immediately so it can be used when resolving `scriptSession`
+        executionContext = component.executionContext().open();
 
         server = component.server();
         server.start();
@@ -222,7 +222,6 @@ public abstract class FlightMessageRoundTripTest {
 
         scriptSession = component.scriptSession();
         sessionService = component.sessionService();
-        executionContext = component.executionContext().open();
 
         serverLocation = Location.forGrpcInsecure("localhost", actualPort);
         currentSession = sessionService.newSession(new AuthContext.SuperUser());
@@ -243,7 +242,9 @@ public abstract class FlightMessageRoundTripTest {
 
         clientChannel = ManagedChannelBuilder.forTarget("localhost:" + actualPort)
                 .usePlaintext()
+                .intercept(new TestAuthClientInterceptor(currentSession.getExpiration().token.toString()))
                 .build();
+
         clientScheduler = Executors.newSingleThreadScheduledExecutor();
         FlightSessionFactory flightSessionFactory =
                 DaggerDeephavenFlightRoot.create().factoryBuilder()
@@ -253,6 +254,20 @@ public abstract class FlightMessageRoundTripTest {
                         .build();
 
         clientSession = flightSessionFactory.newFlightSession();
+    }
+
+    private static final class TestAuthClientInterceptor implements ClientInterceptor {
+        final BearerHandler callCredentials = new BearerHandler();
+
+        public TestAuthClientInterceptor(String bearerToken) {
+            callCredentials.setBearerToken(bearerToken);
+        }
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+                CallOptions callOptions, Channel next) {
+            return next.newCall(method, callOptions.withCallCredentials(callCredentials));
+        }
     }
 
     protected abstract TestComponent component();
@@ -983,5 +998,101 @@ public abstract class FlightMessageRoundTripTest {
         assertEquals(deephavenTable.getDefinition(), uploadedTable.getDefinition());
         assertEquals(0, (long) TableTools
                 .diffPair(deephavenTable, uploadedTable, 0, EnumSet.noneOf(TableDiff.DiffItems.class)).getSecond());
+    }
+
+
+    @Test
+    public void testBarrageMessageAppendingMarshaller() {
+        final int size = 100;
+        final Table source = TableTools.emptyTable(size).update("I = ii", "J = `str_` + i");
+        scriptSession.setVariable("test", source);
+
+        // fetch schema over flight
+        final SchemaResult schema = flightClient.getSchema(arrowFlightDescriptorForName("test"));
+        final BarrageUtil.ConvertedArrowSchema convertedSchema = BarrageUtil.convertArrowSchema(schema.getSchema());
+
+        // The wire chunk types are the chunk types that barrage will fill in.
+        final ChunkType[] wireChunkTypes = convertedSchema.tableDef.getColumnStream()
+                .map(ColumnDefinition::getDataType)
+                .map(ReinterpretUtils::maybeConvertToPrimitiveDataType)
+                .map(ChunkType::fromElementType)
+                .toArray(ChunkType[]::new);
+
+        // The wire types are the expected result types of each column.
+        final Class<?>[] wireTypes = convertedSchema.tableDef.getColumnStream()
+                .map(ColumnDefinition::getDataType).toArray(Class[]::new);
+        final Class<?>[] wireComponentTypes = convertedSchema.tableDef.getColumnStream()
+                .map(ColumnDefinition::getComponentType).toArray(Class[]::new);
+
+        // noinspection unchecked
+        final WritableChunk<Values>[] destChunks = Arrays.stream(wireChunkTypes)
+                .map(chunkType -> chunkType.makeWritableChunk(size)).toArray(WritableChunk[]::new);
+        // zero out the chunks as the marshaller will append to them.
+        Arrays.stream(destChunks).forEach(dest -> dest.setSize(0));
+
+        final MethodDescriptor<Flight.Ticket, Integer> methodDescriptor = getClientDoGetDescriptor(
+                wireChunkTypes, wireTypes, wireComponentTypes, destChunks);
+
+        final Ticket ticket = new Ticket("s/test".getBytes(StandardCharsets.UTF_8));
+        final Iterator<Integer> msgIter = ClientCalls.blockingServerStreamingCall(
+                clientChannel, methodDescriptor, CallOptions.DEFAULT,
+                Flight.Ticket.newBuilder().setTicket(ByteString.copyFrom(ticket.getBytes())).build());
+
+        long totalRows = 0;
+        while (msgIter.hasNext()) {
+            totalRows += msgIter.next();
+        }
+        Assert.eq(totalRows, "totalRows", size, "size");
+        final LongChunk<Values> col_i = destChunks[0].asLongChunk();
+        final ObjectChunk<String, Values> col_j = destChunks[1].asObjectChunk();
+        Assert.eq(col_i.size(), "col_i.size()", size, "size");
+        Assert.eq(col_j.size(), "col_j.size()", size, "size");
+        for (int i = 0; i < size; ++i) {
+            Assert.eq(col_i.get(i), "col_i.get(i)", i, "i");
+            Assert.equals(col_j.get(i), "col_j.get(i)", "str_" + i, "str_" + i);
+        }
+    }
+
+    private static final io.deephaven.extensions.barrage.BarrageSnapshotOptions DEFAULT_BARRAGE_OPTIONS =
+            io.deephaven.extensions.barrage.BarrageSnapshotOptions.builder().build();
+
+    /**
+     * Fetch the client side descriptor for a specific DoGet invocation.
+     *
+     * @param columnChunkTypes the chunk types per column
+     * @param columnTypes the class type per column
+     * @param componentTypes the component class type per column
+     * @param destChunks the destination chunks per column
+     * @return the client side method descriptor
+     */
+    private static MethodDescriptor<Flight.Ticket, Integer> getClientDoGetDescriptor(
+            final ChunkType[] columnChunkTypes,
+            final Class<?>[] columnTypes,
+            final Class<?>[] componentTypes,
+            final WritableChunk<Values>[] destChunks) {
+        return descriptorFor(
+                MethodDescriptor.MethodType.SERVER_STREAMING, FlightServiceGrpc.SERVICE_NAME, "DoGet",
+                ProtoUtils.marshaller(Flight.Ticket.getDefaultInstance()),
+                new BarrageChunkAppendingMarshaller(
+                        DEFAULT_BARRAGE_OPTIONS, columnChunkTypes, columnTypes, componentTypes, destChunks),
+                FlightServiceGrpc.getDoGetMethod());
+    }
+
+    private static <ReqT, RespT> MethodDescriptor<ReqT, RespT> descriptorFor(
+            final MethodDescriptor.MethodType methodType,
+            final String serviceName,
+            final String methodName,
+            final MethodDescriptor.Marshaller<ReqT> requestMarshaller,
+            final MethodDescriptor.Marshaller<RespT> responseMarshaller,
+            final MethodDescriptor<?, ?> descriptor) {
+
+        return MethodDescriptor.<ReqT, RespT>newBuilder()
+                .setType(methodType)
+                .setFullMethodName(MethodDescriptor.generateFullMethodName(serviceName, methodName))
+                .setSampledToLocalTracing(false)
+                .setRequestMarshaller(requestMarshaller)
+                .setResponseMarshaller(responseMarshaller)
+                .setSchemaDescriptor(descriptor.getSchemaDescriptor())
+                .build();
     }
 }


### PR DESCRIPTION
Also fixes #3905. 

I thought about the desire to append directly to a chunk and it greatly simplifies the code. The added test ensures data flows from flight server to destination chunks. After creating and saving that initial table, it relies on overriding gRPC and funneling it through the custom marshaller that appends to chunks.

It might be worth considering doing this for full blink table subscriptions and hand chunks to the update graph similar to the kafka impl.

Nightlies passed: https://github.com/nbauernfeind/deephaven-core/actions/runs/5217035053/