### PR TITLE
List java.time.Instant as the primary classname for datetime types

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
@@ -137,7 +137,7 @@ public enum JsDataHandler {
             addNode.apply(new Node(data.length, nullCount));
         }
     },
-    DATE_TIME(Type.Int, "datetime", "java.time.Instant", "java.time.ZonedDateTime") {
+    DATE_TIME(Type.Int, "java.time.Instant", "datetime", "java.time.ZonedDateTime") {
         // Ensures that the 'T' separator character is in the date time
         private String ensureSeparator(String s) {
             if (s.charAt(SEPARATOR_INDEX) == ' ') {


### PR DESCRIPTION
This ensures that the JS client will mark the column as java.time.Instant when uploading data to the server.

Fixes #3971