### PR TITLE
Set jvm_maxmem on init_jvm

### DIFF
--- a/.github/env/Linux/gradle.properties
+++ b/.github/env/Linux/gradle.properties
@@ -8,7 +8,7 @@
 
 org.gradle.parallel=false
 org.gradle.workers.max=1
-org.gradle.jvmargs=-Xmx6g
+org.gradle.jvmargs=-Xmx5g
 
 # Our CI JDKs should be pre-provisioned and invoked correctly,
 # we shouldn't rely on gradle for any of this logic.

--- a/py/jpy-integration/src/pythonToJava/python/java_debug.py
+++ b/py/jpy-integration/src/pythonToJava/python/java_debug.py
@@ -6,7 +6,7 @@ jpyutil.preload_jvm_dll()
 import jpy
 
 print(jpy.has_jvm())
-print(jpyutil.init_jvm())
+print(jpyutil.init_jvm(jvm_maxmem='256M'))
 print(jpy.has_jvm())
 
 System = jpy.get_type('java.lang.System')

--- a/py/jpy-integration/src/pythonToJava/python/test/test_jpy.py
+++ b/py/jpy-integration/src/pythonToJava/python/test/test_jpy.py
@@ -29,7 +29,7 @@ class TestJpy(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    jpyutil.init_jvm()
+    jpyutil.init_jvm(jvm_maxmem='512M')
 
   @classmethod
   def tearDownClass(cls):

--- a/py/server/test_helper/__init__.py
+++ b/py/server/test_helper/__init__.py
@@ -41,10 +41,6 @@ def start_jvm(jvm_props: Dict[str, str] = None):
             jvm_properties.update(jvm_props)
 
         jvm_options = {
-            '-XX:InitialRAMPercentage=25.0',
-            '-XX:MinRAMPercentage=70.0',
-            '-XX:MaxRAMPercentage=80.0',
-
             # Allow access to java.nio.Buffer fields
             '--add-opens=java.base/java.nio=ALL-UNNAMED',
 
@@ -59,6 +55,7 @@ def start_jvm(jvm_props: Dict[str, str] = None):
         # Start up the JVM
         jpy.VerboseExceptions.enabled = True
         jvm.init_jvm(
+            jvm_maxmem='1G',
             jvm_classpath=_expand_wildcards_in_list(jvm_classpath.split(os.path.pathsep)),
             jvm_properties=jvm_properties,
             jvm_options=jvm_options

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -96,6 +96,7 @@ jvm_options = {
 
 from deephaven_internal import jvm
 jvm.init_jvm(
+    jvm_maxmem='1G',
     jvm_classpath=glob(os.environ.get('DEEPHAVEN_CLASSPATH')),
     jvm_properties=jvm_properties,
     jvm_options=jvm_options,


### PR DESCRIPTION
I suspect we are occasionally running into cases where GHA CI will hard-kill our jobs for going over memory limits.

In essence, the infrastructure we are currently running on has 7GB RAM and we are saying:

* Gradle can have 6GB
* `Integrations:test-py-deephavenRun` can have 80% of 7GB (~5.6GB)

Assuming nightlies pass, I think we can get away w/ Gradle at 5GB (for normal / local development purposes, we have `org.gradle.jvmargs=-Xms1g -Xmx3g`, see gradle.properties), and explicitly set the python integration tests at 1GB.
