### PR TITLE
Move globals scan and exec context scope to Server constructor

### DIFF
--- a/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
+++ b/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
@@ -100,17 +100,17 @@ public class EmbeddedServer {
                 .withErr(null)
                 .build()
                 .injectFields(this);
+
+        checkGlobals(scriptSession.get(), null);
+
+        // We need to open the systemic execution context to permanently install the contexts for this thread.
+        scriptSession.get().getExecutionContext().open();
     }
 
     public void start() throws Exception {
         server.run();
 
-        final ScriptSession scriptSession = this.scriptSession.get();
-        checkGlobals(scriptSession, null);
-        Bootstrap.printf("Server started on port %d%n", server.server().getPort());
-
-        // We need to open the systemic execution context to permanently install the contexts for this thread.
-        scriptSession.getExecutionContext().open();
+        Bootstrap.printf("Server started on port %d%n", getPort());
     }
 
     private void checkGlobals(ScriptSession scriptSession, @Nullable ScriptSession.SnapshotScope lastSnapshot) {


### PR DESCRIPTION
This makes it possible to use the deephaven_server.Server without calling start() - no http server will have started, but the engine is entirely usable from the main python thread. Then, if start() is later called, any tables created will be correctly exposed.

Fixes a regression from #2539.

Partial #3765