### PR TITLE
Improve the release process to better handle PyPi upload failures

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -63,14 +63,15 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingRequired: true
 
-      - name: Upload Applications
+      - name: Upload Artifacts
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         uses: actions/upload-artifact@v3
         with:
-          name: applications
+          name: artifacts
           path: |
             server/jetty-app/build/distributions/
-            server/netty-app/build/distributions/
+            py/server/build/wheel/
+            py/embedded-server/build/wheel/
 
       - name: Publish deephaven-core to PyPi
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -125,17 +125,19 @@ The specific action can be found based off of the name of the release branch: [?
 
 The "Publish" step creates the artifacts and publishes the jars to a [Maven Central staging repository](https://s01.oss.sonatype.org).
 
-The "Upload Applications" step uploads the Deephahven server application as a *temporary* GitHub action artifact.
+The "Upload Artifacts" step uploads the Deephaven server application, the deephaven-core wheel, and the deephaven-server wheel as *temporary* GitHub action artifacts.
 
 The "Publish deephaven-core to PyPi" uploads the deephaven-core wheel to [PyPi](https://pypi.org/project/deephaven-core/).
+If this step fails, the deephaven-core wheel from the "Upload Artifacts" step can be uploaded manually.
 
 The "Publish deephaven-server to PyPi" uploads the deephaven-server wheel to [PyPi](https://pypi.org/project/deephaven-server/).
+If this step fails, the deephaven-server wheel from the "Upload Artifacts" step can be uploaded manually.
 
 Once the workflow job is done, ensure all publication sources have the new artifacts.
 
 ### 5. Download artifacts
 
-Once the full publish-ci.yml worflow is done, the Deephaven server application artifact can be downloaded from the GitHub Artifacts (located in the "Summary" tab of the action), and the deephaven-core wheel can be downloaded from PyPi.
+Once the full publish-ci.yml worflow is done, the release artifacts can be downloaded from the GitHub Artifacts (located in the "Summary" tab of the action).
 These are currently manual steps taken from the browser.
 
 There is potential in the future for QA-ing these artifacts above and beyond the integration testing that CI provides, as the release is not set in stone yet.


### PR DESCRIPTION
This adds the deephaven-core and deephaven-server wheel as a GH artifact, and removes the netty artifacts (as we mainly just build netty to make sure it still builds, but we don't use the output otherwise).