### PR TITLE
Bump protobuf-java to 3.23.0

### DIFF
--- a/buildSrc/src/main/groovy/Classpaths.groovy
+++ b/buildSrc/src/main/groovy/Classpaths.groovy
@@ -101,7 +101,7 @@ class Classpaths {
     // TODO(deephaven-core#1685): Create strategy around updating and maintaining protoc version
     static final String PROTOBUF_GROUP = 'com.google.protobuf'
     static final String PROTOBUF_NAME = 'protobuf-java'
-    static final String PROTOBUF_VERSION = '3.21.9'
+    static final String PROTOBUF_VERSION = '3.23.0'
 
     // See dependency matrix for particular gRPC versions at https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
     static final String BORINGSSL_GROUP = 'io.netty'


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-3171
https://nvd.nist.gov/vuln/detail/CVE-2022-3509
https://nvd.nist.gov/vuln/detail/CVE-2022-3510

This might not be sufficient to take care of the CVEs above - it is probably more important to update the compilation protoc versions, which comes from protoc-base image, https://github.com/deephaven/deephaven-base-images/pull/62