### PR TITLE
Better handling for uncommon/exception gRPC cases

### DIFF
--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
@@ -225,7 +225,12 @@ final class ServletServerStream extends AbstractServerStream {
         @Override
         public void writeHeaders(Metadata headers) {
             writeHeadersToServletResponse(headers);
-            resp.setTrailerFields(trailerSupplier);
+            try {
+                resp.setTrailerFields(trailerSupplier);
+            } catch (IllegalStateException e) {
+                logger.log(WARNING, String.format("[{%s}] Exception writing trailers", logId), e);
+                cancel(Status.fromThrowable(e));
+            }
             try {
                 writer.flush();
             } catch (IOException e) {

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebFilter.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebFilter.java
@@ -1,37 +1,23 @@
 package io.grpc.servlet.jakarta.web;
 
 import io.grpc.internal.GrpcUtil;
-import jakarta.servlet.AsyncContext;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpServletResponseWrapper;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 /**
  * Servlet filter that translates grpc-web on the fly to match what is expected by GrpcServlet. This work is done
  * in-process with no addition copies to the request or response data - only the content type header and the trailer
  * content is specially treated at this time.
- *
+ * <p>
  * Note that grpc-web-text is not yet supported.
  */
 public class GrpcWebFilter extends HttpFilter {
-    private static final Logger logger = Logger.getLogger(GrpcWebFilter.class.getName());
-
     public static final String CONTENT_TYPE_GRPC_WEB = GrpcUtil.CONTENT_TYPE_GRPC + "-web";
 
     @Override
@@ -39,84 +25,8 @@ public class GrpcWebFilter extends HttpFilter {
             throws IOException, ServletException {
         if (isGrpcWeb(request)) {
             // wrap the request and response to paper over the grpc-web details
-            GrpcWebHttpResponse wrappedResponse = new GrpcWebHttpResponse(response);
-            HttpServletRequestWrapper wrappedRequest = new HttpServletRequestWrapper(request) {
-                @Override
-                public String getContentType() {
-                    // Adapt the content-type to replace grpc-web with grpc
-                    return super.getContentType().replaceFirst(Pattern.quote(CONTENT_TYPE_GRPC_WEB),
-                            GrpcUtil.CONTENT_TYPE_GRPC);
-                }
-
-                @Override
-                public AsyncContext startAsync() throws IllegalStateException {
-                    return startAsync(this, wrappedResponse);
-                }
-
-                @Override
-                public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
-                        throws IllegalStateException {
-                    AsyncContext delegate = super.startAsync(servletRequest, servletResponse);
-                    return new DelegatingAsyncContext(delegate) {
-                        @Override
-                        public void complete() {
-                            // Write any trailers out to the output stream as a payload, since grpc-web doesn't
-                            // use proper trailers.
-                            try {
-                                if (wrappedResponse.trailers != null) {
-                                    Map<String, String> map = wrappedResponse.trailers.get();
-                                    if (map != null) {
-                                        // write a payload, even for an empty set of trailers, but not for
-                                        // the absence of trailers.
-                                        int trailerLength = map.entrySet().stream()
-                                                .mapToInt(e -> e.getKey().length() + e.getValue().length() + 4).sum();
-                                        ByteBuffer payload = ByteBuffer.allocate(5 + trailerLength);
-                                        payload.put((byte) 0x80);
-                                        payload.putInt(trailerLength);
-                                        for (Map.Entry<String, String> entry : map.entrySet()) {
-                                            payload.put(entry.getKey().getBytes(StandardCharsets.US_ASCII));
-                                            payload.put((byte) ':');
-                                            payload.put((byte) ' ');
-                                            payload.put(entry.getValue().getBytes(StandardCharsets.US_ASCII));
-                                            payload.put((byte) '\r');
-                                            payload.put((byte) '\n');
-                                        }
-                                        if (payload.hasRemaining()) {
-                                            // Normally we must not throw, but this is an exceptional case. Complete
-                                            // the stream, _then_ throw.
-                                            super.complete();
-                                            throw new IllegalStateException(
-                                                    "Incorrectly sized buffer, trailer payload will be sized wrong");
-                                        }
-                                        ServletOutputStream outputStream = wrappedResponse.getOutputStream();
-
-                                        // Guard for async cases
-                                        // TODO handle "unready" cases
-                                        if (outputStream.isReady()) {
-                                            outputStream.write(payload.array());
-                                        }
-                                    }
-                                }
-                            } catch (IOException e) {
-                                // complete() should not throw, but instead just log the error. In this case,
-                                // the connection has likely been lost, so there is no way to send the trailers,
-                                // so we just let the exception slide.
-                                logger.log(Level.FINE, "Error sending grpc-web trailers", e);
-                            }
-
-                            try {
-                                // Let the superclass complete the stream so we formally close it
-                                super.complete();
-                            } catch (Exception e) {
-                                // As above, complete() should not throw, so just log this failure and continue.
-                                // This statement is somewhat dubious, since Jetty itself is clearly throwing in
-                                // complete()... leading us to add this try/catch to begin with.
-                                logger.log(Level.FINE, "Error invoking complete() on underlying stream", e);
-                            }
-                        }
-                    };
-                }
-            };
+            GrpcWebServletResponse wrappedResponse = new GrpcWebServletResponse(response);
+            GrpcWebServletRequest wrappedRequest = new GrpcWebServletRequest(request, wrappedResponse);
 
             chain.doFilter(wrappedRequest, wrappedResponse);
         } else {
@@ -126,31 +36,5 @@ public class GrpcWebFilter extends HttpFilter {
 
     private static boolean isGrpcWeb(ServletRequest request) {
         return request.getContentType() != null && request.getContentType().startsWith(CONTENT_TYPE_GRPC_WEB);
-    }
-
-    private static class GrpcWebHttpResponse extends HttpServletResponseWrapper {
-        private Supplier<Map<String, String>> trailers;
-
-        public GrpcWebHttpResponse(HttpServletResponse response) {
-            super(response);
-        }
-
-        @Override
-        public void setContentType(String type) {
-            // Adapt the content-type to be grpc-web
-            super.setContentType(
-                    type.replaceFirst(Pattern.quote(GrpcUtil.CONTENT_TYPE_GRPC), CONTENT_TYPE_GRPC_WEB));
-        }
-
-        // intercept trailers and write them out as a message just before we complete
-        @Override
-        public void setTrailerFields(Supplier<Map<String, String>> supplier) {
-            trailers = supplier;
-        }
-
-        @Override
-        public Supplier<Map<String, String>> getTrailerFields() {
-            return trailers;
-        }
     }
 }

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebOutputStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebOutputStream.java
@@ -92,6 +92,7 @@ public class GrpcWebOutputStream extends ServletOutputStream implements WriteLis
         }
         if (waiting != null) {
             waiting.run();
+            waiting = null;
         }
     }
 

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebOutputStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebOutputStream.java
@@ -31,13 +31,15 @@ public class GrpcWebOutputStream extends ServletOutputStream implements WriteLis
      * @param bytes the bytes to write once writing is possible
      * @param close a Runnable to invoke once this write is complete
      */
-    public synchronized void writeAndCloseWhenReady(byte[] bytes, Runnable close) throws IOException {
+    public synchronized void writeAndCloseWhenReady(byte[] bytes, Runnable close) {
         if (writeListener == null) {
             throw new IllegalStateException("writeListener");
         }
         if (isReady()) {
             try {
                 write(bytes);
+            } catch (IOException ignored) {
+                // Ignore this error, we're closing anyway
             } finally {
                 close.run();
             }

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebOutputStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebOutputStream.java
@@ -1,0 +1,104 @@
+package io.grpc.servlet.jakarta.web;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+
+import java.io.IOException;
+
+/**
+ * Wraps the usual ServletOutputStream so as to allow downstream writers to use it according to the servlet spec, but
+ * still make it easy to write trailers as a payload instead of using HTTP trailers at the end of a stream.
+ */
+public class GrpcWebOutputStream extends ServletOutputStream implements WriteListener {
+    private final ServletOutputStream wrapped;
+
+    // Access to these are guarded by synchronized
+    private Runnable waiting;
+    private WriteListener writeListener;
+
+    public GrpcWebOutputStream(ServletOutputStream wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public boolean isReady() {
+        return wrapped.isReady();
+    }
+
+    /**
+     * Internal helper method to correctly write the given bytes, then complete the stream.
+     *
+     * @param bytes the bytes to write once writing is possible
+     * @param close a Runnable to invoke once this write is complete
+     */
+    public synchronized void writeAndCloseWhenReady(byte[] bytes, Runnable close) throws IOException {
+        if (writeListener == null) {
+            throw new IllegalStateException("writeListener");
+        }
+        if (isReady()) {
+            try {
+                write(bytes);
+            } finally {
+                close.run();
+            }
+        } else {
+            waiting = () -> {
+                try {
+                    write(bytes);
+                } catch (IOException e) {
+                    // ignore this, we're closing anyway
+                } finally {
+                    close.run();
+                }
+            };
+        }
+    }
+
+    @Override
+    public synchronized void setWriteListener(WriteListener writeListener) {
+        this.writeListener = writeListener;
+        wrapped.setWriteListener(this);
+    }
+
+    @Override
+    public void write(int i) throws IOException {
+        wrapped.write(i);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        wrapped.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        wrapped.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        wrapped.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        wrapped.close();
+    }
+
+    @Override
+    public synchronized void onWritePossible() throws IOException {
+        if (writeListener != null) {
+            writeListener.onWritePossible();
+        }
+        if (waiting != null) {
+            waiting.run();
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        if (writeListener != null) {
+            writeListener.onError(t);
+        }
+    }
+}

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletRequest.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletRequest.java
@@ -1,0 +1,70 @@
+package io.grpc.servlet.jakarta.web;
+
+import io.grpc.internal.GrpcUtil;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * Wraps an incoming gRPC-web request so that a downstream filter/servlet can read it instead as a gRPC payload. This
+ * currently involves changing the incoming content-type, and managing the wrapped request so that downstream operations
+ * to handle this request behave correctly.
+ */
+public class GrpcWebServletRequest extends HttpServletRequestWrapper {
+    private static final Logger logger = Logger.getLogger(GrpcWebServletRequest.class.getName());
+
+    private final GrpcWebServletResponse wrappedResponse;
+
+    public GrpcWebServletRequest(HttpServletRequest request, GrpcWebServletResponse wrappedResponse) {
+        super(request);
+        this.wrappedResponse = wrappedResponse;
+    }
+
+    @Override
+    public String getContentType() {
+        // Adapt the content-type to replace grpc-web with grpc
+        return super.getContentType().replaceFirst(Pattern.quote(GrpcWebFilter.CONTENT_TYPE_GRPC_WEB),
+                GrpcUtil.CONTENT_TYPE_GRPC);
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return startAsync(this, wrappedResponse);
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+            throws IllegalStateException {
+        AsyncContext delegate = super.startAsync(servletRequest, servletResponse);
+        return new DelegatingAsyncContext(delegate) {
+            private void safelyComplete() {
+                try {
+                    // Let the superclass complete the stream so we formally close it
+                    super.complete();
+                } catch (Exception e) {
+                    // As above, complete() should not throw, so just log this failure and continue.
+                    // This statement is somewhat dubious, since Jetty itself is clearly throwing in
+                    // complete()... leading us to add this try/catch to begin with.
+                    logger.log(Level.FINE, "Error invoking complete() on underlying stream", e);
+                }
+
+            }
+
+            @Override
+            public void complete() {
+                // Emit trailers as part of the response body, then complete the request. Note that this may mean
+                // that we don't actually call super.complete() synchronously.
+                wrappedResponse.writeTrailers(this::safelyComplete);
+            }
+        };
+    }
+}

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletResponse.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletResponse.java
@@ -1,0 +1,116 @@
+package io.grpc.servlet.jakarta.web;
+
+import io.grpc.internal.GrpcUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+/**
+ * Wraps the outgoing gRPC-web response in a way that lets the gRPC servlet/filter write normal gRPC payloads to it, and
+ * let them be translated to gRPC-web. Presently, this only means changing the content-type, and writing trailers as a
+ * streamed response.
+ */
+public class GrpcWebServletResponse extends HttpServletResponseWrapper {
+    private Supplier<Map<String, String>> trailers;
+    private GrpcWebOutputStream outputStream;
+
+    public GrpcWebServletResponse(HttpServletResponse response) {
+        super(response);
+    }
+
+    @Override
+    public void setContentType(String type) {
+        // Adapt the content-type to be grpc-web
+        super.setContentType(
+                type.replaceFirst(Pattern.quote(GrpcUtil.CONTENT_TYPE_GRPC), GrpcWebFilter.CONTENT_TYPE_GRPC_WEB));
+    }
+
+    @Override
+    public void setTrailerFields(Supplier<Map<String, String>> supplier) {
+        // intercept trailers and write them out as a message just before we complete
+        trailers = supplier;
+    }
+
+    @Override
+    public Supplier<Map<String, String>> getTrailerFields() {
+        return trailers;
+    }
+
+    @Override
+    public synchronized GrpcWebOutputStream getOutputStream() throws IOException {
+        if (outputStream == null) {
+            // Provide our own output stream instance, so we can control/monitor the write listener
+            outputStream = new GrpcWebOutputStream(super.getOutputStream());
+        }
+        return outputStream;
+    }
+
+    @Override
+    public PrintWriter getWriter() {
+        // As the GrpcAdapter will only use the getOutputStream method, we will always throw if this is used
+        throw new UnsupportedOperationException("getWriter()");
+    }
+
+    public void writeTrailers(Runnable safelyComplete) {
+        if (outputStream == null) {
+            throw new IllegalStateException("outputStream");
+        }
+        if (trailers != null) {
+            Map<String, String> map = trailers.get();
+            if (map != null) {
+                // Write any trailers out to the output stream as a payload, since grpc-web doesn't
+                // use proper trailers.
+                ByteBuffer payload = createTrailerPayload(map);
+
+                if (payload.hasRemaining()) {
+                    // Normally we must not throw, but this is an exceptional case. Complete the stream, _then_ throw
+                    safelyComplete.run();
+                    throw new IllegalStateException("Incorrectly sized buffer, trailer payload will be sized wrong");
+                }
+
+                // Write the payload to the wire, then complete the stream. This may complete asynchronously, so we
+                // won't call super.complete() here.
+                try {
+                    outputStream.writeAndCloseWhenReady(payload.array(), safelyComplete);
+                } catch (IOException e) {
+                    safelyComplete.run();
+                }
+
+                // return now, we'll manage calling super.complete() in the lambda above
+                return;
+            }
+        }
+
+        // If the map was empty or absent, we wrote nothing, so call super.complete(). This is likely an error from the
+        // client's perspective, but we don't have anything more to tell them.
+        safelyComplete.run();
+    }
+
+    private ByteBuffer createTrailerPayload(Map<String, String> trailers) {
+        // write a payload, even for an empty set of trailers, but not for
+        // the absence of trailers.
+        int trailerLength = trailers.entrySet().stream()
+                .mapToInt(e -> e.getKey().length() + e.getValue().length() + 4).sum();
+        ByteBuffer payload = ByteBuffer.allocate(5 + trailerLength);
+        payload.put((byte) 0x80);
+        payload.putInt(trailerLength);
+        for (Map.Entry<String, String> entry : trailers.entrySet()) {
+            payload.put(entry.getKey().getBytes(StandardCharsets.US_ASCII));
+            payload.put((byte) ':');
+            payload.put((byte) ' ');
+            payload.put(entry.getValue().getBytes(StandardCharsets.US_ASCII));
+            payload.put((byte) '\r');
+            payload.put((byte) '\n');
+        }
+        return payload;
+    }
+
+
+}

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletResponse.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletResponse.java
@@ -77,13 +77,7 @@ public class GrpcWebServletResponse extends HttpServletResponseWrapper {
 
                 // Write the payload to the wire, then complete the stream. This may complete asynchronously, so we
                 // won't call super.complete() here.
-                try {
-                    outputStream.writeAndCloseWhenReady(payload.array(), safelyComplete);
-                } catch (IOException e) {
-                    safelyComplete.run();
-                }
-
-                // return now, we'll manage calling super.complete() in the lambda above
+                outputStream.writeAndCloseWhenReady(payload.array(), safelyComplete);
                 return;
             }
         }


### PR DESCRIPTION
Fixes three logged errors. Two are handed by not permitting an error to be thrown into gRPC internals, but instead catch, cancel the stream, and log the error. The third case is handled by following the appropriate async write pattern required by servlets. 

Fixes #3965 
Fixes #3052