### PR TITLE
Rename Table to ClientTable and move to different namespace, in order to reduce terminology confusion.

### DIFF
--- a/cpp-client/deephaven/client/include/private/deephaven/client/impl/table_handle_impl.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/impl/table_handle_impl.h
@@ -10,7 +10,7 @@
 #include "deephaven/client/server/server.h"
 #include "deephaven/client/subscription/subscription_handle.h"
 #include "deephaven/client/utility/executor.h"
-#include "deephaven/dhcore/table/schema.h"
+#include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/callbacks.h"
@@ -66,7 +66,7 @@ private:
 };
 
 class LazyState final {
-  typedef deephaven::dhcore::table::Schema Schema;
+  typedef deephaven::dhcore::clienttable::Schema Schema;
   typedef io::deephaven::proto::backplane::grpc::ExportedTableCreationResponse ExportedTableCreationResponse;
   typedef io::deephaven::proto::backplane::grpc::Ticket Ticket;
   typedef deephaven::client::server::Server Server;

--- a/cpp-client/deephaven/client/include/private/deephaven/client/subscription/subscribe_thread.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/subscription/subscribe_thread.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include "deephaven/client/server/server.h"
 #include "deephaven/client/subscription/subscription_handle.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 #include "deephaven/proto/ticket.pb.h"
 
@@ -13,7 +14,7 @@ namespace deephaven::client::subscription {
 class SubscriptionThread {
   typedef deephaven::client::server::Server Server;
   typedef deephaven::client::utility::Executor Executor;
-  typedef deephaven::dhcore::table::Schema Schema;
+  typedef deephaven::dhcore::clienttable::Schema Schema;
   typedef io::deephaven::proto::backplane::grpc::Ticket Ticket;
   typedef deephaven::dhcore::ticking::TickingCallback TickingCallback;
 

--- a/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/table_handle_impl.cc
@@ -23,8 +23,8 @@
 #include "deephaven/client/subscription/subscription_handle.h"
 #include "deephaven/client/utility/arrow_util.h"
 #include "deephaven/dhcore/chunk/chunk_maker.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
 #include "deephaven/dhcore/container/row_sequence.h"
-#include "deephaven/dhcore/table/table.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 #include "deephaven/dhcore/utility/callbacks.h"
 #include "deephaven/dhcore/utility/utility.h"
@@ -54,8 +54,8 @@ using deephaven::dhcore::container::RowSequence;
 using deephaven::dhcore::container::RowSequenceBuilder;
 using deephaven::dhcore::container::RowSequenceIterator;
 using deephaven::dhcore::ElementTypeId;
-using deephaven::dhcore::table::Schema;
-using deephaven::dhcore::table::Table;
+using deephaven::dhcore::clienttable::Schema;
+using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::ticking::TickingCallback;
 using deephaven::dhcore::ticking::TickingUpdate;
 using deephaven::dhcore::utility::Callback;

--- a/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
@@ -16,7 +16,7 @@
 
 using deephaven::dhcore::column::ColumnSource;
 using deephaven::dhcore::chunk::AnyChunk;
-using deephaven::dhcore::table::Schema;
+using deephaven::dhcore::clienttable::Schema;
 using deephaven::dhcore::ticking::BarrageProcessor;
 using deephaven::dhcore::ticking::TickingCallback;
 using deephaven::dhcore::utility::Callback;

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -12,6 +12,8 @@ set(ALL_FILES
     src/types.cc
     src/chunk/chunk.cc
     src/chunk/chunk_maker.cc
+    src/clienttable/schema.cc
+    src/clienttable/client_table.cc
     src/column/array_column_source.cc
     src/column/column_source.cc
     src/column/column_source_helpers.cc
@@ -19,8 +21,6 @@ set(ALL_FILES
     src/container/row_sequence.cc
     src/immerutil/abstract_flex_vector.cc
     src/immerutil/immer_column_source.cc
-    src/table/schema.cc
-    src/table/table.cc
     src/ticking/barrage_processor.cc
     src/ticking/immer_table_state.cc
     src/ticking/index_decoder.cc
@@ -40,14 +40,14 @@ set(ALL_FILES
     include/public/deephaven/dhcore/chunk/chunk.h
     include/public/deephaven/dhcore/chunk/chunk_maker.h
     include/public/deephaven/dhcore/chunk/chunk_traits.h
+    include/public/deephaven/dhcore/clienttable/schema.h
+    include/public/deephaven/dhcore/clienttable/client_table.h
     include/public/deephaven/dhcore/column/array_column_source.h
     include/public/deephaven/dhcore/column/buffer_column_source.h
     include/public/deephaven/dhcore/column/column_source.h
     include/public/deephaven/dhcore/column/column_source_helpers.h
     include/public/deephaven/dhcore/column/column_source_utils.h
     include/public/deephaven/dhcore/container/row_sequence.h
-    include/public/deephaven/dhcore/table/schema.h
-    include/public/deephaven/dhcore/table/table.h
     include/public/deephaven/dhcore/ticking/barrage_processor.h
     include/public/deephaven/dhcore/ticking/ticking.h
     include/public/deephaven/dhcore/utility/callbacks.h

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/immer_table_state.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/immer_table_state.h
@@ -7,7 +7,7 @@
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/immerutil/abstract_flex_vector.h"
-#include "deephaven/dhcore/table/table.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
 #include "deephaven/dhcore/ticking/space_mapper.h"
 
 namespace deephaven::dhcore::ticking {
@@ -17,8 +17,8 @@ class ImmerTableState final {
   typedef deephaven::dhcore::column::ColumnSource ColumnSource;
   typedef deephaven::dhcore::container::RowSequence RowSequence;
   typedef deephaven::dhcore::immerutil::AbstractFlexVectorBase AbstractFlexVectorBase;
-  typedef deephaven::dhcore::table::Schema Schema;
-  typedef deephaven::dhcore::table::Table Table;
+  typedef deephaven::dhcore::clienttable::ClientTable ClientTable;
+  typedef deephaven::dhcore::clienttable::Schema Schema;
 
 public:
   explicit ImmerTableState(std::shared_ptr<Schema> schema);
@@ -55,7 +55,7 @@ public:
   void applyShifts(const RowSequence &startIndex, const RowSequence &endIndex,
       const RowSequence &destIndex);
 
-  std::shared_ptr<Table> snapshot() const;
+  std::shared_ptr<ClientTable> snapshot() const;
 
 private:
   std::shared_ptr<Schema> schema_;

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
@@ -10,7 +10,7 @@
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 
-namespace deephaven::dhcore::table {
+namespace deephaven::dhcore::clienttable {
 /**
  * Declaration provided in deephaven/dhcore/schema/schema.h
  */
@@ -18,13 +18,13 @@ class Schema;
 /**
  * Forward declaration (provided below).
  */
-class Table;
+class ClientTable;
 
 namespace internal {
 class TableStreamAdaptor {
   typedef deephaven::dhcore::container::RowSequence RowSequence;
 public:
-  TableStreamAdaptor(const Table &table,
+  TableStreamAdaptor(const ClientTable &table,
       std::vector<std::shared_ptr<RowSequence>> rowSequences, bool wantHeaders, bool wantRowNumbers,
       bool highlightCells) : table_(table), rowSequences_(std::move(rowSequences)),
       wantHeaders_(wantHeaders), wantRowNumbers_(wantRowNumbers), highlightCells_(highlightCells) {}
@@ -33,7 +33,7 @@ public:
   ~TableStreamAdaptor() = default;
 
 private:
-  const Table &table_;
+  const ClientTable &table_;
   std::vector<std::shared_ptr<RowSequence>> rowSequences_;
   bool wantHeaders_ = false;
   bool wantRowNumbers_ = false;
@@ -44,10 +44,10 @@ private:
 }  // namespace internal
 
 /**
- * An abstract base class representing a Deephaven table. This is used for example in
- * TickingUpdate to provide table snapshots to a caller who has subscribed to ticking tables.
+ * An abstract base class representing a Deephaven clienttable. This is used for example in
+ * TickingUpdate to provide clienttable snapshots to a caller who has subscribed to ticking tables.
  */
-class Table {
+class ClientTable {
 public:
   /**
    * Alias.
@@ -61,24 +61,24 @@ public:
   /**
    * Constructor.
    */
-  Table() = default;
+  ClientTable() = default;
   /**
    * Destructor.
    */
-  virtual ~Table() = default;
+  virtual ~ClientTable() = default;
 
   /**
    * Get the RowSequence (in position space) that underlies this Table.
    */
   virtual std::shared_ptr<RowSequence> getRowSequence() const = 0;
   /**
-   * Gets a ColumnSource from the table by index.
+   * Gets a ColumnSource from the clienttable by index.
    * @param columnIndex Must be in the half-open interval [0, numColumns).
    */
   virtual std::shared_ptr<ColumnSource> getColumn(size_t columnIndex) const = 0;
 
   /**
-   * Gets a ColumnSource from the table by name. 'strict' controls whether the method
+   * Gets a ColumnSource from the clienttable by name. 'strict' controls whether the method
    * must succeed.
    * @param name The name of the column.
    * @param strict Whether the method must succeed.
@@ -87,7 +87,7 @@ public:
    */
   std::shared_ptr<ColumnSource> getColumn(std::string_view name, bool strict) const;
   /**
-   * Gets the index of a ColumnSource from the table by name. 'strict' controls whether the method
+   * Gets the index of a ColumnSource from the clienttable by name. 'strict' controls whether the method
    * must succeed.
    * @param name The name of the column.
    * @param strict Whether the method must succeed.
@@ -98,33 +98,33 @@ public:
   std::optional<size_t> getColumnIndex(std::string_view name, bool strict) const;
 
   /**
-   * Number of rows in the table.
+   * Number of rows in the clienttable.
    */
   virtual size_t numRows() const = 0;
   /**
-   * Number of columns in the table.
+   * Number of columns in the clienttable.
    */
   virtual size_t numColumns() const = 0;
   /**
-   * The table schema.
+   * The clienttable schema.
    */
   virtual std::shared_ptr<Schema> schema() const = 0;
 
   /**
-   * Creates an 'ostream adaptor' to use when printing the table. Example usage:
+   * Creates an 'ostream adaptor' to use when printing the clienttable. Example usage:
    * std::cout << myTable.stream(true, false).
    */
   internal::TableStreamAdaptor stream(bool wantHeaders, bool wantRowNumbers) const;
 
   /**
-   * Creates an 'ostream adaptor' to use when printing the table. Example usage:
+   * Creates an 'ostream adaptor' to use when printing the clienttable. Example usage:
    * std::cout << myTable.stream(true, false, rowSeq).
    */
   internal::TableStreamAdaptor stream(bool wantHeaders, bool wantRowNumbers,
       std::shared_ptr<RowSequence> rowSequence) const;
 
   /**
-   * Creates an 'ostream adaptor' to use when printing the table. Example usage:
+   * Creates an 'ostream adaptor' to use when printing the clienttable. Example usage:
    * std::cout << myTable.stream(true, false, rowSequences).
    */
   internal::TableStreamAdaptor stream(bool wantHeaders, bool wantRowNumbers,
@@ -147,4 +147,4 @@ public:
   std::string toString(bool wantHeaders, bool wantRowNumbers,
       std::vector<std::shared_ptr<RowSequence>> rowSequences) const;
 };
-}  // namespace deephaven::dhcore::table
+}  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
@@ -44,8 +44,8 @@ private:
 }  // namespace internal
 
 /**
- * An abstract base class representing a Deephaven clienttable. This is used for example in
- * TickingUpdate to provide clienttable snapshots to a caller who has subscribed to ticking tables.
+ * An abstract base class representing a Deephaven table. This is used for example in
+ * TickingUpdate to provide table snapshots to a caller who has subscribed to ticking tables.
  */
 class ClientTable {
 public:

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
@@ -11,10 +11,10 @@
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 
-namespace deephaven::dhcore::table {
+namespace deephaven::dhcore::clienttable {
 /**
- * The table schema that goes along with a Table class. This Schema object tells you about
- * the names and data types of the table columns.
+ * The clienttable schema that goes along with a Table class. This Schema object tells you about
+ * the names and data types of the clienttable columns.
  */
 class Schema {
   struct Private {};
@@ -54,4 +54,4 @@ private:
   std::vector<ElementTypeId::Enum> types_;
   std::map<std::string_view, size_t, std::less<>> index_;
 };
-}  // namespace deephaven::dhcore::table
+}  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/barrage_processor.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/barrage_processor.h
@@ -8,7 +8,7 @@
 #include <optional>
 #include <vector>
 #include "deephaven/dhcore/chunk/chunk.h"
-#include "deephaven/dhcore/table/schema.h"
+#include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 
 namespace deephaven::dhcore::ticking {
@@ -18,7 +18,7 @@ class BarrageProcessorImpl;
 
 class BarrageProcessor final {
 protected:
-  typedef deephaven::dhcore::table::Schema Schema;
+  typedef deephaven::dhcore::clienttable::Schema Schema;
   typedef deephaven::dhcore::column::ColumnSource ColumnSource;
 
 public:

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/ticking.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/ticking.h
@@ -10,7 +10,7 @@
 #include <set>
 #include "deephaven/dhcore/utility/callbacks.h"
 #include "deephaven/dhcore/container/row_sequence.h"
-#include "deephaven/dhcore/table/table.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
 
 namespace deephaven::dhcore::ticking {
 class TickingUpdate;
@@ -71,7 +71,7 @@ public:
   /**
    * Alias.
    */
-  typedef deephaven::dhcore::table::Table Table;
+  typedef deephaven::dhcore::clienttable::ClientTable Table;
 
   /**
    * Default constructor.

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
@@ -5,7 +5,6 @@
 
 #include <string>
 #include <vector>
-#include "deephaven/dhcore/table/table.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/column/buffer_column_source.h"
 

--- a/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
-#include "deephaven/dhcore/table/table.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
 
 #include "deephaven/dhcore/chunk/chunk_maker.h"
 #include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/container/row_sequence.h"
-#include "deephaven/dhcore/table/schema.h"
 #include "deephaven/dhcore/utility/utility.h"
 
 #include <optional>
@@ -22,19 +22,19 @@ using deephaven::dhcore::utility::separatedList;
 using deephaven::dhcore::utility::SimpleOstringstream;
 using deephaven::dhcore::utility::stringf;
 
-namespace deephaven::dhcore::table {
+namespace deephaven::dhcore::clienttable {
 namespace {
-void printTableData(std::ostream &stream, const Table &table,
+void printTableData(std::ostream &stream, const ClientTable &table,
     const std::vector<size_t> &whichCols,
     const std::vector<std::shared_ptr<RowSequence>> &rowSequences,
     bool wantHeaders, bool wantRowNumbers, bool highlightCells);
 }  // namespace
 
-std::optional<size_t> Table::getColumnIndex(std::string_view name, bool strict) const {
+std::optional<size_t> ClientTable::getColumnIndex(std::string_view name, bool strict) const {
   return schema()->getColumnIndex(name, strict);
 }
 
-std::shared_ptr<ColumnSource> Table::getColumn(std::string_view name, bool strict) const {
+std::shared_ptr<ColumnSource> ClientTable::getColumn(std::string_view name, bool strict) const {
   auto index = getColumnIndex(name, strict);
   if (!index.has_value()) {
     return {};
@@ -42,36 +42,36 @@ std::shared_ptr<ColumnSource> Table::getColumn(std::string_view name, bool stric
   return getColumn(*index);
 }
 
-internal::TableStreamAdaptor Table::stream(bool wantHeaders, bool wantRowNumbers) const {
+internal::TableStreamAdaptor ClientTable::stream(bool wantHeaders, bool wantRowNumbers) const {
   std::vector<std::shared_ptr<RowSequence>> rowSequences{getRowSequence()};
   return {*this, std::move(rowSequences), wantHeaders, wantRowNumbers, false};
 }
 
-internal::TableStreamAdaptor Table::stream(bool wantHeaders, bool wantRowNumbers,
+internal::TableStreamAdaptor ClientTable::stream(bool wantHeaders, bool wantRowNumbers,
     std::shared_ptr<RowSequence> rowSequence) const {
   std::vector<std::shared_ptr<RowSequence>> rowSequences{std::move(rowSequence)};
   return {*this, std::move(rowSequences), wantHeaders, wantRowNumbers, false};
 }
 
-internal::TableStreamAdaptor Table::stream(bool wantHeaders, bool wantRowNumbers,
+internal::TableStreamAdaptor ClientTable::stream(bool wantHeaders, bool wantRowNumbers,
     std::vector<std::shared_ptr<RowSequence>> rowSequences) const {
   return {*this, std::move(rowSequences), wantHeaders, wantRowNumbers, true};
 }
 
-std::string Table::toString(bool wantHeaders, bool wantRowNumbers) const {
+std::string ClientTable::toString(bool wantHeaders, bool wantRowNumbers) const {
   SimpleOstringstream oss;
   oss << stream(wantHeaders, wantRowNumbers);
   return std::move(oss.str());
 }
 
-std::string Table::toString(bool wantHeaders, bool wantRowNumbers,
+std::string ClientTable::toString(bool wantHeaders, bool wantRowNumbers,
     std::shared_ptr<RowSequence> rowSequence) const {
   SimpleOstringstream oss;
   oss << stream(wantHeaders, wantRowNumbers, std::move(rowSequence));
   return std::move(oss.str());
 }
 
-std::string Table::toString(bool wantHeaders, bool wantRowNumbers,
+std::string ClientTable::toString(bool wantHeaders, bool wantRowNumbers,
     std::vector<std::shared_ptr<RowSequence>> rowSequences) const {
   SimpleOstringstream oss;
   oss << stream(wantHeaders, wantRowNumbers, std::move(rowSequences));
@@ -181,7 +181,7 @@ private:
   std::shared_ptr<uint64_t[]> build_;
 };
 
-void printTableData(std::ostream &stream, const Table &table,
+void printTableData(std::ostream &stream, const ClientTable &table,
     const std::vector<size_t> &whichCols,
     const std::vector<std::shared_ptr<RowSequence>> &rowSequences,
     bool wantHeaders, bool wantRowNumbers, bool highlightCells) {
@@ -378,4 +378,4 @@ bool RowMerger::isCellPresent(size_t colIndex, size_t chunkOffset) const {
   return rowSequenceStates_[colIndexToUse].isPresent_[chunkOffset];
 }
 }  // namespace
-}  // namespace deephaven::dhcore::table
+}  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
-#include "deephaven/dhcore/table/schema.h"
+#include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/utility/utility.h"
 
 using deephaven::dhcore::utility::stringf;
 
-namespace deephaven::dhcore::table {
+namespace deephaven::dhcore::clienttable {
 std::shared_ptr<Schema> Schema::create(std::vector<std::string> names, std::vector<ElementTypeId::Enum> types) {
   if (names.size() != types.size()) {
     auto message = stringf("Sizes differ: %o vs %o", names.size(), types.size());
@@ -41,4 +41,4 @@ std::optional<size_t> Schema::getColumnIndex(std::string_view name, bool strict)
   auto message = stringf(R"(Column name "%o" not found)", name);
   throw std::runtime_error(DEEPHAVEN_DEBUG_MSG(message));
 }
-}  // namespace deephaven::dhcore::table
+}  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
@@ -7,11 +7,11 @@
 #include <utility>
 
 #include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/immerutil/abstract_flex_vector.h"
 #include "deephaven/dhcore/ticking/shift_processor.h"
-#include "deephaven/dhcore/table/schema.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 
@@ -30,15 +30,15 @@ using deephaven::dhcore::subscription::ShiftProcessor;
 using deephaven::dhcore::immerutil::AbstractFlexVectorBase;
 using deephaven::dhcore::immerutil::GenericAbstractFlexVector;
 using deephaven::dhcore::immerutil::NumericAbstractFlexVector;
-using deephaven::dhcore::table::Schema;
-using deephaven::dhcore::table::Table;
+using deephaven::dhcore::clienttable::Schema;
+using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::utility::makeReservedVector;
 using deephaven::dhcore::utility::streamf;
 using deephaven::dhcore::utility::stringf;
 
 namespace deephaven::dhcore::ticking {
 namespace {
-class MyTable final : public Table {
+class MyTable final : public ClientTable {
 public:
   explicit MyTable(std::shared_ptr<Schema> schema,
       std::vector<std::shared_ptr<ColumnSource>> sources, size_t numRows);
@@ -183,7 +183,7 @@ void ImmerTableState::applyShifts(const RowSequence &firstIndex, const RowSequen
   ShiftProcessor::applyShiftData(firstIndex, lastIndex, destIndex, processShift);
 }
 
-std::shared_ptr<Table> ImmerTableState::snapshot() const {
+std::shared_ptr<ClientTable> ImmerTableState::snapshot() const {
   auto columnSources = makeReservedVector<std::shared_ptr<ColumnSource>>(flexVectors_.size());
   for (const auto &fv : flexVectors_) {
     columnSources.push_back(fv->makeColumnSource());

--- a/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
@@ -2,8 +2,8 @@
 
 #include <string>
 #include <vector>
-#include "deephaven/dhcore/table/schema.h"
-#include "deephaven/dhcore/table/table.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
+#include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/column/array_column_source.h"

--- a/cpp-examples/demos/chapter2.cc
+++ b/cpp-examples/demos/chapter2.cc
@@ -16,7 +16,7 @@ using deephaven::client::TableHandleManager;
 using deephaven::dhcore::chunk::Int64Chunk;
 using deephaven::dhcore::column::Int64ColumnSource;
 using deephaven::dhcore::container::RowSequence;
-using deephaven::dhcore::table::Table;
+using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::utility::verboseCast;
 
 namespace {
@@ -250,7 +250,7 @@ public:
   }
 
 private:
-  void processDeltas(const Table &table, std::shared_ptr<RowSequence> rows, int64_t parity) {
+  void processDeltas(const ClientTable &table, std::shared_ptr<RowSequence> rows, int64_t parity) {
     auto int64ColGeneric = table.getColumn("IntValue", true);
 
     const auto *typedInt64Col =

--- a/cpp-examples/demos/chapter3.cc
+++ b/cpp-examples/demos/chapter3.cc
@@ -16,7 +16,7 @@ using deephaven::client::TableHandleManager;
 using deephaven::dhcore::chunk::Int64Chunk;
 using deephaven::dhcore::column::Int64ColumnSource;
 using deephaven::dhcore::container::RowSequence;
-using deephaven::dhcore::table::Table;
+using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::utility::verboseCast;
 
 namespace {
@@ -205,7 +205,7 @@ public:
   }
 
 private:
-  void processDeltas(const Table &table, size_t colIndex, std::shared_ptr<RowSequence> rows,
+  void processDeltas(const ClientTable &table, size_t colIndex, std::shared_ptr<RowSequence> rows,
       int64_t parity) {
     const auto int64ColGeneric = table.getColumn(colIndex);
     const auto *typedInt64Col =


### PR DESCRIPTION
Especially for the Python client, who uses Table a lot to mean something else.