### PR TITLE
Enable build parallelism by default.

### DIFF
--- a/.github/env/Linux/gradle.properties
+++ b/.github/env/Linux/gradle.properties
@@ -1,18 +1,8 @@
-# TODO (deephaven-core#639): Customize gradle settings per-CI job
-#
-# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-# GitHub hosted linux runner environment has 2 CPUs and 7G RAM.
-#
-# testParallel seems to run poorly on GH Actions, and is unable to take advantage it seems of 2
-# workers.
-#
-# Our engine-table tests currently request 6g of heap (engine/table/build.gradle); this means we can't have more than
-# 1 worker at a time.
-
-org.gradle.parallel=false
-org.gradle.workers.max=1
-
 # Our CI JDKs should be pre-provisioned and invoked correctly,
 # we shouldn't rely on gradle for any of this logic.
 org.gradle.java.installations.auto-download=false
 org.gradle.java.installations.auto-detect=false
+
+# This will be set on a per environment basis by .github/scripts/print-gradle-workers-max.sh
+# See https://github.com/gradle/gradle/issues/14431#issuecomment-1601724453.
+#org.gradle.workers.max=...

--- a/.github/scripts/print-gradle-workers-max.sh
+++ b/.github/scripts/print-gradle-workers-max.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# We know the gradle daemon takes 1GiB (see gradle.properties)
+DAEMON_BYTES=1073741824
+
+# We'll leave some buffer space for other system resources / processes
+OTHER_BYTES=2147483648
+
+TOTAL_SYSTEM_BYTES="$(free --bytes | grep Mem | awk -F " " '{print $2}')"
+
+# This is accounting for "worst case", assuming every single worker is using the theoretical maximum.
+# Currently, engine/table/build.gradle sets a heap size of 6GiB, so that's the maximum.
+PER_WORKER_BYTES=6442450944
+
+MAX_WORKERS="$(( (TOTAL_SYSTEM_BYTES - DAEMON_BYTES - OTHER_BYTES) / PER_WORKER_BYTES ))"
+MAX_WORKERS="$(( MAX_WORKERS > 0 ? MAX_WORKERS : 1 ))"
+
+echo "org.gradle.workers.max=${MAX_WORKERS}"

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 
@@ -162,6 +164,8 @@ jobs:
       - name: Setup gradle properties
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
+          echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
           echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }}" >> gradle.properties
           cat gradle.properties

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}" >> gradle.properties
           cat gradle.properties
 
@@ -89,6 +91,8 @@ jobs:
       - name: Setup gradle properties
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
+          echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
           echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}" >> gradle.properties
           cat gradle.properties
@@ -151,6 +155,8 @@ jobs:
       - name: Setup gradle properties
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
+          echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
           echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }}" >> gradle.properties
           cat gradle.properties

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -50,6 +50,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }},${{ steps.setup-java-18.outputs.path }}," >> gradle.properties
           cat gradle.properties
 

--- a/.github/workflows/nightly-image-check.yml
+++ b/.github/workflows/nightly-image-check.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }}" >> gradle.properties
           cat gradle.properties
 

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 
@@ -52,8 +54,7 @@ jobs:
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: publish
-          # Note: even though we specify org.gradle.parallel=false in our CI gradle.properties, we want to be explicit
-          # here about no parallelism to ensure we don't create disjointed staging repositories.
+          # We need to be explicit here about no parallelism to ensure we don't create disjointed staging repositories.
           arguments: --no-parallel server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build publish
           gradle-version: wrapper
         env:

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }}" >> gradle.properties
           cat gradle.properties
 

--- a/.github/workflows/tag-base-images.yml
+++ b/.github/workflows/tag-base-images.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           cat .github/env/${{ runner.os }}/gradle.properties >> gradle.properties
           echo >> gradle.properties
+          .github/scripts/print-gradle-workers-max.sh >> gradle.properties
+          echo >> gradle.properties
           echo "org.gradle.java.installations.paths=${{ steps.setup-java-11.outputs.path }},${{ steps.setup-java-17.outputs.path }}," >> gradle.properties
           cat gradle.properties
 

--- a/buildSrc/src/main/groovy/io.deephaven.java-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-test-conventions.gradle
@@ -23,7 +23,16 @@ artifacts {
     archives testJar
 }
 
-project.tasks.withType(Test).all { Test t ->
+// This only applies to the standard "test" task
+project.tasks.named('test', Test, { test ->
+    // We essentially want to set maxParallelForks for all "normal" tests. It will be capped by the number
+    // of gradle workers, org.gradle.workers.max. We aren't able to set set this property for all Test types,
+    // because testSerial needs special handling.
+    test.maxParallelForks = Runtime.runtime.availableProcessors()
+})
+
+// This applies to all test types, including the testOutOfBand, testSerial, and testParallel
+project.tasks.withType(Test).configureEach { Test t ->
     t.with {
         t.defaultCharacterEncoding = 'UTF-8'
 
@@ -43,10 +52,6 @@ project.tasks.withType(Test).all { Test t ->
         enableAssertions = true
         if (!maxHeapSize) {
             maxHeapSize = '3g'
-        }
-
-        if (!maxParallelForks) {
-            maxParallelForks = 4
         }
 
         if (findProperty('shortTests') == 'true') {

--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -128,8 +128,6 @@ spotless {
 }
 
 test {
-    maxParallelForks = Integer.parseInt(findProperty('maxParallelForks') as String ?: '1')
-    forkEvery = Integer.parseInt(findProperty('forkEvery') as String ?: '1')
     //  For now, if you apply @Category(ParallelTest.class) to tests which are not huge CPU/RAM hogs, you can get parallelism
     //  If you have CPU/RAM-heavy tasks that you don't want gumming up :engine-table:test runs, apply @Category(SerialTest.class) instead
     //  (note that the above only works for junit 4 tests; see the documentation on SerialTest class and others for porting instructions)
@@ -147,6 +145,7 @@ TestTools.addEngineParallelTest(project)
 TestTools.addEngineSerialTest(project)
 TestTools.addEngineOutOfBandTest(project)
 
+// If changing, be sure to update .github/scripts/print-gradle-workers-max.sh
 def maxHeapSize = findProperty('maxHeapSize') as String ?: '6g'
 
 tasks.testParallel.maxHeapSize = maxHeapSize

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,13 @@
 # The gradle workers often have their own methods to control additional heap.
 # For example, compilation and java tests are able to set their own memory usage needs through their own configurations.
 org.gradle.jvmargs=-Xmx1g
+org.gradle.parallel=true
+
+# If you are running the full test suite locally, or running gradle builds on infrastructure that has a lot of CPUs but
+# is memory-limited, you may need to explicitly tune your max workers.
+# See .github/scripts/print-gradle-workers-max.sh for the logic we use there.
+# See https://github.com/gradle/gradle/issues/14431#issuecomment-1601724453.
+#org.gradle.workers.max=...
 
 # Setting debugCI to true will cause failed builds to keepalive for three hours so we can do post-mortem inspection of jenkins workspace
 debugCI=false


### PR DESCRIPTION
This also paves the way for larger CI runner support.