### PR TITLE
Fix accidental double-freeing of log entries and fix LogEntry API

### DIFF
--- a/IO/src/main/java/io/deephaven/io/log/LogEntry.java
+++ b/IO/src/main/java/io/deephaven/io/log/LogEntry.java
@@ -20,8 +20,16 @@ public interface LogEntry extends LogOutput, LogSink.Element {
 
     LogEntry start(LogSink sink, LogLevel level, long currentTimeMicros, Throwable t);
 
+    /**
+     * Completes the log entry. Callers should not use {@code this} after completion. End or {@link #endl()} should be
+     * called exactly once.
+     */
     void end();
 
+    /**
+     * Completes the log entry with a newline. Callers should not use {@code this} after completion. Endl or
+     * {@link #end()} should be called exactly once.
+     */
     void endl();
 
     LogEntry append(boolean b);

--- a/IO/src/main/java/io/deephaven/io/log/LogEntry.java
+++ b/IO/src/main/java/io/deephaven/io/log/LogEntry.java
@@ -20,9 +20,9 @@ public interface LogEntry extends LogOutput, LogSink.Element {
 
     LogEntry start(LogSink sink, LogLevel level, long currentTimeMicros, Throwable t);
 
-    LogEntry end();
+    void end();
 
-    LogEntry endl();
+    void endl();
 
     LogEntry append(boolean b);
 
@@ -213,13 +213,13 @@ public interface LogEntry extends LogOutput, LogSink.Element {
         }
 
         @Override
-        public LogEntry end() {
-            return this;
+        public void end() {
+
         }
 
         @Override
-        public LogEntry endl() {
-            return this;
+        public void endl() {
+
         }
 
         @Override

--- a/IO/src/main/java/io/deephaven/io/log/impl/DelayedLogEntryImpl.java
+++ b/IO/src/main/java/io/deephaven/io/log/impl/DelayedLogEntryImpl.java
@@ -117,18 +117,16 @@ public class DelayedLogEntryImpl implements LogEntry {
     }
 
     @Override
-    public LogEntry end() {
+    public void end() {
         // noinspection unchecked
         sink.write(this);
         ends.getAndIncrement();
-        return this;
     }
 
     @Override
-    public LogEntry endl() {
+    public void endl() {
         nl();
         end();
-        return this;
     }
 
     @Override

--- a/IO/src/main/java/io/deephaven/io/log/impl/DelayedLogEntryImpl2.java
+++ b/IO/src/main/java/io/deephaven/io/log/impl/DelayedLogEntryImpl2.java
@@ -144,17 +144,15 @@ public class DelayedLogEntryImpl2 implements LogEntry {
     }
 
     @Override
-    public LogEntry end() {
+    public void end() {
         // noinspection unchecked
         logSink.write(this);
-        return this;
     }
 
     @Override
-    public LogEntry endl() {
+    public void endl() {
         nl();
         end();
-        return this;
     }
 
     @Override

--- a/IO/src/main/java/io/deephaven/io/log/impl/LogEntryImpl.java
+++ b/IO/src/main/java/io/deephaven/io/log/impl/LogEntryImpl.java
@@ -72,18 +72,16 @@ public class LogEntryImpl extends LogOutputCsvImpl implements LogEntry {
     }
 
     @Override
-    public LogEntry end() {
+    public void end() {
         close();
         sink.write(this);
         ends.getAndIncrement();
-        return this;
     }
 
     @Override
-    public LogEntry endl() {
+    public void endl() {
         nl();
         end();
-        return this;
     }
 
     // ------------------------------------------------------------------------------------------------

--- a/IO/src/test/java/io/deephaven/io/log/impl/ConsolidatingLogEntry.java
+++ b/IO/src/test/java/io/deephaven/io/log/impl/ConsolidatingLogEntry.java
@@ -83,15 +83,14 @@ public class ConsolidatingLogEntry extends LogOutputStringImpl implements LogEnt
     }
 
     @Override // from LogEntry
-    public LogEntry end() {
+    public void end() {
         throw Assert.statementNeverExecuted();
     }
 
     @Override // from LogEntry
-    public LogEntry endl() {
+    public void endl() {
         m_monitor.endl(builder.toString());
         builder.setLength(0);
-        return this;
     }
 
     // ################################################################

--- a/authentication/example-providers/psk/src/main/java/io/deephaven/authentication/psk/PskAuthenticationHandler.java
+++ b/authentication/example-providers/psk/src/main/java/io/deephaven/authentication/psk/PskAuthenticationHandler.java
@@ -66,7 +66,7 @@ public class PskAuthenticationHandler implements AuthenticationRequestHandler {
     @Override
     public void initialize(String targetUrl) {
         // Noisily log this, so the user can find the link to click easily
-        logger.warn().endl().endl().endl().endl().endl();
+        logger.warn().nl().nl().nl().nl().endl();
         logger.warn().append("================================================================================").endl();
         logger.warn().append("Superuser access through pre-shared key is enabled - use ").append(PSK)
                 .append(" to connect").endl();
@@ -74,6 +74,6 @@ public class PskAuthenticationHandler implements AuthenticationRequestHandler {
                 .append(PSK)
                 .endl();
         logger.warn().append("================================================================================").endl();
-        logger.warn().endl().endl().endl().endl().endl();
+        logger.warn().nl().nl().nl().nl().endl();
     }
 }

--- a/authentication/src/main/java/io/deephaven/auth/AnonymousAuthenticationHandler.java
+++ b/authentication/src/main/java/io/deephaven/auth/AnonymousAuthenticationHandler.java
@@ -27,14 +27,14 @@ public class AnonymousAuthenticationHandler implements AuthenticationRequestHand
     @Override
     public void initialize(String targetUrl) {
         if (WARN_ANONYMOUS_ACCESS) {
-            log.warn().endl().endl().endl().endl().endl();
+            log.warn().nl().nl().nl().nl().endl();
             log.warn().append("================================================================================")
                     .endl();
             log.warn().append("WARNING! Anonymous authentication is enabled. This is not recommended!").endl();
             log.warn().append("       Listening on ").append(targetUrl).endl();
             log.warn().append("================================================================================")
                     .endl();
-            log.warn().endl().endl().endl().endl().endl();
+            log.warn().nl().nl().nl().nl().endl();
         } else {
             log.info().append("Anonymous authentication is enabled. Listening on ").append(targetUrl).endl();
         }

--- a/log-factory/sinks/log-to-slf4j/src/main/java/io/deephaven/internal/log/LoggerSlf4j.java
+++ b/log-factory/sinks/log-to-slf4j/src/main/java/io/deephaven/internal/log/LoggerSlf4j.java
@@ -92,9 +92,8 @@ public final class LoggerSlf4j implements Logger {
         }
 
         @Override
-        public LogEntry endl() {
+        public void endl() {
             super.end();
-            return this;
         }
     }
 


### PR DESCRIPTION
This logging code was accidentally misusing the LogEntry API, calling endl() multiple times. This resulted in the same entry being put into the pool multiple time. Later on, the entry could be used by multiple threads logging at the same time. Most of the time this would result in garbage logs, but occasionally it would result in an NPE.
  
This also breaks LogEntry binary and (potentially) source compatibility to ensure users can't string together fluent end()/endl().
    
Note: it's still possible for callers to double-free
    
```java
le = log.info();
le.append("hello");
le.append("world");
le.endl();
le.endl();
```

but this is a much rarer pattern. Adding additional runtime safety checks would be possible, but would not be free.

Fixes #4051
