### PR TITLE
Added validation for parameters in head_pct and tail_pct (#4011)

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -366,9 +366,9 @@ public interface Table extends
     /**
      * Provides a head that selects a dynamic number of rows based on a percent.
      *
-     * @param percent the fraction of the table to return (0..1), the number of rows will be rounded up. For example if
-     *        there are 3 rows, headPct(50) returns the first two rows. For percent values outside (0..1), the function
-     *        will throw an exception.
+     * @param percent the fraction of the table to return between [0, 1]. The number of rows will be rounded up. For
+     *        example if there are 3 rows, headPct(50) returns the first two rows. For percent values outside [0, 1],
+     *        the function will throw an exception.
      */
     @ConcurrentMethod
     Table headPct(double percent);
@@ -376,9 +376,9 @@ public interface Table extends
     /**
      * Provides a tail that selects a dynamic number of rows based on a percent.
      *
-     * @param percent the fraction of the table to return (0..1), the number of rows will be rounded up. For example if
-     *        there are 3 rows, tailPct(50) returns the last two rows. For percent values outside (0..1), the function
-     *        will throw an exception.
+     * @param percent the fraction of the table to return between [0, 1]. The number of rows will be rounded up. For
+     *        example if there are 3 rows, tailPct(50) returns the last two rows. For percent values outside [0, 1], the
+     *        function will throw an exception.
      */
     @ConcurrentMethod
     Table tailPct(double percent);

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -367,11 +367,19 @@ public interface Table extends
      * Provides a head that selects a dynamic number of rows based on a percent.
      *
      * @param percent the fraction of the table to return (0..1), the number of rows will be rounded up. For example if
-     *        there are 3 rows, headPct(50) returns the first two rows.
+     *        there are 3 rows, headPct(50) returns the first two rows. For percent values outside (0..1), the function
+     *        will throw an exception.
      */
     @ConcurrentMethod
     Table headPct(double percent);
 
+    /**
+     * Provides a tail that selects a dynamic number of rows based on a percent.
+     *
+     * @param percent the fraction of the table to return (0..1), the number of rows will be rounded up. For example if
+     *        there are 3 rows, tailPct(50) returns the last two rows. For percent values outside (0..1), the function
+     *        will throw an exception.
+     */
     @ConcurrentMethod
     Table tailPct(double percent);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -638,7 +638,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     public Table headPct(final double percent) {
         if (percent < 0 || percent > 1) {
             throw new IllegalArgumentException(
-                    "headPct percentage of rows must be between [0,1]: : percent=" + percent);
+                    "percentage of rows must be between [0,1]: percent=" + percent);
         }
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
@@ -650,7 +650,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     public Table tailPct(final double percent) {
         if (percent < 0 || percent > 1) {
             throw new IllegalArgumentException(
-                    "tailPct percentage of rows must be between [0,1]: percent=" + percent);
+                    "percentage of rows must be between [0,1]: percent=" + percent);
         }
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -636,6 +636,10 @@ public class QueryTable extends BaseTable<QueryTable> {
 
     @Override
     public Table headPct(final double percent) {
+        if (percent < 0 || percent > 1) {
+            throw new IllegalArgumentException(
+                    "headPct percentage provided should be between [0,1]: percent=" + percent);
+        }
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
             return getResult(SliceLikeOperation.headPct(this, percent));
@@ -644,6 +648,10 @@ public class QueryTable extends BaseTable<QueryTable> {
 
     @Override
     public Table tailPct(final double percent) {
+        if (percent < 0 || percent > 1) {
+            throw new IllegalArgumentException(
+                    "tailPct percentage provided should be between [0,1]: percent=" + percent);
+        }
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
             return getResult(SliceLikeOperation.tailPct(this, percent));

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -638,7 +638,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     public Table headPct(final double percent) {
         if (percent < 0 || percent > 1) {
             throw new IllegalArgumentException(
-                    "headPct percentage provided should be between [0,1]: percent=" + percent);
+                    "headPct percentage of rows must be between [0,1]: : percent=" + percent);
         }
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
@@ -650,7 +650,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     public Table tailPct(final double percent) {
         if (percent < 0 || percent > 1) {
             throw new IllegalArgumentException(
-                    "tailPct percentage provided should be between [0,1]: percent=" + percent);
+                    "tailPct percentage of rows must be between [0,1]: percent=" + percent);
         }
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -36,7 +36,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 0, 0, true) {
             @Override
             protected long getLastPositionExclusive() {
-                // Assuming percent is not negative here
+                // Already verified percent is not negative here
                 return (long) Math.ceil(percent * parent.size());
             }
         };
@@ -47,7 +47,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 0, 0, false) {
             @Override
             protected long getFirstPositionInclusive() {
-                // Assuming percent is not negative here
+                // Already verified percent is not negative here
                 return -(long) Math.ceil(percent * parent.size());
             }
         };

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -36,7 +36,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 0, 0, true) {
             @Override
             protected long getLastPositionExclusive() {
-                // Already verified percent is not negative here
+                // Already verified percent is between [0,1] here
                 return (long) Math.ceil(percent * parent.size());
             }
         };
@@ -47,7 +47,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 0, 0, false) {
             @Override
             protected long getFirstPositionInclusive() {
-                // Already verified percent is not negative here
+                // Already verified percent is between [0,1] here
                 return -(long) Math.ceil(percent * parent.size());
             }
         };

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -36,6 +36,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 0, 0, true) {
             @Override
             protected long getLastPositionExclusive() {
+                // Assuming percent is not negative here
                 return (long) Math.ceil(percent * parent.size());
             }
         };
@@ -46,6 +47,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 0, 0, false) {
             @Override
             protected long getFirstPositionInclusive() {
+                // Assuming percent is not negative here
                 return -(long) Math.ceil(percent * parent.size());
             }
         };

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
@@ -442,6 +442,28 @@ public class QueryTableSliceTest extends QueryTableTestBase {
                 TstUtils.testRefreshingTable(i(2).toTracking(), col("x", 1), col("y", 'a')));
         assertTableEquals(table.tailPct(0.1),
                 TstUtils.testRefreshingTable(i(6).toTracking(), col("x", 3), col("y", 'c')));
+
+        // Test for invalid parameters (negative or >1)
+        try {
+            table.headPct(-0.5);
+            Assert.fail("Exception expected for invalid arguments");
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            table.headPct(1.5);
+            Assert.fail("Exception expected for invalid arguments");
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            table.tailPct(-0.5);
+            Assert.fail("Exception expected for invalid arguments");
+        } catch (IllegalArgumentException expected) {
+        }
+        try {
+            table.tailPct(1.5);
+            Assert.fail("Exception expected for invalid arguments");
+        } catch (IllegalArgumentException expected) {
+        }
     }
 
     public void testHeadTailPctIncremental() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
@@ -24,6 +24,8 @@ import org.junit.Assert;
 import org.junit.experimental.categories.Category;
 
 import static io.deephaven.engine.util.TableTools.col;
+import static io.deephaven.engine.util.TableTools.intCol;
+import static io.deephaven.engine.util.TableTools.charCol;
 import static io.deephaven.engine.util.TableTools.emptyTable;
 import static io.deephaven.engine.testutil.TstUtils.*;
 import static io.deephaven.engine.testutil.TstUtils.initColumnInfos;
@@ -443,6 +445,12 @@ public class QueryTableSliceTest extends QueryTableTestBase {
                 TstUtils.testRefreshingTable(i(2).toTracking(), col("x", 1), col("y", 'a')));
         assertTableEquals(table.tailPct(0.1),
                 TstUtils.testRefreshingTable(i(6).toTracking(), col("x", 3), col("y", 'c')));
+        assertTableEquals(table.headPct(0),
+                TstUtils.testRefreshingTable(i().toTracking(), intCol("x"), charCol("y")));
+        assertTableEquals(table.tailPct(0),
+                TstUtils.testRefreshingTable(i().toTracking(), intCol("x"), charCol("y")));
+        assertTableEquals(table.headPct(1), table);
+        assertTableEquals(table.tailPct(1), table);
 
         // Test for invalid parameters (negative or >1)
         try {
@@ -451,12 +459,12 @@ public class QueryTableSliceTest extends QueryTableTestBase {
         } catch (IllegalArgumentException expected) {
         }
         try {
-            table.headPct(1.5);
+            table.tailPct(-0.5);
             Assert.fail("Exception expected for invalid arguments");
         } catch (IllegalArgumentException expected) {
         }
         try {
-            table.tailPct(-0.5);
+            table.headPct(1.5);
             Assert.fail("Exception expected for invalid arguments");
         } catch (IllegalArgumentException expected) {
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
@@ -20,6 +20,7 @@ import io.deephaven.engine.rowset.RowSetShiftData;
 import io.deephaven.test.types.OutOfBandTest;
 import java.util.Random;
 
+import org.junit.Assert;
 import org.junit.experimental.categories.Category;
 
 import static io.deephaven.engine.util.TableTools.col;


### PR DESCRIPTION
Fixes the bug mentioned in #4011

**Change summary:** After this change, the engine will generate an IllegalArgumentException if arguments for head_pct or tail_pct have a value outside [0..1]. Added some unit tests for the change and manually tested it using Java and Groovy UI.

**Documentation Update:** We are requesting an update in the documentation for the [head_pct](https://deephaven.io/core/docs/reference/table-operations/filter/head-pct/) and [tail_pct](https://deephaven.io/core/docs/reference/table-operations/filter/tail-pct/) methods.
The documentation should clarify that the input parameter ("pct" for python and "percent" for Groovy) for the head_pct and tail_pct methods is a floating point number between [0,1]. Any values outside this range will generate an error.