### PR TITLE
Added support for (start<0 & stop>0) in slice

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -356,8 +356,8 @@ public interface Table extends
      * If the firstPosition is negative and the lastPosition is negative, they are both counted from the end of the
      * table. For example, slice(-2, -1) returns the second to last row of the table.
      * <p>
-     * If firstPosition is negative and lastPosition is positive, then the firstRow is counted from the end of
-     * the table, inclusively. The lastPosition is counted from the beginning of the table. For example, slice(-3, 5)
+     * If firstPosition is negative and lastPosition is positive, then firstPosition is counted from the end of the
+     * table, inclusively. The lastPosition is counted from the beginning of the table. For example, slice(-3, 5)
      * returns all rows starting from the third-last row to the fourth row of the table. If there are no rows between
      * these positions, the function will return an empty table.
      *

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -122,7 +122,14 @@ public interface Table extends
     String UNIQUE_KEYS_ATTRIBUTE = "uniqueKeys";
     String FILTERABLE_COLUMNS_ATTRIBUTE = "FilterableColumns";
     String TOTALS_TABLE_ATTRIBUTE = "TotalsTable";
+    /**
+     * If this attribute is set, we can only add new row keys, we can never shift them, modify them, or remove them.
+     */
     String ADD_ONLY_TABLE_ATTRIBUTE = "AddOnly";
+    /**
+     * If this attribute is set, we can only append new row keys to the end of the table. We can never shift them,
+     * modify them, or remove them.
+     */
     String APPEND_ONLY_TABLE_ATTRIBUTE = "AppendOnly";
     String TEST_SOURCE_TABLE_ATTRIBUTE = "TestSource";
     /**

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -357,9 +357,9 @@ public interface Table extends
      * table. For example, slice(-2, -1) returns the second to last row of the table.
      * <p>
      * If firstPosition is negative and lastPosition is positive, then firstPosition is counted from the end of the
-     * table, inclusively. The lastPosition is counted from the beginning of the table. For example, slice(-3, 5)
-     * returns all rows starting from the third-last row to the fourth row of the table. If there are no rows between
-     * these positions, the function will return an empty table.
+     * table, inclusively. The lastPosition is counted from the beginning of the table, exclusively. For example,
+     * slice(-3, 5) returns all rows starting from the third-last row to the fifth row of the table. If there are no
+     * rows between these positions, the function will return an empty table.
      *
      * @param firstPositionInclusive the first position to include in the result
      * @param lastPositionExclusive the last position to include in the result

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -355,6 +355,11 @@ public interface Table extends
      * <p>
      * If the firstPosition is negative and the lastPosition is negative, they are both counted from the end of the
      * table. For example, slice(-2, -1) returns the second to last row of the table.
+     * <p>
+     * If firstPosition is negative and lastPosition is positive, then the firstRow is counted from the end of
+     * the table, inclusively. The lastPosition is counted from the beginning of the table. For example, slice(-3, 5)
+     * returns all rows starting from the third-last row to the fourth row of the table. If there are no rows between
+     * these positions, the function will return an empty table.
      *
      * @param firstPositionInclusive the first position to include in the result
      * @param lastPositionExclusive the last position to include in the result

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -16,10 +16,6 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
     public static SliceLikeOperation slice(final QueryTable parent, final long firstPositionInclusive,
             final long lastPositionExclusive, final String op) {
 
-        if (firstPositionInclusive < 0 && lastPositionExclusive > 0) {
-            throw new IllegalArgumentException("Can not slice with a negative first position (" + firstPositionInclusive
-                    + ") and positive last position (" + lastPositionExclusive + ")");
-        }
         // note: first >= 0 && last < 0 is allowed, otherwise first must be less than last
         if ((firstPositionInclusive < 0 || lastPositionExclusive >= 0)
                 && lastPositionExclusive < firstPositionInclusive) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
@@ -355,13 +355,17 @@ public class QueryTableSliceTest extends QueryTableTestBase {
         }
     }
 
-    public void testGrowthUpdatePattern() {
+    public void testGrowthAppendUpdatePattern() {
         final long steps = 4096;
 
         for (int j = 1; j < 100; j += 7) {
             final QueryTable upTable = getTable(true, 0, new Random(0), new ColumnInfo[0]);
+            upTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+            upTable.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
             final QueryTable queryTable = (QueryTable) upTable.updateView("I=i", "II=ii");
             final EvalNugget[] en = {
+                    EvalNugget.from(() -> queryTable.slice(10, 15)),
+                    EvalNugget.from(() -> queryTable.slice(10, -15)),
                     EvalNugget.from(() -> queryTable.slice(-35, 0)),
                     EvalNugget.from(() -> queryTable.slice(-15, 10))
             };
@@ -371,6 +375,7 @@ public class QueryTableSliceTest extends QueryTableTestBase {
                 final long jj = j;
                 final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
                 updateGraph.runWithinUnitTestCycle(() -> {
+                    // Appending the rows at the end
                     RowSet added1 = RowSetFactory.fromRange(ii * jj, (ii + 1) * jj - 1);
                     upTable.getRowSet().writableCast().insert(added1);
                     TableUpdate update =
@@ -384,6 +389,39 @@ public class QueryTableSliceTest extends QueryTableTestBase {
         }
     }
 
+    public void testGrowthPrependUpdatePattern() {
+        final int numRowsToAdd = 10;
+        final int tableSize = 50;
+        final int steps = (tableSize / numRowsToAdd);
+
+        final QueryTable upTable = getTable(true, 0, new Random(0), new ColumnInfo[0]);
+        upTable.setAttribute(Table.ADD_ONLY_TABLE_ATTRIBUTE, true);
+        final QueryTable queryTable = (QueryTable) upTable.updateView("K=k");
+        final EvalNugget[] en = {
+                EvalNugget.from(() -> queryTable.slice(10, 15)),
+                EvalNugget.from(() -> queryTable.slice(10, -15)),
+                EvalNugget.from(() -> queryTable.slice(-35, 0)),
+                EvalNugget.from(() -> queryTable.slice(-15, 10))
+        };
+
+        for (int i = steps; i > 0; --i) {
+            final long ii = i;
+            final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+            // Prepending 10 rows at time, starting from (40, 49), (30, 39)...
+            updateGraph.runWithinUnitTestCycle(() -> {
+                RowSet added1 = RowSetFactory.fromRange((ii - 1) * numRowsToAdd, ((ii) * numRowsToAdd) - 1);
+                upTable.getRowSet().writableCast().insert(added1);
+                TableUpdate update =
+                        new TableUpdateImpl(added1, RowSetFactory.empty(),
+                                RowSetFactory.empty(), RowSetShiftData.EMPTY, ModifiedColumnSet.EMPTY);
+                upTable.notifyListeners(update);
+            });
+
+            TstUtils.validate("", en);
+        }
+    }
+
+
     public void testShrinkageUpdatePattern() {
         final int numRowsToDelete = 10;
         final int tableSize = 50;
@@ -391,6 +429,8 @@ public class QueryTableSliceTest extends QueryTableTestBase {
         final QueryTable upTable = TstUtils.testRefreshingTable(RowSetFactory.fromRange(0, tableSize - 1).toTracking());
         final QueryTable queryTable = (QueryTable) upTable.updateView("K=k");
         final EvalNugget[] en = {
+                EvalNugget.from(() -> queryTable.slice(10, 15)),
+                EvalNugget.from(() -> queryTable.slice(10, -15)),
                 EvalNugget.from(() -> queryTable.slice(-35, 0)),
                 EvalNugget.from(() -> queryTable.slice(-15, 10))
         };

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSliceTest.java
@@ -420,6 +420,8 @@ public class QueryTableSliceTest extends QueryTableTestBase {
         doSliceTest(table, "bcdefghijklmnopqrstuvwxy", 1, -1);
         doSliceTest(table, "", 2, 2);
         doSliceTest(table, "c", 2, 3);
+        doSliceTest(table, "wxy", -4, 25);
+        doSliceTest(table, "", -4, 20);
     }
 
     private void doSliceTest(QueryTable table, String expected, int firstPositionInclusive, int lastPositionExclusive) {


### PR DESCRIPTION
Feature request, closes #3130 

Change description: Earlier, an error was generated in this scenario. After this change, a subset of rows will be returned where start will be counted from the end of table (inclusively) and stop from the beginning. 

Documentation update: We need to update both the [java](https://deephaven.io/core/groovy/docs/reference/table-operations/filter/slice/#docusaurus_skipToContent_fallback) and [python](https://deephaven.io/core/docs/reference/table-operations/filter/slice/#docusaurus_skipToContent_fallback) documentation to reflect this change. 
Earlier, if (start<0 & stop>0), an error was generated. Now, a subset of rows will be returned. For example, slice(-3, 5)
will return all rows starting from the third-last row to the fifth row of the table. If there are no rows between these positions, the function will return an empty table. 
Note that index 5 corresponds to the sixth row in the table, so we are excluding the sixth row and ending the subset at the fifth row.