### PR TITLE
Deliver initial completed notification when subscribed table is empty

### DIFF
--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -130,8 +130,9 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
                 listener.handleBarrageMessage(barrageMessage);
 
                 // If the initial table is empty the first message will contain a size of 0, which won't get propagated
-                // through the listener because BaseTable will not propagate empty updates, even if they are the initial one.
-                if(!isCompleted() && resultTable.isEmpty()) {
+                // through the listener because BaseTable will not propagate empty updates, even if they are the initial
+                // one.
+                if (!isCompleted() && resultTable.isEmpty()) {
                     signalCompletion();
                 }
             }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -127,8 +127,13 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
                 }
 
                 rowsReceived += barrageMessage.rowsIncluded.size();
-
                 listener.handleBarrageMessage(barrageMessage);
+
+                // If the initial table is empty the first message will contain a size of 0, which won't get propagated
+                // through the listener because BaseTable will not propagate empty updates, even if they are the initial one.
+                if(!isCompleted() && resultTable.isEmpty()) {
+                    signalCompletion();
+                }
             }
         }
 


### PR DESCRIPTION
This fixes #4077.  Simply notify completion if the table is empty after the initial barrage message, since notifications won't get delivered to the listener