### PR TITLE
Test PyDictWrapper.values()

### DIFF
--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ErrorOutTest.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ErrorOutTest.java
@@ -71,7 +71,6 @@ public class ErrorOutTest extends PythonTest {
     }
 
     @Test(expected = RuntimeException.class)
-    @Ignore("Need to wait for the next JPY release to fix https://github.com/jpy-consortium/jpy/issues/98")
     public void errorDoubleOutFromNone() {
         String expr = "[None, []]";
         PyObject in = PyObject.executeCode(expr, PyInputMode.EXPRESSION);

--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/PyDictTest.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/PyDictTest.java
@@ -6,7 +6,9 @@ package io.deephaven.jpy.integration;
 import io.deephaven.jpy.PythonTest;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.jpy.PyDictWrapper;
 import org.jpy.PyInputMode;
@@ -59,6 +61,11 @@ public class PyDictTest extends PythonTest {
         Assert.assertEquals(3, count(dict.entrySet().iterator()));
         Assert.assertEquals(3, count(dict.keySet().stream().iterator()));
         Assert.assertEquals(3, count(dict.entrySet().stream().iterator()));
+
+        Assert.assertTrue(!dict.values().isEmpty());
+        for (PyObject v : dict.values()) {
+            Assert.assertEquals("yeah", v.toString());
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #4118 

```
> Task :test
Watching 1 directories to track changes
Watching 1 directories to track changes
Watching 1 directories to track changes
Caching disabled for task ':test' because:
  Build cache is disabled
Task ':test' is not up-to-date because:
  No history is available.
Watching 1 directories to track changes
Not watching anything anymore
Watching 0 directories to track changes
Starting process 'Gradle Test Executor 1'. Working directory: /project Command: /opt/java/openjdk/bin/java -DPyObject.cleanup_on_thread=false -Djpy.jdlLib=/opt/deephaven/venv/lib/python3.10/site-packages/jdl.cpython-310-x86_64-linux-gnu.so -Djpy.jpyLib=/opt/deephaven/venv/lib/python3.10/site-packages/jpy.cpython-310-x86_64-linux-gnu.so -Djpy.pythonLib=/usr/lib/python3.10/config-3.10-x86_64-linux-gnu/libpython3.10.so -Dorg.gradle.internal.worker.tmpdir=/project/build/tmp/test/work -Dorg.gradle.native=false @/root/.gradle/.tmp/gradle-worker-classpath2154517547804811107txt -Xmx512m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -ea worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Test Executor 1'
Successfully started process 'Gradle Test Executor 1'

io.deephaven.jpy.integration.PyDictTest > simpleDict FAILED
    java.lang.IllegalStateException: PyObjectState has already been taken
        at org.jpy.PyObjectState.borrowPointer(PyObjectState.java:28)
        at org.jpy.PyObject.getPointer(PyObject.java:165)
        at org.jpy.PyObject.callMethod(PyObject.java:432)
        at org.jpy.PyListWrapper.size(PyListWrapper.java:36)
        at org.jpy.PyListWrapper.isEmpty(PyListWrapper.java:43)
        at io.deephaven.jpy.integration.PyDictTest.simpleDict(PyDictTest.java:65)

```