### PR TITLE
C++ Client: support the "ColumnsAsList" Barrage format.

### DIFF
--- a/cpp-client/deephaven/client/include/private/deephaven/client/arrowutil/arrow_column_source.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/arrowutil/arrow_column_source.h
@@ -104,11 +104,13 @@ class NumericArrowColumnSource final : public deephaven::dhcore::column::Numeric
   typedef deephaven::dhcore::column::ColumnSourceVisitor ColumnSourceVisitor;
 
 public:
-  static std::shared_ptr<NumericArrowColumnSource> create(const ARRAY_TYPE *arrowArray) {
-    return std::make_shared<NumericArrowColumnSource>(Private(), arrowArray);
+  static std::shared_ptr<NumericArrowColumnSource> create(std::shared_ptr<arrow::Array> storage,
+      const ARRAY_TYPE *arrowArray) {
+    return std::make_shared<NumericArrowColumnSource>(Private(), std::move(storage), arrowArray);
   }
 
-  explicit NumericArrowColumnSource(Private, const ARRAY_TYPE *arrowArray) : backingStore_(arrowArray) {}
+  explicit NumericArrowColumnSource(Private, std::shared_ptr<arrow::Array> storage, const ARRAY_TYPE *arrowArray) :
+      storage_(std::move(storage)), backingStore_(arrowArray) {}
 
   void fillChunk(const RowSequence &rows, Chunk *destData, BooleanChunk *optionalDestNullFlags) const final {
     typedef typename deephaven::dhcore::chunk::TypeToChunk<ELEMENT_TYPE>::type_t chunkType_t;
@@ -125,6 +127,7 @@ public:
   }
 
 private:
+  std::shared_ptr<arrow::Array> storage_;
   internal::NumericBackingStore<ARRAY_TYPE, ELEMENT_TYPE> backingStore_;
 };
 
@@ -157,11 +160,13 @@ class GenericArrowColumnSource final : public deephaven::dhcore::column::Generic
   typedef deephaven::dhcore::column::ColumnSourceVisitor ColumnSourceVisitor;
 
 public:
-  static std::shared_ptr<GenericArrowColumnSource> create(const ARRAY_TYPE *arrowArray) {
-    return std::make_shared<GenericArrowColumnSource>(Private(), arrowArray);
+  static std::shared_ptr<GenericArrowColumnSource> create(std::shared_ptr<arrow::Array> storage,
+      const ARRAY_TYPE *arrowArray) {
+    return std::make_shared<GenericArrowColumnSource>(Private(), std::move(storage), arrowArray);
   }
 
-  explicit GenericArrowColumnSource(Private, const ARRAY_TYPE *arrowArray) : backingStore_(arrowArray) {}
+  explicit GenericArrowColumnSource(Private, std::shared_ptr<arrow::Array> storage, const ARRAY_TYPE *arrowArray) :
+      storage_(std::move(storage)), backingStore_(arrowArray) {}
 
   void fillChunk(const RowSequence &rows, Chunk *destData, BooleanChunk *optionalDestNullFlags) const final {
     typedef typename deephaven::dhcore::chunk::TypeToChunk<ELEMENT_TYPE>::type_t chunkType_t;
@@ -176,6 +181,7 @@ public:
   }
 
 private:
+  std::shared_ptr<arrow::Array> storage_;
   internal::GenericBackingStore<ARRAY_TYPE, ELEMENT_TYPE> backingStore_;
 };
 

--- a/cpp-client/deephaven/dhcore/src/ticking/barrage_processor.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/barrage_processor.cc
@@ -28,6 +28,7 @@ using deephaven::dhcore::immerutil::AbstractFlexVectorBase;
 using deephaven::dhcore::clienttable::Schema;
 using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::utility::makeReservedVector;
+using deephaven::dhcore::utility::separatedList;
 using deephaven::dhcore::utility::streamf;
 using deephaven::dhcore::utility::stringf;
 
@@ -163,7 +164,7 @@ std::vector<uint8_t> BarrageProcessor::createSubscriptionRequest(const void *tic
   flatbuffers::FlatBufferBuilder payloadBuilder(4096);
 
   auto subOptions = CreateBarrageSubscriptionOptions(payloadBuilder,
-      ColumnConversionMode::ColumnConversionMode_Stringify, true, 0, 4096);
+      ColumnConversionMode::ColumnConversionMode_Stringify, true, 0, 4096, 0, true);
 
   auto ticket = payloadBuilder.CreateVector(static_cast<const int8_t*>(ticketBytes), size);
   auto subreq = CreateBarrageSubscriptionRequest(payloadBuilder, ticket, {}, {}, subOptions);
@@ -517,7 +518,8 @@ std::optional<TickingUpdate> BuildingResult::processNextChunk(BarrageProcessorIm
     const std::vector<std::shared_ptr<ColumnSource>> &/*sources*/,
     std::vector<size_t> *begins, const std::vector<size_t> &ends, const void */*metadata*/, size_t /*metadataSize*/) {
   if (*begins != ends) {
-    const char *message = "Barrage logic is done processing but there is leftover caller-provided data.";
+    auto message = stringf("Barrage logic is done processing but there is leftover caller-provided data. begins = [%o]. ends=[%o]",
+        separatedList(begins->begin(), begins->end()), separatedList(ends.begin(), ends.end()));
     throw std::runtime_error(DEEPHAVEN_DEBUG_MSG(message));
   }
   auto *aa = &owner->awaitingAdds_;


### PR DESCRIPTION
Add C++ support for the ColumnsAsList Barrage feature. Prior to this feature's implementation in Barrage, some clients (including C++ Arrow) would reject Barrage messages that had columns of different lengths in the same update message. This is a case that comes up frequently when Deephaven is sending modifies.

Prior to this change, we needed to patch Arrow C++ to not check for this condition. After this change, we can use an unpatched Arrow.

Testing: The unit test "Ticking table modified rows are eventually all greater than 10" will fail with an unpatched Arrow and C++ code just prior to the change in this PR. That unit test will succeed after this PR is applied.