### PR TITLE
Added support for head() and tail() for blink tables

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
@@ -58,7 +58,6 @@ public class BlinkTableTools {
         final UpdateGraph updateGraph = blinkTable.getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
             return internalBlinkToAppendOnly(blinkTable, true, rowLimit);
-            // How to do it in a better way in Java?
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
@@ -138,13 +138,12 @@ public class BlinkTableTools {
                                 if (upstream.modified().isNonempty() || upstream.shifted().nonempty()) {
                                     throw new IllegalArgumentException("Blink tables should not modify or shift!");
                                 }
-                                if (upstream.added().isEmpty()) {
-                                    return;
-                                }
-
-                                final long currentSize = rowSet.size();
                                 RowSet newRowSet = upstream.added();
                                 long newRowsSize = newRowSet.size();
+                                if (newRowsSize == 0) {
+                                    return;
+                                }
+                                final long currentSize = rowSet.size();
                                 if (currentSize + newRowsSize >= maxRowLimit) {
                                     // TODO Test this
                                     newRowsSize = (maxRowLimit - currentSize);
@@ -165,6 +164,7 @@ public class BlinkTableTools {
                                 downstream.shifted = RowSetShiftData.EMPTY;
                                 result.notifyListeners(downstream);
 
+                                // TODO Should this be left here
                                 if (hasMaxRowLimit && totalSize > maxRowLimit) {
                                     throw new IllegalStateException(
                                             "Size of table cannot exceed the allowable limit, size=" + totalSize

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
@@ -43,7 +43,13 @@ public class BlinkTableTools {
     }
 
     /**
-     * TODO Add description
+     * Convert a Blink Table to an in-memory append only table with a maximum count row limit.
+     * Any updates beyond that limit won't be appended to the table.
+     *
+     * @param blinkTable The input blink table
+     * @param rowLimit The maximum number of rows in the append-only table
+     * @return An append-only in-memory table representing all data encountered in the blink table across all cycles
+     * till maximum row count
      */
     public static Table blinkToAppendOnly(final Table blinkTable, long rowLimit) {
         if (rowLimit < 0) {
@@ -56,7 +62,7 @@ public class BlinkTableTools {
         }
     }
 
-    // TODO Choose better variable names
+    // TODO How do we handle default arguments. Is there a better way to do this
     private static Table internalBlinkToAppendOnly(final Table blinkTable, boolean hasMaxRowLimit, long maxRowLimit) {
         return QueryPerformanceRecorder.withNugget("blinkToAppendOnly", () -> {
             if (!isBlink(blinkTable)) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BlinkTableTools.java
@@ -140,8 +140,7 @@ public class BlinkTableTools {
                                 columns.values().forEach(c -> c.ensureCapacity(totalSize));
                                 final RowSet newRange = RowSetFactory.fromRange(currentSize, totalSize - 1);
 
-                                try (final SafeCloseable ignored = subsetAdded)
-                                {
+                                try (final SafeCloseable ignored = subsetAdded) {
                                     final RowSet newRowSet = (subsetAdded == null) ? upstream.added() : subsetAdded;
                                     ChunkUtils.copyData(sourceColumns, newRowSet, destColumns, newRange, false);
                                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -364,6 +364,7 @@ public class QueryTable extends BaseTable<QueryTable> {
         return (ColumnSource<T>) columnSource;
     }
 
+
     @Override
     public Map<String, ColumnSource<?>> getColumnSourceMap() {
         return Collections.unmodifiableMap(columns);
@@ -612,8 +613,6 @@ public class QueryTable extends BaseTable<QueryTable> {
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
             if (isBlink()) {
-                // TODO Add unit tests for this
-                // This might make it a breaking change
                 throw unsupportedForBlinkTables("slice");
             }
             if (firstPositionInclusive == lastPositionExclusive) {
@@ -642,8 +641,6 @@ public class QueryTable extends BaseTable<QueryTable> {
     @Override
     public Table headPct(final double percent) {
         if (isBlink()) {
-            // TODO Add unit tests for this
-            // This might make it a breaking change
             throw unsupportedForBlinkTables("headPct");
         }
         if (percent < 0 || percent > 1) {
@@ -659,8 +656,6 @@ public class QueryTable extends BaseTable<QueryTable> {
     @Override
     public Table tailPct(final double percent) {
         if (isBlink()) {
-            // TODO Add unit tests for this
-            // This might make it a breaking change
             throw unsupportedForBlinkTables("tailPct");
         }
         if (percent < 0 || percent > 1) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -626,6 +626,9 @@ public class QueryTable extends BaseTable<QueryTable> {
     public Table head(final long size) {
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
+            if (size == 0) {
+                return getSubTable(RowSetFactory.empty().toTracking());
+            }
             return getResult(SliceLikeOperation.slice(this, 0, Require.geqZero(size, "size"), "head"));
         }
     }
@@ -634,6 +637,9 @@ public class QueryTable extends BaseTable<QueryTable> {
     public Table tail(final long size) {
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
+            if (size == 0) {
+                return getSubTable(RowSetFactory.empty().toTracking());
+            }
             return getResult(SliceLikeOperation.slice(this, -Require.geqZero(size, "size"), 0, "tail"));
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -364,7 +364,6 @@ public class QueryTable extends BaseTable<QueryTable> {
         return (ColumnSource<T>) columnSource;
     }
 
-
     @Override
     public Map<String, ColumnSource<?>> getColumnSourceMap() {
         return Collections.unmodifiableMap(columns);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -129,7 +129,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 long size = getLastPositionExclusive();
                 resultTable = (QueryTable) BlinkTableTools.blinkToAppendOnly(parent, size);
             } else if (operation.equals("tail")) {
-                long size = -1 * getFirstPositionInclusive(); // TODO Verify if -1 is correct
+                long size = -1 * getFirstPositionInclusive();
                 resultTable = (QueryTable) RingTableTools.of(parent, (int) size); // TODO Do I need to do something for
                                                                                   // this type cast from long to int?
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -156,6 +156,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
 
         final TrackingWritableRowSet rowSet = resultTable.getRowSet().writableCast();
         final RowSet sliceRowSet = computeSliceIndex(parent.getRowSet());
+
         final TableUpdateImpl downstream = new TableUpdateImpl();
         downstream.removed = upstream.removed().intersect(rowSet);
         rowSet.remove(downstream.removed());
@@ -172,7 +173,6 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
         // Must intersect against modified set before adding the new rows to result rowSet.
         downstream.modified = upstream.modified().intersect(rowSet);
 
-
         downstream.added = sliceRowSet.minus(rowSet);
         rowSet.insert(downstream.added());
 
@@ -182,6 +182,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
             downstream.modifiedColumnSet = resultTable.getModifiedColumnSetForUpdates();
             downstream.modifiedColumnSet.clear();
         }
+
         resultTable.notifyListeners(downstream);
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -95,16 +95,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
 
     @Override
     public Result<QueryTable> initialize(boolean usePrev, long beforeClock) {
-        if (parent.isBlink()) {
-            if (operation.equals("head")) {
-                long size = getLastPositionExclusive();
-                resultTable = (QueryTable) BlinkTableTools.blinkToAppendOnly(parent, size);
-            } else if (operation.equals("tail")) {
-                long size = -1 * getFirstPositionInclusive();
-                resultTable = (QueryTable) RingTableTools.of(parent, (int) size); // TODO Do I need to do something for
-                // this type cast from long to int?
-            }
-        } else {
+        if (!parent.isBlink()) {
             final TrackingRowSet parentRowSet = parent.getRowSet();
             final TrackingRowSet resultRowSet =
                     computeSliceIndex(usePrev ? parentRowSet.prev() : parentRowSet).toTracking();
@@ -129,6 +120,15 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 if (parent.isAppendOnly()) {
                     resultTable.setAttribute(Table.APPEND_ONLY_TABLE_ATTRIBUTE, true);
                 }
+            }
+        } else {
+            if (operation.equals("head")) {
+                long size = getLastPositionExclusive();
+                resultTable = (QueryTable) BlinkTableTools.blinkToAppendOnly(parent, size);
+            } else if (operation.equals("tail")) {
+                long size = -1 * getFirstPositionInclusive();
+                resultTable = (QueryTable) RingTableTools.of(parent, (int) size); // TODO Do I need to do something for
+                // this type cast from long to int?
             }
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SliceLikeOperation.java
@@ -127,8 +127,7 @@ public class SliceLikeOperation implements QueryTable.Operation<QueryTable> {
                 resultTable = (QueryTable) BlinkTableTools.blinkToAppendOnly(parent, size);
             } else if (operation.equals("tail")) {
                 long size = -1 * getFirstPositionInclusive();
-                resultTable = (QueryTable) RingTableTools.of(parent, (int) size); // TODO Do I need to do something for
-                // this type cast from long to int?
+                resultTable = (QueryTable) RingTableTools.of(parent, Math.toIntExact(size));
             }
         }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
@@ -4,6 +4,7 @@
 package io.deephaven.engine.table.impl;
 
 import io.deephaven.base.verify.Assert;
+import io.deephaven.base.verify.RequirementFailure;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
@@ -145,7 +146,6 @@ public class BlinkTableAggregationTest {
                 updateGraph.completeCycleForUnitTests();
             }
             try {
-                // TODO How is addOnly getting updated when normal is being updated
                 TstUtils.assertTableEquals(expected, addOnlyExpected);
                 TstUtils.assertTableEquals(expected, blinkExpected);
             } catch (ComparisonFailure e) {
@@ -416,7 +416,12 @@ public class BlinkTableAggregationTest {
     @Test
     public void testTail() {
         // Assuming refresh sizes to be : 100, 0, 1, 2, 50, 0, 1000, 1, 0
-        doOperatorTest(table -> table.tail(50), false); // TODO Manually Test this case
+        try {
+            doOperatorTest(table -> table.tail(-1), false);
+            org.junit.Assert.fail("Exception expected for negative tail size");
+        } catch (RequirementFailure expected) {
+        }
+        doOperatorTest(table -> table.tail(50), false);
         doOperatorTest(table -> table.tail(101), false);
         doOperatorTest(table -> table.tail(102), false);
         doOperatorTest(table -> table.tail(130), false);
@@ -426,8 +431,14 @@ public class BlinkTableAggregationTest {
 
     @Test
     public void testHead() {
-        doOperatorTest(table -> table.head(50), false); // TODO Manually Test this case
-        doOperatorTest(table -> table.head(100), false); // TODO Manually Test this case
+        // Assuming refresh sizes to be : 100, 0, 1, 2, 50, 0, 1000, 1, 0
+        try {
+            doOperatorTest(table -> table.head(-1), false);
+            org.junit.Assert.fail("Exception expected for negative head size");
+        } catch (RequirementFailure expected) {
+        }
+        doOperatorTest(table -> table.head(50), false);
+        doOperatorTest(table -> table.head(100), false);
         doOperatorTest(table -> table.head(102), false);
         doOperatorTest(table -> table.head(130), false);
         doOperatorTest(table -> table.head(1000), false);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
@@ -35,7 +35,7 @@ import static io.deephaven.api.agg.Aggregation.*;
 
 /**
  * Unit tests that exercise operations (like aggregations) which are specialized for blink tables.
- * */
+ */
 public class BlinkTableAggregationTest {
 
     private static final long INPUT_SIZE = 100_000L;
@@ -416,6 +416,7 @@ public class BlinkTableAggregationTest {
     @Test
     public void testTail() {
         // Assuming refresh sizes to be : 100, 0, 1, 2, 50, 0, 1000, 1, 0
+        doOperatorTest(table -> table.tail(50), false); // TODO Manually Test this case
         doOperatorTest(table -> table.tail(101), false);
         doOperatorTest(table -> table.tail(102), false);
         doOperatorTest(table -> table.tail(130), false);
@@ -425,8 +426,8 @@ public class BlinkTableAggregationTest {
 
     @Test
     public void testHead() {
-        doOperatorTest(table -> table.head(50), false);
-        doOperatorTest(table -> table.head(100), false);
+        doOperatorTest(table -> table.head(50), false); // TODO Manually Test this case
+        doOperatorTest(table -> table.head(100), false); // TODO Manually Test this case
         doOperatorTest(table -> table.head(102), false);
         doOperatorTest(table -> table.head(130), false);
         doOperatorTest(table -> table.head(1000), false);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
@@ -405,4 +405,21 @@ public class BlinkTableAggregationTest {
                 AggSortedFirst("Sym", "SymSortedFirstPrice=Price", "SymSortedFirstSize=Size"),
                 AggSortedLast("Sym", "SymSortedLastPrice=Price", "SymSortedLastSize=Size"))), true);
     }
+
+    public void testUnsupportedImpl(@NotNull final UnaryOperator<Table> operator) {
+        final QueryTable blink = TstUtils.testRefreshingTable(RowSetFactory.fromRange(0, 10).toTracking());
+        blink.setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        try {
+            operator.apply(blink);
+            org.junit.Assert.fail("Exception expected for unsupported operation");
+        } catch (UnsupportedOperationException expected) {
+        }
+    }
+
+    @Test
+    public void testUnsupported() {
+        testUnsupportedImpl(table -> table.slice(0, 1));
+        testUnsupportedImpl(table -> table.headPct(1));
+        testUnsupportedImpl(table -> table.tailPct(1));
+    }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableAggregationTest.java
@@ -90,7 +90,6 @@ public class BlinkTableAggregationTest {
 
         TstUtils.assertTableEquals(normal, blink);
 
-        // Apply the operator to all three tables and store the reference to the expected result
         final Table expected = operator.apply(normal);
         final Table addOnlyExpected = operator.apply(addOnly);
         final Table blinkExpected = operator.apply(blink);
@@ -106,8 +105,6 @@ public class BlinkTableAggregationTest {
         int step = 0;
         long usedSize = 0;
         RowSet blinkLastInserted = RowSetFactory.empty();
-
-        // Now send incremental updates to normal and blink table so that your expected references also update
         while (usedSize < INPUT_SIZE) {
             final long refreshSize = Math.min(INPUT_SIZE - usedSize, refreshSizes.nextLong());
             final RowSet normalStepInserted = refreshSize == 0
@@ -146,7 +143,6 @@ public class BlinkTableAggregationTest {
                 });
             } finally {
                 updateGraph.completeCycleForUnitTests();
-                TstUtils.assertTableEquals(expected, blinkExpected);
             }
             try {
                 // TODO How is addOnly getting updated when normal is being updated

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableSemanticsTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/BlinkTableSemanticsTest.java
@@ -37,7 +37,7 @@ import static io.deephaven.api.agg.Aggregation.*;
 /**
  * Unit tests that exercise operations (like aggregations) which are specialized for blink tables.
  */
-public class BlinkTableAggregationTest {
+public class BlinkTableSemanticsTest {
 
     private static final long INPUT_SIZE = 100_000L;
     private static final long MAX_RANDOM_ITERATION_SIZE = 10_000;


### PR DESCRIPTION
Feature request, closes #2411

**Change description:** Before this change, head/tail operations on blink table would return the head/tail of the rows added to the blink table in the latest update cycle. After this change, head/tail would act the same as they would on an append-only (full history) table derived from the stream. For example, head(10) on a blink table would store the first 10 rows received by the blink table after the operation and then won't change. Similarly, tail(10) would store the latest 10 rows received by the blink table.
Also, after this change, headPct(), taillPct() and slice() will not be supported for blink tables and will return an error.

**Documentation change:**  We need to provide the above description in the documentation pages of blink tables and these operations. These are some places I could find: [Blink table](https://deephaven.io/core/docs/conceptual/kafka-basic-terms/#blink), [head Python](https://deephaven.io/core/docs/reference/table-operations/filter/head/#docusaurus_skipToContent_fallback), [head Java](https://deephaven.io/core/groovy/docs/reference/table-operations/filter/head/#docusaurus_skipToContent_fallback), [tail Python](https://deephaven.io/core/docs/reference/table-operations/filter/tail/#docusaurus_skipToContent_fallback), [tail Java](https://deephaven.io/core/groovy/docs/reference/table-operations/filter/tail/#docusaurus_skipToContent_fallback)
