### PR TITLE
Add optional debug logging to cpp client.

### DIFF
--- a/cpp-client/deephaven/client/include/private/deephaven/client/impl/table_handle_manager_impl.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/impl/table_handle_manager_impl.h
@@ -59,6 +59,7 @@ public:
   const std::shared_ptr<Executor> &flightExecutor() const { return flightExecutor_; }
 
 private:
+  const std::string me_;  // useful printable object name for logging
   std::optional<Ticket> consoleId_;
   std::shared_ptr<Server> server_;
   std::shared_ptr<Executor> executor_;

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -252,7 +252,7 @@ private:
 
   static void sendKeepaliveMessages(const std::shared_ptr<Server> &self);
   bool keepaliveHelper();
-
+  const std::string me_;  // useful printable object name for logging
   std::unique_ptr<ApplicationService::Stub> applicationStub_;
   std::unique_ptr<ConsoleService::Stub> consoleStub_;
   std::unique_ptr<SessionService::Stub> sessionStub_;
@@ -280,7 +280,7 @@ void Server::sendRpc(const TReq &req, std::shared_ptr<SFCallback<TResp>> respons
   auto now = std::chrono::system_clock::now();
   // Keep this in a unique_ptr at first, for cleanup in case addAuthToken throws an exception.
   gpr_log(GPR_DEBUG,
-          "%p: "
+          "Server[%p]: "
           "Sending RPC %s "
           "at time %s.",
           (void*) this,

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -282,16 +282,17 @@ private:
 template<typename TReq, typename TResp, typename TStub, typename TPtrToMember>
 void Server::sendRpc(const TReq &req, std::shared_ptr<SFCallback<TResp>> responseCallback,
     TStub *stub, const TPtrToMember &pm) {
-  using namespace deephaven::dhcore::utility;
-  static const auto typeName = TypeName(req);
+  using deephaven::dhcore::utility::timePointToStr;
+  using deephaven::dhcore::utility::typeName;
+  static const auto tName = typeName(req);
   auto now = std::chrono::system_clock::now();
   gpr_log(GPR_DEBUG,
           "Server[%p]: "
           "Sending RPC %s "
           "at time %s.",
           (void*) this,
-          typeName.c_str(),
-          TimePointToStr(now).c_str());
+          tName.c_str(),
+          timePointToStr(now).c_str());
           
   // Keep this in a unique_ptr at first, in case we leave early due to cancellation or exception.
   auto response = std::make_unique<ServerResponseHolder<TResp>>(now, std::move(responseCallback));

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -240,6 +240,9 @@ public:
   // TODO: make this private
   void setExpirationInterval(std::chrono::milliseconds interval);
 
+  // Useful as a log line prefix for messages coming from this server.
+  const std::string &me() { return me_; }
+
 private:
   static const char *const authorizationKey;
   typedef std::unique_ptr<::grpc::ClientAsyncResponseReader<ExportedTableCreationResponse>>
@@ -249,7 +252,7 @@ private:
   void selectOrUpdateHelper(Ticket parentTicket, std::vector<std::string> columnSpecs,
       std::shared_ptr<EtcCallback> etcCallback, Ticket result, selectOrUpdateMethod_t method);
 
-  static void processCompletionQueueForever(const std::shared_ptr<Server> &self);
+  static void processCompletionQueueLoop(const std::shared_ptr<Server> &self);
   bool processNextCompletionQueueItem();
 
   static void sendKeepaliveMessages(const std::shared_ptr<Server> &self);

--- a/cpp-client/deephaven/client/src/client.cc
+++ b/cpp-client/deephaven/client/src/client.cc
@@ -49,9 +49,9 @@ void printTableData(std::ostream &s, const TableHandle &tableHandle, bool wantHe
 }  // namespace
 
 Client Client::connect(const std::string &target, const ClientOptions &options) {
-  auto executor = Executor::create("Client executor");
-  auto flightExecutor = Executor::create("Flight executor");
   auto server = Server::createFromTarget(target, options);
+  auto executor = Executor::create("Client executor for " + server->me());
+  auto flightExecutor = Executor::create("Flight executor for " + server->me());
   auto impl = ClientImpl::create(std::move(server), executor, flightExecutor, options.sessionType_);
   return Client(std::move(impl));
 }

--- a/cpp-client/deephaven/client/src/client.cc
+++ b/cpp-client/deephaven/client/src/client.cc
@@ -3,6 +3,7 @@
  */
 #include "deephaven/client/client.h"
 
+#include <grpc/support/log.h>
 #include <arrow/array.h>
 #include <arrow/scalar.h>
 #include "deephaven/client/columns.h"

--- a/cpp-client/deephaven/client/src/impl/client_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/client_impl.cc
@@ -20,8 +20,11 @@ using deephaven::dhcore::utility::SFCallback;
 
 namespace deephaven::client {
 namespace impl {
-std::shared_ptr<ClientImpl> ClientImpl::create(std::shared_ptr<Server> server,
-    std::shared_ptr<Executor> executor, std::shared_ptr<Executor> flightExecutor, const std::string &sessionType) {
+std::shared_ptr<ClientImpl> ClientImpl::create(
+    std::shared_ptr<Server> server,
+    std::shared_ptr<Executor> executor,
+    std::shared_ptr<Executor> flightExecutor,
+    const std::string &sessionType) {
   std::optional<Ticket> consoleTicket;
   if (!sessionType.empty()) {
     auto cb = SFCallback<StartConsoleResponse>::createForFuture();
@@ -30,7 +33,10 @@ std::shared_ptr<ClientImpl> ClientImpl::create(std::shared_ptr<Server> server,
     consoleTicket = std::move(*scr.mutable_result_id());
   }
 
-  auto thmi = TableHandleManagerImpl::create(std::move(consoleTicket), std::move(server), std::move(executor),
+  auto thmi = TableHandleManagerImpl::create(
+          std::move(consoleTicket),
+          std::move(server),
+          std::move(executor),
       std::move(flightExecutor));
   return std::make_shared<ClientImpl>(Private(), std::move(thmi));
 }

--- a/cpp-client/deephaven/client/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/table_handle_manager_impl.cc
@@ -4,6 +4,7 @@
 #include "deephaven/client/impl/table_handle_manager_impl.h"
 
 #include <map>
+#include <grpc/support/log.h>
 #include "deephaven/client/utility/executor.h"
 #include "deephaven/client/impl/table_handle_impl.h"
 #include "deephaven/dhcore/utility/callbacks.h"
@@ -28,12 +29,18 @@ std::shared_ptr<TableHandleManagerImpl> TableHandleManagerImpl::create(std::opti
 
 TableHandleManagerImpl::TableHandleManagerImpl(Private, std::optional<Ticket> &&consoleId,
     std::shared_ptr<Server> &&server, std::shared_ptr<Executor> &&executor,
-    std::shared_ptr<Executor> &&flightExecutor) : consoleId_(std::move(consoleId)),
-    server_(std::move(server)), executor_(std::move(executor)),
+    std::shared_ptr<Executor> &&flightExecutor) :
+    me_(deephaven::dhcore::utility::ObjectId("TableHandleManagerImpl", this)),
+    consoleId_(std::move(consoleId)),
+    server_(std::move(server)),
+    executor_(std::move(executor)),
     flightExecutor_(std::move(flightExecutor)) {
+  gpr_log(GPR_DEBUG, "%s: Created.", me_.c_str());
 }
 
-TableHandleManagerImpl::~TableHandleManagerImpl() = default;
+TableHandleManagerImpl::~TableHandleManagerImpl() {
+  gpr_log(GPR_DEBUG,"%s: Destroyed.", me_.c_str());
+}
 
 std::shared_ptr<TableHandleImpl> TableHandleManagerImpl::emptyTable(int64_t size) {
   auto resultTicket = server_->newTicket();

--- a/cpp-client/deephaven/client/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/table_handle_manager_impl.cc
@@ -16,6 +16,7 @@ using deephaven::client::utility::Executor;
 using deephaven::dhcore::utility::SFCallback;
 using deephaven::dhcore::utility::streamf;
 using deephaven::dhcore::utility::stringf;
+using deephaven::dhcore::utility::objectId;
 using io::deephaven::proto::backplane::script::grpc::ExecuteCommandResponse;
 
 
@@ -30,7 +31,7 @@ std::shared_ptr<TableHandleManagerImpl> TableHandleManagerImpl::create(std::opti
 TableHandleManagerImpl::TableHandleManagerImpl(Private, std::optional<Ticket> &&consoleId,
     std::shared_ptr<Server> &&server, std::shared_ptr<Executor> &&executor,
     std::shared_ptr<Executor> &&flightExecutor) :
-    me_(deephaven::dhcore::utility::ObjectId("TableHandleManagerImpl", this)),
+    me_(deephaven::dhcore::utility::objectId("TableHandleManagerImpl", this)),
     consoleId_(std::move(consoleId)),
     server_(std::move(server)),
     executor_(std::move(executor)),

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -226,7 +226,7 @@ Server::Server(Private,
     ClientOptions::extra_headers_t extraHeaders,
     std::string sessionToken, std::chrono::milliseconds expirationInterval,
     std::chrono::system_clock::time_point nextHandshakeTime) :
-    me_(deephaven::dhcore::utility::ObjectId(
+    me_(deephaven::dhcore::utility::objectId(
             "client::server::Server", this)),
     applicationStub_(std::move(applicationStub)),
     consoleStub_(std::move(consoleStub)),

--- a/cpp-client/deephaven/client/src/server/server.cc
+++ b/cpp-client/deephaven/client/src/server/server.cc
@@ -16,14 +16,6 @@
 #include <arrow/array/array_primitive.h>
 
 #include "deephaven/dhcore/utility/utility.h"
-#include "deephaven/proto/config.pb.h"
-#include "deephaven/proto/config.grpc.pb.h"
-#include "deephaven/proto/console.pb.h"
-#include "deephaven/proto/console.grpc.pb.h"
-#include "deephaven/proto/session.pb.h"
-#include "deephaven/proto/session.grpc.pb.h"
-#include "deephaven/proto/table.pb.h"
-#include "deephaven/proto/table.grpc.pb.h"
 
 using namespace std;
 using arrow::flight::FlightClient;

--- a/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/client/src/subscription/subscribe_thread.cc
@@ -7,6 +7,7 @@
 #include <arrow/buffer.h>
 #include <arrow/scalar.h>
 #include <atomic>
+#include <grpc/support/log.h>
 #include "deephaven/client/arrowutil/arrow_column_source.h"
 #include "deephaven/client/server/server.h"
 #include "deephaven/client/utility/arrow_util.h"
@@ -185,12 +186,12 @@ UpdateProcessor::~UpdateProcessor() {
 }
 
 void UpdateProcessor::cancel() {
-  // TODO(cristianferretti): change to logging framework
-  std::cerr << DEEPHAVEN_DEBUG_MSG("Susbcription shutdown requested\n");
+  static const char *const me = "UpdateProcessor::cancel";
+  gpr_log(GPR_INFO, "%s: Subscription shutdown requested.", me);
   std::unique_lock guard(mutex_);
   if (cancelled_) {
     guard.unlock(); // to be nice
-    std::cerr << DEEPHAVEN_DEBUG_MSG("Already cancelled\n");
+    gpr_log(GPR_ERROR, "%s: Already cancelled.", me);
     return;
   }
   cancelled_ = true;

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
@@ -5,9 +5,12 @@
 
 #include <chrono>
 #include <cstring>
+#include <cstdio>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <sstream>
+#include <thread>
 #include <typeinfo>
 #include <vector>
 
@@ -263,6 +266,20 @@ TimePointToStr(
 template <class T> [[nodiscard]] std::string
 TypeName(const T& t) {
   return Demangle(typeid(t).name());
+}
+
+[[nodiscard]] inline std::string
+ObjectId(const std::string &classShortName, void* thisPtr) {
+  std::string id(classShortName + "[0x0000000000000000]");
+  snprintf(&id[classShortName.size() + 3], 16, "%p", thisPtr);
+  return id;
+}
+
+inline std::string
+ThreadIdToString(const std::thread::id tid) {
+  std::stringstream ss;
+  ss << tid;
+  return ss.str();
 }
 
 }  // namespace deephaven::dhcore::utility

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
@@ -3,10 +3,12 @@
  */
 #pragma once
 
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <typeinfo>
 #include <vector>
 
 namespace deephaven::dhcore::utility {
@@ -238,4 +240,29 @@ inline void trueOrThrow(const DebugInfo &debugInfo, bool value) {
   }
   internal::trueOrThrowHelper(debugInfo);
 }
+
+[[nodiscard]] std::string
+EpochMillisToStr(std::int64_t epochMillis);
+
+[[nodiscard]] inline std::int64_t
+TimePointToEpochMillis(
+    const std::chrono::time_point<std::chrono::system_clock> timePoint) {
+  using namespace std::chrono;
+  const milliseconds ms = duration_cast<milliseconds>(timePoint.time_since_epoch());
+  return ms.count();
+}
+
+[[nodiscard]] inline std::string
+TimePointToStr(
+    const std::chrono::time_point<std::chrono::system_clock> timePoint) {
+  return EpochMillisToStr(TimePointToEpochMillis(timePoint));
+}
+
+[[nodiscard]] std::string Demangle(const char* name);
+
+template <class T> [[nodiscard]] std::string
+TypeName(const T& t) {
+  return Demangle(typeid(t).name());
+}
+
 }  // namespace deephaven::dhcore::utility

--- a/cpp-client/deephaven/dhcore/src/utility/utility.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility.cc
@@ -221,11 +221,15 @@ EpochMillisToStr(std::int64_t epochMillis) {
   const unsigned millisRestMod100 = millisRest % 100;
   const unsigned tensMillisRest = millisRestMod100 / 10;
   const unsigned singleMillisRest = millisRestMod100 % 10;
+
   assert(hundredMillisRest < 10);
+  assert(resBuf[20] == '0');
   resBuf[20] = DIGITS[hundredMillisRest];
   assert(tensMillisRest < 10);
+  assert(resBuf[21] == '0');
   resBuf[21] = DIGITS[tensMillisRest];
   assert(singleMillisRest < 10);
+  assert(resBuf[22] == '0');
   resBuf[22] = DIGITS[singleMillisRest];
   return result;
 }

--- a/cpp-client/tests/buffer_column_source_test.cc
+++ b/cpp-client/tests/buffer_column_source_test.cc
@@ -13,7 +13,16 @@ using deephaven::dhcore::container::RowSequence;
 
 namespace deephaven::client::tests {
 TEST_CASE("Simple BufferColumnSource", "[columnsource]") {
-  auto temp = dhcore::utility::epochMillisToStr(1689136824000);
-  CHECK(temp == "hello");
+  std::vector<int64_t> chunk{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+  auto cs = NumericBufferColumnSource<int64_t>::create(chunk.data(), chunk.size());
+
+  auto rs = RowSequence::createSequential(5, 9);
+  auto data = Int64Chunk::create(4);
+  cs->fillChunk(*rs, &data, nullptr);
+
+  std::vector<int64_t> expected{5, 6, 7, 8};
+  std::vector<int64_t> actual(data.begin(), data.end());
+  CHECK(expected == actual);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/tests/buffer_column_source_test.cc
+++ b/cpp-client/tests/buffer_column_source_test.cc
@@ -13,16 +13,7 @@ using deephaven::dhcore::container::RowSequence;
 
 namespace deephaven::client::tests {
 TEST_CASE("Simple BufferColumnSource", "[columnsource]") {
-  std::vector<int64_t> chunk{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-
-  auto cs = NumericBufferColumnSource<int64_t>::create(chunk.data(), chunk.size());
-
-  auto rs = RowSequence::createSequential(5, 9);
-  auto data = Int64Chunk::create(4);
-  cs->fillChunk(*rs, &data, nullptr);
-
-  std::vector<int64_t> expected{5, 6, 7, 8};
-  std::vector<int64_t> actual(data.begin(), data.end());
-  CHECK(expected == actual);
+  auto temp = dhcore::utility::epochMillisToStr(1689136824000);
+  CHECK(temp == "hello");
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/tests/utility_test.cc
+++ b/cpp-client/tests/utility_test.cc
@@ -17,10 +17,20 @@ TEST_CASE("base64encode", "[utility]") {
 }
 
 TEST_CASE("epochMillisToStr", "[utility]") {
+  const char *tzKey = "TZ";
+  const char *originalTz = getenv(tzKey);
+  setenv(tzKey, "America/Denver", 1);
+  tzset();
   auto d1 = epochMillisToStr(1689136824000);
   auto d2 = epochMillisToStr(123456);
-  CHECK(d1 == "2023-07-12T00:40:24.000-0400");
-  CHECK(d2 == "1969-12-31T19:02:03.456-0500");
+  CHECK(d1 == "2023-07-11T22:40:24.000-0600");
+  CHECK(d2 == "1969-12-31T17:02:03.456-0700");
+  if (originalTz != nullptr) {
+    setenv(tzKey, originalTz, 1);
+  } else {
+    unsetenv(tzKey);
+  }
+  tzset();
 }
 
 TEST_CASE("objectId", "[utility]") {

--- a/cpp-client/tests/utility_test.cc
+++ b/cpp-client/tests/utility_test.cc
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "deephaven/dhcore/utility/utility.h"
 
 using deephaven::dhcore::utility::base64Encode;
+using deephaven::dhcore::utility::epochMillisToStr;
+using deephaven::dhcore::utility::objectId;
 
 namespace deephaven::client::tests {
 TEST_CASE("base64encode", "[utility]") {
@@ -13,6 +15,17 @@ TEST_CASE("base64encode", "[utility]") {
   CHECK(base64Encode("light work") == "bGlnaHQgd29yaw==");
   CHECK(base64Encode("light wor") == "bGlnaHQgd29y");
 }
+
+TEST_CASE("epochMillisToStr", "[utility]") {
+  auto d1 = epochMillisToStr(1689136824000);
+  auto d2 = epochMillisToStr(123456);
+  CHECK(d1 == "2023-07-12T00:40:24.000-0400");
+  CHECK(d2 == "1969-12-31T19:02:03.456-0500");
+}
+
+TEST_CASE("objectId", "[utility]") {
+  uintptr_t p = 0xdeadbeef;
+  auto id = objectId("hello", (void*)p);
+  CHECK(id == "hello[0xdeadbeef]");
+}
 }  // namespace deephaven::client::tests
-
-


### PR DESCRIPTION
Sample output follows.  Note below we get mixed lines from the gRPC DEBUG log and our own; for an example
of our own look for a line like

```
D0707 18:58:24.601635804 1824393 server.h:282]               0x564510c70690: Sending RPC io::deephaven::proto::backplane::grpc::FetchTableRequest at time 2023-07-07T18:58:24.601-0400.` 
```

below.

==

```
cfs@coipo 18:58:06 ~/dh/oss1/deephaven-core/cpp-client/deephaven/build
$ (cd ../../../cpp-examples/demos/build && make -j32 && GRPC_VERBOSITY=DEBUG ./chapter3)
Consolidate compiler generated dependencies of target dhcore
[ 33%] Built target dhcore
[ 91%] Built target client
[ 94%] Built target chapter3
[ 97%] Built target chapter2
[100%] Built target chapter1
I0707 18:58:13.414364967 1824393 ev_epoll1_linux.cc:121]     grpc epoll fd: 3
D0707 18:58:13.414447713 1824393 ev_posix.cc:171]            Using polling engine: epoll1
D0707 18:58:13.414510511 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "grpclb"
D0707 18:58:13.414521892 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "rls_experimental"
D0707 18:58:13.414529176 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "priority_experimental"
D0707 18:58:13.414538714 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "weighted_target_experimental"
D0707 18:58:13.414547350 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "pick_first"
D0707 18:58:13.414554193 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "round_robin"
D0707 18:58:13.414561006 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "ring_hash_experimental"
D0707 18:58:13.414567438 1824393 dns_resolver_ares.cc:454]   Using ares dns resolver
D0707 18:58:13.414604808 1824393 certificate_provider_registry.cc:33] registering certificate provider factory for "file_watcher"
D0707 18:58:13.414612573 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "cds_experimental"
D0707 18:58:13.414620448 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "xds_cluster_impl_experimental"
D0707 18:58:13.414628613 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "xds_cluster_resolver_experimental"
D0707 18:58:13.414635847 1824393 lb_policy_registry.cc:42]   registering LB policy factory for "xds_cluster_manager_experimental"
D0707 18:58:13.421390878 1824393 server.h:282]               0x564510c70690: Sending RPC io::deephaven::proto::backplane::script::grpc::StartConsoleRequest at time 2023-07-07T18:58:13.421-0400.
*** CHAPTER 3: MAIN MENU ***
1 - print full table
2 - print diffs with library
3 - process diffs

Please select 1-3: 1
Please enter the table name: demo1
D0707 18:58:24.601635804 1824393 server.h:282]               0x564510c70690: Sending RPC io::deephaven::proto::backplane::grpc::FetchTableRequest at time 2023-07-07T18:58:24.601-0400.
Press enter to unsubscribe: === The Full Table ===
[Row]   Timestamp
[0]     2023-07-07T22:58:20.000000000 UTC

=== The Full Table ===
[Row]   Timestamp
[0]     2023-07-07T22:58:20.000000000 UTC
[1]     2023-07-07T22:58:25.000000000 UTC

=== The Full Table ===
[Row]   Timestamp
[0]     2023-07-07T22:58:20.000000000 UTC
[1]     2023-07-07T22:58:25.000000000 UTC
[2]     2023-07-07T22:58:30.000000000 UTC

```