### PR TITLE
Allow building the C++ client with clang.

### DIFF
--- a/cpp-client/.clang-format
+++ b/cpp-client/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: Google
+IndentWidth: 2
+
+---
+Language: Cpp

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
@@ -61,6 +61,9 @@ struct ImmerColumnSourceImpls {
           if (destNullp != nullptr) {
             *destNullp++ = value == deephaven::dhcore::DeephavenTraits<T>::NULL_VALUE;
           }
+        } else {
+          // avoid clang complaining about unused variables
+          (void)destNullp;
         }
       }
     };
@@ -83,6 +86,11 @@ struct ImmerColumnSourceImpls {
           auto nullsEndp = srcNullFlags->begin() + srcEnd;
           immer::for_each_chunk(nullsBeginp, nullsEndp, copyNullsInner);
         }
+      } else {
+        // avoid clang complaining about unused variables.
+        (void)srcNullFlags;
+        (void)destNullp;
+        (void)copyNullsInner;
       }
     };
     rows.forEachInterval(copyOuter);

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/index_decoder.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/index_decoder.h
@@ -12,8 +12,8 @@ class DataInput {
 public:
   explicit DataInput(const flatbuffers::Vector<int8_t> &vec) : DataInput(vec.data(), vec.size()) {}
 
-  DataInput(const void *start, size_t size) : data_(static_cast<const char *>(start)),
-      size_(size) {}
+  DataInput(const void *start, size_t size) : data_(static_cast<const char *>(start))
+    {}
 
   int64_t readValue(int command);
 
@@ -24,7 +24,6 @@ public:
 
 private:
   const char *data_ = nullptr;
-  size_t size_ = 0;
 };
 
 struct IndexDecoder {

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -117,8 +117,7 @@ public:
   /**
    * The minimum finite value for the Deephaven float type.
    */
-  static constexpr const float MIN_FINITE_FLOAT = std::nextafter(-std::numeric_limits<float>::max(),
-      0.0f);
+  static /* constexpr clang dislikes */ const float MIN_FINITE_FLOAT;
   /**
    * The maximum finite value for the Deephaven float type.
    */
@@ -155,8 +154,7 @@ public:
   /**
    * The minimum finite value for the Deephaven double type.
    */
-  static constexpr const double MIN_FINITE_DOUBLE = std::nextafter(
-      -std::numeric_limits<double>::max(), 0.0f);
+  static /* constexpr clang dislikes */ const double MIN_FINITE_DOUBLE;
   /**
    * The maximum finite value for the Deephaven double type.
    */

--- a/cpp-client/deephaven/dhcore/src/ticking/space_mapper.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/space_mapper.cc
@@ -28,10 +28,6 @@ struct SimpleRangeIterator {
     return *this;
   }
 
-  friend bool operator!=(const SimpleRangeIterator &lhs, const SimpleRangeIterator &rhs) {
-    return lhs.value_ != rhs.value_;
-  }
-
   uint64_t value_;
 };
 }

--- a/cpp-client/deephaven/dhcore/src/types.cc
+++ b/cpp-client/deephaven/dhcore/src/types.cc
@@ -3,6 +3,8 @@
  */
 #include "deephaven/dhcore/types.h"
 
+#include <limits>
+
 namespace deephaven::dhcore {
 const char16_t DeephavenConstants::NULL_CHAR;
 
@@ -12,7 +14,8 @@ const float DeephavenConstants::NEG_INFINITY_FLOAT;
 const float DeephavenConstants::POS_INFINITY_FLOAT;
 const float DeephavenConstants::MIN_FLOAT;
 const float DeephavenConstants::MAX_FLOAT;
-const float DeephavenConstants::MIN_FINITE_FLOAT;
+const float DeephavenConstants::MIN_FINITE_FLOAT =
+  std::nextafter(-std::numeric_limits<float>::max(), 0.0f);
 const float DeephavenConstants::MAX_FINITE_FLOAT;
 const float DeephavenConstants::MIN_POS_FLOAT;
 
@@ -22,7 +25,8 @@ const double DeephavenConstants::NEG_INFINITY_DOUBLE;
 const double DeephavenConstants::POS_INFINITY_DOUBLE;
 const double DeephavenConstants::MIN_DOUBLE;
 const double DeephavenConstants::MAX_DOUBLE;
-const double DeephavenConstants::MIN_FINITE_DOUBLE;
+const double DeephavenConstants::MIN_FINITE_DOUBLE =
+  std::nextafter(-std::numeric_limits<double>::max(), 0.0);
 const double DeephavenConstants::MAX_FINITE_DOUBLE;
 const double DeephavenConstants::MIN_POS_DOUBLE;
 


### PR DESCRIPTION
The goal is to be able to run under memory sanitizer; clang also provides somewhat better error messages and is a bit more strict in its checks.

Had to make a few source tweaks to allow the code to build with clang.

I installed clang in ubuntu with
```
apt install clang
```

I had gcc-12 installed due to another unrelated package (rocm), which required me to also install stdc++12; seems that by default clang installs itself against the libraries of the highest version of gcc in the machine.  That created an issue for me because rocm wanted gcc-12 but did not need stdc++-12, so clang ended up with a C compiler but not C++ libraries.
```
apt install libstdc++-12-dev
```

You can check what version of a gcc installation clang++ is using by running `clang++ --verbose`

A few words about the changes:
* I had to remove some unused data members in some classes, clang will give an error about them.
* I had to remove some constexpr modifiers for constants, clang did not believe the associated function initializer could be evaluated constexpr.
* 