### PR TITLE
Error notifications need to participate in the satisfaction state machine for their listeners in the same way as regular TableUpdate notifications

### DIFF
--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/testcase/RefreshingTableTestCase.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/testcase/RefreshingTableTestCase.java
@@ -166,7 +166,7 @@ abstract public class RefreshingTableTestCase extends BaseArrayTestCase implemen
         // System.gc();
     }
 
-    public class ErrorExpectation implements Closeable {
+    public class ErrorExpectation implements SafeCloseable {
         final boolean originalExpectError;
 
         public ErrorExpectation() {


### PR DESCRIPTION
Fixes #4148 