### PR TITLE
Improve R client instructions to include details about installing R itself

### DIFF
--- a/R/rdeephaven/DESCRIPTION
+++ b/R/rdeephaven/DESCRIPTION
@@ -13,7 +13,7 @@ Description: The `rdeephaven` package provides an R API for communicating with t
              and bind it to a server-side variable so you can access it from any Deephaven client. Finally, you can run Python or Groovy
              scripts on the Deephaven server, so long as your server is equipped with that capability.
 License: Apache License (== 2.0)
-Depends: R (> 4.2.0), Rcpp (>= 1.0.10), arrow (>= 12.0.0), R6 (>= 2.5.0), dplyr (>= 1.1.0)
+Depends: R (> 4.1.2), Rcpp (>= 1.0.10), arrow (>= 12.0.0), R6 (>= 2.5.0), dplyr (>= 1.1.0)
 Imports: Rcpp (>= 1.0.10), arrow (>= 12.0.0), R6 (>= 2.5.0), dplyr (>= 1.1.0)
 LinkingTo: Rcpp
 Suggests: testthat (>= 3.0.0)

--- a/R/rdeephaven/README.md
+++ b/R/rdeephaven/README.md
@@ -32,6 +32,25 @@ or an [R Data Frame](https://stat.ethz.ch/R-manual/R-devel/library/base/html/dat
 
 Currently, the R client is only supported on Ubuntu 20.04 or 22.04 and must be built from source.
 
+0. We need a working installation of R on the machine where the R client will be built.
+   The R client requires R 4.1.2 or newer; you can install R from the standard packages
+   made available by Ubuntu 22.04.  If you want a newer R version or if you are running in
+   Ubuntu 20.04, you should install R from CRAN:
+
+   ```
+   # Download the key and install it
+   $ wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo gpg --dearmor -o /usr/share/keyrings/r-proj
+
+   # Add the R source list to apt's sources list
+   $ echo "deb [signed-by=/usr/share/keyrings/r-project.gpg] https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" | sudo tee -a /etc/apt/sources.list.d/r-project.l
+
+   # update the apt package list
+   $ apt update
+
+   # install R
+   $ sudo apt install r-base r-recommended
+   ```
+
 1. Build the cpp-client (and any dependent libraries) according to the instructions in
    https://github.com/deephaven/deephaven-core/blob/main/cpp-client/README.md.
    Follow the instructions at least to the point for "Build and install Deephaven C++ client".
@@ -56,9 +75,14 @@ Currently, the R client is only supported on Ubuntu 20.04 or 22.04 and must be b
    ```bash
    R
    ```
-   and in that console, install the client
+   In that console, install the dephaven client dependencies (since we are building from source
+   dependencies will not be automatically pulled in):
    ```r
-   install.packages("/path/to/rdeephaven", INSTALL_opts="--install-tests", repos=NULL, type="source", dependencies=TRUE)
+   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr'))
+   ```
+   then install the deephaven client itself:
+   ```r
+   install.packages("/path/to/rdeephaven", INSTALL_opts="--install-tests", repos=NULL, type="source")
    ```
    This last command can also be executed from RStudio without the need for explicitly starting an R console.
 


### PR DESCRIPTION
Updated trying to reflect the last experience from Corey trying to install R from scratch on Ubuntu, and capturing that to improve our instructions to help users with that part.