### PR TITLE
Narrow Scope of QueryTable#select's Intentional PoisonedExecutionContext

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1493,16 +1493,15 @@ public class QueryTable extends BaseTable<QueryTable> {
 
                     final QueryTable resultTable;
                     final LivenessScope liveResultCapture = isRefreshing() ? new LivenessScope() : null;
-                    try (final SafeCloseable ignored1 = liveResultCapture != null ? liveResultCapture::release : null;
-                            final SafeCloseable ignored2 =
-                                    ExecutionContext.getDefaultContext().withUpdateGraph(getUpdateGraph()).open()) {
-                        // we open the default context here to ensure that the update processing happens in the default
-                        // context whether it is processed in parallel or not
+                    try (final SafeCloseable ignored1 = liveResultCapture != null ? liveResultCapture::release : null) {
                         try (final RowSet emptyRowSet = RowSetFactory.empty();
                                 final SelectAndViewAnalyzer.UpdateHelper updateHelper =
                                         new SelectAndViewAnalyzer.UpdateHelper(emptyRowSet, fakeUpdate)) {
 
-                            try {
+                            try (final SafeCloseable ignored2 =
+                                    ExecutionContext.getDefaultContext().withUpdateGraph(getUpdateGraph()).open()) {
+                                // we open the default context here to ensure that the update processing happens in the
+                                // default/poisoned context whether it is processed in parallel or not
                                 analyzer.applyUpdate(fakeUpdate, emptyRowSet, updateHelper, jobScheduler,
                                         liveResultCapture, analyzer.futureCompletionHandler(waitForResult));
                             } catch (Exception e) {


### PR DESCRIPTION
DHE noticed that the AuthContext was not available when the table listener was being constructed -- similarly it was not available during the QueryPerformanceLogger acrobats. The select/update methods intentionally open a poisoned context as that is the state the parallel-processing threads run in - this ensures that users who need an execution context are correctly registering one themselves. If they do not, then this ensures an error occurs during initialization and not one the first table update.

Looking at the code, the intent of that poisoned context can still be achieved with a narrower window. This is that change.

Nightlies are running here: https://github.com/nbauernfeind/deephaven-core/actions/runs/5525474995/