### PR TITLE
Java-Client: Use Arrow's `VarCharVector#setSafe` as the Inner Vector's Size is Unknown

### DIFF
--- a/java-client/flight/src/main/java/io/deephaven/client/impl/VectorHelper.java
+++ b/java-client/flight/src/main/java/io/deephaven/client/impl/VectorHelper.java
@@ -100,7 +100,7 @@ public class VectorHelper {
             if (value == null) {
                 vector.setNull(i);
             } else {
-                vector.set(i, value.getBytes(StandardCharsets.UTF_8));
+                vector.setSafe(i, value.getBytes(StandardCharsets.UTF_8));
             }
             ++i;
         }


### PR DESCRIPTION
Fixes #4168.

Note that `setSafe` will resize the inner vector as needed automatically.