### PR TITLE
C++ Client: add Client::close() for callers to shut things down on demand

### DIFF
--- a/cpp-client/deephaven/client/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client.h
@@ -198,6 +198,16 @@ public:
   ~Client();
 
   /**
+   * Shuts down the Client and all associated state (GRPC connections, subscriptions, etc).
+   * This method is used if a caller wants to shut down Client state early. If it is not called,
+   * the shutdown actions will happen when this Client is destructed. The caller must not use any
+   * associated data structures (TableHandleManager, TableHandle, etc) after close() is called or
+   * after Client's destructor is invoked. If the caller tries to do so, the behavior is
+   * unspecified.
+   */
+  void close();
+
+  /**
    * Gets a TableHandleManager which you can use to create empty tables, fetch tables, and so on.
    * You can create more than one TableHandleManager.
    * @return The TableHandleManager.

--- a/cpp-client/deephaven/client/src/client.cc
+++ b/cpp-client/deephaven/client/src/client.cc
@@ -63,17 +63,25 @@ Client::Client(std::shared_ptr<impl::ClientImpl> impl) : impl_(std::move(impl)) 
 Client::Client(Client &&other) noexcept = default;
 Client &Client::operator=(Client &&other) noexcept = default;
 
-// There is only one Client associated with the server connection. Clients can only be moved, not copied.
-// When the client owning the state is destructed, we tear down the connection.
+// There is only one Client associated with the server connection. Clients can only be moved, not
+// copied. When the Client owning the state is destructed, we tear down the state via close().
 Client::~Client() {
-  if (impl_ != nullptr) {
-    impl_->shutdown();
+  close();
+}
+
+// Tear down Client state.
+void Client::close() {
+  // Move to local variable to be defensive.
+  auto temp = std::move(impl_);
+  if (temp != nullptr) {
+    temp->shutdown();
   }
 }
 
 TableHandleManager Client::getManager() const {
   return TableHandleManager(impl_->managerImpl());
 }
+
 
 TableHandleManager::TableHandleManager() = default;
 TableHandleManager::TableHandleManager(std::shared_ptr<impl::TableHandleManagerImpl> impl) : impl_(std::move(impl)) {}

--- a/cpp-client/tests/CMakeLists.txt
+++ b/cpp-client/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(tests
     add_drop_test.cc
     aggregates_test.cc
     attributes_test.cc
+    basic_test.cc
     buffer_column_source_test.cc
     cython_support_test.cc
     head_and_tail_test.cc

--- a/cpp-client/tests/basic_test.cc
+++ b/cpp-client/tests/basic_test.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+#include <iostream>
+#include "tests/third_party/catch.hpp"
+#include "tests/test_util.h"
+#include "deephaven/client/client.h"
+
+using deephaven::client::Client;
+
+namespace deephaven::client::tests {
+TEST_CASE("Close plays nice with destructor", "[simple]") {
+    auto tm = TableMakerForTests::create();
+    auto table = tm.table();
+    auto updated = table.update("QQQ = i");
+    std::cout << updated.stream(true) << '\n';
+    tm.client().close();
+  }
+}

--- a/cpp-client/tests/test_util.h
+++ b/cpp-client/tests/test_util.h
@@ -89,6 +89,7 @@ public:
       testTable_(std::move(testTable)), columnNames_(std::move(columnNames)),
       columnData_(std::move(columnData)) {}
 
+  Client &client() { return client_; }
   const Client &client() const { return client_; }
 
 private:


### PR DESCRIPTION
(i.e. if it is needed to do so earlier than Client's destructor).