### PR TITLE
Stop using temp dir for GWT compile

### DIFF
--- a/buildSrc/src/main/groovy/GwtTools.groovy
+++ b/buildSrc/src/main/groovy/GwtTools.groovy
@@ -85,12 +85,10 @@ class GwtTools {
                 // See https://github.com/esoco/gwt-gradle-plugin for all options
                 /** The level of logging detail (ERROR, WARN, INFO, TRACE, DEBUG, SPAM, ALL) */
                 logLevel = "INFO"
-                /** The workDir, where we'll save gwt unitcache.  Use /tmp to avoid cluttering jenkins caches*/
-                workDir = Files.createTempDirectory("gradleGwtWork").toFile()
                 /** Where to write output files */
                 war = warPath
                 /** Compile a report that tells the "Story of Your Compile". */
-                compileReport = true
+                compileReport = false
                 /** Compile quickly with minimal optimizations. */
                 draftCompile = false
                 /** Include assert statements in compiled output. */

--- a/buildSrc/src/main/groovy/GwtTools.groovy
+++ b/buildSrc/src/main/groovy/GwtTools.groovy
@@ -9,6 +9,8 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.compile.JavaCompile
 
+import java.nio.file.Files
+
 /**
  * Helper to simplify / centralize configuring gwt plugins in build files
  */
@@ -84,7 +86,7 @@ class GwtTools {
                 /** The level of logging detail (ERROR, WARN, INFO, TRACE, DEBUG, SPAM, ALL) */
                 logLevel = "INFO"
                 /** The workDir, where we'll save gwt unitcache.  Use /tmp to avoid cluttering jenkins caches*/
-                workDir = new File(System.getProperty("java.io.tmpdir"), "gwtWork")
+                workDir = Files.createTempDirectory("gradleGwtWork").toFile()
                 /** Where to write output files */
                 war = warPath
                 /** Compile a report that tells the "Story of Your Compile". */


### PR DESCRIPTION
The file `/tmp/gwtWork/io.deephaven.web.DeephavenApi/compiler/permutation-0.js` is in fact left behind after running `./gradlew prepareCompose`.  Since the file has always the same path regarding of user or user session, this mean two users on the same machine won't be able to build without clashing with each other (because the second user to run won't be able to overwrite the first user's file in /tmp), and for the same user, two parallel executions could clash.