### PR TITLE
Suppress Unpredictable Client-Behavior gRPC related Exceptions

### DIFF
--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
@@ -303,8 +303,13 @@ final class ServletServerStream extends AbstractServerStream {
             close(Status.CANCELLED.withCause(status.asRuntimeException()), new Metadata());
             CountDownLatch countDownLatch = new CountDownLatch(1);
             transportState.runOnTransportThread(() -> {
-                asyncCtx.complete();
-                countDownLatch.countDown();
+                try {
+                    asyncCtx.complete();
+                    countDownLatch.countDown();
+                } catch (final Exception err) {
+                    // this happens when the async context is already complete
+                    logger.info("Unexpected exception completing async context: " + err.getMessage());
+                }
             });
             try {
                 countDownLatch.await(5, TimeUnit.SECONDS);

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
@@ -305,10 +305,11 @@ final class ServletServerStream extends AbstractServerStream {
             transportState.runOnTransportThread(() -> {
                 try {
                     asyncCtx.complete();
-                    countDownLatch.countDown();
                 } catch (final Exception err) {
-                    // this happens when the async context is already complete
-                    logger.info("Unexpected exception completing async context: " + err.getMessage());
+                    // this may happen when the async context is already complete; it isn't surprising this may fail as
+                    // we're trying to notify the user of another known error on this stream
+                } finally {
+                    countDownLatch.countDown();
                 }
             });
             try {

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebSocketServerStream.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebSocketServerStream.java
@@ -17,7 +17,6 @@ import jakarta.websocket.Session;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -219,15 +218,16 @@ public class MultiplexedWebSocketServerStream extends AbstractWebSocketServerStr
     }
 
     @Override
+    @SuppressWarnings("StatementWithEmptyBody")
     public void onError(Session session, Throwable error) {
         for (MultiplexedWebsocketStreamImpl stream : streams.values()) {
             stream.transportReportStatus(Status.UNKNOWN);// transport failure of some kind
         }
         streams.clear();
         // onClose will be called automatically
-        if (error instanceof ClosedChannelException) {
-            // ignore this for now
-            // TODO need to understand why this is happening
+        if (error instanceof IOException) {
+            // IOExceptions frequently occur when clients close the connection
+            // Note we have seen both EofExceptions and ClosedChannelExceptions
         } else {
             logger.log(Level.SEVERE, "Error from websocket", error);
         }

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
@@ -76,7 +76,7 @@ public class MultiplexedWebsocketStreamImpl extends AbstractWebsocketStreamImpl 
             try {
                 websocketSession.getBasicRemote().sendBinary(message);
             } catch (IOException e) {
-                throw Status.fromThrowable(e).asRuntimeException();
+                // ignore IOExceptions; they are likely due to unpredictable client behavior
             }
         }
 

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
@@ -76,7 +76,8 @@ public class MultiplexedWebsocketStreamImpl extends AbstractWebsocketStreamImpl 
             try {
                 websocketSession.getBasicRemote().sendBinary(message);
             } catch (IOException e) {
-                // ignore IOExceptions; they are likely due to unpredictable client behavior
+                // rethrowing from this method adds nonsense to the logs; onError will be invoked for us at a future
+                // time
             }
         }
 

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebsocketStreamImpl.java
@@ -76,8 +76,7 @@ public class MultiplexedWebsocketStreamImpl extends AbstractWebsocketStreamImpl 
             try {
                 websocketSession.getBasicRemote().sendBinary(message);
             } catch (IOException e) {
-                // rethrowing from this method adds nonsense to the logs; onError will be invoked for us at a future
-                // time
+                // rethrowing from this method adds nonsense to the logs; onError will be invoked automatically
             }
         }
 

--- a/server/src/main/java/io/deephaven/server/session/SessionService.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionService.java
@@ -61,8 +61,10 @@ public class SessionService {
         public StatusRuntimeException transform(final Throwable err) {
             if (err instanceof StatusRuntimeException) {
                 final StatusRuntimeException sre = (StatusRuntimeException) err;
-                if (sre.getStatus().equals(Status.UNAUTHENTICATED)) {
-                    log.info().append("ignoring unauthenticated request").endl();
+                if (sre.getStatus().getCode().equals(Status.UNAUTHENTICATED.getCode())) {
+                    log.debug().append("ignoring unauthenticated request").endl();
+                } else if (sre.getStatus().getCode().equals(Status.CANCELLED.getCode())) {
+                    log.debug().append("ignoring cancelled request").endl();
                 } else {
                     log.error().append(sre).endl();
                 }


### PR DESCRIPTION
Fixes #4172
Fixes #4173 

- Do not print out gRPC out-of-band cancellations (such as session expiry, or a dependent export cancellation).
- Suppress all IOExceptions when writing gRPC stream metadata. (there are races between client closing cancelled RPCs and us notifying them)
- Suppress all IOExceptions from `MultiplexedWebsocketStreamImpl#onError` propagation.
- Do not allow Exceptions to leak out when attempting to close AsynContext (which might already be completed whenever an RPC is cancelled and/or errored from different, raceful, code paths).