### PR TITLE
Don't use ExecutionContext to read constants

### DIFF
--- a/extensions/arrow/src/main/java/io/deephaven/extensions/arrow/ArrowWrapperTools.java
+++ b/extensions/arrow/src/main/java/io/deephaven/extensions/arrow/ArrowWrapperTools.java
@@ -122,9 +122,8 @@ import static org.apache.arrow.vector.ipc.message.MessageSerializer.IPC_CONTINUA
  * suggested future improvements.
  */
 public class ArrowWrapperTools {
-    private static final int MAX_POOL_SIZE = Math.max(
-            ExecutionContext.getContext().getUpdateGraph().parallelismFactor(),
-            Configuration.getInstance().getIntegerWithDefault("ArrowWrapperTools.defaultMaxPooledContext", 4));
+    private static final int MAX_POOL_SIZE = Configuration.getInstance().getIntegerWithDefault(
+            "ArrowWrapperTools.defaultMaxPooledContext", Runtime.getRuntime().availableProcessors());
 
     private static final BufferAllocator rootAllocator = new RootAllocator();
 


### PR DESCRIPTION
Instead of reading a constant value from the ExecutionContext, get it from the same root source. This isn't actually used for threading, so much as deciding how much to split up work, so this value is more of a hint than a requirement to have.

Also changes the Math.max to instead server as a default, so that the user-specified value can be either higher _or_ lower than the number of processors.