### PR TITLE
feat: Handle CategoryErrorBarDataSeriesPartitionedTable

### DIFF
--- a/Plot/src/main/java/io/deephaven/plot/datasets/categoryerrorbar/CategoryErrorBarDataSeriesPartitionedTable.java
+++ b/Plot/src/main/java/io/deephaven/plot/datasets/categoryerrorbar/CategoryErrorBarDataSeriesPartitionedTable.java
@@ -144,4 +144,23 @@ public class CategoryErrorBarDataSeriesPartitionedTable extends AbstractTableBas
         return valueCol;
     }
 
+    public TableHandle getTableHandle() {
+        return tableHandle;
+    }
+
+    public String getCategoryColumn() {
+        return categoryCol;
+    }
+
+    public String getValueColumn() {
+        return valueCol;
+    }
+
+    public String getErrorBarLowColumn() {
+        return errorBarLowCol;
+    }
+
+    public String getErrorBarHighColumn() {
+        return errorBarHighCol;
+    }
 }

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -408,11 +408,20 @@ public class FigureWidgetTranslator {
                                                 series.getHoverTextColumn(), SourceType.HOVER_TEXT, null));
                                     }
                                 } else if (s instanceof CategoryErrorBarDataSeriesPartitionedTable) {
-                                    CategoryErrorBarDataSeriesPartitionedTable series = (CategoryErrorBarDataSeriesPartitionedTable) s;
-                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getCategoryColumn(), catAxis == xAxis ? SourceType.X: SourceType.Y, catAxis));
-                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getValueColumn(), numAxis == xAxis ? SourceType.X: SourceType.Y, numAxis));
-                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getErrorBarLowColumn(), numAxis == xAxis ? SourceType.X_LOW: SourceType.Y_LOW, numAxis));
-                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getErrorBarHighColumn(), numAxis == xAxis ? SourceType.X_HIGH: SourceType.Y_HIGH, numAxis));
+                                    CategoryErrorBarDataSeriesPartitionedTable series =
+                                            (CategoryErrorBarDataSeriesPartitionedTable) s;
+                                    clientAxes.add(
+                                            makeSourceDescriptor(series.getTableHandle(), series.getCategoryColumn(),
+                                                    catAxis == xAxis ? SourceType.X : SourceType.Y, catAxis));
+                                    clientAxes
+                                            .add(makeSourceDescriptor(series.getTableHandle(), series.getValueColumn(),
+                                                    numAxis == xAxis ? SourceType.X : SourceType.Y, numAxis));
+                                    clientAxes.add(
+                                            makeSourceDescriptor(series.getTableHandle(), series.getErrorBarLowColumn(),
+                                                    numAxis == xAxis ? SourceType.X_LOW : SourceType.Y_LOW, numAxis));
+                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(),
+                                            series.getErrorBarHighColumn(),
+                                            numAxis == xAxis ? SourceType.X_HIGH : SourceType.Y_HIGH, numAxis));
                                 } else if (s instanceof CategoryDataSeriesMap) {// bar and plot from constant data
                                     errorList.add("OpenAPI presently does not support series of type " + s.getClass());
                                 }

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -23,6 +23,7 @@ import io.deephaven.plot.datasets.category.CategoryDataSeriesMap;
 import io.deephaven.plot.datasets.category.CategoryTreemapDataSeriesTableMap;
 import io.deephaven.plot.datasets.category.CategoryDataSeriesPartitionedTable;
 import io.deephaven.plot.datasets.category.CategoryDataSeriesSwappablePartitionedTable;
+import io.deephaven.plot.datasets.categoryerrorbar.CategoryErrorBarDataSeriesPartitionedTable;
 import io.deephaven.plot.datasets.data.IndexableNumericData;
 import io.deephaven.plot.datasets.data.IndexableNumericDataSwappableTable;
 import io.deephaven.plot.datasets.data.IndexableNumericDataTable;
@@ -406,6 +407,12 @@ public class FigureWidgetTranslator {
                                         clientAxes.add(makeSourceDescriptor(series.getTableHandle(),
                                                 series.getHoverTextColumn(), SourceType.HOVER_TEXT, null));
                                     }
+                                } else if (s instanceof CategoryErrorBarDataSeriesPartitionedTable) {
+                                    CategoryErrorBarDataSeriesPartitionedTable series = (CategoryErrorBarDataSeriesPartitionedTable) s;
+                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getCategoryColumn(), catAxis == xAxis ? SourceType.X: SourceType.Y, catAxis));
+                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getValueColumn(), numAxis == xAxis ? SourceType.X: SourceType.Y, numAxis));
+                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getErrorBarLowColumn(), numAxis == xAxis ? SourceType.X_LOW: SourceType.Y_LOW, numAxis));
+                                    clientAxes.add(makeSourceDescriptor(series.getTableHandle(), series.getErrorBarHighColumn(), numAxis == xAxis ? SourceType.X_HIGH: SourceType.Y_HIGH, numAxis));
                                 } else if (s instanceof CategoryDataSeriesMap) {// bar and plot from constant data
                                     errorList.add("OpenAPI presently does not support series of type " + s.getClass());
                                 }


### PR DESCRIPTION
- CategoryErrorBarDataSeriesPartitionedTable was not supported at all. Wire it up through FigureWidgetTranslator
- Web UI needs to handle data bars correctly as well
- Fixes #2156
