### PR TITLE
Add Bessel correction to weighted variance

### DIFF
--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -548,6 +548,7 @@ public class Numeric {
         double sum = 0;
         double sum2 = 0;
         double count = 0;
+        double count2 = 0;
 
         try (
             final ${pt.vectorIterator} vi = values.iterator();
@@ -561,11 +562,17 @@ public class Numeric {
                     sum += w * c;
                     sum2 += w * c * c;
                     count += w;
+                    count2 += w * w;
                 }
             }
         }
 
-        return sum2 / count - sum * sum / count / count;
+        // For unbiased estimator derivation see https://en.wikipedia.org/wiki/Weighted_arithmetic_mean#Weighted_sample_variance
+        // For unweighted statistics, there is a (N-1)/N = (1-1/N) Bessel correction.  
+        // The analagous correction for weighted statistics is 1-count2/count/count, which yields an effective sample size of Neff = count*count/count2.
+        // This yields an unbiased estimator of (sum2/count - sum*sum/count/count) * ((count*count/count2)/((count*count/count2)-1)).
+        // This can be simplifed to (count * sum2 - sum * sum) / (count * count - count2)
+        return (count * sum2 - sum * sum) / (count * count - count2);
     }
 
     </#if>

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -571,7 +571,7 @@ public class Numeric {
         // For unweighted statistics, there is a (N-1)/N = (1-1/N) Bessel correction.  
         // The analagous correction for weighted statistics is 1-count2/count/count, which yields an effective sample size of Neff = count*count/count2.
         // This yields an unbiased estimator of (sum2/count - sum*sum/count/count) * ((count*count/count2)/((count*count/count2)-1)).
-        // This can be simplifed to (count * sum2 - sum * sum) / (count * count - count2)
+        // This can be simplified to (count * sum2 - sum * sum) / (count * count - count2)
         return (count * sum2 - sum * sum) / (count * count - count2);
     }
 

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -926,8 +926,7 @@ public class TestNumeric extends BaseArrayTestCase {
         final double w2 = 4.0*4.0 + 5.0*5.0 + 6.0*6.0;
         final double sum = 1.0*4.0+2.0*5.0+3.0*6.0;
         final double sum2 = 1.0*1.0*4.0 + 2.0*2.0*5.0 + 3.0*3.0*6.0;
-        final double neff = w*w / w2;
-        final double target = (sum2/w - sum * sum / w / w) * (neff / (neff - 1));
+        final double target = (w * sum2 - sum * sum) / (w * w - w2);
 
         <#list primitiveTypes as pt2>
         <#if pt2.valueType.isNumber >
@@ -955,7 +954,8 @@ public class TestNumeric extends BaseArrayTestCase {
             // pass
         }
 
-        assertEquals(var(new ${pt.primitive}[]{1,2,3}), wvar(new ${pt.primitive}[]{1,1,1,${pt.null},5}, new ${pt2.primitive}[]{4,5,6,7,${pt2.null}}));
+        assertEquals(var(new ${pt.primitive}[]{1,2,3}), wvar(new ${pt.primitive}[]{1,2,3,${pt.null},5}, new ${pt2.primitive}[]{1,1,1,7,${pt2.null}}));
+        assertEquals(var(new ${pt.primitive}[]{1,2,3}), wvar(new ${pt.primitive}[]{1,2,3,${pt.null},5}, new ${pt2.primitive}[]{2,2,2,7,${pt2.null}}));
 
         </#if>
         </#list>
@@ -963,9 +963,10 @@ public class TestNumeric extends BaseArrayTestCase {
 
     public void test${pt.boxed}Wstd() {
         final double w = 4.0 + 5.0 + 6.0;
+        final double w2 = 4.0*4.0 + 5.0*5.0 + 6.0*6.0;
         final double sum = 1.0*4.0+2.0*5.0+3.0*6.0;
         final double sum2 = 1.0*1.0*4.0 + 2.0*2.0*5.0 + 3.0*3.0*6.0;
-        final double target = Math.sqrt(sum2/w - sum * sum / w / w);
+        final double target = Math.sqrt((w * sum2 - sum * sum) / (w * w - w2));
 
         <#list primitiveTypes as pt2>
         <#if pt2.valueType.isNumber >
@@ -996,7 +997,7 @@ public class TestNumeric extends BaseArrayTestCase {
         final double w2 = 4.0*4.0 + 5.0*5.0 + 6.0*6.0;
         final double sum = 1.0*4.0+2.0*5.0+3.0*6.0;
         final double sum2 = 1.0*1.0*4.0 + 2.0*2.0*5.0 + 3.0*3.0*6.0;
-        final double std = Math.sqrt(sum2/w - sum * sum / w / w);
+        final double std = Math.sqrt((w * sum2 - sum * sum) / (w * w - w2));
         final double target = std * Math.sqrt( w2 / w / w);
 
         <#list primitiveTypes as pt2>

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -923,9 +923,11 @@ public class TestNumeric extends BaseArrayTestCase {
 
     public void test${pt.boxed}Wvar() {
         final double w = 4.0 + 5.0 + 6.0;
+        final double w2 = 4.0*4.0 + 5.0*5.0 + 6.0*6.0;
         final double sum = 1.0*4.0+2.0*5.0+3.0*6.0;
         final double sum2 = 1.0*1.0*4.0 + 2.0*2.0*5.0 + 3.0*3.0*6.0;
-        final double target = sum2/w - sum * sum / w / w;
+        final double neff = w*w / w2;
+        final double target = (sum2/w - sum * sum / w / w) * (neff / (neff - 1));
 
         <#list primitiveTypes as pt2>
         <#if pt2.valueType.isNumber >
@@ -953,6 +955,7 @@ public class TestNumeric extends BaseArrayTestCase {
             // pass
         }
 
+        assertEquals(var(new ${pt.primitive}[]{1,2,3}), wvar(new ${pt.primitive}[]{1,1,1,${pt.null},5}, new ${pt2.primitive}[]{4,5,6,7,${pt2.null}}));
 
         </#if>
         </#list>


### PR DESCRIPTION
The weighted variance calculation (and all calculations depending on it) did not have a Bessel correction, so the calculation was performing a biased estimation.

See https://en.wikipedia.org/wiki/Weighted_arithmetic_mean#Weighted_sample_variance for details on the calculation.