### PR TITLE
Fix for failure in reading lists in parquet files

### DIFF
--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
@@ -4,11 +4,11 @@
 package io.deephaven.parquet.base;
 
 import io.deephaven.base.Pair;
+import io.deephaven.base.verify.Assert;
 import io.deephaven.parquet.base.util.Helpers;
 import io.deephaven.parquet.base.util.RunLengthBitPackingHybridBufferDecoder;
 import io.deephaven.parquet.base.util.SeekableChannelsProvider;
 import io.deephaven.parquet.compress.CompressorAdapter;
-import org.apache.commons.io.IOUtils;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -26,7 +26,6 @@ import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.Type;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -80,7 +79,6 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         this.offset = offset;
         this.pageHeader = pageHeader;
         this.numValues = numValues;
-
     }
 
     @Override
@@ -135,6 +133,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
             } while (!success);
             file.position(offset);
         }
+        ensureNumValues();
     }
 
     private int readRowCountFromDataPage(ReadableByteChannel file) throws IOException {
@@ -263,7 +262,6 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
     }
 
     private Encoding getEncoding(org.apache.parquet.format.Encoding encoding) {
-
         return org.apache.parquet.column.Encoding.valueOf(encoding.name());
     }
 
@@ -316,7 +314,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
                     new KeyIndexReader((DictionaryValuesReader) getDataReader(page.getValueEncoding(),
                             bytes, page.getValueCount()));
             Object result = materialize(PageMaterializer.IntFactory, dlDecoder, rlDecoder,
-                    dataReader, nullPlaceholder, numValues);
+                    dataReader, nullPlaceholder);
             if (result instanceof DataWithOffsets) {
                 keyDest.put((int[]) ((DataWithOffsets) result).materializeResult);
                 return ((DataWithOffsets) result).offsets;
@@ -334,7 +332,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         rlDecoder = new RunLengthBitPackingHybridBufferDecoder(path.getMaxRepetitionLevel(), byteBuffer);
         int rowsRead = 0;
         int totalCount = 0;
-        while (rlDecoder.hasNext() && totalCount < numValues()) {
+        while (rlDecoder.hasNext() && totalCount < numValues) {
             rlDecoder.readNextRange();
             int count = rlDecoder.currentRangeCount();
             totalCount += count;
@@ -371,7 +369,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
             ValuesReader dataReader =
                     getDataReader(page.getValueEncoding(), bytes, page.getValueCount());
             return materialize(pageMaterializerFactory, dlDecoder, rlDecoder,
-                    dataReader, nullValue, numValues);
+                    dataReader, nullValue);
         } catch (IOException e) {
             throw new ParquetDecodingException("could not read page " + page + " in col " + path,
                     e);
@@ -380,8 +378,8 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
 
     private Object materialize(PageMaterializer.Factory factory,
             RunLengthBitPackingHybridBufferDecoder dlDecoder,
-            RunLengthBitPackingHybridBufferDecoder rlDecoder, ValuesReader dataReader, Object nullValue,
-            int numValues) throws IOException {
+            RunLengthBitPackingHybridBufferDecoder rlDecoder, ValuesReader dataReader, Object nullValue)
+            throws IOException {
         if (dlDecoder == null) {
             return materializeNonNull(factory, numValues, dataReader);
         } else {
@@ -406,9 +404,9 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
             ValuesReader dataReader = getDataReader(page.getDataEncoding(),
                     page.getData().toByteBuffer(), page.getValueCount());
             if (dlDecoder != null) {
-                readKeysWithNulls(keyDest, nullPlaceholder, numValues(), dlDecoder, dataReader);
+                readKeysWithNulls(keyDest, nullPlaceholder, dlDecoder, dataReader);
             } else {
-                readKeysNonNulls(keyDest, numValues, dataReader);
+                readKeysNonNulls(keyDest, dataReader);
             }
         } catch (IOException e) {
             throw new ParquetDecodingException("could not read page " + page + " in col " + path,
@@ -421,7 +419,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         throw new UnsupportedOperationException("Parquet V2 data pages are not supported");
     }
 
-    private void readKeysWithNulls(IntBuffer keysBuffer, int nullPlaceholder, int numValues,
+    private void readKeysWithNulls(IntBuffer keysBuffer, int nullPlaceholder,
             RunLengthBitPackingHybridBufferDecoder dlDecoder, ValuesReader dataReader)
             throws IOException {
         DictionaryValuesReader dictionaryValuesReader = (DictionaryValuesReader) dataReader;
@@ -444,7 +442,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         }
     }
 
-    private void readKeysNonNulls(IntBuffer keysBuffer, int numValues, ValuesReader dataReader)
+    private void readKeysNonNulls(IntBuffer keysBuffer, ValuesReader dataReader)
             throws IOException {
         DictionaryValuesReader dictionaryValuesReader = (DictionaryValuesReader) dataReader;
         for (int i = 0; i < numValues; i++) {
@@ -452,18 +450,18 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         }
     }
 
-    private Object materializeWithNulls(PageMaterializer.Factory factory,
-            int numValues,
+    private static Object materializeWithNulls(PageMaterializer.Factory factory,
+            int numberOfValues,
             IntBuffer nullOffsets,
             ValuesReader dataReader, Object nullValue) {
-        final PageMaterializer materializer = factory.makeMaterializerWithNulls(dataReader, nullValue, numValues);
+        final PageMaterializer materializer = factory.makeMaterializerWithNulls(dataReader, nullValue, numberOfValues);
         int startIndex = 0;
-        int nextNullPos = nullOffsets.hasRemaining() ? nullOffsets.get() : numValues;
-        while (startIndex < numValues) {
+        int nextNullPos = nullOffsets.hasRemaining() ? nullOffsets.get() : numberOfValues;
+        while (startIndex < numberOfValues) {
             int rangeEnd = startIndex;
-            while (nextNullPos == rangeEnd && rangeEnd < numValues) {
+            while (nextNullPos == rangeEnd && rangeEnd < numberOfValues) {
                 rangeEnd++;
-                nextNullPos = nullOffsets.hasRemaining() ? nullOffsets.get() : numValues;
+                nextNullPos = nullOffsets.hasRemaining() ? nullOffsets.get() : numberOfValues;
             }
             materializer.fillNulls(startIndex, rangeEnd);
             materializer.fillValues(rangeEnd, nextNullPos);
@@ -475,7 +473,8 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
     /**
      * Creates a list of offsets with null entries
      */
-    private IntBuffer combineOptionalAndRepeating(IntBuffer nullOffsets, IntBuffer repeatingRanges, int nullValue) {
+    private static IntBuffer combineOptionalAndRepeating(IntBuffer nullOffsets, IntBuffer repeatingRanges,
+            int nullValue) {
         IntBuffer result = IntBuffer.allocate(nullOffsets.limit() + repeatingRanges.limit());
         int startIndex = 0;
         int nextNullPos = nullOffsets.hasRemaining() ? nullOffsets.get() : result.capacity();
@@ -501,9 +500,8 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
             RunLengthBitPackingHybridBufferDecoder dlDecoder,
             RunLengthBitPackingHybridBufferDecoder rlDecoder, ValuesReader dataReader, Object nullValue)
             throws IOException {
-        Pair<Pair<Type.Repetition, IntBuffer>[], Integer> offsetsAndCount =
-                getOffsetsAndNulls(dlDecoder, rlDecoder, numValues);
-        int numValues = offsetsAndCount.second;
+        Pair<Pair<Type.Repetition, IntBuffer>[], Integer> offsetsAndCount = getOffsetsAndNulls(dlDecoder, rlDecoder);
+        int updatedNumValues = offsetsAndCount.second;
         Pair<Type.Repetition, IntBuffer>[] offsetAndNulls = offsetsAndCount.first;
         List<IntBuffer> offsetsWithNull = new ArrayList<>();
         IntBuffer currentNullOffsets = null;
@@ -525,10 +523,10 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         }
         Object values;
         if (currentNullOffsets != null && currentNullOffsets.hasRemaining()) {
-            values = materializeWithNulls(factory, numValues, currentNullOffsets,
+            values = materializeWithNulls(factory, updatedNumValues, currentNullOffsets,
                     dataReader, nullValue);
         } else {
-            values = materializeNonNull(factory, numValues, dataReader);
+            values = materializeNonNull(factory, updatedNumValues, dataReader);
         }
         if (offsetsWithNull.isEmpty()) {
             return values;
@@ -539,8 +537,9 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         return new DataWithMultiLevelOffsets(offsetsWithNull.toArray(new IntBuffer[0]), values);
     }
 
-    private Object materializeNonNull(PageMaterializer.Factory factory, int numValues, ValuesReader dataReader) {
-        return factory.makeMaterializerNonNull(dataReader, numValues).fillAll();
+    private static Object materializeNonNull(PageMaterializer.Factory factory, int numberOfValues,
+            ValuesReader dataReader) {
+        return factory.makeMaterializerNonNull(dataReader, numberOfValues).fillAll();
     }
 
     private ValuesReader getDataReader(Encoding dataEncoding, ByteBuffer in, int valueCount) {
@@ -570,14 +569,22 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
 
     @Override
     public int numValues() throws IOException {
+        ensureNumValues();
+        return numValues;
+    }
+
+    private void ensureNumValues() throws IOException {
         if (numValues >= 0) {
-            return numValues;
+            return;
         }
+        Assert.neqNull(pageHeader, "pageHeader");
         switch (pageHeader.type) {
             case DATA_PAGE:
-                return numValues = pageHeader.getData_page_header().getNum_values();
+                numValues = pageHeader.getData_page_header().getNum_values();
+                break;
             case DATA_PAGE_V2:
-                return numValues = pageHeader.getData_page_header_v2().getNum_values();
+                numValues = pageHeader.getData_page_header_v2().getNum_values();
+                break;
             default:
                 throw new IOException(
                         String.format("Unexpected page of type {%s}", pageHeader.getType()));
@@ -609,7 +616,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
 
     private Pair<Pair<Type.Repetition, IntBuffer>[], Integer> getOffsetsAndNulls(
             RunLengthBitPackingHybridBufferDecoder dlDecoder,
-            RunLengthBitPackingHybridBufferDecoder rlDecoder, int numValues) throws IOException {
+            RunLengthBitPackingHybridBufferDecoder rlDecoder) throws IOException {
         dlDecoder.readNextRange();
         if (rlDecoder != null) {
             rlDecoder.readNextRange();

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
@@ -80,6 +80,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         this.offset = offset;
         this.pageHeader = pageHeader;
         this.numValues = numValues;
+
     }
 
     @Override
@@ -333,7 +334,7 @@ public class ColumnPageReaderImpl implements ColumnPageReader {
         rlDecoder = new RunLengthBitPackingHybridBufferDecoder(path.getMaxRepetitionLevel(), byteBuffer);
         int rowsRead = 0;
         int totalCount = 0;
-        while (rlDecoder.hasNext() && totalCount < numValues) {
+        while (rlDecoder.hasNext() && totalCount < numValues()) {
             rlDecoder.readNextRange();
             int count = rlDecoder.currentRangeCount();
             totalCount += count;

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -294,6 +294,13 @@ class ParquetTestCase(BaseTestCase):
         # result_table = read('data_from_pandas.parquet')
         # self.assert_table_equals(dh_table, result_table)
 
+    def test_writing_via_pyarrow(self):
+        # This function tests that we can write tables with list types to parquet files via pyarrow and read them back
+        # through deephaven's parquet reader code with no exceptions
+        pa_table = pyarrow.table({'numList': [[2, 2, 4]],
+                                  'stringList': [["Flamingo", "Parrot", "Dog"]]})
+        pyarrow.parquet.write_table(pa_table, 'data_from_pa.parquet')
+        from_disk = read('data_from_pa.parquet').select()
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -11,6 +11,7 @@ import pandas
 import pyarrow.parquet
 
 from deephaven import empty_table, dtypes, new_table
+from deephaven import arrow as dharrow
 from deephaven.column import InputColumn
 from deephaven.pandas import to_pandas, to_table
 from deephaven.parquet import write, batch_write, read, delete, ColumnInstruction
@@ -301,6 +302,9 @@ class ParquetTestCase(BaseTestCase):
                                   'stringList': [["Flamingo", "Parrot", "Dog"]]})
         pyarrow.parquet.write_table(pa_table, 'data_from_pa.parquet')
         from_disk = read('data_from_pa.parquet').select()
+        pa_table_from_disk = dharrow.to_arrow(from_disk)
+        self.assertTrue(pa_table.equals(pa_table_from_disk))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Bug fix, closes #4270 

Some of the variables were not being properly initialized in the code for reading lists. This PR fixes the bug and includes refactoring to improve the code quality.