### PR TITLE
Parquet: Support definition-driven partition parsing for key=value directory-based partitioning

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/page/Page.java
+++ b/engine/table/src/main/java/io/deephaven/engine/page/Page.java
@@ -65,11 +65,12 @@ public interface Page<ATTR extends Any> extends PagingChunkSource<ATTR> {
 
         @Override
         @FinalDefault
-        default void fillChunkAppend(@NotNull final FillContext context,
+        default void fillChunkAppend(
+                @NotNull final FillContext context,
                 @NotNull final WritableChunk<? super ATTR> destination,
-                @NotNull final RowSequence.Iterator RowSequenceIterator) {
+                @NotNull final RowSequence.Iterator rowSequenceIterator) {
             fillChunkAppend(context, destination,
-                    RowSequenceIterator.getNextRowSequenceThrough(maxRow(RowSequenceIterator.peekNextKey())));
+                    rowSequenceIterator.getNextRowSequenceThrough(maxRow(rowSequenceIterator.peekNextKey())));
         }
 
         @Override
@@ -95,11 +96,12 @@ public interface Page<ATTR extends Any> extends PagingChunkSource<ATTR> {
 
         @Override
         @FinalDefault
-        default void fillChunkAppend(@NotNull final FillContext context,
+        default void fillChunkAppend(
+                @NotNull final FillContext context,
                 @NotNull final WritableChunk<? super ATTR> destination,
-                @NotNull final RowSequence.Iterator RowSequenceIterator) {
+                @NotNull final RowSequence.Iterator rowSequenceIterator) {
             fillChunkAppend(context, destination, LongSizedDataStructure.intSize("fillChunkAppend",
-                    RowSequenceIterator.advanceAndGetPositionDistance(maxRow(RowSequenceIterator.peekNextKey()) + 1)));
+                    rowSequenceIterator.advanceAndGetPositionDistance(maxRow(rowSequenceIterator.peekNextKey()) + 1)));
         }
 
         @Override
@@ -118,25 +120,25 @@ public interface Page<ATTR extends Any> extends PagingChunkSource<ATTR> {
     }
 
     /**
-     * Assuming {@code RowSequenceIterator} is position at its first row key on this page, consume all keys on this
+     * Assuming {@code rowSequenceIterator} is position at its first row key on this page, consume all keys on this
      * page.
      *
-     * @param RowSequenceIterator The iterator to advance
+     * @param rowSequenceIterator The iterator to advance
      */
     @FinalDefault
-    default void advanceToNextPage(@NotNull final RowSequence.Iterator RowSequenceIterator) {
-        RowSequenceIterator.advance(maxRow(RowSequenceIterator.peekNextKey()) + 1);
+    default void advanceToNextPage(@NotNull final RowSequence.Iterator rowSequenceIterator) {
+        rowSequenceIterator.advance(maxRow(rowSequenceIterator.peekNextKey()) + 1);
     }
 
     /**
-     * Assuming {@code RowSequenceIterator} is position at its first row key on this page, consume all keys on this page
+     * Assuming {@code rowSequenceIterator} is position at its first row key on this page, consume all keys on this page
      * and return the number of keys consumed.
      *
-     * @param RowSequenceIterator The iterator to advance
+     * @param rowSequenceIterator The iterator to advance
      */
     @FinalDefault
-    default long advanceToNextPageAndGetPositionDistance(@NotNull final RowSequence.Iterator RowSequenceIterator) {
-        return RowSequenceIterator.advanceAndGetPositionDistance(maxRow(RowSequenceIterator.peekNextKey()) + 1);
+    default long advanceToNextPageAndGetPositionDistance(@NotNull final RowSequence.Iterator rowSequenceIterator) {
+        return rowSequenceIterator.advanceAndGetPositionDistance(maxRow(rowSequenceIterator.peekNextKey()) + 1);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/page/PageStore.java
+++ b/engine/table/src/main/java/io/deephaven/engine/page/PageStore.java
@@ -83,17 +83,18 @@ public interface PageStore<ATTR extends Any, INNER_ATTR extends ATTR, PAGE exten
     }
 
     @Override
-    default void fillChunkAppend(@NotNull final FillContext context,
+    default void fillChunkAppend(
+            @NotNull final FillContext context,
             @NotNull final WritableChunk<? super ATTR> destination,
-            @NotNull final RowSequence.Iterator RowSequenceIterator) {
-        long firstKey = RowSequenceIterator.peekNextKey();
+            @NotNull final RowSequence.Iterator rowSequenceIterator) {
+        long firstKey = rowSequenceIterator.peekNextKey();
         final long pageStoreMaxKey = maxRow(firstKey);
 
         do {
             final PAGE page = getPageContaining(context, firstKey);
-            page.fillChunkAppend(context, destination, RowSequenceIterator);
-        } while (RowSequenceIterator.hasMore() &&
-                (firstKey = RowSequenceIterator.peekNextKey()) <= pageStoreMaxKey);
+            page.fillChunkAppend(context, destination, rowSequenceIterator);
+        } while (rowSequenceIterator.hasMore() &&
+                (firstKey = rowSequenceIterator.peekNextKey()) <= pageStoreMaxKey);
     }
 
     /**
@@ -103,13 +104,15 @@ public interface PageStore<ATTR extends Any, INNER_ATTR extends ATTR, PAGE exten
      */
     // Should be private
     @FinalDefault
-    default void doFillChunkAppend(@NotNull final FillContext context,
+    default void doFillChunkAppend(
+            @NotNull final FillContext context,
             @NotNull final WritableChunk<? super ATTR> destination,
-            @NotNull final RowSequence rowSequence, @NotNull final Page<INNER_ATTR> page) {
+            @NotNull final RowSequence rowSequence,
+            @NotNull final Page<INNER_ATTR> page) {
         destination.setSize(0);
-        try (final RowSequence.Iterator RowSequenceIterator = rowSequence.getRowSequenceIterator()) {
-            page.fillChunkAppend(context, destination, RowSequenceIterator);
-            fillChunkAppend(context, destination, RowSequenceIterator);
+        try (final RowSequence.Iterator rowSequenceIterator = rowSequence.getRowSequenceIterator()) {
+            page.fillChunkAppend(context, destination, rowSequenceIterator);
+            fillChunkAppend(context, destination, rowSequenceIterator);
         }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/page/PagingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/page/PagingChunkSource.java
@@ -66,22 +66,24 @@ public interface PagingChunkSource<ATTR extends Any> extends ChunkSource<ATTR> {
      * </p>
      *
      * <p>
-     * The values to fill into {@code destination} are specified by {@code RowSequenceIterator}, whose
+     * The values to fill into {@code destination} are specified by {@code rowSequenceIterator}, whose
      * {@link RowSequence#firstRowKey()} must exist, and must be represented by this {@code PagingChunkSource} (modulo
      * {#link @mask}), otherwise results are undefined.
      * </p>
      *
      * <p>
-     * No more than the elements in {@code RowSequenceIterator}, which are on the same page as
+     * No more than the elements in {@code rowSequenceIterator}, which are on the same page as
      * {@link RowSequence#firstRowKey()}, have their values appended to {@code destination}, and consumed from
-     * {@code RowSequenceIterator}. Indices are on the same page when the bits outside of {@link #mask()} are identical.
+     * {@code rowSequenceIterator}. Indices are on the same page when the bits outside of {@link #mask()} are identical.
      *
      * @param context A context containing all mutable/state related data used in retrieving the Chunk. In particular,
      *        the Context may be used to provide a Chunk data pool
      * @param destination The chunk to append the results to.
-     * @param RowSequenceIterator The iterator to the ordered keys, which contain at least the keys to extract from this
+     * @param rowSequenceIterator The iterator to the ordered keys, which contain at least the keys to extract from this
      *        {@code ChunkSource}. The keys to extract will be at the beginning of iteration order.
      */
-    void fillChunkAppend(@NotNull FillContext context, @NotNull WritableChunk<? super ATTR> destination,
-            @NotNull RowSequence.Iterator RowSequenceIterator);
+    void fillChunkAppend(
+            @NotNull FillContext context,
+            @NotNull WritableChunk<? super ATTR> destination,
+            @NotNull RowSequence.Iterator rowSequenceIterator);
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FormulaChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FormulaChunkedOperator.java
@@ -386,13 +386,13 @@ class FormulaChunkedOperator implements IterativeChunkedAggregationOperator {
         }
 
         void clearObjectColumnData(@NotNull final RowSequence rowSequence) {
-            try (final RowSequence.Iterator RowSequenceIterator = rowSequence.getRowSequenceIterator();
+            try (final RowSequence.Iterator rowSequenceIterator = rowSequence.getRowSequenceIterator();
                     final WritableObjectChunk<?, Values> nullValueChunk =
                             WritableObjectChunk.makeWritableChunk(BLOCK_SIZE)) {
                 nullValueChunk.fillWithNullValue(0, BLOCK_SIZE);
-                while (RowSequenceIterator.hasMore()) {
-                    final RowSequence rowSequenceSlice = RowSequenceIterator.getNextRowSequenceThrough(
-                            calculateContainingBlockLastKey(RowSequenceIterator.peekNextKey()));
+                while (rowSequenceIterator.hasMore()) {
+                    final RowSequence rowSequenceSlice = rowSequenceIterator.getNextRowSequenceThrough(
+                            calculateContainingBlockLastKey(rowSequenceIterator.peekNextKey()));
                     nullValueChunk.setSize(rowSequenceSlice.intSize());
                     for (int ci = 0; ci < columnsToFillMask.length; ++ci) {
                         final WritableColumnSource<?> resultColumn = resultColumns[ci];
@@ -433,10 +433,10 @@ class FormulaChunkedOperator implements IterativeChunkedAggregationOperator {
         }
 
         private void copyData(@NotNull final RowSequence rowSequence, @NotNull final boolean[] columnsMask) {
-            try (final RowSequence.Iterator RowSequenceIterator = rowSequence.getRowSequenceIterator()) {
-                while (RowSequenceIterator.hasMore()) {
-                    final RowSequence rowSequenceSlice = RowSequenceIterator.getNextRowSequenceThrough(
-                            calculateContainingBlockLastKey(RowSequenceIterator.peekNextKey()));
+            try (final RowSequence.Iterator rowSequenceIterator = rowSequence.getRowSequenceIterator()) {
+                while (rowSequenceIterator.hasMore()) {
+                    final RowSequence rowSequenceSlice = rowSequenceIterator.getNextRowSequenceThrough(
+                            calculateContainingBlockLastKey(rowSequenceIterator.peekNextKey()));
                     for (int ci = 0; ci < columnsToGetMask.length; ++ci) {
                         if (columnsMask[ci]) {
                             resultColumns[ci].fillFromChunk(fillFromContexts[ci],

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/local/KeyValuePartitionLayout.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/local/KeyValuePartitionLayout.java
@@ -1,23 +1,18 @@
 /**
  * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
-package io.deephaven.parquet.table.layout;
+package io.deephaven.engine.table.impl.locations.local;
 
 import io.deephaven.base.verify.Require;
-import io.deephaven.csv.util.CsvReaderException;
 import io.deephaven.engine.table.Table;
 import io.deephaven.api.util.NameValidator;
-import io.deephaven.csv.CsvTools;
-import io.deephaven.engine.util.TableTools;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.TableLocationKey;
 import io.deephaven.engine.table.impl.locations.impl.TableLocationKeyFinder;
 import io.deephaven.engine.table.ColumnSource;
-import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
@@ -26,7 +21,6 @@ import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * {@link TableLocationKeyFinder Location finder} that will traverse a directory hierarchy and infer partitions from
@@ -38,14 +32,49 @@ import java.util.stream.Collectors;
  * 
  * Traversal is depth-first, and assumes that target files will only be found at a single depth.
  *
- * @implNote Type inference uses {@link CsvTools#readCsv(java.io.InputStream)} as a conversion tool, and hence follows
- *           the same rules.
  * @implNote Column names will be legalized via {@link NameValidator#legalizeColumnName(String, Set)}.
  */
 public class KeyValuePartitionLayout<TLK extends TableLocationKey> implements TableLocationKeyFinder<TLK> {
 
+    /**
+     * Interface for implementations to perform type coercion and specify a table of partition values for observed table
+     * locations.
+     */
+    public interface LocationTableBuilder {
+
+        /**
+         * Register an ordered collection of {@link String strings} representing partition keys. This should be called
+         * exactly once, and before any calls to {@link #acceptLocation(Collection) acceptLocation}.
+         *
+         * @param partitionKeys The partition keys to register
+         */
+        void registerPartitionKeys(@NotNull Collection<String> partitionKeys);
+
+        /**
+         * Accept an ordered collection of {@link String strings} representing partition values for a particular table
+         * location, parallel to a previously-registered collection of partition keys. Should be called after a single
+         * call to {@link #registerPartitionKeys(Collection) registerPartitionKeys}.
+         * 
+         * @param partitionValueStrings The partition values to accept. Must have the same length as the
+         *        previously-registered partition keys.
+         */
+        void acceptLocation(@NotNull Collection<String> partitionValueStrings);
+
+        /**
+         * Build a {@link Table} with one column per partition key specified in
+         * {@link #registerPartitionKeys(Collection) registerPartitionKeys}, and one row per location provided via
+         * {@link #acceptLocation(Collection) acceptLocation}, with cell values parallel to that location's partition
+         * values after any appropriate conversion has been applied. The implementation is responsible for determining
+         * the appropriate column types.
+         *
+         * @return The {@link Table}
+         */
+        Table build();
+    }
+
     private final File tableRootDirectory;
     private final Predicate<Path> pathFilter;
+    private final LocationTableBuilder locationTableBuilder;
     private final BiFunction<Path, Map<String, Comparable<?>>, TLK> keyFactory;
     private final int maxPartitioningLevels;
 
@@ -56,12 +85,15 @@ public class KeyValuePartitionLayout<TLK extends TableLocationKey> implements Ta
      * @param maxPartitioningLevels Maximum partitioning levels to traverse. Must be {@code >= 0}. {@code 0} means only
      *        look at files in {@code tableRootDirectory} and find no partitions.
      */
-    public KeyValuePartitionLayout(@NotNull final File tableRootDirectory,
+    public KeyValuePartitionLayout(
+            @NotNull final File tableRootDirectory,
             @NotNull final Predicate<Path> pathFilter,
+            @NotNull final LocationTableBuilder locationTableBuilder,
             @NotNull final BiFunction<Path, Map<String, Comparable<?>>, TLK> keyFactory,
             final int maxPartitioningLevels) {
         this.tableRootDirectory = tableRootDirectory;
         this.pathFilter = pathFilter;
+        this.locationTableBuilder = locationTableBuilder;
         this.keyFactory = keyFactory;
         this.maxPartitioningLevels = Require.geqZero(maxPartitioningLevels, "maxPartitioningLevels");
     }
@@ -72,21 +104,21 @@ public class KeyValuePartitionLayout<TLK extends TableLocationKey> implements Ta
 
     @Override
     public void findKeys(@NotNull final Consumer<TLK> locationKeyObserver) {
-        final StringBuilder csvBuilder = new StringBuilder();
         final Deque<Path> targetFiles = new ArrayDeque<>();
+
 
         try {
             Files.walkFileTree(tableRootDirectory.toPath(), EnumSet.of(FileVisitOption.FOLLOW_LINKS),
-                    maxPartitioningLevels + 1, new SimpleFileVisitor<Path>() {
-                        final String ls = System.lineSeparator();
+                    maxPartitioningLevels + 1, new SimpleFileVisitor<>() {
                         final Set<String> takenNames = new HashSet<>();
-                        final List<String> columnKeys = new ArrayList<>();
-                        final List<String> rowValues = new ArrayList<>();
-                        String row;
+                        final List<String> partitionKeys = new ArrayList<>();
+                        final List<String> partitionValues = new ArrayList<>();
+                        boolean registered;
                         int columnCount = -1;
 
                         @Override
-                        public FileVisitResult preVisitDirectory(@NotNull final Path dir,
+                        public FileVisitResult preVisitDirectory(
+                                @NotNull final Path dir,
                                 @NotNull final BasicFileAttributes attrs) {
                             if (++columnCount > 0) {
                                 // We're descending and past the root
@@ -97,43 +129,40 @@ public class KeyValuePartitionLayout<TLK extends TableLocationKey> implements Ta
                                 }
                                 final String columnKey = NameValidator.legalizeColumnName(components[0], takenNames);
                                 final int columnIndex = columnCount - 1;
-                                if (columnCount > columnKeys.size()) {
-                                    columnKeys.add(columnKey);
-                                } else if (!columnKeys.get(columnIndex).equals(columnKey)) {
-                                    throw new TableDataException("Column name mismatch at rowSet " + columnIndex
-                                            + ": expected " + columnKeys.get(columnIndex) + " found " + columnKey
-                                            + " at " + dir);
+                                if (columnCount > partitionKeys.size()) {
+                                    partitionKeys.add(columnKey);
+                                } else if (!partitionKeys.get(columnIndex).equals(columnKey)) {
+                                    throw new TableDataException(String.format(
+                                            "Column name mismatch at column index %d: expected %s found %s at %s",
+                                            columnIndex, partitionKeys.get(columnIndex), columnKey, dir));
                                 }
                                 final String columnValue = components[1];
-                                rowValues.add(columnValue);
+                                partitionValues.add(columnValue);
                             }
                             return FileVisitResult.CONTINUE;
                         }
 
                         @Override
-                        public FileVisitResult visitFile(@NotNull final Path file,
+                        public FileVisitResult visitFile(
+                                @NotNull final Path file,
                                 @NotNull final BasicFileAttributes attrs) {
                             if (attrs.isRegularFile() && pathFilter.test(file)) {
-                                if (!columnKeys.isEmpty()) {
-                                    if (csvBuilder.length() == 0) {
-                                        csvBuilder.append(listToCsvRow(columnKeys)).append(ls);
-                                    }
-                                    if (row == null) {
-                                        row = listToCsvRow(rowValues);
-                                    }
-                                    csvBuilder.append(row).append(ls);
+                                if (!registered) {
+                                    locationTableBuilder.registerPartitionKeys(partitionKeys);
+                                    registered = true;
                                 }
+                                locationTableBuilder.acceptLocation(partitionValues);
                                 targetFiles.add(file);
                             }
                             return FileVisitResult.CONTINUE;
                         }
 
                         @Override
-                        public FileVisitResult postVisitDirectory(@NotNull final Path dir,
+                        public FileVisitResult postVisitDirectory(
+                                @NotNull final Path dir,
                                 @Nullable final IOException exc) throws IOException {
                             if (--columnCount >= 0) {
-                                row = null;
-                                rowValues.remove(columnCount);
+                                partitionValues.remove(columnCount);
                             }
                             return super.postVisitDirectory(dir, exc);
                         }
@@ -142,29 +171,20 @@ public class KeyValuePartitionLayout<TLK extends TableLocationKey> implements Ta
             throw new TableDataException("Error finding locations for under " + tableRootDirectory, e);
         }
 
-        final Table partitioningColumnTable;
-        try {
-            partitioningColumnTable = csvBuilder.length() == 0 ? TableTools.emptyTable(targetFiles.size())
-                    : CsvTools.readCsv(new ByteArrayInputStream(csvBuilder.toString().getBytes()));
-        } catch (CsvReaderException e) {
-            throw new TableDataException("Failed converting partition CSV to table for " + tableRootDirectory, e);
-        }
+        final Table locationTable = locationTableBuilder.build();
 
         final Map<String, Comparable<?>> partitions = new LinkedHashMap<>();
-        final String[] partitionKeys = partitioningColumnTable.getDefinition().getColumnNamesArray();
+        // Note that we allow the location table to define partition priority order.
+        final String[] partitionKeys = locationTable.getDefinition().getColumnNamesArray();
         // noinspection unchecked
         final ColumnSource<? extends Comparable<?>>[] partitionValueSources =
-                partitioningColumnTable.getColumnSources().toArray(ColumnSource.ZERO_LENGTH_COLUMN_SOURCE_ARRAY);
+                locationTable.getColumnSources().toArray(ColumnSource.ZERO_LENGTH_COLUMN_SOURCE_ARRAY);
         final int numColumns = partitionValueSources.length;
-        partitioningColumnTable.getRowSet().forAllRowKeys((final long indexKey) -> {
+        locationTable.getRowSet().forAllRowKeys((final long rowKey) -> {
             for (int ci = 0; ci < numColumns; ++ci) {
-                partitions.put(partitionKeys[ci], partitionValueSources[ci].get(indexKey));
+                partitions.put(partitionKeys[ci], partitionValueSources[ci].get(rowKey));
             }
             locationKeyObserver.accept(keyFactory.apply(targetFiles.remove(), partitions));
         });
-    }
-
-    private static String listToCsvRow(@NotNull final List<String> list) {
-        return list.stream().map(StringEscapeUtils::escapeCsv).collect(Collectors.joining(","));
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/local/LocationTableBuilderDefinition.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/local/LocationTableBuilderDefinition.java
@@ -1,0 +1,118 @@
+package io.deephaven.engine.table.impl.locations.local;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.engine.table.WritableColumnSource;
+import io.deephaven.engine.table.impl.QueryTable;
+import io.deephaven.engine.table.impl.locations.util.PartitionParser;
+import io.deephaven.engine.table.impl.sources.ArrayBackedColumnSource;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * {@link KeyValuePartitionLayout.LocationTableBuilder LocationTableBuilder} implementation that uses the a
+ * {@link TableDefinition} and {@link PartitionParser PartitionParsers} to assemble location tables.
+ */
+public final class LocationTableBuilderDefinition implements KeyValuePartitionLayout.LocationTableBuilder {
+
+    /**
+     * The partitioning columns, mapped from name to state, in definition order.
+     */
+    private final Map<String, PartitioningColumn<?>> nameToPartitioningColumn;
+
+    /**
+     * The partitioning columns, in input order determined by registration.
+     */
+    private PartitioningColumn<?>[] partitioningColumnsInInputOrder;
+
+    /**
+     * Partitioning column information and accumulated data.
+     */
+    private static class PartitioningColumn<DATA_TYPE> {
+
+        private final ColumnDefinition<DATA_TYPE> columnDefinition;
+
+        private final PartitionParser parser;
+        private final WritableColumnSource<DATA_TYPE> data;
+
+        private PartitioningColumn(@NotNull final ColumnDefinition<DATA_TYPE> columnDefinition) {
+            this.columnDefinition = columnDefinition;
+
+            parser = PartitionParser.lookup(columnDefinition.getDataType(), columnDefinition.getComponentType());
+            data = ArrayBackedColumnSource.getMemoryColumnSource(
+                    columnDefinition.getDataType(), columnDefinition.getComponentType());
+        }
+
+        private void set(final int rowKey, @NotNull final String value) {
+            data.ensureCapacity(rowKey + 1, false);
+            // noinspection unchecked
+            data.set(rowKey, (DATA_TYPE) parser.parse(value));
+        }
+    }
+
+    /**
+     * The count of locations accepted.
+     */
+    private int locationCount;
+
+    public LocationTableBuilderDefinition(@NotNull final TableDefinition tableDefinition) {
+        this.nameToPartitioningColumn = tableDefinition.getColumnStream()
+                .sequential()
+                .filter(cd -> cd.getColumnType() == ColumnDefinition.ColumnType.Partitioning)
+                .collect(Collectors.toMap(
+                        ColumnDefinition::getName, PartitioningColumn::new, Assert::neverInvoked, LinkedHashMap::new));
+    }
+
+    @Override
+    public void registerPartitionKeys(@NotNull final Collection<String> partitionKeys) {
+        if (partitioningColumnsInInputOrder != null) {
+            throw new IllegalStateException("Partition keys already registered");
+        }
+        if (!Set.copyOf(partitionKeys).equals(nameToPartitioningColumn.keySet())) {
+            throw new IllegalArgumentException(String.format(
+                    "Partition keys mismatch: expected %s, encountered %s",
+                    nameToPartitioningColumn.keySet(), partitionKeys));
+        }
+        partitioningColumnsInInputOrder = partitionKeys.stream()
+                .map(nameToPartitioningColumn::get).toArray(PartitioningColumn[]::new);
+    }
+
+    @Override
+    public void acceptLocation(@NotNull final Collection<String> partitionValueStrings) {
+        if (partitioningColumnsInInputOrder == null) {
+            throw new IllegalStateException("Partition keys not registered");
+        }
+        if (partitionValueStrings.size() != partitioningColumnsInInputOrder.length) {
+            throw new IllegalArgumentException(String.format(
+                    "Partition mismatch for location: partition keys %s, encountered partition values %s",
+                    Arrays.stream(partitioningColumnsInInputOrder)
+                            .map(pc -> pc.columnDefinition.getName()).collect(Collectors.toList()),
+                    partitionValueStrings));
+        }
+        int pci = 0;
+        for (final String partitionValueString : partitionValueStrings) {
+            partitioningColumnsInInputOrder[pci++].set(locationCount, partitionValueString);
+        }
+        ++locationCount;
+    }
+
+    @Override
+    public Table build() {
+        return new QueryTable(
+                RowSetFactory.flat(locationCount).toTracking(),
+                nameToPartitioningColumn.entrySet().stream().collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        (final Map.Entry<String, PartitioningColumn<?>> entry) -> entry.getValue().data,
+                        Assert::neverInvoked,
+                        LinkedHashMap::new)));
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/util/PartitionParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/util/PartitionParser.java
@@ -1,0 +1,353 @@
+package io.deephaven.engine.table.impl.locations.util;
+
+import io.deephaven.qst.type.ArrayType;
+import io.deephaven.qst.type.BoxedBooleanType;
+import io.deephaven.qst.type.BoxedByteType;
+import io.deephaven.qst.type.BoxedCharType;
+import io.deephaven.qst.type.BoxedDoubleType;
+import io.deephaven.qst.type.BoxedFloatType;
+import io.deephaven.qst.type.BoxedIntType;
+import io.deephaven.qst.type.BoxedLongType;
+import io.deephaven.qst.type.BoxedShortType;
+import io.deephaven.qst.type.BoxedType;
+import io.deephaven.qst.type.CustomType;
+import io.deephaven.qst.type.GenericType;
+import io.deephaven.qst.type.InstantType;
+import io.deephaven.qst.type.PrimitiveType;
+import io.deephaven.qst.type.StringType;
+import io.deephaven.qst.type.Type;
+import io.deephaven.time.DateTimeUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import static io.deephaven.util.type.TypeUtils.box;
+
+/**
+ * Re-usable parsers for partition values encountered as {@link String strings}, e.g. when inferring/assigning partition
+ * values from elements in a path.
+ */
+public enum PartitionParser {
+
+    ForString(String.class) {
+        @Override
+        String parseToType(@NotNull final String stringValue) {
+            return stringValue;
+        }
+    },
+    ForBoolean(Boolean.class) {
+        @Override
+        Boolean parseToType(@NotNull final String stringValue) {
+            return Boolean.parseBoolean(stringValue);
+        }
+    },
+    ForChar(Character.class) {
+        @Override
+        Character parseToType(@NotNull final String stringValue) {
+            if (stringValue.length() != 1) {
+                throw new IllegalArgumentException(String.format(
+                        "Invalid value length %d, expected length 1", stringValue.length()));
+            }
+            return stringValue.charAt(0);
+        }
+    },
+    ForByte(Byte.class) {
+        @Override
+        Byte parseToType(@NotNull final String stringValue) {
+            return box(Byte.parseByte(stringValue));
+        }
+    },
+    ForShort(Short.class) {
+        @Override
+        Short parseToType(@NotNull final String stringValue) {
+            return box(Short.parseShort(stringValue));
+        }
+    },
+    ForInt(Integer.class) {
+        @Override
+        Integer parseToType(@NotNull final String stringValue) {
+            return box(Integer.parseInt(stringValue));
+        }
+    },
+    ForLong(Long.class) {
+        @Override
+        Long parseToType(@NotNull final String stringValue) {
+            return box(Long.parseLong(stringValue));
+        }
+    },
+    ForFloat(Float.class) {
+        @Override
+        Float parseToType(@NotNull final String stringValue) {
+            return box(Float.parseFloat(stringValue));
+        }
+    },
+    ForDouble(Double.class) {
+        @Override
+        Double parseToType(@NotNull final String stringValue) {
+            return box(Double.parseDouble(stringValue));
+        }
+    },
+    ForBigInteger(BigInteger.class) {
+        @Override
+        BigInteger parseToType(@NotNull final String stringValue) {
+            return new BigInteger(stringValue);
+        }
+    },
+    ForBigDecimal(BigDecimal.class) {
+        @Override
+        BigDecimal parseToType(@NotNull final String stringValue) {
+            return new BigDecimal(stringValue);
+        }
+    },
+    ForInstant(Instant.class) {
+        @Override
+        Instant parseToType(@NotNull final String stringValue) {
+            return DateTimeUtils.parseInstant(stringValue);
+        }
+    },
+    ForLocalDate(LocalDate.class) {
+        @Override
+        LocalDate parseToType(@NotNull final String stringValue) {
+            return DateTimeUtils.parseLocalDate(stringValue);
+        }
+    },
+    ForLocalTime(LocalTime.class) {
+        @Override
+        LocalTime parseToType(@NotNull final String stringValue) {
+            return DateTimeUtils.parseLocalTime(stringValue);
+        }
+    },
+    ForZonedDateTime(ZonedDateTime.class) {
+        @Override
+        ZonedDateTime parseToType(@NotNull final String stringValue) {
+            return DateTimeUtils.parseZonedDateTime(stringValue);
+        }
+    };
+
+    private final Class<? extends Comparable<?>> resultType;
+
+    /**
+     * Construct a PartitionParser for the supplied types.
+     *
+     * @param resultType The result type for {@link #parse(String)}
+     */
+    PartitionParser(@NotNull final Class<? extends Comparable<?>> resultType) {
+        this.resultType = Objects.requireNonNull(resultType);
+    }
+
+    /**
+     * Get the {@link Class} of the result type that will be returned by {@link #parse(String) parse}.
+     * 
+     * @return The result type
+     */
+    public Class<? extends Comparable<?>> getResultType() {
+        return resultType;
+    }
+
+    /**
+     * Parse {@code stringValue} to the expected type, boxed as an {@link Object} if primitive. {@link String#isEmpty()
+     * Empty} inputs are always parsed to {@code null}. <em>No</em> other pre-parsing adjustments, e.g.
+     * {@link String#trim() trim}, are performed on {@code stringValue} before applying type-specific parsing logic.
+     *
+     * @param stringValue The {@link String} to parse
+     * @return The parsed result partition value as an {@code Object}
+     * @throws NullPointerException if {@code stringValue} is {@code null}
+     * @throws IllegalArgumentException if {@code stringValue} could not be parsed
+     */
+    public Comparable<?> parse(@NotNull final String stringValue) {
+        if (Objects.requireNonNull(stringValue).isEmpty()) {
+            return null;
+        }
+        try {
+            return parseToType(stringValue);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(String.format("%s partition value parser for type %s failed for \"%s\"",
+                    name(), resultType.getName(), stringValue));
+        }
+    }
+
+    /**
+     * Parse {@code stringValueTrimmed} into an instance of {@link #resultType
+     * 
+     * @param stringValue The (non-{@link String#isEmpty() empty}) input
+     * @return The psrsed result partition value as an {@code Object}
+     */
+    abstract Comparable<?> parseToType(@NotNull final String stringValue);
+
+    /**
+     * Look up the PartitionParser for {@code dataType} and {@code componentType}.
+     *
+     * @param dataType The data type {@link Class} to look up
+     * @param componentType The component type {@link Class} to look up, or {@code null} if there is none
+     * @return The appropriate PartitionParser, or {@code null} for unsupported {@code dataType} or
+     *         {@code componentType} values
+     */
+    @Nullable
+    public static PartitionParser lookup(@NotNull final Class<?> dataType, @Nullable final Class<?> componentType) {
+        if (componentType != null) {
+            return null;
+        }
+        return lookup(Type.find(dataType));
+    }
+
+    /**
+     * Look up the PartitionParser for {@code dataType} and {@code componentType}.
+     *
+     * @param dataType The data type {@link Class} to look up
+     * @param componentType The component type {@link Class} to look up, or {@code null} if there is none
+     * @return The appropriate PartitionParser
+     * @throws IllegalArgumentException for unsupported {@code dataType} values
+     */
+    @NotNull
+    public static PartitionParser lookupSupported(
+            @NotNull final Class<?> dataType,
+            @Nullable final Class<?> componentType) {
+        final PartitionParser supportedParser = lookup(dataType, componentType);
+        if (supportedParser != null) {
+            return supportedParser;
+        }
+        if (componentType == null) {
+            throw new IllegalArgumentException(String.format(
+                    "Unsupported data type %s for partition value parsing", dataType.getName()));
+        }
+
+        throw new IllegalArgumentException(String.format(
+                "Unsupported data type %s or component type %s for partition value parsing",
+                dataType.getName(), componentType.getName()));
+    }
+
+    /**
+     * Look up the PartitionParser for {@code type}.
+     *
+     * @param type The {@link Type} to look up
+     * @return The appropriate PartitionParser, or {@code null} for unsupported {@code type} values
+     */
+    @Nullable
+    public static PartitionParser lookup(@NotNull final Type<?> type) {
+        return type.walk(Resolver.INSTANCE);
+    }
+
+    /**
+     * Look up the PartitionParser for {@code type}.
+     *
+     * @param type The {@link Type} to look up
+     * @return The appropriate PartitionParser, or {@code null} for unsupported {@code type} values
+     */
+    @NotNull
+    public static PartitionParser lookupSupported(@NotNull final Type<?> type) {
+        final PartitionParser supportedParser = lookup(type);
+        if (supportedParser != null) {
+            return supportedParser;
+        }
+        throw new IllegalArgumentException(String.format("Unsupported type %s for partition value parsing", type));
+    }
+
+    /**
+     * Visitor for resolving a {@link Type} and finding the correct PartitionParser.
+     */
+    private static final class Resolver implements
+            Type.Visitor<PartitionParser>, GenericType.Visitor<PartitionParser>, BoxedType.Visitor<PartitionParser> {
+
+        private static final Type.Visitor<PartitionParser> INSTANCE = new Resolver();
+
+        private Resolver() {}
+
+        @Override
+        public PartitionParser visit(@NotNull final PrimitiveType<?> primitiveType) {
+            return visit(primitiveType.boxedType());
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final GenericType<?> genericType) {
+            return genericType.walk((GenericType.Visitor<PartitionParser>) this);
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedType<?> boxedType) {
+            return boxedType.walk((BoxedType.Visitor<PartitionParser>) this);
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final StringType stringType) {
+            return ForString;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final InstantType instantType) {
+            return ForInstant;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final ArrayType<?, ?> arrayType) {
+            return null;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final CustomType<?> customType) {
+            final Class<?> clazz = customType.clazz();
+            if (clazz == BigInteger.class) {
+                return ForBigInteger;
+            }
+            if (clazz == BigDecimal.class) {
+                return ForBigDecimal;
+            }
+            if (clazz == LocalDate.class) {
+                return ForLocalDate;
+            }
+            if (clazz == LocalTime.class) {
+                return ForLocalTime;
+            }
+            if (clazz == ZonedDateTime.class) {
+                return ForZonedDateTime;
+            }
+            return null;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedBooleanType booleanType) {
+            return ForBoolean;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedByteType byteType) {
+            return ForByte;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedCharType charType) {
+            return ForChar;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedShortType shortType) {
+            return ForShort;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedIntType intType) {
+            return ForInt;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedLongType longType) {
+            return ForLong;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedFloatType floatType) {
+            return ForFloat;
+        }
+
+        @Override
+        public PartitionParser visit(@NotNull final BoxedDoubleType doubleType) {
+            return ForDouble;
+        }
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/DeferredColumnRegionBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/DeferredColumnRegionBase.java
@@ -73,9 +73,11 @@ public abstract class DeferredColumnRegionBase<ATTR extends Any, REGION_TYPE ext
     }
 
     @Override
-    public void fillChunkAppend(@NotNull FillContext context, @NotNull WritableChunk<? super ATTR> destination,
-            @NotNull RowSequence.Iterator RowSequenceIterator) {
-        getResultRegion().fillChunkAppend(context, destination, RowSequenceIterator);
+    public void fillChunkAppend(
+            @NotNull final FillContext context,
+            @NotNull final WritableChunk<? super ATTR> destination,
+            @NotNull final RowSequence.Iterator rowSequenceIterator) {
+        getResultRegion().fillChunkAppend(context, destination, rowSequenceIterator);
     }
 
     @Override

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestKeyValuePartitionLayout.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestKeyValuePartitionLayout.java
@@ -4,8 +4,12 @@
 package io.deephaven.engine.table.impl.locations.impl;
 
 import io.deephaven.base.FileUtils;
+import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.local.FileTableLocationKey;
+import io.deephaven.engine.table.impl.locations.local.KeyValuePartitionLayout.LocationTableBuilder;
+import io.deephaven.engine.table.impl.locations.local.LocationTableBuilderDefinition;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.engine.table.impl.locations.local.KeyValuePartitionLayout;
 import io.deephaven.parquet.table.layout.LocationTableBuilderCsv;
@@ -152,33 +156,43 @@ public class TestKeyValuePartitionLayout {
         Files.write(file2.toPath(), "Goodbye cruel world!".getBytes());
         Files.write(file3.toPath(), "Oui!".getBytes());
 
-        final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
-                (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
-        final List<FileTableLocationKey> results =
-                recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
+        final LocationTableBuilder[] locationTableBuilders = new LocationTableBuilder[] {
+                new LocationTableBuilderCsv(dataDirectory),
+                new LocationTableBuilderDefinition(TableDefinition.of(
+                        ColumnDefinition.ofInt("A").withPartitioning(),
+                        ColumnDefinition.ofBoolean("C").withPartitioning(),
+                        ColumnDefinition.ofDouble("B1").withPartitioning()))
+        };
+        for (final LocationTableBuilder locationTableBuilder : locationTableBuilders) {
 
-        TestCase.assertEquals(3, results.size());
+            final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
+            new KeyValuePartitionLayout<>(dataDirectory, path -> true, locationTableBuilder,
+                    (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
+            final List<FileTableLocationKey> results =
+                    recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
 
-        TestCase.assertEquals(file2.getAbsoluteFile(), results.get(0).getFile());
-        TestCase.assertEquals(file3.getAbsoluteFile(), results.get(1).getFile());
-        TestCase.assertEquals(file1.getAbsoluteFile(), results.get(2).getFile());
+            TestCase.assertEquals(3, results.size());
 
-        TestCase.assertEquals(3, results.get(0).getPartitionKeys().size());
-        TestCase.assertEquals(3, results.get(1).getPartitionKeys().size());
-        TestCase.assertEquals(3, results.get(2).getPartitionKeys().size());
+            TestCase.assertEquals(file2.getAbsoluteFile(), results.get(0).getFile());
+            TestCase.assertEquals(file3.getAbsoluteFile(), results.get(1).getFile());
+            TestCase.assertEquals(file1.getAbsoluteFile(), results.get(2).getFile());
 
-        TestCase.assertEquals(Integer.valueOf(1), results.get(0).getPartitionValue("A"));
-        TestCase.assertEquals(Integer.valueOf(1), results.get(1).getPartitionValue("A"));
-        TestCase.assertEquals(Integer.valueOf(2), results.get(2).getPartitionValue("A"));
+            TestCase.assertEquals(3, results.get(0).getPartitionKeys().size());
+            TestCase.assertEquals(3, results.get(1).getPartitionKeys().size());
+            TestCase.assertEquals(3, results.get(2).getPartitionKeys().size());
 
-        TestCase.assertEquals(7.0, results.get(0).getPartitionValue("B1"));
-        TestCase.assertEquals(100.0, results.get(1).getPartitionValue("B1"));
-        TestCase.assertEquals(3.14, results.get(2).getPartitionValue("B1"));
+            TestCase.assertEquals(Integer.valueOf(1), results.get(0).getPartitionValue("A"));
+            TestCase.assertEquals(Integer.valueOf(1), results.get(1).getPartitionValue("A"));
+            TestCase.assertEquals(Integer.valueOf(2), results.get(2).getPartitionValue("A"));
 
-        TestCase.assertEquals(Boolean.FALSE, results.get(0).getPartitionValue("C"));
-        TestCase.assertEquals(Boolean.FALSE, results.get(1).getPartitionValue("C"));
-        TestCase.assertEquals(Boolean.TRUE, results.get(2).getPartitionValue("C"));
+            TestCase.assertEquals(7.0, results.get(0).getPartitionValue("B1"));
+            TestCase.assertEquals(100.0, results.get(1).getPartitionValue("B1"));
+            TestCase.assertEquals(3.14, results.get(2).getPartitionValue("B1"));
+
+            TestCase.assertEquals(Boolean.FALSE, results.get(0).getPartitionValue("C"));
+            TestCase.assertEquals(Boolean.FALSE, results.get(1).getPartitionValue("C"));
+            TestCase.assertEquals(Boolean.TRUE, results.get(2).getPartitionValue("C"));
+        }
     }
 
     @Test

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestKeyValuePartitionLayout.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestKeyValuePartitionLayout.java
@@ -7,7 +7,8 @@ import io.deephaven.base.FileUtils;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.local.FileTableLocationKey;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
-import io.deephaven.parquet.table.layout.KeyValuePartitionLayout;
+import io.deephaven.engine.table.impl.locations.local.KeyValuePartitionLayout;
+import io.deephaven.parquet.table.layout.LocationTableBuilderCsv;
 import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -51,7 +52,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file2.toPath(), "Goodbye cruel world!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true,
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 0).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -75,7 +76,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file2.toPath(), "Goodbye cruel world!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true,
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 1).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -108,7 +109,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file3.toPath(), "Oui!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true,
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -152,7 +153,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file3.toPath(), "Oui!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true,
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -196,7 +197,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file3.toPath(), "Oui!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true,
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -224,7 +225,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file4.toPath(), "Non!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true,
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -252,7 +253,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file3.toPath(), "Oui!".getBytes());
 
         try {
-            new KeyValuePartitionLayout<>(dataDirectory, path -> true,
+            new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
                     (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(ftlk -> {
                     });
             TestCase.fail("Expected exception");

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
@@ -372,7 +372,8 @@ public class ParquetTools {
      * @param instructions Instructions for reading
      * @return A {@link Table}
      */
-    private static Table readTableInternal(@NotNull final File source,
+    private static Table readTableInternal(
+            @NotNull final File source,
             @NotNull final ParquetInstructions instructions) {
         final Path sourcePath = source.toPath();
         if (!Files.exists(sourcePath)) {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/LocationTableBuilderCsv.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/LocationTableBuilderCsv.java
@@ -1,0 +1,84 @@
+package io.deephaven.parquet.table.layout;
+
+import io.deephaven.csv.CsvTools;
+import io.deephaven.csv.util.CsvReaderException;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.locations.TableDataException;
+import io.deephaven.engine.table.impl.locations.local.KeyValuePartitionLayout;
+import io.deephaven.engine.util.TableTools;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link KeyValuePartitionLayout.LocationTableBuilder LocationTableBuilder} implementation that uses the default
+ * Deephaven CSV parser for type inference and coercion.
+ */
+public final class LocationTableBuilderCsv implements KeyValuePartitionLayout.LocationTableBuilder {
+
+    private static final String LS = System.lineSeparator();
+
+    private final File tableRootDirectory;
+
+    private List<String> partitionKeys;
+    private StringBuilder csvBuilder;
+    private int locationCount;
+
+    public LocationTableBuilderCsv(@NotNull final File tableRootDirectory) {
+        this.tableRootDirectory = tableRootDirectory;
+    }
+
+    @Override
+    public void registerPartitionKeys(@NotNull final Collection<String> partitionKeys) {
+        if (this.partitionKeys != null) {
+            throw new IllegalStateException("Partition keys already registered");
+        }
+        this.partitionKeys = List.copyOf(Objects.requireNonNull(partitionKeys));
+        if (this.partitionKeys.isEmpty()) {
+            return;
+        }
+        csvBuilder = new StringBuilder();
+        maybeAppendToCsv(partitionKeys);
+    }
+
+    @Override
+    public void acceptLocation(@NotNull final Collection<String> partitionValueStrings) {
+        if (partitionKeys == null) {
+            throw new IllegalStateException("Partition keys not registered");
+        }
+        ++locationCount;
+        maybeAppendToCsv(partitionValueStrings);
+    }
+
+    private void maybeAppendToCsv(@NotNull final Collection<String> values) {
+        if (partitionKeys.isEmpty()) {
+            return;
+        }
+        boolean first = true;
+        for (final String value : values) {
+            if (first) {
+                first = false;
+            } else {
+                csvBuilder.append(',');
+            }
+            csvBuilder.append(StringEscapeUtils.escapeCsv(value));
+        }
+        csvBuilder.append(LS);
+    }
+
+    @Override
+    public Table build() {
+        try {
+            return partitionKeys == null || partitionKeys.isEmpty()
+                    ? TableTools.emptyTable(locationCount)
+                    : CsvTools.readCsv(new ByteArrayInputStream(csvBuilder.toString().getBytes()));
+        } catch (CsvReaderException e) {
+            throw new TableDataException("Failed converting partition CSV to table for " + tableRootDirectory, e);
+        }
+    }
+}

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
@@ -4,7 +4,10 @@
 package io.deephaven.parquet.table.layout;
 
 import io.deephaven.csv.CsvTools;
+import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.locations.local.KeyValuePartitionLayout;
+import io.deephaven.engine.table.impl.locations.local.LocationTableBuilderDefinition;
 import io.deephaven.parquet.table.location.ParquetTableLocationKey;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,6 +20,16 @@ import java.io.File;
  *           the same rules.
  */
 public class ParquetKeyValuePartitionedLayout extends KeyValuePartitionLayout<ParquetTableLocationKey> {
+
+    public ParquetKeyValuePartitionedLayout(
+            @NotNull final File tableRootDirectory,
+            @NotNull final TableDefinition tableDefinition) {
+        super(tableRootDirectory,
+                ParquetFileHelper::fileNameMatches,
+                new LocationTableBuilderDefinition(tableDefinition),
+                (path, partitions) -> new ParquetTableLocationKey(path.toFile(), 0, partitions),
+                Math.toIntExact(tableDefinition.getColumnStream().filter(ColumnDefinition::isPartitioning).count()));
+    }
 
     public ParquetKeyValuePartitionedLayout(
             @NotNull final File tableRootDirectory,

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
@@ -13,7 +13,8 @@ import java.io.File;
  */
 public class ParquetKeyValuePartitionedLayout extends KeyValuePartitionLayout<ParquetTableLocationKey> {
 
-    public ParquetKeyValuePartitionedLayout(@NotNull final File tableRootDirectory,
+    public ParquetKeyValuePartitionedLayout(
+            @NotNull final File tableRootDirectory,
             final int maxPartitioningLevels) {
         super(tableRootDirectory,
                 ParquetFileHelper::fileNameMatches,

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
@@ -3,6 +3,8 @@
  */
 package io.deephaven.parquet.table.layout;
 
+import io.deephaven.csv.CsvTools;
+import io.deephaven.engine.table.impl.locations.local.KeyValuePartitionLayout;
 import io.deephaven.parquet.table.location.ParquetTableLocationKey;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,6 +12,9 @@ import java.io.File;
 
 /**
  * {@link KeyValuePartitionLayout} for Parquet data.
+ * 
+ * @implNote Type inference uses {@link CsvTools#readCsv(java.io.InputStream)} as a conversion tool, and hence follows
+ *           the same rules.
  */
 public class ParquetKeyValuePartitionedLayout extends KeyValuePartitionLayout<ParquetTableLocationKey> {
 
@@ -18,6 +23,7 @@ public class ParquetKeyValuePartitionedLayout extends KeyValuePartitionLayout<Pa
             final int maxPartitioningLevels) {
         super(tableRootDirectory,
                 ParquetFileHelper::fileNameMatches,
+                new LocationTableBuilderCsv(tableRootDirectory),
                 (path, partitions) -> new ParquetTableLocationKey(path.toFile(), 0, partitions),
                 maxPartitioningLevels);
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetMetadataFileLayout.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetMetadataFileLayout.java
@@ -6,10 +6,9 @@ package io.deephaven.parquet.table.layout;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import io.deephaven.base.Pair;
-import io.deephaven.base.verify.Assert;
-import io.deephaven.base.verify.Require;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.engine.table.impl.locations.util.PartitionParser;
 import io.deephaven.parquet.table.ParquetTools;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.impl.TableLocationKeyFinder;
@@ -26,11 +25,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -68,18 +69,21 @@ public class ParquetMetadataFileLayout implements TableLocationKeyFinder<Parquet
         this(directory, ParquetInstructions.EMPTY);
     }
 
-    public ParquetMetadataFileLayout(@NotNull final File directory,
+    public ParquetMetadataFileLayout(
+            @NotNull final File directory,
             @NotNull final ParquetInstructions inputInstructions) {
         this(new File(directory, METADATA_FILE_NAME), new File(directory, COMMON_METADATA_FILE_NAME),
                 inputInstructions);
     }
 
-    public ParquetMetadataFileLayout(@NotNull final File metadataFile,
+    public ParquetMetadataFileLayout(
+            @NotNull final File metadataFile,
             @Nullable final File commonMetadataFile) {
         this(metadataFile, commonMetadataFile, ParquetInstructions.EMPTY);
     }
 
-    public ParquetMetadataFileLayout(@NotNull final File metadataFile,
+    public ParquetMetadataFileLayout(
+            @NotNull final File metadataFile,
             @Nullable final File commonMetadataFile,
             @NotNull final ParquetInstructions inputInstructions) {
         if (inputInstructions.isRefreshing()) {
@@ -131,8 +135,9 @@ public class ParquetMetadataFileLayout implements TableLocationKeyFinder<Parquet
         }
 
         final List<ColumnDefinition<?>> partitioningColumns = definition.getPartitioningColumns();
-        final Map<String, ColumnDefinition<?>> partitioningColumnsMap = partitioningColumns.stream().collect(
-                toMap(ColumnDefinition::getName, Function.identity(), Assert::neverInvoked, LinkedHashMap::new));
+        final Map<String, PartitionParser> partitionKeyToParser = partitioningColumns.stream().collect(toMap(
+                ColumnDefinition::getName,
+                cd -> PartitionParser.lookupSupported(cd.getDataType(), cd.getComponentType())));
         final Map<String, TIntList> fileNameToRowGroupIndices = new LinkedHashMap<>();
         final List<RowGroup> rowGroups = metadataFileReader.fileMetaData.getRow_groups();
         final int numRowGroups = rowGroups.size();
@@ -163,7 +168,6 @@ public class ParquetMetadataFileLayout implements TableLocationKeyFinder<Parquet
                 final boolean useHiveStyle = filePath.getName(0).toString().contains("=");
                 for (int pi = 0; pi < numPartitions; ++pi) {
                     final String pathElement = filePath.getName(pi).toString();
-                    final ColumnDefinition<?> columnDefinition;
                     final String partitionKey;
                     final String partitionValueRaw;
                     if (useHiveStyle) {
@@ -174,15 +178,13 @@ public class ParquetMetadataFileLayout implements TableLocationKeyFinder<Parquet
                                             + " for " + metadataFile);
                         }
                         partitionKey = instructions.getColumnNameFromParquetColumnNameOrDefault(pathComponents[0]);
-                        columnDefinition = partitioningColumnsMap.get(partitionKey);
                         partitionValueRaw = pathComponents[1];
                     } else {
-                        columnDefinition = partitioningColumns.get(pi);
-                        partitionKey = columnDefinition.getName();
+                        partitionKey = partitioningColumns.get(pi).getName();
                         partitionValueRaw = pathElement;
                     }
                     final Comparable<?> partitionValue =
-                            CONVERSION_FUNCTIONS.get(columnDefinition.getDataType()).apply(partitionValueRaw);
+                            partitionKeyToParser.get(partitionKey).parse(partitionValueRaw);
                     if (partitions.containsKey(partitionKey)) {
                         throw new TableDataException("Unexpected duplicate partition key " + partitionKey
                                 + " when parsing " + filePathString + " for " + metadataFile);
@@ -214,51 +216,33 @@ public class ParquetMetadataFileLayout implements TableLocationKeyFinder<Parquet
     }
 
     private static ColumnDefinition<?> adjustPartitionDefinition(@NotNull final ColumnDefinition<?> columnDefinition) {
-        if (columnDefinition.getComponentType() != null) {
-            return ColumnDefinition.fromGenericType(columnDefinition.getName(), String.class,
-                    null, ColumnDefinition.ColumnType.Partitioning);
-        }
+        // Primitive booleans should be boxed
         final Class<?> dataType = columnDefinition.getDataType();
         if (dataType == boolean.class) {
-            return ColumnDefinition.fromGenericType(columnDefinition.getName(), Boolean.class,
-                    null, ColumnDefinition.ColumnType.Partitioning);
+            return ColumnDefinition.fromGenericType(
+                    columnDefinition.getName(), Boolean.class, null, ColumnDefinition.ColumnType.Partitioning);
         }
-        if (dataType.isPrimitive()) {
+
+        // Non-boolean primitives and boxed Booleans are supported as-is
+        if (dataType.isPrimitive() || dataType == Boolean.class) {
             return columnDefinition.withPartitioning();
         }
-        final Class<?> unboxedType = TypeUtils.getUnboxedType(dataType);
-        if (unboxedType != null && unboxedType.isPrimitive()) {
-            return ColumnDefinition.fromGenericType(columnDefinition.getName(), unboxedType,
-                    null, ColumnDefinition.ColumnType.Partitioning);
+
+        // Non-boolean boxed primitives should be unboxed
+        final Class<?> unboxedType = TypeUtils.getUnboxedTypeIfBoxed(dataType);
+        if (unboxedType != dataType) {
+            return ColumnDefinition.fromGenericType(
+                    columnDefinition.getName(), unboxedType, null, ColumnDefinition.ColumnType.Partitioning);
         }
-        if (dataType == Boolean.class || dataType == String.class || dataType == BigDecimal.class
-                || dataType == BigInteger.class) {
+
+        // Object types we know how to parse are supported as-is
+        if (PartitionParser.lookup(dataType, columnDefinition.getComponentType()) != null) {
             return columnDefinition.withPartitioning();
         }
-        // NB: This fallback includes any kind of timestamp; we don't have a strong grasp of required parsing support at
-        // this time, and preserving the contents as a String allows the user full control.
-        return ColumnDefinition.fromGenericType(columnDefinition.getName(), String.class,
-                null, ColumnDefinition.ColumnType.Partitioning);
-    }
 
-    private static final Map<Class<?>, Function<String, Comparable<?>>> CONVERSION_FUNCTIONS;
-
-    static {
-        final Map<Class<?>, Function<String, Comparable<?>>> conversionFunctionsTemp = new HashMap<>();
-        conversionFunctionsTemp.put(Boolean.class, Boolean::parseBoolean);
-        conversionFunctionsTemp.put(char.class, str -> {
-            Require.eq(str.length(), "length", 1);
-            return str.charAt(0);
-        });
-        conversionFunctionsTemp.put(byte.class, Byte::parseByte);
-        conversionFunctionsTemp.put(short.class, Short::parseShort);
-        conversionFunctionsTemp.put(int.class, Integer::parseInt);
-        conversionFunctionsTemp.put(long.class, Long::parseLong);
-        conversionFunctionsTemp.put(float.class, Float::parseFloat);
-        conversionFunctionsTemp.put(BigInteger.class, BigInteger::new);
-        conversionFunctionsTemp.put(BigDecimal.class, BigDecimal::new);
-        conversionFunctionsTemp.put(String.class, str -> str);
-        CONVERSION_FUNCTIONS = Collections.unmodifiableMap(conversionFunctionsTemp);
+        // Fall back to String for all other types
+        return ColumnDefinition.fromGenericType(
+                columnDefinition.getName(), String.class, null, ColumnDefinition.ColumnType.Partitioning);
     }
 
     public TableDefinition getTableDefinition() {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/region/ParquetColumnRegionBase.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/region/ParquetColumnRegionBase.java
@@ -51,10 +51,11 @@ public abstract class ParquetColumnRegionBase<ATTR extends Any>
     }
 
     @Override
-    public final void fillChunkAppend(@NotNull final FillContext context,
+    public final void fillChunkAppend(
+            @NotNull final FillContext context,
             @NotNull final WritableChunk<? super ATTR> destination,
-            @NotNull final RowSequence.Iterator RowSequenceIterator) {
-        columnChunkPageStore.fillChunkAppend(context, destination, RowSequenceIterator);
+            @NotNull final RowSequence.Iterator rowSequenceIterator) {
+        columnChunkPageStore.fillChunkAppend(context, destination, rowSequenceIterator);
     }
 
     @Override


### PR DESCRIPTION
To use:
```
    public static Table readDefinedKeyValuePartitionedTable(
            @NotNull final File directory,
            @NotNull final ParquetInstructions readInstructions,
            @NotNull final TableDefinition tableDefinition) {
        return TableTools.readPartitionedTable(
                new ParquetKeyValuePartitionedLayout(directory, tableDefinition),
                readInstructions,
                tableDefinition);
    }
```