### PR TITLE
Remove nightly benchmark badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ which functions as the data backbone for prominent hedge funds, banks, and finan
 ![Docs CI](https://github.com/deephaven/deephaven-core/actions/workflows/docs-ci.yml/badge.svg?branch=main)
 ![Check CI](https://github.com/deephaven/deephaven-core/actions/workflows/check-ci.yml/badge.svg?branch=main)
 ![Nightly Check CI](https://github.com/deephaven/deephaven-core/actions/workflows/nightly-check-ci.yml/badge.svg?branch=main)
-![Nightly Benchmarks](https://github.com/deephaven/deephaven-core/actions/workflows/nightly-benchmarks.yml/badge.svg?branch=main)
 
 ## Supported Languages
 


### PR DESCRIPTION
The nightly-benchmark.yml workflow has been removed.  Remove the badge in the README as well.