### PR TITLE
Catch ISE When `ServletServerStream` Writer is Flushed

### DIFF
--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
@@ -233,7 +233,7 @@ final class ServletServerStream extends AbstractServerStream {
             }
             try {
                 writer.flush();
-            } catch (IOException e) {
+            } catch (IllegalStateException | IOException e) {
                 logger.log(WARNING, String.format("[{%s}] Exception when flushBuffer", logId), e);
                 cancel(Status.fromThrowable(e));
             }


### PR DESCRIPTION
This change prevents an ISE from hitting the error log that the user can't do anything about.

```
Internal Error 'f10bcfe6-b227-428a-aa21-7ab0efd88cef' java.lang.IllegalStateException: AsyncContext completed and/or Request lifecycle recycled
	at org.eclipse.jetty.server.AsyncContextState.state(AsyncContextState.java:47)
	at org.eclipse.jetty.server.AsyncContextState.getResponse(AsyncContextState.java:113)
	at io.grpc.servlet.jakarta.AsyncServletOutputStreamWriter.lambda$new$0(AsyncServletOutputStreamWriter.java:90)
	at io.grpc.servlet.jakarta.AsyncServletOutputStreamWriter.runOrBuffer(AsyncServletOutputStreamWriter.java:183)
	at io.grpc.servlet.jakarta.AsyncServletOutputStreamWriter.flush(AsyncServletOutputStreamWriter.java:121)
	at io.grpc.servlet.jakarta.ServletServerStream$Sink.writeHeaders(ServletServerStream.java:235)
	at io.grpc.internal.AbstractServerStream.writeHeaders(AbstractServerStream.java:103)
	at io.grpc.internal.ServerCallImpl.sendHeadersInternal(ServerCallImpl.java:147)
	at io.grpc.internal.ServerCallImpl.sendHeaders(ServerCallImpl.java:104)
	at io.grpc.PartialForwardingServerCall.sendHeaders(PartialForwardingServerCall.java:38)
	at io.grpc.ForwardingServerCall.sendHeaders(ForwardingServerCall.java:22)
	at io.grpc.ForwardingServerCall$SimpleForwardingServerCall.sendHeaders(ForwardingServerCall.java:39)
	at io.deephaven.server.session.SessionServiceGrpcImpl$InterceptedCall.sendHeaders(SessionServiceGrpcImpl.java:265)
	at io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onNext(ServerCalls.java:377)
	at io.deephaven.extensions.barrage.BarrageStreamGeneratorImpl$SchemaView.forEachStream(BarrageStreamGeneratorImpl.java:582)
	at io.deephaven.server.arrow.ArrowModule$1.onNext(ArrowModule.java:48)
	at io.deephaven.server.arrow.ArrowModule$1.onNext(ArrowModule.java:43)
	at io.deephaven.server.barrage.BarrageMessageProducer.propagateSnapshotForSubscription(BarrageMessageProducer.java:1583)
	at io.deephaven.server.barrage.BarrageMessageProducer.updateSubscriptionsSnapshotAndPropagate(BarrageMessageProducer.java:1455)
	at io.deephaven.server.barrage.BarrageMessageProducer$UpdatePropagationJob.run(BarrageMessageProducer.java:999)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at io.deephaven.server.runner.scheduler.SchedulerModule$ThreadFactory.lambda$newThread$0(SchedulerModule.java:78)
	at java.base/java.lang.Thread.run(Thread.java:832)
```