### PR TITLE
Allow multiple invocations of KeyValuePartitionLayout.findKeys(...), by allocating LocationTableBuilders per call

### DIFF
--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestKeyValuePartitionLayout.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestKeyValuePartitionLayout.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -56,7 +57,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file2.toPath(), "Goodbye cruel world!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, () -> new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 0).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -80,7 +81,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file2.toPath(), "Goodbye cruel world!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, () -> new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 1).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -113,7 +114,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file3.toPath(), "Oui!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, () -> new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -156,42 +157,48 @@ public class TestKeyValuePartitionLayout {
         Files.write(file2.toPath(), "Goodbye cruel world!".getBytes());
         Files.write(file3.toPath(), "Oui!".getBytes());
 
-        final LocationTableBuilder[] locationTableBuilders = new LocationTableBuilder[] {
-                new LocationTableBuilderCsv(dataDirectory),
-                new LocationTableBuilderDefinition(TableDefinition.of(
+        final List<Supplier<LocationTableBuilder>> locationTableBuilderSuppliers = List.of(
+                () -> new LocationTableBuilderCsv(dataDirectory),
+                () -> new LocationTableBuilderDefinition(TableDefinition.of(
                         ColumnDefinition.ofInt("A").withPartitioning(),
                         ColumnDefinition.ofBoolean("C").withPartitioning(),
-                        ColumnDefinition.ofDouble("B1").withPartitioning()))
-        };
-        for (final LocationTableBuilder locationTableBuilder : locationTableBuilders) {
+                        ColumnDefinition.ofDouble("B1").withPartitioning())));
+        for (final Supplier<LocationTableBuilder> locationTableBuilderSupplier : locationTableBuilderSuppliers) {
+            final TableLocationKeyFinder<FileTableLocationKey> finder = new KeyValuePartitionLayout<>(
+                    dataDirectory, path -> true, locationTableBuilderSupplier,
+                    (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3);
 
-            final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-            new KeyValuePartitionLayout<>(dataDirectory, path -> true, locationTableBuilder,
-                    (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
-            final List<FileTableLocationKey> results =
-                    recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
+            final RecordingLocationKeyFinder<FileTableLocationKey> recorder1 = new RecordingLocationKeyFinder<>();
+            finder.findKeys(recorder1);
+            final RecordingLocationKeyFinder<FileTableLocationKey> recorder2 = new RecordingLocationKeyFinder<>();
+            finder.findKeys(recorder2);
+            final List<FileTableLocationKey> results1 =
+                    recorder1.getRecordedKeys().stream().sorted().collect(Collectors.toList());
+            final List<FileTableLocationKey> results2 =
+                    recorder2.getRecordedKeys().stream().sorted().collect(Collectors.toList());
+            TestCase.assertEquals(results1, results2);
 
-            TestCase.assertEquals(3, results.size());
+            TestCase.assertEquals(3, results1.size());
 
-            TestCase.assertEquals(file2.getAbsoluteFile(), results.get(0).getFile());
-            TestCase.assertEquals(file3.getAbsoluteFile(), results.get(1).getFile());
-            TestCase.assertEquals(file1.getAbsoluteFile(), results.get(2).getFile());
+            TestCase.assertEquals(file2.getAbsoluteFile(), results1.get(0).getFile());
+            TestCase.assertEquals(file3.getAbsoluteFile(), results1.get(1).getFile());
+            TestCase.assertEquals(file1.getAbsoluteFile(), results1.get(2).getFile());
 
-            TestCase.assertEquals(3, results.get(0).getPartitionKeys().size());
-            TestCase.assertEquals(3, results.get(1).getPartitionKeys().size());
-            TestCase.assertEquals(3, results.get(2).getPartitionKeys().size());
+            TestCase.assertEquals(3, results1.get(0).getPartitionKeys().size());
+            TestCase.assertEquals(3, results1.get(1).getPartitionKeys().size());
+            TestCase.assertEquals(3, results1.get(2).getPartitionKeys().size());
 
-            TestCase.assertEquals(Integer.valueOf(1), results.get(0).getPartitionValue("A"));
-            TestCase.assertEquals(Integer.valueOf(1), results.get(1).getPartitionValue("A"));
-            TestCase.assertEquals(Integer.valueOf(2), results.get(2).getPartitionValue("A"));
+            TestCase.assertEquals(Integer.valueOf(1), results1.get(0).getPartitionValue("A"));
+            TestCase.assertEquals(Integer.valueOf(1), results1.get(1).getPartitionValue("A"));
+            TestCase.assertEquals(Integer.valueOf(2), results1.get(2).getPartitionValue("A"));
 
-            TestCase.assertEquals(7.0, results.get(0).getPartitionValue("B1"));
-            TestCase.assertEquals(100.0, results.get(1).getPartitionValue("B1"));
-            TestCase.assertEquals(3.14, results.get(2).getPartitionValue("B1"));
+            TestCase.assertEquals(7.0, results1.get(0).getPartitionValue("B1"));
+            TestCase.assertEquals(100.0, results1.get(1).getPartitionValue("B1"));
+            TestCase.assertEquals(3.14, results1.get(2).getPartitionValue("B1"));
 
-            TestCase.assertEquals(Boolean.FALSE, results.get(0).getPartitionValue("C"));
-            TestCase.assertEquals(Boolean.FALSE, results.get(1).getPartitionValue("C"));
-            TestCase.assertEquals(Boolean.TRUE, results.get(2).getPartitionValue("C"));
+            TestCase.assertEquals(Boolean.FALSE, results1.get(0).getPartitionValue("C"));
+            TestCase.assertEquals(Boolean.FALSE, results1.get(1).getPartitionValue("C"));
+            TestCase.assertEquals(Boolean.TRUE, results1.get(2).getPartitionValue("C"));
         }
     }
 
@@ -211,7 +218,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file3.toPath(), "Oui!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, () -> new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -239,7 +246,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file4.toPath(), "Non!".getBytes());
 
         final RecordingLocationKeyFinder<FileTableLocationKey> recorder = new RecordingLocationKeyFinder<>();
-        new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
+        new KeyValuePartitionLayout<>(dataDirectory, path -> true, () -> new LocationTableBuilderCsv(dataDirectory),
                 (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(recorder);
         final List<FileTableLocationKey> results =
                 recorder.getRecordedKeys().stream().sorted().collect(Collectors.toList());
@@ -267,7 +274,7 @@ public class TestKeyValuePartitionLayout {
         Files.write(file3.toPath(), "Oui!".getBytes());
 
         try {
-            new KeyValuePartitionLayout<>(dataDirectory, path -> true, new LocationTableBuilderCsv(dataDirectory),
+            new KeyValuePartitionLayout<>(dataDirectory, path -> true, () -> new LocationTableBuilderCsv(dataDirectory),
                     (path, partitions) -> new FileTableLocationKey(path.toFile(), 0, partitions), 3).findKeys(ftlk -> {
                     });
             TestCase.fail("Expected exception");

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/layout/ParquetKeyValuePartitionedLayout.java
@@ -26,7 +26,7 @@ public class ParquetKeyValuePartitionedLayout extends KeyValuePartitionLayout<Pa
             @NotNull final TableDefinition tableDefinition) {
         super(tableRootDirectory,
                 ParquetFileHelper::fileNameMatches,
-                new LocationTableBuilderDefinition(tableDefinition),
+                () -> new LocationTableBuilderDefinition(tableDefinition),
                 (path, partitions) -> new ParquetTableLocationKey(path.toFile(), 0, partitions),
                 Math.toIntExact(tableDefinition.getColumnStream().filter(ColumnDefinition::isPartitioning).count()));
     }
@@ -36,7 +36,7 @@ public class ParquetKeyValuePartitionedLayout extends KeyValuePartitionLayout<Pa
             final int maxPartitioningLevels) {
         super(tableRootDirectory,
                 ParquetFileHelper::fileNameMatches,
-                new LocationTableBuilderCsv(tableRootDirectory),
+                () -> new LocationTableBuilderCsv(tableRootDirectory),
                 (path, partitions) -> new ParquetTableLocationKey(path.toFile(), 0, partitions),
                 maxPartitioningLevels);
     }


### PR DESCRIPTION
Fixes #4312