### PR TITLE
Create and Replicate Single Type Timsort Kernels

### DIFF
--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/ByteSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/ByteSortKernelBenchmark.java
@@ -77,7 +77,8 @@ public class ByteSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestByteTimSortKernel.ByteSortKernelStuff sortStuff = new BaseTestByteTimSortKernel.ByteSortKernelStuff(stuffToSort);
+                final BaseTestByteTimSortKernel.ByteLongSortKernelStuff sortStuff
+                        = new BaseTestByteTimSortKernel.ByteLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/CharSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/CharSortKernelBenchmark.java
@@ -72,7 +72,8 @@ public class CharSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestCharTimSortKernel.CharSortKernelStuff sortStuff = new BaseTestCharTimSortKernel.CharSortKernelStuff(stuffToSort);
+                final BaseTestCharTimSortKernel.CharLongSortKernelStuff sortStuff
+                        = new BaseTestCharTimSortKernel.CharLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/DoubleSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/DoubleSortKernelBenchmark.java
@@ -77,7 +77,8 @@ public class DoubleSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestDoubleTimSortKernel.DoubleSortKernelStuff sortStuff = new BaseTestDoubleTimSortKernel.DoubleSortKernelStuff(stuffToSort);
+                final BaseTestDoubleTimSortKernel.DoubleLongSortKernelStuff sortStuff
+                        = new BaseTestDoubleTimSortKernel.DoubleLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/FloatSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/FloatSortKernelBenchmark.java
@@ -77,7 +77,8 @@ public class FloatSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestFloatTimSortKernel.FloatSortKernelStuff sortStuff = new BaseTestFloatTimSortKernel.FloatSortKernelStuff(stuffToSort);
+                final BaseTestFloatTimSortKernel.FloatLongSortKernelStuff sortStuff
+                        = new BaseTestFloatTimSortKernel.FloatLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/IntSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/IntSortKernelBenchmark.java
@@ -77,7 +77,8 @@ public class IntSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestIntTimSortKernel.IntSortKernelStuff sortStuff = new BaseTestIntTimSortKernel.IntSortKernelStuff(stuffToSort);
+                final BaseTestIntTimSortKernel.IntLongSortKernelStuff sortStuff
+                        = new BaseTestIntTimSortKernel.IntLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/LongSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/LongSortKernelBenchmark.java
@@ -77,7 +77,8 @@ public class LongSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestLongTimSortKernel.LongSortKernelStuff sortStuff = new BaseTestLongTimSortKernel.LongSortKernelStuff(stuffToSort);
+                final BaseTestLongTimSortKernel.LongLongSortKernelStuff sortStuff
+                        = new BaseTestLongTimSortKernel.LongLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/ObjectSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/ObjectSortKernelBenchmark.java
@@ -77,7 +77,8 @@ public class ObjectSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestObjectTimSortKernel.ObjectSortKernelStuff sortStuff = new BaseTestObjectTimSortKernel.ObjectSortKernelStuff(stuffToSort);
+                final BaseTestObjectTimSortKernel.ObjectLongSortKernelStuff sortStuff
+                        = new BaseTestObjectTimSortKernel.ObjectLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/ShortSortKernelBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/sort/timsort/ShortSortKernelBenchmark.java
@@ -77,7 +77,8 @@ public class ShortSortKernelBenchmark {
                 doSort = () -> Arrays.sort(javaArray);
                 break;
             case "timsort":
-                final BaseTestShortTimSortKernel.ShortSortKernelStuff sortStuff = new BaseTestShortTimSortKernel.ShortSortKernelStuff(stuffToSort);
+                final BaseTestShortTimSortKernel.ShortLongSortKernelStuff sortStuff
+                        = new BaseTestShortTimSortKernel.ShortLongSortKernelStuff(stuffToSort);
                 doSort = sortStuff::run;
                 break;
             case "mergesort":

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.ByteComparisons;
 
 /**
  * This implements a timsort kernel for Bytes.
@@ -158,7 +157,7 @@ public class ByteTimsortDescendingKernel {
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
     private static int doComparison(byte lhs, byte rhs) {
-        return -1 * ByteComparisons.compare(lhs, rhs);
+        return -1 * Byte.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
@@ -3,46 +3,46 @@
  */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
  * ---------------------------------------------------------------------------------------------------------------------
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.ByteChunk;
+import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.ByteComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Bytes.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class ByteTimsortDescendingKernel {
+    private ByteTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class ByteSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableByteChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private ByteSortKernelContext(int size) {
+            temporaryValues = WritableByteChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            ByteTimsortDescendingKernel.sort(this, valuesToSort.asWritableByteChunk());
         }
 
         public void close() {
@@ -51,8 +51,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> ByteSortKernelContext<ATTR> createContext(int size) {
+        return new ByteSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +63,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +88,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            byte current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +97,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                byte next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +156,29 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
+    private static int doComparison(byte lhs, byte rhs) {
+        return -1 * ByteComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +201,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +248,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +261,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final byte run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +270,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final byte run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +295,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +307,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        byte val1 = context.temporaryValues.get(tempCursor);
+        byte val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +399,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +411,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        byte val1 = valuesToSort.get(run1Cursor);
+        byte val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +501,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +510,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final ByteChunk<ATTR> valuesSource,
+            final WritableByteChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +525,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final ByteChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final byte searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final ByteChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final byte searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final ByteChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final byte searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final byte testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +566,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableByteChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +578,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableByteChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final byte tempByte = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempByte);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
@@ -322,7 +322,7 @@ public class ByteTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -332,7 +332,7 @@ public class ByteTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -427,7 +427,7 @@ public class ByteTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -437,7 +437,7 @@ public class ByteTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.ByteComparisons;
 
 /**
  * This implements a timsort kernel for Bytes.
@@ -157,7 +156,7 @@ public class ByteTimsortKernel {
 
     // region comparison functions
     private static int doComparison(byte lhs, byte rhs) {
-        return ByteComparisons.compare(lhs, rhs);
+        return Byte.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
@@ -8,41 +8,41 @@
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.ByteChunk;
+import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.ByteComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Bytes.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class ByteTimsortKernel {
+    private ByteTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class ByteSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableByteChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private ByteSortKernelContext(int size) {
+            temporaryValues = WritableByteChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            ByteTimsortKernel.sort(this, valuesToSort.asWritableByteChunk());
         }
 
         public void close() {
@@ -51,8 +51,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> ByteSortKernelContext<ATTR> createContext(int size) {
+        return new ByteSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +63,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +88,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            byte current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +97,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                byte next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +156,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(byte lhs, byte rhs) {
+        return ByteComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(byte lhs, byte rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +200,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +247,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +260,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final byte run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +269,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final byte run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +294,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +306,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        byte val1 = context.temporaryValues.get(tempCursor);
+        byte val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +398,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +410,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        byte val1 = valuesToSort.get(run1Cursor);
+        byte val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +500,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ByteSortKernelContext<ATTR> context,
+            final WritableByteChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +509,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final ByteChunk<ATTR> valuesSource,
+            final WritableByteChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +524,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final ByteChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final byte searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final ByteChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final byte searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final ByteChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final byte searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final byte testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +565,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableByteChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +577,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableByteChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final byte tempByte = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempByte);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
@@ -321,7 +321,7 @@ public class ByteTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -331,7 +331,7 @@ public class ByteTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -426,7 +426,7 @@ public class ByteTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -436,7 +436,7 @@ public class ByteTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortDescendingKernel.java
@@ -152,7 +152,7 @@ public class CharTimsortDescendingKernel {
 
     // region comparison functions
     private static int doComparison(char lhs, char rhs) {
-        return -1 * CharComparisons.compare(lhs, rhs);
+        return -1 * Character.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortDescendingKernel.java
@@ -1,48 +1,43 @@
 /**
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
-/*
- * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
- * ---------------------------------------------------------------------------------------------------------------------
- */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.CharChunk;
+import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.CharComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Characters.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class CharTimsortDescendingKernel {
+    private CharTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableCharChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private CharSortKernelContext(int size) {
+            temporaryValues = WritableCharChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            CharTimsortDescendingKernel.sort(this, valuesToSort.asWritableCharChunk());
         }
 
         public void close() {
@@ -51,8 +46,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> CharSortKernelContext<ATTR> createContext(int size) {
+        return new CharSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +58,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +83,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            char current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +92,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                char next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +151,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(char lhs, char rhs) {
+        return -1 * CharComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(char lhs, char rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(char lhs, char rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(char lhs, char rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(char lhs, char rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +195,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +242,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +255,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final char run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +264,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final char run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +289,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +301,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        char val1 = context.temporaryValues.get(tempCursor);
+        char val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +393,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +405,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        char val1 = valuesToSort.get(run1Cursor);
+        char val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +495,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +504,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final CharChunk<ATTR> valuesSource,
+            final WritableCharChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +519,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final char searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final char testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +560,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +572,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final char tempChar = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempChar);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
@@ -316,7 +316,7 @@ public class CharTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -326,7 +326,7 @@ public class CharTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -421,7 +421,7 @@ public class CharTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -431,7 +431,7 @@ public class CharTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
@@ -8,7 +8,6 @@ import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.CharComparisons;
 
 /**
  * This implements a timsort kernel for Characters.
@@ -152,7 +151,7 @@ public class CharTimsortKernel {
 
     // region comparison functions
     private static int doComparison(char lhs, char rhs) {
-        return CharComparisons.compare(lhs, rhs);
+        return Character.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
@@ -1,48 +1,43 @@
 /**
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
-/*
- * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
- * ---------------------------------------------------------------------------------------------------------------------
- */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.CharChunk;
+import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.CharComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Characters.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class CharTimsortKernel {
+    private CharTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableCharChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private CharSortKernelContext(int size) {
+            temporaryValues = WritableCharChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            CharTimsortKernel.sort(this, valuesToSort.asWritableCharChunk());
         }
 
         public void close() {
@@ -51,8 +46,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> CharSortKernelContext<ATTR> createContext(int size) {
+        return new CharSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +58,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +83,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            char current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +92,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                char next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +151,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(char lhs, char rhs) {
+        return CharComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(char lhs, char rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(char lhs, char rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(char lhs, char rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(char lhs, char rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +195,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +242,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +255,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final char run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +264,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final char run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +289,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +301,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        char val1 = context.temporaryValues.get(tempCursor);
+        char val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +393,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +405,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        char val1 = valuesToSort.get(run1Cursor);
+        char val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +495,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +504,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final CharChunk<ATTR> valuesSource,
+            final WritableCharChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +519,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final char searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final char testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +560,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +572,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final char tempChar = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempChar);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
@@ -324,7 +324,7 @@ public class DoubleTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -334,7 +334,7 @@ public class DoubleTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -429,7 +429,7 @@ public class DoubleTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -439,7 +439,7 @@ public class DoubleTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
@@ -15,7 +15,6 @@ import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.DoubleComparisons;
 
 /**
  * This implements a timsort kernel for Doubles.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
@@ -3,46 +3,48 @@
  */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
  * ---------------------------------------------------------------------------------------------------------------------
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.util.compare.DoubleComparisons;
+
+import io.deephaven.chunk.DoubleChunk;
+import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.DoubleComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Doubles.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class DoubleTimsortDescendingKernel {
+    private DoubleTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class DoubleSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableDoubleChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private DoubleSortKernelContext(int size) {
+            temporaryValues = WritableDoubleChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            DoubleTimsortDescendingKernel.sort(this, valuesToSort.asWritableDoubleChunk());
         }
 
         public void close() {
@@ -51,8 +53,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> DoubleSortKernelContext<ATTR> createContext(int size) {
+        return new DoubleSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +65,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +90,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            double current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +99,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                double next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +158,29 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
+    private static int doComparison(double lhs, double rhs) {
+        return -1 * DoubleComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(double lhs, double rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(double lhs, double rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(double lhs, double rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(double lhs, double rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +203,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +250,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +263,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final double run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +272,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final double run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +297,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +309,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        double val1 = context.temporaryValues.get(tempCursor);
+        double val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +401,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +413,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        double val1 = valuesToSort.get(run1Cursor);
+        double val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +503,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +512,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final DoubleChunk<ATTR> valuesSource,
+            final WritableDoubleChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +527,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final DoubleChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final double searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final DoubleChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final double searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final DoubleChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final double searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final double testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +568,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableDoubleChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +580,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableDoubleChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final double tempDouble = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempDouble);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
@@ -15,7 +15,6 @@ import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.DoubleComparisons;
 
 /**
  * This implements a timsort kernel for Doubles.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
@@ -323,7 +323,7 @@ public class DoubleTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -333,7 +333,7 @@ public class DoubleTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -428,7 +428,7 @@ public class DoubleTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -438,7 +438,7 @@ public class DoubleTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
@@ -8,41 +8,43 @@
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.util.compare.DoubleComparisons;
+
+import io.deephaven.chunk.DoubleChunk;
+import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.DoubleComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Doubles.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class DoubleTimsortKernel {
+    private DoubleTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class DoubleSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableDoubleChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private DoubleSortKernelContext(int size) {
+            temporaryValues = WritableDoubleChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            DoubleTimsortKernel.sort(this, valuesToSort.asWritableDoubleChunk());
         }
 
         public void close() {
@@ -51,8 +53,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> DoubleSortKernelContext<ATTR> createContext(int size) {
+        return new DoubleSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +65,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +90,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            double current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +99,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                double next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +158,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(double lhs, double rhs) {
+        return DoubleComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(double lhs, double rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(double lhs, double rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(double lhs, double rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(double lhs, double rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +202,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +249,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +262,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final double run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +271,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final double run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +296,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +308,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        double val1 = context.temporaryValues.get(tempCursor);
+        double val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +400,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +412,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        double val1 = valuesToSort.get(run1Cursor);
+        double val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +502,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final DoubleSortKernelContext<ATTR> context,
+            final WritableDoubleChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +511,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final DoubleChunk<ATTR> valuesSource,
+            final WritableDoubleChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +526,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final DoubleChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final double searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final DoubleChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final double searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final DoubleChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final double searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final double testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +567,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableDoubleChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +579,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableDoubleChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final double tempDouble = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempDouble);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
@@ -15,7 +15,6 @@ import io.deephaven.chunk.WritableFloatChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.FloatComparisons;
 
 /**
  * This implements a timsort kernel for Floats.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
@@ -3,46 +3,48 @@
  */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
  * ---------------------------------------------------------------------------------------------------------------------
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.util.compare.FloatComparisons;
+
+import io.deephaven.chunk.FloatChunk;
+import io.deephaven.chunk.WritableFloatChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.FloatComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Floats.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class FloatTimsortDescendingKernel {
+    private FloatTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class FloatSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableFloatChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private FloatSortKernelContext(int size) {
+            temporaryValues = WritableFloatChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            FloatTimsortDescendingKernel.sort(this, valuesToSort.asWritableFloatChunk());
         }
 
         public void close() {
@@ -51,8 +53,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> FloatSortKernelContext<ATTR> createContext(int size) {
+        return new FloatSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +65,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +90,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            float current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +99,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                float next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +158,29 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
+    private static int doComparison(float lhs, float rhs) {
+        return -1 * FloatComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(float lhs, float rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(float lhs, float rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(float lhs, float rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(float lhs, float rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +203,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +250,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +263,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final float run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +272,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final float run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +297,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +309,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        float val1 = context.temporaryValues.get(tempCursor);
+        float val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +401,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +413,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        float val1 = valuesToSort.get(run1Cursor);
+        float val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +503,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +512,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final FloatChunk<ATTR> valuesSource,
+            final WritableFloatChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +527,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final FloatChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final float searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final FloatChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final float searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final FloatChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final float searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final float testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +568,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableFloatChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +580,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableFloatChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final float tempFloat = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempFloat);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
@@ -324,7 +324,7 @@ public class FloatTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -334,7 +334,7 @@ public class FloatTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -429,7 +429,7 @@ public class FloatTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -439,7 +439,7 @@ public class FloatTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
@@ -15,7 +15,6 @@ import io.deephaven.chunk.WritableFloatChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.FloatComparisons;
 
 /**
  * This implements a timsort kernel for Floats.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
@@ -323,7 +323,7 @@ public class FloatTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -333,7 +333,7 @@ public class FloatTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -428,7 +428,7 @@ public class FloatTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -438,7 +438,7 @@ public class FloatTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
@@ -8,41 +8,43 @@
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.util.compare.FloatComparisons;
+
+import io.deephaven.chunk.FloatChunk;
+import io.deephaven.chunk.WritableFloatChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.FloatComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Floats.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class FloatTimsortKernel {
+    private FloatTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class FloatSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableFloatChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private FloatSortKernelContext(int size) {
+            temporaryValues = WritableFloatChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            FloatTimsortKernel.sort(this, valuesToSort.asWritableFloatChunk());
         }
 
         public void close() {
@@ -51,8 +53,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> FloatSortKernelContext<ATTR> createContext(int size) {
+        return new FloatSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +65,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +90,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            float current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +99,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                float next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +158,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(float lhs, float rhs) {
+        return FloatComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(float lhs, float rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(float lhs, float rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(float lhs, float rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(float lhs, float rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +202,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +249,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +262,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final float run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +271,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final float run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +296,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +308,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        float val1 = context.temporaryValues.get(tempCursor);
+        float val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +400,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +412,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        float val1 = valuesToSort.get(run1Cursor);
+        float val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +502,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final FloatSortKernelContext<ATTR> context,
+            final WritableFloatChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +511,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final FloatChunk<ATTR> valuesSource,
+            final WritableFloatChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +526,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final FloatChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final float searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final FloatChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final float searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final FloatChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final float searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final float testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +567,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableFloatChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +579,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableFloatChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final float tempFloat = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempFloat);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
 
 /**
  * This implements a timsort kernel for Integers.
@@ -158,7 +157,7 @@ public class IntTimsortDescendingKernel {
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
     private static int doComparison(int lhs, int rhs) {
-        return -1 * IntComparisons.compare(lhs, rhs);
+        return -1 * Integer.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
@@ -322,7 +322,7 @@ public class IntTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -332,7 +332,7 @@ public class IntTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -427,7 +427,7 @@ public class IntTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -437,7 +437,7 @@ public class IntTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
@@ -3,7 +3,7 @@
  */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
  * ---------------------------------------------------------------------------------------------------------------------
  */
 package io.deephaven.engine.table.impl.sort.timsort;
@@ -21,8 +21,8 @@ import io.deephaven.util.compare.IntComparisons;
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class IntTimsortDescendingKernel {
+    private IntTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
@@ -42,7 +42,7 @@ public class IntTimsortKernel {
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            IntTimsortDescendingKernel.sort(this, valuesToSort.asWritableIntChunk());
         }
 
         public void close() {
@@ -156,8 +156,9 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
     private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+        return -1 * IntComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
 
 /**
  * This implements a timsort kernel for Integers.
@@ -157,7 +156,7 @@ public class IntTimsortKernel {
 
     // region comparison functions
     private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+        return Integer.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortKernel.java
@@ -321,7 +321,7 @@ public class IntTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -331,7 +331,7 @@ public class IntTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -426,7 +426,7 @@ public class IntTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -436,7 +436,7 @@ public class IntTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
@@ -3,46 +3,46 @@
  */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
  * ---------------------------------------------------------------------------------------------------------------------
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.LongChunk;
+import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.LongComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Longs.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class LongTimsortDescendingKernel {
+    private LongTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class LongSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableLongChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private LongSortKernelContext(int size) {
+            temporaryValues = WritableLongChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            LongTimsortDescendingKernel.sort(this, valuesToSort.asWritableLongChunk());
         }
 
         public void close() {
@@ -51,8 +51,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> LongSortKernelContext<ATTR> createContext(int size) {
+        return new LongSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +63,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +88,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            long current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +97,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                long next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +156,29 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
+    private static int doComparison(long lhs, long rhs) {
+        return -1 * LongComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(long lhs, long rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(long lhs, long rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(long lhs, long rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(long lhs, long rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +201,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +248,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +261,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final long run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +270,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final long run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +295,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +307,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        long val1 = context.temporaryValues.get(tempCursor);
+        long val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +399,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +411,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        long val1 = valuesToSort.get(run1Cursor);
+        long val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +501,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +510,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final LongChunk<ATTR> valuesSource,
+            final WritableLongChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +525,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final LongChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final long searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final LongChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final long searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final LongChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final long searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final long testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +566,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableLongChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +578,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableLongChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final long tempLong = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempLong);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
@@ -322,7 +322,7 @@ public class LongTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -332,7 +332,7 @@ public class LongTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -427,7 +427,7 @@ public class LongTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -437,7 +437,7 @@ public class LongTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.LongComparisons;
 
 /**
  * This implements a timsort kernel for Longs.
@@ -158,7 +157,7 @@ public class LongTimsortDescendingKernel {
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
     private static int doComparison(long lhs, long rhs) {
-        return -1 * LongComparisons.compare(lhs, rhs);
+        return -1 * Long.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.LongComparisons;
 
 /**
  * This implements a timsort kernel for Longs.
@@ -157,7 +156,7 @@ public class LongTimsortKernel {
 
     // region comparison functions
     private static int doComparison(long lhs, long rhs) {
-        return LongComparisons.compare(lhs, rhs);
+        return Long.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
@@ -321,7 +321,7 @@ public class LongTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -331,7 +331,7 @@ public class LongTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -426,7 +426,7 @@ public class LongTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -436,7 +436,7 @@ public class LongTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
@@ -8,41 +8,41 @@
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.LongChunk;
+import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.LongComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Longs.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class LongTimsortKernel {
+    private LongTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class LongSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableLongChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private LongSortKernelContext(int size) {
+            temporaryValues = WritableLongChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            LongTimsortKernel.sort(this, valuesToSort.asWritableLongChunk());
         }
 
         public void close() {
@@ -51,8 +51,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> LongSortKernelContext<ATTR> createContext(int size) {
+        return new LongSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +63,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +88,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            long current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +97,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                long next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +156,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(long lhs, long rhs) {
+        return LongComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(long lhs, long rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(long lhs, long rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(long lhs, long rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(long lhs, long rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +200,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +247,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +260,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final long run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +269,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final long run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +294,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +306,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        long val1 = context.temporaryValues.get(tempCursor);
+        long val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +398,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +410,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        long val1 = valuesToSort.get(run1Cursor);
+        long val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +500,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final LongSortKernelContext<ATTR> context,
+            final WritableLongChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +509,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final LongChunk<ATTR> valuesSource,
+            final WritableLongChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +524,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final LongChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final long searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final LongChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final long searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final LongChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final long searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final long testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +565,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableLongChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +577,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableLongChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final long tempLong = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempLong);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
@@ -1,48 +1,49 @@
 /**
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
-/*
- * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
- * ---------------------------------------------------------------------------------------------------------------------
- */
+/* ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
+ * ------------------------------------------------------------------------------------------------------------------ */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.util.compare.CharComparisons;
+
+import io.deephaven.chunk.CharChunk;
+import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.CharComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Characters.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class NullAwareCharTimsortDescendingKernel {
+    private NullAwareCharTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableCharChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private CharSortKernelContext(int size) {
+            temporaryValues = WritableCharChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            NullAwareCharTimsortDescendingKernel.sort(this, valuesToSort.asWritableCharChunk());
         }
 
         public void close() {
@@ -51,8 +52,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> CharSortKernelContext<ATTR> createContext(int size) {
+        return new CharSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +64,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +89,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            char current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +98,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                char next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +157,29 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
+    private static int doComparison(char lhs, char rhs) {
+        return -1 * CharComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(char lhs, char rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(char lhs, char rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(char lhs, char rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(char lhs, char rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +202,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +249,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +262,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final char run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +271,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final char run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +296,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +308,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        char val1 = context.temporaryValues.get(tempCursor);
+        char val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +400,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +412,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        char val1 = valuesToSort.get(run1Cursor);
+        char val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +502,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +511,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final CharChunk<ATTR> valuesSource,
+            final WritableCharChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +526,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final char searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final char testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +567,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +579,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final char tempChar = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempChar);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
@@ -14,7 +14,6 @@ import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.CharComparisons;
 
 /**
  * This implements a timsort kernel for Characters.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
@@ -323,7 +323,7 @@ public class NullAwareCharTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -333,7 +333,7 @@ public class NullAwareCharTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -428,7 +428,7 @@ public class NullAwareCharTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -438,7 +438,7 @@ public class NullAwareCharTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
@@ -14,7 +14,6 @@ import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.CharComparisons;
 
 /**
  * This implements a timsort kernel for Characters.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
@@ -1,48 +1,49 @@
 /**
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
-/*
- * ---------------------------------------------------------------------------------------------------------------------
+/* ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
- * ---------------------------------------------------------------------------------------------------------------------
- */
+ * ------------------------------------------------------------------------------------------------------------------ */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.util.compare.CharComparisons;
+
+import io.deephaven.chunk.CharChunk;
+import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.CharComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Characters.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class NullAwareCharTimsortKernel {
+    private NullAwareCharTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableCharChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private CharSortKernelContext(int size) {
+            temporaryValues = WritableCharChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            NullAwareCharTimsortKernel.sort(this, valuesToSort.asWritableCharChunk());
         }
 
         public void close() {
@@ -51,8 +52,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> CharSortKernelContext<ATTR> createContext(int size) {
+        return new CharSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +64,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +89,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            char current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +98,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                char next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +157,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(char lhs, char rhs) {
+        return CharComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(char lhs, char rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(char lhs, char rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(char lhs, char rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(char lhs, char rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +201,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +248,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +261,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final char run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +270,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final char run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +295,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +307,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        char val1 = context.temporaryValues.get(tempCursor);
+        char val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +399,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +411,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        char val1 = valuesToSort.get(run1Cursor);
+        char val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +501,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final CharSortKernelContext<ATTR> context,
+            final WritableCharChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +510,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final CharChunk<ATTR> valuesSource,
+            final WritableCharChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +525,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final char searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final CharChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final char searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final char testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +566,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +578,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableCharChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final char tempChar = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempChar);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
@@ -322,7 +322,7 @@ public class NullAwareCharTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -332,7 +332,7 @@ public class NullAwareCharTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -427,7 +427,7 @@ public class NullAwareCharTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -437,7 +437,7 @@ public class NullAwareCharTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
@@ -15,7 +15,6 @@ import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.ObjectComparisons;
 
 /**
  * This implements a timsort kernel for Objects.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
@@ -3,46 +3,48 @@
  */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
  * ---------------------------------------------------------------------------------------------------------------------
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import java.util.Objects;
+
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.ObjectComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Objects.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class ObjectTimsortDescendingKernel {
+    private ObjectTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class ObjectSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableObjectChunk<Object, ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private ObjectSortKernelContext(int size) {
+            temporaryValues = WritableObjectChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            ObjectTimsortDescendingKernel.sort(this, valuesToSort.asWritableObjectChunk());
         }
 
         public void close() {
@@ -51,8 +53,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> ObjectSortKernelContext<ATTR> createContext(int size) {
+        return new ObjectSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +65,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +90,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            Object current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +99,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                Object next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +158,39 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // descending comparison
+    private static int doComparison(Object lhs, Object rhs) {
+        if (lhs == rhs) {
+            return 0;
+        }
+        if (lhs == null) {
+            return 1;
+        }
+        if (rhs == null) {
+            return -1;
+        }
+        //noinspection unchecked,rawtypes
+        return ((Comparable)rhs).compareTo(lhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +213,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +260,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +273,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final Object run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +282,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final Object run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +307,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +319,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        Object val1 = context.temporaryValues.get(tempCursor);
+        Object val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +411,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +423,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        Object val1 = valuesToSort.get(run1Cursor);
+        Object val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +513,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +522,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final ObjectChunk<Object, ATTR> valuesSource,
+            final WritableObjectChunk<Object, ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +537,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final ObjectChunk<Object, ?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final Object searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final ObjectChunk<Object, ?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final Object searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final ObjectChunk<Object, ?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final Object searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final Object testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +578,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableObjectChunk<Object, ?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +590,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableObjectChunk<Object, ?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final Object tempObject = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempObject);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
@@ -334,7 +334,7 @@ public class ObjectTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -344,7 +344,7 @@ public class ObjectTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -439,7 +439,7 @@ public class ObjectTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -449,7 +449,7 @@ public class ObjectTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
@@ -8,41 +8,43 @@
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import java.util.Objects;
+
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.ObjectComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Objects.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class ObjectTimsortKernel {
+    private ObjectTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class ObjectSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableObjectChunk<Object, ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private ObjectSortKernelContext(int size) {
+            temporaryValues = WritableObjectChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            ObjectTimsortKernel.sort(this, valuesToSort.asWritableObjectChunk());
         }
 
         public void close() {
@@ -51,8 +53,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> ObjectSortKernelContext<ATTR> createContext(int size) {
+        return new ObjectSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +65,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +90,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            Object current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +99,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                Object next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +158,40 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // ascending comparison
+    private static int doComparison(Object lhs, Object rhs) {
+       if (lhs == rhs) {
+            return 0;
+        }
+        if (lhs == null) {
+            return -1;
+        }
+        if (rhs == null) {
+            return 1;
+        }
+        //noinspection unchecked,rawtypes
+        return ((Comparable)lhs).compareTo(rhs);
     }
+
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(Object lhs, Object rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +214,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +261,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +274,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final Object run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +283,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final Object run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +308,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +320,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        Object val1 = context.temporaryValues.get(tempCursor);
+        Object val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +412,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +424,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        Object val1 = valuesToSort.get(run1Cursor);
+        Object val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +514,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ObjectSortKernelContext<ATTR> context,
+            final WritableObjectChunk<Object, ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +523,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final ObjectChunk<Object, ATTR> valuesSource,
+            final WritableObjectChunk<Object, ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +538,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final ObjectChunk<Object, ?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final Object searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final ObjectChunk<Object, ?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final Object searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final ObjectChunk<Object, ?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final Object searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final Object testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +579,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableObjectChunk<Object, ?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +591,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableObjectChunk<Object, ?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final Object tempObject = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempObject);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
@@ -15,7 +15,6 @@ import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.ObjectComparisons;
 
 /**
  * This implements a timsort kernel for Objects.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
@@ -335,7 +335,7 @@ public class ObjectTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -345,7 +345,7 @@ public class ObjectTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -440,7 +440,7 @@ public class ObjectTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -450,7 +450,7 @@ public class ObjectTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
@@ -3,46 +3,46 @@
  */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
- * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortKernel and regenerate
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharTimsortDescendingKernel and regenerate
  * ---------------------------------------------------------------------------------------------------------------------
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.ShortChunk;
+import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.ShortComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Shorts.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class ShortTimsortDescendingKernel {
+    private ShortTimsortDescendingKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class ShortSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableShortChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private ShortSortKernelContext(int size) {
+            temporaryValues = WritableShortChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            ShortTimsortDescendingKernel.sort(this, valuesToSort.asWritableShortChunk());
         }
 
         public void close() {
@@ -51,8 +51,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> ShortSortKernelContext<ATTR> createContext(int size) {
+        return new ShortSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +63,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +88,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            short current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +97,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                short next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +156,29 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
+    private static int doComparison(short lhs, short rhs) {
+        return -1 * ShortComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(short lhs, short rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(short lhs, short rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(short lhs, short rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(short lhs, short rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +201,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +248,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +261,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final short run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +270,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final short run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +295,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +307,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        short val1 = context.temporaryValues.get(tempCursor);
+        short val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +399,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +411,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        short val1 = valuesToSort.get(run1Cursor);
+        short val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +501,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +510,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final ShortChunk<ATTR> valuesSource,
+            final WritableShortChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +525,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final ShortChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final short searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final ShortChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final short searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final ShortChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final short searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final short testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +566,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableShortChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +578,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableShortChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final short tempShort = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempShort);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
@@ -322,7 +322,7 @@ public class ShortTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -332,7 +332,7 @@ public class ShortTimsortDescendingKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -427,7 +427,7 @@ public class ShortTimsortDescendingKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -437,7 +437,7 @@ public class ShortTimsortDescendingKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.ShortComparisons;
 
 /**
  * This implements a timsort kernel for Shorts.
@@ -158,7 +157,7 @@ public class ShortTimsortDescendingKernel {
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
     private static int doComparison(short lhs, short rhs) {
-        return -1 * ShortComparisons.compare(lhs, rhs);
+        return -1 * Short.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
@@ -13,7 +13,6 @@ import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.ShortComparisons;
 
 /**
  * This implements a timsort kernel for Shorts.
@@ -157,7 +156,7 @@ public class ShortTimsortKernel {
 
     // region comparison functions
     private static int doComparison(short lhs, short rhs) {
-        return ShortComparisons.compare(lhs, rhs);
+        return Short.compare(lhs, rhs);
     }
     // endregion comparison functions
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
@@ -8,41 +8,41 @@
  */
 package io.deephaven.engine.table.impl.sort.timsort;
 
-import io.deephaven.chunk.IntChunk;
-import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.ShortChunk;
+import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.compare.ShortComparisons;
 
 /**
- * This implements a timsort kernel for Integers.
+ * This implements a timsort kernel for Shorts.
  * <p>
  * <a href="https://bugs.python.org/file4451/timsort.txt">Python</a> and <a href="https://en.wikipedia.org/wiki/Timsort">Wikipedia</a> do a decent job of describing
  * the algorithm.
  */
-public class IntTimsortKernel {
-    private IntTimsortKernel() {
+public class ShortTimsortKernel {
+    private ShortTimsortKernel() {
         throw new UnsupportedOperationException();
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class ShortSortKernelContext<ATTR extends Any> {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;
         private final int [] runLengths;
-        private final WritableIntChunk<ATTR> temporaryValues;
+        private final WritableShortChunk<ATTR> temporaryValues;
 
-        private IntSortKernelContext(int size) {
-            temporaryValues = WritableIntChunk.makeWritableChunk((size + 2) / 2);
+        private ShortSortKernelContext(int size) {
+            temporaryValues = WritableShortChunk.makeWritableChunk((size + 2) / 2);
             runStarts = new int[(size + 31) / 32];
             runLengths = new int[(size + 31) / 32];
             minGallop = TimsortUtils.INITIAL_GALLOP;
         }
 
         public void sort(WritableChunk<ATTR> valuesToSort) {
-            IntTimsortKernel.sort(this, valuesToSort.asWritableIntChunk());
+            ShortTimsortKernel.sort(this, valuesToSort.asWritableShortChunk());
         }
 
         public void close() {
@@ -51,8 +51,8 @@ public class IntTimsortKernel {
     }
     // endregion Context
 
-    public static <ATTR extends Any> IntSortKernelContext<ATTR> createContext(int size) {
-        return new IntSortKernelContext<>(size);
+    public static <ATTR extends Any> ShortSortKernelContext<ATTR> createContext(int size) {
+        return new ShortSortKernelContext<>(size);
     }
 
     /**
@@ -63,14 +63,14 @@ public class IntTimsortKernel {
      * runs sorted on each pass.
      */
     public static <ATTR extends Any> void sort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort) {
         timSort(context, valuesToSort, 0, valuesToSort.size());
     }
 
     static private <ATTR extends Any> void timSort(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int offset,
             final int length) {
         if (length <= 1) {
@@ -88,7 +88,7 @@ public class IntTimsortKernel {
 
         int startRun = offset;
         while (startRun < offset + length) {
-            int current = valuesToSort.get(startRun);
+            short current = valuesToSort.get(startRun);
 
             int endRun; // note that endrun is exclusive
             final boolean descending;
@@ -97,7 +97,7 @@ public class IntTimsortKernel {
                 endRun = offset + length;
                 descending = false;
             } else {
-                int next = valuesToSort.get(startRun + 1);
+                short next = valuesToSort.get(startRun + 1);
                 endRun = startRun + 2;
                 descending = gt(current, next);
 
@@ -156,28 +156,28 @@ public class IntTimsortKernel {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static int doComparison(short lhs, short rhs) {
+        return ShortComparisons.compare(lhs, rhs);
     }
     // endregion comparison functions
 
     @VisibleForTesting
-    static boolean gt(int lhs, int rhs) {
+    static boolean gt(short lhs, short rhs) {
         return doComparison(lhs, rhs) > 0;
     }
 
     @VisibleForTesting
-    static boolean lt(int lhs, int rhs) {
+    static boolean lt(short lhs, short rhs) {
         return doComparison(lhs, rhs) < 0;
     }
 
     @VisibleForTesting
-    static boolean geq(int lhs, int rhs) {
+    static boolean geq(short lhs, short rhs) {
         return doComparison(lhs, rhs) >= 0;
     }
 
     @VisibleForTesting
-    static boolean leq(int lhs, int rhs) {
+    static boolean leq(short lhs, short rhs) {
         return doComparison(lhs, rhs) <= 0;
     }
 
@@ -200,8 +200,8 @@ public class IntTimsortKernel {
      * <p>On reaching the end of the data, Timsort repeatedly merges the two runs on the top of the stack, until only one run of the entire data remains.</p>
      */
     private static <ATTR extends Any> void ensureMergeInvariants(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort) {
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort) {
         while (context.runCount > 1) {
             final int xIndex = context.runCount - 1;
             final int yIndex = context.runCount - 2;
@@ -247,8 +247,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void merge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int start1,
             final int length1,
             final int length2) {
@@ -260,7 +260,7 @@ public class IntTimsortKernel {
 
         final int start2 = start1 + length1;
         // find the location of run2[0] in run1
-        final int run2lo = valuesToSort.get(start2);
+        final short run2lo = valuesToSort.get(start2);
         final int mergeStartPosition = upperBound(valuesToSort, start1, start1 + length1, run2lo);
 
         if (mergeStartPosition == start1 + length1) {
@@ -269,7 +269,7 @@ public class IntTimsortKernel {
         }
 
         // find the location of run1[length1 - 1] in run2
-        final int run1hi = valuesToSort.get(start1 + length1 - 1);
+        final short run1hi = valuesToSort.get(start1 + length1 - 1);
         final int mergeEndPosition = lowerBound(valuesToSort, start2, start2 + length2, run1hi);
 
         // figure out which of the two runs is now shorter
@@ -294,8 +294,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void frontMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int start2,
             final int length2) {
@@ -306,8 +306,8 @@ public class IntTimsortKernel {
         int ii;
         final int mergeEndExclusive = start2 + length2;
 
-        int val1 = context.temporaryValues.get(tempCursor);
-        int val2 = valuesToSort.get(run2Cursor);
+        short val1 = context.temporaryValues.get(tempCursor);
+        short val2 = valuesToSort.get(run2Cursor);
 
         ii = mergeStartPosition;
 
@@ -398,8 +398,8 @@ public class IntTimsortKernel {
      * We eventually need to do galloping here, but are skipping that for now
      */
     private static <ATTR extends Any> void backMerge(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int length1) {
         final int run1End = mergeStartPosition + length1;
@@ -410,8 +410,8 @@ public class IntTimsortKernel {
         int ii;
 
 
-        int val1 = valuesToSort.get(run1Cursor);
-        int val2 = context.temporaryValues.get(tempCursor);
+        short val1 = valuesToSort.get(run1Cursor);
+        short val2 = context.temporaryValues.get(tempCursor);
 
         final int mergeEnd = mergeStartPosition + mergeLength;
         ii = mergeEnd - 1;
@@ -500,8 +500,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToTemporary(
-            final IntSortKernelContext<ATTR> context,
-            final WritableIntChunk<ATTR> valuesToSort,
+            final ShortSortKernelContext<ATTR> context,
+            final WritableShortChunk<ATTR> valuesToSort,
             final int mergeStartPosition,
             final int remaining1) {
         context.temporaryValues.setSize(remaining1);
@@ -509,8 +509,8 @@ public class IntTimsortKernel {
     }
 
     private static <ATTR extends Any> void copyToChunk(
-            final IntChunk<ATTR> valuesSource,
-            final WritableIntChunk<ATTR> valuesDest,
+            final ShortChunk<ATTR> valuesSource,
+            final WritableShortChunk<ATTR> valuesDest,
             final int sourceStart,
             final int destStart,
             final int length) {
@@ -524,34 +524,34 @@ public class IntTimsortKernel {
     //
     // returns the position of the first element that is > searchValue or hi if there is no such element
     private static int upperBound(
-            final IntChunk<?> valuesToSort,
+            final ShortChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final short searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, false);
     }
 
     // when we binary search in 2, we must identify a position for search value that is *before* our test values;
     // because the values from run 1 may never be inserted after an equal value from run 2
     private static int lowerBound(
-            final IntChunk<?> valuesToSort,
+            final ShortChunk<?> valuesToSort,
             final int lo,
             final int hi,
-            final int searchValue) {
+            final short searchValue) {
         return bound(valuesToSort, lo, hi, searchValue, true);
     }
 
     private static int bound(
-            final IntChunk<?> valuesToSort,
+            final ShortChunk<?> valuesToSort,
             int lo,
             int hi,
-            final int searchValue,
+            final short searchValue,
             final boolean lower) {
         final int compareLimit = lower ? -1 : 0;  // lt or leq
 
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
-            final int testValue = valuesToSort.get(mid);
+            final short testValue = valuesToSort.get(mid);
             final boolean moveLo = doComparison(testValue, searchValue) <= compareLimit;
             if (moveLo) {
                 // For bound, (testValue OP searchValue) means that the result somewhere later than 'mid' [OP=lt or leq]
@@ -565,7 +565,7 @@ public class IntTimsortKernel {
     }
 
     private static void insertionSort(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableShortChunk<?> valuesToSort,
             final int offset,
             final int length) {
         // this could eventually be done with intrinsics (AVX 512/64 bits for byte keys == 16 elements, and can be combined up to 256)
@@ -577,11 +577,11 @@ public class IntTimsortKernel {
     }
 
     static private void swap(
-            final WritableIntChunk<?> valuesToSort,
+            final WritableShortChunk<?> valuesToSort,
             final int a,
             final int b) {
-        final int tempInt = valuesToSort.get(a);
+        final short tempShort = valuesToSort.get(a);
         valuesToSort.set(a, valuesToSort.get(b));
-        valuesToSort.set(b, tempInt);
+        valuesToSort.set(b, tempShort);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
@@ -321,7 +321,7 @@ public class ShortTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (leq(val1, val2)) {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii++, val1);
 
                     if (++tempCursor == run1size) {
                         break nodataleft;
@@ -331,7 +331,7 @@ public class ShortTimsortKernel {
                     run1wins++;
                     run2wins = 0;
                 } else {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii++, val2);
 
                     if (++run2Cursor == mergeEndExclusive) {
                         break nodataleft;
@@ -426,7 +426,7 @@ public class ShortTimsortKernel {
 
             while (run1wins < context.minGallop && run2wins < context.minGallop) {
                 if (geq(val2, val1)) {
-                    valuesToSort.set(ii, val2);
+                    valuesToSort.set(ii--, val2);
 
                     if (--tempCursor < 0) {
                         break nodataleft;
@@ -436,7 +436,7 @@ public class ShortTimsortKernel {
                     run2wins++;
                     run1wins = 0;
                 } else {
-                    valuesToSort.set(ii, val1);
+                    valuesToSort.set(ii--, val1);
 
                     if (--run1Cursor < mergeStartPosition) {
                         break nodataleft;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestByteTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestByteTimSortKernel.java
@@ -49,9 +49,41 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
     public static class ByteSortKernelStuff extends SortKernelStuff<ByteLongTuple> {
 
         private final WritableByteChunk<Any> byteChunk;
-        private final ByteLongTimsortKernel.ByteLongSortKernelContext context;
+        private final ByteTimsortKernel.ByteSortKernelContext<Any> context;
 
         public ByteSortKernelStuff(List<ByteLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            byteChunk = WritableByteChunk.makeWritableChunk(size);
+            context = ByteTimsortKernel.createContext(size);
+
+            prepareByteChunks(javaTuples, byteChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            ByteTimsortKernel.sort(context, byteChunk);
+        }
+
+        @Override
+        void check(List<ByteLongTuple> expected) {
+            verify(expected.size(), expected, byteChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            byteChunk.close();
+            context.close();
+        }
+    }
+
+    public static class ByteLongSortKernelStuff extends SortKernelStuff<ByteLongTuple> {
+
+        private final WritableByteChunk<Any> byteChunk;
+        private final ByteLongTimsortKernel.ByteLongSortKernelContext<Any, RowKeys> context;
+
+        public ByteLongSortKernelStuff(List<ByteLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             byteChunk = WritableByteChunk.makeWritableChunk(size);
@@ -80,7 +112,7 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
 
     public static class BytePartitionKernelStuff extends PartitionKernelStuff<ByteLongTuple> {
 
-        private final WritableByteChunk valuesChunk;
+        private final WritableByteChunk<Any> valuesChunk;
         private final BytePartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Byte> columnSource;
@@ -93,7 +125,7 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -138,7 +170,7 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
 
     public static class ByteMergeStuff extends MergeStuff<ByteLongTuple> {
 
-        private final byte arrayValues[];
+        private final byte[] arrayValues;
 
         public ByteMergeStuff(List<ByteLongTuple> javaTuples) {
             super(javaTuples);
@@ -187,7 +219,7 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
 
             prepareMultiByteChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -353,6 +385,11 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<ByteLongTuple> javaTuples, ByteChunk byteChunk) {
+        verify(size, javaTuples, byteChunk, null);
+    }
+
     static private void verify(int size, List<ByteLongTuple> javaTuples, ByteChunk byteChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -361,11 +398,13 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
             final byte timSorted = byteChunk.get(ii);
             final byte javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestByteTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestByteTimSortKernel.java
@@ -391,18 +391,14 @@ public abstract class BaseTestByteTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<ByteLongTuple> javaTuples, ByteChunk byteChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final byte timSorted = byteChunk.get(ii);
             final byte javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestCharTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestCharTimSortKernel.java
@@ -386,18 +386,14 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<CharLongTuple> javaTuples, CharChunk charChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final char timSorted = charChunk.get(ii);
             final char javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestCharTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestCharTimSortKernel.java
@@ -44,9 +44,41 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
     public static class CharSortKernelStuff extends SortKernelStuff<CharLongTuple> {
 
         private final WritableCharChunk<Any> charChunk;
-        private final CharLongTimsortKernel.CharLongSortKernelContext context;
+        private final CharTimsortKernel.CharSortKernelContext<Any> context;
 
         public CharSortKernelStuff(List<CharLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            charChunk = WritableCharChunk.makeWritableChunk(size);
+            context = CharTimsortKernel.createContext(size);
+
+            prepareCharChunks(javaTuples, charChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            CharTimsortKernel.sort(context, charChunk);
+        }
+
+        @Override
+        void check(List<CharLongTuple> expected) {
+            verify(expected.size(), expected, charChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            charChunk.close();
+            context.close();
+        }
+    }
+
+    public static class CharLongSortKernelStuff extends SortKernelStuff<CharLongTuple> {
+
+        private final WritableCharChunk<Any> charChunk;
+        private final CharLongTimsortKernel.CharLongSortKernelContext<Any, RowKeys> context;
+
+        public CharLongSortKernelStuff(List<CharLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             charChunk = WritableCharChunk.makeWritableChunk(size);
@@ -75,7 +107,7 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
 
     public static class CharPartitionKernelStuff extends PartitionKernelStuff<CharLongTuple> {
 
-        private final WritableCharChunk valuesChunk;
+        private final WritableCharChunk<Any> valuesChunk;
         private final CharPartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Character> columnSource;
@@ -88,7 +120,7 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -133,7 +165,7 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
 
     public static class CharMergeStuff extends MergeStuff<CharLongTuple> {
 
-        private final char arrayValues[];
+        private final char[] arrayValues;
 
         public CharMergeStuff(List<CharLongTuple> javaTuples) {
             super(javaTuples);
@@ -182,7 +214,7 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
 
             prepareMultiCharChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -348,6 +380,11 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<CharLongTuple> javaTuples, CharChunk charChunk) {
+        verify(size, javaTuples, charChunk, null);
+    }
+
     static private void verify(int size, List<CharLongTuple> javaTuples, CharChunk charChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -356,11 +393,13 @@ public abstract class BaseTestCharTimSortKernel extends TestTimSortKernel {
             final char timSorted = charChunk.get(ii);
             final char javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestDoubleTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestDoubleTimSortKernel.java
@@ -391,18 +391,14 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<DoubleLongTuple> javaTuples, DoubleChunk doubleChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final double timSorted = doubleChunk.get(ii);
             final double javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestDoubleTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestDoubleTimSortKernel.java
@@ -49,9 +49,41 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
     public static class DoubleSortKernelStuff extends SortKernelStuff<DoubleLongTuple> {
 
         private final WritableDoubleChunk<Any> doubleChunk;
-        private final DoubleLongTimsortKernel.DoubleLongSortKernelContext context;
+        private final DoubleTimsortKernel.DoubleSortKernelContext<Any> context;
 
         public DoubleSortKernelStuff(List<DoubleLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            doubleChunk = WritableDoubleChunk.makeWritableChunk(size);
+            context = DoubleTimsortKernel.createContext(size);
+
+            prepareDoubleChunks(javaTuples, doubleChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            DoubleTimsortKernel.sort(context, doubleChunk);
+        }
+
+        @Override
+        void check(List<DoubleLongTuple> expected) {
+            verify(expected.size(), expected, doubleChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            doubleChunk.close();
+            context.close();
+        }
+    }
+
+    public static class DoubleLongSortKernelStuff extends SortKernelStuff<DoubleLongTuple> {
+
+        private final WritableDoubleChunk<Any> doubleChunk;
+        private final DoubleLongTimsortKernel.DoubleLongSortKernelContext<Any, RowKeys> context;
+
+        public DoubleLongSortKernelStuff(List<DoubleLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             doubleChunk = WritableDoubleChunk.makeWritableChunk(size);
@@ -80,7 +112,7 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
 
     public static class DoublePartitionKernelStuff extends PartitionKernelStuff<DoubleLongTuple> {
 
-        private final WritableDoubleChunk valuesChunk;
+        private final WritableDoubleChunk<Any> valuesChunk;
         private final DoublePartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Double> columnSource;
@@ -93,7 +125,7 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -138,7 +170,7 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
 
     public static class DoubleMergeStuff extends MergeStuff<DoubleLongTuple> {
 
-        private final double arrayValues[];
+        private final double[] arrayValues;
 
         public DoubleMergeStuff(List<DoubleLongTuple> javaTuples) {
             super(javaTuples);
@@ -187,7 +219,7 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
 
             prepareMultiDoubleChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -353,6 +385,11 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<DoubleLongTuple> javaTuples, DoubleChunk doubleChunk) {
+        verify(size, javaTuples, doubleChunk, null);
+    }
+
     static private void verify(int size, List<DoubleLongTuple> javaTuples, DoubleChunk doubleChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -361,11 +398,13 @@ public abstract class BaseTestDoubleTimSortKernel extends TestTimSortKernel {
             final double timSorted = doubleChunk.get(ii);
             final double javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestFloatTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestFloatTimSortKernel.java
@@ -49,9 +49,41 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
     public static class FloatSortKernelStuff extends SortKernelStuff<FloatLongTuple> {
 
         private final WritableFloatChunk<Any> floatChunk;
-        private final FloatLongTimsortKernel.FloatLongSortKernelContext context;
+        private final FloatTimsortKernel.FloatSortKernelContext<Any> context;
 
         public FloatSortKernelStuff(List<FloatLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            floatChunk = WritableFloatChunk.makeWritableChunk(size);
+            context = FloatTimsortKernel.createContext(size);
+
+            prepareFloatChunks(javaTuples, floatChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            FloatTimsortKernel.sort(context, floatChunk);
+        }
+
+        @Override
+        void check(List<FloatLongTuple> expected) {
+            verify(expected.size(), expected, floatChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            floatChunk.close();
+            context.close();
+        }
+    }
+
+    public static class FloatLongSortKernelStuff extends SortKernelStuff<FloatLongTuple> {
+
+        private final WritableFloatChunk<Any> floatChunk;
+        private final FloatLongTimsortKernel.FloatLongSortKernelContext<Any, RowKeys> context;
+
+        public FloatLongSortKernelStuff(List<FloatLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             floatChunk = WritableFloatChunk.makeWritableChunk(size);
@@ -80,7 +112,7 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
 
     public static class FloatPartitionKernelStuff extends PartitionKernelStuff<FloatLongTuple> {
 
-        private final WritableFloatChunk valuesChunk;
+        private final WritableFloatChunk<Any> valuesChunk;
         private final FloatPartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Float> columnSource;
@@ -93,7 +125,7 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -138,7 +170,7 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
 
     public static class FloatMergeStuff extends MergeStuff<FloatLongTuple> {
 
-        private final float arrayValues[];
+        private final float[] arrayValues;
 
         public FloatMergeStuff(List<FloatLongTuple> javaTuples) {
             super(javaTuples);
@@ -187,7 +219,7 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
 
             prepareMultiFloatChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -353,6 +385,11 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<FloatLongTuple> javaTuples, FloatChunk floatChunk) {
+        verify(size, javaTuples, floatChunk, null);
+    }
+
     static private void verify(int size, List<FloatLongTuple> javaTuples, FloatChunk floatChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -361,11 +398,13 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
             final float timSorted = floatChunk.get(ii);
             final float javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestFloatTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestFloatTimSortKernel.java
@@ -391,18 +391,14 @@ public abstract class BaseTestFloatTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<FloatLongTuple> javaTuples, FloatChunk floatChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final float timSorted = floatChunk.get(ii);
             final float javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestIntTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestIntTimSortKernel.java
@@ -49,9 +49,41 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
     public static class IntSortKernelStuff extends SortKernelStuff<IntLongTuple> {
 
         private final WritableIntChunk<Any> intChunk;
-        private final IntLongTimsortKernel.IntLongSortKernelContext context;
+        private final IntTimsortKernel.IntSortKernelContext<Any> context;
 
         public IntSortKernelStuff(List<IntLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            intChunk = WritableIntChunk.makeWritableChunk(size);
+            context = IntTimsortKernel.createContext(size);
+
+            prepareIntChunks(javaTuples, intChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            IntTimsortKernel.sort(context, intChunk);
+        }
+
+        @Override
+        void check(List<IntLongTuple> expected) {
+            verify(expected.size(), expected, intChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            intChunk.close();
+            context.close();
+        }
+    }
+
+    public static class IntLongSortKernelStuff extends SortKernelStuff<IntLongTuple> {
+
+        private final WritableIntChunk<Any> intChunk;
+        private final IntLongTimsortKernel.IntLongSortKernelContext<Any, RowKeys> context;
+
+        public IntLongSortKernelStuff(List<IntLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             intChunk = WritableIntChunk.makeWritableChunk(size);
@@ -80,7 +112,7 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
 
     public static class IntPartitionKernelStuff extends PartitionKernelStuff<IntLongTuple> {
 
-        private final WritableIntChunk valuesChunk;
+        private final WritableIntChunk<Any> valuesChunk;
         private final IntPartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Integer> columnSource;
@@ -93,7 +125,7 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -138,7 +170,7 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
 
     public static class IntMergeStuff extends MergeStuff<IntLongTuple> {
 
-        private final int arrayValues[];
+        private final int[] arrayValues;
 
         public IntMergeStuff(List<IntLongTuple> javaTuples) {
             super(javaTuples);
@@ -187,7 +219,7 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
 
             prepareMultiIntChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -353,6 +385,11 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<IntLongTuple> javaTuples, IntChunk intChunk) {
+        verify(size, javaTuples, intChunk, null);
+    }
+
     static private void verify(int size, List<IntLongTuple> javaTuples, IntChunk intChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -361,11 +398,13 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
             final int timSorted = intChunk.get(ii);
             final int javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestIntTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestIntTimSortKernel.java
@@ -391,18 +391,14 @@ public abstract class BaseTestIntTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<IntLongTuple> javaTuples, IntChunk intChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final int timSorted = intChunk.get(ii);
             final int javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestLongTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestLongTimSortKernel.java
@@ -391,18 +391,14 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<LongLongTuple> javaTuples, LongChunk longChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final long timSorted = longChunk.get(ii);
             final long javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestLongTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestLongTimSortKernel.java
@@ -49,9 +49,41 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
     public static class LongSortKernelStuff extends SortKernelStuff<LongLongTuple> {
 
         private final WritableLongChunk<Any> longChunk;
-        private final LongLongTimsortKernel.LongLongSortKernelContext context;
+        private final LongTimsortKernel.LongSortKernelContext<Any> context;
 
         public LongSortKernelStuff(List<LongLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            longChunk = WritableLongChunk.makeWritableChunk(size);
+            context = LongTimsortKernel.createContext(size);
+
+            prepareLongChunks(javaTuples, longChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            LongTimsortKernel.sort(context, longChunk);
+        }
+
+        @Override
+        void check(List<LongLongTuple> expected) {
+            verify(expected.size(), expected, longChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            longChunk.close();
+            context.close();
+        }
+    }
+
+    public static class LongLongSortKernelStuff extends SortKernelStuff<LongLongTuple> {
+
+        private final WritableLongChunk<Any> longChunk;
+        private final LongLongTimsortKernel.LongLongSortKernelContext<Any, RowKeys> context;
+
+        public LongLongSortKernelStuff(List<LongLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             longChunk = WritableLongChunk.makeWritableChunk(size);
@@ -80,7 +112,7 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
 
     public static class LongPartitionKernelStuff extends PartitionKernelStuff<LongLongTuple> {
 
-        private final WritableLongChunk valuesChunk;
+        private final WritableLongChunk<Any> valuesChunk;
         private final LongPartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Long> columnSource;
@@ -93,7 +125,7 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -138,7 +170,7 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
 
     public static class LongMergeStuff extends MergeStuff<LongLongTuple> {
 
-        private final long arrayValues[];
+        private final long[] arrayValues;
 
         public LongMergeStuff(List<LongLongTuple> javaTuples) {
             super(javaTuples);
@@ -187,7 +219,7 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
 
             prepareMultiLongChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -353,6 +385,11 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<LongLongTuple> javaTuples, LongChunk longChunk) {
+        verify(size, javaTuples, longChunk, null);
+    }
+
     static private void verify(int size, List<LongLongTuple> javaTuples, LongChunk longChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -361,11 +398,13 @@ public abstract class BaseTestLongTimSortKernel extends TestTimSortKernel {
             final long timSorted = longChunk.get(ii);
             final long javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestObjectTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestObjectTimSortKernel.java
@@ -391,18 +391,14 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<ObjectLongTuple> javaTuples, ObjectChunk ObjectChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final Object timSorted = ObjectChunk.get(ii);
             final Object javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestObjectTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestObjectTimSortKernel.java
@@ -53,9 +53,41 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
     public static class ObjectSortKernelStuff extends SortKernelStuff<ObjectLongTuple> {
 
         private final WritableObjectChunk<Object, Any> ObjectChunk;
-        private final ObjectLongTimsortKernel.ObjectLongSortKernelContext context;
+        private final ObjectTimsortKernel.ObjectSortKernelContext<Any> context;
 
         public ObjectSortKernelStuff(List<ObjectLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            ObjectChunk = WritableObjectChunk.makeWritableChunk(size);
+            context = ObjectTimsortKernel.createContext(size);
+
+            prepareObjectChunks(javaTuples, ObjectChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            ObjectTimsortKernel.sort(context, ObjectChunk);
+        }
+
+        @Override
+        void check(List<ObjectLongTuple> expected) {
+            verify(expected.size(), expected, ObjectChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            ObjectChunk.close();
+            context.close();
+        }
+    }
+
+    public static class ObjectLongSortKernelStuff extends SortKernelStuff<ObjectLongTuple> {
+
+        private final WritableObjectChunk<Object, Any> ObjectChunk;
+        private final ObjectLongTimsortKernel.ObjectLongSortKernelContext<Any, RowKeys> context;
+
+        public ObjectLongSortKernelStuff(List<ObjectLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             ObjectChunk = WritableObjectChunk.makeWritableChunk(size);
@@ -84,7 +116,7 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
 
     public static class ObjectPartitionKernelStuff extends PartitionKernelStuff<ObjectLongTuple> {
 
-        private final WritableObjectChunk valuesChunk;
+        private final WritableObjectChunk<Object, Any> valuesChunk;
         private final ObjectPartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Object> columnSource;
@@ -97,7 +129,7 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -137,7 +169,7 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
 
     public static class ObjectMergeStuff extends MergeStuff<ObjectLongTuple> {
 
-        private final Object arrayValues[];
+        private final Object[] arrayValues;
 
         public ObjectMergeStuff(List<ObjectLongTuple> javaTuples) {
             super(javaTuples);
@@ -187,7 +219,7 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
 
             prepareMultiObjectChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -353,6 +385,11 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<ObjectLongTuple> javaTuples, ObjectChunk ObjectChunk) {
+        verify(size, javaTuples, ObjectChunk, null);
+    }
+
     static private void verify(int size, List<ObjectLongTuple> javaTuples, ObjectChunk ObjectChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -361,11 +398,13 @@ public abstract class BaseTestObjectTimSortKernel extends TestTimSortKernel {
             final Object timSorted = ObjectChunk.get(ii);
             final Object javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestShortTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestShortTimSortKernel.java
@@ -391,18 +391,14 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
     }
 
     static private void verify(int size, List<ShortLongTuple> javaTuples, ShortChunk shortChunk, LongChunk rowKeys) {
-//        System.out.println("Verify: " + javaTuples);
-//        dumpChunk(valuesChunk);
-
         for (int ii = 0; ii < size; ++ii) {
             final short timSorted = shortChunk.get(ii);
             final short javaSorted = javaTuples.get(ii).getFirstElement();
-
-            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
-            final long javaIndex = javaTuples.get(ii).getSecondElement();
-
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
+
             if (rowKeys != null) {
+                final long timIndex = rowKeys.get(ii);
+                final long javaIndex = javaTuples.get(ii).getSecondElement();
                 TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
             }
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestShortTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/BaseTestShortTimSortKernel.java
@@ -49,9 +49,41 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
     public static class ShortSortKernelStuff extends SortKernelStuff<ShortLongTuple> {
 
         private final WritableShortChunk<Any> shortChunk;
-        private final ShortLongTimsortKernel.ShortLongSortKernelContext context;
+        private final ShortTimsortKernel.ShortSortKernelContext<Any> context;
 
         public ShortSortKernelStuff(List<ShortLongTuple> javaTuples) {
+            super(javaTuples.size());
+            final int size = javaTuples.size();
+            shortChunk = WritableShortChunk.makeWritableChunk(size);
+            context = ShortTimsortKernel.createContext(size);
+
+            prepareShortChunks(javaTuples, shortChunk, rowKeys);
+        }
+
+        @Override
+        public void run() {
+            ShortTimsortKernel.sort(context, shortChunk);
+        }
+
+        @Override
+        void check(List<ShortLongTuple> expected) {
+            verify(expected.size(), expected, shortChunk);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            shortChunk.close();
+            context.close();
+        }
+    }
+
+    public static class ShortLongSortKernelStuff extends SortKernelStuff<ShortLongTuple> {
+
+        private final WritableShortChunk<Any> shortChunk;
+        private final ShortLongTimsortKernel.ShortLongSortKernelContext<Any, RowKeys> context;
+
+        public ShortLongSortKernelStuff(List<ShortLongTuple> javaTuples) {
             super(javaTuples.size());
             final int size = javaTuples.size();
             shortChunk = WritableShortChunk.makeWritableChunk(size);
@@ -80,7 +112,7 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
 
     public static class ShortPartitionKernelStuff extends PartitionKernelStuff<ShortLongTuple> {
 
-        private final WritableShortChunk valuesChunk;
+        private final WritableShortChunk<Any> valuesChunk;
         private final ShortPartitionKernel.PartitionKernelContext context;
         private final RowSet rowSet;
         private final ColumnSource<Short> columnSource;
@@ -93,7 +125,7 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
 
             for (int ii = 0; ii < javaTuples.size(); ++ii) {
                 final long indexKey = javaTuples.get(ii).getSecondElement();
-                if (indexKey != ii * 10) {
+                if (indexKey != ii * 10L) {
                     throw new IllegalStateException();
                 }
             }
@@ -138,7 +170,7 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
 
     public static class ShortMergeStuff extends MergeStuff<ShortLongTuple> {
 
-        private final short arrayValues[];
+        private final short[] arrayValues;
 
         public ShortMergeStuff(List<ShortLongTuple> javaTuples) {
             super(javaTuples);
@@ -187,7 +219,7 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
 
             prepareMultiShortChunks(javaTuples, primaryChunk, secondaryChunk, rowKeys);
 
-            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<Long>(long.class) {
+            secondaryColumnSource = new AbstractColumnSource.DefaultedImmutable<>(long.class) {
                 @Override
                 public Long get(long rowKey) {
                     final long result = getLong(rowKey);
@@ -353,6 +385,11 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
         return javaTuples;
     }
 
+
+    static private void verify(int size, List<ShortLongTuple> javaTuples, ShortChunk shortChunk) {
+        verify(size, javaTuples, shortChunk, null);
+    }
+
     static private void verify(int size, List<ShortLongTuple> javaTuples, ShortChunk shortChunk, LongChunk rowKeys) {
 //        System.out.println("Verify: " + javaTuples);
 //        dumpChunk(valuesChunk);
@@ -361,11 +398,13 @@ public abstract class BaseTestShortTimSortKernel extends TestTimSortKernel {
             final short timSorted = shortChunk.get(ii);
             final short javaSorted = javaTuples.get(ii).getFirstElement();
 
-            final long timIndex = rowKeys.get(ii);
+            final long timIndex = rowKeys == null ? 0 : rowKeys.get(ii);
             final long javaIndex = javaTuples.get(ii).getSecondElement();
 
             TestCase.assertEquals("values[" + ii + "]", javaSorted, timSorted);
-            TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            if (rowKeys != null) {
+                TestCase.assertEquals("rowKeys[" + ii + "]", javaIndex, timIndex);
+            }
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestByteTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestByteTimSortKernel.java
@@ -40,21 +40,7 @@ public class TestByteTimSortKernel extends BaseTestByteTimSortKernel {
     @Test
     public void byteRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestByteTimSortKernel::generateByteRandom, getJavaComparator(), ByteSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void byteRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestByteTimSortKernel::generateByteRandom, getJavaComparator(), BytePartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestByteTimSortKernel::generateByteRandom, getJavaComparator(), ByteLongSortKernelStuff::new);
         }
     }
 
@@ -78,6 +64,49 @@ public class TestByteTimSortKernel extends BaseTestByteTimSortKernel {
             correctnessTest(size, TestByteTimSortKernel::generateByteRuns, getJavaComparator(), ByteSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void byteLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestByteTimSortKernel::generateByteRandom, getJavaComparator(), ByteLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void byteLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestByteTimSortKernel::generateAscendingByteRuns, getJavaComparator(), ByteLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void byteLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestByteTimSortKernel::generateDescendingByteRuns, getJavaComparator(), ByteLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void byteLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestByteTimSortKernel::generateByteRuns, getJavaComparator(), ByteLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void byteRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestByteTimSortKernel::generateByteRandom, getJavaComparator(), BytePartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void byteMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestCharTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestCharTimSortKernel.java
@@ -35,21 +35,7 @@ public class TestCharTimSortKernel extends BaseTestCharTimSortKernel {
     @Test
     public void charRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestCharTimSortKernel::generateCharRandom, getJavaComparator(), CharSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void charRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestCharTimSortKernel::generateCharRandom, getJavaComparator(), CharPartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestCharTimSortKernel::generateCharRandom, getJavaComparator(), CharLongSortKernelStuff::new);
         }
     }
 
@@ -73,6 +59,49 @@ public class TestCharTimSortKernel extends BaseTestCharTimSortKernel {
             correctnessTest(size, TestCharTimSortKernel::generateCharRuns, getJavaComparator(), CharSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void charLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestCharTimSortKernel::generateCharRandom, getJavaComparator(), CharLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void charLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestCharTimSortKernel::generateAscendingCharRuns, getJavaComparator(), CharLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void charLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestCharTimSortKernel::generateDescendingCharRuns, getJavaComparator(), CharLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void charLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestCharTimSortKernel::generateCharRuns, getJavaComparator(), CharLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void charRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestCharTimSortKernel::generateCharRandom, getJavaComparator(), CharPartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void charMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestDoubleTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestDoubleTimSortKernel.java
@@ -40,21 +40,7 @@ public class TestDoubleTimSortKernel extends BaseTestDoubleTimSortKernel {
     @Test
     public void doubleRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestDoubleTimSortKernel::generateDoubleRandom, getJavaComparator(), DoubleSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void doubleRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestDoubleTimSortKernel::generateDoubleRandom, getJavaComparator(), DoublePartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestDoubleTimSortKernel::generateDoubleRandom, getJavaComparator(), DoubleLongSortKernelStuff::new);
         }
     }
 
@@ -78,6 +64,49 @@ public class TestDoubleTimSortKernel extends BaseTestDoubleTimSortKernel {
             correctnessTest(size, TestDoubleTimSortKernel::generateDoubleRuns, getJavaComparator(), DoubleSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void doubleLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestDoubleTimSortKernel::generateDoubleRandom, getJavaComparator(), DoubleLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void doubleLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestDoubleTimSortKernel::generateAscendingDoubleRuns, getJavaComparator(), DoubleLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void doubleLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestDoubleTimSortKernel::generateDescendingDoubleRuns, getJavaComparator(), DoubleLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void doubleLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestDoubleTimSortKernel::generateDoubleRuns, getJavaComparator(), DoubleLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void doubleRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestDoubleTimSortKernel::generateDoubleRandom, getJavaComparator(), DoublePartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void doubleMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestFloatTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestFloatTimSortKernel.java
@@ -40,21 +40,7 @@ public class TestFloatTimSortKernel extends BaseTestFloatTimSortKernel {
     @Test
     public void floatRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestFloatTimSortKernel::generateFloatRandom, getJavaComparator(), FloatSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void floatRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestFloatTimSortKernel::generateFloatRandom, getJavaComparator(), FloatPartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestFloatTimSortKernel::generateFloatRandom, getJavaComparator(), FloatLongSortKernelStuff::new);
         }
     }
 
@@ -78,6 +64,49 @@ public class TestFloatTimSortKernel extends BaseTestFloatTimSortKernel {
             correctnessTest(size, TestFloatTimSortKernel::generateFloatRuns, getJavaComparator(), FloatSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void floatLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestFloatTimSortKernel::generateFloatRandom, getJavaComparator(), FloatLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void floatLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestFloatTimSortKernel::generateAscendingFloatRuns, getJavaComparator(), FloatLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void floatLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestFloatTimSortKernel::generateDescendingFloatRuns, getJavaComparator(), FloatLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void floatLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestFloatTimSortKernel::generateFloatRuns, getJavaComparator(), FloatLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void floatRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestFloatTimSortKernel::generateFloatRandom, getJavaComparator(), FloatPartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void floatMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestIntTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestIntTimSortKernel.java
@@ -40,21 +40,7 @@ public class TestIntTimSortKernel extends BaseTestIntTimSortKernel {
     @Test
     public void intRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestIntTimSortKernel::generateIntRandom, getJavaComparator(), IntSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void intRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestIntTimSortKernel::generateIntRandom, getJavaComparator(), IntPartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestIntTimSortKernel::generateIntRandom, getJavaComparator(), IntLongSortKernelStuff::new);
         }
     }
 
@@ -78,6 +64,49 @@ public class TestIntTimSortKernel extends BaseTestIntTimSortKernel {
             correctnessTest(size, TestIntTimSortKernel::generateIntRuns, getJavaComparator(), IntSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void intLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestIntTimSortKernel::generateIntRandom, getJavaComparator(), IntLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void intLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestIntTimSortKernel::generateAscendingIntRuns, getJavaComparator(), IntLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void intLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestIntTimSortKernel::generateDescendingIntRuns, getJavaComparator(), IntLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void intLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestIntTimSortKernel::generateIntRuns, getJavaComparator(), IntLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void intRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestIntTimSortKernel::generateIntRandom, getJavaComparator(), IntPartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void intMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestLongTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestLongTimSortKernel.java
@@ -40,21 +40,7 @@ public class TestLongTimSortKernel extends BaseTestLongTimSortKernel {
     @Test
     public void longRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestLongTimSortKernel::generateLongRandom, getJavaComparator(), LongSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void longRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestLongTimSortKernel::generateLongRandom, getJavaComparator(), LongPartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestLongTimSortKernel::generateLongRandom, getJavaComparator(), LongLongSortKernelStuff::new);
         }
     }
 
@@ -78,6 +64,49 @@ public class TestLongTimSortKernel extends BaseTestLongTimSortKernel {
             correctnessTest(size, TestLongTimSortKernel::generateLongRuns, getJavaComparator(), LongSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void longLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestLongTimSortKernel::generateLongRandom, getJavaComparator(), LongLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void longLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestLongTimSortKernel::generateAscendingLongRuns, getJavaComparator(), LongLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void longLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestLongTimSortKernel::generateDescendingLongRuns, getJavaComparator(), LongLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void longLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestLongTimSortKernel::generateLongRuns, getJavaComparator(), LongLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void longRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestLongTimSortKernel::generateLongRandom, getJavaComparator(), LongPartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void longMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestObjectTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestObjectTimSortKernel.java
@@ -40,21 +40,7 @@ public class TestObjectTimSortKernel extends BaseTestObjectTimSortKernel {
     @Test
     public void ObjectRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestObjectTimSortKernel::generateObjectRandom, getJavaComparator(), ObjectSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void ObjectRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestObjectTimSortKernel::generateObjectRandom, getJavaComparator(), ObjectPartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestObjectTimSortKernel::generateObjectRandom, getJavaComparator(), ObjectLongSortKernelStuff::new);
         }
     }
 
@@ -78,6 +64,49 @@ public class TestObjectTimSortKernel extends BaseTestObjectTimSortKernel {
             correctnessTest(size, TestObjectTimSortKernel::generateObjectRuns, getJavaComparator(), ObjectSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void ObjectLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestObjectTimSortKernel::generateObjectRandom, getJavaComparator(), ObjectLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void ObjectLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestObjectTimSortKernel::generateAscendingObjectRuns, getJavaComparator(), ObjectLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void ObjectLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestObjectTimSortKernel::generateDescendingObjectRuns, getJavaComparator(), ObjectLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void ObjectLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestObjectTimSortKernel::generateObjectRuns, getJavaComparator(), ObjectLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void ObjectRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestObjectTimSortKernel::generateObjectRandom, getJavaComparator(), ObjectPartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void ObjectMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestShortTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestShortTimSortKernel.java
@@ -40,21 +40,7 @@ public class TestShortTimSortKernel extends BaseTestShortTimSortKernel {
     @Test
     public void shortRandomCorrectness() {
         for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
-            correctnessTest(size, TestShortTimSortKernel::generateShortRandom, getJavaComparator(), ShortSortKernelStuff::new);
-        }
-    }
-
-    @Test
-    public void shortRandomPartitionCorrectness() {
-        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
-            int partitions = 2;
-            while (partitions < (int)Math.sqrt(size)) {
-                partitionCorrectnessTest(size, size, partitions, TestShortTimSortKernel::generateShortRandom, getJavaComparator(), ShortPartitionKernelStuff::new);
-                if (size < 1000) {
-                    break;
-                }
-                partitions *= 3;
-            }
+            correctnessTest(size, TestShortTimSortKernel::generateShortRandom, getJavaComparator(), ShortLongSortKernelStuff::new);
         }
     }
 
@@ -78,6 +64,49 @@ public class TestShortTimSortKernel extends BaseTestShortTimSortKernel {
             correctnessTest(size, TestShortTimSortKernel::generateShortRuns, getJavaComparator(), ShortSortKernelStuff::new);
         }
     }
+
+    @Test
+    public void shortLongRandomCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestShortTimSortKernel::generateShortRandom, getJavaComparator(), ShortLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void shortLongAscendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestShortTimSortKernel::generateAscendingShortRuns, getJavaComparator(), ShortLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void shortLongDescendingRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestShortTimSortKernel::generateDescendingShortRuns, getJavaComparator(), ShortLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void shortLongRunCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_CHUNK_SIZE; size *= 2) {
+            correctnessTest(size, TestShortTimSortKernel::generateShortRuns, getJavaComparator(), ShortLongSortKernelStuff::new);
+        }
+    }
+
+    @Test
+    public void shortRandomPartitionCorrectness() {
+        for (int size = INITIAL_CORRECTNESS_SIZE; size <= MAX_PARTTITION_CHUNK_SIZE; size *= 2) {
+            int partitions = 2;
+            while (partitions < (int)Math.sqrt(size)) {
+                partitionCorrectnessTest(size, size, partitions, TestShortTimSortKernel::generateShortRandom, getJavaComparator(), ShortPartitionKernelStuff::new);
+                if (size < 1000) {
+                    break;
+                }
+                partitions *= 3;
+            }
+        }
+    }
+
 
     @Test
     public void shortMultiRandomCorrectness() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestTimSortKernel.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sort/timsort/TestTimSortKernel.java
@@ -178,7 +178,7 @@ public abstract class TestTimSortKernel {
     <T> void correctnessTest(int size, GenerateTupleList<T> tupleListGenerator, Comparator<T> comparator,
             Function<List<T>, SortKernelStuff<T>> prepareFunction) {
         for (int seed = 0; seed < CORRECTNESS_SEEDS; ++seed) {
-            System.out.println("Size = " + size + ", seed=" + seed);
+            System.out.println("size = " + size + ", seed = " + seed);
             final Random random = new Random(seed);
 
             final List<T> javaTuples = tupleListGenerator.generate(random, size);

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSortKernel.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSortKernel.java
@@ -25,6 +25,8 @@ public class ReplicateSortKernel {
         replicateLongToInt();
         replicateLongToByte();
         doCharReplication(
+                "engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java");
+        doCharReplication(
                 "engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharLongTimsortKernel.java");
         doCharReplication(
                 "engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharIntTimsortKernel.java");

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateVectorTests.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateVectorTests.java
@@ -33,7 +33,7 @@ public class ReplicateVectorTests {
                 "import io.deephaven.engine.primitive.iterator.CloseableIterator;"));
         lines = ReplicationUtils.removeRegion(lines, "NullConstantImport");
         lines = ReplicationUtils.replaceRegion(lines, "TestType", List.of(
-                "        assertEquals(ObjectVector.type(io.deephaven.qst.type.StringType.instance()).clazz(), ObjectVector.class);"));
+                "        assertEquals(ObjectVector.type(io.deephaven.qst.type.StringType.of()).clazz(), ObjectVector.class);"));
         lines = ReplicationUtils.globalReplacements(lines,
                 "new ObjectVectorDirect", "new ObjectVectorDirect<>",
                 "ObjectVector ", "ObjectVector<Object> ",


### PR DESCRIPTION
I'm breaking up pushdown predicates into multiple PRs to get the non-controversial pieces merged. These kernels are used within the regions to perform matching.