### PR TITLE
Fix print outputs in Jupyter notebook 

### DIFF
--- a/py/server/deephaven_internal/stream.py
+++ b/py/server/deephaven_internal/stream.py
@@ -93,3 +93,7 @@ class TeeStream(io.TextIOBase):
     def __del__(self):
         # Do nothing, override superclass which would call close()
         pass
+
+    def set_parent(self, parent):
+        # Parent needs to be set on the original stream so that output shows in proper cell
+        self._stream.set_parent(parent)


### PR DESCRIPTION
Fixes https://github.com/deephaven/deephaven-core/issues/4277

Essentially, the parent needs to be updated so that Jupyter's `OutputStream` can redirect the output properly
More info here: https://github.com/StanfordLegion/legion/issues/1393

Tested with code at https://github.com/deephaven/deephaven-core/issues/4277
Initial run:
<img width="1246" alt="Screenshot 2023-08-15 at 11 07 37 AM" src="https://github.com/deephaven/deephaven-core/assets/10480451/45de3a37-26c3-4b74-b89c-f0e60b0239fb">
rerun: 
<img width="1254" alt="Screenshot 2023-08-15 at 11 08 02 AM" src="https://github.com/deephaven/deephaven-core/assets/10480451/8d0506ac-cbbb-450a-bb67-a593548ecaef">


