### PR TITLE
Change TimeTable API to support strings, int64, or std::chrono values.

### DIFF
--- a/cpp-client/deephaven/client/CMakeLists.txt
+++ b/cpp-client/deephaven/client/CMakeLists.txt
@@ -63,7 +63,6 @@ set(ALL_FILES
     include/public/deephaven/client/client_options.h
     include/public/deephaven/client/flight.h
     include/public/deephaven/client/update_by.h
-    include/public/deephaven/client/utility/arrow_util.h
 
     src/subscription/subscribe_thread.cc
 
@@ -75,6 +74,8 @@ set(ALL_FILES
     include/private/deephaven/client/utility/executor.h
 
     src/utility/table_maker.cc
+    include/public/deephaven/client/utility/arrow_util.h
+    include/public/deephaven/client/utility/misc_types.h
     include/public/deephaven/client/utility/table_maker.h
 
     proto/deephaven/proto/application.grpc.pb.cc
@@ -113,7 +114,7 @@ set(ALL_FILES
     proto/deephaven/proto/ticket.grpc.pb.h
     proto/deephaven/proto/ticket.pb.cc
     proto/deephaven/proto/ticket.pb.h
-    )
+)
 
 add_library(client ${ALL_FILES})
 # In order to make a shared library suitable for Cython.

--- a/cpp-client/deephaven/client/include/private/deephaven/client/impl/table_handle_manager_impl.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/impl/table_handle_manager_impl.h
@@ -23,6 +23,8 @@ class TableHandleManagerImpl final : public std::enable_shared_from_this<TableHa
   using SortDescriptor = io::deephaven::proto::backplane::grpc::SortDescriptor;
   using Ticket = io::deephaven::proto::backplane::grpc::Ticket;
   using BindTableToVariableResponse = io::deephaven::proto::backplane::script::grpc::BindTableToVariableResponse;
+  using DurationSpecifier = deephaven::client::utility::DurationSpecifier;
+  using TimePointSpecifier = deephaven::client::utility::TimePointSpecifier;
 
   template<typename ...Args>
   using SFCallback = deephaven::dhcore::utility::SFCallback<Args...>;
@@ -47,7 +49,8 @@ public:
   [[nodiscard]]
   std::shared_ptr<TableHandleImpl> FetchTable(std::string table_name);
   [[nodiscard]]
-  std::shared_ptr<TableHandleImpl> TimeTable(int64_t start_time_nanos, int64_t period_nanos);
+  std::shared_ptr<TableHandleImpl> TimeTable(DurationSpecifier period, TimePointSpecifier start_time,
+      bool blink_table);
   void RunScriptAsync(std::string code, std::shared_ptr<SFCallback<>> callback);
 
   /**

--- a/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/client/include/private/deephaven/client/server/server.h
@@ -16,6 +16,7 @@
 
 #include "deephaven/client/client_options.h"
 #include "deephaven/client/utility/executor.h"
+#include "deephaven/client/utility/misc_types.h"
 #include "deephaven/dhcore/utility/callbacks.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/proto/ticket.pb.h"
@@ -94,6 +95,8 @@ class Server : public std::enable_shared_from_this<Server> {
   using ConsoleService = io::deephaven::proto::backplane::script::grpc::ConsoleService;
   using StartConsoleResponse = io::deephaven::proto::backplane::script::grpc::StartConsoleResponse;
   using ExecuteCommandResponse = io::deephaven::proto::backplane::script::grpc::ExecuteCommandResponse;
+  using DurationSpecifier = deephaven::client::utility::DurationSpecifier;
+  using TimePointSpecifier = deephaven::client::utility::TimePointSpecifier;
 
   using ClientOptions = deephaven::client::ClientOptions;
   using Executor = deephaven::client::utility::Executor;
@@ -167,8 +170,8 @@ public:
   //  std::shared_ptr<TableHandle> tempTableAsync(std::shared_ptr<std::vector<std::shared_ptr<ColumnHolder>>> columnHolders,
   //      std::shared_ptr<ItdCallback> itdCallback);
 
-  void TimeTableAsync(int64_t start_time_nanos, int64_t period_nanos, std::shared_ptr<EtcCallback> etc_callback,
-      Ticket result);
+  void TimeTableAsync(DurationSpecifier period, TimePointSpecifier start_time, bool blink_table,
+      std::shared_ptr<EtcCallback> etc_callback, Ticket result);
   //
   //  std::shared_ptr<TableHandle> snapshotAsync(std::shared_ptr<TableHandle> leftTableHandle,
   //      std::shared_ptr<TableHandle> rightTableHandle,

--- a/cpp-client/deephaven/client/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/client.h
@@ -113,9 +113,9 @@ public:
   /**
    * Creates a ticking table.
    * @param period Table ticking frequency, specified as a std::chrono::duration,
-   *   int64_t nanoseconds, or a string containing an ISO duration representation.
+   *   int64_t nanoseconds, or a string containing an ISO 8601 duration representation.
    * @param start_time When the table should start ticking, specified as a std::chrono::time_point,
-   *   int64_t nanoseconds since the epoch, or a string containing an ISO time point specifier.
+   *   int64_t nanoseconds since the epoch, or a string containing an ISO 8601 time point specifier.
    * @return The TableHandle of the new table.
    */
   [[nodiscard]]

--- a/cpp-client/deephaven/client/include/public/deephaven/client/update_by.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/update_by.h
@@ -7,6 +7,7 @@
 #include "deephaven/client/columns.h"
 #include "deephaven/client/client_options.h"
 #include "deephaven/client/expressions.h"
+#include "deephaven/client/utility/misc_types.h"
 #include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 #include "deephaven/dhcore/utility/callbacks.h"
@@ -86,12 +87,6 @@ struct OperationControl {
 };
 
 /**
- * Allows the caller to specify durations either as any of the std::chrono::durations (which will
- * be auto-converted to nanoseconds) or as an ISO 8601 duration string.
- */
-using durationSpecifier_t = std::variant<std::chrono::nanoseconds, std::string>;
-
-/**
  * Creates a cumulative sum UpdateByOperation for the supplied column names.
  * @param cols the column(s) to be operated on, can include expressions to rename the output,
  *  i.e. "new_col = col"; when empty, update_by performs the operation on all applicable columns.
@@ -160,8 +155,9 @@ UpdateByOperation emaTick(double decay_ticks, std::vector<std::string> cols,
  *   i.e. "new_col = col"; when empty, update_by performs the operation on all applicable columns.
  * @param opControl defines how special cases should behave
  */
-UpdateByOperation emaTime(std::string timestamp_col, durationSpecifier_t decay_time,
-    std::vector<std::string> cols, const OperationControl &op_control = OperationControl());
+UpdateByOperation emaTime(std::string timestamp_col,
+    deephaven::client::utility::DurationSpecifier decay_time, std::vector<std::string> cols,
+    const OperationControl &op_control = OperationControl());
 /**
  * Creates an EMS (exponential moving sum) UpdateByOperation for the supplied column names, using
  * ticks as the decay unit.
@@ -189,8 +185,9 @@ UpdateByOperation emsTick(double decay_ticks, std::vector<std::string> cols,
  *   i.e. "new_col = col"; when empty, update_by performs the operation on all applicable columns.
  * @param opControl defines how special cases should behave
  */
-UpdateByOperation emsTime(std::string timestamp_col, durationSpecifier_t decay_time,
-    std::vector<std::string> cols, const OperationControl &op_control = OperationControl());
+UpdateByOperation emsTime(std::string timestamp_col,
+    deephaven::client::utility::DurationSpecifier decay_time, std::vector<std::string> cols,
+    const OperationControl &op_control = OperationControl());
 /**
  * Creates an EM Min (exponential moving minimum) UpdateByOperation for the supplied column names,
  * using ticks as the decay unit.
@@ -217,8 +214,9 @@ UpdateByOperation emminTick(double decay_ticks, std::vector<std::string> cols,
  *   i.e. "new_col = col"; when empty, update_by performs the operation on all applicable columns.
  * @param opControl defines how special cases should behave
  */
-UpdateByOperation emminTime(std::string timestamp_col, durationSpecifier_t decay_time,
-    std::vector<std::string> cols, const OperationControl &op_control = OperationControl());
+UpdateByOperation emminTime(std::string timestamp_col,
+    deephaven::client::utility::DurationSpecifier decay_time, std::vector<std::string> cols,
+    const OperationControl &op_control = OperationControl());
 /**
  * Creates an EM Max (exponential moving maximum) UpdateByOperation for the supplied column names,
  * using ticks as the decay unit.
@@ -245,8 +243,9 @@ UpdateByOperation emmaxTick(double decay_ticks, std::vector<std::string> cols,
  *   i.e. "new_col = col"; when empty, update_by performs the operation on all applicable columns.
  * @param opControl defines how special cases should behave
  */
-UpdateByOperation emmaxTime(std::string timestamp_col, durationSpecifier_t decay_time,
-    std::vector<std::string> cols, const OperationControl &op_control = OperationControl());
+UpdateByOperation emmaxTime(std::string timestamp_col,
+    deephaven::client::utility::DurationSpecifier decay_time, std::vector<std::string> cols,
+    const OperationControl &op_control = OperationControl());
 /**
  * Creates an EM Std (exponential moving standard deviation) UpdateByOperation for the supplied
  * column names, using ticks as the decay unit.
@@ -277,8 +276,9 @@ UpdateByOperation emstdTick(double decay_ticks, std::vector<std::string> cols,
  *   i.e. "new_col = col"; when empty, update_by performs the operation on all applicable columns.
  * @param opControl defines how special cases should behave
  */
-UpdateByOperation emstdTime(std::string timestamp_col, durationSpecifier_t decay_time,
-    std::vector<std::string> cols, const OperationControl &op_control = OperationControl());
+UpdateByOperation emstdTime(std::string timestamp_col,
+    deephaven::client::utility::DurationSpecifier decay_time, std::vector<std::string> cols,
+    const OperationControl &op_control = OperationControl());
 /**
  * Creates a rolling sum UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -330,7 +330,8 @@ UpdateByOperation rollingSumTick(std::vector<std::string> cols, int rev_ticks, i
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingSumTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling Group UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -362,7 +363,8 @@ UpdateByOperation rollingGroupTick(std::vector<std::string> cols, int rev_ticks,
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingGroupTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling average UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -394,7 +396,8 @@ UpdateByOperation rollingAvgTick(std::vector<std::string> cols, int rev_ticks, i
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingAvgTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling Min UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -426,7 +429,8 @@ UpdateByOperation rollingMinTick(std::vector<std::string> cols, int rev_ticks, i
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingMinTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling Max UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -458,7 +462,8 @@ UpdateByOperation rollingMaxTick(std::vector<std::string> cols, int rev_ticks, i
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingMaxTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling product UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -490,7 +495,8 @@ UpdateByOperation rollingProdTick(std::vector<std::string> cols, int rev_ticks, 
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingProdTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling count UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -522,7 +528,8 @@ UpdateByOperation rollingCountTick(std::vector<std::string> cols, int rev_ticks,
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingCountTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling standard deviation UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -554,7 +561,8 @@ UpdateByOperation rollingStdTick(std::vector<std::string> cols, int rev_ticks, i
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingStdTime(std::string timestamp_col, std::vector<std::string> cols,
-    durationSpecifier_t rev_time, durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 /**
  * Creates a rolling weighted average UpdateByOperation for the supplied column names, using ticks as the
  * windowing unit. Ticks are row counts, and you may specify the reverse and forward window in
@@ -589,6 +597,6 @@ UpdateByOperation rollingWavgTick(std::string weight_col, std::vector<std::strin
  * @param fwdTime the look-ahead window size
  */
 UpdateByOperation rollingWavgTime(std::string timestamp_col, std::string weight_col,
-    std::vector<std::string> cols, durationSpecifier_t rev_time,
-    durationSpecifier_t fwd_time = std::chrono::nanoseconds(0));
+    std::vector<std::string> cols, deephaven::client::utility::DurationSpecifier rev_time,
+    deephaven::client::utility::DurationSpecifier fwd_time = 0);
 }  // namespace deephaven::client::update_by

--- a/cpp-client/deephaven/client/include/public/deephaven/client/utility/misc_types.h
+++ b/cpp-client/deephaven/client/include/public/deephaven/client/utility/misc_types.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <variant>
+
+namespace deephaven::client::utility {
+/**
+ * Allows the caller to specify time points either as std::chrono::time_point, nanoseconds since
+ * the epoch, or as an ISO 8601 time string.
+ */
+using TimePointSpecifier = std::variant<std::chrono::system_clock::time_point, int64_t, std::string>;
+
+/**
+ * Allows the caller to specify durations either as any of the std::chrono::durations (which will
+ * be auto-converted to nanoseconds), as nanoseconds since the epoch, or as an ISO 8601 duration
+ * string.
+ */
+using DurationSpecifier = std::variant<std::chrono::nanoseconds, int64_t, std::string>;
+} // namespace deephaven::client::utility

--- a/cpp-client/deephaven/client/src/client.cc
+++ b/cpp-client/deephaven/client/src/client.cc
@@ -109,16 +109,10 @@ TableHandle TableHandleManager::FetchTable(std::string tableName) const {
   return TableHandle(std::move(qs_impl));
 }
 
-TableHandle TableHandleManager::TimeTable(int64_t startTimeNanos, int64_t periodNanos) const {
-  auto qs_impl = impl_->TimeTable(startTimeNanos, periodNanos);
-  return TableHandle(std::move(qs_impl));
-}
-
-TableHandle TableHandleManager::TimeTable(std::chrono::system_clock::time_point startTime,
-    std::chrono::system_clock::duration period) const {
-  auto st_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(startTime.time_since_epoch()).count();
-  auto d_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(period).count();
-  return TimeTable(st_nanos, d_nanos);
+TableHandle TableHandleManager::TimeTable(DurationSpecifier period, TimePointSpecifier start_time,
+    bool blink_table) const {
+  auto impl = impl_->TimeTable(std::move(period), std::move(start_time), blink_table);
+  return TableHandle(std::move(impl));
 }
 
 std::string TableHandleManager::NewTicket() const {
@@ -200,7 +194,7 @@ Aggregate Aggregate::Min(std::vector<std::string> column_specs) {
   return createAggForMatchPairs(ComboAggregateRequest::MIN, std::move(column_specs));
 }
 
-Aggregate Aggregate::pct(double percentile, bool avg_median, std::vector<std::string> column_specs) {
+Aggregate Aggregate::Pct(double percentile, bool avg_median, std::vector<std::string> column_specs) {
   ComboAggregateRequest::Aggregate pd;
   pd.set_type(ComboAggregateRequest::PERCENTILE);
   pd.set_percentile(percentile);

--- a/cpp-client/deephaven/client/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/client/src/impl/table_handle_manager_impl.cc
@@ -66,11 +66,12 @@ std::shared_ptr<TableHandleImpl> TableHandleManagerImpl::FetchTable(std::string 
   return TableHandleImpl::Create(shared_from_this(), std::move(result_ticket), std::move(ls));
 }
 
-std::shared_ptr<TableHandleImpl> TableHandleManagerImpl::TimeTable(int64_t start_time_nanos,
-    int64_t period_nanos) {
+std::shared_ptr<TableHandleImpl> TableHandleManagerImpl::TimeTable(DurationSpecifier period,
+    TimePointSpecifier start_time, bool blink_table) {
   auto result_ticket = server_->NewTicket();
   auto [cb, ls] = TableHandleImpl::CreateEtcCallback(nullptr, this, result_ticket);
-  server_->TimeTableAsync(start_time_nanos, period_nanos, std::move(cb), result_ticket);
+  server_->TimeTableAsync(std::move(period), std::move(start_time), blink_table, std::move(cb),
+      result_ticket);
   return TableHandleImpl::Create(shared_from_this(), std::move(result_ticket), std::move(ls));
 }
 

--- a/cpp-client/tests/attributes_test.cc
+++ b/cpp-client/tests/attributes_test.cc
@@ -18,7 +18,7 @@ TEST_CASE("TableHandle Attributes", "[attributes]") {
 TEST_CASE("TableHandle Dynamic Attributes", "[attributes]") {
   auto client = TableMakerForTests::CreateClient();
   auto thm = client.GetManager();
-  auto t = thm.TimeTable(0, 1'000'000'000).Update("II = ii");
+  auto t = thm.TimeTable(1'000'000'000).Update("II = ii");
   CHECK(!t.IsStatic());
 }
 

--- a/cpp-client/tests/ticking_test.cc
+++ b/cpp-client/tests/ticking_test.cc
@@ -73,7 +73,7 @@ TEST_CASE("Ticking Table eventually reaches 10 rows", "[ticking]") {
   auto client = TableMakerForTests::CreateClient();
   auto tm = client.GetManager();
 
-  auto table = tm.TimeTable(0, 500'000'000).Update("II = ii");
+  auto table = tm.TimeTable(std::chrono::milliseconds(500)).Update("II = ii");
   table.BindToVariable("ticking");
   auto callback = std::make_shared<ReachesNRowsCallback>(max_rows);
   auto cookie = table.Subscribe(callback);
@@ -128,7 +128,7 @@ TEST_CASE("Ticking Table modified rows are eventually all greater than 10", "[ti
   auto client = TableMakerForTests::CreateClient();
   auto tm = client.GetManager();
 
-  auto table = tm.TimeTable(0, 500'000'000)
+  auto table = tm.TimeTable(std::chrono::milliseconds(500))
       .View({"Key = (long)(ii % 10)", "Value = ii"})
       .LastBy("Key");
   table.BindToVariable("ticking");

--- a/cpp-client/tests/update_by_test.cc
+++ b/cpp-client/tests/update_by_test.cc
@@ -157,7 +157,7 @@ std::vector<TableHandle> MakeTables(const Client &client) {
   std::vector<TableHandle> result;
   auto tm = client.GetManager();
   auto static_table = MakeRandomTable(client).Update("Timestamp=now()");
-  auto ticking_table = tm.TimeTable(std::chrono::system_clock::now(), std::chrono::seconds(1))
+  auto ticking_table = tm.TimeTable(std::chrono::seconds(1))
       .Update("a = i", "b = i*i % 13", "c = i * 13 % 23", "d = a + b", "e = a - b");
   return {static_table, ticking_table};
 }


### PR DESCRIPTION
Also swap the order of the parameters (breaking change)/
Also change 'pct' to 'Pct' (style guide)