### PR TITLE
C++ client: Fix docs build by locking sphinx to version 7.1.2 for now

### DIFF
--- a/sphinx/sphinx.gradle
+++ b/sphinx/sphinx.gradle
@@ -39,9 +39,14 @@ def sphinxDockerfile = tasks.register('sphinxDockerfile', Dockerfile) {
     environmentVariable 'DEEPHAVEN_PROPFILE', 'dh-defaults.prop'
     environmentVariable 'DEEPHAVEN_VERSION', project.version
 
+    // For the time being we lock the sphinx version to 7.1.2
+    // This works around the bug described in
+    // https://github.com/sphinx-doc/sphinx/issues/11605
+    // We should leave this here until 'breathe' updates their code to be
+    // compatible with the breaking sphinx change.
     runCommand '''set -eux; \\
                   mkdir /tmp/workspace; \\
-                  python -m pip install sphinx sphinx-autodoc-typehints pyarrow protobuf grpcio bitstring /wheel/*.whl breathe furo
+                  python -m pip install sphinx==7.1.2 sphinx-autodoc-typehints pyarrow protobuf grpcio bitstring /wheel/*.whl breathe furo
                   '''
 }
 


### PR DESCRIPTION
For the time being we lock the Sphinx version to 7.1.2

This works around the bug described in
https://github.com/sphinx-doc/sphinx/issues/11605

Sphinx made a breaking change, but believes that the Breathe project is incorrectly relying on the wrong behavior, so at this point it's up to Breathe to fix.

Until then we sync to an older version of Sphinx.