### PR TITLE
Accept strings for time_table

### DIFF
--- a/R/rdeephaven/R/client_wrapper.R
+++ b/R/rdeephaven/R/client_wrapper.R
@@ -177,20 +177,27 @@ setMethod(
 
 setGeneric(
   "time_table",
-  function(client_instance, period, ...) {
+  function(client_instance, period, start_time = "missing") {
     return(standardGeneric("time_table"))
   },
-  signature = c("client_instance", "period")
+  signature = c("client_instance", "period", "start_time")
 )
 
 #' @export
 setMethod(
   "time_table",
-  signature = c(client_instance = "Client", period = "numeric"),
-  function(client_instance, period, start_time = 0) {
-    verify_any_int("period", period, TRUE)
-    verify_any_int("start_time", start_time, TRUE)
-    return(new("TableHandle", .internal_rcpp_object = client_instance@.internal_rcpp_object$time_table(start_time, period)))
+  signature = c(client_instance = "Client", period = "character", start_time = "missing"),
+  function(client_instance, period, start_time = "now") {
+    return(new("TableHandle", .internal_rcpp_object = client_instance@.internal_rcpp_object$time_table(period, start_time)))
+  }
+)
+
+#' @export
+setMethod(
+  "time_table",
+  signature = c(client_instance = "Client", period = "character", start_time = "character"),
+  function(client_instance, period, start_time) {
+    return(new("TableHandle", .internal_rcpp_object = client_instance@.internal_rcpp_object$time_table(period, start_time)))
   }
 )
 

--- a/R/rdeephaven/src/client.cpp
+++ b/R/rdeephaven/src/client.cpp
@@ -104,9 +104,8 @@ AggregateWrapper* INTERNAL_agg_std(std::vector<std::string> columnSpecs) {
     return new AggregateWrapper(deephaven::client::Aggregate::Std(columnSpecs));
 }
 
-// TODO: capitalize the pct method when a fix is merged
 AggregateWrapper* INTERNAL_agg_percentile(double percentile, std::vector<std::string> columnSpecs) {
-    return new AggregateWrapper(deephaven::client::Aggregate::pct(percentile, false, columnSpecs));
+    return new AggregateWrapper(deephaven::client::Aggregate::Pct(percentile, false, columnSpecs));
 }
 
 AggregateWrapper* INTERNAL_agg_count(std::string columnSpec) {
@@ -382,8 +381,11 @@ public:
         return new TableHandleWrapper(internal_tbl_hdl_mngr.EmptyTable(size));
     }
 
-    TableHandleWrapper* TimeTable(int64_t startTimeNanos, int64_t periodNanos) {
-        return new TableHandleWrapper(internal_tbl_hdl_mngr.TimeTable(startTimeNanos, periodNanos));
+    TableHandleWrapper* TimeTable(std::string periodISO, std::string startTimeISO) {
+        if(startTimeISO == "now") {
+            return new TableHandleWrapper(internal_tbl_hdl_mngr.TimeTable(periodISO));
+        }
+        return new TableHandleWrapper(internal_tbl_hdl_mngr.TimeTable(periodISO, startTimeISO));
     };
 
     void RunScript(std::string code) {


### PR DESCRIPTION
This enables the R time_table method to accept ISO 8601-formatted strings for `period` and `start_time`. This is MVP signature for this function and more support for R date time types will be added in the future.

This PR also fixes the `Pct` typo from the C++ refactor.