### PR TITLE
Add additional methods to the `MultiJoinFactory` and `MultiJoinInput` Java/Groovy interface for simple construction.

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/MultiJoinFactory.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/MultiJoinFactory.java
@@ -85,6 +85,19 @@ public class MultiJoinFactory {
     }
 
     /**
+     * Join tables that have common key column names; include all columns from the input tables.
+     * <p>
+     *
+     * @param columnsToMatch A comma separated list of key columns, in string format (e.g. "ResultKey=SourceKey" or
+     *        "KeyInBoth").
+     * @param inputTables the tables to join together
+     * @return a MultiJoinTable with one row for each key and the corresponding row in each input table
+     */
+    public static MultiJoinTable of(@NotNull final String columnsToMatch, @NotNull final Table... inputTables) {
+        return multiJoinTableCreator().of(MultiJoinInput.from(columnsToMatch, inputTables));
+    }
+
+    /**
      * Perform a multiJoin for one or more tables; allows renaming of key column names and specifying individual input
      * table columns to include in the final output table.
      *

--- a/engine/api/src/main/java/io/deephaven/engine/table/MultiJoinInput.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/MultiJoinInput.java
@@ -6,6 +6,7 @@ import io.deephaven.api.JoinMatch;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -103,6 +104,24 @@ public abstract class MultiJoinInput {
     public static MultiJoinInput[] from(@NotNull final String[] keys, @NotNull final Table[] inputTables) {
         return Arrays.stream(inputTables)
                 .map(t -> MultiJoinInput.of(t, keys))
+                .toArray(MultiJoinInput[]::new);
+    }
+
+    /**
+     * Create an array of {@link MultiJoinInput} with common keys; includes all non-key columns as output columns.
+     *
+     * @param columnsToMatch A comma separated list of key columns, in string format (e.g. "ResultKey=SourceKey" or
+     *        "KeyInBoth").
+     * @param inputTables An array of tables to include in the output
+     */
+    @NotNull
+    public static MultiJoinInput[] from(@Nullable final String columnsToMatch, @NotNull final Table... inputTables) {
+        return Arrays.stream(inputTables)
+                .map(t -> MultiJoinInput.of(t,
+                        columnsToMatch == null || columnsToMatch.isEmpty()
+                                ? Collections.emptyList()
+                                : JoinMatch.from(columnsToMatch.split(",")),
+                        Collections.emptyList()))
                 .toArray(MultiJoinInput[]::new);
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMultiJoinTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMultiJoinTest.java
@@ -786,6 +786,35 @@ public class QueryTableMultiJoinTest extends QueryTableTestBase {
         Assert.assertEquals(mji.columnsToAdd()[0].existingColumn().name(), "C");
         Assert.assertEquals(mji.columnsToAdd()[1].newColumn().name(), "D1");
         Assert.assertEquals(mji.columnsToAdd()[1].existingColumn().name(), "D");
+
+        // Assert that the factory methods are equivalent.
+        final Table dummyTable2 = emptyTable(0);
+
+        MultiJoinInput[] mjiArr = MultiJoinInput.from("Key1=A,Key2=B", dummyTable, dummyTable2);
+        Assert.assertEquals(mjiArr[0].inputTable(), dummyTable);
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[0].left().name(), "Key1");
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[0].right().name(), "A");
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[1].left().name(), "Key2");
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[1].right().name(), "B");
+        Assert.assertEquals(mjiArr[1].inputTable(), dummyTable2);
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[0].left().name(), "Key1");
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[0].right().name(), "A");
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[1].left().name(), "Key2");
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[1].right().name(), "B");
+
+        mjiArr = MultiJoinInput.from(
+                new String[] {"Key1=A", "Key2=B"},
+                new Table[] {dummyTable, dummyTable2});
+        Assert.assertEquals(mjiArr[0].inputTable(), dummyTable);
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[0].left().name(), "Key1");
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[0].right().name(), "A");
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[1].left().name(), "Key2");
+        Assert.assertEquals(mjiArr[0].columnsToMatch()[1].right().name(), "B");
+        Assert.assertEquals(mjiArr[1].inputTable(), dummyTable2);
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[0].left().name(), "Key1");
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[0].right().name(), "A");
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[1].left().name(), "Key2");
+        Assert.assertEquals(mjiArr[1].columnsToMatch()[1].right().name(), "B");
     }
 
 


### PR DESCRIPTION
Support comma-separated string arguments for the `MultiJoinFactory` construction methods similar to the other join methods.