### PR TITLE
Binary search kernel for pushdown predicates

### DIFF
--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     testImplementation project(':BenchmarkSupport')
     testImplementation project(':extensions-csv')
     testImplementation project(':extensions-parquet-table')
+    testImplementation project(':extensions-source-support')
     testImplementation project(':Numerics')
 
     Classpaths.inheritJUnitClassic(project, 'testImplementation')

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortDescendingKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.ByteChunk;
 import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class ByteTimsortDescendingKernel {
     }
 
     // region Context
-    public static class ByteSortKernelContext<ATTR extends Any> {
+    public static class ByteSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ByteTimsortKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.ByteChunk;
 import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class ByteTimsortKernel {
     }
 
     // region Context
-    public static class ByteSortKernelContext<ATTR extends Any> {
+    public static class ByteSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortDescendingKernel.java
@@ -7,6 +7,7 @@ import io.deephaven.chunk.CharChunk;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 import io.deephaven.util.compare.CharComparisons;
 
@@ -22,7 +23,7 @@ public class CharTimsortDescendingKernel {
     }
 
     // region Context
-    public static class CharSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/CharTimsortKernel.java
@@ -7,6 +7,7 @@ import io.deephaven.chunk.CharChunk;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -21,7 +22,7 @@ public class CharTimsortKernel {
     }
 
     // region Context
-    public static class CharSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortDescendingKernel.java
@@ -14,6 +14,7 @@ import io.deephaven.chunk.DoubleChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -28,7 +29,7 @@ public class DoubleTimsortDescendingKernel {
     }
 
     // region Context
-    public static class DoubleSortKernelContext<ATTR extends Any> {
+    public static class DoubleSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/DoubleTimsortKernel.java
@@ -14,6 +14,7 @@ import io.deephaven.chunk.DoubleChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -28,7 +29,7 @@ public class DoubleTimsortKernel {
     }
 
     // region Context
-    public static class DoubleSortKernelContext<ATTR extends Any> {
+    public static class DoubleSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortDescendingKernel.java
@@ -14,6 +14,7 @@ import io.deephaven.chunk.FloatChunk;
 import io.deephaven.chunk.WritableFloatChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -28,7 +29,7 @@ public class FloatTimsortDescendingKernel {
     }
 
     // region Context
-    public static class FloatSortKernelContext<ATTR extends Any> {
+    public static class FloatSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/FloatTimsortKernel.java
@@ -14,6 +14,7 @@ import io.deephaven.chunk.FloatChunk;
 import io.deephaven.chunk.WritableFloatChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -28,7 +29,7 @@ public class FloatTimsortKernel {
     }
 
     // region Context
-    public static class FloatSortKernelContext<ATTR extends Any> {
+    public static class FloatSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortDescendingKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class IntTimsortDescendingKernel {
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class IntSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/IntTimsortKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.IntChunk;
 import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class IntTimsortKernel {
     }
 
     // region Context
-    public static class IntSortKernelContext<ATTR extends Any> {
+    public static class IntSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortDescendingKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class LongTimsortDescendingKernel {
     }
 
     // region Context
-    public static class LongSortKernelContext<ATTR extends Any> {
+    public static class LongSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/LongTimsortKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class LongTimsortKernel {
     }
 
     // region Context
-    public static class LongSortKernelContext<ATTR extends Any> {
+    public static class LongSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortDescendingKernel.java
@@ -13,6 +13,7 @@ import io.deephaven.chunk.CharChunk;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -27,7 +28,7 @@ public class NullAwareCharTimsortDescendingKernel {
     }
 
     // region Context
-    public static class CharSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/NullAwareCharTimsortKernel.java
@@ -13,6 +13,7 @@ import io.deephaven.chunk.CharChunk;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -27,7 +28,7 @@ public class NullAwareCharTimsortKernel {
     }
 
     // region Context
-    public static class CharSortKernelContext<ATTR extends Any> {
+    public static class CharSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortDescendingKernel.java
@@ -14,6 +14,7 @@ import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -28,7 +29,7 @@ public class ObjectTimsortDescendingKernel {
     }
 
     // region Context
-    public static class ObjectSortKernelContext<ATTR extends Any> {
+    public static class ObjectSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ObjectTimsortKernel.java
@@ -14,6 +14,7 @@ import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -28,7 +29,7 @@ public class ObjectTimsortKernel {
     }
 
     // region Context
-    public static class ObjectSortKernelContext<ATTR extends Any> {
+    public static class ObjectSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortDescendingKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.ShortChunk;
 import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class ShortTimsortDescendingKernel {
     }
 
     // region Context
-    public static class ShortSortKernelContext<ATTR extends Any> {
+    public static class ShortSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sort/timsort/ShortTimsortKernel.java
@@ -12,6 +12,7 @@ import io.deephaven.chunk.ShortChunk;
 import io.deephaven.chunk.WritableShortChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.table.Context;
 import io.deephaven.util.annotations.VisibleForTesting;
 
 /**
@@ -26,7 +27,7 @@ public class ShortTimsortKernel {
     }
 
     // region Context
-    public static class ShortSortKernelContext<ATTR extends Any> {
+    public static class ShortSortKernelContext<ATTR extends Any> implements Context {
         int minGallop;
         int runCount = 0;
         private final int [] runStarts;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
@@ -22,14 +22,28 @@ import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class ByteRegionBinarySearchKernel {
-    public static RowSet binSearchMatch(
+    /**
+     * Performs a binary search on a given column region to find the positions (row keys) of specified sorted keys.
+     * The method returns the RowSet containing the matched row keys.
+     *
+     * @param region         The column region in which the search will be performed.
+     * @param firstKey       The first key in the column region to consider for the search.
+     * @param lastKey        The last key in the column region to consider for the search.
+     * @param sortColumn     A {@link SortColumn} object representing the sorting order of the column.
+     * @param searchValues   An array of keys to find within the column region.
+     *
+     * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
+     *
+     * @throws IllegalArgumentException If any input argument is invalid or null.
+     */
+    public static RowSet binarySearchMatch(
             ColumnRegionByte<?> region,
             long firstKey,
             final long lastKey,
             @NotNull final SortColumn sortColumn,
-            @NotNull final Object[] sortedKeys) {
+            @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        final byte[] unboxed = ArrayTypeUtils.getUnboxedByteArray(sortedKeys);
+        final byte[] unboxed = ArrayTypeUtils.getUnboxedByteArray(searchValues);
         if (order == SortColumn.Order.DESCENDING) {
             try (final ByteTimsortDescendingKernel.ByteSortKernelContext<Any> context =
                          ByteTimsortDescendingKernel.createContext(unboxed.length)) {
@@ -44,7 +58,7 @@ public class ByteRegionBinarySearchKernel {
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
         for (final byte toFind : unboxed) {
-            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+            final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
                 firstKey = lastFound + 1;
@@ -64,7 +78,7 @@ public class ByteRegionBinarySearchKernel {
      * @param toFind        the element to find
      * @return the last key in the found range.
      */
-    private static long binSearchSingle(
+    private static long binarySearchSingle(
             @NotNull final ColumnRegionByte<?> region,
             @NotNull final RowSetBuilderSequential builder,
             final long firstKey,
@@ -72,7 +86,7 @@ public class ByteRegionBinarySearchKernel {
             SortColumn.Order sortDirection,
             final byte toFind) {
         // Find the beginning of the range
-        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        long matchStart = binarySearchRange(region, toFind, firstKey, lastKey, sortDirection, -1);
         if (matchStart < 0) {
             return -1;
         }
@@ -80,14 +94,30 @@ public class ByteRegionBinarySearchKernel {
         // Now we have to locate the actual start and end of the range.
         long matchEnd = matchStart;
         if (matchStart < lastKey && ByteComparisons.eq(region.getByte(matchStart + 1),toFind)) {
-            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+            matchEnd = binarySearchRange(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
         }
 
         builder.appendRange(matchStart, matchEnd);
         return matchEnd;
     }
 
-    private static long findRangePart(
+    /**
+     * Performs a binary search on a specified column region to find a byteacter within a given range.
+     * The method returns the row key where the byteacter was found. If the byteacter is not found, it returns -1.
+     *
+     * @param region          The column region in which the search will be performed.
+     * @param toFind          The byteacter to find within the column region.
+     * @param start           The first row key in the column region to consider for the search.
+     * @param end             The last row key in the column region to consider for the search.
+     * @param sortDirection   An enum specifying the sorting direction of the column.
+     * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
+     *                        negative for backward search.
+     *
+     * @return                The row key where the specified byteacter was found. If not found, returns -1.
+     *
+     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     */
+    private static long binarySearchRange(
             @NotNull final ColumnRegionByte<?> region,
             final byte toFind,
             long start,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableByteChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.ByteTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.ByteTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionByte;
+import io.deephaven.util.compare.ByteComparisons;
+import io.deephaven.util.type.ArrayTypeUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class ByteRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionByte<?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        final byte[] unboxed = ArrayTypeUtils.getUnboxedByteArray(sortedKeys);
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final ByteTimsortDescendingKernel.ByteSortKernelContext<Any> context =
+                         ByteTimsortDescendingKernel.createContext(unboxed.length)) {
+                context.sort(WritableByteChunk.writableChunkWrap(unboxed));
+            }
+        } else {
+            try (final ByteTimsortKernel.ByteSortKernelContext<Any> context =
+                         ByteTimsortKernel.createContext(unboxed.length)) {
+                context.sort(WritableByteChunk.writableChunkWrap(unboxed));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final byte toFind : unboxed) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionByte<?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final byte toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && ByteComparisons.eq(region.getByte(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionByte<?> region,
+            final byte toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final byte curVal = region.getByte(pivot);
+            final int comparison = ByteComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
@@ -33,8 +33,6 @@ public class ByteRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionByte<?> region,
@@ -102,20 +100,18 @@ public class ByteRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a byteacter within a given range.
-     * The method returns the row key where the byteacter was found. If the byteacter is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a byte within a given range.
+     * The method returns the row key where the byte was found. If the byte is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The byteacter to find within the column region.
+     * @param toFind          The byte to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified byteacter was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified byte was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionByte<?> region,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableCharChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.CharTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.CharTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionChar;
+import io.deephaven.util.compare.CharComparisons;
+import io.deephaven.util.type.ArrayTypeUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class CharRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionChar<?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        final char[] unboxed = ArrayTypeUtils.getUnboxedCharArray(sortedKeys);
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final CharTimsortDescendingKernel.CharSortKernelContext<Any> context =
+                         CharTimsortDescendingKernel.createContext(unboxed.length)) {
+                context.sort(WritableCharChunk.writableChunkWrap(unboxed));
+            }
+        } else {
+            try (final CharTimsortKernel.CharSortKernelContext<Any> context =
+                         CharTimsortKernel.createContext(unboxed.length)) {
+                context.sort(WritableCharChunk.writableChunkWrap(unboxed));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final char toFind : unboxed) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionChar<?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final char toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && CharComparisons.eq(region.getChar(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionChar<?> region,
+            final char toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final char curVal = region.getChar(pivot);
+            final int comparison = CharComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
@@ -28,8 +28,6 @@ public class CharRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionChar<?> region,
@@ -97,20 +95,18 @@ public class CharRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a character within a given range.
-     * The method returns the row key where the character was found. If the character is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a char within a given range.
+     * The method returns the row key where the char was found. If the char is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The character to find within the column region.
+     * @param toFind          The char to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified character was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified char was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionChar<?> region,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
@@ -17,14 +17,28 @@ import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class CharRegionBinarySearchKernel {
-    public static RowSet binSearchMatch(
+    /**
+     * Performs a binary search on a given column region to find the positions (row keys) of specified sorted keys.
+     * The method returns the RowSet containing the matched row keys.
+     *
+     * @param region         The column region in which the search will be performed.
+     * @param firstKey       The first key in the column region to consider for the search.
+     * @param lastKey        The last key in the column region to consider for the search.
+     * @param sortColumn     A {@link SortColumn} object representing the sorting order of the column.
+     * @param searchValues   An array of keys to find within the column region.
+     *
+     * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
+     *
+     * @throws IllegalArgumentException If any input argument is invalid or null.
+     */
+    public static RowSet binarySearchMatch(
             ColumnRegionChar<?> region,
             long firstKey,
             final long lastKey,
             @NotNull final SortColumn sortColumn,
-            @NotNull final Object[] sortedKeys) {
+            @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        final char[] unboxed = ArrayTypeUtils.getUnboxedCharArray(sortedKeys);
+        final char[] unboxed = ArrayTypeUtils.getUnboxedCharArray(searchValues);
         if (order == SortColumn.Order.DESCENDING) {
             try (final CharTimsortDescendingKernel.CharSortKernelContext<Any> context =
                          CharTimsortDescendingKernel.createContext(unboxed.length)) {
@@ -39,7 +53,7 @@ public class CharRegionBinarySearchKernel {
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
         for (final char toFind : unboxed) {
-            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+            final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
                 firstKey = lastFound + 1;
@@ -59,7 +73,7 @@ public class CharRegionBinarySearchKernel {
      * @param toFind        the element to find
      * @return the last key in the found range.
      */
-    private static long binSearchSingle(
+    private static long binarySearchSingle(
             @NotNull final ColumnRegionChar<?> region,
             @NotNull final RowSetBuilderSequential builder,
             final long firstKey,
@@ -67,7 +81,7 @@ public class CharRegionBinarySearchKernel {
             SortColumn.Order sortDirection,
             final char toFind) {
         // Find the beginning of the range
-        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        long matchStart = binarySearchRange(region, toFind, firstKey, lastKey, sortDirection, -1);
         if (matchStart < 0) {
             return -1;
         }
@@ -75,14 +89,30 @@ public class CharRegionBinarySearchKernel {
         // Now we have to locate the actual start and end of the range.
         long matchEnd = matchStart;
         if (matchStart < lastKey && CharComparisons.eq(region.getChar(matchStart + 1),toFind)) {
-            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+            matchEnd = binarySearchRange(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
         }
 
         builder.appendRange(matchStart, matchEnd);
         return matchEnd;
     }
 
-    private static long findRangePart(
+    /**
+     * Performs a binary search on a specified column region to find a character within a given range.
+     * The method returns the row key where the character was found. If the character is not found, it returns -1.
+     *
+     * @param region          The column region in which the search will be performed.
+     * @param toFind          The character to find within the column region.
+     * @param start           The first row key in the column region to consider for the search.
+     * @param end             The last row key in the column region to consider for the search.
+     * @param sortDirection   An enum specifying the sorting direction of the column.
+     * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
+     *                        negative for backward search.
+     *
+     * @return                The row key where the specified character was found. If not found, returns -1.
+     *
+     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     */
+    private static long binarySearchRange(
             @NotNull final ColumnRegionChar<?> region,
             final char toFind,
             long start,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
@@ -33,8 +33,6 @@ public class DoubleRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionDouble<?> region,
@@ -102,20 +100,18 @@ public class DoubleRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a doubleacter within a given range.
-     * The method returns the row key where the doubleacter was found. If the doubleacter is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a double within a given range.
+     * The method returns the row key where the double was found. If the double is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The doubleacter to find within the column region.
+     * @param toFind          The double to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified doubleacter was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified double was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionDouble<?> region,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableDoubleChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.DoubleTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.DoubleTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionDouble;
+import io.deephaven.util.compare.DoubleComparisons;
+import io.deephaven.util.type.ArrayTypeUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class DoubleRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionDouble<?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        final double[] unboxed = ArrayTypeUtils.getUnboxedDoubleArray(sortedKeys);
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final DoubleTimsortDescendingKernel.DoubleSortKernelContext<Any> context =
+                         DoubleTimsortDescendingKernel.createContext(unboxed.length)) {
+                context.sort(WritableDoubleChunk.writableChunkWrap(unboxed));
+            }
+        } else {
+            try (final DoubleTimsortKernel.DoubleSortKernelContext<Any> context =
+                         DoubleTimsortKernel.createContext(unboxed.length)) {
+                context.sort(WritableDoubleChunk.writableChunkWrap(unboxed));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final double toFind : unboxed) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionDouble<?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final double toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && DoubleComparisons.eq(region.getDouble(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionDouble<?> region,
+            final double toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final double curVal = region.getDouble(pivot);
+            final int comparison = DoubleComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
@@ -22,14 +22,28 @@ import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class DoubleRegionBinarySearchKernel {
-    public static RowSet binSearchMatch(
+    /**
+     * Performs a binary search on a given column region to find the positions (row keys) of specified sorted keys.
+     * The method returns the RowSet containing the matched row keys.
+     *
+     * @param region         The column region in which the search will be performed.
+     * @param firstKey       The first key in the column region to consider for the search.
+     * @param lastKey        The last key in the column region to consider for the search.
+     * @param sortColumn     A {@link SortColumn} object representing the sorting order of the column.
+     * @param searchValues   An array of keys to find within the column region.
+     *
+     * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
+     *
+     * @throws IllegalArgumentException If any input argument is invalid or null.
+     */
+    public static RowSet binarySearchMatch(
             ColumnRegionDouble<?> region,
             long firstKey,
             final long lastKey,
             @NotNull final SortColumn sortColumn,
-            @NotNull final Object[] sortedKeys) {
+            @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        final double[] unboxed = ArrayTypeUtils.getUnboxedDoubleArray(sortedKeys);
+        final double[] unboxed = ArrayTypeUtils.getUnboxedDoubleArray(searchValues);
         if (order == SortColumn.Order.DESCENDING) {
             try (final DoubleTimsortDescendingKernel.DoubleSortKernelContext<Any> context =
                          DoubleTimsortDescendingKernel.createContext(unboxed.length)) {
@@ -44,7 +58,7 @@ public class DoubleRegionBinarySearchKernel {
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
         for (final double toFind : unboxed) {
-            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+            final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
                 firstKey = lastFound + 1;
@@ -64,7 +78,7 @@ public class DoubleRegionBinarySearchKernel {
      * @param toFind        the element to find
      * @return the last key in the found range.
      */
-    private static long binSearchSingle(
+    private static long binarySearchSingle(
             @NotNull final ColumnRegionDouble<?> region,
             @NotNull final RowSetBuilderSequential builder,
             final long firstKey,
@@ -72,7 +86,7 @@ public class DoubleRegionBinarySearchKernel {
             SortColumn.Order sortDirection,
             final double toFind) {
         // Find the beginning of the range
-        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        long matchStart = binarySearchRange(region, toFind, firstKey, lastKey, sortDirection, -1);
         if (matchStart < 0) {
             return -1;
         }
@@ -80,14 +94,30 @@ public class DoubleRegionBinarySearchKernel {
         // Now we have to locate the actual start and end of the range.
         long matchEnd = matchStart;
         if (matchStart < lastKey && DoubleComparisons.eq(region.getDouble(matchStart + 1),toFind)) {
-            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+            matchEnd = binarySearchRange(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
         }
 
         builder.appendRange(matchStart, matchEnd);
         return matchEnd;
     }
 
-    private static long findRangePart(
+    /**
+     * Performs a binary search on a specified column region to find a doubleacter within a given range.
+     * The method returns the row key where the doubleacter was found. If the doubleacter is not found, it returns -1.
+     *
+     * @param region          The column region in which the search will be performed.
+     * @param toFind          The doubleacter to find within the column region.
+     * @param start           The first row key in the column region to consider for the search.
+     * @param end             The last row key in the column region to consider for the search.
+     * @param sortDirection   An enum specifying the sorting direction of the column.
+     * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
+     *                        negative for backward search.
+     *
+     * @return                The row key where the specified doubleacter was found. If not found, returns -1.
+     *
+     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     */
+    private static long binarySearchRange(
             @NotNull final ColumnRegionDouble<?> region,
             final double toFind,
             long start,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
@@ -33,8 +33,6 @@ public class FloatRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionFloat<?> region,
@@ -102,20 +100,18 @@ public class FloatRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a floatacter within a given range.
-     * The method returns the row key where the floatacter was found. If the floatacter is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a float within a given range.
+     * The method returns the row key where the float was found. If the float is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The floatacter to find within the column region.
+     * @param toFind          The float to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified floatacter was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified float was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionFloat<?> region,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableFloatChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.FloatTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.FloatTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionFloat;
+import io.deephaven.util.compare.FloatComparisons;
+import io.deephaven.util.type.ArrayTypeUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class FloatRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionFloat<?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        final float[] unboxed = ArrayTypeUtils.getUnboxedFloatArray(sortedKeys);
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final FloatTimsortDescendingKernel.FloatSortKernelContext<Any> context =
+                         FloatTimsortDescendingKernel.createContext(unboxed.length)) {
+                context.sort(WritableFloatChunk.writableChunkWrap(unboxed));
+            }
+        } else {
+            try (final FloatTimsortKernel.FloatSortKernelContext<Any> context =
+                         FloatTimsortKernel.createContext(unboxed.length)) {
+                context.sort(WritableFloatChunk.writableChunkWrap(unboxed));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final float toFind : unboxed) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionFloat<?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final float toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && FloatComparisons.eq(region.getFloat(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionFloat<?> region,
+            final float toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final float curVal = region.getFloat(pivot);
+            final int comparison = FloatComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
@@ -22,14 +22,28 @@ import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class FloatRegionBinarySearchKernel {
-    public static RowSet binSearchMatch(
+    /**
+     * Performs a binary search on a given column region to find the positions (row keys) of specified sorted keys.
+     * The method returns the RowSet containing the matched row keys.
+     *
+     * @param region         The column region in which the search will be performed.
+     * @param firstKey       The first key in the column region to consider for the search.
+     * @param lastKey        The last key in the column region to consider for the search.
+     * @param sortColumn     A {@link SortColumn} object representing the sorting order of the column.
+     * @param searchValues   An array of keys to find within the column region.
+     *
+     * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
+     *
+     * @throws IllegalArgumentException If any input argument is invalid or null.
+     */
+    public static RowSet binarySearchMatch(
             ColumnRegionFloat<?> region,
             long firstKey,
             final long lastKey,
             @NotNull final SortColumn sortColumn,
-            @NotNull final Object[] sortedKeys) {
+            @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        final float[] unboxed = ArrayTypeUtils.getUnboxedFloatArray(sortedKeys);
+        final float[] unboxed = ArrayTypeUtils.getUnboxedFloatArray(searchValues);
         if (order == SortColumn.Order.DESCENDING) {
             try (final FloatTimsortDescendingKernel.FloatSortKernelContext<Any> context =
                          FloatTimsortDescendingKernel.createContext(unboxed.length)) {
@@ -44,7 +58,7 @@ public class FloatRegionBinarySearchKernel {
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
         for (final float toFind : unboxed) {
-            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+            final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
                 firstKey = lastFound + 1;
@@ -64,7 +78,7 @@ public class FloatRegionBinarySearchKernel {
      * @param toFind        the element to find
      * @return the last key in the found range.
      */
-    private static long binSearchSingle(
+    private static long binarySearchSingle(
             @NotNull final ColumnRegionFloat<?> region,
             @NotNull final RowSetBuilderSequential builder,
             final long firstKey,
@@ -72,7 +86,7 @@ public class FloatRegionBinarySearchKernel {
             SortColumn.Order sortDirection,
             final float toFind) {
         // Find the beginning of the range
-        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        long matchStart = binarySearchRange(region, toFind, firstKey, lastKey, sortDirection, -1);
         if (matchStart < 0) {
             return -1;
         }
@@ -80,14 +94,30 @@ public class FloatRegionBinarySearchKernel {
         // Now we have to locate the actual start and end of the range.
         long matchEnd = matchStart;
         if (matchStart < lastKey && FloatComparisons.eq(region.getFloat(matchStart + 1),toFind)) {
-            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+            matchEnd = binarySearchRange(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
         }
 
         builder.appendRange(matchStart, matchEnd);
         return matchEnd;
     }
 
-    private static long findRangePart(
+    /**
+     * Performs a binary search on a specified column region to find a floatacter within a given range.
+     * The method returns the row key where the floatacter was found. If the floatacter is not found, it returns -1.
+     *
+     * @param region          The column region in which the search will be performed.
+     * @param toFind          The floatacter to find within the column region.
+     * @param start           The first row key in the column region to consider for the search.
+     * @param end             The last row key in the column region to consider for the search.
+     * @param sortDirection   An enum specifying the sorting direction of the column.
+     * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
+     *                        negative for backward search.
+     *
+     * @return                The row key where the specified floatacter was found. If not found, returns -1.
+     *
+     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     */
+    private static long binarySearchRange(
             @NotNull final ColumnRegionFloat<?> region,
             final float toFind,
             long start,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
@@ -33,8 +33,6 @@ public class IntRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionInt<?> region,
@@ -102,20 +100,18 @@ public class IntRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a intacter within a given range.
-     * The method returns the row key where the intacter was found. If the intacter is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a int within a given range.
+     * The method returns the row key where the int was found. If the int is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The intacter to find within the column region.
+     * @param toFind          The int to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified intacter was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified int was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionInt<?> region,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.IntTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.IntTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionInt;
+import io.deephaven.util.compare.IntComparisons;
+import io.deephaven.util.type.ArrayTypeUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class IntRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionInt<?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        final int[] unboxed = ArrayTypeUtils.getUnboxedIntArray(sortedKeys);
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final IntTimsortDescendingKernel.IntSortKernelContext<Any> context =
+                         IntTimsortDescendingKernel.createContext(unboxed.length)) {
+                context.sort(WritableIntChunk.writableChunkWrap(unboxed));
+            }
+        } else {
+            try (final IntTimsortKernel.IntSortKernelContext<Any> context =
+                         IntTimsortKernel.createContext(unboxed.length)) {
+                context.sort(WritableIntChunk.writableChunkWrap(unboxed));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final int toFind : unboxed) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionInt<?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final int toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && IntComparisons.eq(region.getInt(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionInt<?> region,
+            final int toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final int curVal = region.getInt(pivot);
+            final int comparison = IntComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
@@ -22,14 +22,28 @@ import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class IntRegionBinarySearchKernel {
-    public static RowSet binSearchMatch(
+    /**
+     * Performs a binary search on a given column region to find the positions (row keys) of specified sorted keys.
+     * The method returns the RowSet containing the matched row keys.
+     *
+     * @param region         The column region in which the search will be performed.
+     * @param firstKey       The first key in the column region to consider for the search.
+     * @param lastKey        The last key in the column region to consider for the search.
+     * @param sortColumn     A {@link SortColumn} object representing the sorting order of the column.
+     * @param searchValues   An array of keys to find within the column region.
+     *
+     * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
+     *
+     * @throws IllegalArgumentException If any input argument is invalid or null.
+     */
+    public static RowSet binarySearchMatch(
             ColumnRegionInt<?> region,
             long firstKey,
             final long lastKey,
             @NotNull final SortColumn sortColumn,
-            @NotNull final Object[] sortedKeys) {
+            @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        final int[] unboxed = ArrayTypeUtils.getUnboxedIntArray(sortedKeys);
+        final int[] unboxed = ArrayTypeUtils.getUnboxedIntArray(searchValues);
         if (order == SortColumn.Order.DESCENDING) {
             try (final IntTimsortDescendingKernel.IntSortKernelContext<Any> context =
                          IntTimsortDescendingKernel.createContext(unboxed.length)) {
@@ -44,7 +58,7 @@ public class IntRegionBinarySearchKernel {
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
         for (final int toFind : unboxed) {
-            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+            final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
                 firstKey = lastFound + 1;
@@ -64,7 +78,7 @@ public class IntRegionBinarySearchKernel {
      * @param toFind        the element to find
      * @return the last key in the found range.
      */
-    private static long binSearchSingle(
+    private static long binarySearchSingle(
             @NotNull final ColumnRegionInt<?> region,
             @NotNull final RowSetBuilderSequential builder,
             final long firstKey,
@@ -72,7 +86,7 @@ public class IntRegionBinarySearchKernel {
             SortColumn.Order sortDirection,
             final int toFind) {
         // Find the beginning of the range
-        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        long matchStart = binarySearchRange(region, toFind, firstKey, lastKey, sortDirection, -1);
         if (matchStart < 0) {
             return -1;
         }
@@ -80,14 +94,30 @@ public class IntRegionBinarySearchKernel {
         // Now we have to locate the actual start and end of the range.
         long matchEnd = matchStart;
         if (matchStart < lastKey && IntComparisons.eq(region.getInt(matchStart + 1),toFind)) {
-            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+            matchEnd = binarySearchRange(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
         }
 
         builder.appendRange(matchStart, matchEnd);
         return matchEnd;
     }
 
-    private static long findRangePart(
+    /**
+     * Performs a binary search on a specified column region to find a intacter within a given range.
+     * The method returns the row key where the intacter was found. If the intacter is not found, it returns -1.
+     *
+     * @param region          The column region in which the search will be performed.
+     * @param toFind          The intacter to find within the column region.
+     * @param start           The first row key in the column region to consider for the search.
+     * @param end             The last row key in the column region to consider for the search.
+     * @param sortDirection   An enum specifying the sorting direction of the column.
+     * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
+     *                        negative for backward search.
+     *
+     * @return                The row key where the specified intacter was found. If not found, returns -1.
+     *
+     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     */
+    private static long binarySearchRange(
             @NotNull final ColumnRegionInt<?> region,
             final int toFind,
             long start,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.LongTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.LongTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionLong;
+import io.deephaven.util.compare.LongComparisons;
+import io.deephaven.util.type.ArrayTypeUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class LongRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionLong<?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        final long[] unboxed = ArrayTypeUtils.getUnboxedLongArray(sortedKeys);
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final LongTimsortDescendingKernel.LongSortKernelContext<Any> context =
+                         LongTimsortDescendingKernel.createContext(unboxed.length)) {
+                context.sort(WritableLongChunk.writableChunkWrap(unboxed));
+            }
+        } else {
+            try (final LongTimsortKernel.LongSortKernelContext<Any> context =
+                         LongTimsortKernel.createContext(unboxed.length)) {
+                context.sort(WritableLongChunk.writableChunkWrap(unboxed));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final long toFind : unboxed) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionLong<?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final long toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && LongComparisons.eq(region.getLong(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionLong<?> region,
+            final long toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final long curVal = region.getLong(pivot);
+            final int comparison = LongComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
@@ -22,14 +22,28 @@ import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class LongRegionBinarySearchKernel {
-    public static RowSet binSearchMatch(
+    /**
+     * Performs a binary search on a given column region to find the positions (row keys) of specified sorted keys.
+     * The method returns the RowSet containing the matched row keys.
+     *
+     * @param region         The column region in which the search will be performed.
+     * @param firstKey       The first key in the column region to consider for the search.
+     * @param lastKey        The last key in the column region to consider for the search.
+     * @param sortColumn     A {@link SortColumn} object representing the sorting order of the column.
+     * @param searchValues   An array of keys to find within the column region.
+     *
+     * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
+     *
+     * @throws IllegalArgumentException If any input argument is invalid or null.
+     */
+    public static RowSet binarySearchMatch(
             ColumnRegionLong<?> region,
             long firstKey,
             final long lastKey,
             @NotNull final SortColumn sortColumn,
-            @NotNull final Object[] sortedKeys) {
+            @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        final long[] unboxed = ArrayTypeUtils.getUnboxedLongArray(sortedKeys);
+        final long[] unboxed = ArrayTypeUtils.getUnboxedLongArray(searchValues);
         if (order == SortColumn.Order.DESCENDING) {
             try (final LongTimsortDescendingKernel.LongSortKernelContext<Any> context =
                          LongTimsortDescendingKernel.createContext(unboxed.length)) {
@@ -44,7 +58,7 @@ public class LongRegionBinarySearchKernel {
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
         for (final long toFind : unboxed) {
-            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+            final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
                 firstKey = lastFound + 1;
@@ -64,7 +78,7 @@ public class LongRegionBinarySearchKernel {
      * @param toFind        the element to find
      * @return the last key in the found range.
      */
-    private static long binSearchSingle(
+    private static long binarySearchSingle(
             @NotNull final ColumnRegionLong<?> region,
             @NotNull final RowSetBuilderSequential builder,
             final long firstKey,
@@ -72,7 +86,7 @@ public class LongRegionBinarySearchKernel {
             SortColumn.Order sortDirection,
             final long toFind) {
         // Find the beginning of the range
-        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        long matchStart = binarySearchRange(region, toFind, firstKey, lastKey, sortDirection, -1);
         if (matchStart < 0) {
             return -1;
         }
@@ -80,14 +94,30 @@ public class LongRegionBinarySearchKernel {
         // Now we have to locate the actual start and end of the range.
         long matchEnd = matchStart;
         if (matchStart < lastKey && LongComparisons.eq(region.getLong(matchStart + 1),toFind)) {
-            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+            matchEnd = binarySearchRange(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
         }
 
         builder.appendRange(matchStart, matchEnd);
         return matchEnd;
     }
 
-    private static long findRangePart(
+    /**
+     * Performs a binary search on a specified column region to find a longacter within a given range.
+     * The method returns the row key where the longacter was found. If the longacter is not found, it returns -1.
+     *
+     * @param region          The column region in which the search will be performed.
+     * @param toFind          The longacter to find within the column region.
+     * @param start           The first row key in the column region to consider for the search.
+     * @param end             The last row key in the column region to consider for the search.
+     * @param sortDirection   An enum specifying the sorting direction of the column.
+     * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
+     *                        negative for backward search.
+     *
+     * @return                The row key where the specified longacter was found. If not found, returns -1.
+     *
+     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     */
+    private static long binarySearchRange(
             @NotNull final ColumnRegionLong<?> region,
             final long toFind,
             long start,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
@@ -33,8 +33,6 @@ public class LongRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionLong<?> region,
@@ -102,20 +100,18 @@ public class LongRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a longacter within a given range.
-     * The method returns the row key where the longacter was found. If the longacter is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a long within a given range.
+     * The method returns the row key where the long was found. If the long is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The longacter to find within the column region.
+     * @param toFind          The long to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified longacter was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified long was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionLong<?> region,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
@@ -21,14 +21,28 @@ import io.deephaven.util.compare.ObjectComparisons;
 import org.jetbrains.annotations.NotNull;
 
 public class ObjectRegionBinarySearchKernel {
-    public static RowSet binSearchMatch(
+    /**
+     * Performs a binary search on a given column region to find the positions (row keys) of specified sorted keys.
+     * The method returns the RowSet containing the matched row keys.
+     *
+     * @param region         The column region in which the search will be performed.
+     * @param firstKey       The first key in the column region to consider for the search.
+     * @param lastKey        The last key in the column region to consider for the search.
+     * @param sortColumn     A {@link SortColumn} object representing the sorting order of the column.
+     * @param searchValues   An array of keys to find within the column region.
+     *
+     * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
+     *
+     * @throws IllegalArgumentException If any input argument is invalid or null.
+     */
+    public static RowSet binarySearchMatch(
             ColumnRegionObject<?, ?> region,
             long firstKey,
             final long lastKey,
             @NotNull final SortColumn sortColumn,
-            @NotNull final Object[] sortedKeys) {
+            @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        
+        final Object[] sortedKeys = ArrayTypeUtils.getUnboxedObjectArray(searchValues);
         if (order == SortColumn.Order.DESCENDING) {
             try (final ObjectTimsortDescendingKernel.ObjectSortKernelContext<Any> context =
                          ObjectTimsortDescendingKernel.createContext(sortedKeys.length)) {
@@ -43,7 +57,7 @@ public class ObjectRegionBinarySearchKernel {
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
         for (final Object toFind : sortedKeys) {
-            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+            final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
                 firstKey = lastFound + 1;
@@ -63,7 +77,7 @@ public class ObjectRegionBinarySearchKernel {
      * @param toFind        the element to find
      * @return the last key in the found range.
      */
-    private static long binSearchSingle(
+    private static long binarySearchSingle(
             @NotNull final ColumnRegionObject<?, ?> region,
             @NotNull final RowSetBuilderSequential builder,
             final long firstKey,
@@ -71,7 +85,7 @@ public class ObjectRegionBinarySearchKernel {
             SortColumn.Order sortDirection,
             final Object toFind) {
         // Find the beginning of the range
-        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        long matchStart = binarySearchRange(region, toFind, firstKey, lastKey, sortDirection, -1);
         if (matchStart < 0) {
             return -1;
         }
@@ -79,14 +93,30 @@ public class ObjectRegionBinarySearchKernel {
         // Now we have to locate the actual start and end of the range.
         long matchEnd = matchStart;
         if (matchStart < lastKey && ObjectComparisons.eq(region.getObject(matchStart + 1),toFind)) {
-            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+            matchEnd = binarySearchRange(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
         }
 
         builder.appendRange(matchStart, matchEnd);
         return matchEnd;
     }
 
-    private static long findRangePart(
+    /**
+     * Performs a binary search on a specified column region to find a Objectacter within a given range.
+     * The method returns the row key where the Objectacter was found. If the Objectacter is not found, it returns -1.
+     *
+     * @param region          The column region in which the search will be performed.
+     * @param toFind          The Objectacter to find within the column region.
+     * @param start           The first row key in the column region to consider for the search.
+     * @param end             The last row key in the column region to consider for the search.
+     * @param sortDirection   An enum specifying the sorting direction of the column.
+     * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
+     *                        negative for backward search.
+     *
+     * @return                The row key where the specified Objectacter was found. If not found, returns -1.
+     *
+     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     */
+    private static long binarySearchRange(
             @NotNull final ColumnRegionObject<?, ?> region,
             final Object toFind,
             long start,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
@@ -32,8 +32,6 @@ public class ObjectRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionObject<?, ?> region,
@@ -42,21 +40,21 @@ public class ObjectRegionBinarySearchKernel {
             @NotNull final SortColumn sortColumn,
             @NotNull final Object[] searchValues) {
         final SortColumn.Order order = sortColumn.order();
-        final Object[] sortedKeys = ArrayTypeUtils.getUnboxedObjectArray(searchValues);
+        
         if (order == SortColumn.Order.DESCENDING) {
             try (final ObjectTimsortDescendingKernel.ObjectSortKernelContext<Any> context =
-                         ObjectTimsortDescendingKernel.createContext(sortedKeys.length)) {
-                context.sort(WritableObjectChunk.writableChunkWrap(sortedKeys));
+                         ObjectTimsortDescendingKernel.createContext(searchValues.length)) {
+                context.sort(WritableObjectChunk.writableChunkWrap(searchValues));
             }
         } else {
             try (final ObjectTimsortKernel.ObjectSortKernelContext<Any> context =
-                         ObjectTimsortKernel.createContext(sortedKeys.length)) {
-                context.sort(WritableObjectChunk.writableChunkWrap(sortedKeys));
+                         ObjectTimsortKernel.createContext(searchValues.length)) {
+                context.sort(WritableObjectChunk.writableChunkWrap(searchValues));
             }
         }
 
         final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
-        for (final Object toFind : sortedKeys) {
+        for (final Object toFind : searchValues) {
             final long lastFound = binarySearchSingle(region, builder, firstKey, lastKey, order, toFind);
 
             if (lastFound >= 0) {
@@ -101,20 +99,18 @@ public class ObjectRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a Objectacter within a given range.
-     * The method returns the row key where the Objectacter was found. If the Objectacter is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a Object within a given range.
+     * The method returns the row key where the Object was found. If the Object is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The Objectacter to find within the column region.
+     * @param toFind          The Object to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified Objectacter was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified Object was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionObject<?, ?> region,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.ObjectTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.ObjectTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionObject;
+import io.deephaven.util.compare.ObjectComparisons;
+import org.jetbrains.annotations.NotNull;
+
+public class ObjectRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionObject<?, ?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final ObjectTimsortDescendingKernel.ObjectSortKernelContext<Any> context =
+                         ObjectTimsortDescendingKernel.createContext(sortedKeys.length)) {
+                context.sort(WritableObjectChunk.writableChunkWrap(sortedKeys));
+            }
+        } else {
+            try (final ObjectTimsortKernel.ObjectSortKernelContext<Any> context =
+                         ObjectTimsortKernel.createContext(sortedKeys.length)) {
+                context.sort(WritableObjectChunk.writableChunkWrap(sortedKeys));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final Object toFind : sortedKeys) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionObject<?, ?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final Object toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && ObjectComparisons.eq(region.getObject(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionObject<?, ?> region,
+            final Object toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final Object curVal = region.getObject(pivot);
+            final int comparison = ObjectComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernel.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernel and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableShortChunk;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.impl.sort.timsort.ShortTimsortDescendingKernel;
+import io.deephaven.engine.table.impl.sort.timsort.ShortTimsortKernel;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionShort;
+import io.deephaven.util.compare.ShortComparisons;
+import io.deephaven.util.type.ArrayTypeUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class ShortRegionBinarySearchKernel {
+    public static RowSet binSearchMatch(
+            ColumnRegionShort<?> region,
+            long firstKey,
+            final long lastKey,
+            @NotNull final SortColumn sortColumn,
+            @NotNull final Object[] sortedKeys) {
+        final SortColumn.Order order = sortColumn.order();
+        final short[] unboxed = ArrayTypeUtils.getUnboxedShortArray(sortedKeys);
+        if (order == SortColumn.Order.DESCENDING) {
+            try (final ShortTimsortDescendingKernel.ShortSortKernelContext<Any> context =
+                         ShortTimsortDescendingKernel.createContext(unboxed.length)) {
+                context.sort(WritableShortChunk.writableChunkWrap(unboxed));
+            }
+        } else {
+            try (final ShortTimsortKernel.ShortSortKernelContext<Any> context =
+                         ShortTimsortKernel.createContext(unboxed.length)) {
+                context.sort(WritableShortChunk.writableChunkWrap(unboxed));
+            }
+        }
+
+        final RowSetBuilderSequential builder = RowSetFactory.builderSequential();
+        for (final short toFind : unboxed) {
+            final long lastFound = binSearchSingle(region, builder, firstKey, lastKey, order, toFind);
+
+            if (lastFound >= 0) {
+                firstKey = lastFound + 1;
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Find the extents of the range containing the key to find, returning the last index found.
+     *
+     * @param builder       the builder to accumulate into
+     * @param firstKey      the key to start searching
+     * @param lastKey       the key to end searching
+     * @param sortDirection the sort direction of the column
+     * @param toFind        the element to find
+     * @return the last key in the found range.
+     */
+    private static long binSearchSingle(
+            @NotNull final ColumnRegionShort<?> region,
+            @NotNull final RowSetBuilderSequential builder,
+            final long firstKey,
+            final long lastKey,
+            SortColumn.Order sortDirection,
+            final short toFind) {
+        // Find the beginning of the range
+        long matchStart = findRangePart(region, toFind, firstKey, lastKey, sortDirection, -1);
+        if (matchStart < 0) {
+            return -1;
+        }
+
+        // Now we have to locate the actual start and end of the range.
+        long matchEnd = matchStart;
+        if (matchStart < lastKey && ShortComparisons.eq(region.getShort(matchStart + 1),toFind)) {
+            matchEnd = findRangePart(region, toFind, matchStart + 1, lastKey, sortDirection, 1);
+        }
+
+        builder.appendRange(matchStart, matchEnd);
+        return matchEnd;
+    }
+
+    private static long findRangePart(
+            @NotNull final ColumnRegionShort<?> region,
+            final short toFind,
+            long start,
+            long end,
+            final SortColumn.Order sortDirection,
+            final int rangeDirection) {
+        final int sortDirectionInt = sortDirection == SortColumn.Order.ASCENDING ? 1 : -1;
+        long matchStart = -1;
+        while (start <= end) {
+            long pivot = (start + end) >>> 1;
+            final short curVal = region.getShort(pivot);
+            final int comparison = ShortComparisons.compare(curVal, toFind) * sortDirectionInt;
+            if (comparison < 0) {
+                start = pivot + 1;
+            } else if (comparison == 0) {
+                matchStart = pivot;
+                if (rangeDirection > 0) {
+                    start = pivot + 1;
+                } else {
+                    end = pivot - 1;
+                }
+            } else {
+                end = pivot - 1;
+            }
+        }
+
+        return matchStart;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernel.java
@@ -33,8 +33,6 @@ public class ShortRegionBinarySearchKernel {
      * @param searchValues   An array of keys to find within the column region.
      *
      * @return               A {@link RowSet} containing the row keys where the sorted keys were found.
-     *
-     * @throws IllegalArgumentException If any input argument is invalid or null.
      */
     public static RowSet binarySearchMatch(
             ColumnRegionShort<?> region,
@@ -102,20 +100,18 @@ public class ShortRegionBinarySearchKernel {
     }
 
     /**
-     * Performs a binary search on a specified column region to find a shortacter within a given range.
-     * The method returns the row key where the shortacter was found. If the shortacter is not found, it returns -1.
+     * Performs a binary search on a specified column region to find a short within a given range.
+     * The method returns the row key where the short was found. If the short is not found, it returns -1.
      *
      * @param region          The column region in which the search will be performed.
-     * @param toFind          The shortacter to find within the column region.
+     * @param toFind          The short to find within the column region.
      * @param start           The first row key in the column region to consider for the search.
      * @param end             The last row key in the column region to consider for the search.
      * @param sortDirection   An enum specifying the sorting direction of the column.
      * @param rangeDirection  An integer indicating the direction of the range search. Positive for forward search,
      *                        negative for backward search.
      *
-     * @return                The row key where the specified shortacter was found. If not found, returns -1.
-     *
-     * @throws IllegalArgumentException If any of the input arguments is invalid or null.
+     * @return                The row key where the specified short was found. If not found, returns -1.
      */
     private static long binarySearchRange(
             @NotNull final ColumnRegionShort<?> region,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernelTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernelTest and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionByte;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionByte;
+import io.deephaven.generic.region.AppendOnlyRegionAccessor;
+import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.compare.ByteComparisons;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntToLongFunction;
+
+@Category(ParallelTest.class)
+public class ByteRegionBinarySearchKernelTest {
+    private static final int[] SIZES = { 10, 100, 1000000 };
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private void randomizedTestRunner(
+            int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+
+        final Random rnd = new Random(seed);
+        final List<Byte> data = new ArrayList<>(size);
+        for (int ii = 0; ii < size; ++ii) {
+            data.add((byte) rnd.nextInt());
+        }
+        data.sort(ByteComparisons::compare);
+        if (inverted) {
+            java.util.Collections.reverse(data);
+        }
+        final ColumnRegionByte<Values> region = makeColumnRegionByte(data);
+        ColumnName columnName = ColumnName.of("test");
+        final SortColumn sortColumn = inverted ? SortColumn.desc(columnName) : SortColumn.asc(columnName);
+
+        for (int ii = 0; ii < size; ++ii) {
+            final byte value = data.get(ii);
+            final long startRow = Math.max(0, firstKey.applyAsLong(ii));
+            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            try (final RowSet valuesFound = ByteRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Byte[] { value }
+            )) {
+                if (startRow <= ii && ii <= endRow) {
+                    Assert.assertTrue("Expected to find " + value + " at index " + ii,
+                            valuesFound.containsRange(ii, ii));
+                } else {
+                    Assert.assertFalse("Index should not be populated.",
+                            valuesFound.containsRange(ii, ii));
+                }
+            }
+        }
+    }
+
+    private void randomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, false, firstKey, lastKey);
+    }
+
+    private void invertedRandomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, true, firstKey, lastKey);
+    }
+
+    @Test
+    public void testRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testRowIsAboveRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testRowUpperBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testRowInLowerRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testRowIsBelowRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowLowerBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowInUpperRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowIsRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testInvertedRowIsAboveRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowUpperBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInLowerRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsBelowRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowLowerBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInUpperRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    private static final int PAGE_SIZE = 1 << 16;
+    private static ColumnRegionByte<Values> makeColumnRegionByte(@NotNull final List<Byte> values) {
+        return new AppendOnlyFixedSizePageRegionByte<>(
+                RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK, PAGE_SIZE, new AppendOnlyRegionAccessor<>() {
+            @Override
+            public void readChunkPage(long firstRowPosition, int minimumSize, @NotNull WritableChunk<Values> destination) {
+                int finalSize = (int) Math.min(minimumSize, values.size() - firstRowPosition);
+                destination.setSize(finalSize);
+                for (int ii = 0; ii < finalSize; ++ii) {
+                    destination.asWritableByteChunk().set(ii, values.get((int) firstRowPosition + ii));
+                }
+            }
+
+            @Override
+            public long size() {
+                return values.size();
+            }
+        });
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernelTest.java
@@ -13,12 +13,16 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionByte;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionByte;
 import io.deephaven.generic.region.AppendOnlyRegionAccessor;
 import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.compare.ByteComparisons;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -27,6 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntToLongFunction;
@@ -34,6 +39,8 @@ import java.util.function.IntToLongFunction;
 @Category(ParallelTest.class)
 public class ByteRegionBinarySearchKernelTest {
     private static final int[] SIZES = { 10, 100, 1000000 };
+    private static final int MAX_FAILED_LOOKUPS = 1000;
+    private static final int NUM_NEGATIVE_LOOKUPS = 100;
 
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
@@ -42,11 +49,12 @@ public class ByteRegionBinarySearchKernelTest {
             int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
 
         final Random rnd = new Random(seed);
-        final List<Byte> data = new ArrayList<>(size);
+        final List<Byte> origData = new ArrayList<>(size);
         for (int ii = 0; ii < size; ++ii) {
-            data.add((byte) rnd.nextInt());
+            origData.add((byte) rnd.nextInt());
         }
-        data.sort(ByteComparisons::compare);
+        origData.sort(ByteComparisons::compare);
+        final List<Byte> data = new ArrayList<>(origData);
         if (inverted) {
             java.util.Collections.reverse(data);
         }
@@ -57,7 +65,7 @@ public class ByteRegionBinarySearchKernelTest {
         for (int ii = 0; ii < size; ++ii) {
             final byte value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
-            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
             try (final RowSet valuesFound = ByteRegionBinarySearchKernel.binSearchMatch(
                     region,
                     startRow, endRow,
@@ -71,6 +79,29 @@ public class ByteRegionBinarySearchKernelTest {
                     Assert.assertFalse("Index should not be populated.",
                             valuesFound.containsRange(ii, ii));
                 }
+            }
+        }
+
+        // Test negative lookups
+        int numFailedLookups = 0;
+        for (int ii = 0; ii < NUM_NEGATIVE_LOOKUPS && numFailedLookups < MAX_FAILED_LOOKUPS; ++ii) {
+            final byte value = (byte) rnd.nextInt();
+            if (value == QueryConstants.NULL_BYTE
+                    || Collections.binarySearch(origData, value, ByteComparisons::compare) >= 0) {
+                --ii;
+                ++numFailedLookups;
+                continue;
+            }
+
+            final long startRow = 0;
+            final long endRow = size - 1;
+            try (final RowSet valuesFound = ByteRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Byte[] { value }
+            )) {
+                Assert.assertTrue(valuesFound.isEmpty());
             }
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernelTest.java
@@ -13,9 +13,6 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionByte;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -66,7 +63,7 @@ public class ByteRegionBinarySearchKernelTest {
             final byte value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
             final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
-            try (final RowSet valuesFound = ByteRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = ByteRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,
@@ -95,7 +92,7 @@ public class ByteRegionBinarySearchKernelTest {
 
             final long startRow = 0;
             final long endRow = size - 1;
-            try (final RowSet valuesFound = ByteRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = ByteRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernelTest.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionChar;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionChar;
+import io.deephaven.generic.region.AppendOnlyRegionAccessor;
+import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.compare.CharComparisons;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntToLongFunction;
+
+@Category(ParallelTest.class)
+public class CharRegionBinarySearchKernelTest {
+    private static final int[] SIZES = { 10, 100, 1000000 };
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private void randomizedTestRunner(
+            int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+
+        final Random rnd = new Random(seed);
+        final List<Character> data = new ArrayList<>(size);
+        for (int ii = 0; ii < size; ++ii) {
+            data.add((char) rnd.nextInt());
+        }
+        data.sort(CharComparisons::compare);
+        if (inverted) {
+            java.util.Collections.reverse(data);
+        }
+        final ColumnRegionChar<Values> region = makeColumnRegionChar(data);
+        ColumnName columnName = ColumnName.of("test");
+        final SortColumn sortColumn = inverted ? SortColumn.desc(columnName) : SortColumn.asc(columnName);
+
+        for (int ii = 0; ii < size; ++ii) {
+            final char value = data.get(ii);
+            final long startRow = Math.max(0, firstKey.applyAsLong(ii));
+            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            try (final RowSet valuesFound = CharRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Character[] { value }
+            )) {
+                if (startRow <= ii && ii <= endRow) {
+                    Assert.assertTrue("Expected to find " + value + " at index " + ii,
+                            valuesFound.containsRange(ii, ii));
+                } else {
+                    Assert.assertFalse("Index should not be populated.",
+                            valuesFound.containsRange(ii, ii));
+                }
+            }
+        }
+    }
+
+    private void randomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, false, firstKey, lastKey);
+    }
+
+    private void invertedRandomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, true, firstKey, lastKey);
+    }
+
+    @Test
+    public void testRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testRowIsAboveRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testRowUpperBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testRowInLowerRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testRowIsBelowRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowLowerBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowInUpperRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowIsRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testInvertedRowIsAboveRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowUpperBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInLowerRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsBelowRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowLowerBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInUpperRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    private static final int PAGE_SIZE = 1 << 16;
+    private static ColumnRegionChar<Values> makeColumnRegionChar(@NotNull final List<Character> values) {
+        return new AppendOnlyFixedSizePageRegionChar<>(
+                RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK, PAGE_SIZE, new AppendOnlyRegionAccessor<>() {
+            @Override
+            public void readChunkPage(long firstRowPosition, int minimumSize, @NotNull WritableChunk<Values> destination) {
+                int finalSize = (int) Math.min(minimumSize, values.size() - firstRowPosition);
+                destination.setSize(finalSize);
+                for (int ii = 0; ii < finalSize; ++ii) {
+                    destination.asWritableCharChunk().set(ii, values.get((int) firstRowPosition + ii));
+                }
+            }
+
+            @Override
+            public long size() {
+                return values.size();
+            }
+        });
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernelTest.java
@@ -8,9 +8,6 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionChar;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -61,7 +58,7 @@ public class CharRegionBinarySearchKernelTest {
             final char value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
             final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
-            try (final RowSet valuesFound = CharRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = CharRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,
@@ -90,7 +87,7 @@ public class CharRegionBinarySearchKernelTest {
 
             final long startRow = 0;
             final long endRow = size - 1;
-            try (final RowSet valuesFound = CharRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = CharRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernelTest.java
@@ -8,12 +8,16 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionChar;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionChar;
 import io.deephaven.generic.region.AppendOnlyRegionAccessor;
 import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.compare.CharComparisons;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -22,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntToLongFunction;
@@ -29,6 +34,8 @@ import java.util.function.IntToLongFunction;
 @Category(ParallelTest.class)
 public class CharRegionBinarySearchKernelTest {
     private static final int[] SIZES = { 10, 100, 1000000 };
+    private static final int MAX_FAILED_LOOKUPS = 1000;
+    private static final int NUM_NEGATIVE_LOOKUPS = 100;
 
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
@@ -37,11 +44,12 @@ public class CharRegionBinarySearchKernelTest {
             int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
 
         final Random rnd = new Random(seed);
-        final List<Character> data = new ArrayList<>(size);
+        final List<Character> origData = new ArrayList<>(size);
         for (int ii = 0; ii < size; ++ii) {
-            data.add((char) rnd.nextInt());
+            origData.add((char) rnd.nextInt());
         }
-        data.sort(CharComparisons::compare);
+        origData.sort(CharComparisons::compare);
+        final List<Character> data = new ArrayList<>(origData);
         if (inverted) {
             java.util.Collections.reverse(data);
         }
@@ -52,7 +60,7 @@ public class CharRegionBinarySearchKernelTest {
         for (int ii = 0; ii < size; ++ii) {
             final char value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
-            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
             try (final RowSet valuesFound = CharRegionBinarySearchKernel.binSearchMatch(
                     region,
                     startRow, endRow,
@@ -66,6 +74,29 @@ public class CharRegionBinarySearchKernelTest {
                     Assert.assertFalse("Index should not be populated.",
                             valuesFound.containsRange(ii, ii));
                 }
+            }
+        }
+
+        // Test negative lookups
+        int numFailedLookups = 0;
+        for (int ii = 0; ii < NUM_NEGATIVE_LOOKUPS && numFailedLookups < MAX_FAILED_LOOKUPS; ++ii) {
+            final char value = (char) rnd.nextInt();
+            if (value == QueryConstants.NULL_CHAR
+                    || Collections.binarySearch(origData, value, CharComparisons::compare) >= 0) {
+                --ii;
+                ++numFailedLookups;
+                continue;
+            }
+
+            final long startRow = 0;
+            final long endRow = size - 1;
+            try (final RowSet valuesFound = CharRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Character[] { value }
+            )) {
+                Assert.assertTrue(valuesFound.isEmpty());
             }
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernelTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernelTest and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionDouble;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionDouble;
+import io.deephaven.generic.region.AppendOnlyRegionAccessor;
+import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.compare.DoubleComparisons;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntToLongFunction;
+
+@Category(ParallelTest.class)
+public class DoubleRegionBinarySearchKernelTest {
+    private static final int[] SIZES = { 10, 100, 1000000 };
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private void randomizedTestRunner(
+            int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+
+        final Random rnd = new Random(seed);
+        final List<Double> data = new ArrayList<>(size);
+        for (int ii = 0; ii < size; ++ii) {
+            data.add((double) rnd.nextInt());
+        }
+        data.sort(DoubleComparisons::compare);
+        if (inverted) {
+            java.util.Collections.reverse(data);
+        }
+        final ColumnRegionDouble<Values> region = makeColumnRegionDouble(data);
+        ColumnName columnName = ColumnName.of("test");
+        final SortColumn sortColumn = inverted ? SortColumn.desc(columnName) : SortColumn.asc(columnName);
+
+        for (int ii = 0; ii < size; ++ii) {
+            final double value = data.get(ii);
+            final long startRow = Math.max(0, firstKey.applyAsLong(ii));
+            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            try (final RowSet valuesFound = DoubleRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Double[] { value }
+            )) {
+                if (startRow <= ii && ii <= endRow) {
+                    Assert.assertTrue("Expected to find " + value + " at index " + ii,
+                            valuesFound.containsRange(ii, ii));
+                } else {
+                    Assert.assertFalse("Index should not be populated.",
+                            valuesFound.containsRange(ii, ii));
+                }
+            }
+        }
+    }
+
+    private void randomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, false, firstKey, lastKey);
+    }
+
+    private void invertedRandomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, true, firstKey, lastKey);
+    }
+
+    @Test
+    public void testRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testRowIsAboveRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testRowUpperBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testRowInLowerRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testRowIsBelowRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowLowerBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowInUpperRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowIsRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testInvertedRowIsAboveRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowUpperBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInLowerRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsBelowRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowLowerBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInUpperRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    private static final int PAGE_SIZE = 1 << 16;
+    private static ColumnRegionDouble<Values> makeColumnRegionDouble(@NotNull final List<Double> values) {
+        return new AppendOnlyFixedSizePageRegionDouble<>(
+                RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK, PAGE_SIZE, new AppendOnlyRegionAccessor<>() {
+            @Override
+            public void readChunkPage(long firstRowPosition, int minimumSize, @NotNull WritableChunk<Values> destination) {
+                int finalSize = (int) Math.min(minimumSize, values.size() - firstRowPosition);
+                destination.setSize(finalSize);
+                for (int ii = 0; ii < finalSize; ++ii) {
+                    destination.asWritableDoubleChunk().set(ii, values.get((int) firstRowPosition + ii));
+                }
+            }
+
+            @Override
+            public long size() {
+                return values.size();
+            }
+        });
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernelTest.java
@@ -13,9 +13,6 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionDouble;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -66,7 +63,7 @@ public class DoubleRegionBinarySearchKernelTest {
             final double value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
             final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
-            try (final RowSet valuesFound = DoubleRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = DoubleRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,
@@ -95,7 +92,7 @@ public class DoubleRegionBinarySearchKernelTest {
 
             final long startRow = 0;
             final long endRow = size - 1;
-            try (final RowSet valuesFound = DoubleRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = DoubleRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernelTest.java
@@ -13,12 +13,16 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionDouble;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionDouble;
 import io.deephaven.generic.region.AppendOnlyRegionAccessor;
 import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.compare.DoubleComparisons;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -27,6 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntToLongFunction;
@@ -34,6 +39,8 @@ import java.util.function.IntToLongFunction;
 @Category(ParallelTest.class)
 public class DoubleRegionBinarySearchKernelTest {
     private static final int[] SIZES = { 10, 100, 1000000 };
+    private static final int MAX_FAILED_LOOKUPS = 1000;
+    private static final int NUM_NEGATIVE_LOOKUPS = 100;
 
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
@@ -42,11 +49,12 @@ public class DoubleRegionBinarySearchKernelTest {
             int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
 
         final Random rnd = new Random(seed);
-        final List<Double> data = new ArrayList<>(size);
+        final List<Double> origData = new ArrayList<>(size);
         for (int ii = 0; ii < size; ++ii) {
-            data.add((double) rnd.nextInt());
+            origData.add((double) rnd.nextInt());
         }
-        data.sort(DoubleComparisons::compare);
+        origData.sort(DoubleComparisons::compare);
+        final List<Double> data = new ArrayList<>(origData);
         if (inverted) {
             java.util.Collections.reverse(data);
         }
@@ -57,7 +65,7 @@ public class DoubleRegionBinarySearchKernelTest {
         for (int ii = 0; ii < size; ++ii) {
             final double value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
-            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
             try (final RowSet valuesFound = DoubleRegionBinarySearchKernel.binSearchMatch(
                     region,
                     startRow, endRow,
@@ -71,6 +79,29 @@ public class DoubleRegionBinarySearchKernelTest {
                     Assert.assertFalse("Index should not be populated.",
                             valuesFound.containsRange(ii, ii));
                 }
+            }
+        }
+
+        // Test negative lookups
+        int numFailedLookups = 0;
+        for (int ii = 0; ii < NUM_NEGATIVE_LOOKUPS && numFailedLookups < MAX_FAILED_LOOKUPS; ++ii) {
+            final double value = (double) rnd.nextInt();
+            if (value == QueryConstants.NULL_DOUBLE
+                    || Collections.binarySearch(origData, value, DoubleComparisons::compare) >= 0) {
+                --ii;
+                ++numFailedLookups;
+                continue;
+            }
+
+            final long startRow = 0;
+            final long endRow = size - 1;
+            try (final RowSet valuesFound = DoubleRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Double[] { value }
+            )) {
+                Assert.assertTrue(valuesFound.isEmpty());
             }
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernelTest.java
@@ -13,9 +13,6 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionFloat;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -66,7 +63,7 @@ public class FloatRegionBinarySearchKernelTest {
             final float value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
             final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
-            try (final RowSet valuesFound = FloatRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = FloatRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,
@@ -95,7 +92,7 @@ public class FloatRegionBinarySearchKernelTest {
 
             final long startRow = 0;
             final long endRow = size - 1;
-            try (final RowSet valuesFound = FloatRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = FloatRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernelTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernelTest and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionFloat;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionFloat;
+import io.deephaven.generic.region.AppendOnlyRegionAccessor;
+import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.compare.FloatComparisons;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntToLongFunction;
+
+@Category(ParallelTest.class)
+public class FloatRegionBinarySearchKernelTest {
+    private static final int[] SIZES = { 10, 100, 1000000 };
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private void randomizedTestRunner(
+            int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+
+        final Random rnd = new Random(seed);
+        final List<Float> data = new ArrayList<>(size);
+        for (int ii = 0; ii < size; ++ii) {
+            data.add((float) rnd.nextInt());
+        }
+        data.sort(FloatComparisons::compare);
+        if (inverted) {
+            java.util.Collections.reverse(data);
+        }
+        final ColumnRegionFloat<Values> region = makeColumnRegionFloat(data);
+        ColumnName columnName = ColumnName.of("test");
+        final SortColumn sortColumn = inverted ? SortColumn.desc(columnName) : SortColumn.asc(columnName);
+
+        for (int ii = 0; ii < size; ++ii) {
+            final float value = data.get(ii);
+            final long startRow = Math.max(0, firstKey.applyAsLong(ii));
+            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            try (final RowSet valuesFound = FloatRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Float[] { value }
+            )) {
+                if (startRow <= ii && ii <= endRow) {
+                    Assert.assertTrue("Expected to find " + value + " at index " + ii,
+                            valuesFound.containsRange(ii, ii));
+                } else {
+                    Assert.assertFalse("Index should not be populated.",
+                            valuesFound.containsRange(ii, ii));
+                }
+            }
+        }
+    }
+
+    private void randomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, false, firstKey, lastKey);
+    }
+
+    private void invertedRandomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, true, firstKey, lastKey);
+    }
+
+    @Test
+    public void testRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testRowIsAboveRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testRowUpperBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testRowInLowerRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testRowIsBelowRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowLowerBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowInUpperRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowIsRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testInvertedRowIsAboveRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowUpperBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInLowerRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsBelowRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowLowerBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInUpperRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    private static final int PAGE_SIZE = 1 << 16;
+    private static ColumnRegionFloat<Values> makeColumnRegionFloat(@NotNull final List<Float> values) {
+        return new AppendOnlyFixedSizePageRegionFloat<>(
+                RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK, PAGE_SIZE, new AppendOnlyRegionAccessor<>() {
+            @Override
+            public void readChunkPage(long firstRowPosition, int minimumSize, @NotNull WritableChunk<Values> destination) {
+                int finalSize = (int) Math.min(minimumSize, values.size() - firstRowPosition);
+                destination.setSize(finalSize);
+                for (int ii = 0; ii < finalSize; ++ii) {
+                    destination.asWritableFloatChunk().set(ii, values.get((int) firstRowPosition + ii));
+                }
+            }
+
+            @Override
+            public long size() {
+                return values.size();
+            }
+        });
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernelTest.java
@@ -13,9 +13,6 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionInt;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -66,7 +63,7 @@ public class IntRegionBinarySearchKernelTest {
             final int value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
             final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
-            try (final RowSet valuesFound = IntRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = IntRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,
@@ -95,7 +92,7 @@ public class IntRegionBinarySearchKernelTest {
 
             final long startRow = 0;
             final long endRow = size - 1;
-            try (final RowSet valuesFound = IntRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = IntRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernelTest.java
@@ -13,12 +13,16 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionInt;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionInt;
 import io.deephaven.generic.region.AppendOnlyRegionAccessor;
 import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.compare.IntComparisons;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -27,6 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntToLongFunction;
@@ -34,6 +39,8 @@ import java.util.function.IntToLongFunction;
 @Category(ParallelTest.class)
 public class IntRegionBinarySearchKernelTest {
     private static final int[] SIZES = { 10, 100, 1000000 };
+    private static final int MAX_FAILED_LOOKUPS = 1000;
+    private static final int NUM_NEGATIVE_LOOKUPS = 100;
 
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
@@ -42,11 +49,12 @@ public class IntRegionBinarySearchKernelTest {
             int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
 
         final Random rnd = new Random(seed);
-        final List<Integer> data = new ArrayList<>(size);
+        final List<Integer> origData = new ArrayList<>(size);
         for (int ii = 0; ii < size; ++ii) {
-            data.add((int) rnd.nextInt());
+            origData.add((int) rnd.nextInt());
         }
-        data.sort(IntComparisons::compare);
+        origData.sort(IntComparisons::compare);
+        final List<Integer> data = new ArrayList<>(origData);
         if (inverted) {
             java.util.Collections.reverse(data);
         }
@@ -57,7 +65,7 @@ public class IntRegionBinarySearchKernelTest {
         for (int ii = 0; ii < size; ++ii) {
             final int value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
-            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
             try (final RowSet valuesFound = IntRegionBinarySearchKernel.binSearchMatch(
                     region,
                     startRow, endRow,
@@ -71,6 +79,29 @@ public class IntRegionBinarySearchKernelTest {
                     Assert.assertFalse("Index should not be populated.",
                             valuesFound.containsRange(ii, ii));
                 }
+            }
+        }
+
+        // Test negative lookups
+        int numFailedLookups = 0;
+        for (int ii = 0; ii < NUM_NEGATIVE_LOOKUPS && numFailedLookups < MAX_FAILED_LOOKUPS; ++ii) {
+            final int value = (int) rnd.nextInt();
+            if (value == QueryConstants.NULL_INT
+                    || Collections.binarySearch(origData, value, IntComparisons::compare) >= 0) {
+                --ii;
+                ++numFailedLookups;
+                continue;
+            }
+
+            final long startRow = 0;
+            final long endRow = size - 1;
+            try (final RowSet valuesFound = IntRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Integer[] { value }
+            )) {
+                Assert.assertTrue(valuesFound.isEmpty());
             }
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernelTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernelTest and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionInt;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionInt;
+import io.deephaven.generic.region.AppendOnlyRegionAccessor;
+import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.compare.IntComparisons;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntToLongFunction;
+
+@Category(ParallelTest.class)
+public class IntRegionBinarySearchKernelTest {
+    private static final int[] SIZES = { 10, 100, 1000000 };
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private void randomizedTestRunner(
+            int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+
+        final Random rnd = new Random(seed);
+        final List<Integer> data = new ArrayList<>(size);
+        for (int ii = 0; ii < size; ++ii) {
+            data.add((int) rnd.nextInt());
+        }
+        data.sort(IntComparisons::compare);
+        if (inverted) {
+            java.util.Collections.reverse(data);
+        }
+        final ColumnRegionInt<Values> region = makeColumnRegionInt(data);
+        ColumnName columnName = ColumnName.of("test");
+        final SortColumn sortColumn = inverted ? SortColumn.desc(columnName) : SortColumn.asc(columnName);
+
+        for (int ii = 0; ii < size; ++ii) {
+            final int value = data.get(ii);
+            final long startRow = Math.max(0, firstKey.applyAsLong(ii));
+            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            try (final RowSet valuesFound = IntRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Integer[] { value }
+            )) {
+                if (startRow <= ii && ii <= endRow) {
+                    Assert.assertTrue("Expected to find " + value + " at index " + ii,
+                            valuesFound.containsRange(ii, ii));
+                } else {
+                    Assert.assertFalse("Index should not be populated.",
+                            valuesFound.containsRange(ii, ii));
+                }
+            }
+        }
+    }
+
+    private void randomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, false, firstKey, lastKey);
+    }
+
+    private void invertedRandomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, true, firstKey, lastKey);
+    }
+
+    @Test
+    public void testRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testRowIsAboveRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testRowUpperBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testRowInLowerRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testRowIsBelowRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowLowerBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowInUpperRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowIsRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testInvertedRowIsAboveRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowUpperBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInLowerRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsBelowRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowLowerBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInUpperRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    private static final int PAGE_SIZE = 1 << 16;
+    private static ColumnRegionInt<Values> makeColumnRegionInt(@NotNull final List<Integer> values) {
+        return new AppendOnlyFixedSizePageRegionInt<>(
+                RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK, PAGE_SIZE, new AppendOnlyRegionAccessor<>() {
+            @Override
+            public void readChunkPage(long firstRowPosition, int minimumSize, @NotNull WritableChunk<Values> destination) {
+                int finalSize = (int) Math.min(minimumSize, values.size() - firstRowPosition);
+                destination.setSize(finalSize);
+                for (int ii = 0; ii < finalSize; ++ii) {
+                    destination.asWritableIntChunk().set(ii, values.get((int) firstRowPosition + ii));
+                }
+            }
+
+            @Override
+            public long size() {
+                return values.size();
+            }
+        });
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernelTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernelTest and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionLong;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionLong;
+import io.deephaven.generic.region.AppendOnlyRegionAccessor;
+import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.compare.LongComparisons;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntToLongFunction;
+
+@Category(ParallelTest.class)
+public class LongRegionBinarySearchKernelTest {
+    private static final int[] SIZES = { 10, 100, 1000000 };
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private static void randomizedTestRunner(
+            int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+
+        final Random rnd = new Random(seed);
+        final List<Long> data = new ArrayList<>(size);
+        for (int ii = 0; ii < size; ++ii) {
+            data.add((long) rnd.nextInt());
+        }
+        data.sort(LongComparisons::compare);
+        if (inverted) {
+            java.util.Collections.reverse(data);
+        }
+        final ColumnRegionLong<Values> region = makeColumnRegionLong(data);
+        ColumnName columnName = ColumnName.of("test");
+        final SortColumn sortColumn = inverted ? SortColumn.desc(columnName) : SortColumn.asc(columnName);
+
+        for (int ii = 0; ii < size; ++ii) {
+            final long value = data.get(ii);
+            final long startRow = Math.max(0, firstKey.applyAsLong(ii));
+            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            try (final RowSet valuesFound = LongRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Long[] { value }
+            )) {
+                if (startRow <= ii && ii <= endRow) {
+                    Assert.assertTrue("Expected to find " + value + " at index " + ii,
+                            valuesFound.containsRange(ii, ii));
+                } else {
+                    Assert.assertFalse("Index should not be populated.",
+                            valuesFound.containsRange(ii, ii));
+                }
+            }
+        }
+    }
+
+    private static void randomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, false, firstKey, lastKey);
+    }
+
+    private static void invertedRandomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, true, firstKey, lastKey);
+    }
+
+    @Test
+    public void testRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testRowIsAboveRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testRowUpperBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testRowInLowerRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testRowIsBelowRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowLowerBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowInUpperRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowIsRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testInvertedRowIsAboveRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowUpperBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInLowerRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsBelowRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowLowerBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInUpperRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    private static final int PAGE_SIZE = 1 << 16;
+    private static ColumnRegionLong<Values> makeColumnRegionLong(@NotNull final List<Long> values) {
+        return new AppendOnlyFixedSizePageRegionLong<>(
+                RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK, PAGE_SIZE, new AppendOnlyRegionAccessor<>() {
+            @Override
+            public void readChunkPage(long firstRowPosition, int minimumSize, @NotNull WritableChunk<Values> destination) {
+                int finalSize = (int) Math.min(minimumSize, values.size() - firstRowPosition);
+                destination.setSize(finalSize);
+                for (int ii = 0; ii < finalSize; ++ii) {
+                    destination.asWritableLongChunk().set(ii, values.get((int) firstRowPosition + ii));
+                }
+            }
+
+            @Override
+            public long size() {
+                return values.size();
+            }
+        });
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernelTest.java
@@ -13,9 +13,6 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionLong;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -66,7 +63,7 @@ public class LongRegionBinarySearchKernelTest {
             final long value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
             final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
-            try (final RowSet valuesFound = LongRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = LongRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,
@@ -95,7 +92,7 @@ public class LongRegionBinarySearchKernelTest {
 
             final long startRow = 0;
             final long endRow = size - 1;
-            try (final RowSet valuesFound = LongRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = LongRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernelTest.java
@@ -13,12 +13,16 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionLong;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionLong;
 import io.deephaven.generic.region.AppendOnlyRegionAccessor;
 import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.compare.LongComparisons;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -27,6 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntToLongFunction;
@@ -34,19 +39,22 @@ import java.util.function.IntToLongFunction;
 @Category(ParallelTest.class)
 public class LongRegionBinarySearchKernelTest {
     private static final int[] SIZES = { 10, 100, 1000000 };
+    private static final int MAX_FAILED_LOOKUPS = 1000;
+    private static final int NUM_NEGATIVE_LOOKUPS = 100;
 
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
 
-    private static void randomizedTestRunner(
+    private void randomizedTestRunner(
             int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
 
         final Random rnd = new Random(seed);
-        final List<Long> data = new ArrayList<>(size);
+        final List<Long> origData = new ArrayList<>(size);
         for (int ii = 0; ii < size; ++ii) {
-            data.add((long) rnd.nextInt());
+            origData.add((long) rnd.nextInt());
         }
-        data.sort(LongComparisons::compare);
+        origData.sort(LongComparisons::compare);
+        final List<Long> data = new ArrayList<>(origData);
         if (inverted) {
             java.util.Collections.reverse(data);
         }
@@ -57,7 +65,7 @@ public class LongRegionBinarySearchKernelTest {
         for (int ii = 0; ii < size; ++ii) {
             final long value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
-            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
             try (final RowSet valuesFound = LongRegionBinarySearchKernel.binSearchMatch(
                     region,
                     startRow, endRow,
@@ -73,14 +81,37 @@ public class LongRegionBinarySearchKernelTest {
                 }
             }
         }
+
+        // Test negative lookups
+        int numFailedLookups = 0;
+        for (int ii = 0; ii < NUM_NEGATIVE_LOOKUPS && numFailedLookups < MAX_FAILED_LOOKUPS; ++ii) {
+            final long value = (long) rnd.nextInt();
+            if (value == QueryConstants.NULL_LONG
+                    || Collections.binarySearch(origData, value, LongComparisons::compare) >= 0) {
+                --ii;
+                ++numFailedLookups;
+                continue;
+            }
+
+            final long startRow = 0;
+            final long endRow = size - 1;
+            try (final RowSet valuesFound = LongRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Long[] { value }
+            )) {
+                Assert.assertTrue(valuesFound.isEmpty());
+            }
+        }
     }
 
-    private static void randomizedTestRunner(
+    private void randomizedTestRunner(
             int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
         randomizedTestRunner(size, seed, false, firstKey, lastKey);
     }
 
-    private static void invertedRandomizedTestRunner(
+    private void invertedRandomizedTestRunner(
             int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
         randomizedTestRunner(size, seed, true, firstKey, lastKey);
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernelTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharRegionBinarySearchKernelTest and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionShort;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionShort;
+import io.deephaven.generic.region.AppendOnlyRegionAccessor;
+import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.compare.ShortComparisons;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntToLongFunction;
+
+@Category(ParallelTest.class)
+public class ShortRegionBinarySearchKernelTest {
+    private static final int[] SIZES = { 10, 100, 1000000 };
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private void randomizedTestRunner(
+            int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+
+        final Random rnd = new Random(seed);
+        final List<Short> data = new ArrayList<>(size);
+        for (int ii = 0; ii < size; ++ii) {
+            data.add((short) rnd.nextInt());
+        }
+        data.sort(ShortComparisons::compare);
+        if (inverted) {
+            java.util.Collections.reverse(data);
+        }
+        final ColumnRegionShort<Values> region = makeColumnRegionShort(data);
+        ColumnName columnName = ColumnName.of("test");
+        final SortColumn sortColumn = inverted ? SortColumn.desc(columnName) : SortColumn.asc(columnName);
+
+        for (int ii = 0; ii < size; ++ii) {
+            final short value = data.get(ii);
+            final long startRow = Math.max(0, firstKey.applyAsLong(ii));
+            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            try (final RowSet valuesFound = ShortRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Short[] { value }
+            )) {
+                if (startRow <= ii && ii <= endRow) {
+                    Assert.assertTrue("Expected to find " + value + " at index " + ii,
+                            valuesFound.containsRange(ii, ii));
+                } else {
+                    Assert.assertFalse("Index should not be populated.",
+                            valuesFound.containsRange(ii, ii));
+                }
+            }
+        }
+    }
+
+    private void randomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, false, firstKey, lastKey);
+    }
+
+    private void invertedRandomizedTestRunner(
+            int size, int seed, IntToLongFunction firstKey, IntToLongFunction lastKey) {
+        randomizedTestRunner(size, seed, true, firstKey, lastKey);
+    }
+
+    @Test
+    public void testRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testRowIsAboveRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testRowUpperBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testRowInLowerRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testRowIsBelowRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowLowerBoundRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowInUpperRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testRowIsRange() {
+        for (int size : SIZES) {
+            randomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRandomizedDataFullRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> size);
+        }
+    }
+    @Test
+    public void testInvertedRowIsAboveRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i - 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowUpperBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInLowerRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> 0, i -> i + 1);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsBelowRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i + 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowLowerBoundRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowInUpperRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i - 1, i -> size);
+        }
+    }
+
+    @Test
+    public void testInvertedRowIsRange() {
+        for (int size : SIZES) {
+            invertedRandomizedTestRunner(size, 0, i -> i, i -> i);
+        }
+    }
+
+    private static final int PAGE_SIZE = 1 << 16;
+    private static ColumnRegionShort<Values> makeColumnRegionShort(@NotNull final List<Short> values) {
+        return new AppendOnlyFixedSizePageRegionShort<>(
+                RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK, PAGE_SIZE, new AppendOnlyRegionAccessor<>() {
+            @Override
+            public void readChunkPage(long firstRowPosition, int minimumSize, @NotNull WritableChunk<Values> destination) {
+                int finalSize = (int) Math.min(minimumSize, values.size() - firstRowPosition);
+                destination.setSize(finalSize);
+                for (int ii = 0; ii < finalSize; ++ii) {
+                    destination.asWritableShortChunk().set(ii, values.get((int) firstRowPosition + ii));
+                }
+            }
+
+            @Override
+            public long size() {
+                return values.size();
+            }
+        });
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernelTest.java
@@ -13,12 +13,16 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionShort;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.generic.region.AppendOnlyFixedSizePageRegionShort;
 import io.deephaven.generic.region.AppendOnlyRegionAccessor;
 import io.deephaven.test.types.ParallelTest;
+import io.deephaven.util.QueryConstants;
 import io.deephaven.util.compare.ShortComparisons;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -27,6 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntToLongFunction;
@@ -34,6 +39,8 @@ import java.util.function.IntToLongFunction;
 @Category(ParallelTest.class)
 public class ShortRegionBinarySearchKernelTest {
     private static final int[] SIZES = { 10, 100, 1000000 };
+    private static final int MAX_FAILED_LOOKUPS = 1000;
+    private static final int NUM_NEGATIVE_LOOKUPS = 100;
 
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
@@ -42,11 +49,12 @@ public class ShortRegionBinarySearchKernelTest {
             int size, int seed, boolean inverted, IntToLongFunction firstKey, IntToLongFunction lastKey) {
 
         final Random rnd = new Random(seed);
-        final List<Short> data = new ArrayList<>(size);
+        final List<Short> origData = new ArrayList<>(size);
         for (int ii = 0; ii < size; ++ii) {
-            data.add((short) rnd.nextInt());
+            origData.add((short) rnd.nextInt());
         }
-        data.sort(ShortComparisons::compare);
+        origData.sort(ShortComparisons::compare);
+        final List<Short> data = new ArrayList<>(origData);
         if (inverted) {
             java.util.Collections.reverse(data);
         }
@@ -57,7 +65,7 @@ public class ShortRegionBinarySearchKernelTest {
         for (int ii = 0; ii < size; ++ii) {
             final short value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
-            final long endRow = Math.min(size, lastKey.applyAsLong(ii));
+            final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
             try (final RowSet valuesFound = ShortRegionBinarySearchKernel.binSearchMatch(
                     region,
                     startRow, endRow,
@@ -71,6 +79,29 @@ public class ShortRegionBinarySearchKernelTest {
                     Assert.assertFalse("Index should not be populated.",
                             valuesFound.containsRange(ii, ii));
                 }
+            }
+        }
+
+        // Test negative lookups
+        int numFailedLookups = 0;
+        for (int ii = 0; ii < NUM_NEGATIVE_LOOKUPS && numFailedLookups < MAX_FAILED_LOOKUPS; ++ii) {
+            final short value = (short) rnd.nextInt();
+            if (value == QueryConstants.NULL_SHORT
+                    || Collections.binarySearch(origData, value, ShortComparisons::compare) >= 0) {
+                --ii;
+                ++numFailedLookups;
+                continue;
+            }
+
+            final long startRow = 0;
+            final long endRow = size - 1;
+            try (final RowSet valuesFound = ShortRegionBinarySearchKernel.binSearchMatch(
+                    region,
+                    startRow, endRow,
+                    sortColumn,
+                    new Short[] { value }
+            )) {
+                Assert.assertTrue(valuesFound.isEmpty());
             }
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernelTest.java
@@ -13,9 +13,6 @@ import io.deephaven.api.SortColumn;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionShort;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -66,7 +63,7 @@ public class ShortRegionBinarySearchKernelTest {
             final short value = data.get(ii);
             final long startRow = Math.max(0, firstKey.applyAsLong(ii));
             final long endRow = Math.min(size - 1, lastKey.applyAsLong(ii));
-            try (final RowSet valuesFound = ShortRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = ShortRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,
@@ -95,7 +92,7 @@ public class ShortRegionBinarySearchKernelTest {
 
             final long startRow = 0;
             final long endRow = size - 1;
-            try (final RowSet valuesFound = ShortRegionBinarySearchKernel.binSearchMatch(
+            try (final RowSet valuesFound = ShortRegionBinarySearchKernel.binarySearchMatch(
                     region,
                     startRow, endRow,
                     sortColumn,

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateRegionAndRegionedSourceTests.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateRegionAndRegionedSourceTests.java
@@ -19,5 +19,7 @@ public class ReplicateRegionAndRegionedSourceTests {
                 "engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceChar.java");
         charToAllButBooleanAndByte(
                 "engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TstColumnRegionChar.java");
+        charToAllButBoolean(
+                "engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernelTest.java");
     }
 }

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateRegionsAndRegionedSources.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateRegionsAndRegionedSources.java
@@ -213,8 +213,8 @@ public class ReplicateRegionsAndRegionedSources {
         lines = removeImport(lines, "import io\\.deephaven\\.util\\.type\\.ArrayTypeUtils;");
         lines = globalReplacements(lines,
                 "<\\?>", "<?, ?>",
-                "final Object\\[\\] unboxed = ArrayTypeUtils.getUnboxedObjectArray\\(sortedKeys\\);", "",
-                "unboxed", "sortedKeys");
+                "final Object\\[\\] unboxed = ArrayTypeUtils.getUnboxedObjectArray\\(searchValues\\);", "",
+                "unboxed", "searchValues");
         FileUtils.writeLines(new File(charToObject), lines);
     }
 }

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateRegionsAndRegionedSources.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateRegionsAndRegionedSources.java
@@ -31,6 +31,8 @@ public class ReplicateRegionsAndRegionedSources {
 
     private static final String GENERIC_REGION_CHAR_PATH =
             "extensions/source-support/src/main/java/io/deephaven/generic/region/AppendOnlyFixedSizePageRegionChar.java";
+    private static final String GENERIC_REGION_BINARY_SEARCH_KERNEL_PATH =
+            "engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java";
 
     public static void main(String... args) throws IOException {
         // Note that Byte and Object regions are not replicated!
@@ -39,9 +41,13 @@ public class ReplicateRegionsAndRegionedSources {
         charToAllButBooleanAndByte(
                 "engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/DeferredColumnRegionChar.java");
 
+
         // Note that Object regions are not replicated!
-        charToAllButBooleanAndByte(PARQUET_REGION_CHAR_PATH);
+        fixupParquetColumnRegions(charToAllButBooleanAndByte(PARQUET_REGION_CHAR_PATH));
         fixupChunkColumnRegionByte(charToByte(PARQUET_REGION_CHAR_PATH));
+
+        charToAllButBoolean(GENERIC_REGION_BINARY_SEARCH_KERNEL_PATH);
+        fixupBinSearchObject(charToObject(GENERIC_REGION_BINARY_SEARCH_KERNEL_PATH));
 
         charToAllButBooleanAndByte(GENERIC_REGION_CHAR_PATH);
         fixupChunkColumnRegionByte(charToByte(GENERIC_REGION_CHAR_PATH));
@@ -179,5 +185,36 @@ public class ReplicateRegionsAndRegionedSources {
                 "    }"));
 
         FileUtils.writeLines(new File(path), lines);
+    }
+
+    private static void fixupParquetColumnRegions(List<String> files) throws IOException {
+        for (String file : files) {
+            if (file.contains("Double")) {
+                replaceStatistics(file, "Double");
+            } else if (file.contains("Float")) {
+                replaceStatistics(file, "Float");
+            } else if (file.contains("Long")) {
+                replaceStatistics(file, "Long");
+            }
+        }
+    }
+
+    private static void replaceStatistics(final String f, final String statsReplacement) throws IOException {
+        final File file = new File(f);
+        List<String> lines = FileUtils.readLines(file, Charset.defaultCharset());
+        lines = globalReplacements(lines, "IntStatistics", statsReplacement + "Statistics",
+                "intValue\\(\\)", statsReplacement.toLowerCase() + "Value()");
+        FileUtils.writeLines(new File(f), lines);
+    }
+
+    private static void fixupBinSearchObject(String charToObject) throws IOException {
+        final File file = new File(charToObject);
+        List<String> lines = FileUtils.readLines(file, Charset.defaultCharset());
+        lines = removeImport(lines, "import io\\.deephaven\\.util\\.type\\.ArrayTypeUtils;");
+        lines = globalReplacements(lines,
+                "<\\?>", "<?, ?>",
+                "final Object\\[\\] unboxed = ArrayTypeUtils.getUnboxedObjectArray\\(sortedKeys\\);", "",
+                "unboxed", "sortedKeys");
+        FileUtils.writeLines(new File(charToObject), lines);
     }
 }


### PR DESCRIPTION
This includes the binary search kernel from the pushdown predicate port, a fix to make timsort Context's as AutoCloseable. (Closing was missed in the original PR, and we usually use that pattern anyway).

I've written a handful of replicated tests as well; these tests give us good coverage on the implementation.