### PR TITLE
Support and test "psk" in client connection

### DIFF
--- a/R/rdeephaven/R/client_wrapper.R
+++ b/R/rdeephaven/R/client_wrapper.R
@@ -40,6 +40,13 @@ Client <- R6Class("Client",
         } else {
           stop("Basic authentication was requested, but 'auth_token' was not provided, and at most one of 'username' or 'password' was provided. Please provide either 'username' and 'password', or 'auth_token'.")
         }
+      } else if (auth_type == "psk") {
+        if (auth_token != "") {
+          verify_string("auth_token", auth_token, TRUE)
+          options$set_custom_authentication("io.deephaven.authentication.psk.PskAuthenticationHandler", auth_token)
+        } else {
+          stop("Pre-shared key authentication was requested, but no 'auth_token' was provided.")
+        }
       } else {
         if (auth_token != "") {
           verify_string("auth_token", auth_token, TRUE)

--- a/R/rdeephaven/inst/tests/testthat/test_client_wrapper.R
+++ b/R/rdeephaven/inst/tests/testthat/test_client_wrapper.R
@@ -175,6 +175,10 @@ test_that("client constructor fails nicely with bad inputs", {
     "Basic authentication was requested, but 'auth_token' was provided, as well as least one of 'username' and 'password'. Please provide either 'username' and 'password', or 'auth_token'."
   )
   expect_error(
+    Client$new(target = "localhost:10000", auth_type = "psk"),
+    "Pre-shared key authentication was requested, but no 'auth_token' was provided."
+  )
+  expect_error(
     Client$new(target = "localhost:10000", auth_type = "custom"),
     "Custom authentication was requested, but no 'auth_token' was provided."
   )


### PR DESCRIPTION
I see no reason to not support `"psk"` in the client connection function, given that psk is our new default and it's not straightforward to find that "io.deephaven.authentication.psk.PskAuthenticationHandler" is what you should be using for server defaults.