### PR TITLE
If SessionExport is Cancelled, use gRPC Cancel msg

### DIFF
--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -1320,8 +1320,13 @@ public class SessionState {
                 final String dependentStr = dependentExportId == null ? ""
                         : (" (related parent export id: " + dependentExportId + ")");
                 if (cause == null) {
-                    errorHandler.onError(Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
-                            "Export in state " + resultState + dependentStr));
+                    if (resultState == ExportNotification.State.CANCELLED) {
+                        errorHandler.onError(Exceptions.statusRuntimeException(Code.CANCELLED,
+                                "Export is cancelled" + dependentStr));
+                    } else {
+                        errorHandler.onError(Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
+                                "Export in state " + resultState + dependentStr));
+                    }
                 } else {
                     errorHandler.onError(Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
                             "Details Logged w/ID '" + errorContext + "'" + dependentStr));


### PR DESCRIPTION
This eliminates some unnecessary logging as we do not log cancellations but do log failed preconditions. 