### PR TITLE
Kafka Publisher: allow null values in Instant columns

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/publish/GenericRecordKeyOrValueSerializer.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/publish/GenericRecordKeyOrValueSerializer.java
@@ -295,8 +295,10 @@ public class GenericRecordKeyOrValueSerializer implements KeyOrValueSerializer<G
         return makeGenericFieldProcessor(
                 fieldName,
                 chunkSource,
-                (final int ii, final ObjectChunk<?, Values> inputChunk) -> ((Instant) inputChunk.get(ii))
-                        .toEpochMilli());
+                (final int ii, final ObjectChunk<?, Values> inputChunk) -> {
+                    Instant val = (Instant) inputChunk.get(ii);
+                    return val == null ? null : val.toEpochMilli();
+                });
     }
 
     private static GenericRecordFieldProcessor makeInstantToMicrosFieldProcessor(
@@ -305,8 +307,10 @@ public class GenericRecordKeyOrValueSerializer implements KeyOrValueSerializer<G
         return makeGenericFieldProcessor(
                 fieldName,
                 chunkSource,
-                (final int ii, final ObjectChunk<?, Values> inputChunk) -> DateTimeUtils
-                        .epochMicros((Instant) inputChunk.get(ii)));
+                (final int ii, final ObjectChunk<?, Values> inputChunk) -> {
+                    Instant val = (Instant) inputChunk.get(ii);
+                    return val == null ? null : DateTimeUtils.epochMicros(val);
+                });
     }
 
     private static BigInteger toBigIntegerAtPrecisionAndScale(


### PR DESCRIPTION
Kafka exhaust would NPE despite marking that time field as nullable in an avro schema such as the one below:

```json
{
    "namespace": "io.deephaven",
    "type": "record",
    "name": "TimeNotification",
    "fields": [
        {"name": "Time", "type": ["null", {"type": "long", "logicalType": "timestamp-micros"}]}
    ]
}
```