### PR TITLE
Handle infinitesimal and negative variance in `UpdateBy#RollingStd()`

### DIFF
--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -476,7 +476,14 @@ public class Numeric {
             }
         }
 
-        return sum2 / (count - 1) - sum * sum / count / (count - 1);
+        // Perform the calculation in a way that minimizes the impact of floating point error.
+        final double eps = Math.ulp(sum2);
+        final double vs2bar = sum * (sum / count);
+        final double delta = sum2 - vs2bar;
+        final double rel_eps = delta / eps;
+
+        // Return zero when the variance is leq the floating point error.
+        return Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
     }
 
     <#list primitiveTypes as pt2>

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -476,6 +476,11 @@ public class Numeric {
             }
         }
 
+        // Return NaN if poisoned or too few values to compute variance.
+        if (count <= 1 || Double.isNaN(sum) || Double.isNaN(sum2)) {
+            return Double.NaN;
+        }
+
         // Perform the calculation in a way that minimizes the impact of floating point error.
         final double eps = Math.ulp(sum2);
         final double vs2bar = sum * (sum / count);
@@ -574,8 +579,13 @@ public class Numeric {
             }
         }
 
+        // Return NaN if poisoned or too few values to compute variance.
+        if (count <= 1 || Double.isNaN(sum) || Double.isNaN(sum2) || Double.isNaN(count) || Double.isNaN(count2)) {
+            return Double.NaN;
+        }
+
         // For unbiased estimator derivation see https://en.wikipedia.org/wiki/Weighted_arithmetic_mean#Weighted_sample_variance
-        // For unweighted statistics, there is a (N-1)/N = (1-1/N) Bessel correction.  
+        // For unweighted statistics, there is a (N-1)/N = 1-(1/N) Bessel correction.
         // The analagous correction for weighted statistics is 1-count2/count/count, which yields an effective sample size of Neff = count*count/count2.
         // This yields an unbiased estimator of (sum2/count - sum*sum/count/count) * ((count*count/count2)/((count*count/count2)-1)).
         // This can be simplified to (count * sum2 - sum * sum) / (count * count - count2)

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
@@ -22,6 +22,7 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class ByteRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
+    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     final byte nullValue;
     // endregion extra-fields
@@ -115,10 +116,12 @@ public class ByteRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // When the values are extremely close to zero, the variance can be negative due to floating point
-                // rounding errors.  Use the absolute value to avoid NaNs in the output.
-                final double variance =
-                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
+                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
+                // defined threshold.
+                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
@@ -115,7 +115,10 @@ public class ByteRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                final double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                // When the values are extremely close to zero, the variance can be negative due to floating point
+                // rounding errors.  Use the absolute value to avoid NaNs in the output.
+                final double variance =
+                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
@@ -22,7 +22,6 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class ByteRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
-    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     final byte nullValue;
     // endregion extra-fields
@@ -116,11 +115,10 @@ public class ByteRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
-                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
-                // defined threshold.
-                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
-                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
+                // Detect and handle this by setting the variance to zero when negative.
+                final double variance = Math.max(0.0,
+                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
@@ -115,10 +115,15 @@ public class ByteRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
-                // Detect and handle this by setting the variance to zero when negative.
-                final double variance = Math.max(0.0,
-                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
+                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                final double eps = Math.ulp(valueSquareSum);
+                final double vs2bar = valueSum * (valueSum / count);
+                final double delta = valueSquareSum - vs2bar;
+                final double rel_eps = delta / eps;
+
+                // Assign zero when the variance is <= the floating point error.
+                final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ByteRollingStdOperator.java
@@ -112,17 +112,27 @@ public class ByteRollingStdOperator extends BaseDoubleUpdateByOperator {
                 outputValues.set(outIdx, NULL_DOUBLE);
             } else {
                 final int count = valueBuffer.size() - nullCount;
+
+                if (count <= 1) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
-                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                if (Double.isNaN(valueSquareSum) || Double.isNaN(valueSum)) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
+                // Perform the calculation in a way that minimizes the impact of floating point error.
                 final double eps = Math.ulp(valueSquareSum);
                 final double vs2bar = valueSum * (valueSum / count);
                 final double delta = valueSquareSum - vs2bar;
                 final double rel_eps = delta / eps;
 
-                // Assign zero when the variance is <= the floating point error.
+                // Assign zero when the variance is leq the floating point error.
                 final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
@@ -17,6 +17,7 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class CharRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
+    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -109,10 +110,12 @@ public class CharRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // When the values are extremely close to zero, the variance can be negative due to floating point
-                // rounding errors.  Use the absolute value to avoid NaNs in the output.
-                final double variance =
-                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
+                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
+                // defined threshold.
+                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
@@ -109,7 +109,10 @@ public class CharRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                final double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                // When the values are extremely close to zero, the variance can be negative due to floating point
+                // rounding errors.  Use the absolute value to avoid NaNs in the output.
+                final double variance =
+                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
@@ -17,7 +17,6 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class CharRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
-    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -110,11 +109,10 @@ public class CharRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
-                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
-                // defined threshold.
-                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
-                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
+                // Detect and handle this by setting the variance to zero when negative.
+                final double variance = Math.max(0.0,
+                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
@@ -106,8 +106,19 @@ public class CharRollingStdOperator extends BaseDoubleUpdateByOperator {
                 outputValues.set(outIdx, NULL_DOUBLE);
             } else {
                 final int count = valueBuffer.size() - nullCount;
+
+                if (count <= 1) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
+
+                if (Double.isNaN(valueSquareSum) || Double.isNaN(valueSum)) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
 
                 // Perform the calculation in a way that minimizes the impact of floating point error.
                 final double eps = Math.ulp(valueSquareSum);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/CharRollingStdOperator.java
@@ -109,10 +109,14 @@ public class CharRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
-                // Detect and handle this by setting the variance to zero when negative.
-                final double variance = Math.max(0.0,
-                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Perform the calculation in a way that minimizes the impact of floating point error.
+                final double eps = Math.ulp(valueSquareSum);
+                final double vs2bar = valueSum * (valueSum / count);
+                final double delta = valueSquareSum - vs2bar;
+                final double rel_eps = delta / eps;
+
+                // Assign zero when the variance is leq the floating point error.
+                final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
@@ -114,10 +114,15 @@ public class DoubleRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
-                // Detect and handle this by setting the variance to zero when negative.
-                final double variance = Math.max(0.0,
-                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
+                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                final double eps = Math.ulp(valueSquareSum);
+                final double vs2bar = valueSum * (valueSum / count);
+                final double delta = valueSquareSum - vs2bar;
+                final double rel_eps = delta / eps;
+
+                // Assign zero when the variance is <= the floating point error.
+                final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
@@ -22,7 +22,6 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class DoubleRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
-    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -115,11 +114,10 @@ public class DoubleRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
-                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
-                // defined threshold.
-                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
-                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
+                // Detect and handle this by setting the variance to zero when negative.
+                final double variance = Math.max(0.0,
+                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
@@ -114,7 +114,10 @@ public class DoubleRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                final double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                // When the values are extremely close to zero, the variance can be negative due to floating point
+                // rounding errors.  Use the absolute value to avoid NaNs in the output.
+                final double variance =
+                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/DoubleRollingStdOperator.java
@@ -111,17 +111,27 @@ public class DoubleRollingStdOperator extends BaseDoubleUpdateByOperator {
                 outputValues.set(outIdx, NULL_DOUBLE);
             } else {
                 final int count = valueBuffer.size() - nullCount;
+
+                if (count <= 1) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
-                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                if (Double.isNaN(valueSquareSum) || Double.isNaN(valueSum)) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
+                // Perform the calculation in a way that minimizes the impact of floating point error.
                 final double eps = Math.ulp(valueSquareSum);
                 final double vs2bar = valueSum * (valueSum / count);
                 final double delta = valueSquareSum - vs2bar;
                 final double rel_eps = delta / eps;
 
-                // Assign zero when the variance is <= the floating point error.
+                // Assign zero when the variance is leq the floating point error.
                 final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
@@ -114,7 +114,10 @@ public class FloatRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                final double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                // When the values are extremely close to zero, the variance can be negative due to floating point
+                // rounding errors.  Use the absolute value to avoid NaNs in the output.
+                final double variance =
+                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
@@ -22,7 +22,6 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class FloatRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
-    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -115,11 +114,10 @@ public class FloatRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
-                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
-                // defined threshold.
-                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
-                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
+                // Detect and handle this by setting the variance to zero when negative.
+                final double variance = Math.max(0.0,
+                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
@@ -114,10 +114,15 @@ public class FloatRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
-                // Detect and handle this by setting the variance to zero when negative.
-                final double variance = Math.max(0.0,
-                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
+                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                final double eps = Math.ulp(valueSquareSum);
+                final double vs2bar = valueSum * (valueSum / count);
+                final double delta = valueSquareSum - vs2bar;
+                final double rel_eps = delta / eps;
+
+                // Assign zero when the variance is <= the floating point error.
+                final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/FloatRollingStdOperator.java
@@ -22,6 +22,7 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class FloatRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
+    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -114,10 +115,12 @@ public class FloatRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // When the values are extremely close to zero, the variance can be negative due to floating point
-                // rounding errors.  Use the absolute value to avoid NaNs in the output.
-                final double variance =
-                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
+                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
+                // defined threshold.
+                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
@@ -114,10 +114,15 @@ public class IntRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
-                // Detect and handle this by setting the variance to zero when negative.
-                final double variance = Math.max(0.0,
-                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
+                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                final double eps = Math.ulp(valueSquareSum);
+                final double vs2bar = valueSum * (valueSum / count);
+                final double delta = valueSquareSum - vs2bar;
+                final double rel_eps = delta / eps;
+
+                // Assign zero when the variance is <= the floating point error.
+                final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
@@ -22,6 +22,7 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class IntRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
+    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -114,10 +115,12 @@ public class IntRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // When the values are extremely close to zero, the variance can be negative due to floating point
-                // rounding errors.  Use the absolute value to avoid NaNs in the output.
-                final double variance =
-                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
+                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
+                // defined threshold.
+                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
@@ -114,7 +114,10 @@ public class IntRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                final double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                // When the values are extremely close to zero, the variance can be negative due to floating point
+                // rounding errors.  Use the absolute value to avoid NaNs in the output.
+                final double variance =
+                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
@@ -22,7 +22,6 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class IntRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
-    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -115,11 +114,10 @@ public class IntRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
-                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
-                // defined threshold.
-                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
-                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
+                // Detect and handle this by setting the variance to zero when negative.
+                final double variance = Math.max(0.0,
+                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/IntRollingStdOperator.java
@@ -111,17 +111,27 @@ public class IntRollingStdOperator extends BaseDoubleUpdateByOperator {
                 outputValues.set(outIdx, NULL_DOUBLE);
             } else {
                 final int count = valueBuffer.size() - nullCount;
+
+                if (count <= 1) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
-                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                if (Double.isNaN(valueSquareSum) || Double.isNaN(valueSum)) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
+                // Perform the calculation in a way that minimizes the impact of floating point error.
                 final double eps = Math.ulp(valueSquareSum);
                 final double vs2bar = valueSum * (valueSum / count);
                 final double delta = valueSquareSum - vs2bar;
                 final double rel_eps = delta / eps;
 
-                // Assign zero when the variance is <= the floating point error.
+                // Assign zero when the variance is leq the floating point error.
                 final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
@@ -114,7 +114,10 @@ public class LongRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                final double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                // When the values are extremely close to zero, the variance can be negative due to floating point
+                // rounding errors.  Use the absolute value to avoid NaNs in the output.
+                final double variance =
+                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
@@ -111,17 +111,27 @@ public class LongRollingStdOperator extends BaseDoubleUpdateByOperator {
                 outputValues.set(outIdx, NULL_DOUBLE);
             } else {
                 final int count = valueBuffer.size() - nullCount;
+
+                if (count <= 1) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
-                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                if (Double.isNaN(valueSquareSum) || Double.isNaN(valueSum)) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
+                // Perform the calculation in a way that minimizes the impact of floating point error.
                 final double eps = Math.ulp(valueSquareSum);
                 final double vs2bar = valueSum * (valueSum / count);
                 final double delta = valueSquareSum - vs2bar;
                 final double rel_eps = delta / eps;
 
-                // Assign zero when the variance is <= the floating point error.
+                // Assign zero when the variance is leq the floating point error.
                 final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
@@ -22,6 +22,7 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class LongRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
+    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -114,10 +115,12 @@ public class LongRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // When the values are extremely close to zero, the variance can be negative due to floating point
-                // rounding errors.  Use the absolute value to avoid NaNs in the output.
-                final double variance =
-                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
+                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
+                // defined threshold.
+                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
@@ -114,10 +114,15 @@ public class LongRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
-                // Detect and handle this by setting the variance to zero when negative.
-                final double variance = Math.max(0.0,
-                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
+                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                final double eps = Math.ulp(valueSquareSum);
+                final double vs2bar = valueSum * (valueSum / count);
+                final double delta = valueSquareSum - vs2bar;
+                final double rel_eps = delta / eps;
+
+                // Assign zero when the variance is <= the floating point error.
+                final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/LongRollingStdOperator.java
@@ -22,7 +22,6 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class LongRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
-    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -115,11 +114,10 @@ public class LongRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
-                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
-                // defined threshold.
-                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
-                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
+                // Detect and handle this by setting the variance to zero when negative.
+                final double variance = Math.max(0.0,
+                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
@@ -22,6 +22,7 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class ShortRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
+    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -114,10 +115,12 @@ public class ShortRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // When the values are extremely close to zero, the variance can be negative due to floating point
-                // rounding errors.  Use the absolute value to avoid NaNs in the output.
-                final double variance =
-                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
+                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
+                // defined threshold.
+                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
@@ -114,7 +114,10 @@ public class ShortRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                final double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
+                // When the values are extremely close to zero, the variance can be negative due to floating point
+                // rounding errors.  Use the absolute value to avoid NaNs in the output.
+                final double variance =
+                        Math.abs(valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
                 final double std = Math.sqrt(variance);
 
                 outputValues.set(outIdx, std);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
@@ -22,7 +22,6 @@ import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
 
 public class ShortRollingStdOperator extends BaseDoubleUpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 128;
-    private static final double VARIANCE_THRESHOLD = 1e-12;
     // region extra-fields
     // endregion extra-fields
 
@@ -115,11 +114,10 @@ public class ShortRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero or infinitesimally small (when it
-                // should be exactly zero).  Handle these cases by clamping variance it to 0 when it is lower than a
-                // defined threshold.
-                double variance = valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1);
-                variance = variance < VARIANCE_THRESHOLD ? 0.0 : variance;
+                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
+                // Detect and handle this by setting the variance to zero when negative.
+                final double variance = Math.max(0.0,
+                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
@@ -114,10 +114,15 @@ public class ShortRollingStdOperator extends BaseDoubleUpdateByOperator {
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Due to floating point error, variance can become less than zero (which is mathematically impossible).
-                // Detect and handle this by setting the variance to zero when negative.
-                final double variance = Math.max(0.0,
-                        valueSquareSum / (count - 1) - valueSum * valueSum / count / (count - 1));
+                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
+                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                final double eps = Math.ulp(valueSquareSum);
+                final double vs2bar = valueSum * (valueSum / count);
+                final double delta = valueSquareSum - vs2bar;
+                final double rel_eps = delta / eps;
+
+                // Assign zero when the variance is <= the floating point error.
+                final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingstd/ShortRollingStdOperator.java
@@ -111,17 +111,27 @@ public class ShortRollingStdOperator extends BaseDoubleUpdateByOperator {
                 outputValues.set(outIdx, NULL_DOUBLE);
             } else {
                 final int count = valueBuffer.size() - nullCount;
+
+                if (count <= 1) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
                 final double valueSquareSum = valueSquareBuffer.evaluate();
                 final double valueSum = valueBuffer.evaluate();
 
-                // Perform the calculation in a way that minimizes the impact of floating point error. For details,
-                // see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+                if (Double.isNaN(valueSquareSum) || Double.isNaN(valueSum)) {
+                    outputValues.set(outIdx, Double.NaN);
+                    return;
+                }
+
+                // Perform the calculation in a way that minimizes the impact of floating point error.
                 final double eps = Math.ulp(valueSquareSum);
                 final double vs2bar = valueSum * (valueSum / count);
                 final double delta = valueSquareSum - vs2bar;
                 final double rel_eps = delta / eps;
 
-                // Assign zero when the variance is <= the floating point error.
+                // Assign zero when the variance is leq the floating point error.
                 final double variance = Math.abs(rel_eps) > 1.0 ? delta / (count - 1) : 0.0;
 
                 final double std = Math.sqrt(variance);


### PR DESCRIPTION
When computing `std` / `variance` on effectively constant values, floating point error can result in the computed `variance` becoming a negative value, forcing `std` (which is `sqrt(variance)`) to become `NaN` in the output columns.   This PR clamps variance values to zero when smaller than a defined threshold (currently 1e-12) which also corrects the case when mathematically the variance should be zero but is instead a near-zero floating point value.

Will close #4397