### PR TITLE
Remove jackson from the public API of extensions-parquet-table

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -3,7 +3,6 @@
  */
 package io.deephaven.parquet.table;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.stringset.StringSet;
 import io.deephaven.engine.table.impl.locations.TableDataException;
@@ -110,7 +109,7 @@ public class ParquetSchemaReader {
         }
         try {
             return Optional.of(TableInfo.deserializeFromJSON(tableInfoRaw));
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             throw new TableDataException("Failed to parse " + ParquetTableWriter.METADATA_KEY + " metadata", e);
         }
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/metadata/TableInfo.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/metadata/TableInfo.java
@@ -4,7 +4,6 @@
 package io.deephaven.parquet.table.metadata;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -14,6 +13,7 @@ import io.deephaven.annotations.BuildableStyle;
 import org.immutables.value.Value;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,11 +39,11 @@ public abstract class TableInfo {
         OBJECT_MAPPER = objectMapper;
     }
 
-    public final String serializeToJSON() throws JsonProcessingException {
+    public final String serializeToJSON() throws IOException {
         return OBJECT_MAPPER.writeValueAsString(this);
     }
 
-    public static TableInfo deserializeFromJSON(@NotNull final String tableInfoRaw) throws JsonProcessingException {
+    public static TableInfo deserializeFromJSON(@NotNull final String tableInfoRaw) throws IOException {
         return OBJECT_MAPPER.readValue(tableInfoRaw, ImmutableTableInfo.class);
     }
 


### PR DESCRIPTION
Afaict, this was the only instance in this project where jackson was exposed. There are annotations attached to public objects, but that doesn't effect the public API. Tooling related to #4401 may help automate this process and eliminate bugs like this from happening in the future.

Fixes #4402