### PR TITLE
Fix thread safety for gRPC websocket transports 

### DIFF
--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletAdapter.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletAdapter.java
@@ -172,8 +172,10 @@ public final class ServletAdapter {
                 getAuthority(req),
                 logId);
 
-        transportListener.streamCreated(stream, method, headers);
-        stream.transportState().runOnTransportThread(stream.transportState()::onStreamAllocated);
+        stream.transportState().runOnTransportThread(() -> {
+            transportListener.streamCreated(stream, method, headers);
+            stream.transportState().onStreamAllocated();
+        });
 
         asyncCtx.getRequest().getInputStream()
                 .setReadListener(new GrpcReadListener(stream, asyncCtx, logId));

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/AbstractWebsocketStreamImpl.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/AbstractWebsocketStreamImpl.java
@@ -91,16 +91,20 @@ public abstract class AbstractWebsocketStreamImpl extends AbstractServerStream {
     }
 
     public void createStream(ServerTransportListener transportListener, String methodName, Metadata headers) {
-        transportListener.streamCreated(this, methodName, headers);
-        transportState().onStreamAllocated();
+        transportState().runOnTransportThread(() -> {
+            transportListener.streamCreated(this, methodName, headers);
+            transportState().onStreamAllocated();
+        });
     }
 
     public void inboundDataReceived(ReadableBuffer message, boolean endOfStream) {
-        transportState().inboundDataReceived(message, endOfStream);
+        transportState().runOnTransportThread(() -> {
+            transportState().inboundDataReceived(message, endOfStream);
+        });
     }
 
     public void transportReportStatus(Status status) {
-        transportState().transportReportStatus(status);
+        transportState().runOnTransportThread(() -> transportState().transportReportStatus(status));
     }
 
     @Override

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebSocketServerStream.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebSocketServerStream.java
@@ -62,8 +62,6 @@ public class MultiplexedWebSocketServerStream extends AbstractWebSocketServerStr
 
     public static final String GRPC_WEBSOCKETS_MULTIPLEX_PROTOCOL = "grpc-websockets-multiplex";
 
-    private final InternalLogId logId = InternalLogId.allocate(MultiplexedWebSocketServerStream.class, null);
-
     // No need to be thread-safe, this will only be accessed from the transport thread.
     private final Map<Integer, MultiplexedWebsocketStreamImpl> streams = new HashMap<>();
     private final boolean isTextRequest = false;// not supported yet
@@ -246,6 +244,8 @@ public class MultiplexedWebSocketServerStream extends AbstractWebSocketServerStr
 
         StatsTraceContext statsTraceCtx =
                 StatsTraceContext.newServerContext(streamTracerFactories, path, headers);
+
+        InternalLogId logId = InternalLogId.allocate(MultiplexedWebSocketServerStream.class, null);
 
         MultiplexedWebsocketStreamImpl stream =
                 new MultiplexedWebsocketStreamImpl(statsTraceCtx, maxInboundMessageSize, websocketSession, logId,

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebSocketServerStream.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/MultiplexedWebSocketServerStream.java
@@ -39,10 +39,6 @@ import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
  * On the initial request, an extra header is sent from the client, indicating the path to the service method.
  * Technically, this makes it possible for a grpc message to split across several websocket frames, but at this time
  * each grpc message is exactly one websocket frame.
- * <p>
- * </p>
- * JSR356 websockets always handle their incoming messages in a serial manner, so we don't need to worry here about
- * runOnTransportThread while in onMessage, as we're already in the transport thread.
  */
 public class MultiplexedWebSocketServerStream extends AbstractWebSocketServerStream {
     public static final String GRACEFUL_CLOSE = MultiplexedWebSocketServerStream.class.getName() + ".graceful_close";
@@ -62,7 +58,7 @@ public class MultiplexedWebSocketServerStream extends AbstractWebSocketServerStr
 
     public static final String GRPC_WEBSOCKETS_MULTIPLEX_PROTOCOL = "grpc-websockets-multiplex";
 
-    // No need to be thread-safe, this will only be accessed from the transport thread.
+    // No need to be thread-safe, this will only be accessed from the jsr356 callbacks in a serial manner
     private final Map<Integer, MultiplexedWebsocketStreamImpl> streams = new HashMap<>();
     private final boolean isTextRequest = false;// not supported yet
 

--- a/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebSocketServerStream.java
+++ b/grpc-java/grpc-servlet-websocket-jakarta/src/main/java/io/grpc/servlet/web/websocket/WebSocketServerStream.java
@@ -22,9 +22,6 @@ import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 
 /**
  * Each instance of this type represents a single active websocket, which maps to a single gRPC stream.
- *
- * JSR356 websockets always handle their incoming messages in a serial manner, so we don't need to worry here about
- * runOnTransportThread while in onMessage, as we're already in the transport thread.
  */
 public class WebSocketServerStream extends AbstractWebSocketServerStream {
     private static final Logger logger = Logger.getLogger(WebSocketServerStream.class.getName());


### PR DESCRIPTION
Some gRPC operations on `ServerTransportListener` and `TransportState` are specified as only intended to be called from the "transport thread" - prior to this patch, we had incorrectly interpreted this to allow serial operations from the websocket handler in the server. This patch ensures that those operations are additionally serialized against calls from gRPC internals. Among other things, this fixes an issue where messages could be closed while being deframed.

Fixes #4406