### PR TITLE
Fix kafka json byte and char types

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.QueryConstants;
+import io.deephaven.util.type.TypeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -75,8 +76,7 @@ public class JsonNodeUtil {
      */
     public static int getInt(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getInt(tmpNode);
+        return getInt(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -88,8 +88,7 @@ public class JsonNodeUtil {
      */
     public static int getInt(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getInt(tmpNode);
+        return getInt(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -112,8 +111,7 @@ public class JsonNodeUtil {
     @Nullable
     public static Integer getBoxedInt(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoxedInt(tmpNode);
+        return TypeUtils.box(getInt(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -124,7 +122,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static Integer getBoxedInt(final JsonNode node) {
-        return isNullOrMissingField(node) ? null : node.asInt();
+        return TypeUtils.box(getInt(node));
     }
 
     /**
@@ -136,8 +134,7 @@ public class JsonNodeUtil {
      */
     public static short getShort(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getShort(tmpNode);
+        return getShort(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -149,8 +146,7 @@ public class JsonNodeUtil {
      */
     public static short getShort(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getShort(tmpNode);
+        return getShort(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -173,13 +169,12 @@ public class JsonNodeUtil {
     @Nullable
     public static Short getBoxedShort(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoxedShort(tmpNode);
+        return TypeUtils.box(getShort(node, key, allowMissingKeys, allowNullValues));
     }
 
     @Nullable
     public static Short getBoxedShort(final JsonNode node) {
-        return isNullOrMissingField(node) ? null : (short) node.asInt();
+        return TypeUtils.box(getShort(node));
     }
 
     /**
@@ -191,8 +186,7 @@ public class JsonNodeUtil {
      */
     public static long getLong(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getLong(tmpNode);
+        return getLong(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -204,8 +198,7 @@ public class JsonNodeUtil {
      */
     public static long getLong(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getLong(tmpNode);
+        return getLong(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -228,8 +221,7 @@ public class JsonNodeUtil {
     @Nullable
     public static Long getBoxedLong(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoxedLong(tmpNode);
+        return TypeUtils.box(getLong(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -240,7 +232,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static Long getBoxedLong(final JsonNode node) {
-        return isNullOrMissingField(node) ? null : node.asLong();
+        return TypeUtils.box(getLong(node));
     }
 
     /**
@@ -252,8 +244,7 @@ public class JsonNodeUtil {
      */
     public static double getDouble(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getDouble(tmpNode);
+        return getDouble(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -265,8 +256,7 @@ public class JsonNodeUtil {
      */
     public static double getDouble(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getDouble(tmpNode);
+        return getDouble(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -289,8 +279,8 @@ public class JsonNodeUtil {
     @Nullable
     public static Double getBoxedDouble(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoxedDouble(tmpNode);
+        return TypeUtils.box(getDouble(node, key, allowMissingKeys, allowNullValues));
+
     }
 
     /**
@@ -301,7 +291,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static Double getBoxedDouble(final JsonNode node) {
-        return isNullOrMissingField(node) ? null : node.asDouble();
+        return TypeUtils.box(getDouble(node));
     }
 
     /**
@@ -313,8 +303,7 @@ public class JsonNodeUtil {
      */
     public static float getFloat(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getFloat(tmpNode);
+        return getFloat(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -326,8 +315,7 @@ public class JsonNodeUtil {
      */
     public static float getFloat(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getFloat(tmpNode);
+        return getFloat(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -350,8 +338,7 @@ public class JsonNodeUtil {
     @Nullable
     public static Float getBoxedFloat(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoxedFloat(tmpNode);
+        return TypeUtils.box(getFloat(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -362,7 +349,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static Float getBoxedFloat(final JsonNode node) {
-        return isNullOrMissingField(node) ? null : (float) node.asDouble();
+        return TypeUtils.box(getFloat(node));
     }
 
     /**
@@ -374,8 +361,7 @@ public class JsonNodeUtil {
      */
     public static byte getByte(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getByte(tmpNode);
+        return getByte(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -387,8 +373,7 @@ public class JsonNodeUtil {
      */
     public static byte getByte(@NotNull final JsonNode node, @NotNull JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getByte(tmpNode);
+        return getByte(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -414,8 +399,7 @@ public class JsonNodeUtil {
     @Nullable
     public static Byte getBoxedByte(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoxedByte(tmpNode);
+        return TypeUtils.box(getByte(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -426,10 +410,7 @@ public class JsonNodeUtil {
      */
     @Nullable
     public static Byte getBoxedByte(final JsonNode node) {
-        if (isNullOrMissingField(node)) {
-            return null;
-        }
-        return (byte) node.asInt();
+        return TypeUtils.box(getByte(node));
     }
 
     /**
@@ -441,8 +422,7 @@ public class JsonNodeUtil {
      */
     public static char getChar(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getChar(tmpNode);
+        return getChar(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -454,8 +434,7 @@ public class JsonNodeUtil {
      */
     public static char getChar(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getChar(tmpNode);
+        return getChar(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -493,28 +472,12 @@ public class JsonNodeUtil {
     @Nullable
     public static Character getBoxedChar(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoxedChar(tmpNode);
+        return TypeUtils.box(getChar(node, key, allowMissingKeys, allowNullValues));
     }
 
     @Nullable
     public static Character getBoxedChar(final JsonNode node) {
-        if (isNullOrMissingField(node)) {
-            return null;
-        }
-        if (node.isNumber()) {
-            // We don't expect this to be a common case; but if the node happens to be a number, we'll assume it's meant
-            // to represent a char by casting. This is much more appropriate than just taking the first character of the
-            // number's string.
-            return (char) node.numberValue().intValue();
-        }
-        final String s = node.asText();
-        // It would not be unreasonable for us to throw an error if s.length() != 1.
-        // All of the other code paths are very lenient though, so we'll be lenient here too.
-        if (s.isEmpty()) {
-            return null;
-        }
-        return s.charAt(0);
+        return TypeUtils.box(getChar(node));
     }
 
     /**
@@ -527,8 +490,7 @@ public class JsonNodeUtil {
     @Nullable
     public static String getString(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getString(tmpNode);
+        return getString(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -541,8 +503,7 @@ public class JsonNodeUtil {
     @Nullable
     public static String getString(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getString(tmpNode);
+        return getString(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -568,8 +529,7 @@ public class JsonNodeUtil {
      */
     public static Boolean getBoolean(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBoolean(tmpNode);
+        return getBoolean(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -581,8 +541,7 @@ public class JsonNodeUtil {
      */
     public static Boolean getBoolean(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getBoolean(tmpNode);
+        return getBoolean(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -605,8 +564,7 @@ public class JsonNodeUtil {
      */
     public static BigInteger getBigInteger(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBigInteger(tmpNode);
+        return getBigInteger(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -618,8 +576,7 @@ public class JsonNodeUtil {
      */
     public static BigInteger getBigInteger(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getBigInteger(tmpNode);
+        return getBigInteger(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -643,8 +600,7 @@ public class JsonNodeUtil {
     @Nullable
     public static BigDecimal getBigDecimal(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getBigDecimal(tmpNode);
+        return getBigDecimal(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -657,8 +613,7 @@ public class JsonNodeUtil {
     @Nullable
     public static BigDecimal getBigDecimal(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getBigDecimal(tmpNode);
+        return getBigDecimal(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -682,8 +637,7 @@ public class JsonNodeUtil {
     @Nullable
     public static Object getValue(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getValue(tmpNode);
+        return getValue(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -709,8 +663,7 @@ public class JsonNodeUtil {
     @Nullable
     public static Instant getInstant(@NotNull final JsonNode node, @NotNull final String key,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues);
-        return getInstant(tmpNode);
+        return getInstant(checkAllowMissingOrNull(node, key, allowMissingKeys, allowNullValues));
     }
 
     /**
@@ -725,8 +678,7 @@ public class JsonNodeUtil {
     @Nullable
     public static Instant getInstant(@NotNull final JsonNode node, @NotNull final JsonPointer ptr,
             final boolean allowMissingKeys, final boolean allowNullValues) {
-        final JsonNode tmpNode = checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues);
-        return getInstant(tmpNode);
+        return getInstant(checkAllowMissingOrNull(node, ptr, allowMissingKeys, allowNullValues));
     }
 
     /**

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/JsonNodeUtil.java
@@ -401,11 +401,7 @@ public class JsonNodeUtil {
         if (isNullOrMissingField(node)) {
             return QueryConstants.NULL_BYTE;
         }
-        final byte[] bytes = node.asText().getBytes();
-        if (bytes.length == 0) {
-            return QueryConstants.NULL_BYTE;
-        }
-        return bytes[0];
+        return (byte) node.asInt();
     }
 
     /**
@@ -433,11 +429,7 @@ public class JsonNodeUtil {
         if (isNullOrMissingField(node)) {
             return null;
         }
-        final byte[] bytes = node.asText().getBytes();
-        if (bytes.length == 0) {
-            return null;
-        }
-        return bytes[0];
+        return (byte) node.asInt();
     }
 
     /**
@@ -476,7 +468,15 @@ public class JsonNodeUtil {
         if (isNullOrMissingField(node)) {
             return QueryConstants.NULL_CHAR;
         }
+        if (node.isNumber()) {
+            // We don't expect this to be a common case; but if the node happens to be a number, we'll assume it's meant
+            // to represent a char by casting. This is much more appropriate than just taking the first character of the
+            // number's string.
+            return (char) node.numberValue().intValue();
+        }
         final String s = node.asText();
+        // It would not be unreasonable for us to throw an error if s.length() != 1.
+        // All of the other code paths are very lenient though, so we'll be lenient here too.
         if (s.isEmpty()) {
             return QueryConstants.NULL_CHAR;
         }
@@ -498,11 +498,19 @@ public class JsonNodeUtil {
     }
 
     @Nullable
-    public static Character getBoxedChar(final JsonNode tmpNode) {
-        if (isNullOrMissingField(tmpNode)) {
+    public static Character getBoxedChar(final JsonNode node) {
+        if (isNullOrMissingField(node)) {
             return null;
         }
-        final String s = tmpNode.asText();
+        if (node.isNumber()) {
+            // We don't expect this to be a common case; but if the node happens to be a number, we'll assume it's meant
+            // to represent a char by casting. This is much more appropriate than just taking the first character of the
+            // number's string.
+            return (char) node.numberValue().intValue();
+        }
+        final String s = node.asText();
+        // It would not be unreasonable for us to throw an error if s.length() != 1.
+        // All of the other code paths are very lenient though, so we'll be lenient here too.
         if (s.isEmpty()) {
             return null;
         }

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/publish/JsonKeyOrValueSerializer.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/publish/JsonKeyOrValueSerializer.java
@@ -168,7 +168,9 @@ public class JsonKeyOrValueSerializer implements KeyOrValueSerializer<String> {
                         node.putNull(childNodeFieldName);
                     }
                 } else {
-                    node.put(childNodeFieldName, raw);
+                    // No signature matches ObjectNode#put(String, byte).
+                    // #set w/ ContainerNode#numberNode(byte) is the most appropriately typed call.
+                    node.set(childNodeFieldName, node.numberNode(raw));
                 }
             }
         };
@@ -184,7 +186,8 @@ public class JsonKeyOrValueSerializer implements KeyOrValueSerializer<String> {
                         node.putNull(childNodeFieldName);
                     }
                 } else {
-                    node.put(childNodeFieldName, raw);
+                    // No native support for char type; we'll treat as String.
+                    node.put(childNodeFieldName, String.valueOf(raw));
                 }
             }
         };


### PR DESCRIPTION
byte consumption was incorrect; it was being deserialized as a text node with the first byte of that text being the result. Instead, it should be treated as a numeric node, and cast to byte. This matches how other numeric types are handled.

char production was incorrect; it was being serialized as an int node. Instead, it should be treated as a text node which matches the expectations of the existing deserialization logic. Additionally, we can extend char deserialization to work in the case where the node actually _is_ a number.

Fixes #4384