### PR TITLE
Fix Static Initialization Deadlock

### DIFF
--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/RefCountedCow.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/RefCountedCow.java
@@ -72,9 +72,9 @@ import io.deephaven.util.annotations.VisibleForTesting;
  * @param <T> A class that will extend us, to get RefCounted functionality.
  */
 public abstract class RefCountedCow<T> {
-    private static final boolean debug = RspArray.debug ||
-            Configuration.getInstance().getBooleanForClassWithDefault(
-                    RefCountedCow.class, "debug", false);
+    private static final boolean debug =
+            Configuration.getInstance().getBooleanForClassWithDefault(RspArray.class, "debug", false)
+                    || Configuration.getInstance().getBooleanForClassWithDefault(RefCountedCow.class, "debug", false);
 
     /**
      * Field updater for refCount, so we can avoid creating an {@link java.util.concurrent.atomic.AtomicInteger} for


### PR DESCRIPTION
RspArray is a subclass of RefCountedCow. Two threads deadlock as one resolves RefCountedCow.debug while the other resolves RspArray.debug. To resolve RspArray it seems we need initialize the super class, but find it locked. To resolve the super class we need to resolve the sub class (as it references the subclass's debug value), but it is also found locked.

This change is in effect the same thing, but avoids the deadlock.

Release Notes: Fixed static initialization deadlock that was likely in app-mode.