### PR TITLE
Rename weight column parameter for `update_by` weighted avg.

### DIFF
--- a/py/client/pydeephaven/updateby.py
+++ b/py/client/pydeephaven/updateby.py
@@ -1376,7 +1376,7 @@ def rolling_std_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[i
         raise DHError(e, "failed to create a rolling standard deviation (time) UpdateByOperation.") from e
 
 
-def rolling_wavg_tick(weight_col: str, cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int = 0) -> UpdateByOperation:
+def rolling_wavg_tick(wcol: str, cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int = 0) -> UpdateByOperation:
     """Creates a rolling weighted average UpdateByOperation for the supplied column names, using ticks as the windowing unit. Ticks
     are row counts, and you may specify the reverse and forward window in number of rows to include. The current row
     is considered to belong to the reverse window but not the forward window. Also, negative values are allowed and
@@ -1397,7 +1397,7 @@ def rolling_wavg_tick(weight_col: str, cols: Union[str, List[str]], rev_ticks: i
     Args:
         cols (Union[str, List[str]]): the column(s) to be operated on, can include expressions to rename the output,
             i.e. "new_col = col"; when empty, update_by perform the rolling weighted average operation on all columns.
-        weight_col (str):  the column containing the weight values
+        wcol (str):  the column containing the weight values
         rev_ticks (int): the look-behind window size (in rows/ticks)
         fwd_ticks (int): the look-forward window size (int rows/ticks), default is 0
 
@@ -1412,7 +1412,7 @@ def rolling_wavg_tick(weight_col: str, cols: Union[str, List[str]], rev_ticks: i
         fwd_window_scale = _GrpcUpdateByWindowScale(ticks=_GrpcUpdateByWindowTicks(ticks=fwd_ticks))
         ub_rolling = _GrpcUpdateByRollingWAvg(reverse_window_scale=rev_window_scale,
                                               forward_window_scale=fwd_window_scale,
-                                              weight_column=weight_col)
+                                              weight_column=wcol)
         ub_spec = _GrpcUpdateBySpec(rolling_wavg=ub_rolling)
         ub_column = _GrpcUpdateByColumn(spec=ub_spec, match_pairs=to_list(cols))
         return UpdateByOperation(ub_column=ub_column)
@@ -1420,7 +1420,7 @@ def rolling_wavg_tick(weight_col: str, cols: Union[str, List[str]], rev_ticks: i
         raise DHError(e, "failed to create a rolling weighted average (tick) UpdateByOperation.") from e
 
 
-def rolling_wavg_time(ts_col: str, weight_col: str, cols: Union[str, List[str]], rev_time: Union[int, str],
+def rolling_wavg_time(ts_col: str, wcol: str, cols: Union[str, List[str]], rev_time: Union[int, str],
                       fwd_time: Union[int, str] = 0) -> UpdateByOperation:
     """Creates a rolling weighted average UpdateByOperation for the supplied column names, using time as the windowing unit. This
     function accepts nanoseconds or time strings as the reverse and forward window parameters. Negative values are
@@ -1445,7 +1445,7 @@ def rolling_wavg_time(ts_col: str, weight_col: str, cols: Union[str, List[str]],
         ts_col (str): the timestamp column for determining the window
         cols (Union[str, List[str]]): the column(s) to be operated on, can include expressions to rename the output,
             i.e. "new_col = col"; when empty, update_by perform the rolling weighted average operation on all columns.
-        weight_col (str):  the column containing the weight values
+        wcol (str):  the column containing the weight values
         rev_time (Union[int, str]): the look-behind window size, can be expressed as an integer in nanoseconds or a time
             interval string, e.g. "PT00:00:.001" or "PT5M"
         fwd_time (Union[int, str]): the look-ahead window size, can be expressed as an integer in nanoseconds or a time
@@ -1470,7 +1470,7 @@ def rolling_wavg_time(ts_col: str, weight_col: str, cols: Union[str, List[str]],
 
         ub_rolling = _GrpcUpdateByRollingWAvg(reverse_window_scale=rev_window_scale,
                                               forward_window_scale=fwd_window_scale,
-                                              weight_column=weight_col)
+                                              weight_column=wcol)
         ub_spec = _GrpcUpdateBySpec(rolling_wavg=ub_rolling)
         ub_column = _GrpcUpdateByColumn(spec=ub_spec, match_pairs=to_list(cols))
         return UpdateByOperation(ub_column=ub_column)

--- a/py/client/tests/test_updateby.py
+++ b/py/client/tests/test_updateby.py
@@ -156,11 +156,11 @@ class UpdateByTestCase(BaseTestCase):
             rolling_std_time(ts_col="Timestamp", cols=["rstd_b = b", "rstd_e = e"], rev_time="PT30S",
                              fwd_time="-PT00:00:20"),
             # rolling weighted average (using "b" as the weight column)
-            rolling_wavg_tick(weight_col="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
-            rolling_wavg_tick(weight_col="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10, fwd_ticks=10),
-            rolling_wavg_time(ts_col="Timestamp", weight_col="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT00:00:10"),
-            rolling_wavg_time(ts_col="Timestamp", weight_col="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time=10_000_000_000, fwd_time=-10_000_000_00),
-            rolling_wavg_time(ts_col="Timestamp", weight_col="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT30S", fwd_time="-PT00:00:20"),
+            rolling_wavg_tick(wcol="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
+            rolling_wavg_tick(wcol="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10, fwd_ticks=10),
+            rolling_wavg_time(ts_col="Timestamp", wcol="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT00:00:10"),
+            rolling_wavg_time(ts_col="Timestamp", wcol="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time=10_000_000_000, fwd_time=-10_000_000_00),
+            rolling_wavg_time(ts_col="Timestamp", wcol="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT30S", fwd_time="-PT00:00:20"),
         ]
 
 
@@ -199,7 +199,7 @@ class UpdateByTestCase(BaseTestCase):
             cum_max(["max_a=a", "max_d=d"]),
             ema_tick(10, ["ema_d=d", "ema_e=e"]),
             ema_time("Timestamp", "PT00:00:00.1", ["ema_time_d=d", "ema_time_e=e"]),
-            rolling_wavg_tick(weight_col="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
+            rolling_wavg_tick(wcol="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
         ]
         for t in (self.static_table, self.ticking_table):
             rt = t.update_by(ops=multiple_ops, by="c")

--- a/py/server/deephaven/updateby.py
+++ b/py/server/deephaven/updateby.py
@@ -1249,7 +1249,7 @@ def rolling_std_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[i
         raise DHError(e, "failed to create a rolling standard deviation (time) UpdateByOperation.") from e
 
 
-def rolling_wavg_tick(weight_col: str, cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int = 0) -> UpdateByOperation:
+def rolling_wavg_tick(wcol: str, cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int = 0) -> UpdateByOperation:
     """Creates a rolling weighted average UpdateByOperation for the supplied column names, using ticks as the windowing unit. Ticks
     are row counts, and you may specify the reverse and forward window in number of rows to include. The current row
     is considered to belong to the reverse window but not the forward window. Also, negative values are allowed and
@@ -1272,7 +1272,7 @@ def rolling_wavg_tick(weight_col: str, cols: Union[str, List[str]], rev_ticks: i
             i.e. "new_col = col"; when empty, update_by perform the rolling weighted average operation on all columns.
         cols (Union[str, List[str]]): the column(s) to be operated on, can include expressions to rename the output,
             i.e. "new_col = col"; when empty, update_by perform the rolling weighted average operation on all columns.
-        weight_col (str):  the column containing the weight values
+        wcol (str):  the column containing the weight values
         rev_ticks (int): the look-behind window size (in rows/ticks)
         fwd_ticks (int): the look-forward window size (int rows/ticks), default is 0
 
@@ -1284,12 +1284,12 @@ def rolling_wavg_tick(weight_col: str, cols: Union[str, List[str]], rev_ticks: i
     """
     try:
         cols = to_sequence(cols)
-        return UpdateByOperation(j_updateby_op=_JUpdateByOperation.RollingWAvg(rev_ticks, fwd_ticks, weight_col, *cols))
+        return UpdateByOperation(j_updateby_op=_JUpdateByOperation.RollingWAvg(rev_ticks, fwd_ticks, wcol, *cols))
     except Exception as e:
         raise DHError(e, "failed to create a rolling weighted average (tick) UpdateByOperation.") from e
 
 
-def rolling_wavg_time(ts_col: str, weight_col: str, cols: Union[str, List[str]], rev_time: Union[int, str],
+def rolling_wavg_time(ts_col: str, wcol: str, cols: Union[str, List[str]], rev_time: Union[int, str],
                       fwd_time: Union[int, str] = 0) -> UpdateByOperation:
     """Creates a rolling weighted average UpdateByOperation for the supplied column names, using time as the windowing unit. This
     function accepts nanoseconds or time strings as the reverse and forward window parameters. Negative values are
@@ -1314,7 +1314,7 @@ def rolling_wavg_time(ts_col: str, weight_col: str, cols: Union[str, List[str]],
         ts_col (str): the timestamp column for determining the window
         cols (Union[str, List[str]]): the column(s) to be operated on, can include expressions to rename the output,
             i.e. "new_col = col"; when empty, update_by perform the rolling weighted average operation on all columns.
-        weight_col (str):  the column containing the weight values
+        wcol (str):  the column containing the weight values
         rev_time (int): the look-behind window size, can be expressed as an integer in nanoseconds or a time
             interval string, e.g. "PT00:00:00.001" or "PT5M"
         fwd_time (int): the look-ahead window size, can be expressed as an integer in nanoseconds or a time
@@ -1330,6 +1330,6 @@ def rolling_wavg_time(ts_col: str, weight_col: str, cols: Union[str, List[str]],
         cols = to_sequence(cols)
         rev_time = _JDateTimeUtils.parseDurationNanos(rev_time) if isinstance(rev_time, str) else rev_time
         fwd_time = _JDateTimeUtils.parseDurationNanos(fwd_time) if isinstance(fwd_time, str) else fwd_time
-        return UpdateByOperation(j_updateby_op=_JUpdateByOperation.RollingWAvg(ts_col, rev_time, fwd_time, weight_col, *cols))
+        return UpdateByOperation(j_updateby_op=_JUpdateByOperation.RollingWAvg(ts_col, rev_time, fwd_time, wcol, *cols))
     except Exception as e:
         raise DHError(e, "failed to create a rolling weighted average (time) UpdateByOperation.") from e

--- a/py/server/tests/test_updateby.py
+++ b/py/server/tests/test_updateby.py
@@ -148,11 +148,11 @@ class UpdateByTestCase(BaseTestCase):
             rolling_std_time(ts_col="Timestamp", cols=["rstd_b = b", "rstd_e = e"], rev_time="PT30S",
                              fwd_time="-PT00:00:20"),
             # rolling weighted average (using "b" as the weight column)
-            rolling_wavg_tick(weight_col="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
-            rolling_wavg_tick(weight_col="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10, fwd_ticks=10),
-            rolling_wavg_time(ts_col="Timestamp", weight_col="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT00:00:10"),
-            rolling_wavg_time(ts_col="Timestamp", weight_col="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time=10_000_000_000, fwd_time=-10_000_000_00),
-            rolling_wavg_time(ts_col="Timestamp", weight_col="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT30S", fwd_time="-PT00:00:20"),
+            rolling_wavg_tick(wcol="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
+            rolling_wavg_tick(wcol="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10, fwd_ticks=10),
+            rolling_wavg_time(ts_col="Timestamp", wcol="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT00:00:10"),
+            rolling_wavg_time(ts_col="Timestamp", wcol="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time=10_000_000_000, fwd_time=-10_000_000_00),
+            rolling_wavg_time(ts_col="Timestamp", wcol="b", cols=["rwavg_b = b", "rwavg_e = e"], rev_time="PT30S", fwd_time="-PT00:00:20"),
         ]
 
     @classmethod
@@ -245,7 +245,7 @@ class UpdateByTestCase(BaseTestCase):
             cum_max(["max_a=a", "max_d=d"]),
             ema_tick(10, ["ema_d=d", "ema_e=e"]),
             ema_time("Timestamp", "PT00:00:00.1", ["ema_time_d=d", "ema_time_e=e"]),
-            rolling_wavg_tick(weight_col="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
+            rolling_wavg_tick(wcol="b", cols=["rwavg_a = a", "rwavg_d = d"], rev_ticks=10),
         ]
         for t in (self.static_table, self.ticking_table):
             rt = t.update_by(ops=multiple_ops, by="c")


### PR DESCRIPTION
Harmonize our weighted column parameter name to `wcol` in the python api.

Closes #4377 