### PR TITLE
C++ client: input table support

### DIFF
--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_impl.h
@@ -269,6 +269,9 @@ public:
   std::shared_ptr<TableHandleImpl> WhereIn(const TableHandleImpl &filter_table,
       std::vector<std::string> columns);
 
+  void AddTable(const TableHandleImpl &table_to_add);
+  void RemoveTable(const TableHandleImpl &table_to_remove);
+
   [[nodiscard]]
   std::vector<std::shared_ptr<ColumnImpl>> GetColumnImpls();
   [[nodiscard]]

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_manager_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_manager_impl.h
@@ -52,7 +52,9 @@ public:
   std::shared_ptr<TableHandleImpl> TimeTable(DurationSpecifier period, TimePointSpecifier start_time,
       bool blink_table);
   void RunScriptAsync(std::string code, std::shared_ptr<SFCallback<>> callback);
-
+  [[nodiscard]]
+  std::shared_ptr<TableHandleImpl> InputTable(const TableHandleImpl &initial_table,
+      std::vector<std::string> columns);
   /**
    * See the documentation for Server::NewTicket().
    */

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/server/server.h
@@ -27,6 +27,8 @@
 #include "deephaven/proto/config.grpc.pb.h"
 #include "deephaven/proto/console.pb.h"
 #include "deephaven/proto/console.grpc.pb.h"
+#include "deephaven/proto/inputtable.pb.h"
+#include "deephaven/proto/inputtable.grpc.pb.h"
 #include "deephaven/proto/session.pb.h"
 #include "deephaven/proto/session.grpc.pb.h"
 #include "deephaven/proto/table.pb.h"
@@ -77,13 +79,16 @@ class Server : public std::enable_shared_from_this<Server> {
   };
 
   using ApplicationService = io::deephaven::proto::backplane::grpc::ApplicationService;
+  using AddTableResponse = io::deephaven::proto::backplane::grpc::AddTableResponse;
   using AsOfJoinTablesRequest = io::deephaven::proto::backplane::grpc::AsOfJoinTablesRequest;
   using AuthenticationConstantsResponse = io::deephaven::proto::backplane::grpc::AuthenticationConstantsResponse;
   using ComboAggregateRequest = io::deephaven::proto::backplane::grpc::ComboAggregateRequest;
   using ConfigurationConstantsResponse = io::deephaven::proto::backplane::grpc::ConfigurationConstantsResponse;
   using ConfigService = io::deephaven::proto::backplane::grpc::ConfigService;
+  using DeleteTableResponse = io::deephaven::proto::backplane::grpc::DeleteTableResponse;
   using ExportedTableCreationResponse = io::deephaven::proto::backplane::grpc::ExportedTableCreationResponse;
   using HandshakeResponse = io::deephaven::proto::backplane::grpc::HandshakeResponse;
+  using InputTableService = io::deephaven::proto::backplane::grpc::InputTableService;
   using ReleaseResponse = io::deephaven::proto::backplane::grpc::ReleaseResponse;
   using SelectOrUpdateRequest = io::deephaven::proto::backplane::grpc::SelectOrUpdateRequest;
   using SessionService = io::deephaven::proto::backplane::grpc::SessionService;
@@ -118,6 +123,7 @@ public:
       std::unique_ptr<SessionService::Stub> session_stub,
       std::unique_ptr<TableService::Stub> table_stub,
       std::unique_ptr<ConfigService::Stub> config_stub,
+      std::unique_ptr<InputTableService::Stub> input_table_stub,
       std::unique_ptr<arrow::flight::FlightClient> flight_client,
       ClientOptions::extra_headers_t extra_headers,
       std::string session_token,
@@ -133,6 +139,9 @@ public:
 
   [[nodiscard]]
   ConsoleService::Stub *ConsoleStub() const { return consoleStub_.get(); }
+
+  [[nodiscard]]
+  InputTableService::Stub *InputTableStub() const { return input_table_stub_.get(); }
 
   [[nodiscard]]
   SessionService::Stub *SessionStub() const { return sessionStub_.get(); }
@@ -253,8 +262,17 @@ public:
   void SelectDistinctAsync(Ticket source, std::vector<std::string> columns,
       std::shared_ptr<EtcCallback> etc_callback, Ticket result);
 
+  void InputTableAsync(Ticket initial_table_ticket, std::vector<std::string> columns,
+      std::shared_ptr<EtcCallback> etc_callback, Ticket result);
+
   void WhereInAsync(Ticket left_table_ticket, Ticket right_table_ticket,
       std::vector<std::string> columns,  std::shared_ptr<EtcCallback> etc_callback, Ticket result);
+
+  void AddTable(Ticket input_table_ticket, Ticket table_to_add_ticket,
+      std::shared_ptr<SFCallback<AddTableResponse>> callback);
+
+  void RemoveTable(Ticket input_table_ticket, Ticket table_to_remove_ticket,
+      std::shared_ptr<SFCallback<DeleteTableResponse>> callback);
 
   void BindToVariableAsync(const Ticket &console_id, const Ticket &table_id, std::string variable,
       std::shared_ptr<SFCallback<BindTableToVariableResponse>> callback);
@@ -301,6 +319,7 @@ private:
   std::unique_ptr<SessionService::Stub> sessionStub_;
   std::unique_ptr<TableService::Stub> tableStub_;
   std::unique_ptr<ConfigService::Stub> configStub_;
+  std::unique_ptr<InputTableService::Stub> input_table_stub_;
   std::unique_ptr<arrow::flight::FlightClient> flightClient_;
   const ClientOptions::extra_headers_t extraHeaders_;
   grpc::CompletionQueue completionQueue_;

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
@@ -1527,6 +1527,7 @@ public:
    * documentation for the difference between "Where" and "WhereIn".
    * @param filter_table The table containing the set of values to filter on
    * @param columns The columns to match on
+   * @return A TableHandle referencing the new table
    */
   [[nodiscard]]
   TableHandle WhereIn(const TableHandle &filter_table, std::vector<std::string> columns) const;

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
@@ -76,6 +76,8 @@ class TableHandleManager {
   using DurationSpecifier = deephaven::client::utility::DurationSpecifier;
   using TimePointSpecifier = deephaven::client::utility::TimePointSpecifier;
 
+  using SchemaType = deephaven::dhcore::clienttable::Schema;
+
 public:
   /*
    * Default constructor. Creates a (useless) empty client object.
@@ -129,6 +131,28 @@ public:
   [[nodiscard]]
   TableHandle TimeTable(DurationSpecifier period, TimePointSpecifier start_time = 0,
       bool blink_table = false) const;
+
+  /**
+   * Creates an input table from an initial table. When key columns are provided, the InputTable
+   * will be keyed, otherwise it will be append-only.
+   * @param columns The set of key columns
+   * @return A TableHandle referencing the new table
+   */
+  [[nodiscard]]
+  TableHandle InputTable(const TableHandle &initial_table,
+      std::vector<std::string> key_columns = {}) const;
+
+  // TODO(kosak): not implemented yet.
+  /**
+   * Creates an input table from a Schema. When key columns are provided, the InputTable
+   * will be keyed, otherwise it will be append-only.
+   * @param schema The table schema.
+   * @return A TableHandle referencing the new table
+   */
+//  [[nodiscard]]
+//  TableHandle InputTable(std::shared_ptr<SchemaType> schema,
+//      std::vector<std::string> key_columns = {}) const;
+
   /**
    * Allocate a fresh client ticket. This is a low level operation, typically used when the caller wants to do an Arrow
    * doPut operation.
@@ -1503,10 +1527,24 @@ public:
    * documentation for the difference between "Where" and "WhereIn".
    * @param filter_table The table containing the set of values to filter on
    * @param columns The columns to match on
-   * @return
    */
   [[nodiscard]]
   TableHandle WhereIn(const TableHandle &filter_table, std::vector<std::string> columns) const;
+
+  /**
+   * Adds a table to an input table. Requires that this object be an InputTable (such as that
+   * created by TableHandleManager::InputTable).
+   * @param table_to_add The table to add to the InputTable
+   */
+  void AddTable(const TableHandle &table_to_add);
+
+  /**
+   * Removes a table from an input table. Requires that this object be an InputTable (such as that
+   * created by TableHandleManager::InputTable).
+   * @param table_to_add The table to remove from the InputTable
+   * @return The new table
+   */
+  void RemoveTable(const TableHandle &table_to_remove);
 
   /**
    * Binds this table to a variable name in the QueryScope.

--- a/cpp-client/deephaven/dhclient/src/client.cc
+++ b/cpp-client/deephaven/dhclient/src/client.cc
@@ -115,6 +115,12 @@ TableHandle TableHandleManager::TimeTable(DurationSpecifier period, TimePointSpe
   return TableHandle(std::move(impl));
 }
 
+TableHandle TableHandleManager::InputTable(const TableHandle &initial_table,
+    std::vector<std::string> key_columns) const {
+  auto th_impl = impl_->InputTable(*initial_table.Impl(), std::move(key_columns));
+  return TableHandle(std::move(th_impl));
+}
+
 std::string TableHandleManager::NewTicket() const {
   return impl_->NewTicket();
 }
@@ -558,6 +564,14 @@ TableHandle TableHandle::WhereIn(const TableHandle &filter_table,
     std::vector<std::string> columns) const {
   auto th_impl = impl_->WhereIn(*filter_table.impl_, std::move(columns));
   return TableHandle(std::move(th_impl));
+}
+
+void TableHandle::AddTable(const deephaven::client::TableHandle &table_to_add) {
+  impl_->AddTable(*table_to_add.impl_);
+}
+
+void TableHandle::RemoveTable(const deephaven::client::TableHandle &table_to_remove) {
+  impl_->RemoveTable(*table_to_remove.impl_);
 }
 
 void TableHandle::BindToVariable(std::string variable) const {

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
@@ -28,7 +28,9 @@
 #include "deephaven/dhcore/utility/callbacks.h"
 #include "deephaven/dhcore/utility/utility.h"
 
+using io::deephaven::proto::backplane::grpc::AddTableResponse;
 using io::deephaven::proto::backplane::grpc::ComboAggregateRequest;
+using io::deephaven::proto::backplane::grpc::DeleteTableResponse;
 using io::deephaven::proto::backplane::grpc::ReleaseResponse;
 using io::deephaven::proto::backplane::grpc::SortDescriptor;
 using io::deephaven::proto::backplane::grpc::TableReference;
@@ -430,6 +432,22 @@ TableHandleImpl::WhereIn(const deephaven::client::impl::TableHandleImpl &filter_
   auto [cb, ls] = TableHandleImpl::CreateEtcCallback(shared_from_this(), managerImpl_.get(), result_ticket);
   server->WhereInAsync(ticket_, filter_table.ticket_, std::move(columns), std::move(cb), result_ticket);
   return TableHandleImpl::Create(managerImpl_, std::move(result_ticket), std::move(ls));
+}
+
+void TableHandleImpl::AddTable(const TableHandleImpl &table_to_add) {
+  // We're going to manually make this a synchronous call.
+  auto result = SFCallback<AddTableResponse>::CreateForFuture();
+  auto *server = managerImpl_->Server().get();
+  server->AddTable(ticket_, table_to_add.ticket_, std::move(result.first));
+  result.second.wait();
+}
+
+void TableHandleImpl::RemoveTable(const TableHandleImpl &table_to_add) {
+  // We're going to manually make this a synchronous call.
+  auto result = SFCallback<DeleteTableResponse>::CreateForFuture();
+  auto *server = managerImpl_->Server().get();
+  server->RemoveTable(ticket_, table_to_add.ticket_, std::move(result.first));
+  result.second.wait();
 }
 
 namespace {

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
@@ -75,6 +75,15 @@ std::shared_ptr<TableHandleImpl> TableHandleManagerImpl::TimeTable(DurationSpeci
   return TableHandleImpl::Create(shared_from_this(), std::move(result_ticket), std::move(ls));
 }
 
+std::shared_ptr<TableHandleImpl> TableHandleManagerImpl::InputTable(
+    const TableHandleImpl &initial_table, std::vector<std::string> columns) {
+  auto *server = server_.get();
+  auto result_ticket = server->NewTicket();
+  auto [cb, ls] = TableHandleImpl::CreateEtcCallback(nullptr, this, result_ticket);
+  server->InputTableAsync(initial_table.Ticket(), std::move(columns), std::move(cb), result_ticket);
+  return TableHandleImpl::Create(shared_from_this(), std::move(result_ticket), std::move(ls));
+}
+
 void TableHandleManagerImpl::RunScriptAsync(std::string code, std::shared_ptr<SFCallback<>> callback) {
   struct cb_t final : public SFCallback<ExecuteCommandResponse> {
     explicit cb_t(std::shared_ptr<SFCallback<>> outer_cb) : outerCb_(std::move(outer_cb)) {}

--- a/cpp-client/deephaven/dhclient/src/server/server.cc
+++ b/cpp-client/deephaven/dhclient/src/server/server.cc
@@ -25,12 +25,17 @@ using deephaven::dhcore::utility::SFCallback;
 using deephaven::dhcore::utility::Bit_cast;
 using deephaven::dhcore::utility::Streamf;
 using deephaven::dhcore::utility::Stringf;
+using io::deephaven::proto::backplane::grpc::AddTableRequest;
+using io::deephaven::proto::backplane::grpc::AddTableResponse;
 using io::deephaven::proto::backplane::grpc::AjRajTablesRequest;
 using io::deephaven::proto::backplane::grpc::AuthenticationConstantsRequest;
 using io::deephaven::proto::backplane::grpc::ConfigurationConstantsRequest;
 using io::deephaven::proto::backplane::grpc::ConfigurationConstantsResponse;
 using io::deephaven::proto::backplane::grpc::ConfigService;
+using io::deephaven::proto::backplane::grpc::CreateInputTableRequest;
 using io::deephaven::proto::backplane::grpc::CrossJoinTablesRequest;
+using io::deephaven::proto::backplane::grpc::DeleteTableRequest;
+using io::deephaven::proto::backplane::grpc::DeleteTableResponse;
 using io::deephaven::proto::backplane::grpc::DropColumnsRequest;
 using io::deephaven::proto::backplane::grpc::EmptyTableRequest;
 using io::deephaven::proto::backplane::grpc::ExactJoinTablesRequest;
@@ -142,6 +147,7 @@ std::shared_ptr<Server> Server::CreateFromTarget(
   auto ss = SessionService::NewStub(channel);
   auto ts = TableService::NewStub(channel);
   auto cfs = ConfigService::NewStub(channel);
+  auto its = InputTableService::NewStub(channel);
 
   // TODO(kosak): Warn about this string conversion or do something more general.
   auto flightTarget = ((client_options.UseTls()) ? "grpc+tls://" : "grpc://") + target;
@@ -218,8 +224,8 @@ std::shared_ptr<Server> Server::CreateFromTarget(
   auto nextHandshakeTime = sendTime + expirationInterval;
 
   auto result = std::make_shared<Server>(Private(), std::move(as), std::move(cs),
-      std::move(ss), std::move(ts), std::move(cfs), std::move(fc), client_options.ExtraHeaders(),
-      std::move(sessionToken), expirationInterval, nextHandshakeTime);
+      std::move(ss), std::move(ts), std::move(cfs), std::move(its), std::move(fc),
+      client_options.ExtraHeaders(), std::move(sessionToken), expirationInterval, nextHandshakeTime);
   result->completionQueueThread_ = std::thread(&ProcessCompletionQueueLoop, result);
   result->keepAliveThread_ = std::thread(&SendKeepaliveMessages, result);
   return result;
@@ -231,6 +237,7 @@ Server::Server(Private,
     std::unique_ptr<SessionService::Stub> session_stub,
     std::unique_ptr<TableService::Stub> table_stub,
     std::unique_ptr<ConfigService::Stub> config_stub,
+    std::unique_ptr<InputTableService::Stub> input_table_stub,
     std::unique_ptr<arrow::flight::FlightClient> flight_client,
     ClientOptions::extra_headers_t extra_headers,
     std::string session_token, std::chrono::milliseconds expiration_interval,
@@ -242,6 +249,7 @@ Server::Server(Private,
     sessionStub_(std::move(session_stub)),
     tableStub_(std::move(table_stub)),
     configStub_(std::move(config_stub)),
+    input_table_stub_(std::move(input_table_stub)),
     flightClient_(std::move(flight_client)),
     extraHeaders_(std::move(extra_headers)),
     nextFreeTicketId_(1),
@@ -612,6 +620,20 @@ void Server::SelectDistinctAsync(Ticket source, std::vector<std::string> columns
   SendRpc(req, std::move(etc_callback), TableStub(), &TableService::Stub::AsyncSelectDistinct);
 }
 
+void Server::InputTableAsync(Ticket initial_table_ticket, std::vector<std::string> columns,
+    std::shared_ptr<EtcCallback> etc_callback, Ticket result) {
+  CreateInputTableRequest req;
+  *req.mutable_result_id() = std::move(result);
+  *req.mutable_source_table_id()->mutable_ticket() = std::move(initial_table_ticket);
+  if (columns.empty()) {
+    (void)req.mutable_kind()->mutable_in_memory_append_only();
+  } else {
+    MoveVectorData(std::move(columns),
+        req.mutable_kind()->mutable_in_memory_key_backed()->mutable_key_columns());
+  }
+  SendRpc(req, std::move(etc_callback), TableStub(), &TableService::Stub::AsyncCreateInputTable);
+}
+
 void Server::WhereInAsync(Ticket left_table_ticket, Ticket right_table_ticket,
     std::vector<std::string> columns, std::shared_ptr<EtcCallback> etc_callback, Ticket result) {
   WhereInRequest req;
@@ -621,6 +643,24 @@ void Server::WhereInAsync(Ticket left_table_ticket, Ticket right_table_ticket,
   req.set_inverted(false);
   MoveVectorData(std::move(columns), req.mutable_columns_to_match());
   SendRpc(req, std::move(etc_callback), TableStub(), &TableService::Stub::AsyncWhereIn);
+}
+
+void Server::AddTable(Ticket input_table_ticket, Ticket table_to_add_ticket,
+    std::shared_ptr<SFCallback<AddTableResponse>> callback) {
+  AddTableRequest req;
+  *req.mutable_input_table() = std::move(input_table_ticket);
+  *req.mutable_table_to_add() = std::move(table_to_add_ticket);
+  SendRpc(req, std::move(callback), InputTableStub(),
+      &InputTableService::Stub::AsyncAddTableToInputTable);
+}
+
+void Server::RemoveTable(Ticket input_table_ticket, Ticket table_to_remove_ticket,
+    std::shared_ptr<SFCallback<DeleteTableResponse>> callback) {
+  DeleteTableRequest req;
+  *req.mutable_input_table() = std::move(input_table_ticket);
+  *req.mutable_table_to_remove() = std::move(table_to_remove_ticket);
+  SendRpc(req, std::move(callback), InputTableStub(),
+      &InputTableService::Stub::AsyncDeleteTableFromInputTable);
 }
 
 void

--- a/cpp-client/deephaven/tests/CMakeLists.txt
+++ b/cpp-client/deephaven/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(tests
     date_time_test.cc
     filter_test.cc
     head_and_tail_test.cc
+    input_table_test.cc
     join_test.cc
     lastby_test.cc
     main.cc

--- a/cpp-client/deephaven/tests/input_table_test.cc
+++ b/cpp-client/deephaven/tests/input_table_test.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+#include "tests/third_party/catch.hpp"
+#include "tests/test_util.h"
+#include "deephaven/dhcore/utility/utility.h"
+
+using deephaven::client::utility::TableMaker;
+using deephaven::dhcore::utility::Streamf;
+
+namespace deephaven::client::tests {
+TEST_CASE("Input Table: append", "[input_table]") {
+  auto client = TableMakerForTests::CreateClient();
+  auto tm = client.GetManager();
+  auto source = tm.EmptyTable(3).Update({"A = ii", "B = ii + 100"});
+  // No keys, so InputTable will be in append-only mode.
+  auto input_table = tm.InputTable(source);
+  input_table.AddTable(source);
+
+  // expect input_table to be {0, 100}, {1, 101}, {2, 102}
+  {
+    std::vector<int64_t> a_data = {0, 1, 2};
+    std::vector<int64_t> b_data = {100, 101, 102};
+    CompareTable(input_table,
+        "A", a_data,
+        "B", b_data);
+  }
+
+  auto table_to_append = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
+  input_table.AddTable(table_to_append);
+
+  // Because of append, expect input_table to be {0, 100}, {1, 101}, {2, 102}, {0, 200}, {1, 201}
+  {
+    std::vector<int64_t> a_data = {0, 1, 2, 0, 1};
+    std::vector<int64_t> b_data = {100, 101, 102, 200, 201};
+    CompareTable(input_table,
+        "A", a_data,
+        "B", b_data);
+  }
+}
+
+TEST_CASE("Input Table: keyed", "[input_table]") {
+  auto client = TableMakerForTests::CreateClient();
+  auto tm = client.GetManager();
+  auto source = tm.EmptyTable(3).Update({"A = ii", "B = ii + 100"});
+  // Keys = {"A"}, so InputTable will be in keyed mode
+  auto input_table = tm.InputTable(source, {"A"});
+  input_table.AddTable(source);
+
+  // expect input_table to be {0, 100}, {1, 101}, {2, 102}
+  {
+    std::vector<int64_t> a_data = {0, 1, 2};
+    std::vector<int64_t> b_data = {100, 101, 102};
+    CompareTable(input_table,
+        "A", a_data,
+        "B", b_data);
+  }
+
+  auto table_to_append = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
+  input_table.AddTable(table_to_append);
+
+  // Because key is "A", expect input_table to be {0, 200}, {1, 201}, {2, 102}
+  {
+    std::vector<int64_t> a_data = {0, 1, 2};
+    std::vector<int64_t> b_data = {200, 201, 102};
+    CompareTable(input_table,
+        "A", a_data,
+        "B", b_data);
+  }
+}
+}  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/input_table_test.cc
+++ b/cpp-client/deephaven/tests/input_table_test.cc
@@ -26,8 +26,8 @@ TEST_CASE("Input Table: append", "[input_table]") {
         "B", b_data);
   }
 
-  auto table_to_append = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
-  input_table.AddTable(table_to_append);
+  auto table_to_add = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
+  input_table.AddTable(table_to_add);
 
   // Because of append, expect input_table to be {0, 100}, {1, 101}, {2, 102}, {0, 200}, {1, 201}
   {
@@ -56,8 +56,8 @@ TEST_CASE("Input Table: keyed", "[input_table]") {
         "B", b_data);
   }
 
-  auto table_to_append = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
-  input_table.AddTable(table_to_append);
+  auto table_to_add = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
+  input_table.AddTable(table_to_add);
 
   // Because key is "A", expect input_table to be {0, 200}, {1, 201}, {2, 102}
   {


### PR DESCRIPTION
This change allows the creation of an `InputTable` based on another existing table's schema. It does not (yet) support the creation of an `InputTable` based on providing the schema directly.