### PR TITLE
add import for Table

### DIFF
--- a/py/client/pydeephaven/__init__.py
+++ b/py/client/pydeephaven/__init__.py
@@ -27,6 +27,7 @@ from .session import Session
 from .dherror import DHError
 from ._table_interface import SortDirection
 from .query import Query
+from .table import Table
 
 try:
     from pydeephaven_ticking.table_listener import TableListener, TableListenerHandle, TableUpdate, listen


### PR DESCRIPTION
All of the examples are currently broken.
This PR fixes the problem.
Currently, the examples produce output like this:
```
18:07 $ python3 -m examples.demo_query
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/kosak/git/deephaven-core/py/client/examples/demo_query.py", line 8, in <module>
    from examples.import_test_data import import_taxi_records
  File "/home/kosak/git/deephaven-core/py/client/examples/import_test_data.py", line 16, in <module>
    from pydeephaven import Session, Table
ImportError: cannot import name 'Table' from 'pydeephaven' (/home/kosak/git/deephaven-core/py/client/pydeephaven/__init__.py)
```

After this PR they work again.
