### PR TITLE
Make the definitions of col_defs consistent

### DIFF
--- a/py/server/deephaven/stream/kafka/cdc.py
+++ b/py/server/deephaven/stream/kafka/cdc.py
@@ -51,7 +51,7 @@ def consume(
         stream_table (bool):  if true, produce a streaming table of changed rows keeping the CDC 'op' column
             indicating the type of column change; if false, return a Deephaven ticking table that tracks the underlying
             database table through the CDC Stream.
-        cols_to_drop (list[str]): a list of column names to omit from the resulting DHC table. Note that only columns
+        cols_to_drop (List[str]): a list of column names to omit from the resulting DHC table. Note that only columns
             not included in the primary key for the table can be dropped at this stage; you can chain a drop column
             operation after this call if you need to do this.
 

--- a/py/server/deephaven/stream/table_publisher.py
+++ b/py/server/deephaven/stream/table_publisher.py
@@ -4,9 +4,8 @@
 """The table_publisher module supports publishing Deephaven Tables into blink Tables."""
 
 import jpy
-import traceback
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Tuple
 
 from deephaven._wrapper import JObjectWrapper
 from deephaven.column import Column
@@ -81,7 +80,7 @@ def table_publisher(
     on_shutdown_callback: Optional[Callable[[], None]] = None,
     update_graph: Optional[UpdateGraph] = None,
     chunk_size: int = 2048,
-) -> tuple[Table, TablePublisher]:
+) -> Tuple[Table, TablePublisher]:
     """Constructs a blink Table and TablePublisher to populate it.
 
     Args:

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -2293,7 +2293,7 @@ class PartitionedTable(JObjectWrapper):
             unique_keys: False
             constituent_column: the name of the first column with a Table data type
             constituent_table_columns: the column definitions of the first cell (constituent table) in the constituent
-                column. Consequently the constituent column can't be empty
+                column. Consequently, the constituent column can't be empty
             constituent_changes_permitted: the value of table.is_refreshing
 
 
@@ -2302,7 +2302,7 @@ class PartitionedTable(JObjectWrapper):
             key_cols (Union[str, List[str]]): the key column name(s) of 'table'
             unique_keys (bool): whether the keys in 'table' are guaranteed to be unique
             constituent_column (str): the constituent column name in 'table'
-            constituent_table_columns (list[Column]): the column definitions of the constituent table
+            constituent_table_columns (List[Column]): the column definitions of the constituent table
             constituent_changes_permitted (bool): whether the values of the constituent column can change
 
         Returns:

--- a/py/server/deephaven_internal/auto_completer/_completer.py
+++ b/py/server/deephaven_internal/auto_completer/_completer.py
@@ -1,9 +1,9 @@
 # only python 3.8 needs this, but it must be the first expression in the file, so we can't predicate it
 from __future__ import annotations
 from enum import Enum
-from typing import Any, Union
+from typing import Any, Union, List
 from jedi import Interpreter, Script
-from jedi.api.classes import Name, Completion, Signature
+from jedi.api.classes import Completion, Signature
 
 
 class Mode(Enum):
@@ -127,7 +127,7 @@ class Completer:
 
     def do_completion(
         self, uri: str, version: int, line: int, col: int
-    ) -> list[list[Any]]:
+    ) -> List[List[Any]]:
         """ Gets completion items at the position
 
         Modeled after Jedi language server
@@ -145,9 +145,9 @@ class Completer:
 
         # for now, a simple sorting based on number of preceding _
         # we may want to apply additional sorting to each list before combining
-        results: list = []
-        results_: list = []
-        results__: list = []
+        results: List = []
+        results_: List = []
+        results__: List = []
         for completion in completions:
             # keep checking the latest version as we run, so updated doc can cancel us
             if not self._versions[uri] == version:
@@ -164,11 +164,11 @@ class Completer:
         return results + results_ + results__
 
     @staticmethod
-    def to_completion_result(completion: Completion, col: int) -> list[Any]:
+    def to_completion_result(completion: Completion, col: int) -> List[Any]:
         name: str = completion.name
         prefix_length: int = completion.get_completion_prefix_length()
         start: int = col - prefix_length
-        signatures: list[Signature] = completion.get_signatures()
+        signatures: List[Signature] = completion.get_signatures()
         detail: str = signatures[0].to_string() if len(signatures) > 0 else completion.description
 
         return [
@@ -181,7 +181,7 @@ class Completer:
 
     def do_signature_help(
             self, uri: str, version: int, line: int, col: int
-    ) -> list[list[Any]]:
+    ) -> List[List[Any]]:
         """ Gets signature help at the position
 
         Modeled after Jedi language server

--- a/py/server/tests/test_kafka_consumer.py
+++ b/py/server/tests/test_kafka_consumer.py
@@ -52,42 +52,59 @@ class KafkaConsumerTestCase(BaseTestCase):
         """
         Check a JSON Kafka subscription creates the right table.
         """
+        value_specs = [ck.json_spec(
+            col_defs=[('Symbol', dtypes.string),
+                      ('Side', dtypes.string),
+                      ('Price', dtypes.double),
+                      ('Qty', dtypes.int_),
+                      ('Tstamp', dtypes.Instant)],
+            mapping={
+                'jsymbol': 'Symbol',
+                'jside': 'Side',
+                'jprice': 'Price',
+                'jqty': 'Qty',
+                'jts': 'Tstamp'
+            }
+        ), ck.json_spec(
+            col_defs={
+                'Symbol': dtypes.string,
+                'Side': dtypes.string,
+                'Price': dtypes.double,
+                'Qty': dtypes.int_,
+                'Tstamp': dtypes.Instant
+            },
+            mapping={
+                'jsymbol': 'Symbol',
+                'jside': 'Side',
+                'jprice': 'Price',
+                'jqty': 'Qty',
+                'jts': 'Tstamp'
+            }
+        )]
 
-        t = ck.consume(
-            {'bootstrap.servers': 'redpanda:29092'},
-            'orders',
-            key_spec=KeyValueSpec.IGNORE,
-            value_spec=ck.json_spec(
-                [('Symbol', dtypes.string),
-                 ('Side', dtypes.string),
-                 ('Price', dtypes.double),
-                 ('Qty', dtypes.int_),
-                 ('Tstamp', dtypes.Instant)],
-                mapping={
-                    'jsymbol': 'Symbol',
-                    'jside': 'Side',
-                    'jprice': 'Price',
-                    'jqty': 'Qty',
-                    'jts': 'Tstamp'
-                }
-            ),
-            table_type=TableType.append()
-        )
+        for value_spec in value_specs:
+            t = ck.consume(
+                {'bootstrap.servers': 'redpanda:29092'},
+                'orders',
+                key_spec=KeyValueSpec.IGNORE,
+                value_spec=value_spec,
+                table_type=TableType.append()
+            )
 
-        cols = t.columns
-        self.assertEqual(8, len(cols))
-        self._assert_common_cols(cols)
+            cols = t.columns
+            self.assertEqual(8, len(cols))
+            self._assert_common_cols(cols)
 
-        self.assertEqual("Symbol", cols[3].name)
-        self.assertEqual(dtypes.string, cols[3].data_type)
-        self.assertEqual("Side", cols[4].name)
-        self.assertEqual(dtypes.string, cols[4].data_type)
-        self.assertEqual("Price", cols[5].name)
-        self.assertEqual(dtypes.double, cols[5].data_type)
-        self.assertEqual("Qty", cols[6].name)
-        self.assertEqual(dtypes.int_, cols[6].data_type)
-        self.assertEqual("Tstamp", cols[7].name)
-        self.assertEqual(dtypes.Instant, cols[7].data_type)
+            self.assertEqual("Symbol", cols[3].name)
+            self.assertEqual(dtypes.string, cols[3].data_type)
+            self.assertEqual("Side", cols[4].name)
+            self.assertEqual(dtypes.string, cols[4].data_type)
+            self.assertEqual("Price", cols[5].name)
+            self.assertEqual(dtypes.double, cols[5].data_type)
+            self.assertEqual("Qty", cols[6].name)
+            self.assertEqual(dtypes.int_, cols[6].data_type)
+            self.assertEqual("Tstamp", cols[7].name)
+            self.assertEqual(dtypes.Instant, cols[7].data_type)
 
     def test_avro_spec(self):
         """


### PR DESCRIPTION
Also fixed some py38 incompatible bugs

Where `col_defs: Dict[str, DType]` are used, they are to provide the definitions for the to-be-created table.
Where `List[Column]` are used, they are actually used to select a subset of existing Columns. 

Fixes #4274