### PR TITLE
DeferredViewTable: Only Manage When Refreshing

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
@@ -300,8 +300,11 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
      */
     public static abstract class TableReference extends LivenessArtifact implements SimpleReference<Table> {
 
+        private final boolean isRefreshing;
+
         TableReference(Table t) {
-            if (t.isRefreshing()) {
+            isRefreshing = t.isRefreshing();
+            if (isRefreshing) {
                 manage(t);
             }
         }
@@ -311,7 +314,9 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
          *
          * @return true if the node is updating; false otherwise.
          */
-        public abstract boolean isRefreshing();
+        public final boolean isRefreshing() {
+            return isRefreshing;
+        }
 
         /**
          * Returns the table in a form that the user can run queries on it. This may be as simple as returning a
@@ -382,11 +387,6 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
         public SimpleTableReference(Table table) {
             super(table);
             this.table = table;
-        }
-
-        @Override
-        public boolean isRefreshing() {
-            return table.isRefreshing();
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/DeferredViewTable.java
@@ -51,8 +51,9 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
         this.deferredFilters = deferredFilters == null ? WhereFilter.ZERO_LENGTH_SELECT_FILTER_ARRAY : deferredFilters;
         for (final WhereFilter sf : this.deferredFilters) {
             sf.init(parentDefinition);
-            if (sf instanceof LivenessReferent) {
+            if (sf instanceof LivenessReferent && sf.isRefreshing()) {
                 manage((LivenessReferent) sf);
+                setRefreshing(true);
             }
         }
 
@@ -61,7 +62,10 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
         final boolean haveView = this.deferredViewColumns.length > 0;
         final boolean haveFilter = this.deferredFilters.length > 0;
 
-        manage(tableReference);
+        if (tableReference.isRefreshing()) {
+            manage(tableReference);
+            setRefreshing(true);
+        }
 
         if (haveDrop && haveFilter) {
             throw new IllegalStateException("Why do we have a drop and a filter all at the same time?");
@@ -269,7 +273,6 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
     protected DeferredViewTable copy() {
         final DeferredViewTable result = new DeferredViewTable(definition, description, new SimpleTableReference(this),
                 null, null, null);
-        result.setRefreshing(isRefreshing());
         LiveAttributeMap.copyAttributes(this, result, ak -> true);
         return result;
     }
@@ -281,19 +284,15 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
         for (int cdi = 0; cdi < newView.length; ++cdi) {
             newView[cdi] = new SourceColumn(cDefs.get(cdi).getName());
         }
-        DeferredViewTable deferredViewTable = new DeferredViewTable(newDefinition, description + "-redefined",
+        return new DeferredViewTable(newDefinition, description + "-redefined",
                 new SimpleTableReference(this), null, newView, null);
-        deferredViewTable.setRefreshing(isRefreshing());
-        return deferredViewTable;
     }
 
     @Override
     protected Table redefine(TableDefinition newDefinitionExternal, TableDefinition newDefinitionInternal,
             SelectColumn[] viewColumns) {
-        DeferredViewTable deferredViewTable = new DeferredViewTable(newDefinitionExternal, description + "-redefined",
+        return new DeferredViewTable(newDefinitionExternal, description + "-redefined",
                 new SimpleTableReference(this), null, viewColumns, null);
-        deferredViewTable.setRefreshing(isRefreshing());
-        return deferredViewTable;
     }
 
     /**
@@ -306,6 +305,13 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
                 manage(t);
             }
         }
+
+        /**
+         * Is the node updating?
+         *
+         * @return true if the node is updating; false otherwise.
+         */
+        public abstract boolean isRefreshing();
 
         /**
          * Returns the table in a form that the user can run queries on it. This may be as simple as returning a
@@ -376,6 +382,11 @@ public class DeferredViewTable extends RedefinableTable<DeferredViewTable> {
         public SimpleTableReference(Table table) {
             super(table);
             this.table = table;
+        }
+
+        @Override
+        public boolean isRefreshing() {
+            return table.isRefreshing();
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
@@ -202,7 +202,6 @@ public class PartitionAwareSourceTable extends SourceTable<PartitionAwareSourceT
                 description + "-retainColumns",
                 componentFactory, locationProvider, updateSourceRegistrar, partitioningColumnDefinitions,
                 partitioningColumnFilters);
-        Assert.equals(redefined.isRefreshing(), "redefined.isRefreshing()", isRefreshing(), "isRefreshing()");
         return new DeferredViewTable(newDefinition, description + "-retainColumns",
                 new PartitionAwareQueryTableReference(redefined),
                 droppedPartitioningColumnDefinitions.stream().map(ColumnDefinition::getName).toArray(String[]::new),

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
@@ -202,25 +202,22 @@ public class PartitionAwareSourceTable extends SourceTable<PartitionAwareSourceT
                 description + "-retainColumns",
                 componentFactory, locationProvider, updateSourceRegistrar, partitioningColumnDefinitions,
                 partitioningColumnFilters);
-        final DeferredViewTable deferredViewTable = new DeferredViewTable(newDefinition, description + "-retainColumns",
+        Assert.equals(redefined.isRefreshing(), "redefined.isRefreshing()", isRefreshing(), "isRefreshing()");
+        return new DeferredViewTable(newDefinition, description + "-retainColumns",
                 new PartitionAwareQueryTableReference(redefined),
                 droppedPartitioningColumnDefinitions.stream().map(ColumnDefinition::getName).toArray(String[]::new),
                 null, null);
-        deferredViewTable.setRefreshing(isRefreshing());
-        return deferredViewTable;
     }
 
     @Override
     protected final Table redefine(TableDefinition newDefinitionExternal, TableDefinition newDefinitionInternal,
             SelectColumn[] viewColumns) {
-        BaseTable redefined = redefine(newDefinitionInternal);
+        BaseTable<?> redefined = redefine(newDefinitionInternal);
         DeferredViewTable.TableReference reference = redefined instanceof PartitionAwareSourceTable
                 ? new PartitionAwareQueryTableReference((PartitionAwareSourceTable) redefined)
                 : new DeferredViewTable.SimpleTableReference(redefined);
-        DeferredViewTable deferredViewTable = new DeferredViewTable(newDefinitionExternal, description + "-redefined",
+        return new DeferredViewTable(newDefinitionExternal, description + "-redefined",
                 reference, null, viewColumns, null);
-        deferredViewTable.setRefreshing(isRefreshing());
-        return deferredViewTable;
     }
 
     private static final String LOCATION_KEY_COLUMN_NAME = "__PartitionAwareSourceTable_TableLocationKey__";
@@ -301,11 +298,8 @@ public class PartitionAwareSourceTable extends SourceTable<PartitionAwareSourceT
 
         // if there was nothing that actually required the partition, defer the result.
         if (partitionFilters.isEmpty()) {
-            DeferredViewTable deferredViewTable =
-                    new DeferredViewTable(definition, description + "-withDeferredFilters",
-                            new PartitionAwareQueryTableReference(this), null, null, whereFilters);
-            deferredViewTable.setRefreshing(isRefreshing());
-            return deferredViewTable;
+            return new DeferredViewTable(definition, description + "-withDeferredFilters",
+                    new PartitionAwareQueryTableReference(this), null, null, whereFilters);
         }
 
         WhereFilter[] partitionFilterArray = partitionFilters.toArray(WhereFilter.ZERO_LENGTH_SELECT_FILTER_ARRAY);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -54,7 +54,6 @@ import io.deephaven.engine.table.impl.util.OperationInitializationPoolJobSchedul
 import io.deephaven.engine.table.impl.select.analyzers.SelectAndViewAnalyzerWrapper;
 import io.deephaven.engine.table.impl.util.FieldUtils;
 import io.deephaven.engine.table.impl.sources.ring.RingTableTools;
-import io.deephaven.engine.table.impl.BlinkTableTools;
 import io.deephaven.engine.table.iterators.*;
 import io.deephaven.engine.updategraph.DynamicNode;
 import io.deephaven.engine.util.*;
@@ -91,7 +90,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SimpleSourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SimpleSourceTable.java
@@ -59,9 +59,7 @@ public class SimpleSourceTable extends SourceTable<SimpleSourceTable> {
     @Override
     protected final Table redefine(TableDefinition newDefinitionExternal, TableDefinition newDefinitionInternal,
             SelectColumn[] viewColumns) {
-        DeferredViewTable deferredViewTable = new DeferredViewTable(newDefinitionExternal, description + "-redefined",
+        return new DeferredViewTable(newDefinitionExternal, description + "-redefined",
                 new QueryTableReference(redefine(newDefinitionInternal)), new String[0], viewColumns, null);
-        deferredViewTable.setRefreshing(isRefreshing());
-        return deferredViewTable;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
@@ -295,11 +295,6 @@ public abstract class SourceTable<IMPL_TYPE extends SourceTable<IMPL_TYPE>> exte
         }
 
         @Override
-        final public boolean isRefreshing() {
-            return table.isRefreshing();
-        }
-
-        @Override
         public long getSize() {
             return QueryConstants.NULL_LONG;
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
@@ -295,6 +295,11 @@ public abstract class SourceTable<IMPL_TYPE extends SourceTable<IMPL_TYPE>> exte
         }
 
         @Override
+        final public boolean isRefreshing() {
+            return table.isRefreshing();
+        }
+
+        @Override
         public long getSize() {
             return QueryConstants.NULL_LONG;
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ComposedFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ComposedFilter.java
@@ -25,7 +25,7 @@ public abstract class ComposedFilter extends WhereFilterLivenessArtifactImpl imp
         this.componentFilters = componentFilters;
 
         for (WhereFilter f : this.componentFilters) {
-            if (f instanceof LivenessArtifact) {
+            if (f instanceof LivenessArtifact && f.isRefreshing()) {
                 manage((LivenessArtifact) f);
             }
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/WhereFilter.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Interface for individual filters within a where clause.

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/DeferredViewTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/DeferredViewTableTest.java
@@ -1,11 +1,13 @@
 package io.deephaven.engine.table.impl;
 
 import io.deephaven.api.Selectable;
+import io.deephaven.base.verify.Assert;
 import io.deephaven.datastructures.util.CollectionUtil;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.select.SelectColumn;
+import io.deephaven.engine.table.impl.select.TimeSeriesFilter;
 import io.deephaven.engine.table.impl.select.WhereFilter;
 import io.deephaven.engine.testutil.TstUtils;
 import io.deephaven.engine.util.TableTools;
@@ -13,6 +15,7 @@ import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Arrays;
 
 public class DeferredViewTableTest {
@@ -40,5 +43,54 @@ public class DeferredViewTableTest {
         final Table resultTable = deferredTable.coalesce();
         final Table expectedTable = sourceTable.update(Arrays.asList(viewColumns));
         TstUtils.assertTableEquals(expectedTable, resultTable);
+    }
+
+    @Test
+    public void testIsRefreshingViaSource() {
+        testIsRefreshingViaSource(false);
+        testIsRefreshingViaSource(true);
+    }
+
+    private void testIsRefreshingViaSource(boolean sourceRefreshing) {
+        final TableDefinition resultDef = TableDefinition.of(
+                ColumnDefinition.fromGenericType("X", int.class),
+                ColumnDefinition.fromGenericType("Y", int.class));
+        final Table sourceTable = TableTools.emptyTable(10);
+        if (sourceRefreshing) {
+            sourceTable.setRefreshing(true);
+        }
+
+        final DeferredViewTable deferredTable = new DeferredViewTable(
+                resultDef,
+                "test",
+                new DeferredViewTable.SimpleTableReference(sourceTable),
+                CollectionUtil.ZERO_LENGTH_STRING_ARRAY,
+                SelectColumn.ZERO_LENGTH_SELECT_COLUMN_ARRAY,
+                WhereFilter.ZERO_LENGTH_SELECT_FILTER_ARRAY);
+
+        Assert.eq(deferredTable.isRefreshing(), "deferredTable.isRefreshing()", sourceRefreshing, "sourceRefreshing");
+    }
+
+    @Test
+    public void testIsRefreshingViaFilter() {
+        final TableDefinition resultDef = TableDefinition.of(
+                ColumnDefinition.fromGenericType("Timestamp", Instant.class));
+        final Table sourceTable = TableTools.emptyTable(10).update("Timestamp = DateTimeUtils.now()");
+
+        // We'll use a time series filter for convenience but any refreshing filter will do.
+        final WhereFilter[] whereFilters = new WhereFilter[] {
+                new TimeSeriesFilter("Timestamp", "PT1s")
+        };
+        Assert.eqTrue(whereFilters[0].isRefreshing(), "whereFilters[0].isRefreshing()");
+
+        final DeferredViewTable deferredTable = new DeferredViewTable(
+                resultDef,
+                "test",
+                new DeferredViewTable.SimpleTableReference(sourceTable),
+                CollectionUtil.ZERO_LENGTH_STRING_ARRAY,
+                SelectColumn.ZERO_LENGTH_SELECT_COLUMN_ARRAY,
+                whereFilters);
+
+        Assert.eqTrue(deferredTable.isRefreshing(), "deferredTable.isRefreshing()");
     }
 }


### PR DESCRIPTION
Fixes #4448.

`WhereFilterLivenessArtifactImpl` is not also a `DynamicNode`, which leads to an unusual relationship where a `DeferredViewTable` might manage a `WhereFilter`, but then the DVT is not managed by the `SessionState.ExportObject` infrastructure, causing liveness issues later when the where filter is finally applied to the coalesced table when resolving downstream gRPC table operations.

Instead of unconditionally managing WhereFilters, now we'll only manage them if they are `WhereFilter#isRefreshing`.

Release Notes: Fixed liveness issues related to DeferredViewTable and non-refreshing where filters

Nightlies: https://github.com/nbauernfeind/deephaven-core/actions/runs/6092770745