### PR TITLE
C++ Client: fix docs build

### DIFF
--- a/cpp-client/doc/Doxyfile
+++ b/cpp-client/doc/Doxyfile
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../deephaven/client ../deephaven/dhcore
+INPUT                  = ../deephaven/dhclient ../deephaven/dhcore
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
`cpp-client/deephaven/client` was renamed to `cpp-client/deephaven/dhclient` in https://github.com/deephaven/deephaven-core/pull/4345
