### PR TITLE
Setup ExecutionContext in Barrage Client Examples

### DIFF
--- a/Util/src/main/java/io/deephaven/util/thread/ThreadInitializationFactory.java
+++ b/Util/src/main/java/io/deephaven/util/thread/ThreadInitializationFactory.java
@@ -25,6 +25,7 @@ public interface ThreadInitializationFactory {
                 } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException
                         | InstantiationException | IllegalAccessException e) {
 
+                    // TODO (https://github.com/deephaven/deephaven-core/issues/4040):
                     // Currently the default property file is shared between both the java client and the server. This
                     // means that client-side usage will attempt to load the thread.initialization property intended for
                     // the server which is not available on the class path.

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
@@ -72,7 +72,7 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
             System.out.println("Table info: rows = " + subscriptionTable.size() + ", cols = " +
                     DataAccessHelpers.getColumns(subscriptionTable).length);
             TableTools.show(subscriptionTable);
-            System.out.println("");
+            System.out.println();
 
             subscriptionTable.addUpdateListener(listener = new InstrumentedTableUpdateListener("example-listener") {
                 @ReferentialIntegrity

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -148,14 +148,15 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
 
         @Override
         public void onError(final Throwable t) {
-            log.error().append(BarrageSubscriptionImpl.this)
-                    .append(": Error detected in subscription: ")
-                    .append(t).endl();
-
             final Listener listener = resultTable;
             if (!connected || listener == null) {
                 return;
             }
+
+            log.error().append(BarrageSubscriptionImpl.this)
+                    .append(": Error detected in subscription: ")
+                    .append(t).endl();
+
             listener.handleBarrageError(t);
             handleDisconnect();
         }


### PR DESCRIPTION
It was recently discovered that the barrage client examples were no longer working. This was a side effect of adding multiple update graph support to the engine. 

Additionally, there is server-side configuration that is accessible to the client that requires a class that is only in the server package. This server-side configuration is likely to be reworked in the near future and even possibly the need for this server-side class that can't be loaded. For now, I've modified the thread factory initialization to ignore class not found exceptions within the server-side package.

To work around this while still using a previous release one either needs to provide their own `dh-defaults.prop` file or add the following jvm flag `-Dthread.initialization=` to remove the reference to the server-side class.

From a documentation perspective, we should add setup instructions for the ticking java-client use case (as otherwise demonstrated by the example).