### PR TITLE
AbstractFormulaColumn Must Copy ColumnDefinitionMap as it is Mutated by Caller

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -110,7 +110,8 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
     }
 
     protected void applyUsedVariables(Map<String, ColumnDefinition<?>> columnDefinitionMap, Set<String> variablesUsed) {
-        columnDefinitions = columnDefinitionMap;
+        // the column definition map passed in is being mutated by the caller, so we need to make a copy
+        columnDefinitions = Map.copyOf(columnDefinitionMap);
 
         final Map<String, QueryScopeParam<?>> possibleParams = new HashMap<>();
         final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
@@ -83,11 +83,12 @@ public interface SelectColumn extends Selectable {
     /**
      * Initialize any internal column definitions from the provided initial.
      *
-     * @param columnDefinitionMap the starting set of column definitions
+     * @param columnDefinitionMap the starting set of column definitions; valid for this call only
      *
      * @return a list of columns on which the result of this is dependent
      * @apiNote Any {@link io.deephaven.engine.context.QueryLibrary}, {@link io.deephaven.engine.context.QueryScope}, or
      *          {@link QueryCompiler} usage needs to be resolved within initDef. Implementations must be idempotent.
+     *          Implementations that want to hold on to the {@code columnDefinitionMap} must make a defensive copy.
      */
     List<String> initDef(Map<String, ColumnDefinition<?>> columnDefinitionMap);
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/DeferredViewTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/DeferredViewTableTest.java
@@ -93,4 +93,25 @@ public class DeferredViewTableTest {
 
         Assert.eqTrue(deferredTable.isRefreshing(), "deferredTable.isRefreshing()");
     }
+
+    @Test
+    public void testUpdateColumnToDifferentType() {
+        final TableDefinition resultDef = TableDefinition.of(
+                ColumnDefinition.ofLong("X"));
+        final Table sourceTable = TableTools.emptyTable(10).update("X = ii");
+
+        final SelectColumn[] viewColumns = SelectColumn.from(
+                Selectable.parse("X = (int)X"));
+
+        final DeferredViewTable deferredTable = new DeferredViewTable(
+                resultDef,
+                "test",
+                new DeferredViewTable.SimpleTableReference(sourceTable),
+                CollectionUtil.ZERO_LENGTH_STRING_ARRAY,
+                viewColumns,
+                WhereFilter.ZERO_LENGTH_SELECT_FILTER_ARRAY);
+
+        final Class<?> resultType = deferredTable.coalesce().getDefinition().getColumn("X").getDataType();
+        Assert.eq(resultType, "resultType", int.class, "int.class");
+    }
 }


### PR DESCRIPTION
Fixes #4468 