### PR TITLE
Tweaks to support building the cpp-client in older linux distros/GCC versions.

### DIFF
--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -33,7 +33,7 @@ C++ compiler and tool suite (cmake etc).
    Get the `build-dependencies.sh` script from Deephaven's base images repository
    at the correct version.
    You can download it directly from the link
-   https://raw.githubusercontent.com/deephaven/deephaven-base-images/53081b141aebea4c43238ddae233be49db28cf7b/cpp-client/build-dependencies.sh
+   https://raw.githubusercontent.com/deephaven/deephaven-base-images/166befad816acbc9dff55d2d8354d60612cd9a8a/cpp-client/build-dependencies.sh
    (this script is also used from our automated tools, to generate a docker image to
    support tests runs; that's why it lives in a separate repo).
    The script downloads, builds and installs the dependent libraries
@@ -60,7 +60,7 @@ C++ compiler and tool suite (cmake etc).
    # If the directory already exists from a previous attempt, ensure is clean/empty
    mkdir -p $DHCPP
    cd $DHCPP
-   wget https://raw.githubusercontent.com/deephaven/deephaven-base-images/53081b141aebea4c43238ddae233be49db28cf7b/cpp-client/build-dependencies.sh
+   wget https://raw.githubusercontent.com/deephaven/deephaven-base-images/166befad816acbc9dff55d2d8354d60612cd9a8a/cpp-client/build-dependencies.sh
    chmod +x ./build-dependencies.sh
    # Maybe edit build-dependencies.sh to reflect choices of build tools and build target, if you
    # want anything different than defaults; defaults are tested to work,

--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -11,7 +11,7 @@ C++ compiler and tool suite (cmake etc).
 3. Get build tools
    ```
    sudo apt update
-   sudo apt install curl git g++ cmake make build-essential zlib1g-dev libssl-dev pkg-config
+   sudo apt install curl git g++ cmake make build-essential zlib1g-dev libbz2-dev libssl-dev pkg-config
    ```
 
 4. Make a new directory for the Deephaven source code and assign that directory

--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -41,9 +41,9 @@ C++ compiler and tool suite (cmake etc).
    Decide on a directory for the dependencies to live (eg, "$HOME/dhcpp").
    Create that directory and save the script there.
 
-   The two main build types of a standard cmake build are supported,
-   `Release` and `Debug`.  By default. `build-dependencies.sh`
-   creates a `Debug` build.  To create a `Release` build, set the
+   The three main build types of a standard cmake build are supported,
+   `Release`, `Debug` and `RelWithDebInfo`.  By default. `build-dependencies.sh`
+   creates a `RelWithDebInfo` build.  To create a `Release` build, set the
    environment variable `BUILD_TYPE=Release` (1)
 
    Edit your local copy of the script if necessary to reflect your selection
@@ -102,7 +102,7 @@ C++ compiler and tool suite (cmake etc).
    cd $DHSRC/deephaven-core/cpp-client/deephaven/
    mkdir build && cd build
    cmake -DCMAKE_INSTALL_PREFIX=${DHCPP}/local \
-       -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON .. && \
+       -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON .. && \
      make -j$NCPUS install
    ```
 
@@ -125,6 +125,26 @@ C++ compiler and tool suite (cmake etc).
     make -j$NCPUS
     ./tests
     ```
+
+10. Building in different distributions or with older toolchains.
+    While we don't support other linux distributions or GCC versions earlier
+    than 11, this section provides some notes that may help you
+    in that situation.
+
+    * GCC 8 mixed with older versions of GNU as/binutils may fail to compile
+      `roaring.c` with an error similar to:
+      ```
+      /tmp/cczCvQKd.s: Assembler messages:
+      /tmp/cczCvQKd.s:45826: Error: no such instruction: `vpcompressb %zmm0,%zmm1{%k2}'
+      /tmp/cczCvQKd.s:46092: Error: no such instruction: `vpcompressb %zmm0,%zmm1{%k1}'
+      ```
+      In that case, add `-DCMAKE_C_FLAGS=-DCROARING_COMPILER_SUPPORTS_AVX512=0`
+      to the list of arguments to `cmake`.
+
+    * Some platforms combining old versions of GCC and cmake may fail
+      to set the cmake C++ standard to 17 without explicitly adding
+      `-DCMAKE_CXX_STANDARD=17` to the list of arguments to `cmake`.
+      Note the default mode for C++ is `-std=gnu++17` for GCC 11.
 
 Notes
   (1) The standard assumptions for `Debug` and `Release` apply here.

--- a/cpp-client/build.gradle
+++ b/cpp-client/build.gradle
@@ -90,7 +90,7 @@ def testCppClient = Docker.registerDockerTask(project, 'testCppClient') {
                       cd /cpp-client/deephaven/build; \\
                       . /cpp-client/deps/env.sh; \\
                       cmake -DCMAKE_INSTALL_PREFIX=/cpp-client/install \\
-                        -DCMAKE_BUILD_TYPE=Debug \\
+                        -DCMAKE_BUILD_TYPE=Release \\
                         -DBUILD_SHARED_LIBS=ON \\
                         .. ; \\
                       make -j\$NCPUS install

--- a/cpp-client/deephaven/CMakeLists.txt
+++ b/cpp-client/deephaven/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.14)
 
 if(TARGET client)
     # The library has already been built (i.e. through some

--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.14)
 project(dhclient)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
@@ -88,17 +88,9 @@ public:
    */
   explicit TableHandleManager(std::shared_ptr<impl::TableHandleManagerImpl> impl);
   /**
-   * Copy constructor
-   */
-  TableHandleManager(const TableHandleManager &other) noexcept;
-  /**
    * Move constructor
    */
   TableHandleManager(TableHandleManager &&other) noexcept;
-  /**
-   * Copy assigment operator.
-   */
-  TableHandleManager &operator=(const TableHandleManager &other) noexcept;
   /**
    * Move assigment operator.
    */

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
@@ -26,11 +26,10 @@ public:
    * Default constructor. Creates a default ClientOptions object with default authentication and Python scripting.
    */
   ClientOptions();
-#if __GLIBCXX__ > 20190223
   /**
    * Copy constructor
    */
-  ClientOptions(const ClientOptions &other) noexcept;
+  ClientOptions(const ClientOptions &other);
   /**
    * Move constructor
    */
@@ -38,30 +37,11 @@ public:
   /**
    * Copy assigment operator.
    */
-  ClientOptions &operator=(const ClientOptions &other) noexcept;
-  /**
-   * Move assigment operator.
-   */
-  ClientOptions &operator=(ClientOptions &&other) noexcept;
-#else
-  // Earlier GLIBCXX versions lack the proper noexcept specifier in some of our contained types.
-  /**
-   * Copy constructor
-   */  
-  ClientOptions(const ClientOptions &other);
-  /**
-   * Move constructor
-   */
-  ClientOptions(ClientOptions &&other);
-  /**
-   * Copy assigment operator.
-   */
   ClientOptions &operator=(const ClientOptions &other);
   /**
    * Move assigment operator.
    */
-  ClientOptions &operator=(ClientOptions &&other);
-#endif
+  ClientOptions &operator=(ClientOptions &&other) noexcept;
   /**
    * Destructor
    */

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
@@ -28,8 +28,8 @@ public:
   ClientOptions();
 #if __GLIBCXX__ > 20190223
   /**
- * Copy constructor
- */
+   * Copy constructor
+   */
   ClientOptions(const ClientOptions &other) noexcept;
   /**
    * Move constructor
@@ -46,8 +46,8 @@ public:
 #else
   // Earlier GLIBCXX versions lack the proper noexcept specifier in some of our contained types.
   /**
- * Copy constructor
- */  
+   * Copy constructor
+   */  
   ClientOptions(const ClientOptions &other);
   /**
    * Move constructor

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
@@ -26,6 +26,7 @@ public:
    * Default constructor. Creates a default ClientOptions object with default authentication and Python scripting.
    */
   ClientOptions();
+#if __GLIBCXX__ > 20190223
   /**
  * Copy constructor
  */
@@ -42,6 +43,25 @@ public:
    * Move assigment operator.
    */
   ClientOptions &operator=(ClientOptions &&other) noexcept;
+#else
+  // Earlier GLIBCXX versions lack the proper noexcept specifier in some of our contained types.
+  /**
+ * Copy constructor
+ */  
+  ClientOptions(const ClientOptions &other);
+  /**
+   * Move constructor
+   */
+  ClientOptions(ClientOptions &&other);
+  /**
+   * Copy assigment operator.
+   */
+  ClientOptions &operator=(const ClientOptions &other);
+  /**
+   * Move assigment operator.
+   */
+  ClientOptions &operator=(ClientOptions &&other);
+#endif
   /**
    * Destructor
    */

--- a/cpp-client/deephaven/dhclient/src/client.cc
+++ b/cpp-client/deephaven/dhclient/src/client.cc
@@ -104,9 +104,7 @@ bool Client::RemoveOnCloseCallback(OnCloseCbId cb_id) {
 
 TableHandleManager::TableHandleManager() = default;
 TableHandleManager::TableHandleManager(std::shared_ptr<impl::TableHandleManagerImpl> impl) : impl_(std::move(impl)) {}
-TableHandleManager::TableHandleManager(const TableHandleManager &other) noexcept = default;
 TableHandleManager::TableHandleManager(TableHandleManager &&other) noexcept = default;
-TableHandleManager &TableHandleManager::operator=(const TableHandleManager &other) noexcept = default;
 TableHandleManager &TableHandleManager::operator=(TableHandleManager &&other) noexcept = default;
 TableHandleManager::~TableHandleManager() = default;
 

--- a/cpp-client/deephaven/dhclient/src/client_options.cc
+++ b/cpp-client/deephaven/dhclient/src/client_options.cc
@@ -13,17 +13,10 @@ ClientOptions::ClientOptions() {
   SetSessionType("python");
 }
 
-#if __GLIBCXX__ > 20190223
-ClientOptions::ClientOptions(const ClientOptions &other) noexcept = default;
-ClientOptions::ClientOptions(ClientOptions &&other) noexcept = default;
-ClientOptions &ClientOptions::operator=(const ClientOptions &other) noexcept = default;
-ClientOptions &ClientOptions::operator=(ClientOptions &&other) noexcept = default;
-#else
 ClientOptions::ClientOptions(const ClientOptions &other) = default;
-ClientOptions::ClientOptions(ClientOptions &&other) = default;
+ClientOptions::ClientOptions(ClientOptions &&other) noexcept = default;
 ClientOptions &ClientOptions::operator=(const ClientOptions &other) = default;
-ClientOptions &ClientOptions::operator=(ClientOptions &&other) = default;
-#endif
+ClientOptions &ClientOptions::operator=(ClientOptions &&other) noexcept = default;
 
 ClientOptions::~ClientOptions() = default;
 

--- a/cpp-client/deephaven/dhclient/src/client_options.cc
+++ b/cpp-client/deephaven/dhclient/src/client_options.cc
@@ -13,10 +13,18 @@ ClientOptions::ClientOptions() {
   SetSessionType("python");
 }
 
+#if __GLIBCXX__ > 20190223
 ClientOptions::ClientOptions(const ClientOptions &other) noexcept = default;
 ClientOptions::ClientOptions(ClientOptions &&other) noexcept = default;
 ClientOptions &ClientOptions::operator=(const ClientOptions &other) noexcept = default;
 ClientOptions &ClientOptions::operator=(ClientOptions &&other) noexcept = default;
+#else
+ClientOptions::ClientOptions(const ClientOptions &other) = default;
+ClientOptions::ClientOptions(ClientOptions &&other) = default;
+ClientOptions &ClientOptions::operator=(const ClientOptions &other) = default;
+ClientOptions &ClientOptions::operator=(ClientOptions &&other) = default;
+#endif
+
 ClientOptions::~ClientOptions() = default;
 
 ClientOptions &ClientOptions::SetDefaultAuthentication() {

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.14)
 project(dhcore)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
@@ -61,9 +61,11 @@ bool DumpFormat(std::ostream &s, const char **fmt, bool placeholder_expected);
 std::ostream &Streamf(std::ostream &s, const char *fmt);
 
 template<typename HEAD, typename... REST>
-std::ostream &Streamf(std::ostream &s, const char *fmt, const HEAD &head, REST &&... rest) {
-  (void) deephaven::dhcore::utility::internal::DumpFormat(s, &fmt, true);
-  s << head;
+std::ostream &Streamf(std::ostream &s, const char *fmt, HEAD &&head, REST &&... rest) {
+  if (!deephaven::dhcore::utility::internal::DumpFormat(s, &fmt, true)) {
+    return s;
+  }
+  s << std::forward<HEAD>(head);
   return Streamf(s, fmt, std::forward<REST>(rest)...);
 }
 

--- a/cpp-client/deephaven/examples/create_table_with_arrow_flight/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/create_table_with_arrow_flight/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
 project(create_table_with_arrow_flight)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/examples/create_table_with_table_maker/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/create_table_with_table_maker/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
 project(create_table_with_table_maker)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/examples/demos/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/demos/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
 project(demos)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/examples/hello_world/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/hello_world/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
 project(hello_world)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/examples/read_csv/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/read_csv/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
 project(read_csv)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/examples/read_table_with_arrow_flight/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/read_table_with_arrow_flight/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
 project(read_table_with_arrow_flight)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/examples/table_cleanup/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/table_cleanup/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.14)
 project(table_cleanup)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/tests/CMakeLists.txt
+++ b/cpp-client/deephaven/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.14)
 project(tests)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cpp-client/deephaven/tests/select_test.cc
+++ b/cpp-client/deephaven/tests/select_test.cc
@@ -39,7 +39,7 @@ TEST_CASE("Support all types", "[select]") {
     byte_data.push_back(i * 11);
     short_data.push_back(i * 1000);
     int_data.push_back(i * 1'000'000);
-    long_data.push_back(i * 1'000'000'000);
+    long_data.push_back(static_cast<long>(i) * 1'000'000'000);
     float_data.push_back(i * 123.456F);
     doubleData.push_back(i * 987654.321);
     stringData.push_back(Stringf("test %o", i));

--- a/docker/registry/cpp-client-base/gradle.properties
+++ b/docker/registry/cpp-client-base/gradle.properties
@@ -7,6 +7,6 @@ deephaven.registry.imageName=ghcr.io/deephaven/cpp-client-base:latest
 # It is in two different parts of the file (text and command examples).
 # If you have the image sha for this file, you can get the commit sha for the README using:
 # docker buildx imagetools inspect ghcr.io/deephaven/cpp-client-base@sha256:$IMAGESHA --format '{{ $metadata := index .Provenance.SLSA.metadata "https://mobyproject.org/buildkit@v1#metadata" }} {{ $metadata.vcs.revision }}'
-deephaven.registry.imageId=ghcr.io/deephaven/cpp-client-base@sha256:105b358c20bd004daa67a5a947e0da1190568854da07adf7b2ac66e2c78f9287
+deephaven.registry.imageId=ghcr.io/deephaven/cpp-client-base@sha256:74034b2c26a26033258a8d0808f45d6a010300c07a9135260fcb0c1691de04dd
 # TODO(deephaven-base-images#54): arm64 native image for cpp-client-base
 deephaven.registry.platform=linux/amd64


### PR DESCRIPTION
* I removed the requirement for 3.16 in most of the chained/deeper level `CMakeLists.txt` files.
* I reduced the requirement to 3.14 in the rest.
