### PR TITLE
Use new C++ base image that removes local from the directory layout.

### DIFF
--- a/R/rdeephaven/src/Makevars
+++ b/R/rdeephaven/src/Makevars
@@ -7,7 +7,7 @@ CXX_STD = CXX17
 # and its dependent libraries was built, as per the instructions in
 # https://github.com/deephaven/deephaven-core/blob/main/cpp-client/README.md
 #
-DEPENDENCY_DIRS = -L$(DHCPP)/local/lib
+DEPENDENCY_DIRS = -L$(DHCPP)/lib
 
 
 #
@@ -18,16 +18,16 @@ DEPENDENCY_DIRS = -L$(DHCPP)/local/lib
 # The line below tries to automatically guess whether to use
 # `-lprotbufd` or `-lprotobuf` depending on which file is available.
 #
-PROTOBUF_LIB = `[ -f \${DHCPP}/local/lib/libprotobufd.so ] && echo -lprotobufd || echo -lprotobuf`
+PROTOBUF_LIB = `[ -f \${DHCPP}/lib/libprotobufd.so ] && echo -lprotobufd || echo -lprotobuf`
 
 DEPENDENCY_LIBS = \
         $(PROTOBUF_LIB) \
         -larrow \
-        `PKG_CONFIG_PATH=\${DHCPP}/local/lib/pkgconfig pkg-config --libs grpc++`
+        `PKG_CONFIG_PATH=\${DHCPP}/lib/pkgconfig pkg-config --libs grpc++`
 
 # tells the compiler where to look for additional include directories
 PKG_CXXFLAGS = \
-	-I$(DHCPP)/local/include \
+	-I$(DHCPP)/include \
 	-I/usr/share/R/include \
 	-I/usr/local/lib/R/site-library/Rcpp/include
 
@@ -47,9 +47,8 @@ PKG_CXXFLAGS = \
 PKG_LIBS = \
         $(EXTRA_LD_FLAGS) \
 	-L/usr/lib/R/lib -lR \
-        -L$(DHCPP)/local/lib \
-	-ldhclient -ldhcore \
 	$(DEPENDENCY_DIRS) \
+	-ldhclient -ldhcore \
 	$(DEPENDENCY_LIBS) \
 
 # all src directory c++ source files

--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -37,7 +37,7 @@ on them anymore so we do notguarantee they are current for those platforms.
    Get the `build-dependencies.sh` script from Deephaven's base images repository
    at the correct version.
    You can download it directly from the link
-   https://raw.githubusercontent.com/deephaven/deephaven-base-images/72427ce29901bf0419dd05db8e4abf31b57253d9/cpp-client/build-dependencies.sh
+   https://raw.githubusercontent.com/deephaven/deephaven-base-images/4eab90690888fbd5abfcbaf5dbacc750e90d9c2f/cpp-client/build-dependencies.sh
    (this script is also used from our automated tools, to generate a docker image to
    support tests runs; that's why it lives in a separate repo).
    The script downloads, builds and installs the dependent libraries
@@ -64,7 +64,7 @@ on them anymore so we do notguarantee they are current for those platforms.
    # If the directory already exists from a previous attempt, ensure is clean/empty
    mkdir -p $DHCPP
    cd $DHCPP
-   wget https://raw.githubusercontent.com/deephaven/deephaven-base-images/72427ce29901bf0419dd05db8e4abf31b57253d9/cpp-client/build-dependencies.sh
+   wget https://raw.githubusercontent.com/deephaven/deephaven-base-images/4eab90690888fbd5abfcbaf5dbacc750e90d9c2f/cpp-client/build-dependencies.sh
    chmod +x ./build-dependencies.sh
    # Maybe edit build-dependencies.sh to reflect choices of build tools and build target, if you
    # want anything different than defaults; defaults are tested to work,
@@ -108,12 +108,25 @@ on them anymore so we do notguarantee they are current for those platforms.
    cmake \
        -DCMAKE_INSTALL_LIBDIR=lib \
        -DCMAKE_CXX_STANDARD=17 \
-       -DCMAKE_INSTALL_PREFIX=${DHCPP}/local \
+       -DCMAKE_INSTALL_PREFIX=${DHCPP} \
        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
        -DBUILD_SHARED_LIBS=ON \
        .. \
      && \
        make -j$NCPUS install
+   ```
+
+   If you need `make` to generate detailed output of the commands it is running
+   (which may be helpful for debugging the paths being used etc),
+   you can set the environment variable `VERBOSE=1`.
+   This is true in general of cmake-generated Makefiles.
+   It is useful to keep the output of make for later reference
+   in case you need to be sure of the exact compiler flags
+   that were used to compile the library and its objects.
+   You can tweak the last command above as
+
+   ```
+   VERBOSE=1 make -j$NCPUS install 2>&1 | tee make-install.log
    ```
 
 8. Run one Deephaven example which uses the installed client.

--- a/docker/registry/cpp-client-base/gradle.properties
+++ b/docker/registry/cpp-client-base/gradle.properties
@@ -7,7 +7,7 @@ deephaven.registry.imageName=ghcr.io/deephaven/cpp-client-base:latest
 # It is in two different parts of the file (text and command examples).
 # If you have the image sha for this file, you can get the commit sha for the README using:
 # docker buildx imagetools inspect ghcr.io/deephaven/cpp-client-base@sha256:$IMAGESHA --format '{{ $metadata := index .Provenance.SLSA.metadata "https://mobyproject.org/buildkit@v1#metadata" }} {{ $metadata.vcs.revision }}'
-deephaven.registry.imageId=ghcr.io/deephaven/cpp-client-base@sha256:061a3b87bd8cf7afa9bfacc3ebfbe904224cadc62b88e5232bf493c341bc4ed3
+deephaven.registry.imageId=ghcr.io/deephaven/cpp-client-base@sha256:a31ce4b5c0864a35cc8f358dce50950fd3f10413595e773803b9939498b4eb91
 
 # TODO(deephaven-base-images#54): arm64 native image for cpp-client-base
 deephaven.registry.platform=linux/amd64

--- a/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
+++ b/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
@@ -2,7 +2,11 @@
 
 set -euxo pipefail
 
-: ${DHCPP:=$HOME/dhcpp}
+if [ -z "$PROTOC_BIN" ] && [ -z "$DHCPP" ]; then
+    echo "$0: At least one of the environment variables 'PROTOC_BIN' and 'DHCPP' must be defined, aborting." 1>&2
+    exit 1
+fi
+
 : ${PROTOC_BIN:=$DHCPP/bin}
 : ${CPP_PROTO_BUILD_DIR:=build}
 

--- a/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
+++ b/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
@@ -2,14 +2,15 @@
 
 set -euxo pipefail
 
-: ${DHCPP_LOCAL:=$HOME/dhcpp}
+: ${DHCPP:=$HOME/dhcpp}
+: ${PROTOC_BIN:=$DHCPP/bin}
 : ${CPP_PROTO_BUILD_DIR:=build}
 
 mkdir -p "${CPP_PROTO_BUILD_DIR}"
-$DHCPP_LOCAL/bin/protoc \
+$DHCPP/bin/protoc \
     $(find . -name '*.proto') \
     --cpp_out=${CPP_PROTO_BUILD_DIR} \
     --grpc_out=${CPP_PROTO_BUILD_DIR} \
-    --plugin=protoc-gen-grpc=$DHCPP_LOCAL/bin/grpc_cpp_plugin
+    --plugin=protoc-gen-grpc=${PROTOC_BIN}/grpc_cpp_plugin
 mv -f ${CPP_PROTO_BUILD_DIR}/deephaven/proto/*.{h,cc} \
    ../../../../../cpp-client/deephaven/dhclient/proto/deephaven/proto

--- a/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
+++ b/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
@@ -2,11 +2,11 @@
 
 set -euxo pipefail
 
-: ${DHCPP_LOCAL:=$HOME/dhcpp/local}
+: ${DHCPP_LOCAL:=$HOME/dhcpp}
 : ${CPP_PROTO_BUILD_DIR:=build}
 
 mkdir -p "${CPP_PROTO_BUILD_DIR}"
-$DHCPP_LOCAL/protobuf/bin/protoc \
+$DHCPP_LOCAL/bin/protoc \
     $(find . -name '*.proto') \
     --cpp_out=${CPP_PROTO_BUILD_DIR} \
     --grpc_out=${CPP_PROTO_BUILD_DIR} \

--- a/py/client-ticking/README.md
+++ b/py/client-ticking/README.md
@@ -51,7 +51,7 @@ cd ${DHROOT}/py/client-ticking
 ```
 # Ensure the DHCPP environment variable is set per the instructions above
 rm -rf build  # Ensure we clean the remnants of any pre-existing build.
-CFLAGS="-I${DHCPP}/local/include" LDFLAGS="-L${DHCPP}/local/lib" python setup.py build_ext -i
+CFLAGS="-I${DHCPP}/include" LDFLAGS="-L${DHCPP}/lib" python setup.py build_ext -i
 ```
 
 ### Install pydeephaven-ticking


### PR DESCRIPTION
This simplifies our deployment layout, eliminated one unnecessary level of indirection (the intermediate `.../local/...` directory).
The C++ base image being adopted was already modified to do this, and also trim down the number of files
in the final deployment hierarchy; for builds that include debug information, we are still keeping the source files of 
all libraries, including dependent, but the object files and in general the intermediate results of compilation are not necessary after install is done, so this trims down our install footprint considerably.