### PR TITLE
KafkaStreamPublisher: Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/KafkaStreamPublisher.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/ingest/KafkaStreamPublisher.java
@@ -203,8 +203,7 @@ public class KafkaStreamPublisher extends StreamPublisherBase implements Consume
                     : null;
 
             for (ConsumerRecord<?, ?> record : records) {
-                // Note we only flush if we are about to overflow the chunks.
-                if (--remaining < 0) {
+                if (remaining == 0) {
                     if (keyChunk != null) {
                         flushKeyChunk(keyChunk, chunks);
                     }
@@ -218,9 +217,8 @@ public class KafkaStreamPublisher extends StreamPublisherBase implements Consume
                     chunks = getChunksToFill();
                     checkChunkSizes(chunks);
 
-                    // Note that remaining should account for the row we are about to write.
-                    remaining = chunks[0].capacity() - chunks[0].size() - 1;
-                    Assert.geqZero(remaining, "remaining");
+                    remaining = chunks[0].capacity() - chunks[0].size();
+                    Assert.gtZero(remaining, "remaining");
 
                     if (kafkaPartitionColumnIndex >= 0) {
                         partitionChunk = chunks[kafkaPartitionColumnIndex].asWritableIntChunk();
@@ -275,6 +273,8 @@ public class KafkaStreamPublisher extends StreamPublisherBase implements Consume
                         bytesProcessed += valueBytes;
                     }
                 }
+
+                --remaining;
             }
             if (keyChunk != null) {
                 flushKeyChunk(keyChunk, chunks);


### PR DESCRIPTION
Fixes #4516

Since we append to these chunks off of the update-graph, we only flush when we need to acquire a new set of chunks. Note that `StreamPublisherBase#flush` does not check to see if the chunk has `.size() > 0` but `IntChunkColumnSource.addChunk` does ensure that you are not adding empty chunks. (Noting that flush() is what happens first during an update graph cycle for the blink table adapter.)

We attempt to be clever to only allocate a new chunk if we are going to write a row to it. To do this, we pre-decrement a counter `remaining` and if the chunk is full we flush. Note this check `if (--remaining == 0) {`  is an off-by-one as we have not yet written the row we are counting. That isn't a big deal though; that just means we never actually fill the chunks. The `AIOBE` actually comes from recalculating the new `remaining` whenever we flush -- we are not accounting for the row that is about to be written.

This causes us to leave the method with `remaining == 1` but the chunks are already full. 