### PR TITLE
SourceTable should remove itself from registrar, not UG

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
@@ -238,7 +238,7 @@ public abstract class SourceTable<IMPL_TYPE extends SourceTable<IMPL_TYPE>> exte
                 rowSet.insert(added);
                 notifyListeners(added, RowSetFactory.empty(), RowSetFactory.empty());
             } catch (Exception e) {
-                getUpdateGraph().removeSource(this);
+                updateSourceRegistrar.removeSource(this);
 
                 // Notify listeners to the SourceTable when we had an issue refreshing available locations.
                 notifyListenersOnError(e, null);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
@@ -213,6 +213,11 @@ public class SourcePartitionedTableTest extends RefreshingTableTestCase {
             updateGraph.refreshSources();
             registrar.run();
         });
+
+        assertEquals(1, partitionTable.size());
+        try (final CloseableIterator<Table> tableIt = partitionTable.columnIterator("LocationTable")) {
+            assertTableEquals(tableIt.next(), p2);
+        }
     }
 
     /**

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
@@ -193,8 +193,8 @@ public class SourcePartitionedTableTest extends RefreshingTableTestCase {
         removeRows(tlks[0].table(), rowSet);
         tlp.getTableLocation(tlks[0]).refresh();
 
-        // First Cause the location to fail. for example size -> 0 because "someone deleted my data"
-        // We expect an error here because the tble itself is going to fail.
+        // First cause the location to fail. for example size -> 0 because "someone deleted my data"
+        // We expect an error here because the table itself is going to fail.
         allowingError(() -> updateGraph.getDelegate().runWithinUnitTestCycle(() -> {
             // This should process the pending update from the refresh above.
             updateGraph.refreshSources();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
@@ -186,7 +186,7 @@ public class SourcePartitionedTableTest extends RefreshingTableTestCase {
 
         TableBackedTableLocationKey[] tlks = tlp.getTableLocationKeys().stream()
                 .sorted()
-                .map(k -> (TableBackedTableLocationKey)k)
+                .map(k -> (TableBackedTableLocationKey) k)
                 .toArray(TableBackedTableLocationKey[]::new);
 
         final RowSet rowSet = p1.getRowSet().copy();
@@ -199,7 +199,7 @@ public class SourcePartitionedTableTest extends RefreshingTableTestCase {
             // This should process the pending update from the refresh above.
             updateGraph.refreshSources();
             registrar.run();
-            }),
+        }),
                 errors -> errors.size() == 1 &&
                         FindExceptionCause.isOrCausedBy(errors.get(0), TableDataException.class).isPresent());
         getUpdateErrors().clear();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/SourcePartitionedTableTest.java
@@ -4,8 +4,6 @@ import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.TrackingRowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.locations.ImmutableTableLocationKey;
 import io.deephaven.engine.table.impl.locations.InvalidatedRegionException;
@@ -174,6 +172,7 @@ public class SourcePartitionedTableTest extends RefreshingTableTestCase {
     /**
      * This is a test for PR 4537, where SourceTable removes itself from the wrong refresh provider
      */
+    @Test
     public void testRemoveAndFail() {
         final SourcePartitionedTable spt = setUpData();
 


### PR DESCRIPTION
This fixes Issue #4537.