### PR TITLE
Fix missing AuthContext on New Partition

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/perf/PerformanceEntry.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/perf/PerformanceEntry.java
@@ -50,6 +50,9 @@ public class PerformanceEntry extends BasePerformanceEntry implements TableListe
         this.description = description;
         this.callerLine = callerLine;
         authContext = id == QueryConstants.NULL_INT ? null : ExecutionContext.getContext().getAuthContext();
+        if (id != QueryConstants.NULL_INT && authContext == null) {
+            throw new IllegalStateException("No Auth Context is Installed. Do you need to open an ExecutionContext?");
+        }
         this.updateGraphName = updateGraphName;
         startSample = new RuntimeMemory.Sample();
         endSample = new RuntimeMemory.Sample();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/perf/PerformanceEntry.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/perf/PerformanceEntry.java
@@ -50,9 +50,6 @@ public class PerformanceEntry extends BasePerformanceEntry implements TableListe
         this.description = description;
         this.callerLine = callerLine;
         authContext = id == QueryConstants.NULL_INT ? null : ExecutionContext.getContext().getAuthContext();
-        if (id != QueryConstants.NULL_INT && authContext == null) {
-            throw new IllegalStateException("No AuthContext is installed. Do you need to open an ExecutionContext?");
-        }
         this.updateGraphName = updateGraphName;
         startSample = new RuntimeMemory.Sample();
         endSample = new RuntimeMemory.Sample();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/perf/PerformanceEntry.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/perf/PerformanceEntry.java
@@ -51,7 +51,7 @@ public class PerformanceEntry extends BasePerformanceEntry implements TableListe
         this.callerLine = callerLine;
         authContext = id == QueryConstants.NULL_INT ? null : ExecutionContext.getContext().getAuthContext();
         if (id != QueryConstants.NULL_INT && authContext == null) {
-            throw new IllegalStateException("No Auth Context is Installed. Do you need to open an ExecutionContext?");
+            throw new IllegalStateException("No AuthContext is installed. Do you need to open an ExecutionContext?");
         }
         this.updateGraphName = updateGraphName;
         startSample = new RuntimeMemory.Sample();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
@@ -67,10 +67,6 @@ public class UnionSourceManager {
     public UnionSourceManager(@NotNull final PartitionedTable partitionedTable) {
         constituentChangesPermitted = partitionedTable.constituentChangesPermitted();
         columnNames = partitionedTable.constituentDefinition().getColumnNamesArray();
-        executionContext = ExecutionContext.newBuilder()
-                .markSystemic()
-                .captureUpdateGraph()
-                .build();
 
         final Table coalescedPartitions = partitionedTable.table().coalesce().select(List.of(
                 new TableTransformationColumn(
@@ -105,11 +101,17 @@ public class UnionSourceManager {
 
             updateCommitter = new UpdateCommitter<>(this, partitionedTable.table().getUpdateGraph(),
                     usm -> usm.unionRedirection.copyCurrToPrev());
+
+            executionContext = ExecutionContext.newBuilder()
+                    .markSystemic()
+                    .captureUpdateGraph()
+                    .build();
         } else {
             listenerRecorders = null;
             mergedListener = null;
             constituentChangesListener = null;
             updateCommitter = null;
+            executionContext = null;
         }
 
         try (final Stream<Table> initialConstituents = currConstituents()) {


### PR DESCRIPTION
Fixes #4543 by improving the time of error when auth context is not provided and by installing an auth context when processing changes to a union source manager (which might create new listeners).