### PR TITLE
Fix formatting and formulas in UpdateBy docs

### DIFF
--- a/py/server/deephaven/updateby.py
+++ b/py/server/deephaven/updateby.py
@@ -114,6 +114,7 @@ def ema_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
+
         |  a = e^(-1 / decay_ticks)
         |  ema_first = first_value
         |  ema_current = a * ema_prev + (1 - a) * current_value
@@ -148,6 +149,7 @@ def ema_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[str
     decay unit.
 
     The formula used is
+
         |  dt_current = current_timestamp - prev_timestamp
         |  a_current = e^(-dt_current / decay_time)
         |  ema_first = first_value
@@ -186,6 +188,7 @@ def ems_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
+
         |  a = e^(-1 / decay_ticks)
         |  ems_first = first_value
         |  ems_current = a * ems_prev + current_value
@@ -220,6 +223,7 @@ def ems_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[str
     decay unit.
 
     The formula used is
+
         |  dt_current = current_timestamp - prev_timestamp
         |  a_current = e^(-dt_current / decay_time)
         |  ems_first = first_value
@@ -258,6 +262,7 @@ def emmin_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
+
         |  a = e^(-1 / decay_ticks)
         |  emmin_first = first_value
         |  emmin_current = min(a * emmin_prev, current_value)
@@ -292,6 +297,7 @@ def emmin_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[s
     decay unit.
 
     The formula used is
+
         |  dt_current = current_timestamp - prev_timestamp
         |  a_current = e^(-dt_current / decay_time)
         |  emmin_first = first_value
@@ -330,6 +336,7 @@ def emmax_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
+
         |  a = e^(-1 / decay_ticks)
         |  emmax_first = first_value
         |  emmax_current = max(a * emmax_prev, current_value)
@@ -364,6 +371,7 @@ def emmax_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[s
     decay unit.
 
     The formula used is
+
         |  dt_current = current_timestamp - prev_timestamp
         |  a_current = e^(-dt_current / decay_time)
         |  emmax_first = first_value
@@ -401,6 +409,7 @@ def emstd_tick(decay_ticks: float, cols: Union[str, List[str]],
     ticks as the decay unit.
 
     The formula used is
+
         |  a = e^(-1 / decay_ticks)
         |  em_variance_current = a * (em_variance_prev + (1 − a) * (current_value − ema_prev)^2)
         |  emstd_current = sqrt(em_variance_current)
@@ -435,6 +444,7 @@ def emstd_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[s
     time as the decay unit.
 
     The formula used is
+
         |  dt_current = current_timestamp - prev_timestamp
         |  a_current = e^(-dt_current / decay_time)
         |  em_variance_first = 0
@@ -609,7 +619,7 @@ def rolling_sum_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int
     """Creates a rolling sum UpdateByOperation for the supplied column names, using ticks as the windowing unit. Ticks 
     are row counts, and you may specify the reverse and forward window in number of rows to include. The current row
     is considered to belong to the reverse window but not the forward window. Also, negative values are allowed and 
-    can be used to generate completely forward or completely reverse windows. 
+    can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
         |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row

--- a/py/server/deephaven/updateby.py
+++ b/py/server/deephaven/updateby.py
@@ -114,8 +114,9 @@ def ema_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
-        a = e^(-1 / decay_ticks)
-        ema_next = a * ema_last + (1 - a) * value
+        |  a = e^(-1 / decay_ticks)
+        |  ema_first = first_value
+        |  ema_current = a * ema_prev + (1 - a) * current_value
 
     Args:
         decay_ticks (float): the decay rate in ticks
@@ -147,8 +148,10 @@ def ema_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[str
     decay unit.
 
     The formula used is
-        a = e^(-dt / decay_time)
-        ema_next = a * ema_last + (1 - a) * value
+        |  dt_current = current_timestamp - prev_timestamp
+        |  a_current = e^(-dt_current / decay_time)
+        |  ema_first = first_value
+        |  ema_current = a_current * ema_prev + (1 - a_current) * current_value
 
     Args:
         ts_col (str): the column in the source table to use for timestamps
@@ -183,8 +186,9 @@ def ems_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
-        a = e^(-1 / decay_ticks)
-        ems_next = a * ems_last + value
+        |  a = e^(-1 / decay_ticks)
+        |  ems_first = first_value
+        |  ems_current = a * ems_prev + current_value
 
     Args:
         decay_ticks (float): the decay rate in ticks
@@ -216,8 +220,10 @@ def ems_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[str
     decay unit.
 
     The formula used is
-        a = e^(-dt / decay_time)
-        ems_next = a * ems_last + value
+        |  dt_current = current_timestamp - prev_timestamp
+        |  a_current = e^(-dt_current / decay_time)
+        |  ems_first = first_value
+        |  ems_current = a_current * ems_prev + current_value
 
     Args:
         ts_col (str): the column in the source table to use for timestamps
@@ -252,8 +258,9 @@ def emmin_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
-        a = e^(-1 / decay_ticks)
-        emmin_next = min(a * emmin_last, value)
+        |  a = e^(-1 / decay_ticks)
+        |  emmin_first = first_value
+        |  emmin_current = min(a * emmin_prev, current_value)
 
     Args:
         decay_ticks (float): the decay rate in ticks
@@ -285,8 +292,10 @@ def emmin_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[s
     decay unit.
 
     The formula used is
-        a = e^(-dt / decay_time)
-        emmin_next = min(a * emmin_last, value)
+        |  dt_current = current_timestamp - prev_timestamp
+        |  a_current = e^(-dt_current / decay_time)
+        |  emmin_first = first_value
+        |  emmin_current = min(a_current * emmin_last, value)
 
     Args:
         ts_col (str): the column in the source table to use for timestamps
@@ -321,8 +330,9 @@ def emmax_tick(decay_ticks: float, cols: Union[str, List[str]],
     the decay unit.
 
     The formula used is
-        a = e^(-1 / decay_ticks)
-        emmax_next = max(a * emmax_last, value)
+        |  a = e^(-1 / decay_ticks)
+        |  emmax_first = first_value
+        |  emmax_current = max(a * emmax_prev, current_value)
 
     Args:
         decay_ticks (float): the decay rate in ticks
@@ -354,8 +364,10 @@ def emmax_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[s
     decay unit.
 
     The formula used is
-        a = e^(-dt / decay_time)
-        emmax_next = max(a * emmax_last, value)
+        |  dt_current = current_timestamp - prev_timestamp
+        |  a_current = e^(-dt_current / decay_time)
+        |  emmax_first = first_value
+        |  emmax_current = max(a_current * emmax_prev, current_value)
 
     Args:
         ts_col (str): the column in the source table to use for timestamps
@@ -389,10 +401,9 @@ def emstd_tick(decay_ticks: float, cols: Union[str, List[str]],
     ticks as the decay unit.
 
     The formula used is
-        a = e^(-1 / decay_ticks)
-        ema_next = a * ema_last + (1 - a) * value
-        em_variance_next = a * (em_variance_last + (1 − a) * (value − ema_last)^2)
-        emstd_next = sqrt(em_variance_next)
+        |  a = e^(-1 / decay_ticks)
+        |  em_variance_current = a * (em_variance_prev + (1 − a) * (current_value − ema_prev)^2)
+        |  emstd_current = sqrt(em_variance_current)
 
     Args:
         decay_ticks (float): the decay rate in ticks
@@ -424,10 +435,11 @@ def emstd_time(ts_col: str, decay_time: Union[int, str], cols: Union[str, List[s
     time as the decay unit.
 
     The formula used is
-        a = e^(-dt / decay_time)
-        ema_next = a * ema_last + (1 - a) * value
-        em_variance_next = a * (em_variance_last + (1 − a) * (value − ema_last)^2)
-        emstd_next = sqrt(em_variance_next)
+        |  dt_current = current_timestamp - prev_timestamp
+        |  a_current = e^(-dt_current / decay_time)
+        |  em_variance_first = 0
+        |  em_variance_current = a_current * (em_variance_prev + (1 − a_current) * (current_value − ema_prev)^2)
+        |  emstd_current = sqrt(em_variance_current)
 
     Args:
         ts_col (str): the column in the source table to use for timestamps
@@ -567,9 +579,9 @@ def delta(cols: Union[str, List[str]], delta_control: DeltaControl = DeltaContro
     the difference between the current value and the previous value. When the current value is null, this operation
     will output null. When the current value is valid, the output will depend on the DeltaControl provided.
 
-        When delta_control is not provided or set to NULL_DOMINATES, a value following a null value returns null.
-        When delta_control is set to VALUE_DOMINATES, a value following a null value returns the value.
-        When delta_control is set to ZERO_DOMINATES, a value following a null value returns zero.
+    When delta_control is not provided or set to NULL_DOMINATES, a value following a null value returns null.
+    When delta_control is set to VALUE_DOMINATES, a value following a null value returns the value.
+    When delta_control is set to ZERO_DOMINATES, a value following a null value returns zero.
 
     Args:
 
@@ -600,15 +612,15 @@ def rolling_sum_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int
     can be used to generate completely forward or completely reverse windows. 
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -639,16 +651,16 @@ def rolling_sum_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[i
     be null.
      
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
     
     Args:
@@ -682,15 +694,15 @@ def rolling_group_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: i
     can be used to generate completely forward or completely reverse windows. 
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -721,16 +733,16 @@ def rolling_group_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union
     be null.
      
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
     
     Args:
@@ -764,15 +776,15 @@ def rolling_avg_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int
     can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -803,16 +815,16 @@ def rolling_avg_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[i
     be null.
      
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
     
     Args:
@@ -846,15 +858,15 @@ def rolling_min_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int
     can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -885,16 +897,16 @@ def rolling_min_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[i
     be null.
      
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
     
     Args:
@@ -928,15 +940,15 @@ def rolling_max_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int
     can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -967,16 +979,16 @@ def rolling_max_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[i
     be null.
      
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
     
     Args:
@@ -1010,15 +1022,15 @@ def rolling_prod_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: in
     can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -1049,16 +1061,16 @@ def rolling_prod_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[
     be null.
      
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
     
     Args:
@@ -1092,15 +1104,15 @@ def rolling_count_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: i
     can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -1131,16 +1143,16 @@ def rolling_count_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union
     be null.
 
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
 
     Args:
@@ -1174,15 +1186,15 @@ def rolling_std_tick(cols: Union[str, List[str]], rev_ticks: int, fwd_ticks: int
     can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -1213,16 +1225,16 @@ def rolling_std_time(ts_col: str, cols: Union[str, List[str]], rev_time: Union[i
     be null.
 
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
 
     Args:
@@ -1256,15 +1268,15 @@ def rolling_wavg_tick(wcol: str, cols: Union[str, List[str]], rev_ticks: int, fw
     can be used to generate completely forward or completely reverse windows.
 
     Here are some examples of window values:
-        rev_ticks = 1, fwd_ticks = 0 - contains only the current row
-        rev_ticks = 10, fwd_ticks = 0 - contains 9 previous rows and the current row
-        rev_ticks = 0, fwd_ticks = 10 - contains the following 10 rows, excludes the current row
-        rev_ticks = 10, fwd_ticks = 10 - contains the previous 9 rows, the current row and the 10 rows following
-        rev_ticks = 10, fwd_ticks = -5 - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
+        |  `rev_ticks = 1, fwd_ticks = 0` - contains only the current row
+        |  `rev_ticks = 10, fwd_ticks = 0` - contains 9 previous rows and the current row
+        |  `rev_ticks = 0, fwd_ticks = 10` - contains the following 10 rows, excludes the current row
+        |  `rev_ticks = 10, fwd_ticks = 10` - contains the previous 9 rows, the current row and the 10 rows following
+        |  `rev_ticks = 10, fwd_ticks = -5` - contains 5 rows, beginning at 9 rows before, ending at 5 rows before  the
             current row (inclusive)
-        rev_ticks = 11, fwd_ticks = -1 - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
+        |  `rev_ticks = 11, fwd_ticks = -1` - contains 10 rows, beginning at 10 rows before, ending at 1 row before the
             current row (inclusive)
-        rev_ticks = -5, fwd_ticks = 10 - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
+        |  `rev_ticks = -5, fwd_ticks = 10` - contains 5 rows, beginning 5 rows following, ending at 10 rows  following the
             current row (inclusive)
 
     Args:
@@ -1298,16 +1310,16 @@ def rolling_wavg_time(ts_col: str, wcol: str, cols: Union[str, List[str]], rev_t
     be null.
 
     Here are some examples of window values:
-        rev_time = 0, fwd_time = 0 - contains rows that exactly match the current row timestamp
-        rev_time = "PT00:10:00", fwd_time = "0" - contains rows from 10m before through the current row timestamp (
+        |  `rev_time = 0, fwd_time = 0` - contains rows that exactly match the current row timestamp
+        |  `rev_time = "PT00:10:00", fwd_time = "0"` - contains rows from 10m before through the current row timestamp (
             inclusive)
-        rev_time = 0, fwd_time = 600_000_000_000 - contains rows from the current row through 10m following the
+        |  `rev_time = 0, fwd_time = 600_000_000_000` - contains rows from the current row through 10m following the
             current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "PT00:10:00" - contains rows from 10m before through 10m following
+        |  `rev_time = "PT00:10:00", fwd_time = "PT00:10:00"` - contains rows from 10m before through 10m following
             the current row timestamp (inclusive)
-        rev_time = "PT00:10:00", fwd_time = "-PT00:05:00" - contains rows from 10m before through 5m before the
+        |  `rev_time = "PT00:10:00", fwd_time = "-PT00:05:00"` - contains rows from 10m before through 5m before the
             current row timestamp (inclusive), this is a purely backwards looking window
-        rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"} - contains rows from 5m following through 10m
+        |  `rev_time = "-PT00:05:00", fwd_time = "PT00:10:00"` - contains rows from 5m following through 10m
             following the current row timestamp (inclusive), this is a purely forwards looking window
 
     Args:


### PR DESCRIPTION
This PR fixes the formatting issue in the UpdateBy Pydocs described in [4553](https://github.com/deephaven/deephaven-core/issues/4553). Additionally, this updates the formulas to make them as clear as possible, consistent with the changes made in [deephaven.io 3225](https://github.com/deephaven/deephaven.io/pull/3225).

Old `rolling*` formatting:
<img width="1728" alt="Screenshot 2023-09-27 at 11 09 07 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/0a25d75e-bb67-4bcf-b31c-98caa4b7a47a">

New `rolling*` formatting:
<img width="1728" alt="Screenshot 2023-09-27 at 11 10 14 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/ea3b1a66-b315-4dc2-b803-a74d66460bb4">

Old formula formatting:
<img width="1728" alt="Screenshot 2023-09-27 at 11 08 52 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/fb86be50-845d-475f-acc6-e4cb63db3dae">

New formula formatting:
<img width="1728" alt="Screenshot 2023-09-27 at 11 47 41 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/df9503ae-1620-4332-b242-e368d469807b">

