### PR TITLE
Fix bug in converting a DH table with all columns of the same type

### DIFF
--- a/py/server/deephaven/pandas.py
+++ b/py/server/deephaven/pandas.py
@@ -170,13 +170,7 @@ def to_pandas(table: Table, cols: List[str] = None, dtype_backend: str = None, c
             series = _column_to_series(table, col_def_dict[col], conv_null)
             data[col] = series
 
-        dtype_set = set([v.dtype for k, v in data.items()])
-        if len(dtype_set) == 1:
-            return pd.DataFrame(data=np.stack([v.array for k, v in data.items()], axis=1),
-                                columns=cols,
-                                copy=False)
-        else:
-            return pd.DataFrame(data=data, columns=cols, copy=False)
+        return pd.DataFrame(data=data, columns=cols, copy=False)
     except DHError:
         raise
     except Exception as e:


### PR DESCRIPTION
There is a bug in the `table.to_pandas()` function that causes tables that have columns of all the same data type to not be properly converted. Here is an example of the bug:

```
from deephaven import empty_table
from deephaven import pandas as dhpd

test_table1 = empty_table(10).update(["X = i", "Y = Math.sin(X)"])
test_df1 = dhpd.to_pandas(test_table1.view(["X", "Y"]))

test_table2 = empty_table(10).update(["X = (float)i", "Y = (float)Math.sin(X)"])
test_df2 = dhpd.to_pandas(test_table2.view(["X", "Y"]))
```

Here are the resulting tables and metadata:
<img width="464" alt="Screenshot 2023-09-28 at 11 45 06 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/6f30b13b-3395-40c1-9d2b-8fc75520c1a2">
<img width="219" alt="Screenshot 2023-09-28 at 11 45 54 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/8dc37085-7942-4701-8c4b-7faf8cc57a75">

This is due to a small block of code that creates a set containing all of the column datatypes, checks to see if this set is singular, and makes a call to `np.stack()` to collect the data into a single nd-array before calling `pd.DataFrame`. The problem is that `np.stack()` is not made aware of the desired datatypes of its elements, and they are not type-aware automatically, so the resulting nd-array has type `object`. This entire process can be bypassed, as pandas can look at the data and figure out the types correctly, regardless of whether or not all columns are the same.

I suspect stacking things into a single nd-array if appropriate before calling `to_pandas()` was done for efficiency. I am curious what the set creation, checking length of the set, creating the list to call `np.stack()` on, and calling `np.stack()` costs in terms of efficiency. This whole process adds at least two for-loops through the columns. It is not clear to me that this beats just calling `pd.DataFrame()` on the dict of data without worrying about what the types are. Someone can probably tell me more about this.

Here are the results of the above code with my fix:
<img width="378" alt="Screenshot 2023-09-28 at 11 54 15 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/5b3ca5d9-717b-45b5-a724-335d7206551e">
<img width="216" alt="Screenshot 2023-09-28 at 11 54 37 AM" src="https://github.com/deephaven/deephaven-core/assets/80283343/20907464-b69f-4fcc-8869-7ad656192c84">

