### PR TITLE
Make newTable, emptyTable flat. Fix flatten.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1387,18 +1387,17 @@ public class QueryTable extends BaseTable<QueryTable> {
 
     @Override
     public Table flatten() {
+        if (!flat && !isRefreshing() && rowSet.isFlat()) {
+            // We're already flat, and we'll never update; so we can just return a flat copy
+            final QueryTable copyWithFlat = copy();
+            copyWithFlat.setFlat();
+            return copyWithFlat;
+        }
         final UpdateGraph updateGraph = getUpdateGraph();
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
-            if (!isFlat() && !isRefreshing() && rowSet.size() - 1 == rowSet.lastRowKey()) {
-                // We're already flat, and we'll never update; so we can just return ourselves, after setting ourselves
-                // flat
-                setFlat();
-            }
-
             if (isFlat()) {
                 return prepareReturnThis();
             }
-
             return getResult(new FlattenOperation(this));
         }
     }
@@ -1410,9 +1409,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     @Override
     public boolean isFlat() {
         if (flat) {
-            Assert.assertion(rowSet.lastRowKey() == rowSet.size() - 1, "rowSet.lastRowKey() == rowSet.size() - 1",
-                    rowSet,
-                    "rowSet");
+            Assert.assertion(rowSet.isFlat(), "rowSet.isFlat()", rowSet, "rowSet");
         }
         return flat;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
@@ -665,9 +665,11 @@ public class TableTools {
      * @return a Deephaven Table with no columns.
      */
     public static Table emptyTable(long size) {
-        final QueryTable result = new QueryTable(RowSetFactory.flat(size).toTracking(), Collections.emptyMap());
-        result.setFlat();
-        return result;
+        return new QueryTable(RowSetFactory.flat(size).toTracking(), Collections.emptyMap()) {
+            {
+                setFlat();
+            }
+        };
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -713,9 +715,11 @@ public class TableTools {
                 throw new ArgumentException("Column source for " + columnName + " is null");
             }
         }
-        final QueryTable result = new QueryTable(RowSetFactory.flat(size).toTracking(), columns);
-        result.setFlat();
-        return result;
+        return new QueryTable(RowSetFactory.flat(size).toTracking(), columns) {
+            {
+                setFlat();
+            }
+        };
     }
 
     /**
@@ -730,9 +734,11 @@ public class TableTools {
             columns.put(columnDefinition.getName(), ArrayBackedColumnSource.getMemoryColumnSource(0,
                     columnDefinition.getDataType(), columnDefinition.getComponentType()));
         }
-        final QueryTable result = new QueryTable(definition, RowSetFactory.empty().toTracking(), columns);
-        result.setFlat();
-        return result;
+        return new QueryTable(definition, RowSetFactory.empty().toTracking(), columns) {
+            {
+                setFlat();
+            }
+        };
     }
 
     /**
@@ -745,18 +751,22 @@ public class TableTools {
         checkSizes(columnHolders);
         WritableRowSet rowSet = getRowSet(columnHolders);
         Map<String, ColumnSource<?>> columns = Arrays.stream(columnHolders).collect(COLUMN_HOLDER_LINKEDMAP_COLLECTOR);
-        final QueryTable result = new QueryTable(rowSet.toTracking(), columns);
-        result.setFlat();
-        return result;
+        return new QueryTable(rowSet.toTracking(), columns) {
+            {
+                setFlat();
+            }
+        };
     }
 
     public static Table newTable(TableDefinition definition, ColumnHolder<?>... columnHolders) {
         checkSizes(columnHolders);
         WritableRowSet rowSet = getRowSet(columnHolders);
         Map<String, ColumnSource<?>> columns = Arrays.stream(columnHolders).collect(COLUMN_HOLDER_LINKEDMAP_COLLECTOR);
-        final QueryTable result = new QueryTable(definition, rowSet.toTracking(), columns);
-        result.setFlat();
-        return result;
+        return new QueryTable(definition, rowSet.toTracking(), columns) {
+            {
+                setFlat();
+            }
+        };
     }
 
     private static void checkSizes(ColumnHolder<?>[] columnHolders) {

--- a/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
@@ -665,8 +665,9 @@ public class TableTools {
      * @return a Deephaven Table with no columns.
      */
     public static Table emptyTable(long size) {
-        return new QueryTable(RowSetFactory.flat(size).toTracking(),
-                Collections.emptyMap());
+        final QueryTable result = new QueryTable(RowSetFactory.flat(size).toTracking(), Collections.emptyMap());
+        result.setFlat();
+        return result;
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -712,8 +713,9 @@ public class TableTools {
                 throw new ArgumentException("Column source for " + columnName + " is null");
             }
         }
-
-        return new QueryTable(RowSetFactory.flat(size).toTracking(), columns);
+        final QueryTable result = new QueryTable(RowSetFactory.flat(size).toTracking(), columns);
+        result.setFlat();
+        return result;
     }
 
     /**
@@ -728,7 +730,9 @@ public class TableTools {
             columns.put(columnDefinition.getName(), ArrayBackedColumnSource.getMemoryColumnSource(0,
                     columnDefinition.getDataType(), columnDefinition.getComponentType()));
         }
-        return new QueryTable(definition, RowSetFactory.empty().toTracking(), columns);
+        final QueryTable result = new QueryTable(definition, RowSetFactory.empty().toTracking(), columns);
+        result.setFlat();
+        return result;
     }
 
     /**
@@ -741,14 +745,18 @@ public class TableTools {
         checkSizes(columnHolders);
         WritableRowSet rowSet = getRowSet(columnHolders);
         Map<String, ColumnSource<?>> columns = Arrays.stream(columnHolders).collect(COLUMN_HOLDER_LINKEDMAP_COLLECTOR);
-        return new QueryTable(rowSet.toTracking(), columns);
+        final QueryTable result = new QueryTable(rowSet.toTracking(), columns);
+        result.setFlat();
+        return result;
     }
 
     public static Table newTable(TableDefinition definition, ColumnHolder<?>... columnHolders) {
         checkSizes(columnHolders);
         WritableRowSet rowSet = getRowSet(columnHolders);
         Map<String, ColumnSource<?>> columns = Arrays.stream(columnHolders).collect(COLUMN_HOLDER_LINKEDMAP_COLLECTOR);
-        return new QueryTable(definition, rowSet.toTracking(), columns);
+        final QueryTable result = new QueryTable(definition, rowSet.toTracking(), columns);
+        result.setFlat();
+        return result;
     }
 
     private static void checkSizes(ColumnHolder<?>[] columnHolders) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableFlattenTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableFlattenTest.java
@@ -37,7 +37,7 @@ public class QueryTableFlattenTest extends QueryTableTestBase {
             showWithRowSet(queryTable);
         }
         final EvalNuggetInterface[] en = new EvalNuggetInterface[] {
-                new FlatChecker(queryTable.flatten()),
+                new FlatChecker(queryTable, queryTable.flatten()),
                 new TableComparator(queryTable, queryTable.flatten()),
                 new EvalNugget() {
                     public Table e() {
@@ -304,25 +304,29 @@ public class QueryTableFlattenTest extends QueryTableTestBase {
     }
 
     /**
-     * Makes sure that the row set of our table is actually contiguous.
+     * Makes sure that the table and row set of our table is actually contiguous.
      */
     protected static class FlatChecker implements EvalNuggetInterface {
-        private final Table t1;
+        private final Table original;
+        private final Table flattened;
 
-        FlatChecker(Table t1) {
-            this.t1 = t1;
+        FlatChecker(Table original, Table flattened) {
+            this.original = original;
+            this.flattened = flattened;
         }
 
         @Override
         public void validate(String msg) {
-            if (t1.getRowSet().size() > 0) {
-                Assert.assertEquals(msg, t1.getRowSet().size() - 1, t1.getRowSet().lastRowKey());
-            }
+            Assert.assertFalse(original.isFlat());
+            Assert.assertTrue(original.getRowSet().isFlat());
+
+            Assert.assertTrue(flattened.isFlat());
+            Assert.assertTrue(flattened.getRowSet().isFlat());
         }
 
         @Override
         public void show() throws IOException {
-            showWithRowSet(t1);
+            showWithRowSet(flattened);
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestTableTools.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestTableTools.java
@@ -222,6 +222,36 @@ public class TestTableTools {
     }
 
     @Test
+    public void testEmptyTableIsFlat() {
+        Assert.assertTrue(emptyTable(0).isFlat());
+        Assert.assertTrue(emptyTable(42).isFlat());
+    }
+
+    @Test
+    public void testNewTableIsFlat() {
+        Table t1 = newTable(
+                col("String", "c", "e", "g"),
+                col("Int", 2, 4, 6),
+                col("Double", 1.2, 2.6, Double.NaN),
+                col("Float", 1.2f, 2.6f, Float.NaN));
+        Assert.assertTrue(t1.isFlat());
+
+        final Table t2 = newTable(t1.getDefinition());
+        Assert.assertTrue(t2.isFlat());
+
+        final Table t3 = newTable(t1.getDefinition(),
+                col("String", "c", "e", "g"),
+                col("Int", 2, 4, 6),
+                col("Double", 1.2, 2.6, Double.NaN),
+                col("Float", 1.2f, 2.6f, Float.NaN));
+        Assert.assertTrue(t3.isFlat());
+
+        final Table t4 = newTable(3, Arrays.asList("String", "Int"),
+                Arrays.asList(TableTools.objColSource("c", "e", "g"), TableTools.colSource(2, 4, 6)));
+        Assert.assertTrue(t4.isFlat());
+    }
+
+    @Test
     public void testRoundDecimalColumns() {
         Table table = newTable(
                 col("String", "c", "e", "g"),


### PR DESCRIPTION
Originally reported by @elijahpetty. Noticed that

```groovy
t1 = newTable(
    stringCol("Title", "content"),
    stringCol("ColumnName", "column_content")
)

println t1.isFlat()

t1.flatten()

println t1.isFlat()
```

printed out `false` then `true`. This change makes sure that `newTable` and `emptyTable` produces an `isFlat()` Table out of the box, as well as ensuring that `Table.flatten` doesn't modify the existing table.