### PR TITLE
C++ client: in some contexts, catch and log exceptions rather than propagate

### DIFF
--- a/cpp-client/deephaven/dhclient/src/client.cc
+++ b/cpp-client/deephaven/dhclient/src/client.cc
@@ -35,6 +35,7 @@ using deephaven::client::subscription::SubscriptionHandle;
 using deephaven::client::utility::Executor;
 using deephaven::client::utility::OkOrThrow;
 using deephaven::dhcore::clienttable::Schema;
+using deephaven::dhcore::utility::GetWhat;
 using deephaven::dhcore::utility::MakeReservedVector;
 using deephaven::dhcore::utility::separatedList;
 using deephaven::dhcore::utility::SimpleOstringstream;
@@ -73,7 +74,12 @@ Client &Client::operator=(Client &&other) noexcept = default;
 Client::~Client() {
   gpr_log(GPR_INFO, "Destructing Client ClientImpl(%p).",
       static_cast<void*>(impl_.get()));
-  Close();
+  try {
+    Close();
+  } catch (...) {
+    auto what = GetWhat(std::current_exception());
+    gpr_log(GPR_INFO, "Client destructor is ignoring thrown exception: %s", what.c_str());
+  }
 }
 
 // Tear down Client state.

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
@@ -104,7 +104,12 @@ TableHandleImpl::TableHandleImpl(Private, std::shared_ptr<TableHandleManagerImpl
     ticket_(std::move(ticket)), num_rows_(num_rows), is_static_(is_static) {}
 
 TableHandleImpl::~TableHandleImpl() {
-  managerImpl_->Server()->Release(std::move(ticket_));
+  try {
+    managerImpl_->Server()->Release(std::move(ticket_));
+  } catch (...) {
+    auto what = GetWhat(std::current_exception());
+    gpr_log(GPR_INFO, "TableHandleImpl destructor is ignoring thrown exception: %s", what.c_str());
+  }
 }
 
 std::shared_ptr<TableHandleImpl> TableHandleImpl::Select(std::vector<std::string> column_specs) {

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
@@ -177,6 +177,11 @@ void TableHandleManagerImpl::RemoveSubscriptionHandle(const std::shared_ptr<Subs
 }
 namespace {
 Ticket MakeScopeReference(std::string_view table_name) {
+  if (table_name.empty()) {
+    auto message = DEEPHAVEN_LOCATION_STR("table_name is empty");
+    throw std::runtime_error(message);
+  }
+
   Ticket result;
   result.mutable_ticket()->reserve(2 + table_name.size());
   result.mutable_ticket()->append("s/");


### PR DESCRIPTION
We should never allow exceptions to bubble out of destructors (destructors are noexcept).
Also in certain shutdown contexts it is better to swallow the exception than to abort the shutdown.

Note to reviewer: the usage of std::move in server.cc was incorrect (but harmless). Incorrect because I'm iterating over a set and so I'm getting const elements back. Harmless because attempting to std::move from a const won't do anything.

Also made a validation in MakeScopeReference so I don't try to return "s/" when given an empty string.