### PR TITLE
R client: remove call to "Observe" in the C++ client, add missing dependencies

### DIFF
--- a/R/rdeephaven/README.md
+++ b/R/rdeephaven/README.md
@@ -100,7 +100,7 @@ Currently, the R client is only supported on Ubuntu 20.04 or 22.04 and must be b
 4. Start an R console inside the rdeephaven directory. In that console, install the dephaven client dependencies
    (since we are building from source, dependencies will not be automatically pulled in):
    ```r
-   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr', 'lubridate', 'zoo'))
+   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr'))
    ```
    then install the deephaven client itself:
    ```r
@@ -161,7 +161,12 @@ this means that the C++ compiler does not know where to find the relevant header
 
 ## Running the unit tests
 
-The Deephaven R client utilizes R's `testthat` package to perform unit tests. In order to run these unit tests, install `testthat` via `install.packages("testthat")`. Then, from an R session with `rdeephaven` installed, run the unit tests:
+The Deephaven R client utilizes R's `testthat` package to perform unit tests. In order to run these unit tests, install `testthat` and the other dependent packages:
+```r
+install.packages(c('testthat', 'lubridate', 'zoo'))
+```
+
+Then, from an R session with `rdeephaven` installed, run the unit tests:
 ```r
 library(testthat)
 test_package("rdeephaven")

--- a/R/rdeephaven/README.md
+++ b/R/rdeephaven/README.md
@@ -100,7 +100,7 @@ Currently, the R client is only supported on Ubuntu 20.04 or 22.04 and must be b
 4. Start an R console inside the rdeephaven directory. In that console, install the dephaven client dependencies
    (since we are building from source, dependencies will not be automatically pulled in):
    ```r
-   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr'))
+   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr', 'lubridate', 'zoo'))
    ```
    then install the deephaven client itself:
    ```r

--- a/R/rdeephaven/src/client.cpp
+++ b/R/rdeephaven/src/client.cpp
@@ -673,10 +673,9 @@ public:
      * @return Boolean indicating whether table_name exists on the server or not.
     */
     bool CheckForTable(std::string table_name) {
-        // we have to first fetchTable to check existence, fetchTable does not fail on its own, but .observe() will fail if table doesn't exist
-        deephaven::client::TableHandle table_handle = internal_tbl_hdl_mngr.FetchTable(table_name);
+        // we have to fetchTable to check existence.
         try {
-            table_handle.Observe();
+            deephaven::client::TableHandle table_handle = internal_tbl_hdl_mngr.FetchTable(table_name);
         } catch(...) {
             return false;
         }


### PR DESCRIPTION
"Observe" has been deleted form the C++ client. Exceptions are "eager" now so this code will crash at `FetchTable` time rather than later.

Also the tests use 'lubridate' (cringe) and 'zoo' libraries, so I updated the README. I don't know if this is the right place.