### PR TITLE
Make extensions-kafka source-compatible with confluent 5.5.x

### DIFF
--- a/extensions/kafka/build.gradle
+++ b/extensions/kafka/build.gradle
@@ -17,8 +17,15 @@ dependencies {
     // version, but has a different version to make it easier to keep confluent dependencies aligned.
     api 'org.apache.kafka:kafka-clients:7.4.0-ccs'
     api 'io.confluent:kafka-avro-serializer:7.4.0'
-
     api 'io.confluent:kafka-protobuf-serializer:7.4.0'
+
+    // When updating the kafka implementation, it may be useful to test out the minimum kafka version that our code
+    // compiles, tests, and runs with. If we want to offer more strict guarantees in these regards in the future, at
+    // that time we can setup explicit scaffolding to compile and test with other versions.
+    // api 'org.apache.kafka:kafka-clients:5.5.15-ccs'
+    // api 'io.confluent:kafka-avro-serializer:5.5.15'
+    // api 'io.confluent:kafka-protobuf-serializer:5.5.15'
+
     api project(':extensions-protobuf')
 
     implementation project(':Configuration')

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.Descriptors.Descriptor;
 import gnu.trove.map.hash.TIntLongHashMap;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
@@ -1258,11 +1258,14 @@ public class KafkaTools {
     }
 
     static SchemaRegistryClient newSchemaRegistryClient(Map<String, ?> configs, List<SchemaProvider> providers) {
+        // Note: choosing to not use the constructor with doLog which is a newer API; this is in support of downstream
+        // users _potentially_ being able to replace kafka jars with previous versions.
         final AbstractKafkaSchemaSerDeConfig config = new AbstractKafkaSchemaSerDeConfig(
                 AbstractKafkaSchemaSerDeConfig.baseConfigDef(),
-                configs,
-                false);
-        return SchemaRegistryClientFactory.newClient(
+                configs);
+        // Note: choosing to not use SchemaRegistryClientFactory.newClient which is a newer API; this is in support of
+        // downstream users _potentially_ being able to replace kafka jars with previous versions.
+        return new CachedSchemaRegistryClient(
                 config.getSchemaRegistryUrls(),
                 config.getMaxSchemasPerSubject(),
                 List.copyOf(providers),


### PR DESCRIPTION
This is a simple change that removes our usage of a few "newer" confluent APIs. This in effect makes our code source-compitable with confluent platform 5.5.x. There has been minimal testing to ensure this code compiles with 5.5.x dependencies.