### PR TITLE
Upgrade jetty to 11.0.17

### DIFF
--- a/buildSrc/src/main/groovy/Classpaths.groovy
+++ b/buildSrc/src/main/groovy/Classpaths.groovy
@@ -118,7 +118,7 @@ class Classpaths {
 
     static final String JETTY11_GROUP = 'org.eclipse.jetty'
     static final String JETTY11_NAME = 'jetty-bom'
-    static final String JETTY11_VERSION = '11.0.16'
+    static final String JETTY11_VERSION = '11.0.17'
 
     static final String GUAVA_GROUP = 'com.google.guava'
     static final String GUAVA_NAME = 'guava'


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2023-44487
See https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.17