### PR TITLE
A few cleanups and bug fixes

### DIFF
--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/RefCountedCow.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/RefCountedCow.java
@@ -72,14 +72,15 @@ import io.deephaven.util.annotations.VisibleForTesting;
  * @param <T> A class that will extend us, to get RefCounted functionality.
  */
 public abstract class RefCountedCow<T> {
+
     private static final boolean debug =
-            Configuration.getInstance().getBooleanForClassWithDefault(RspArray.class, "debug", false)
-                    || Configuration.getInstance().getBooleanForClassWithDefault(RefCountedCow.class, "debug", false);
+            Configuration.getInstance().getBooleanForClassWithDefault(RefCountedCow.class, "debug", false);
 
     /**
      * Field updater for refCount, so we can avoid creating an {@link java.util.concurrent.atomic.AtomicInteger} for
      * each instance.
      */
+    @SuppressWarnings("rawtypes")
     private static final AtomicIntegerFieldUpdater<RefCountedCow> REFCOUNT_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(RefCountedCow.class, "refCount");
 

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspRowSequence.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/rsp/RspRowSequence.java
@@ -37,7 +37,7 @@ public class RspRowSequence extends RowSequenceAsChunkImpl {
             final RspArray arr,
             final int startIdx, final long startOffset, final long cardBeforeStartIdx,
             final int endIdx, final long endOffset, final long cardBeforeEndIdx) {
-        if (RspBitmap.debug) {
+        if (RspArray.debug) {
             if (endIdx < startIdx ||
                     (endIdx == startIdx && endOffset < startOffset)) {
                 throw new IllegalArgumentException("Empty " + RspRowSequence.class.getSimpleName() + " :" +

--- a/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/singlerange/SingleRange.java
+++ b/engine/rowset/src/main/java/io/deephaven/engine/rowset/impl/singlerange/SingleRange.java
@@ -4,6 +4,7 @@
 package io.deephaven.engine.rowset.impl.singlerange;
 
 import io.deephaven.base.verify.Assert;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.impl.OrderedLongSet;
 import io.deephaven.engine.rowset.impl.OrderedLongSetBuilderSequential;
@@ -13,7 +14,6 @@ import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.util.datastructures.LongAbortableConsumer;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.chunk.LongChunk;
-import io.deephaven.engine.rowset.impl.rsp.RspArray;
 import io.deephaven.engine.rowset.impl.rsp.RspBitmap;
 import io.deephaven.engine.rowset.impl.sortedranges.SortedRanges;
 import io.deephaven.util.datastructures.LongRangeAbortableConsumer;
@@ -22,6 +22,10 @@ import java.util.PrimitiveIterator;
 import java.util.function.LongConsumer;
 
 public abstract class SingleRange implements OrderedLongSet {
+
+    private static final boolean debug =
+            Configuration.getInstance().getBooleanForClassWithDefault(SingleRange.class, "debug", false);
+
     public abstract long rangeStart();
 
     public abstract long rangeEnd();
@@ -129,7 +133,7 @@ public abstract class SingleRange implements OrderedLongSet {
 
     @SuppressWarnings("unused")
     private void ifDebugValidate() {
-        if (RspArray.debug) {
+        if (debug) {
             ixValidate();
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/BaseTableTransformationColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/BaseTableTransformationColumn.java
@@ -18,18 +18,12 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * Base {@link SelectColumn} implementation to wrap transformer functions for
- * {@link PartitionedTable#transform(Function)} and
- * {@link PartitionedTable#partitionedTransform(PartitionedTable, BiFunction)}.
+ * Base {@link SelectColumn} implementation to wrap transformer functions for {@link PartitionedTable#transform} and
+ * {@link PartitionedTable#partitionedTransform}.
  */
 abstract class BaseTableTransformationColumn implements SelectColumn {
 
     BaseTableTransformationColumn() {}
-
-    @Override
-    public final List<String> initInputs(@NotNull final Table table) {
-        return initInputs(table.getRowSet(), table.getColumnSourceMap());
-    }
 
     @Override
     public final Class<?> getReturnedType() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
@@ -12,8 +12,7 @@ import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.MatchPair;
 import io.deephaven.engine.table.impl.select.Formula;
 import io.deephaven.engine.table.impl.select.SelectColumn;
-import io.deephaven.engine.table.impl.sources.InMemoryColumnSource;
-import io.deephaven.engine.table.impl.sources.SparseArrayColumnSource;
+import io.deephaven.engine.table.impl.sources.LongSingleValueSource;
 import io.deephaven.engine.table.impl.sources.ViewColumnSource;
 import io.deephaven.util.type.TypeUtils;
 import org.jetbrains.annotations.NotNull;
@@ -93,12 +92,12 @@ class LongConstantColumn implements SelectColumn {
 
     @Override
     public final WritableColumnSource<?> newDestInstance(final long size) {
-        return SparseArrayColumnSource.getSparseMemoryColumnSource(size, long.class);
+        return new LongSingleValueSource();
     }
 
     @Override
     public final WritableColumnSource<?> newFlatDestInstance(final long size) {
-        return InMemoryColumnSource.getImmutableMemoryColumnSource(size, long.class, null);
+        return new LongSingleValueSource();
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/partitioned/LongConstantColumn.java
@@ -71,13 +71,8 @@ class LongConstantColumn implements SelectColumn {
     }
 
     @Override
-    public final List<String> initInputs(@NotNull final Table table) {
-        return initInputs(table.getRowSet(), table.getColumnSourceMap());
-    }
-
-    @Override
     public final Class<?> getReturnedType() {
-        return Table.class;
+        return long.class;
     }
 
     @Override
@@ -98,12 +93,12 @@ class LongConstantColumn implements SelectColumn {
 
     @Override
     public final WritableColumnSource<?> newDestInstance(final long size) {
-        return SparseArrayColumnSource.getSparseMemoryColumnSource(size, Table.class);
+        return SparseArrayColumnSource.getSparseMemoryColumnSource(size, long.class);
     }
 
     @Override
     public final WritableColumnSource<?> newFlatDestInstance(final long size) {
-        return InMemoryColumnSource.getImmutableMemoryColumnSource(size, Table.class, null);
+        return InMemoryColumnSource.getImmutableMemoryColumnSource(size, long.class, null);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -67,11 +67,6 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
     }
 
     @Override
-    public List<String> initInputs(Table table) {
-        return initInputs(table.getRowSet(), table.getColumnSourceMap());
-    }
-
-    @Override
     public Class<?> getReturnedType() {
         return returnedType;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumn.java
@@ -8,6 +8,8 @@ import io.deephaven.engine.table.*;
 import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.table.impl.MatchPair;
 import io.deephaven.engine.table.impl.NoSuchColumnException;
+import io.deephaven.engine.table.impl.sources.InMemoryColumnSource;
+import io.deephaven.engine.table.impl.sources.SparseArrayColumnSource;
 import io.deephaven.engine.table.impl.sources.ViewColumnSource;
 import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.chunk.*;
@@ -84,11 +86,6 @@ public class FunctionalColumn<S, D> implements SelectColumn {
     @Override
     public String toString() {
         return "function(" + sourceName + ',' + destName + ')';
-    }
-
-    @Override
-    public List<String> initInputs(Table table) {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -207,13 +204,13 @@ public class FunctionalColumn<S, D> implements SelectColumn {
     }
 
     @Override
-    public WritableColumnSource<?> newDestInstance(long size) {
-        throw new UnsupportedOperationException();
+    public final WritableColumnSource<?> newDestInstance(final long size) {
+        return SparseArrayColumnSource.getSparseMemoryColumnSource(size, destDataType);
     }
 
     @Override
-    public WritableColumnSource<?> newFlatDestInstance(long size) {
-        throw new UnsupportedOperationException();
+    public final WritableColumnSource<?> newFlatDestInstance(final long size) {
+        return InMemoryColumnSource.getImmutableMemoryColumnSource(size, destDataType, componentType);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
@@ -9,6 +9,8 @@ import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.table.impl.MatchPair;
 import io.deephaven.engine.table.impl.NoSuchColumnException;
 import io.deephaven.engine.table.impl.PrevColumnSource;
+import io.deephaven.engine.table.impl.sources.InMemoryColumnSource;
+import io.deephaven.engine.table.impl.sources.SparseArrayColumnSource;
 import io.deephaven.engine.table.impl.sources.ViewColumnSource;
 import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.chunk.attributes.Values;
@@ -39,8 +41,6 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
     @NotNull
     private final Class<?> componentType;
 
-    boolean usesPython;
-
     public MultiSourceFunctionalColumn(@NotNull List<String> sourceNames,
             @NotNull String destName,
             @NotNull Class<D> destDataType,
@@ -67,11 +67,6 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
     @Override
     public String toString() {
         return "function(" + String.join(",", sourceNames) + ',' + destName + ')';
-    }
-
-    @Override
-    public List<String> initInputs(Table table) {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -203,13 +198,13 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
     }
 
     @Override
-    public WritableColumnSource<?> newDestInstance(long size) {
-        throw new UnsupportedOperationException();
+    public final WritableColumnSource<?> newDestInstance(final long size) {
+        return SparseArrayColumnSource.getSparseMemoryColumnSource(size, destDataType);
     }
 
     @Override
-    public WritableColumnSource<?> newFlatDestInstance(long size) {
-        throw new UnsupportedOperationException();
+    public final WritableColumnSource<?> newFlatDestInstance(final long size) {
+        return InMemoryColumnSource.getImmutableMemoryColumnSource(size, destDataType, componentType);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
@@ -26,11 +26,6 @@ public class NullSelectColumn<T> implements SelectColumn {
     }
 
     @Override
-    public List<String> initInputs(final Table table) {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<String> initInputs(final TrackingRowSet rowSet,
             final Map<String, ? extends ColumnSource<?>> columnsOfInterest) {
         return Collections.emptyList();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/NullSelectColumn.java
@@ -75,12 +75,12 @@ public class NullSelectColumn<T> implements SelectColumn {
 
     @Override
     public WritableColumnSource<?> newDestInstance(final long size) {
-        return SparseArrayColumnSource.getSparseMemoryColumnSource(size, nvcs.getType(), nvcs.getComponentType());
+        return nvcs;
     }
 
     @Override
     public WritableColumnSource<?> newFlatDestInstance(final long size) {
-        return InMemoryColumnSource.getImmutableMemoryColumnSource(size, nvcs.getType(), nvcs.getComponentType());
+        return nvcs;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ReinterpretedColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ReinterpretedColumn.java
@@ -94,11 +94,6 @@ public class ReinterpretedColumn<S, D> implements SelectColumn {
     }
 
     @Override
-    public List<String> initInputs(Table table) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public List<String> initInputs(TrackingRowSet rowSet, Map<String, ? extends ColumnSource<?>> columnsOfInterest) {
         // noinspection unchecked
         final ColumnSource<S> localSourceColumnSource = (ColumnSource<S>) columnsOfInterest.get(sourceName);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
@@ -68,7 +68,9 @@ public interface SelectColumn extends Selectable {
      * @param table the table to initialize internals from
      * @return a list containing all columns from 'table' that the result depends on
      */
-    List<String> initInputs(Table table);
+    default List<String> initInputs(Table table) {
+        return initInputs(table.getRowSet(), table.getColumnSourceMap());
+    }
 
     /**
      * Initialize the column from the provided set of underlying columns and row set.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SelectColumn.java
@@ -17,7 +17,6 @@ import io.deephaven.engine.rowset.TrackingRowSet;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.impl.MatchPair;
-import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.table.impl.BaseTable;
 import org.jetbrains.annotations.NotNull;
@@ -60,17 +59,6 @@ public interface SelectColumn extends Selectable {
      * Convenient static final instance of a zero length Array of SelectColumns for use in toArray calls.
      */
     SelectColumn[] ZERO_LENGTH_SELECT_COLUMN_ARRAY = new SelectColumn[0];
-
-    /**
-     * Initialize the SelectColumn using the input table and return a list of underlying columns that this SelectColumn
-     * is dependent upon.
-     *
-     * @param table the table to initialize internals from
-     * @return a list containing all columns from 'table' that the result depends on
-     */
-    default List<String> initInputs(Table table) {
-        return initInputs(table.getRowSet(), table.getColumnSourceMap());
-    }
 
     /**
      * Initialize the column from the provided set of underlying columns and row set.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SourceColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SourceColumn.java
@@ -52,15 +52,6 @@ public class SourceColumn implements SelectColumn {
     }
 
     @Override
-    public List<String> initInputs(Table table) {
-        this.sourceColumn = table.getColumnSource(sourceName);
-        if (sourceColumn == null) {
-            throw new NoSuchColumnException(table.getDefinition().getColumnNames(), sourceName);
-        }
-        return Collections.singletonList(sourceName);
-    }
-
-    @Override
     public List<String> initInputs(TrackingRowSet rowSet, Map<String, ? extends ColumnSource<?>> columnsOfInterest) {
         this.sourceColumn = columnsOfInterest.get(sourceName);
         if (sourceColumn == null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SwitchColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SwitchColumn.java
@@ -33,18 +33,6 @@ public class SwitchColumn implements SelectColumn {
     }
 
     @Override
-    public List<String> initInputs(Table table) {
-        if (realColumn == null) {
-            if (table.getDefinition().getColumn(expression) != null) {
-                realColumn = new SourceColumn(expression, columnName);
-            } else {
-                realColumn = FormulaColumn.createFormulaColumn(columnName, expression, parser);
-            }
-        }
-        return realColumn.initInputs(table);
-    }
-
-    @Override
     public List<String> initInputs(TrackingRowSet rowSet, Map<String, ? extends ColumnSource<?>> columnsOfInterest) {
         if (realColumn == null) {
             if (columnsOfInterest.get(expression) != null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/NullValueColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/NullValueColumnSource.java
@@ -5,6 +5,7 @@ package io.deephaven.engine.table.impl.sources;
 
 import io.deephaven.base.Pair;
 import io.deephaven.base.verify.Assert;
+import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.chunkattributes.RowKeys;
@@ -12,10 +13,10 @@ import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.rowset.RowSequence;
+import io.deephaven.engine.table.WritableColumnSource;
 import io.deephaven.engine.table.impl.AbstractColumnSource;
 import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
-import io.deephaven.util.QueryConstants;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.engine.table.impl.util.ShiftData;
 import org.jetbrains.annotations.NotNull;
@@ -24,11 +25,21 @@ import org.jetbrains.annotations.Nullable;
 import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 
+import static io.deephaven.util.QueryConstants.NULL_BYTE;
+import static io.deephaven.util.QueryConstants.NULL_CHAR;
+import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
+import static io.deephaven.util.QueryConstants.NULL_FLOAT;
+import static io.deephaven.util.QueryConstants.NULL_INT;
+import static io.deephaven.util.QueryConstants.NULL_LONG;
+import static io.deephaven.util.QueryConstants.NULL_SHORT;
+
 /**
- * A column source that returns null for all keys.
+ * A column source that returns null for all keys. Trivially "writable" since it can only contain null values.
  */
-public class NullValueColumnSource<T> extends AbstractColumnSource<T>
-        implements ShiftData.ShiftCallback, InMemoryColumnSource, RowKeyAgnosticChunkSource<Values> {
+public final class NullValueColumnSource<T> extends AbstractColumnSource<T>
+        implements ShiftData.ShiftCallback, InMemoryColumnSource, RowKeyAgnosticChunkSource<Values>,
+        WritableColumnSource<T> {
+
     private static final KeyedObjectKey.Basic<Pair<Class<?>, Class<?>>, NullValueColumnSource<?>> KEY_TYPE =
             new KeyedObjectKey.Basic<>() {
                 @Override
@@ -78,37 +89,37 @@ public class NullValueColumnSource<T> extends AbstractColumnSource<T>
 
     @Override
     public byte getByte(long rowKey) {
-        return QueryConstants.NULL_BYTE;
+        return NULL_BYTE;
     }
 
     @Override
     public char getChar(long rowKey) {
-        return QueryConstants.NULL_CHAR;
+        return NULL_CHAR;
     }
 
     @Override
     public double getDouble(long rowKey) {
-        return QueryConstants.NULL_DOUBLE;
+        return NULL_DOUBLE;
     }
 
     @Override
     public float getFloat(long rowKey) {
-        return QueryConstants.NULL_FLOAT;
+        return NULL_FLOAT;
     }
 
     @Override
     public int getInt(long rowKey) {
-        return QueryConstants.NULL_INT;
+        return NULL_INT;
     }
 
     @Override
     public long getLong(long rowKey) {
-        return QueryConstants.NULL_LONG;
+        return NULL_LONG;
     }
 
     @Override
     public short getShort(long rowKey) {
-        return QueryConstants.NULL_SHORT;
+        return NULL_SHORT;
     }
 
     @Override
@@ -123,37 +134,37 @@ public class NullValueColumnSource<T> extends AbstractColumnSource<T>
 
     @Override
     public byte getPrevByte(long rowKey) {
-        return QueryConstants.NULL_BYTE;
+        return NULL_BYTE;
     }
 
     @Override
     public char getPrevChar(long rowKey) {
-        return QueryConstants.NULL_CHAR;
+        return NULL_CHAR;
     }
 
     @Override
     public double getPrevDouble(long rowKey) {
-        return QueryConstants.NULL_DOUBLE;
+        return NULL_DOUBLE;
     }
 
     @Override
     public float getPrevFloat(long rowKey) {
-        return QueryConstants.NULL_FLOAT;
+        return NULL_FLOAT;
     }
 
     @Override
     public int getPrevInt(long rowKey) {
-        return QueryConstants.NULL_INT;
+        return NULL_INT;
     }
 
     @Override
     public long getPrevLong(long rowKey) {
-        return QueryConstants.NULL_LONG;
+        return NULL_LONG;
     }
 
     @Override
     public short getPrevShort(long rowKey) {
-        return QueryConstants.NULL_SHORT;
+        return NULL_SHORT;
     }
 
     @Override
@@ -212,5 +223,95 @@ public class NullValueColumnSource<T> extends AbstractColumnSource<T>
     @Override
     public boolean providesFillUnordered() {
         return true;
+    }
+
+    private static void throwUnsupported() {
+        throw new UnsupportedOperationException("NullValueColumnSource cannot contain non-null values");
+    }
+
+    @Override
+    public void set(final long key, final T value) {
+        if (value != null) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void set(final long key, final byte value) {
+        if (value != NULL_BYTE) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void set(final long key, final char value) {
+        if (value != NULL_CHAR) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void set(final long key, final double value) {
+        if (value != NULL_DOUBLE) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void set(final long key, final float value) {
+        if (value != NULL_FLOAT) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void set(final long key, final int value) {
+        if (value != NULL_INT) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void set(final long key, final long value) {
+        if (value != NULL_LONG) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void set(final long key, final short value) {
+        if (value != NULL_SHORT) {
+            throwUnsupported();
+        }
+    }
+
+    @Override
+    public void setNull(final long key) {}
+
+    @Override
+    public void setNull(@NotNull final RowSequence orderedKeys) {}
+
+    @Override
+    public void ensureCapacity(final long capacity, final boolean nullFilled) {}
+
+    @Override
+    public FillFromContext makeFillFromContext(int chunkCapacity) {
+        return DEFAULT_FILL_FROM_INSTANCE;
+    }
+
+    @Override
+    public void fillFromChunk(
+            @NotNull final FillFromContext context,
+            @NotNull final Chunk<? extends Values> src,
+            @NotNull final RowSequence rowSequence) {
+        // Assume all values in src are null, which will be true for any correct usage.
+    }
+
+    @Override
+    public void fillFromChunkUnordered(
+            @NotNull final FillFromContext context,
+            @NotNull final Chunk<? extends Values> src,
+            @NotNull final LongChunk<RowKeys> keys) {
+        // Assume all values in src are null, which will be true for any correct usage.
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
@@ -270,8 +270,9 @@ public class TestFormulaArrayEvaluation {
             simulateShiftAwareStep(size, random, queryTable, columnInfo, en);
         }
         final long duration = System.currentTimeMillis() - startTm;
-        Assert.assertTrue("test finishes in less than 15 seconds", duration < 15_000);
-    }
+        Assert.assertTrue(
+                String.format("Test finishes in less than 15 seconds, instead duration was %d ms", duration),
+                duration < 15_000);    }
 
     @Test
     public void updateTableStableMultiShiftedColValuesTest() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestFormulaArrayEvaluation.java
@@ -272,7 +272,8 @@ public class TestFormulaArrayEvaluation {
         final long duration = System.currentTimeMillis() - startTm;
         Assert.assertTrue(
                 String.format("Test finishes in less than 15 seconds, instead duration was %d ms", duration),
-                duration < 15_000);    }
+                duration < 15_000);
+    }
 
     @Test
     public void updateTableStableMultiShiftedColValuesTest() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestFormulaColumn.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestFormulaColumn.java
@@ -357,7 +357,7 @@ public class TestFormulaColumn {
         {
             FormulaColumn formulaColumn = FormulaColumn.createFormulaColumn("Foo", "(double)IntCol");
             formulaColumn.initDef(availableColumns);
-            formulaColumn.initInputs(testDataTable);
+            formulaColumn.initInputs(testDataTable.getRowSet(), testDataTable.getColumnSourceMap());
 
             result = formulaColumn.getDataView().getDouble(0);
             assertEquals((double) BASE_VALUES[0], result);
@@ -557,7 +557,7 @@ public class TestFormulaColumn {
     private FormulaColumn initCheck(String formulaString) {
         FormulaColumn formulaColumn = FormulaColumn.createFormulaColumn("Foo", formulaString);
         formulaColumn.initDef(availableColumns);
-        formulaColumn.initInputs(testDataTable);
+        formulaColumn.initInputs(testDataTable.getRowSet(), testDataTable.getColumnSourceMap());
         return formulaColumn;
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestFormulaColumnGeneration.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestFormulaColumnGeneration.java
@@ -74,7 +74,7 @@ public class TestFormulaColumnGeneration {
         // final DhFormulaColumn fc = new DhFormulaColumn("Value", "k * i * ii");
         // final DhFormulaColumn fc = new DhFormulaColumn("Value", "'2019-04-11T09:30 NY'");
         final FormulaColumn fc = FormulaColumn.createFormulaColumn("Value", "I * II + q * ii + II_[i - 1]");
-        fc.initInputs(table);
+        fc.initInputs(table.getRowSet(), table.getColumnSourceMap());
         return fc;
     }
 }


### PR DESCRIPTION
* Add more details to the failure message seen in `TestFormulaArrayEvaluation.testViewIncrementalRandomizedPerformanceTest`
* Some simplification and cleanups for `SelectColumn` implementations
* Install the correct (default) `UpdateGraph` in the `ExecutionContext` when initializing `UpdatePerformanceTracker.InternalState`. Don't install an unnecessary one during flush.
* Re-address `RefCountedCow`/`RspArray` static initialization deadlock due to debug flag, by making `RefCountedCow`'s debug flag independent. Introduce private debug flag for `SingleRange`, rather than sharing `RspArray`'s.

Fixes #4383 
