### PR TITLE
Don't remove Kafka consumer properties

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -1566,7 +1566,6 @@ public class KafkaTools {
                 } else {
                     result = definitionFactory.apply(commonColumnName);
                 }
-                consumerProperties.remove(nameProperty);
             } else if (nameDefault == null) {
                 result = null;
             } else {


### PR DESCRIPTION
Don't remove Kafka consumer properties (they should be reusable by multiple ingesters).