### PR TITLE
Add ColumnDefinition#getType

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
@@ -11,6 +11,7 @@ import io.deephaven.base.log.LogOutputAppendable;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.io.log.impl.LogOutputStringImpl;
 import io.deephaven.qst.column.header.ColumnHeader;
+import io.deephaven.qst.type.Type;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map.Entry;
@@ -265,6 +266,13 @@ public class TableDefinition implements LogOutputAppendable {
      */
     public Class<?>[] getColumnTypesArray() {
         return getColumnStream().map(ColumnDefinition::getDataType).toArray(Class[]::new);
+    }
+
+    /**
+     * @return The column {@link ColumnDefinition#getType()} types} as a list in the same order as {@link #getColumns()}
+     */
+    public List<Type<?>> getColumnTypes2() {
+        return getColumnStream().map(ColumnDefinition::getType).collect(Collectors.toList());
     }
 
     /**

--- a/engine/api/src/test/java/io/deephaven/engine/table/ColumnDefinitionTypeTest.java
+++ b/engine/api/src/test/java/io/deephaven/engine/table/ColumnDefinitionTypeTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.table;
+
+import io.deephaven.qst.type.BoxedType;
+import io.deephaven.qst.type.GenericType;
+import io.deephaven.qst.type.GenericTypeBase;
+import io.deephaven.qst.type.PrimitiveType;
+import io.deephaven.qst.type.PrimitiveVectorType;
+import io.deephaven.qst.type.Type;
+import io.deephaven.vector.ByteVector;
+import io.deephaven.vector.ByteVectorDirect;
+import io.deephaven.vector.CharVector;
+import io.deephaven.vector.CharVectorDirect;
+import io.deephaven.vector.DoubleVector;
+import io.deephaven.vector.DoubleVectorDirect;
+import io.deephaven.vector.FloatVector;
+import io.deephaven.vector.FloatVectorDirect;
+import io.deephaven.vector.IntVector;
+import io.deephaven.vector.IntVectorDirect;
+import io.deephaven.vector.LongVector;
+import io.deephaven.vector.LongVectorDirect;
+import io.deephaven.vector.ObjectVector;
+import io.deephaven.vector.ShortVector;
+import io.deephaven.vector.ShortVectorDirect;
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+
+public class ColumnDefinitionTypeTest {
+
+    private static final String FOO = "Foo";
+
+    public interface FooCustom {
+
+    }
+
+    @Test
+    public void testPrimitives() {
+        checkTransitiveType(Type.booleanType().boxedType());
+        checkTransitiveType(Type.byteType());
+        checkTransitiveType(Type.charType());
+        checkTransitiveType(Type.shortType());
+        checkTransitiveType(Type.intType());
+        checkTransitiveType(Type.longType());
+        checkTransitiveType(Type.floatType());
+        checkTransitiveType(Type.doubleType());
+
+        checkTransformedType(Type.booleanType(), Type.booleanType().boxedType());
+        checkTransformedType(Type.byteType().boxedType(), Type.byteType());
+        checkTransformedType(Type.charType().boxedType(), Type.charType());
+        checkTransformedType(Type.shortType().boxedType(), Type.shortType());
+        checkTransformedType(Type.intType().boxedType(), Type.intType());
+        checkTransformedType(Type.longType().boxedType(), Type.longType());
+        checkTransformedType(Type.floatType().boxedType(), Type.floatType());
+        checkTransformedType(Type.doubleType().boxedType(), Type.doubleType());
+    }
+
+    @Test
+    public void testGenerics() {
+        checkTransitiveType(Type.stringType());
+        checkTransitiveType(Type.instantType());
+        checkTransitiveType(Type.ofCustom(FooCustom.class));
+    }
+
+    @Test
+    public void testPrimitiveArrays() {
+        PrimitiveType.instances().forEach(primitiveType -> checkTransitiveType(primitiveType.arrayType()));
+    }
+
+    @Test
+    public void testGenericArrays() {
+        BoxedType.instances().map(GenericType::arrayType).forEach(ColumnDefinitionTypeTest::checkTransitiveType);
+
+        checkTransitiveType(Type.stringType().arrayType());
+        checkTransitiveType(Type.instantType().arrayType());
+        checkTransitiveType(Type.ofCustom(FooCustom.class).arrayType());
+
+        PrimitiveType.instances().map(Type::arrayType).map(GenericTypeBase::arrayType)
+                .forEach(ColumnDefinitionTypeTest::checkTransitiveType);
+
+        checkTransitiveType(Type.stringType().arrayType().arrayType());
+        checkTransitiveType(Type.instantType().arrayType().arrayType());
+        checkTransitiveType(Type.ofCustom(FooCustom.class).arrayType().arrayType());
+    }
+
+    @Test
+    public void testPrimitiveVectors() {
+        checkTransitiveType(ByteVector.type());
+        checkTransitiveType(CharVector.type());
+        checkTransitiveType(ShortVector.type());
+        checkTransitiveType(IntVector.type());
+        checkTransitiveType(LongVector.type());
+        checkTransitiveType(FloatVector.type());
+        checkTransitiveType(DoubleVector.type());
+    }
+
+    @Test
+    public void testGenericVectors() {
+        checkTransitiveType(ObjectVector.type(Type.stringType()));
+        checkTransitiveType(ObjectVector.type(Type.instantType()));
+        checkTransitiveType(ObjectVector.type(Type.ofCustom(FooCustom.class)));
+
+        BoxedType.instances().map(ObjectVector::type).forEach(ColumnDefinitionTypeTest::checkTransitiveType);
+    }
+
+    @Test
+    public void testOfBooleanType() {
+        checkType(Type.booleanType().boxedType(), ColumnDefinition.ofBoolean(FOO));
+    }
+
+    @Test
+    public void testOfCharType() {
+        checkType(Type.charType(), ColumnDefinition.ofChar(FOO));
+    }
+
+    @Test
+    public void testOfByteType() {
+        checkType(Type.byteType(), ColumnDefinition.ofByte(FOO));
+    }
+
+    @Test
+    public void testOfShortType() {
+        checkType(Type.shortType(), ColumnDefinition.ofShort(FOO));
+    }
+
+    @Test
+    public void testOfIntType() {
+        checkType(Type.intType(), ColumnDefinition.ofInt(FOO));
+    }
+
+    @Test
+    public void testOfLongType() {
+        checkType(Type.longType(), ColumnDefinition.ofLong(FOO));
+    }
+
+    @Test
+    public void testOfFloatType() {
+        checkType(Type.floatType(), ColumnDefinition.ofFloat(FOO));
+    }
+
+    @Test
+    public void testOfDoubleType() {
+        checkType(Type.doubleType(), ColumnDefinition.ofDouble(FOO));
+    }
+
+    @Test
+    public void testOfStringType() {
+        checkType(Type.stringType(), ColumnDefinition.ofString(FOO));
+    }
+
+    @Test
+    public void testOfTimeType() {
+        checkType(Type.instantType(), ColumnDefinition.ofTime(FOO));
+    }
+
+    @Test
+    public void testOfVector() {
+        checkType(CharVector.type(), ColumnDefinition.ofVector(FOO, CharVector.class));
+        checkType(ByteVector.type(), ColumnDefinition.ofVector(FOO, ByteVector.class));
+        checkType(ShortVector.type(), ColumnDefinition.ofVector(FOO, ShortVector.class));
+        checkType(IntVector.type(), ColumnDefinition.ofVector(FOO, IntVector.class));
+        checkType(LongVector.type(), ColumnDefinition.ofVector(FOO, LongVector.class));
+        checkType(FloatVector.type(), ColumnDefinition.ofVector(FOO, FloatVector.class));
+        checkType(DoubleVector.type(), ColumnDefinition.ofVector(FOO, DoubleVector.class));
+        checkType(ObjectVector.type(Type.ofCustom(Object.class)), ColumnDefinition.ofVector(FOO, ObjectVector.class));
+    }
+
+    @Test
+    public void testFromGenericType() {
+        checkType(ObjectVector.type(Type.stringType()),
+                ColumnDefinition.fromGenericType(FOO, ObjectVector.class, String.class));
+        checkType(ObjectVector.type(Type.instantType()),
+                ColumnDefinition.fromGenericType(FOO, ObjectVector.class, Instant.class));
+        checkType(ObjectVector.type(Type.ofCustom(FooCustom.class)),
+                ColumnDefinition.fromGenericType(FOO, ObjectVector.class, FooCustom.class));
+        BoxedType.instances().forEach(boxedType -> checkType(ObjectVector.type(boxedType),
+                ColumnDefinition.fromGenericType(FOO, ObjectVector.class, boxedType.clazz())));
+    }
+
+    @Test
+    public void testExplicitVectorTypes() {
+        checkType(PrimitiveVectorType.of(CharVectorDirect.class, Type.charType()),
+                ColumnDefinition.ofVector(FOO, CharVectorDirect.class));
+        checkType(PrimitiveVectorType.of(ByteVectorDirect.class, Type.byteType()),
+                ColumnDefinition.ofVector(FOO, ByteVectorDirect.class));
+        checkType(PrimitiveVectorType.of(ShortVectorDirect.class, Type.shortType()),
+                ColumnDefinition.ofVector(FOO, ShortVectorDirect.class));
+        checkType(PrimitiveVectorType.of(IntVectorDirect.class, Type.intType()),
+                ColumnDefinition.ofVector(FOO, IntVectorDirect.class));
+        checkType(PrimitiveVectorType.of(LongVectorDirect.class, Type.longType()),
+                ColumnDefinition.ofVector(FOO, LongVectorDirect.class));
+        checkType(PrimitiveVectorType.of(FloatVectorDirect.class, Type.floatType()),
+                ColumnDefinition.ofVector(FOO, FloatVectorDirect.class));
+        checkType(PrimitiveVectorType.of(DoubleVectorDirect.class, Type.doubleType()),
+                ColumnDefinition.ofVector(FOO, DoubleVectorDirect.class));
+    }
+
+    private static void checkTransitiveType(Type<?> type) {
+        checkType(type, cd(type));
+    }
+
+    private static void checkTransformedType(Type<?> cdInput, Type<?> expected) {
+        checkType(expected, cd(cdInput));
+    }
+
+    private static void checkType(Type<?> expected, ColumnDefinition<?> actual) {
+        assertEquals(expected, actual.getType());
+    }
+
+    private static ColumnDefinition<?> cd(Type<?> type) {
+        return ColumnDefinition.of(FOO, type);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/qst/type/GenericVectorTest.java
+++ b/engine/table/src/test/java/io/deephaven/qst/type/GenericVectorTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.qst.type;
+
+import io.deephaven.vector.ObjectVector;
+import io.deephaven.vector.ObjectVectorDirect;
+import io.deephaven.vector.Vector;
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class GenericVectorTest {
+
+    @Test
+    public void stringType() {
+        final GenericVectorType<ObjectVector<String>, String> type = ObjectVector.type(Type.stringType());
+        assertThat(type.clazz()).isEqualTo(ObjectVector.class);
+        assertThat(type.componentType()).isEqualTo(Type.stringType());
+    }
+
+    @Test
+    public void instantType() {
+        final GenericVectorType<ObjectVector<Instant>, Instant> type = ObjectVector.type(Type.instantType());
+        assertThat(type.clazz()).isEqualTo(ObjectVector.class);
+        assertThat(type.componentType()).isEqualTo(Type.instantType());
+    }
+
+    @Test
+    public void boxedTypes() {
+        BoxedType.instances().forEach(boxedType -> {
+            final GenericVectorType<? extends ObjectVector<?>, ?> type = ObjectVector.type(boxedType);
+            assertThat(type.clazz()).isEqualTo(ObjectVector.class);
+            assertThat(type.componentType()).isEqualTo(boxedType);
+        });
+    }
+
+    @Test
+    public void badClass() {
+        try {
+            GenericVectorType.of(Vector.class, Type.stringType());
+            failBecauseExceptionWasNotThrown(IllegalAccessError.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void alternativeTypes() {
+        final GenericVectorType<ObjectVectorDirect, String> type =
+                GenericVectorType.of(ObjectVectorDirect.class, Type.stringType());
+        assertThat(type.clazz()).isEqualTo(ObjectVectorDirect.class);
+        assertThat(type.componentType()).isEqualTo(Type.stringType());
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/qst/type/PrimitiveVectorTest.java
+++ b/engine/table/src/test/java/io/deephaven/qst/type/PrimitiveVectorTest.java
@@ -3,13 +3,28 @@
  */
 package io.deephaven.qst.type;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.deephaven.vector.*;
+import io.deephaven.vector.ByteVector;
+import io.deephaven.vector.ByteVectorDirect;
+import io.deephaven.vector.CharVector;
+import io.deephaven.vector.CharVectorDirect;
+import io.deephaven.vector.DoubleVector;
+import io.deephaven.vector.DoubleVectorDirect;
+import io.deephaven.vector.FloatVector;
+import io.deephaven.vector.FloatVectorDirect;
+import io.deephaven.vector.IntVector;
+import io.deephaven.vector.IntVectorDirect;
+import io.deephaven.vector.LongVector;
+import io.deephaven.vector.LongVectorDirect;
+import io.deephaven.vector.ShortVector;
+import io.deephaven.vector.ShortVectorDirect;
+import io.deephaven.vector.Vector;
+import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class PrimitiveVectorTest {
 
@@ -24,5 +39,155 @@ public class PrimitiveVectorTest {
                 LongVector.type(),
                 FloatVector.type(),
                 DoubleVector.type());
+    }
+
+    @Test
+    public void noBooleanVector() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.booleanType());
+            failBecauseExceptionWasNotThrown(IllegalAccessError.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void byteBadClass() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.byteType());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void charBadClass() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.charType());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void shortBadClass() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.shortType());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void intBadClass() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.intType());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void longBadClass() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.longType());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void floatBadClass() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.floatType());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void doubleBadClass() {
+        try {
+            PrimitiveVectorType.of(Vector.class, Type.doubleType());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    // While we technically allow types that properly extend from
+
+    @Test
+    public void byteVectorAlt() {
+        for (Class<? extends ByteVector> clazz : List.of(ByteVectorDirect.class)) {
+            final PrimitiveVectorType<? extends ByteVector, Byte> type = PrimitiveVectorType.of(clazz, Type.byteType());
+            assertThat(type.clazz()).isEqualTo(clazz);
+            assertThat(type.componentType()).isEqualTo(Type.byteType());
+        }
+    }
+
+    @Test
+    public void charVectorAlt() {
+        for (Class<? extends CharVector> clazz : List.of(CharVectorDirect.class)) {
+            final PrimitiveVectorType<? extends CharVector, Character> type =
+                    PrimitiveVectorType.of(clazz, Type.charType());
+            assertThat(type.clazz()).isEqualTo(clazz);
+            assertThat(type.componentType()).isEqualTo(Type.charType());
+        }
+    }
+
+    @Test
+    public void shortVectorAlt() {
+        for (Class<? extends ShortVector> clazz : List.of(ShortVectorDirect.class)) {
+            final PrimitiveVectorType<? extends ShortVector, Short> type =
+                    PrimitiveVectorType.of(clazz, Type.shortType());
+            assertThat(type.clazz()).isEqualTo(clazz);
+            assertThat(type.componentType()).isEqualTo(Type.shortType());
+        }
+    }
+
+    @Test
+    public void intVectorAlt() {
+        for (Class<? extends IntVector> clazz : List.of(IntVectorDirect.class)) {
+            final PrimitiveVectorType<? extends IntVector, Integer> type =
+                    PrimitiveVectorType.of(clazz, Type.intType());
+            assertThat(type.clazz()).isEqualTo(clazz);
+            assertThat(type.componentType()).isEqualTo(Type.intType());
+        }
+    }
+
+    @Test
+    public void longVectorAlt() {
+        for (Class<? extends LongVector> clazz : List.of(LongVectorDirect.class)) {
+            final PrimitiveVectorType<? extends LongVector, Long> type = PrimitiveVectorType.of(clazz, Type.longType());
+            assertThat(type.clazz()).isEqualTo(clazz);
+            assertThat(type.componentType()).isEqualTo(Type.longType());
+        }
+    }
+
+    @Test
+    public void floatVectorAlt() {
+        for (Class<? extends FloatVector> clazz : List.of(FloatVectorDirect.class)) {
+            final PrimitiveVectorType<? extends FloatVector, Float> type =
+                    PrimitiveVectorType.of(clazz, Type.floatType());
+            assertThat(type.clazz()).isEqualTo(clazz);
+            assertThat(type.componentType()).isEqualTo(Type.floatType());
+        }
+    }
+
+    @Test
+    public void doubleVectorAlt() {
+        for (Class<? extends DoubleVector> clazz : List.of(DoubleVectorDirect.class)) {
+            final PrimitiveVectorType<? extends DoubleVector, Double> type =
+                    PrimitiveVectorType.of(clazz, Type.doubleType());
+            assertThat(type.clazz()).isEqualTo(clazz);
+            assertThat(type.componentType()).isEqualTo(Type.doubleType());
+        }
     }
 }

--- a/engine/vector/src/main/java/io/deephaven/vector/ByteVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/ByteVector.java
@@ -10,7 +10,6 @@ package io.deephaven.vector;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfByte;
-import io.deephaven.qst.type.ByteType;
 import io.deephaven.qst.type.PrimitiveVectorType;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.annotations.FinalDefault;
@@ -27,7 +26,7 @@ public interface ByteVector extends Vector<ByteVector>, Iterable<Byte> {
     long serialVersionUID = -1373264425081841175L;
 
     static PrimitiveVectorType<ByteVector, Byte> type() {
-        return PrimitiveVectorType.of(ByteVector.class, ByteType.of());
+        return Types.BYTE;
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/CharVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/CharVector.java
@@ -5,7 +5,6 @@ package io.deephaven.vector;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfChar;
-import io.deephaven.qst.type.CharType;
 import io.deephaven.qst.type.PrimitiveVectorType;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.annotations.FinalDefault;
@@ -22,7 +21,7 @@ public interface CharVector extends Vector<CharVector>, Iterable<Character> {
     long serialVersionUID = -1373264425081841175L;
 
     static PrimitiveVectorType<CharVector, Character> type() {
-        return PrimitiveVectorType.of(CharVector.class, CharType.of());
+        return Types.CHAR;
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/DoubleVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/DoubleVector.java
@@ -10,7 +10,6 @@ package io.deephaven.vector;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfDouble;
-import io.deephaven.qst.type.DoubleType;
 import io.deephaven.qst.type.PrimitiveVectorType;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.annotations.FinalDefault;
@@ -27,7 +26,7 @@ public interface DoubleVector extends Vector<DoubleVector>, Iterable<Double> {
     long serialVersionUID = -1373264425081841175L;
 
     static PrimitiveVectorType<DoubleVector, Double> type() {
-        return PrimitiveVectorType.of(DoubleVector.class, DoubleType.of());
+        return Types.DOUBLE;
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/FloatVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/FloatVector.java
@@ -10,7 +10,6 @@ package io.deephaven.vector;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfFloat;
-import io.deephaven.qst.type.FloatType;
 import io.deephaven.qst.type.PrimitiveVectorType;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.annotations.FinalDefault;
@@ -27,7 +26,7 @@ public interface FloatVector extends Vector<FloatVector>, Iterable<Float> {
     long serialVersionUID = -1373264425081841175L;
 
     static PrimitiveVectorType<FloatVector, Float> type() {
-        return PrimitiveVectorType.of(FloatVector.class, FloatType.of());
+        return Types.FLOAT;
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/IntVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/IntVector.java
@@ -10,7 +10,6 @@ package io.deephaven.vector;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfInt;
-import io.deephaven.qst.type.IntType;
 import io.deephaven.qst.type.PrimitiveVectorType;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.annotations.FinalDefault;
@@ -27,7 +26,7 @@ public interface IntVector extends Vector<IntVector>, Iterable<Integer> {
     long serialVersionUID = -1373264425081841175L;
 
     static PrimitiveVectorType<IntVector, Integer> type() {
-        return PrimitiveVectorType.of(IntVector.class, IntType.of());
+        return Types.INT;
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/LongVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/LongVector.java
@@ -10,7 +10,6 @@ package io.deephaven.vector;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfLong;
-import io.deephaven.qst.type.LongType;
 import io.deephaven.qst.type.PrimitiveVectorType;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.annotations.FinalDefault;
@@ -27,7 +26,7 @@ public interface LongVector extends Vector<LongVector>, Iterable<Long> {
     long serialVersionUID = -1373264425081841175L;
 
     static PrimitiveVectorType<LongVector, Long> type() {
-        return PrimitiveVectorType.of(LongVector.class, LongType.of());
+        return Types.LONG;
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/ObjectVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/ObjectVector.java
@@ -25,8 +25,9 @@ public interface ObjectVector<COMPONENT_TYPE> extends Vector<ObjectVector<COMPON
     long serialVersionUID = 2691131699080413017L;
 
     static <T> GenericVectorType<ObjectVector<T>, T> type(GenericType<T> genericType) {
-        // noinspection unchecked
-        return GenericVectorType.of((Class<ObjectVector<T>>) (Class<?>) ObjectVector.class, genericType);
+        //noinspection unchecked,rawtypes
+        final Class<ObjectVector<T>> objectVectorClass = (Class) ObjectVector.class;
+        return GenericVectorType.of(objectVectorClass, genericType);
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/ShortVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/ShortVector.java
@@ -10,7 +10,6 @@ package io.deephaven.vector;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfShort;
-import io.deephaven.qst.type.ShortType;
 import io.deephaven.qst.type.PrimitiveVectorType;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.annotations.FinalDefault;
@@ -27,7 +26,7 @@ public interface ShortVector extends Vector<ShortVector>, Iterable<Short> {
     long serialVersionUID = -1373264425081841175L;
 
     static PrimitiveVectorType<ShortVector, Short> type() {
-        return PrimitiveVectorType.of(ShortVector.class, ShortType.of());
+        return Types.SHORT;
     }
 
     /**

--- a/engine/vector/src/main/java/io/deephaven/vector/Types.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/Types.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.vector;
+
+import io.deephaven.qst.type.PrimitiveVectorType;
+import io.deephaven.qst.type.Type;
+
+class Types {
+    static final PrimitiveVectorType<ByteVector, Byte> BYTE = PrimitiveVectorType.of(ByteVector.class, Type.byteType());
+    static final PrimitiveVectorType<CharVector, Character> CHAR =
+            PrimitiveVectorType.of(CharVector.class, Type.charType());
+    static final PrimitiveVectorType<ShortVector, Short> SHORT =
+            PrimitiveVectorType.of(ShortVector.class, Type.shortType());
+    static final PrimitiveVectorType<IntVector, Integer> INT = PrimitiveVectorType.of(IntVector.class, Type.intType());
+    static final PrimitiveVectorType<LongVector, Long> LONG = PrimitiveVectorType.of(LongVector.class, Type.longType());
+    static final PrimitiveVectorType<FloatVector, Float> FLOAT =
+            PrimitiveVectorType.of(FloatVector.class, Type.floatType());
+    static final PrimitiveVectorType<DoubleVector, Double> DOUBLE =
+            PrimitiveVectorType.of(DoubleVector.class, Type.doubleType());
+}

--- a/qst/src/main/java/io/deephaven/qst/type/GenericVectorType.java
+++ b/qst/src/main/java/io/deephaven/qst/type/GenericVectorType.java
@@ -4,12 +4,15 @@
 package io.deephaven.qst.type;
 
 import io.deephaven.annotations.SimpleStyle;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 
 @Immutable
 @SimpleStyle
 public abstract class GenericVectorType<T, ComponentType> extends ArrayTypeBase<T, ComponentType> {
+
+    private static final String OBJECT_VECTOR = "io.deephaven.vector.ObjectVector";
 
     public static <T, ComponentType> GenericVectorType<T, ComponentType> of(
             Class<T> clazz,
@@ -26,5 +29,19 @@ public abstract class GenericVectorType<T, ComponentType> extends ArrayTypeBase<
     @Override
     public final <R> R walk(ArrayType.Visitor<R> visitor) {
         return visitor.visit(this);
+    }
+
+    @Check
+    final void checkClazz() {
+        final Class<?> baseClass;
+        try {
+            baseClass = Class.forName(OBJECT_VECTOR, false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+        if (!baseClass.isAssignableFrom(clazz())) {
+            throw new IllegalArgumentException(
+                    String.format("Expected %s to be assignable to %s", clazz().getName(), OBJECT_VECTOR));
+        }
     }
 }

--- a/qst/src/main/java/io/deephaven/qst/type/PrimitiveVectorType.java
+++ b/qst/src/main/java/io/deephaven/qst/type/PrimitiveVectorType.java
@@ -74,9 +74,64 @@ public abstract class PrimitiveVectorType<T, ComponentType>
 
     @Check
     final void checkClazz() {
-        if (!VALID_CLASSES.contains(clazz().getName())) {
-            throw new IllegalArgumentException(String.format("Class '%s' is not a valid '%s'",
-                    clazz(), PrimitiveVectorType.class));
+        final String baseClassName = componentType().walk(ExpectedVectorBase.INSTANCE);
+        if (baseClassName == null) {
+            throw new IllegalArgumentException("No support for boolean vectors");
+        }
+        final Class<?> baseClass;
+        try {
+            baseClass = Class.forName(baseClassName, false, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+        if (!baseClass.isAssignableFrom(clazz())) {
+            throw new IllegalArgumentException(
+                    String.format("Expected %s to be assignable to %s for primitive component type %s",
+                            clazz().getName(), baseClassName, componentType()));
+        }
+    }
+
+    private enum ExpectedVectorBase implements PrimitiveType.Visitor<String> {
+        INSTANCE;
+
+        @Override
+        public String visit(BooleanType booleanType) {
+            return null;
+        }
+
+        @Override
+        public String visit(ByteType byteType) {
+            return BYTE_VECTOR;
+        }
+
+        @Override
+        public String visit(CharType charType) {
+            return CHAR_VECTOR;
+        }
+
+        @Override
+        public String visit(ShortType shortType) {
+            return SHORT_VECTOR;
+        }
+
+        @Override
+        public String visit(IntType intType) {
+            return INT_VECTOR;
+        }
+
+        @Override
+        public String visit(LongType longType) {
+            return LONG_VECTOR;
+        }
+
+        @Override
+        public String visit(FloatType floatType) {
+            return FLOAT_VECTOR;
+        }
+
+        @Override
+        public String visit(DoubleType doubleType) {
+            return DOUBLE_VECTOR;
         }
     }
 }


### PR DESCRIPTION
This also necessitates the inclusion of "alternative" / explicit vectors. While it's not recommended, a user _can_ do

```java
ColumnDefinition.ofVector("Foo", IntVectorDirect.class)
```

and so we should aim to be at least as expressive w/ `io.deephaven.qst.type.Type`