### PR TITLE
Better error message when input is ndim > 1 numpy array for dtypes.array()

### DIFF
--- a/py/server/deephaven/dtypes.py
+++ b/py/server/deephaven/dtypes.py
@@ -251,6 +251,9 @@ def array(dtype: DType, seq: Sequence, remap: Callable[[Any], Any] = None) -> jp
     Raises:
         DHError
     """
+    if isinstance(seq, np.ndarray) and seq.ndim > 1:
+        raise ValueError("array() does not support multi-dimensional arrays")
+
     if not isinstance(dtype, DType):
         raise TypeError(f"array() expects a DType for the first argument but given a {type(dtype).__name__}")
 

--- a/py/server/tests/test_dtypes.py
+++ b/py/server/tests/test_dtypes.py
@@ -18,6 +18,7 @@ from tests.testbase import BaseTestCase
 
 _JDateTimeUtils = jpy.get_type("io.deephaven.time.DateTimeUtils")
 
+
 def remap_double(v, null_value):
     if v != v or v == NULL_DOUBLE or v == float('inf'):
         return null_value
@@ -251,6 +252,11 @@ class DTypesTestCase(BaseTestCase):
         j_array2 = dtypes.array(dtypes.bool_, [True, False])
         self.assertEqual(j_array[0], j_array2[0])
         self.assertEqual(j_array[1], j_array2[1])
+
+    def test_np_ndim_array(self):
+        np_array = np.ndarray([1, 2, 3], np.int32)
+        with self.assertRaises(ValueError):
+            j_array = dtypes.array(dtypes.int32, np_array)
 
 
 if __name__ == '__main__':

--- a/py/server/tests/test_pyfunc_return_java_values.py
+++ b/py/server/tests/test_pyfunc_return_java_values.py
@@ -202,9 +202,9 @@ foo = Foo()
         self.assertEqual(t3.columns[2].data_type, dtypes.int64)
         self.assertEqual(t3.columns[3].data_type, dtypes.int64)
 
-    def test_vectorization_off_on_return_type_2(self):
+    def test_ndim_nparray_return_type(self):
         def f() -> np.ndarray[np.int64]:
-            return np.ndarray([1,2],dtype=np.int64)
+            return np.ndarray([1, 2], dtype=np.int64)
 
         with self.assertRaises(DHError) as cm:
             t = empty_table(10).update(["X1 = f()"])


### PR DESCRIPTION
Fixes #4656 