### PR TITLE
Python ticking client: support ColumnsAsList server protocol

### DIFF
--- a/py/client-ticking/setup.py
+++ b/py/client-ticking/setup.py
@@ -13,7 +13,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='pydeephaven-ticking',
-    version='0.29.0.dev',
+    version='0.29.0.dev0',
     description='The Deephaven Python Client for Ticking Tables',
     long_description=README,
     long_description_content_type="text/markdown",

--- a/py/client-ticking/src/pydeephaven_ticking/_core.pxd
+++ b/py/client-ticking/src/pydeephaven_ticking/_core.pxd
@@ -39,7 +39,7 @@ cdef extern from *:
 cdef extern from "deephaven/dhcore/chunk/chunk.h" namespace "deephaven::dhcore::chunk":
     cdef cppclass CChunk "deephaven::dhcore::chunk::Chunk":
         CChunk()
-        CChunk(CChunk &&other)
+        CChunk(CChunk other)
 
     cdef cppclass CGenericChunk "deephaven::dhcore::chunk::GenericChunk" [T] (CChunk):
         @staticmethod
@@ -53,7 +53,7 @@ cdef extern from "deephaven/dhcore/chunk/chunk.h" namespace "deephaven::dhcore::
 cdef extern from "deephaven/dhcore/container/row_sequence.h" namespace "deephaven::dhcore::container":
     cdef cppclass CRowSequence "deephaven::dhcore::container::RowSequence":
         CRowSequence()
-        CRowSequence(CRowSequence &&other)
+        CRowSequence(CRowSequence other)
 
         shared_ptr[CRowSequence] Take(size_t size)
         shared_ptr[CRowSequence] Drop(size_t size)
@@ -90,7 +90,7 @@ cdef extern from "deephaven/dhcore/clienttable/schema.h" namespace "deephaven::d
 cdef extern from "deephaven/dhcore/ticking/ticking.h" namespace "deephaven::dhcore::ticking":
     cdef cppclass CTickingUpdate "deephaven::dhcore::ticking::TickingUpdate":
         CTickingUpdate()
-        CTickingUpdate(CTickingUpdate &&other)
+        CTickingUpdate(CTickingUpdate other)
 
         shared_ptr[CClientTable] Prev()
         shared_ptr[CClientTable] BeforeRemoves()

--- a/py/client-ticking/src/pydeephaven_ticking/table_listener.py
+++ b/py/client-ticking/src/pydeephaven_ticking/table_listener.py
@@ -36,8 +36,8 @@ def _make_generator(table: dhc.ClientTable,
 
     col_names = tick_util.canonicalize_cols_param(table, col_names)
     while not rows.empty:
-        these_rows = rows.take(chunk_size)
-        rows = rows.drop(chunk_size)
+        these_rows = rows.Take(chunk_size)
+        rows = rows.Drop(chunk_size)
 
         result: ColDictType = {}
         for i in range(len(col_names)):


### PR DESCRIPTION
Python ticking was broken because it was not respecting the ColumnsAsList protocol.
Also fix up a few errors that are caught by the more-strict Cython 3.0 version.
Also correct the capitalization of the calls to Take and Drop.
Also correct a couple Cython type annotations.
