### PR TITLE
`BarrageSession` Subscription/Snapshot Methods now Return `Future<Table>`

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/exceptions/RequestCancelledException.java
+++ b/engine/table/src/main/java/io/deephaven/engine/exceptions/RequestCancelledException.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.exceptions;
+
+import io.deephaven.UncheckedDeephavenException;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This exception is used when a result cannot be returned because the request was cancelled.
+ */
+public class RequestCancelledException extends UncheckedDeephavenException {
+    public RequestCancelledException(@NotNull final String message) {
+        super(message);
+    }
+
+    public RequestCancelledException(@NotNull final String message, @NotNull final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphAwareCompletableFuture.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphAwareCompletableFuture.java
@@ -1,0 +1,164 @@
+package io.deephaven.engine.updategraph;
+
+import io.deephaven.util.SafeCloseable;
+import io.deephaven.util.function.ThrowingSupplier;
+import io.deephaven.util.locks.FunctionalLock;
+import io.deephaven.util.locks.FunctionalReentrantLock;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.Condition;
+
+public class UpdateGraphAwareCompletableFuture<T> implements Future<T> {
+
+    private final UpdateGraph updateGraph;
+
+    /** This condition is used to signal any threads waiting on the UpdateGraph exclusive lock. */
+    private volatile Condition updateGraphCondition;
+
+    private final FunctionalLock lock = new FunctionalReentrantLock();
+    private volatile Condition lockCondition;
+
+    private volatile ThrowingSupplier<T, ExecutionException> resultSupplier;
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<UpdateGraphAwareCompletableFuture, ThrowingSupplier> RESULT_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(
+                    UpdateGraphAwareCompletableFuture.class, ThrowingSupplier.class, "resultSupplier");
+
+    /** The encoding of the cancelled supplier. */
+    private static final ThrowingSupplier<?, ExecutionException> CANCELLATION_SUPPLIER = () -> {
+        throw new CancellationException();
+    };
+
+    public UpdateGraphAwareCompletableFuture(@NotNull final UpdateGraph updateGraph) {
+        this.updateGraph = updateGraph;
+    }
+
+    ////////////////
+    // Future API //
+    ////////////////
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        // noinspection unchecked
+        return trySignalCompletion((ThrowingSupplier<T, ExecutionException>) CANCELLATION_SUPPLIER);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return resultSupplier == CANCELLATION_SUPPLIER;
+    }
+
+    @Override
+    public boolean isDone() {
+        return resultSupplier != null;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        if (resultSupplier != null) {
+            return resultSupplier.get();
+        }
+        try {
+            return getInternal(0, null);
+        } catch (TimeoutException toe) {
+            throw new IllegalStateException("Unexpected TimeoutException", toe);
+        }
+    }
+
+    @Override
+    public T get(final long timeout, @NotNull final TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        if (resultSupplier != null) {
+            return resultSupplier.get();
+        }
+        if (timeout <= 0) {
+            throw new TimeoutException();
+        }
+        return getInternal(timeout, unit);
+    }
+
+    private T getInternal(long timeout, @Nullable TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        // test lock conditions
+        if (updateGraph.sharedLock().isHeldByCurrentThread()) {
+            throw new UnsupportedOperationException(
+                    "Cannot Future#get while holding the " + updateGraph + " shared lock");
+        }
+
+        final boolean holdingUpdateGraphLock = updateGraph.exclusiveLock().isHeldByCurrentThread();
+        if (updateGraphCondition == null && holdingUpdateGraphLock) {
+            try (final SafeCloseable ignored = lock.lockCloseable()) {
+                if (updateGraphCondition == null) {
+                    updateGraphCondition = updateGraph.exclusiveLock().newCondition();
+                }
+            }
+        } else if (lockCondition == null) {
+            try (final SafeCloseable ignored = lock.lockCloseable()) {
+                if (lockCondition == null) {
+                    lockCondition = lock.newCondition();
+                }
+            }
+        }
+
+        if (holdingUpdateGraphLock) {
+            waitForResult(updateGraphCondition, timeout, unit);
+        } else {
+            try (final SafeCloseable ignored = lock.lockCloseable()) {
+                waitForResult(lockCondition, timeout, unit);
+            }
+        }
+
+        return resultSupplier.get();
+    }
+
+    private void waitForResult(final Condition condition, final long timeout, @Nullable final TimeUnit unit)
+            throws InterruptedException, TimeoutException {
+        if (unit == null) {
+            while (resultSupplier == null) {
+                condition.await();
+            }
+            return;
+        }
+
+        long nanosLeft = unit.toNanos(timeout);
+        while (resultSupplier == null) {
+            nanosLeft = condition.awaitNanos(nanosLeft);
+            if (nanosLeft <= 0) {
+                throw new TimeoutException();
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////
+    // Completion API modeled after CompletableFuture //
+    ////////////////////////////////////////////////////
+
+    public boolean complete(T value) {
+        return trySignalCompletion(() -> value);
+    }
+
+    public boolean completeExceptionally(Throwable ex) {
+        if (ex == null)
+            throw new NullPointerException();
+        return trySignalCompletion(() -> {
+            throw new ExecutionException(ex);
+        });
+    }
+
+    private boolean trySignalCompletion(@NotNull final ThrowingSupplier<T, ExecutionException> result) {
+        if (!RESULT_UPDATER.compareAndSet(UpdateGraphAwareCompletableFuture.this, null, result)) {
+            return false;
+        }
+
+        final Condition localCondition = updateGraphCondition;
+        try (final SafeCloseable ignored = lock.lockCloseable()) {
+            if (localCondition != null) {
+                updateGraph.requestSignal(localCondition);
+            }
+        }
+
+        return true;
+    }
+}

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphAwareCompletableFuture.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateGraphAwareCompletableFuture.java
@@ -138,8 +138,9 @@ public class UpdateGraphAwareCompletableFuture<T> implements Future<T> {
     }
 
     public boolean completeExceptionally(Throwable ex) {
-        if (ex == null)
+        if (ex == null) {
             throw new NullPointerException();
+        }
         return trySignalCompletion(() -> {
             throw new ExecutionException(ex);
         });

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -396,6 +396,24 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
         }
     }
 
+    public void unsubscribe() {
+        unsubscribed = true;
+
+        if (!isRefreshing()) {
+            try {
+                realRefresh();
+            } catch (Throwable err) {
+                if (viewportChangedCallback != null) {
+                    viewportChangedCallback.onError(err);
+                    viewportChangedCallback = null;
+                }
+                throw err;
+            }
+        } else {
+            doWakeup();
+        }
+    }
+
     private void cleanup() {
         unsubscribed = true;
         if (stats != null) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -74,7 +74,7 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
          *
          * @param t the error
          */
-        void onError(Throwable t);
+        void onError(@NotNull Throwable t);
     }
 
     public static final boolean DEBUG_ENABLED =

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -566,6 +566,7 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
     @Override
     protected void destroy() {
         super.destroy();
+        discardAnyPendingUpdates();
         if (stats != null) {
             stats.stop();
         }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/table/BarrageTable.java
@@ -341,6 +341,8 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
             }
             // once we notify on error we are done, we can not notify any further, we are failed
             cleanup();
+            // we are quite certain the shadow copies should have been drained on the last run
+            Assert.eqZero(shadowPendingUpdates.size(), "shadowPendingUpdates.size()");
             return;
         }
 
@@ -390,8 +392,6 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
         }
         // release any pending snapshots, as we will never process them
         discardAnyPendingUpdates();
-        // we are quite certain the shadow copies should have been drained on the last run
-        Assert.eqZero(shadowPendingUpdates.size(), "shadowPendingUpdates.size()");
     }
 
     @Override
@@ -566,10 +566,7 @@ public abstract class BarrageTable extends QueryTable implements BarrageMessage.
     @Override
     protected void destroy() {
         super.destroy();
-        discardAnyPendingUpdates();
-        if (stats != null) {
-            stats.stop();
-        }
+        cleanup();
     }
 
     public LongConsumer getDeserializationTmConsumer() {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
@@ -9,7 +9,10 @@ import io.deephaven.proto.util.Exceptions;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.util.function.ThrowingRunnable;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
@@ -37,7 +40,7 @@ public class GrpcUtil {
      * @param observer the stream that will be used in the runnable
      * @param runner the runnable to execute safely
      */
-    public static void safelyExecuteLocked(final StreamObserver<?> observer,
+    private static void safelyExecuteLocked(final StreamObserver<?> observer,
             final ThrowingRunnable<Exception> runner) {
         try {
             // noinspection SynchronizationOnLocalVariableOrMethodParameter
@@ -87,22 +90,46 @@ public class GrpcUtil {
     /**
      * Writes an error to the observer in a try/catch block to minimize damage caused by failing observer call.
      * <p>
-     * </p>
      * This will always synchronize on the observer to ensure thread safety when interacting with the grpc response
      * stream.
      */
-    public static void safelyError(final StreamObserver<?> observer, final Code statusCode, final String msg) {
+    public static void safelyError(
+            @NotNull final StreamObserver<?> observer,
+            final Code statusCode,
+            @NotNull final String msg) {
         safelyError(observer, Exceptions.statusRuntimeException(statusCode, msg));
     }
 
     /**
      * Writes an error to the observer in a try/catch block to minimize damage caused by failing observer call.
      * <p>
-     * </p>
      * This will always synchronize on the observer to ensure thread safety when interacting with the grpc response
      * stream.
      */
-    public static void safelyError(final StreamObserver<?> observer, StatusRuntimeException exception) {
+    public static void safelyError(
+            @NotNull final StreamObserver<?> observer,
+            @NotNull final StatusRuntimeException exception) {
         safelyExecuteLocked(observer, () -> observer.onError(exception));
+    }
+
+    /**
+     * Cancels the observer in a try/catch block to minimize damage caused by failing observer call.
+     * <p>
+     * This will always synchronize on the observer to ensure thread safety when interacting with the grpc response
+     * stream.
+     * <p>
+     * It is recommended that at least one of {@code message} or {@code cause} to be non-{@code null}, to provide useful
+     * debug information. Both argument being null may log warnings and result in suboptimal performance. Also note that
+     * the provided information will not be sent to the server.
+     *
+     * @param observer the stream that will be used in the runnable
+     * @param message if not {@code null}, will appear as the description of the CANCELLED status
+     * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
+     */
+    public static void safelyCancel(
+            @NotNull final ClientCallStreamObserver<?> observer,
+            @Nullable final String message,
+            @Nullable final Throwable cause) {
+        safelyExecuteLocked(observer, () -> observer.cancel(message, cause));
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
@@ -37,7 +37,7 @@ public class GrpcUtil {
      * @param observer the stream that will be used in the runnable
      * @param runner the runnable to execute safely
      */
-    private static void safelyExecuteLocked(final StreamObserver<?> observer,
+    public static void safelyExecuteLocked(final StreamObserver<?> observer,
             final ThrowingRunnable<Exception> runner) {
         try {
             // noinspection SynchronizationOnLocalVariableOrMethodParameter

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
@@ -119,8 +119,8 @@ public class GrpcUtil {
      * stream.
      * <p>
      * It is recommended that at least one of {@code message} or {@code cause} to be non-{@code null}, to provide useful
-     * debug information. Both argument being null may log warnings and result in suboptimal performance. Also note that
-     * the provided information will not be sent to the server.
+     * debug information. Both arguments being null may log warnings and result in suboptimal performance. Also note
+     * that the provided information will not be sent to the server.
      *
      * @param observer the stream that will be used in the runnable
      * @param message if not {@code null}, will appear as the description of the CANCELLED status

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
@@ -6,11 +6,11 @@ package io.deephaven.client.examples;
 import io.deephaven.client.impl.*;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.DataAccessHelpers;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
-import io.deephaven.extensions.barrage.table.BarrageTable;
 import io.deephaven.qst.TableCreationLogic;
 import picocli.CommandLine;
 
@@ -46,7 +46,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             System.out.println("Requesting all rows, all columns");
 
             // expect this to block until all reading complete
-            final BarrageTable table = snapshot.entireTable();
+            final Table table = snapshot.entireTable();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -63,7 +63,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
             // expect this to block until all reading complete
             final RowSet viewport = RowSetFactory.fromRange(0, 5); // range inclusive
-            final BarrageTable table = snapshot.partialTable(viewport, null);
+            final Table table = snapshot.partialTable(viewport, null);
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -80,7 +80,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
             // expect this to block until all reading complete
             final RowSet viewport = RowSetFactory.fromRange(6, 10); // range inclusive
-            final BarrageTable table = snapshot.partialTable(viewport, null);
+            final Table table = snapshot.partialTable(viewport, null);
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -99,7 +99,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             final BitSet columns = new BitSet();
             columns.set(0, 2); // range not inclusive (sets bits 0-1)
 
-            final BarrageTable table = snapshot.partialTable(null, columns);
+            final Table table = snapshot.partialTable(null, columns);
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -119,7 +119,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             final BitSet columns = new BitSet();
             columns.set(0, 2); // range not inclusive (sets bits 0-1)
 
-            final BarrageTable table = snapshot.partialTable(viewport, columns);
+            final Table table = snapshot.partialTable(viewport, columns);
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -137,7 +137,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             System.out.println("Requesting rows from end 0-4, all columns");
 
             // expect this to block until all reading complete
-            final BarrageTable table = snapshot.partialTable(viewport, null, true);
+            final Table table = snapshot.partialTable(viewport, null, true);
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -157,7 +157,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             columns.set(0, 2); // range not inclusive (sets bits 0-1)
 
             // expect this to block until all reading complete
-            final BarrageTable table = snapshot.partialTable(viewport, columns, true);
+            final Table table = snapshot.partialTable(viewport, columns, true);
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -178,7 +178,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
             System.out.println("Snapshot created");
 
-            final BarrageTable table = subscription.snapshotEntireTable();
+            final Table table = subscription.snapshotEntireTable();
 
             System.out.println(
                     "Table info: rows = " + table.size() + ", cols = " + DataAccessHelpers.getColumns(table).length);

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
@@ -49,7 +49,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             System.out.println("Requesting all rows, all columns");
 
             // expect this to block until all reading complete
-            final Table table = snapshot.entireTable();
+            final Table table = snapshot.entireTable().get();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -67,7 +67,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
             // expect this to block until all reading complete
             final RowSet viewport = RowSetFactory.fromRange(0, 5); // range inclusive
-            final Table table = snapshot.partialTable(viewport, null);
+            final Table table = snapshot.partialTable(viewport, null).get();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -85,7 +85,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
             // expect this to block until all reading complete
             final RowSet viewport = RowSetFactory.fromRange(6, 10); // range inclusive
-            final Table table = snapshot.partialTable(viewport, null);
+            final Table table = snapshot.partialTable(viewport, null).get();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -105,7 +105,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             final BitSet columns = new BitSet();
             columns.set(0, 2); // range not inclusive (sets bits 0-1)
 
-            final Table table = snapshot.partialTable(null, columns);
+            final Table table = snapshot.partialTable(null, columns).get();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -126,7 +126,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             final BitSet columns = new BitSet();
             columns.set(0, 2); // range not inclusive (sets bits 0-1)
 
-            final Table table = snapshot.partialTable(viewport, columns);
+            final Table table = snapshot.partialTable(viewport, columns).get();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -145,7 +145,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             System.out.println("Requesting rows from end 0-4, all columns");
 
             // expect this to block until all reading complete
-            final Table table = snapshot.partialTable(viewport, null, true);
+            final Table table = snapshot.partialTable(viewport, null, true).get();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -167,7 +167,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
             columns.set(0, 2); // range not inclusive (sets bits 0-1)
 
             // expect this to block until all reading complete
-            final Table table = snapshot.partialTable(viewport, columns, true);
+            final Table table = snapshot.partialTable(viewport, columns, true).get();
 
             System.out.println("Table info: rows = " + table.size()
                     + ", cols = " + table.numColumns());
@@ -189,7 +189,7 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
             System.out.println("Snapshot created");
 
-            final Table table = subscription.snapshotEntireTable();
+            final Table table = subscription.snapshotEntireTable().get();
 
             System.out.println(
                     "Table info: rows = " + table.size() + ", cols = " + DataAccessHelpers.getColumns(table).length);

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
@@ -40,8 +40,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
                 : mode.batch ? client.session().batch() : client.session().serial();
 
         // example #1 - verify full table reading
-        try (final TableHandle handle = manager.executeLogic(logic());
-                final BarrageSnapshot snapshot = client.snapshot(handle, options)) {
+        try (final TableHandle handle = manager.executeLogic(logic())) {
+            final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting all rows, all columns");
 
@@ -56,8 +56,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #2 - reading all columns, but only subset of rows starting with 0
-        try (final TableHandle handle = manager.executeLogic(logic());
-                final BarrageSnapshot snapshot = client.snapshot(handle, options)) {
+        try (final TableHandle handle = manager.executeLogic(logic())) {
+            final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows 0-5, all columns");
 
@@ -73,8 +73,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #3 - reading all columns, but only subset of rows starting at >0
-        try (final TableHandle handle = manager.executeLogic(logic());
-                final BarrageSnapshot snapshot = client.snapshot(handle, options)) {
+        try (final TableHandle handle = manager.executeLogic(logic())) {
+            final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows 6-10, all columns");
 
@@ -90,8 +90,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #4 - reading some columns but all rows
-        try (final TableHandle handle = manager.executeLogic(logic());
-                final BarrageSnapshot snapshot = client.snapshot(handle, options)) {
+        try (final TableHandle handle = manager.executeLogic(logic())) {
+            final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting all rows, columns 0-1");
 
@@ -109,8 +109,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #5 - reading some columns and only some rows
-        try (final TableHandle handle = manager.executeLogic(logic());
-                final BarrageSnapshot snapshot = client.snapshot(handle, options)) {
+        try (final TableHandle handle = manager.executeLogic(logic())) {
+            final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows 100-150, columns 0-1");
 
@@ -130,9 +130,9 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
         // example #6 - reverse viewport, all columns
         try (final TableHandle handle = manager.executeLogic(logic());
-                final RowSet viewport = RowSetFactory.flat(5); // range inclusive
-
-                final BarrageSnapshot snapshot = client.snapshot(handle, options)) {
+                // range inclusive
+                final RowSet viewport = RowSetFactory.flat(5)) {
+            final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows from end 0-4, all columns");
 
@@ -148,8 +148,9 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
 
         // example #7 - reverse viewport, some columns
         try (final TableHandle handle = manager.executeLogic(logic());
-                final RowSet viewport = RowSetFactory.flat(5); // range inclusive
-                final BarrageSnapshot snapshot = client.snapshot(handle, options)) {
+                // range inclusive
+                final RowSet viewport = RowSetFactory.flat(5)) {
+            final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows from end 0-4, columns 0-1");
 
@@ -173,8 +174,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         // terminated and the table returned to the user.
         final BarrageSubscriptionOptions subOptions = BarrageSubscriptionOptions.builder().build();
 
-        try (final TableHandle handle = manager.executeLogic(logic());
-                final BarrageSubscription subscription = client.subscribe(handle, subOptions)) {
+        try (final TableHandle handle = manager.executeLogic(logic())) {
+            final BarrageSubscription subscription = client.subscribe(handle, subOptions);
 
             System.out.println("Snapshot created");
 

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SnapshotExampleBase.java
@@ -4,6 +4,7 @@
 package io.deephaven.client.examples;
 
 import io.deephaven.client.impl.*;
+import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.Table;
@@ -12,6 +13,7 @@ import io.deephaven.engine.util.TableTools;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
 import io.deephaven.qst.TableCreationLogic;
+import io.deephaven.util.SafeCloseable;
 import picocli.CommandLine;
 
 import java.util.BitSet;
@@ -40,7 +42,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
                 : mode.batch ? client.session().batch() : client.session().serial();
 
         // example #1 - verify full table reading
-        try (final TableHandle handle = manager.executeLogic(logic())) {
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic())) {
             final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting all rows, all columns");
@@ -56,7 +59,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #2 - reading all columns, but only subset of rows starting with 0
-        try (final TableHandle handle = manager.executeLogic(logic())) {
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic())) {
             final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows 0-5, all columns");
@@ -73,7 +77,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #3 - reading all columns, but only subset of rows starting at >0
-        try (final TableHandle handle = manager.executeLogic(logic())) {
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic())) {
             final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows 6-10, all columns");
@@ -90,7 +95,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #4 - reading some columns but all rows
-        try (final TableHandle handle = manager.executeLogic(logic())) {
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic())) {
             final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting all rows, columns 0-1");
@@ -109,7 +115,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #5 - reading some columns and only some rows
-        try (final TableHandle handle = manager.executeLogic(logic())) {
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic())) {
             final BarrageSnapshot snapshot = client.snapshot(handle, options);
 
             System.out.println("Requesting rows 100-150, columns 0-1");
@@ -129,7 +136,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #6 - reverse viewport, all columns
-        try (final TableHandle handle = manager.executeLogic(logic());
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic());
                 // range inclusive
                 final RowSet viewport = RowSetFactory.flat(5)) {
             final BarrageSnapshot snapshot = client.snapshot(handle, options);
@@ -147,7 +155,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         }
 
         // example #7 - reverse viewport, some columns
-        try (final TableHandle handle = manager.executeLogic(logic());
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic());
                 // range inclusive
                 final RowSet viewport = RowSetFactory.flat(5)) {
             final BarrageSnapshot snapshot = client.snapshot(handle, options);
@@ -174,7 +183,8 @@ abstract class SnapshotExampleBase extends BarrageClientExampleBase {
         // terminated and the table returned to the user.
         final BarrageSubscriptionOptions subOptions = BarrageSubscriptionOptions.builder().build();
 
-        try (final TableHandle handle = manager.executeLogic(logic())) {
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = manager.executeLogic(logic())) {
             final BarrageSubscription subscription = client.subscribe(handle, subOptions);
 
             System.out.println("Snapshot created");

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
@@ -62,13 +62,13 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
             final Table subscriptionTable;
             if (headerSize > 0) {
                 // create a Table subscription with forward viewport of the specified size
-                subscriptionTable = subscription.partialTable(RowSetFactory.flat(headerSize), null, false);
+                subscriptionTable = subscription.partialTable(RowSetFactory.flat(headerSize), null, false).get();
             } else if (tailSize > 0) {
                 // create a Table subscription with reverse viewport of the specified size
-                subscriptionTable = subscription.partialTable(RowSetFactory.flat(tailSize), null, true);
+                subscriptionTable = subscription.partialTable(RowSetFactory.flat(tailSize), null, true).get();
             } else {
                 // create a Table subscription of the entire Table
-                subscriptionTable = subscription.entireTable();
+                subscriptionTable = subscription.entireTable().get();
             }
 
             System.out.println("Subscription established");
@@ -107,9 +107,6 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
             });
 
             countDownLatch.await();
-
-            // inform the server we're done with the subscription
-            subscription.cancel();
 
             // Note that when the LivenessScope, which is opened in the try-with-resources block, is closed the
             // listener, resultTable, and subscription objects will be destroyed.

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
@@ -7,6 +7,7 @@ import io.deephaven.client.impl.BarrageSession;
 import io.deephaven.client.impl.BarrageSubscription;
 import io.deephaven.client.impl.TableHandle;
 import io.deephaven.client.impl.TableHandleManager;
+import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.DataAccessHelpers;
@@ -16,6 +17,7 @@ import io.deephaven.engine.table.impl.InstrumentedTableUpdateListener;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
 import io.deephaven.qst.TableCreationLogic;
+import io.deephaven.util.SafeCloseable;
 import io.deephaven.util.annotations.ReferentialIntegrity;
 import picocli.CommandLine;
 
@@ -53,7 +55,8 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
         final TableHandleManager subscriptionManager = mode == null ? client.session()
                 : mode.batch ? client.session().batch() : client.session().serial();
 
-        try (final TableHandle handle = subscriptionManager.executeLogic(logic())) {
+        try (final SafeCloseable ignored = LivenessScopeStack.open();
+                final TableHandle handle = subscriptionManager.executeLogic(logic())) {
             final BarrageSubscription subscription = client.subscribe(handle, options);
 
             final Table subscriptionTable;
@@ -108,8 +111,8 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
             // inform the server we're done with the subscription
             subscription.cancel();
 
-            // For a "real" implementation, we would use liveness tracking for the listener, and ensure that it was
-            // destroyed and unreachable when we no longer needed it.
+            // Note that when the LivenessScope, which is opened in the try-with-resources block, is closed the
+            // listener, resultTable, and subscription objects will be destroyed.
             listener = null;
         }
     }

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
@@ -15,7 +15,6 @@ import io.deephaven.engine.table.TableUpdateListener;
 import io.deephaven.engine.table.impl.InstrumentedTableUpdateListener;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
-import io.deephaven.extensions.barrage.table.BarrageTable;
 import io.deephaven.qst.TableCreationLogic;
 import io.deephaven.util.annotations.ReferentialIntegrity;
 import picocli.CommandLine;
@@ -54,8 +53,8 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
         final TableHandleManager subscriptionManager = mode == null ? client.session()
                 : mode.batch ? client.session().batch() : client.session().serial();
 
-        try (final TableHandle handle = subscriptionManager.executeLogic(logic());
-                final BarrageSubscription subscription = client.subscribe(handle, options)) {
+        try (final TableHandle handle = subscriptionManager.executeLogic(logic())) {
+            final BarrageSubscription subscription = client.subscribe(handle, options);
 
             final Table subscriptionTable;
             if (headerSize > 0) {
@@ -105,6 +104,9 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
             });
 
             countDownLatch.await();
+
+            // inform the server we're done with the subscription
+            subscription.cancel();
 
             // For a "real" implementation, we would use liveness tracking for the listener, and ensure that it was
             // destroyed and unreachable when we no longer needed it.

--- a/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
+++ b/java-client/barrage-examples/src/main/java/io/deephaven/client/examples/SubscribeExampleBase.java
@@ -8,6 +8,7 @@ import io.deephaven.client.impl.BarrageSubscription;
 import io.deephaven.client.impl.TableHandle;
 import io.deephaven.client.impl.TableHandleManager;
 import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.DataAccessHelpers;
 import io.deephaven.engine.table.TableUpdate;
 import io.deephaven.engine.table.TableUpdateListener;
@@ -56,7 +57,7 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
         try (final TableHandle handle = subscriptionManager.executeLogic(logic());
                 final BarrageSubscription subscription = client.subscribe(handle, options)) {
 
-            final BarrageTable subscriptionTable;
+            final Table subscriptionTable;
             if (headerSize > 0) {
                 // create a Table subscription with forward viewport of the specified size
                 subscriptionTable = subscription.partialTable(RowSetFactory.flat(headerSize), null, false);
@@ -76,7 +77,7 @@ abstract class SubscribeExampleBase extends BarrageClientExampleBase {
 
             subscriptionTable.addUpdateListener(listener = new InstrumentedTableUpdateListener("example-listener") {
                 @ReferentialIntegrity
-                final BarrageTable tableRef = subscriptionTable;
+                final Table tableRef = subscriptionTable;
                 {
                     // Maintain a liveness ownership relationship with subscriptionTable for the lifetime of the
                     // listener

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
@@ -39,6 +39,13 @@ public interface BarrageSnapshot {
     }
 
     /**
+     * This call will return false until all rows for the result table are available or the snapshot failed.
+     *
+     * @return true when all rows for the result table are available or the snapshot failed, false otherwise
+     */
+    boolean isCompleted();
+
+    /**
      * Request a full snapshot of the data and populate a {@link Table} with the data that is received.
      *
      * @return the {@code Table}

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
@@ -41,9 +41,11 @@ public interface BarrageSnapshot {
     /**
      * Request a full snapshot of the data and populate a {@link Table} with the data that is received.
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated with the snapshot
      */
-    Future<Table> entireTable() throws InterruptedException;
+    Future<Table> entireTable();
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
@@ -52,9 +54,11 @@ public interface BarrageSnapshot {
      * @param viewport the position-space viewport to use for the snapshot
      * @param columns the columns to include in the snapshot
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated with the snapshot
      */
-    Future<Table> partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
+    Future<Table> partialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
@@ -65,7 +69,9 @@ public interface BarrageSnapshot {
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated with the snapshot
      */
-    Future<Table> partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
+    Future<Table> partialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
@@ -4,7 +4,6 @@
 package io.deephaven.client.impl;
 
 import io.deephaven.UncheckedDeephavenException;
-import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
@@ -16,7 +15,7 @@ import java.util.BitSet;
  * A {@code BarrageSnapshot} represents a snapshot of a table that may or may not be filtered to a viewport of the
  * remote source table.
  */
-public interface BarrageSnapshot extends LivenessReferent {
+public interface BarrageSnapshot {
     interface Factory {
         /**
          * Sources a barrage snapshot from a {@link TableSpec}.

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
@@ -3,13 +3,13 @@
  */
 package io.deephaven.client.impl;
 
-import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
 import io.deephaven.qst.table.TableSpec;
 
 import java.util.BitSet;
+import java.util.concurrent.Future;
 
 /**
  * A {@code BarrageSnapshot} represents a snapshot of a table that may or may not be filtered to a viewport of the
@@ -39,27 +39,11 @@ public interface BarrageSnapshot {
     }
 
     /**
-     * This call will return false until all rows for the result table are available or the snapshot failed.
-     *
-     * @return true when all rows for the result table are available or the snapshot failed, false otherwise
-     */
-    boolean isCompleted();
-
-    /**
      * Request a full snapshot of the data and populate a {@link Table} with the data that is received.
      *
      * @return the {@code Table}
      */
-    Table entireTable() throws InterruptedException;
-
-    /**
-     * Request a full snapshot of the data and populate a {@link Table} with the data that is received.
-     *
-     * @param blockUntilComplete Whether to block execution until all rows for the subscribed table are available
-     *
-     * @return the {@code Table}
-     */
-    Table entireTable(boolean blockUntilComplete) throws InterruptedException;
+    Future<Table> entireTable() throws InterruptedException;
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
@@ -70,7 +54,7 @@ public interface BarrageSnapshot {
      *
      * @return the {@code Table}
      */
-    Table partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
+    Future<Table> partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
@@ -83,39 +67,5 @@ public interface BarrageSnapshot {
      *
      * @return the {@code Table}
      */
-    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
-
-    /**
-     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
-     * data that is received. Allows the viewport to be reversed.
-     *
-     * @param viewport the position-space viewport to use for the subscription
-     * @param columns the columns to include in the subscription
-     * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
-     *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
-     * @param blockUntilComplete Whether to block execution until the subscribed table viewport is satisfied
-     *
-     * @return the {@code Table}
-     */
-    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport, boolean blockUntilComplete)
-            throws InterruptedException;
-
-    /**
-     * Block until the snapshot is complete.
-     * <p>
-     * It is an error to {@code blockUntilComplete} if the current thread holds the result table's UpdateGraph shared
-     * lock. If the current thread holds the result table's UpdateGraph exclusive lock, then this method will use an
-     * update graph condition variable to wait for completion. Otherwise, this method will use the snapshot's object
-     * monitor to wait for completion.
-     *
-     * @throws InterruptedException if the current thread is interrupted while waiting for completion
-     * @throws UncheckedDeephavenException if an error occurred while handling the snapshot
-     * @return the {@code Table}
-     */
-    Table blockUntilComplete() throws InterruptedException;
-
-    /**
-     * Cancel the snapshot.
-     */
-    void cancel();
+    Future<Table> partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
@@ -6,8 +6,8 @@ package io.deephaven.client.impl;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.Table;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
-import io.deephaven.extensions.barrage.table.BarrageTable;
 import io.deephaven.qst.table.TableSpec;
 
 import java.util.BitSet;
@@ -16,7 +16,7 @@ import java.util.BitSet;
  * A {@code BarrageSnapshot} represents a snapshot of a table that may or may not be filtered to a viewport of the
  * remote source table.
  */
-public interface BarrageSnapshot extends LivenessReferent, AutoCloseable {
+public interface BarrageSnapshot extends LivenessReferent {
     interface Factory {
         /**
          * Sources a barrage snapshot from a {@link TableSpec}.
@@ -40,48 +40,48 @@ public interface BarrageSnapshot extends LivenessReferent, AutoCloseable {
     }
 
     /**
-     * Request a full snapshot of the data and populate a {@link BarrageTable} with the data that is received.
+     * Request a full snapshot of the data and populate a {@link Table} with the data that is received.
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable entireTable() throws InterruptedException;
+    Table entireTable() throws InterruptedException;
 
     /**
-     * Request a full snapshot of the data and populate a {@link BarrageTable} with the data that is received.
+     * Request a full snapshot of the data and populate a {@link Table} with the data that is received.
      *
      * @param blockUntilComplete Whether to block execution until all rows for the subscribed table are available
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable entireTable(boolean blockUntilComplete) throws InterruptedException;
+    Table entireTable(boolean blockUntilComplete) throws InterruptedException;
 
     /**
-     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link BarrageTable} with
-     * the data that is received.
+     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
+     * data that is received.
      *
      * @param viewport the position-space viewport to use for the snapshot
      * @param columns the columns to include in the snapshot
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
+    Table partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
 
     /**
-     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link BarrageTable} with
-     * the data that is received. Allows the viewport to be reversed.
+     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
+     * data that is received. Allows the viewport to be reversed.
      *
      * @param viewport the position-space viewport to use for the snapshot
      * @param columns the columns to include in the snapshot
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
+    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
 
     /**
-     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link BarrageTable} with
-     * the data that is received. Allows the viewport to be reversed.
+     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
+     * data that is received. Allows the viewport to be reversed.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
@@ -89,9 +89,9 @@ public interface BarrageSnapshot extends LivenessReferent, AutoCloseable {
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      * @param blockUntilComplete Whether to block execution until the subscribed table viewport is satisfied
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable partialTable(RowSet viewport, BitSet columns, boolean reverseViewport, boolean blockUntilComplete)
+    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport, boolean blockUntilComplete)
             throws InterruptedException;
 
     /**
@@ -104,10 +104,12 @@ public interface BarrageSnapshot extends LivenessReferent, AutoCloseable {
      *
      * @throws InterruptedException if the current thread is interrupted while waiting for completion
      * @throws UncheckedDeephavenException if an error occurred while handling the snapshot
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable blockUntilComplete() throws InterruptedException;
+    Table blockUntilComplete() throws InterruptedException;
 
-    @Override
-    void close();
+    /**
+     * Cancel the snapshot.
+     */
+    void cancel();
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshot.java
@@ -39,39 +39,35 @@ public interface BarrageSnapshot {
     }
 
     /**
-     * Request a full snapshot of the data and populate a {@link Table} with the data that is received.
+     * Request a full snapshot of the data and populate a {@link Table} with the data that is received. The returned
+     * future will block until all rows for the snapshot table are available.
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated with the snapshot
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> entireTable();
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
-     * data that is received.
+     * data that is received. The returned future will block until the snapshot table viewport is satisfied.
      *
      * @param viewport the position-space viewport to use for the snapshot
      * @param columns the columns to include in the snapshot
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated with the snapshot
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> partialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
-     * data that is received. Allows the viewport to be reversed.
+     * data that is received. Allows the viewport to be reversed. The returned future will block until the snapshot
+     * table viewport is satisfied.
      *
      * @param viewport the position-space viewport to use for the snapshot
      * @param columns the columns to include in the snapshot
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated with the snapshot
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> partialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
@@ -78,7 +78,6 @@ public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements
         final BarrageUtil.ConvertedArrowSchema schema = BarrageUtil.convertArrowSchema(tableHandle.response());
         final TableDefinition tableDefinition = schema.tableDef;
         resultTable = BarrageTable.make(executorService, tableDefinition, schema.attributes, new CheckForCompletion());
-        resultTable.addParentReference(this);
 
         final MethodDescriptor<FlightData, BarrageMessage> snapshotDescriptor =
                 getClientDoExchangeDescriptor(options, schema.computeWireChunkTypes(), schema.computeWireTypes(),

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
@@ -43,10 +43,10 @@ import java.util.concurrent.locks.Condition;
  * This class is an intermediary helper class that uses a {@code DoExchange} to populate a {@link BarrageTable} using
  * snapshot data from a remote server.
  * <p>
- * Users may call {@code entireTable}, or {@code partialTable}, to initiate the gRPC call to the server. These methods
+ * Users may call {@link #entireTable}, or {@link #partialTable}, to initiate the gRPC call to the server. These methods
  * return the eventually populated {@code BarrageTable} to the user. The user must either set {@code blockUntilComplete}
- * to {@code true} or call {@code blockUntilComplete} to ensure that the {@code BarrageTable} is fully populated before
- * using it.
+ * to {@code true} or call {@link #blockUntilComplete()} to ensure that the {@code BarrageTable} is fully populated
+ * before using it.
  */
 public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements BarrageSnapshot {
     private static final Logger log = LoggerFactory.getLogger(BarrageSnapshotImpl.class);

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
@@ -221,16 +221,16 @@ public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements
     @Override
     protected void destroy() {
         super.destroy();
-        cancel();
+        cancel("no longer live");
     }
 
-    private void cancel() {
+    private void cancel(@NotNull final String reason) {
         if (!tryRecordDisconnect()) {
             return;
         }
 
-        GrpcUtil.safelyCancel(observer, "Barrage snapshot is cancelled",
-                new RequestCancelledException("Barrage snapshot cancelled by client"));
+        GrpcUtil.safelyCancel(observer, "Barrage snapshot is " + reason,
+                new RequestCancelledException("Barrage snapshot is " + reason));
         cleanup();
     }
 
@@ -364,7 +364,7 @@ public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
             if (super.cancel(mayInterruptIfRunning)) {
-                BarrageSnapshotImpl.this.cancel();
+                BarrageSnapshotImpl.this.cancel("cancelled by user");
                 return true;
             }
 

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSnapshotImpl.java
@@ -306,6 +306,7 @@ public class BarrageSnapshotImpl extends ReferenceCountedLivenessNode implements
             return;
         }
 
+        resultTable.unsubscribe();
         signalCompletion(new RequestCancelledException("BarrageSnapshotImpl closed"));
         GrpcUtil.safelyCancel(observer, "BarrageSnapshotImpl closed", exceptionWhileCompleting);
     }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
@@ -5,9 +5,9 @@ package io.deephaven.client.impl;
 
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.Table;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
 import io.deephaven.engine.liveness.LivenessReferent;
-import io.deephaven.extensions.barrage.table.BarrageTable;
 import io.deephaven.qst.table.TableSpec;
 
 import java.util.BitSet;
@@ -16,7 +16,7 @@ import java.util.BitSet;
  * A {@code BarrageSubscription} represents a subscription over a table that may or may not be filtered to a viewport of
  * the remote source table.
  */
-public interface BarrageSubscription extends LivenessReferent, AutoCloseable {
+public interface BarrageSubscription extends LivenessReferent {
     interface Factory {
         /**
          * Sources a barrage subscription from a {@link TableSpec}.
@@ -47,95 +47,37 @@ public interface BarrageSubscription extends LivenessReferent, AutoCloseable {
     boolean isCompleted();
 
     /**
-     * Request a full subscription of the data and populate a {@link BarrageTable} with the incrementally updating data
-     * that is received. This call will block until all rows for the subscribed table are available.
+     * Request a full subscription of the data and populate a {@link Table} with the incrementally updating data that is
+     * received. This call will block until all rows for the subscribed table are available.
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable entireTable() throws InterruptedException;
+    Table entireTable() throws InterruptedException;
 
     /**
-     * Request a full subscription of the data and populate a {@link BarrageTable} with the incrementally updating data
-     * that is received.
+     * Request a full subscription of the data and populate a {@link Table} with the incrementally updating data that is
+     * received.
      *
      * @param blockUntilComplete block execution until all rows for the subscribed table are available
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable entireTable(boolean blockUntilComplete) throws InterruptedException;
+    Table entireTable(boolean blockUntilComplete) throws InterruptedException;
 
     // TODO (deephaven-core#712): java-client viewport support
     /**
-     * Request a partial subscription of the data limited by viewport or column set and populate a {@link BarrageTable}
-     * with the data that is received. This call will block until the subscribed table viewport is satisfied.
-     *
-     * @param viewport the position-space viewport to use for the subscription
-     * @param columns the columns to include in the subscription
-     *
-     * @return the {@code BarrageTable}
-     */
-    BarrageTable partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
-
-    /**
-     * Request a partial subscription of the data limited by viewport or column set and populate a {@link BarrageTable}
-     * with the data that is received. Allows the viewport to be reversed. This call will block until the subscribed
-     * table viewport is satisfied.
-     *
-     * @param viewport the position-space viewport to use for the subscription
-     * @param columns the columns to include in the subscription
-     * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
-     *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
-     *
-     * @return the {@code BarrageTable}
-     */
-    BarrageTable partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
-
-    /**
-     * Request a partial subscription of the data limited by viewport or column set and populate a {@link BarrageTable}
-     * with the data that is received. Allows the viewport to be reversed.
-     *
-     * @param viewport the position-space viewport to use for the subscription
-     * @param columns the columns to include in the subscription
-     * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
-     *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
-     * @param blockUntilComplete block execution until the subscribed table viewport is satisfied
-     *
-     * @return the {@code BarrageTable}
-     */
-    BarrageTable partialTable(RowSet viewport, BitSet columns, boolean reverseViewport, boolean blockUntilComplete)
-            throws InterruptedException;
-
-    /**
-     * Request a full snapshot of the data and populate a {@link BarrageTable} with the incrementally updating data that
-     * is received. This call will block until all rows for the subscribed table are available.
-     *
-     * @return the {@code BarrageTable}
-     */
-    BarrageTable snapshotEntireTable() throws InterruptedException;
-
-    /**
-     * Request a full snapshot of the data and populate a {@link BarrageTable} with the incrementally updating data that
-     * is received.
-     *
-     * @param blockUntilComplete block execution until all rows for the subscribed table are available
-     *
-     * @return the {@code BarrageTable}
-     */
-    BarrageTable snapshotEntireTable(boolean blockUntilComplete) throws InterruptedException;
-
-    /**
-     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link BarrageTable} with
+     * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
      * the data that is received. This call will block until the subscribed table viewport is satisfied.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable snapshotPartialTable(RowSet viewport, BitSet columns) throws InterruptedException;
+    Table partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
 
     /**
-     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link BarrageTable} with
+     * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
      * the data that is received. Allows the viewport to be reversed. This call will block until the subscribed table
      * viewport is satisfied.
      *
@@ -144,14 +86,13 @@ public interface BarrageSubscription extends LivenessReferent, AutoCloseable {
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport)
-            throws InterruptedException;
+    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
 
     /**
-     * Request a snapshot of the data limited by viewport or column set and populate a {@link BarrageTable} with the
-     * data that is received. Allows the viewport to be reversed.
+     * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
+     * the data that is received. Allows the viewport to be reversed.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
@@ -159,9 +100,68 @@ public interface BarrageSubscription extends LivenessReferent, AutoCloseable {
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      * @param blockUntilComplete block execution until the subscribed table viewport is satisfied
      *
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport,
+    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport, boolean blockUntilComplete)
+            throws InterruptedException;
+
+    /**
+     * Request a full snapshot of the data and populate a {@link Table} with the incrementally updating data that is
+     * received. This call will block until all rows for the subscribed table are available.
+     *
+     * @return the {@code Table}
+     */
+    Table snapshotEntireTable() throws InterruptedException;
+
+    /**
+     * Request a full snapshot of the data and populate a {@link Table} with the incrementally updating data that is
+     * received.
+     *
+     * @param blockUntilComplete block execution until all rows for the subscribed table are available
+     *
+     * @return the {@code Table}
+     */
+    Table snapshotEntireTable(boolean blockUntilComplete) throws InterruptedException;
+
+    /**
+     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
+     * data that is received. This call will block until the subscribed table viewport is satisfied.
+     *
+     * @param viewport the position-space viewport to use for the subscription
+     * @param columns the columns to include in the subscription
+     *
+     * @return the {@code Table}
+     */
+    Table snapshotPartialTable(RowSet viewport, BitSet columns) throws InterruptedException;
+
+    /**
+     * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
+     * data that is received. Allows the viewport to be reversed. This call will block until the subscribed table
+     * viewport is satisfied.
+     *
+     * @param viewport the position-space viewport to use for the subscription
+     * @param columns the columns to include in the subscription
+     * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
+     *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
+     *
+     * @return the {@code Table}
+     */
+    Table snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport)
+            throws InterruptedException;
+
+    /**
+     * Request a snapshot of the data limited by viewport or column set and populate a {@link Table} with the data that
+     * is received. Allows the viewport to be reversed.
+     *
+     * @param viewport the position-space viewport to use for the subscription
+     * @param columns the columns to include in the subscription
+     * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
+     *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
+     * @param blockUntilComplete block execution until the subscribed table viewport is satisfied
+     *
+     * @return the {@code Table}
+     */
+    Table snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport,
             boolean blockUntilComplete)
             throws InterruptedException;
 
@@ -175,10 +175,12 @@ public interface BarrageSubscription extends LivenessReferent, AutoCloseable {
      *
      * @throws InterruptedException if the current thread is interrupted while waiting for completion
      * @throws UncheckedDeephavenException if an error occurred while handling the subscription
-     * @return the {@code BarrageTable}
+     * @return the {@code Table}
      */
-    BarrageTable blockUntilComplete() throws InterruptedException;
+    Table blockUntilComplete() throws InterruptedException;
 
-    @Override
-    void close();
+    /**
+     * Cancel the subscription.
+     */
+    void cancel();
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
@@ -7,7 +7,6 @@ import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
-import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.qst.table.TableSpec;
 
 import java.util.BitSet;
@@ -16,7 +15,7 @@ import java.util.BitSet;
  * A {@code BarrageSubscription} represents a subscription over a table that may or may not be filtered to a viewport of
  * the remote source table.
  */
-public interface BarrageSubscription extends LivenessReferent {
+public interface BarrageSubscription {
     interface Factory {
         /**
          * Sources a barrage subscription from a {@link TableSpec}.

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
@@ -39,9 +39,9 @@ public interface BarrageSubscription {
     }
 
     /**
-     * This call will return false until all rows for the subscribed table are available.
+     * This call will return false until all rows for the subscribed table are available or the subscription failed.
      *
-     * @return true when all rows for the subscribed table are available, false otherwise
+     * @return true when all rows for the subscribed table are available or the subscription failed, false otherwise
      */
     boolean isCompleted();
 

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
@@ -40,78 +40,68 @@ public interface BarrageSubscription {
 
     /**
      * Request a full subscription of the data and populate a {@link Table} with the incrementally updating data that is
-     * received.
+     * received. The returned future will block until all rows for the subscribed table are available.
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated when the result table is ready
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> entireTable();
 
     // TODO (deephaven-core#712): java-client viewport support
     /**
      * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
-     * the data that is received.
+     * the data that is received. The returned future will block until the subscribed table viewport is satisfied.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated when the result table is ready
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> partialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
-     * the data that is received. Allows the viewport to be reversed.
+     * the data that is received. Allows the viewport to be reversed. The returned future will block until the
+     * subscribed table viewport is satisfied.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated when the result table is ready
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> partialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 
     /**
      * Request a full snapshot of the data and populate a {@link Table} with the incrementally updating data that is
-     * received.
+     * received. The returned future will block until all rows for the snapshot table are available.
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated when the result snapshot table is ready
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> snapshotEntireTable();
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
-     * data that is received.
+     * data that is received. The returned future will block until the snapshot table viewport is satisfied.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated when the result snapshot table is ready
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> snapshotPartialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
-     * data that is received. Allows the viewport to be reversed.
+     * data that is received. Allows the viewport to be reversed. The returned future will block until the snapshot
+     * table viewport is satisfied.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return a {@link Future
-     *         <Table>
-     *         } that will be populated when the result snapshot table is ready
+     * @return a {@link Future} that will be populated with the result {@link Table}
      */
     Future<Table> snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
@@ -40,68 +40,78 @@ public interface BarrageSubscription {
 
     /**
      * Request a full subscription of the data and populate a {@link Table} with the incrementally updating data that is
-     * received. This call will block until all rows for the subscribed table are available.
+     * received.
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated when the result table is ready
      */
     Future<Table> entireTable();
 
     // TODO (deephaven-core#712): java-client viewport support
     /**
      * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
-     * the data that is received. This call will block until the subscribed table viewport is satisfied.
+     * the data that is received.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated when the result table is ready
      */
     Future<Table> partialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
-     * the data that is received. Allows the viewport to be reversed. This call will block until the subscribed table
-     * viewport is satisfied.
+     * the data that is received. Allows the viewport to be reversed.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated when the result table is ready
      */
     Future<Table> partialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 
     /**
      * Request a full snapshot of the data and populate a {@link Table} with the incrementally updating data that is
-     * received. This call will block until all rows for the subscribed table are available.
+     * received.
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated when the result snapshot table is ready
      */
     Future<Table> snapshotEntireTable();
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
-     * data that is received. This call will block until the subscribed table viewport is satisfied.
+     * data that is received.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated when the result snapshot table is ready
      */
     Future<Table> snapshotPartialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
-     * data that is received. Allows the viewport to be reversed. This call will block until the subscribed table
-     * viewport is satisfied.
+     * data that is received. Allows the viewport to be reversed.
      *
      * @param viewport the position-space viewport to use for the subscription
      * @param columns the columns to include in the subscription
      * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
      *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
      *
-     * @return the {@code Table}
+     * @return a {@link Future
+     *         <Table>
+     *         } that will be populated when the result snapshot table is ready
      */
     Future<Table> snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscription.java
@@ -3,13 +3,13 @@
  */
 package io.deephaven.client.impl;
 
-import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.extensions.barrage.BarrageSubscriptionOptions;
 import io.deephaven.qst.table.TableSpec;
 
 import java.util.BitSet;
+import java.util.concurrent.Future;
 
 /**
  * A {@code BarrageSubscription} represents a subscription over a table that may or may not be filtered to a viewport of
@@ -39,29 +39,12 @@ public interface BarrageSubscription {
     }
 
     /**
-     * This call will return false until all rows for the subscribed table are available or the subscription failed.
-     *
-     * @return true when all rows for the subscribed table are available or the subscription failed, false otherwise
-     */
-    boolean isCompleted();
-
-    /**
      * Request a full subscription of the data and populate a {@link Table} with the incrementally updating data that is
      * received. This call will block until all rows for the subscribed table are available.
      *
      * @return the {@code Table}
      */
-    Table entireTable() throws InterruptedException;
-
-    /**
-     * Request a full subscription of the data and populate a {@link Table} with the incrementally updating data that is
-     * received.
-     *
-     * @param blockUntilComplete block execution until all rows for the subscribed table are available
-     *
-     * @return the {@code Table}
-     */
-    Table entireTable(boolean blockUntilComplete) throws InterruptedException;
+    Future<Table> entireTable();
 
     // TODO (deephaven-core#712): java-client viewport support
     /**
@@ -73,7 +56,7 @@ public interface BarrageSubscription {
      *
      * @return the {@code Table}
      */
-    Table partialTable(RowSet viewport, BitSet columns) throws InterruptedException;
+    Future<Table> partialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
@@ -87,22 +70,7 @@ public interface BarrageSubscription {
      *
      * @return the {@code Table}
      */
-    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport) throws InterruptedException;
-
-    /**
-     * Request a partial subscription of the data limited by viewport or column set and populate a {@link Table} with
-     * the data that is received. Allows the viewport to be reversed.
-     *
-     * @param viewport the position-space viewport to use for the subscription
-     * @param columns the columns to include in the subscription
-     * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
-     *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
-     * @param blockUntilComplete block execution until the subscribed table viewport is satisfied
-     *
-     * @return the {@code Table}
-     */
-    Table partialTable(RowSet viewport, BitSet columns, boolean reverseViewport, boolean blockUntilComplete)
-            throws InterruptedException;
+    Future<Table> partialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 
     /**
      * Request a full snapshot of the data and populate a {@link Table} with the incrementally updating data that is
@@ -110,17 +78,7 @@ public interface BarrageSubscription {
      *
      * @return the {@code Table}
      */
-    Table snapshotEntireTable() throws InterruptedException;
-
-    /**
-     * Request a full snapshot of the data and populate a {@link Table} with the incrementally updating data that is
-     * received.
-     *
-     * @param blockUntilComplete block execution until all rows for the subscribed table are available
-     *
-     * @return the {@code Table}
-     */
-    Table snapshotEntireTable(boolean blockUntilComplete) throws InterruptedException;
+    Future<Table> snapshotEntireTable();
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
@@ -131,7 +89,7 @@ public interface BarrageSubscription {
      *
      * @return the {@code Table}
      */
-    Table snapshotPartialTable(RowSet viewport, BitSet columns) throws InterruptedException;
+    Future<Table> snapshotPartialTable(RowSet viewport, BitSet columns);
 
     /**
      * Request a partial snapshot of the data limited by viewport or column set and populate a {@link Table} with the
@@ -145,41 +103,5 @@ public interface BarrageSubscription {
      *
      * @return the {@code Table}
      */
-    Table snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport)
-            throws InterruptedException;
-
-    /**
-     * Request a snapshot of the data limited by viewport or column set and populate a {@link Table} with the data that
-     * is received. Allows the viewport to be reversed.
-     *
-     * @param viewport the position-space viewport to use for the subscription
-     * @param columns the columns to include in the subscription
-     * @param reverseViewport Whether to treat {@code posRowSet} as offsets from
-     *        {@link io.deephaven.engine.table.Table#size()} rather than {@code 0}
-     * @param blockUntilComplete block execution until the subscribed table viewport is satisfied
-     *
-     * @return the {@code Table}
-     */
-    Table snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport,
-            boolean blockUntilComplete)
-            throws InterruptedException;
-
-    /**
-     * Block until the subscription is complete.
-     * <p>
-     * It is an error to {@code blockUntilComplete} if the current thread holds the result table's UpdateGraph shared
-     * lock. If the current thread holds the result table's UpdateGraph exclusive lock, then this method will use an
-     * update graph condition variable to wait for completion. Otherwise, this method will use the subscription's object
-     * monitor to wait for completion.
-     *
-     * @throws InterruptedException if the current thread is interrupted while waiting for completion
-     * @throws UncheckedDeephavenException if an error occurred while handling the subscription
-     * @return the {@code Table}
-     */
-    Table blockUntilComplete() throws InterruptedException;
-
-    /**
-     * Cancel the subscription.
-     */
-    void cancel();
+    Future<Table> snapshotPartialTable(RowSet viewport, BitSet columns, boolean reverseViewport);
 }

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -359,6 +359,7 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
             return;
         }
 
+        resultTable.unsubscribe();
         signalCompletion(new RequestCancelledException("BarrageSubscriptionImpl closed"));
         GrpcUtil.safelyComplete(observer);
         cleanup();

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -345,8 +345,9 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
 
         // if we are building a snapshot via a growing viewport subscription, then cancel our subscription
         if (isSnapshot) {
-            tryRecordDisconnect();
-            GrpcUtil.safelyCancel(observer, "Barrage snapshot is complete", null);
+            if (tryRecordDisconnect()) {
+                GrpcUtil.safelyCancel(observer, "Barrage snapshot is complete", null);
+            }
         }
 
         final Condition localCondition = completedCondition;

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -345,6 +345,7 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
 
         // if we are building a snapshot via a growing viewport subscription, then cancel our subscription
         if (isSnapshot) {
+            tryRecordDisconnect();
             GrpcUtil.safelyCancel(observer, "Barrage snapshot is complete", null);
         }
 

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -250,8 +250,9 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
     protected void destroy() {
         super.destroy();
         cancel("no longer live");
-        if (future != null) {
-            future.completeExceptionally(new RequestCancelledException("Barrage subscription is no longer live"));
+        final FutureAdapter localFuture = future;
+        if (localFuture != null) {
+            localFuture.completeExceptionally(new RequestCancelledException("Barrage subscription is no longer live"));
         }
     }
 

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -43,26 +43,26 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * This class is an intermediary helper class that uses a {@code DoExchange} to populate, and propagate updates if the
- * request is not a snapshot, to a {@link BarrageTable} using subscription data from a remote server.
+ * This class is an intermediary helper class that uses a {@code DoExchange} to populate a {@link BarrageTable} using
+ * subscription data from a remote server, propagating updates if the request is a subscription.
  * <p>
- * For Subscriptions (refreshing tables):
+ * For Subscriptions (refreshing result tables):
  * <p>
- * Users may call {@code entireTable}, or {@code partialTable}, to initiate the gRPC call to the server. These methods
+ * Users may call {@link #entireTable} or {@link #partialTable} to initiate the gRPC call to the server. These methods
  * return the eventually populated {@code BarrageTable} to the user.
  * <p>
  * If the user wants to ensure that the table is completely populated with an initial state of the remote table prior to
- * using the result they must either set {@code blockUntilComplete} to {@code true} or call {@code blockUntilComplete}
- * to ensure that the {@code BarrageTable} is respecting the requested subscription.
+ * using the result they must either set {@code blockUntilComplete} to {@code true} or call
+ * {@link #blockUntilComplete()} to ensure that the {@code BarrageTable} is respecting the requested subscription.
  * <p>
  * It is not an error to create derived tables from the {@code BarrageTable} prior to the subscription being complete,
  * as all changes are propagated to downstream tables.
  * <p>
- * For Snapshots (static tables):
+ * For Snapshots (static result tables):
  * <p>
- * Users may call {@code snapshotEntireTable}, or {@code snapshotPartialTable}, to initiate the gRPC call to the server.
+ * Users may call {@link #snapshotEntireTable} or {@link #snapshotPartialTable} to initiate the gRPC call to the server.
  * These methods return the eventually populated {@code BarrageTable} to the user. The user must either set
- * {@code blockUntilComplete} to {@code true} during initiation or call {@code blockUntilComplete} to ensure that the
+ * {@code blockUntilComplete} to {@code true} during initiation or call {@link #blockUntilComplete()} to ensure that the
  * {@code BarrageTable} is fully populated before using it. Noting that snapshots are static tables that do not
  * propagate changes on any update graph.
  */

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -658,6 +658,12 @@ public class ArrowFlightUtil {
                 final Object export = parent.get();
                 if (export instanceof QueryTable) {
                     final QueryTable table = (QueryTable) export;
+
+                    if (table.isFailed()) {
+                        throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
+                                "Table is already failed");
+                    }
+
                     final UpdateGraph ug = table.getUpdateGraph();
                     try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(ug).open()) {
                         bmp = table.getResult(bmpOperationFactory.create(table, minUpdateIntervalMs));

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -494,6 +494,11 @@ public class ArrowFlightUtil {
                                 metrics.tableId = Integer.toHexString(System.identityHashCode(table));
                                 metrics.tableKey = BarragePerformanceLog.getKeyFor(table);
 
+                                if (table.isFailed()) {
+                                    throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
+                                            "Table is already failed");
+                                }
+
                                 // push the schema to the listener
                                 listener.onNext(streamGeneratorFactory.getSchemaView(
                                         fbb -> BarrageUtil.makeTableSchemaPayload(fbb,

--- a/server/src/main/java/io/deephaven/server/uri/BarrageTableResolver.java
+++ b/server/src/main/java/io/deephaven/server/uri/BarrageTableResolver.java
@@ -238,9 +238,7 @@ public final class BarrageTableResolver implements UriResolver {
     public Table snapshot(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options)
             throws TableHandleException, InterruptedException {
         final BarrageSession session = session(target);
-        try (final BarrageSubscription sub = session.subscribe(table, options)) {
-            return sub.snapshotEntireTable();
-        }
+        return session.subscribe(table, options).snapshotEntireTable();
     }
 
     /**
@@ -290,9 +288,7 @@ public final class BarrageTableResolver implements UriResolver {
             BitSet columns, boolean reverseViewport)
             throws TableHandleException, InterruptedException {
         final BarrageSession session = session(target);
-        try (final BarrageSubscription sub = session.subscribe(table, options)) {
-            return sub.snapshotPartialTable(viewport, columns, reverseViewport);
-        }
+        return session.subscribe(table, options).snapshotPartialTable(viewport, columns, reverseViewport);
     }
 
     private BarrageSession session(DeephavenTarget target) {

--- a/server/src/main/java/io/deephaven/server/uri/BarrageTableResolver.java
+++ b/server/src/main/java/io/deephaven/server/uri/BarrageTableResolver.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -102,7 +103,7 @@ public final class BarrageTableResolver implements UriResolver {
     }
 
     @Override
-    public Table resolve(URI uri) throws InterruptedException {
+    public Future<Table> resolve(URI uri) throws InterruptedException {
         try {
             return subscribe(RemoteUri.of(uri));
         } catch (TableHandleException e) {
@@ -116,7 +117,7 @@ public final class BarrageTableResolver implements UriResolver {
      * @param remoteUri the remote URI
      * @return the subscribed table
      */
-    public Table subscribe(RemoteUri remoteUri) throws InterruptedException, TableHandleException {
+    public Future<Table> subscribe(RemoteUri remoteUri) throws InterruptedException, TableHandleException {
         final DeephavenTarget target = remoteUri.target();
         final TableSpec table = RemoteResolver.of(remoteUri);
         return subscribe(target, table, SUB_OPTIONS);
@@ -129,7 +130,8 @@ public final class BarrageTableResolver implements UriResolver {
      * @param table the table spec
      * @return the subscribed table
      */
-    public Table subscribe(String targetUri, TableSpec table) throws TableHandleException, InterruptedException {
+    public Future<Table> subscribe(String targetUri, TableSpec table)
+            throws TableHandleException, InterruptedException {
         return subscribe(DeephavenTarget.of(URI.create(targetUri)), table, SUB_OPTIONS);
     }
 
@@ -141,7 +143,7 @@ public final class BarrageTableResolver implements UriResolver {
      * @param options the options
      * @return the subscribed table
      */
-    public Table subscribe(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options)
+    public Future<Table> subscribe(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options)
             throws TableHandleException, InterruptedException {
         final BarrageSession session = session(target);
         final BarrageSubscription sub = session.subscribe(table, options);
@@ -157,7 +159,7 @@ public final class BarrageTableResolver implements UriResolver {
      * @param columns the columns to include in the subscription
      * @return the subscribed table
      */
-    public Table subscribe(String targetUri, TableSpec table, RowSet viewport, BitSet columns)
+    public Future<Table> subscribe(String targetUri, TableSpec table, RowSet viewport, BitSet columns)
             throws TableHandleException, InterruptedException {
         return subscribe(DeephavenTarget.of(URI.create(targetUri)), table, SUB_OPTIONS, viewport, columns, false);
     }
@@ -173,7 +175,8 @@ public final class BarrageTableResolver implements UriResolver {
      *        {@code 0}
      * @return the subscribed table
      */
-    public Table subscribe(String targetUri, TableSpec table, RowSet viewport, BitSet columns, boolean reverseViewport)
+    public Future<Table> subscribe(String targetUri, TableSpec table, RowSet viewport, BitSet columns,
+            boolean reverseViewport)
             throws TableHandleException, InterruptedException {
         return subscribe(DeephavenTarget.of(URI.create(targetUri)), table, SUB_OPTIONS, viewport, columns,
                 reverseViewport);
@@ -191,7 +194,8 @@ public final class BarrageTableResolver implements UriResolver {
      *        {@code 0}
      * @return the subscribed table
      */
-    public Table subscribe(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options, RowSet viewport,
+    public Future<Table> subscribe(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options,
+            RowSet viewport,
             BitSet columns, boolean reverseViewport)
             throws TableHandleException, InterruptedException {
         final BarrageSession session = session(target);
@@ -210,7 +214,7 @@ public final class BarrageTableResolver implements UriResolver {
      * @param remoteUri the remote URI
      * @return the table to snapshot
      */
-    public Table snapshot(RemoteUri remoteUri) throws InterruptedException, TableHandleException {
+    public Future<Table> snapshot(RemoteUri remoteUri) throws InterruptedException, TableHandleException {
         final DeephavenTarget target = remoteUri.target();
         final TableSpec table = RemoteResolver.of(remoteUri);
         return snapshot(target, table, SUB_OPTIONS);
@@ -223,7 +227,7 @@ public final class BarrageTableResolver implements UriResolver {
      * @param table the table spec
      * @return the table to snapshot
      */
-    public Table snapshot(String targetUri, TableSpec table) throws TableHandleException, InterruptedException {
+    public Future<Table> snapshot(String targetUri, TableSpec table) throws TableHandleException, InterruptedException {
         return snapshot(DeephavenTarget.of(URI.create(targetUri)), table, SUB_OPTIONS);
     }
 
@@ -235,7 +239,7 @@ public final class BarrageTableResolver implements UriResolver {
      * @param options the options
      * @return the table to snapshot
      */
-    public Table snapshot(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options)
+    public Future<Table> snapshot(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options)
             throws TableHandleException, InterruptedException {
         final BarrageSession session = session(target);
         return session.subscribe(table, options).snapshotEntireTable();
@@ -250,7 +254,7 @@ public final class BarrageTableResolver implements UriResolver {
      * @param columns the columns to include in the snapshot
      * @return the table to snapshot
      */
-    public Table snapshot(String targetUri, TableSpec table, RowSet viewport, BitSet columns)
+    public Future<Table> snapshot(String targetUri, TableSpec table, RowSet viewport, BitSet columns)
             throws TableHandleException, InterruptedException {
         return snapshot(DeephavenTarget.of(URI.create(targetUri)), table, SUB_OPTIONS, viewport, columns, false);
     }
@@ -266,7 +270,8 @@ public final class BarrageTableResolver implements UriResolver {
      *        {@code 0}
      * @return the table to snapshot
      */
-    public Table snapshot(String targetUri, TableSpec table, RowSet viewport, BitSet columns, boolean reverseViewport)
+    public Future<Table> snapshot(String targetUri, TableSpec table, RowSet viewport, BitSet columns,
+            boolean reverseViewport)
             throws TableHandleException, InterruptedException {
         return snapshot(DeephavenTarget.of(URI.create(targetUri)), table, SUB_OPTIONS, viewport, columns,
                 reverseViewport);
@@ -284,7 +289,8 @@ public final class BarrageTableResolver implements UriResolver {
      *        {@code 0}
      * @return the table to snapshot
      */
-    public Table snapshot(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options, RowSet viewport,
+    public Future<Table> snapshot(DeephavenTarget target, TableSpec table, BarrageSubscriptionOptions options,
+            RowSet viewport,
             BitSet columns, boolean reverseViewport)
             throws TableHandleException, InterruptedException {
         final BarrageSession session = session(target);


### PR DESCRIPTION
Fix #4675 

This includes breaking changes to the barrage java-client API. The snapshot/subscription methods now return `Future<Table>` instead of `BarrageTable` and users are no longer required to `blockUntilCompletion` as this is handled by `Future#get`.

Subscribed tables can now be canceled only through `Liveness` destruction such as using an explicit `LivenessScope` or invoking `ReferenceCounted#forceReferenceCountToZero()`.