### PR TITLE
Create a dockerized gradle task to update the generated R client documentation.

### DIFF
--- a/R/build.gradle
+++ b/R/build.gradle
@@ -33,7 +33,6 @@ def buildRClient = Docker.registerDockerTask(project, 'rClient') {
     copyIn {
         from(layout.projectDirectory) {
             include 'r-build.sh'
-            include 'r-tests.sh'
             include 'rdeephaven/DESCRIPTION'
             include 'rdeephaven/LICENSE'
             include 'rdeephaven/NAMESPACE'
@@ -67,7 +66,6 @@ def buildRClient = Docker.registerDockerTask(project, 'rClient') {
         copyFile('rdeephaven/R/', "${prefix}/src/rdeephaven/R/")
         copyFile('rdeephaven/src/*.cpp', "${prefix}/src/rdeephaven/src/")
         copyFile('rdeephaven/src/Makevars', "${prefix}/src/rdeephaven/src/")
-        copyFile('r-tests.sh', "${prefix}/bin/rdeephaven")
         copyFile('r-build.sh', "${prefix}/bin/rdeephaven")
         runCommand("PREFIX=${prefix}; " +
                   '''set -eux ; \
@@ -93,6 +91,7 @@ def testRClient = Docker.registerDockerTask(project, 'testRClient') {
     }
     dockerfile {
         from('deephaven/r-client:local-build')
+        copyFile('r-tests.sh', "${prefix}/bin/rdeephaven")
         //
         // Setup for test run; we should be inheriting other env vars
         // like LD_LIBRARY_PATH from the cpp-client image.
@@ -105,6 +104,67 @@ def testRClient = Docker.registerDockerTask(project, 'testRClient') {
     network = deephavenDocker.networkName.get()
     parentContainers = [ project.tasks.getByName('rClient') ]
     entrypoint = ["${prefix}/bin/rdeephaven/r-tests.sh", '/out/r-test.xml', '/out/r-test.log']
+}
+
+def rClientDoc = Docker.registerDockerTask(project, 'rClientDoc') {
+    // Only tested on x86-64, and we only build dependencies for x86-64
+    platform = 'linux/amd64'
+    copyIn {
+        from(layout.projectDirectory) {
+            include 'r-doc.sh'
+        }
+    }
+    copyOut {
+        into layout.buildDirectory.dir('man')
+    }
+    dockerfile {
+        from('deephaven/r-client:local-build')
+        runCommand('''set -eux; \
+                      rm -fr /out; \
+                      mkdir -p /out; \
+                      apt-get -qq update; \
+                      apt-get -qq -y --no-install-recommends install \
+                        libcurl4-openssl-dev \
+                        libfontconfig1-dev \
+                        libxml2-dev \
+                        libharfbuzz-dev \
+                        libfribidi-dev \
+                        libfreetype6-dev \
+                        libpng-dev \
+                        libtiff5-dev \
+                        libjpeg-dev \
+                        ; \
+                      rm -rf /var/lib/apt/lists/*
+                   ''')
+        runCommand('''echo "status = tryCatch(" \
+                           "   {" \
+                           "      install.packages('roxygen2', repos='http://cran.us.r-project.org'); " \
+                           "      0" \
+                           "   }," \
+                           "  error=function(e) 1," \
+                           "  warning=function(w) 2" \
+                           ");" \
+                           "print(paste0('status=', status));" \
+                           "quit(save='no', status=status)" | \
+                        MAKE="make -j`getconf _NPROCESSORS_ONLN`" R --no-save --no-restore
+                   ''')
+        // Keep this after the package installs above;
+        // it is likely it changes more frequently.
+        copyFile('r-doc.sh', "${prefix}/bin/rdeephaven")
+    }
+    parentContainers = [ project.tasks.getByName('rClient') ]
+    entrypoint = ["${prefix}/bin/rdeephaven/r-doc.sh", '/out']
+}
+
+task updateRClientDoc {
+    dependsOn rClientDoc
+    doLast {
+        exec {
+            workingDir '.'
+            commandLine 'rm', '-f', 'man/*'
+            commandLine 'tar', '-C', 'rdeephaven', '-zxvf', 'build/man/man.tgz'
+        }
+    }
 }
 
 deephavenDocker.shouldLogIfTaskFails testRClient

--- a/R/r-doc.sh
+++ b/R/r-doc.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 output-dir" 1>&2
+    exit 1
+fi
+
+if [ -z "${DH_PREFIX}" ]; then
+    echo "$0: Environment variable DH_PREFIX is not set, aborting." 1>&2
+    exit 1
+fi
+
+source $DH_PREFIX/env.sh
+
+cd $DH_PREFIX/src/rdeephaven
+
+OUT_DIR="$1"
+
+R --no-save --no-restore <<EOF
+library('roxygen2')
+status = tryCatch(
+  {
+     roxygen2::roxygenize()
+     0
+  },
+  error=function(e) 1
+)
+print(paste0('status=', status))
+quit(save='no', status=status)
+EOF
+
+tar -zcf $OUT_DIR/man.tgz man
+
+exit 0


### PR DESCRIPTION
Towards #4689

This PR adds two new gradle tasks to `R/build.gradle`:
* `rClientDoc` creates a docker image with R doc support and runs it in a container generating a tar bundle in `build/man/man.tar.gz` with the updated documentation.
* `updateRClientDoc` overwrites the contents of `R/rdeephaven/man` with the newly generated doc by the task above.

You can run either (they have proper dependencies) like so, from the root of a `deephave-core` clone:
`./gradlew :R:rClientDoc`
`./gradlew :R:updateRClientDoc`

Notes

* Something that is less than ideal in terms of dependencies is that R/roxygen2 (the package/tool that generates doc) requires the package that we intend to document (eg, rdeephaven) to be already installed.  This implies we are forced to have the image that supports generating documentation depend on the image that builds the rdeephaven package; this is unfortunate because the image that supports generating documentation has to install a lot of base OS packages and then build the roxygen2 R package; all this does not depend on any way on our own rdeephaven sources, however, since the image depends on a base image that builds from those sources, any changes in rdeephaven sources will trigger dependencies in a way that will regenerate the documentation base image which will require reinstalling the OS base packages and roxygen2 in R, etc.  We could make this less expensive by making all these additional OS packages and R roxygen package installation be part already of the `cpp-clients-multi-base` image from the `deephaven-base-images` repository... but then we will be taxing every deephaven developer who does not need to work on R related changes with a constant tax.  So I think the tradeoff right now is to make this slightly less convenient to R developers only on the specific instance when doc needs to be regenerated in favor of avoiding that tax for everybody else on any and every change.