### PR TITLE
Barrage Protocol: Fix Writer of `byte[]` to Use Var Binary Encoding

### DIFF
--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/generator/ByteArrayGenerator.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/generator/ByteArrayGenerator.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.testutil.generator;
+
+import java.util.Random;
+
+public class ByteArrayGenerator extends AbstractGenerator<byte[]> {
+    private final byte min;
+    private final byte max;
+    private final int minSize;
+    private final int maxSize;
+
+    public ByteArrayGenerator(byte min, byte max, int minSize, int maxSize) {
+        this.min = min;
+        this.max = max;
+        this.minSize = minSize;
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    public Class<byte[]> getType() {
+        return byte[].class;
+    }
+
+    @Override
+    byte[] nextValue(Random random) {
+        final int size = random.nextInt(maxSize - minSize) + minSize;
+        final byte[] arr = new byte[size];
+        for (int ii = 0; ii < size; ii++) {
+            arr[ii] = (byte) (random.nextInt(max - min) + min);
+        }
+        return arr;
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
@@ -64,7 +64,12 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
                 return new DoubleChunkInputStreamGenerator(chunk.asDoubleChunk(), Double.BYTES, rowOffset);
             case Object:
                 if (type.isArray()) {
-                    return new VarListChunkInputStreamGenerator<>(type, chunk.asObjectChunk(), rowOffset);
+                    if (componentType == byte.class) {
+                        return new VarBinaryChunkInputStreamGenerator<>(chunk.asObjectChunk(), rowOffset,
+                                (out, item) -> out.write((byte[]) item));
+                    } else {
+                        return new VarListChunkInputStreamGenerator<>(type, chunk.asObjectChunk(), rowOffset);
+                    }
                 }
                 if (Vector.class.isAssignableFrom(type)) {
                     //noinspection unchecked
@@ -205,7 +210,7 @@ public interface ChunkInputStreamGenerator extends SafeCloseable {
                         Double.BYTES, options,fieldNodeIter, bufferInfoIter, is, outChunk, outOffset, totalRows);
             case Object:
                 if (type.isArray()) {
-                    if(componentType == byte.class) {
+                    if (componentType == byte.class) {
                         return VarBinaryChunkInputStreamGenerator.extractChunkFromInputStream(
                               is,
                               fieldNodeIter,

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -1287,7 +1287,8 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
                         public void createTable() {
                             columnInfo = initColumnInfos(
                                     new String[] {"longCol", "intCol", "objCol", "byteCol", "doubleCol", "floatCol",
-                                            "shortCol", "charCol", "boolCol", "strArrCol", "datetimeCol"},
+                                            "shortCol", "charCol", "boolCol", "strArrCol", "datetimeCol",
+                                            "bytePrimArray", "intPrimArray"},
                                     new SortedLongGenerator(0, Long.MAX_VALUE - 1),
                                     new IntGenerator(10, 100, 0.1),
                                     new SetGenerator<>("a", "b", "c", "d"), // covers object
@@ -1301,7 +1302,11 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
                                             new String[] {}, null),
                                     new UnsortedInstantGenerator(
                                             DateTimeUtils.parseInstant("2020-02-14T00:00:00 NY"),
-                                            DateTimeUtils.parseInstant("2020-02-25T00:00:00 NY")));
+                                            DateTimeUtils.parseInstant("2020-02-25T00:00:00 NY")),
+                                    // uses var binary encoding
+                                    new ByteArrayGenerator(Byte.MIN_VALUE, Byte.MAX_VALUE, 0, 32),
+                                    // uses var list encoding
+                                    new IntArrayGenerator(0, Integer.MAX_VALUE, 0, 32));
                             sourceTable = getTable(size / 4, random, columnInfo);
                         }
                     };


### PR DESCRIPTION
Thanks to @abaranec who noticed the lack of symmetry between writer and reader.

Indeed the transport VarBinary encoding is not equal to VarList<Byte> encoding as verified by the test I added that broke.

I also verified that the UI continues to properly handle byte[] (it uses a stringified preview column).