### PR TITLE
Fix NullPointerException if connection is closed after server goes away

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -673,7 +673,10 @@ public class WorkerConnection {
         }
 
         newSessionReconnect.disconnected();
-        DomGlobal.clearTimeout(scheduledAuthUpdate);
+        if (scheduledAuthUpdate != null) {
+            DomGlobal.clearTimeout(scheduledAuthUpdate);
+            scheduledAuthUpdate = null;
+        }
     }
 
     public void setSessionTimeoutMs(double sessionTimeoutMs) {


### PR DESCRIPTION
Issue arose from docs snapshot testing where I was restarting the server and then calling `connection.disconnect()`. Tested w/ local build that docs tool now does not throw NullPointerException in that case