### PR TITLE
Update cpp-client headers

### DIFF
--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_column_source.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_column_source.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 #include <string>

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_value_converter.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_value_converter.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_visitors.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_visitors.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/aggregate_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/aggregate_impl.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/client_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/client_impl.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/escape_utils.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/escape_utils.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_impl.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_manager_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_manager_impl.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/update_by_operation_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/update_by_operation_impl.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/util.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/util.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/server/server.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/server/server.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/subscription/subscribe_thread.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/subscription/subscribe_thread.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/subscription/subscription_handle.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/subscription/subscription_handle.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/utility/executor.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/utility/executor.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/flight.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/flight.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/update_by.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/update_by.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/misc_types.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/misc_types.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhclient/src/client_options.cc
+++ b/cpp-client/deephaven/dhclient/src/client_options.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/client_options.h"
 #include "deephaven/dhcore/utility/utility.h"

--- a/cpp-client/deephaven/dhclient/src/flight.cc
+++ b/cpp-client/deephaven/dhclient/src/flight.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/flight.h"
 #include "deephaven/client/impl/table_handle_impl.h"

--- a/cpp-client/deephaven/dhclient/src/impl/aggregate_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/aggregate_impl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/impl/aggregate_impl.h"
 

--- a/cpp-client/deephaven/dhclient/src/impl/client_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/client_impl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/impl/client_impl.h"
 

--- a/cpp-client/deephaven/dhclient/src/impl/escape_utils.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/escape_utils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/impl/escape_utils.h"
 

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/impl/table_handle_impl.h"
 

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/impl/table_handle_manager_impl.h"
 

--- a/cpp-client/deephaven/dhclient/src/impl/update_by_operation_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/update_by_operation_impl.cc
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/impl/update_by_operation_impl.h"

--- a/cpp-client/deephaven/dhclient/src/server/server.cc
+++ b/cpp-client/deephaven/dhclient/src/server/server.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/server/server.h"
 

--- a/cpp-client/deephaven/dhclient/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/dhclient/src/subscription/subscribe_thread.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/subscription/subscribe_thread.h"
 

--- a/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/utility/arrow_util.h"
 

--- a/cpp-client/deephaven/dhclient/src/utility/executor.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/executor.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/utility/executor.h"
 

--- a/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/flight.h"
 #include "deephaven/client/flight.h"

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/abstract_flex_vector.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/abstract_flex_vector.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 #include <immer/algorithm.hpp>

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/immer_table_state.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/immer_table_state.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 #include <memory>

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/index_decoder.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/index_decoder.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/shift_processor.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/shift_processor.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/space_mapper.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/space_mapper.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/subscription_handle.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/ticking/subscription_handle.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk_maker.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk_maker.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk_traits.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk_traits.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
@@ -1,7 +1,6 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
-
 #pragma once
 
 #include "deephaven/dhcore/chunk/chunk.h"

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/buffer_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/buffer_column_source.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_helpers.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_helpers.h
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
 #pragma once
 
 #include <type_traits>

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_utils.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_utils.h
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
 #pragma once
 
 #include <type_traits>

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/row_sequence.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/row_sequence.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/barrage_processor.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/barrage_processor.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/ticking.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/ticking/ticking.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/dhcore/src/chunk/chunk.cc
+++ b/cpp-client/deephaven/dhcore/src/chunk/chunk.cc
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/utility/utility.h"

--- a/cpp-client/deephaven/dhcore/src/chunk/chunk_maker.cc
+++ b/cpp-client/deephaven/dhcore/src/chunk/chunk_maker.cc
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/chunk/chunk_maker.h"
 

--- a/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/clienttable/client_table.h"
 

--- a/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/utility/utility.h"

--- a/cpp-client/deephaven/dhcore/src/column/array_column_source.cc
+++ b/cpp-client/deephaven/dhcore/src/column/array_column_source.cc
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <cstdlib>
 #include "deephaven/dhcore/column/array_column_source.h"

--- a/cpp-client/deephaven/dhcore/src/column/column_source.cc
+++ b/cpp-client/deephaven/dhcore/src/column/column_source.cc
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/column/column_source.h"
 

--- a/cpp-client/deephaven/dhcore/src/column/column_source_helpers.cc
+++ b/cpp-client/deephaven/dhcore/src/column/column_source_helpers.cc
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
 #include "deephaven/dhcore/column/column_source_helpers.h"
 
 namespace deephaven::dhcore::column::internal {

--- a/cpp-client/deephaven/dhcore/src/column/column_source_utils.cc
+++ b/cpp-client/deephaven/dhcore/src/column/column_source_utils.cc
@@ -1,7 +1,6 @@
-/**
+/*
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
-
 #include "deephaven/dhcore/column/column_source_utils.h"
 #include "deephaven/dhcore/utility/utility.h"
 

--- a/cpp-client/deephaven/dhcore/src/container/row_sequence.cc
+++ b/cpp-client/deephaven/dhcore/src/container/row_sequence.cc
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/container/row_sequence.h"
 

--- a/cpp-client/deephaven/dhcore/src/immerutil/abstract_flex_vector.cc
+++ b/cpp-client/deephaven/dhcore/src/immerutil/abstract_flex_vector.cc
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/chunk/chunk_maker.h"

--- a/cpp-client/deephaven/dhcore/src/immerutil/immer_column_source.cc
+++ b/cpp-client/deephaven/dhcore/src/immerutil/immer_column_source.cc
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/immerutil/immer_column_source.h"
 

--- a/cpp-client/deephaven/dhcore/src/ticking/barrage_processor.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/barrage_processor.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/ticking/barrage_processor.h"
 

--- a/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/ticking/immer_table_state.h"
 

--- a/cpp-client/deephaven/dhcore/src/ticking/index_decoder.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/index_decoder.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/ticking/index_decoder.h"
 

--- a/cpp-client/deephaven/dhcore/src/ticking/shift_processor.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/shift_processor.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/ticking/shift_processor.h"
 #include "deephaven/dhcore/utility/utility.h"

--- a/cpp-client/deephaven/dhcore/src/ticking/space_mapper.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/space_mapper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/ticking/space_mapper.h"

--- a/cpp-client/deephaven/dhcore/src/ticking/ticking.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/ticking.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/ticking/ticking.h"

--- a/cpp-client/deephaven/dhcore/src/types.cc
+++ b/cpp-client/deephaven/dhcore/src/types.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/types.h"
 

--- a/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
+ */
 #include "deephaven/dhcore/utility/cython_support.h"
 
 #include <string>

--- a/cpp-client/deephaven/dhcore/src/utility/utility.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/utility/utility.h"
 

--- a/cpp-client/deephaven/examples/create_table_with_arrow_flight/main.cc
+++ b/cpp-client/deephaven/examples/create_table_with_arrow_flight/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <iostream>
 #include "deephaven/client/client.h"

--- a/cpp-client/deephaven/examples/create_table_with_table_maker/main.cc
+++ b/cpp-client/deephaven/examples/create_table_with_table_maker/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <iostream>
 #include "deephaven/client/client.h"

--- a/cpp-client/deephaven/examples/demos/chapter1.cc
+++ b/cpp-client/deephaven/examples/demos/chapter1.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <charconv>
 #include <exception>

--- a/cpp-client/deephaven/examples/demos/chapter2.cc
+++ b/cpp-client/deephaven/examples/demos/chapter2.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <charconv>
 #include <exception>

--- a/cpp-client/deephaven/examples/demos/chapter3.cc
+++ b/cpp-client/deephaven/examples/demos/chapter3.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <charconv>
 #include <exception>

--- a/cpp-client/deephaven/examples/read_csv/main.cc
+++ b/cpp-client/deephaven/examples/read_csv/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <cstdlib>
 #include <iostream>

--- a/cpp-client/deephaven/examples/read_table_with_arrow_flight/main.cc
+++ b/cpp-client/deephaven/examples/read_table_with_arrow_flight/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <iostream>
 #include "deephaven/client/client.h"

--- a/cpp-client/deephaven/tests/add_drop_test.cc
+++ b/cpp-client/deephaven/tests/add_drop_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/aggregates_test.cc
+++ b/cpp-client/deephaven/tests/aggregates_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/attributes_test.cc
+++ b/cpp-client/deephaven/tests/attributes_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <iostream>
 #include "tests/third_party/catch.hpp"

--- a/cpp-client/deephaven/tests/buffer_column_source_test.cc
+++ b/cpp-client/deephaven/tests/buffer_column_source_test.cc
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
-
 #include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/column/buffer_column_source.h"
 #include "deephaven/dhcore/container/row_sequence.h"

--- a/cpp-client/deephaven/tests/filter_test.cc
+++ b/cpp-client/deephaven/tests/filter_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <iostream>
 #include "tests/third_party/catch.hpp"

--- a/cpp-client/deephaven/tests/head_and_tail_test.cc
+++ b/cpp-client/deephaven/tests/head_and_tail_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/join_test.cc
+++ b/cpp-client/deephaven/tests/join_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/lastby_test.cc
+++ b/cpp-client/deephaven/tests/lastby_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/main.cc
+++ b/cpp-client/deephaven/tests/main.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #define CATCH_CONFIG_MAIN
 #include "tests/third_party/catch.hpp"

--- a/cpp-client/deephaven/tests/merge_tables_test.cc
+++ b/cpp-client/deephaven/tests/merge_tables_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/new_table_test.cc
+++ b/cpp-client/deephaven/tests/new_table_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <optional>
 

--- a/cpp-client/deephaven/tests/script_test.cc
+++ b/cpp-client/deephaven/tests/script_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <iostream>
 #include "tests/third_party/catch.hpp"

--- a/cpp-client/deephaven/tests/select_test.cc
+++ b/cpp-client/deephaven/tests/select_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include <iostream>
 #include "tests/third_party/catch.hpp"

--- a/cpp-client/deephaven/tests/sort_test.cc
+++ b/cpp-client/deephaven/tests/sort_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/string_filter_test.cc
+++ b/cpp-client/deephaven/tests/string_filter_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/test_util.cc
+++ b/cpp-client/deephaven/tests/test_util.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "test_util.h"
 #include "deephaven/client/utility/table_maker.h"

--- a/cpp-client/deephaven/tests/test_util.h
+++ b/cpp-client/deephaven/tests/test_util.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+/*
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #pragma once
 

--- a/cpp-client/deephaven/tests/ungroup_test.cc
+++ b/cpp-client/deephaven/tests/ungroup_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/validation_test.cc
+++ b/cpp-client/deephaven/tests/validation_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"

--- a/cpp-client/deephaven/tests/view_test.cc
+++ b/cpp-client/deephaven/tests/view_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ * Copyright (c) 2016-2023 Deephaven Data Labs and Patent Pending
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"


### PR DESCRIPTION
This patch is in anticipation of a change to how spotless is configured so that license headers are generated automatically. If you have strong feelings about the format being changed, I'll change spotless and regenerate the commit.