### PR TITLE
Select: Reuse Results When Possible

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1525,8 +1525,9 @@ public class QueryTable extends BaseTable<QueryTable> {
                             }
                         }
 
-                        final TrackingRowSet resultRowSet =
-                                analyzer.flattenedResult() ? RowSetFactory.flat(rowSet.size()).toTracking() : rowSet;
+                        final TrackingRowSet resultRowSet = analyzer.flattenedResult() && !rowSet.isFlat()
+                                ? RowSetFactory.flat(rowSet.size()).toTracking()
+                                : rowSet;
                         resultTable = new QueryTable(resultRowSet, analyzerWrapper.getPublishedColumnResources());
                         if (liveResultCapture != null) {
                             analyzer.startTrackingPrev();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1525,9 +1525,8 @@ public class QueryTable extends BaseTable<QueryTable> {
                             }
                         }
 
-                        final TrackingRowSet resultRowSet = analyzer.flattenedResult() && !rowSet.isFlat()
-                                ? RowSetFactory.flat(rowSet.size()).toTracking()
-                                : rowSet;
+                        final TrackingRowSet resultRowSet =
+                                analyzer.flattenedResult() ? RowSetFactory.flat(rowSet.size()).toTracking() : rowSet;
                         resultTable = new QueryTable(resultRowSet, analyzerWrapper.getPublishedColumnResources());
                         if (liveResultCapture != null) {
                             analyzer.startTrackingPrev();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
@@ -77,10 +77,10 @@ final public class PreserveColumnLayer extends DependencyLayerBase {
 
     @Override
     public boolean flattenedResult() {
-        // a preserve layer is only flattened if the inner is flattened
-        // the "flattenedResult" means that we are flattening the table as part of select.  For a pre-existing column, we
-        // could not preserve a layer while flattening, but if we are preserving a newly generated column; it is valid for
-        // the result to have been flattened as part of select.
+        // preserve layer is only flattened if the inner is flattened
+        // the "flattenedResult" means that we are flattening the table as part of select. For a pre-existing column, we
+        // could not preserve a layer while flattening, but if we are preserving a newly generated column; it is valid
+        // for the result to have been flattened as part of select.
         return inner.flattenedResult();
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
@@ -24,13 +24,11 @@ import java.util.Map;
  */
 final public class PreserveColumnLayer extends DependencyLayerBase {
     private final BitSet dependencyBitSet;
-    private final boolean flattenedResult;
 
     PreserveColumnLayer(SelectAndViewAnalyzer inner, String name, SelectColumn sc, ColumnSource<?> cs, String[] deps,
-            ModifiedColumnSet mcsBuilder, boolean flattenedResult) {
+            ModifiedColumnSet mcsBuilder) {
         super(inner, name, sc, cs, deps, mcsBuilder);
         this.dependencyBitSet = new BitSet();
-        this.flattenedResult = flattenedResult;
         Arrays.stream(deps).mapToInt(inner::getLayerIndexFor).forEach(dependencyBitSet::set);
     }
 
@@ -79,13 +77,14 @@ final public class PreserveColumnLayer extends DependencyLayerBase {
 
     @Override
     public boolean flattenedResult() {
-        return flattenedResult;
+        // a preserve layer is only flattened if the inner is flattened
+        return inner.flattenedResult();
     }
 
     @Override
     public boolean alreadyFlattenedSources() {
-        // we can only preserve a flat source if it was already made flat
-        return flattenedResult;
+        // a preserve layer is only already flattened if the inner is already flattened
+        return inner.alreadyFlattenedSources();
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
@@ -24,11 +24,13 @@ import java.util.Map;
  */
 final public class PreserveColumnLayer extends DependencyLayerBase {
     private final BitSet dependencyBitSet;
+    private final boolean flattenedResult;
 
     PreserveColumnLayer(SelectAndViewAnalyzer inner, String name, SelectColumn sc, ColumnSource<?> cs, String[] deps,
-            ModifiedColumnSet mcsBuilder) {
+            ModifiedColumnSet mcsBuilder, boolean flattenedResult) {
         super(inner, name, sc, cs, deps, mcsBuilder);
         this.dependencyBitSet = new BitSet();
+        this.flattenedResult = flattenedResult;
         Arrays.stream(deps).mapToInt(inner::getLayerIndexFor).forEach(dependencyBitSet::set);
     }
 
@@ -75,6 +77,16 @@ final public class PreserveColumnLayer extends DependencyLayerBase {
                 .append("}");
     }
 
+    @Override
+    public boolean flattenedResult() {
+        return flattenedResult;
+    }
+
+    @Override
+    public boolean alreadyFlattenedSources() {
+        // we can only preserve a flat source if it was already made flat
+        return flattenedResult;
+    }
 
     @Override
     public boolean allowCrossColumnParallelization() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/PreserveColumnLayer.java
@@ -78,6 +78,9 @@ final public class PreserveColumnLayer extends DependencyLayerBase {
     @Override
     public boolean flattenedResult() {
         // a preserve layer is only flattened if the inner is flattened
+        // the "flattenedResult" means that we are flattening the table as part of select.  For a pre-existing column, we
+        // could not preserve a layer while flattening, but if we are preserving a newly generated column; it is valid for
+        // the result to have been flattened as part of select.
         return inner.flattenedResult();
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
@@ -182,7 +182,7 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
                 }
 
                 analyzer = analyzer.createLayerForPreserve(
-                        sc.getName(), sc, sc.getDataView(), distinctDeps, mcsBuilder, flatResult && flattenedResult);
+                        sc.getName(), sc, sc.getDataView(), distinctDeps, mcsBuilder);
 
                 if (!sourceIsNew) {
                     // we can not flatten future columns because we are preserving a column that may not be flat
@@ -195,8 +195,7 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
             if (realColumn != null) {
                 final ColumnSource<?> alias = resultAlias.get(realColumn.getSourceName());
                 if (alias != null) {
-                    analyzer = analyzer.createLayerForPreserve(
-                            sc.getName(), sc, alias, distinctDeps, mcsBuilder, flatResult);
+                    analyzer = analyzer.createLayerForPreserve(sc.getName(), sc, alias, distinctDeps, mcsBuilder);
                     continue;
                 }
             }
@@ -387,8 +386,8 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
     }
 
     private SelectAndViewAnalyzer createLayerForPreserve(String name, SelectColumn sc, ColumnSource<?> cs,
-            String[] parentColumnDependencies, ModifiedColumnSet mcsBuilder, boolean flatResult) {
-        return new PreserveColumnLayer(this, name, sc, cs, parentColumnDependencies, mcsBuilder, flatResult);
+            String[] parentColumnDependencies, ModifiedColumnSet mcsBuilder) {
+        return new PreserveColumnLayer(this, name, sc, cs, parentColumnDependencies, mcsBuilder);
     }
 
     abstract void populateModifiedColumnSetRecurse(ModifiedColumnSet mcsBuilder, Set<String> remainingDepsToSatisfy);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
@@ -174,20 +174,22 @@ public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
 
             if (realColumn != null && shouldPreserve(sc)) {
                 boolean sourceIsNew = resultColumns.contains(realColumn.getSourceName());
-                if (!sourceIsNew && numberOfInternallyFlattenedColumns > 0) {
-                    // we must preserve this column, but have already created an analyzer for the internally flattened
-                    // column, therefore must start over without permitting internal flattening
-                    return create(sourceTable, mode, columnSources, originalRowSet, parentMcs, publishTheseSources,
-                            useShiftedColumns, false, selectColumns);
+                if (!sourceIsNew) {
+                    if (numberOfInternallyFlattenedColumns > 0) {
+                        // we must preserve this column, but have already created an analyzer for the internally
+                        // flattened
+                        // column, therefore must start over without permitting internal flattening
+                        return create(sourceTable, mode, columnSources, originalRowSet, parentMcs, publishTheseSources,
+                                useShiftedColumns, false, selectColumns);
+                    } else {
+                        // we can not flatten future columns because we are preserving a column that may not be flat
+                        flattenedResult = false;
+                    }
                 }
 
                 analyzer = analyzer.createLayerForPreserve(
                         sc.getName(), sc, sc.getDataView(), distinctDeps, mcsBuilder);
 
-                if (!sourceIsNew) {
-                    // we can not flatten future columns because we are preserving a column that may not be flat
-                    flattenedResult = false;
-                }
                 continue;
             }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectAndViewAnalyzer.java
@@ -37,7 +37,8 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public abstract class SelectAndViewAnalyzer implements LogOutputAppendable {
-    private static final Consumer<ColumnSource<?>> NOOP = ignore -> {};
+    private static final Consumer<ColumnSource<?>> NOOP = ignore -> {
+    };
 
     public enum Mode {
         VIEW_LAZY, VIEW_EAGER, SELECT_STATIC, SELECT_REFRESHING, SELECT_REDIRECTED_REFRESHING, SELECT_REDIRECTED_STATIC

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/StaticFlattenLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/StaticFlattenLayer.java
@@ -136,4 +136,16 @@ final public class StaticFlattenLayer extends SelectAndViewAnalyzer {
     public boolean allowCrossColumnParallelization() {
         return inner.allowCrossColumnParallelization();
     }
+
+    @Override
+    public boolean flattenedResult() {
+        // this layer performs a flatten, so the result is flattened
+        return true;
+    }
+
+    @Override
+    public boolean alreadyFlattenedSources() {
+        // this layer performs a flatten, so the sources are now flattened
+        return true;
+    }
 }


### PR DESCRIPTION
Fixes #4751; enabling re-use of an already flattened parent column.

This also fixes:
- an infinite recursion when flattening is reverted (it was recursively calling the wrong version of the method)
- the loss of internally flattening if a SourceColumn refers to a new, already flattened, result column (cause this is safe)

Nightlies: https://github.com/nbauernfeind/deephaven-core/actions/runs/6746760106/