### PR TITLE
Add support for MultiXYErrorBarSeries, MultiOHLCSeries figures

### DIFF
--- a/Plot/src/main/java/io/deephaven/plot/datasets/multiseries/MultiOHLCSeries.java
+++ b/Plot/src/main/java/io/deephaven/plot/datasets/multiseries/MultiOHLCSeries.java
@@ -83,6 +83,26 @@ public class MultiOHLCSeries extends AbstractPartitionedTableHandleMultiSeries<O
                 timeCol, openCol, highCol, lowCol, closeCol);
     }
 
+    public String getTimeCol() {
+        return timeCol;
+    }
+
+    public String getOpenCol() {
+        return openCol;
+    }
+
+    public String getHighCol() {
+        return highCol;
+    }
+
+    public String getLowCol() {
+        return lowCol;
+    }
+
+    public String getCloseCol() {
+        return closeCol;
+    }
+
     ////////////////////////////// CODE BELOW HERE IS GENERATED -- DO NOT EDIT BY HAND //////////////////////////////
     ////////////////////////////// TO REGENERATE RUN GenerateMultiSeries //////////////////////////////
     ////////////////////////////// AND THEN RUN GenerateFigureImmutable //////////////////////////////

--- a/Plot/src/main/java/io/deephaven/plot/datasets/multiseries/MultiXYErrorBarSeries.java
+++ b/Plot/src/main/java/io/deephaven/plot/datasets/multiseries/MultiXYErrorBarSeries.java
@@ -107,6 +107,38 @@ public class MultiXYErrorBarSeries extends AbstractPartitionedTableHandleMultiSe
                 drawXError, drawYError);
     }
 
+    public boolean getDrawXError() {
+        return drawXError;
+    }
+
+    public boolean getDrawYError() {
+        return drawYError;
+    }
+
+    public String getX() {
+        return x;
+    }
+
+    public String getXLow() {
+        return xLow;
+    }
+
+    public String getXHigh() {
+        return xHigh;
+    }
+
+    public String getY() {
+        return y;
+    }
+
+    public String getYLow() {
+        return yLow;
+    }
+
+    public String getYHigh() {
+        return yHigh;
+    }
+
     ////////////////////////////// CODE BELOW HERE IS GENERATED -- DO NOT EDIT BY HAND //////////////////////////////
     ////////////////////////////// TO REGENERATE RUN GenerateMultiSeries //////////////////////////////
     ////////////////////////////// AND THEN RUN GenerateFigureImmutable //////////////////////////////

--- a/Plot/src/main/java/io/deephaven/plot/datasets/multiseries/MultiXYErrorBarSeries.java
+++ b/Plot/src/main/java/io/deephaven/plot/datasets/multiseries/MultiXYErrorBarSeries.java
@@ -115,20 +115,12 @@ public class MultiXYErrorBarSeries extends AbstractPartitionedTableHandleMultiSe
         return drawYError;
     }
 
-    public String getX() {
-        return x;
-    }
-
     public String getXLow() {
         return xLow;
     }
 
     public String getXHigh() {
         return xHigh;
-    }
-
-    public String getY() {
-        return y;
     }
 
     public String getYLow() {

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -518,6 +518,10 @@ public class FigureWidgetTranslator {
                                     clientSeries.setPointShape(stringMapWithDefault(mergeShapes(
                                             multiCatSeries.pointShapeSeriesNameToStringMap(),
                                             multiCatSeries.pointShapeSeriesNameToShapeMap())));
+                                } else {
+                                    errorList.add(
+                                            "OpenAPI presently does not support series of type "
+                                                    + partitionedTableMultiSeries.getClass());
                                 }
                             } else {
                                 errorList.add(
@@ -530,7 +534,6 @@ public class FigureWidgetTranslator {
                         } else {
                             errorList.add(
                                     "OpenAPI presently does not support series of type " + seriesInternal.getClass());
-                            // TODO handle multi-series, possibly transformed case?
                         }
                     });
         });

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -32,6 +32,7 @@ import io.deephaven.plot.datasets.interval.IntervalXYDataSeriesArray;
 import io.deephaven.plot.datasets.multiseries.AbstractMultiSeries;
 import io.deephaven.plot.datasets.multiseries.AbstractPartitionedTableHandleMultiSeries;
 import io.deephaven.plot.datasets.multiseries.MultiCatSeries;
+import io.deephaven.plot.datasets.multiseries.MultiOHLCSeries;
 import io.deephaven.plot.datasets.multiseries.MultiXYErrorBarSeries;
 import io.deephaven.plot.datasets.multiseries.MultiXYSeries;
 import io.deephaven.plot.datasets.ohlc.OHLCDataSeriesArray;
@@ -542,6 +543,56 @@ public class FigureWidgetTranslator {
                                                 plotHandle, multiXYErrorBarSeries.getYHigh(), SourceType.Y_HIGH,
                                                 yAxis));
                                     }
+
+                                    clientSeries.setLineColor(stringMapWithDefault(mergeColors(
+                                            multiXYErrorBarSeries.lineColorSeriesNameTointMap(),
+                                            multiXYErrorBarSeries.lineColorSeriesNameToStringMap(),
+                                            multiXYErrorBarSeries.lineColorSeriesNameToPaintMap())));
+                                    clientSeries.setPointColor(stringMapWithDefault(mergeColors(
+                                            multiXYErrorBarSeries.pointColorSeriesNameTointMap(),
+                                            multiXYErrorBarSeries.pointColorSeriesNameToStringMap(),
+                                            multiXYErrorBarSeries.pointColorSeriesNameToPaintMap())));
+                                    clientSeries.setLinesVisible(
+                                            boolMapWithDefault(
+                                                    multiXYErrorBarSeries.linesVisibleSeriesNameToBooleanMap()));
+                                    clientSeries.setPointsVisible(
+                                            boolMapWithDefault(
+                                                    multiXYErrorBarSeries.pointsVisibleSeriesNameToBooleanMap()));
+                                    clientSeries.setGradientVisible(
+                                            boolMapWithDefault(
+                                                    multiXYErrorBarSeries.gradientVisibleSeriesNameTobooleanMap()));
+                                    clientSeries.setPointLabelFormat(stringMapWithDefault(
+                                            multiXYErrorBarSeries.pointLabelFormatSeriesNameToStringMap()));
+                                    clientSeries.setXToolTipPattern(
+                                            stringMapWithDefault(
+                                                    multiXYErrorBarSeries.xToolTipPatternSeriesNameToStringMap()));
+                                    clientSeries.setYToolTipPattern(
+                                            stringMapWithDefault(
+                                                    multiXYErrorBarSeries.yToolTipPatternSeriesNameToStringMap()));
+                                    clientSeries.setPointLabel(stringMapWithDefault(
+                                            multiXYErrorBarSeries.pointColorSeriesNameToStringMap(),
+                                            Objects::toString));
+                                    clientSeries.setPointSize(doubleMapWithDefault(
+                                            multiXYErrorBarSeries.pointSizeSeriesNameToNumberMap(),
+                                            number -> number == null ? null : number.doubleValue()));
+
+                                    clientSeries.setPointShape(stringMapWithDefault(mergeShapes(
+                                            multiXYErrorBarSeries.pointShapeSeriesNameToStringMap(),
+                                            multiXYErrorBarSeries.pointShapeSeriesNameToShapeMap())));
+                                } else if (partitionedTableMultiSeries instanceof MultiOHLCSeries) {
+                                    MultiOHLCSeries multiXYErrorBarSeries =
+                                            (MultiOHLCSeries) partitionedTableMultiSeries;
+
+                                    clientAxes.add(makePartitionedTableSourceDescriptor(
+                                            plotHandle, multiXYErrorBarSeries.getTimeCol(), SourceType.TIME, xAxis));
+                                    clientAxes.add(makePartitionedTableSourceDescriptor(
+                                            plotHandle, multiXYErrorBarSeries.getOpenCol(), SourceType.OPEN, yAxis));
+                                    clientAxes.add(makePartitionedTableSourceDescriptor(
+                                            plotHandle, multiXYErrorBarSeries.getCloseCol(), SourceType.CLOSE, yAxis));
+                                    clientAxes.add(makePartitionedTableSourceDescriptor(
+                                            plotHandle, multiXYErrorBarSeries.getHighCol(), SourceType.HIGH, yAxis));
+                                    clientAxes.add(makePartitionedTableSourceDescriptor(
+                                            plotHandle, multiXYErrorBarSeries.getLowCol(), SourceType.LOW, yAxis));
 
                                     clientSeries.setLineColor(stringMapWithDefault(mergeColors(
                                             multiXYErrorBarSeries.lineColorSeriesNameTointMap(),

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -570,7 +570,7 @@ public class FigureWidgetTranslator {
                                             stringMapWithDefault(
                                                     multiXYErrorBarSeries.yToolTipPatternSeriesNameToStringMap()));
                                     clientSeries.setPointLabel(stringMapWithDefault(
-                                            multiXYErrorBarSeries.pointColorSeriesNameToStringMap(),
+                                            multiXYErrorBarSeries.pointLabelSeriesNameToObjectMap(),
                                             Objects::toString));
                                     clientSeries.setPointSize(doubleMapWithDefault(
                                             multiXYErrorBarSeries.pointSizeSeriesNameToNumberMap(),

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -580,55 +580,55 @@ public class FigureWidgetTranslator {
                                             multiXYErrorBarSeries.pointShapeSeriesNameToStringMap(),
                                             multiXYErrorBarSeries.pointShapeSeriesNameToShapeMap())));
                                 } else if (partitionedTableMultiSeries instanceof MultiOHLCSeries) {
-                                    MultiOHLCSeries multiXYErrorBarSeries =
+                                    MultiOHLCSeries multiOHLCSeries =
                                             (MultiOHLCSeries) partitionedTableMultiSeries;
 
                                     clientAxes.add(makePartitionedTableSourceDescriptor(
-                                            plotHandle, multiXYErrorBarSeries.getTimeCol(), SourceType.TIME, xAxis));
+                                            plotHandle, multiOHLCSeries.getTimeCol(), SourceType.TIME, xAxis));
                                     clientAxes.add(makePartitionedTableSourceDescriptor(
-                                            plotHandle, multiXYErrorBarSeries.getOpenCol(), SourceType.OPEN, yAxis));
+                                            plotHandle, multiOHLCSeries.getOpenCol(), SourceType.OPEN, yAxis));
                                     clientAxes.add(makePartitionedTableSourceDescriptor(
-                                            plotHandle, multiXYErrorBarSeries.getCloseCol(), SourceType.CLOSE, yAxis));
+                                            plotHandle, multiOHLCSeries.getCloseCol(), SourceType.CLOSE, yAxis));
                                     clientAxes.add(makePartitionedTableSourceDescriptor(
-                                            plotHandle, multiXYErrorBarSeries.getHighCol(), SourceType.HIGH, yAxis));
+                                            plotHandle, multiOHLCSeries.getHighCol(), SourceType.HIGH, yAxis));
                                     clientAxes.add(makePartitionedTableSourceDescriptor(
-                                            plotHandle, multiXYErrorBarSeries.getLowCol(), SourceType.LOW, yAxis));
+                                            plotHandle, multiOHLCSeries.getLowCol(), SourceType.LOW, yAxis));
 
                                     clientSeries.setLineColor(stringMapWithDefault(mergeColors(
-                                            multiXYErrorBarSeries.lineColorSeriesNameTointMap(),
-                                            multiXYErrorBarSeries.lineColorSeriesNameToStringMap(),
-                                            multiXYErrorBarSeries.lineColorSeriesNameToPaintMap())));
+                                            multiOHLCSeries.lineColorSeriesNameTointMap(),
+                                            multiOHLCSeries.lineColorSeriesNameToStringMap(),
+                                            multiOHLCSeries.lineColorSeriesNameToPaintMap())));
                                     clientSeries.setPointColor(stringMapWithDefault(mergeColors(
-                                            multiXYErrorBarSeries.pointColorSeriesNameTointMap(),
-                                            multiXYErrorBarSeries.pointColorSeriesNameToStringMap(),
-                                            multiXYErrorBarSeries.pointColorSeriesNameToPaintMap())));
+                                            multiOHLCSeries.pointColorSeriesNameTointMap(),
+                                            multiOHLCSeries.pointColorSeriesNameToStringMap(),
+                                            multiOHLCSeries.pointColorSeriesNameToPaintMap())));
                                     clientSeries.setLinesVisible(
                                             boolMapWithDefault(
-                                                    multiXYErrorBarSeries.linesVisibleSeriesNameToBooleanMap()));
+                                                    multiOHLCSeries.linesVisibleSeriesNameToBooleanMap()));
                                     clientSeries.setPointsVisible(
                                             boolMapWithDefault(
-                                                    multiXYErrorBarSeries.pointsVisibleSeriesNameToBooleanMap()));
+                                                    multiOHLCSeries.pointsVisibleSeriesNameToBooleanMap()));
                                     clientSeries.setGradientVisible(
                                             boolMapWithDefault(
-                                                    multiXYErrorBarSeries.gradientVisibleSeriesNameTobooleanMap()));
+                                                    multiOHLCSeries.gradientVisibleSeriesNameTobooleanMap()));
                                     clientSeries.setPointLabelFormat(stringMapWithDefault(
-                                            multiXYErrorBarSeries.pointLabelFormatSeriesNameToStringMap()));
+                                            multiOHLCSeries.pointLabelFormatSeriesNameToStringMap()));
                                     clientSeries.setXToolTipPattern(
                                             stringMapWithDefault(
-                                                    multiXYErrorBarSeries.xToolTipPatternSeriesNameToStringMap()));
+                                                    multiOHLCSeries.xToolTipPatternSeriesNameToStringMap()));
                                     clientSeries.setYToolTipPattern(
                                             stringMapWithDefault(
-                                                    multiXYErrorBarSeries.yToolTipPatternSeriesNameToStringMap()));
+                                                    multiOHLCSeries.yToolTipPatternSeriesNameToStringMap()));
                                     clientSeries.setPointLabel(stringMapWithDefault(
-                                            multiXYErrorBarSeries.pointColorSeriesNameToStringMap(),
+                                            multiOHLCSeries.pointColorSeriesNameToStringMap(),
                                             Objects::toString));
                                     clientSeries.setPointSize(doubleMapWithDefault(
-                                            multiXYErrorBarSeries.pointSizeSeriesNameToNumberMap(),
+                                            multiOHLCSeries.pointSizeSeriesNameToNumberMap(),
                                             number -> number == null ? null : number.doubleValue()));
 
                                     clientSeries.setPointShape(stringMapWithDefault(mergeShapes(
-                                            multiXYErrorBarSeries.pointShapeSeriesNameToStringMap(),
-                                            multiXYErrorBarSeries.pointShapeSeriesNameToShapeMap())));
+                                            multiOHLCSeries.pointShapeSeriesNameToStringMap(),
+                                            multiOHLCSeries.pointShapeSeriesNameToShapeMap())));
                                 } else {
                                     errorList.add(
                                             "OpenAPI presently does not support series of type "

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -620,7 +620,7 @@ public class FigureWidgetTranslator {
                                             stringMapWithDefault(
                                                     multiOHLCSeries.yToolTipPatternSeriesNameToStringMap()));
                                     clientSeries.setPointLabel(stringMapWithDefault(
-                                            multiOHLCSeries.pointColorSeriesNameToStringMap(),
+                                            multiOHLCSeries.pointLabelSeriesNameToObjectMap(),
                                             Objects::toString));
                                     clientSeries.setPointSize(doubleMapWithDefault(
                                             multiOHLCSeries.pointSizeSeriesNameToNumberMap(),

--- a/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
+++ b/plugin/figure/src/main/java/io/deephaven/figure/FigureWidgetTranslator.java
@@ -32,6 +32,7 @@ import io.deephaven.plot.datasets.interval.IntervalXYDataSeriesArray;
 import io.deephaven.plot.datasets.multiseries.AbstractMultiSeries;
 import io.deephaven.plot.datasets.multiseries.AbstractPartitionedTableHandleMultiSeries;
 import io.deephaven.plot.datasets.multiseries.MultiCatSeries;
+import io.deephaven.plot.datasets.multiseries.MultiXYErrorBarSeries;
 import io.deephaven.plot.datasets.multiseries.MultiXYSeries;
 import io.deephaven.plot.datasets.ohlc.OHLCDataSeriesArray;
 import io.deephaven.plot.datasets.xy.AbstractXYDataSeries;
@@ -518,6 +519,65 @@ public class FigureWidgetTranslator {
                                     clientSeries.setPointShape(stringMapWithDefault(mergeShapes(
                                             multiCatSeries.pointShapeSeriesNameToStringMap(),
                                             multiCatSeries.pointShapeSeriesNameToShapeMap())));
+                                } else if (partitionedTableMultiSeries instanceof MultiXYErrorBarSeries) {
+                                    MultiXYErrorBarSeries multiXYErrorBarSeries =
+                                            (MultiXYErrorBarSeries) partitionedTableMultiSeries;
+
+                                    clientAxes.add(makePartitionedTableSourceDescriptor(
+                                            plotHandle, multiXYErrorBarSeries.getX(), SourceType.X, xAxis));
+                                    if (multiXYErrorBarSeries.getDrawXError()) {
+                                        clientAxes.add(makePartitionedTableSourceDescriptor(
+                                                plotHandle, multiXYErrorBarSeries.getXLow(), SourceType.X_LOW, xAxis));
+                                        clientAxes.add(makePartitionedTableSourceDescriptor(
+                                                plotHandle, multiXYErrorBarSeries.getXHigh(), SourceType.X_HIGH,
+                                                xAxis));
+                                    }
+
+                                    clientAxes.add(makePartitionedTableSourceDescriptor(
+                                            plotHandle, multiXYErrorBarSeries.getY(), SourceType.Y, yAxis));
+                                    if (multiXYErrorBarSeries.getDrawYError()) {
+                                        clientAxes.add(makePartitionedTableSourceDescriptor(
+                                                plotHandle, multiXYErrorBarSeries.getYLow(), SourceType.Y_LOW, yAxis));
+                                        clientAxes.add(makePartitionedTableSourceDescriptor(
+                                                plotHandle, multiXYErrorBarSeries.getYHigh(), SourceType.Y_HIGH,
+                                                yAxis));
+                                    }
+
+                                    clientSeries.setLineColor(stringMapWithDefault(mergeColors(
+                                            multiXYErrorBarSeries.lineColorSeriesNameTointMap(),
+                                            multiXYErrorBarSeries.lineColorSeriesNameToStringMap(),
+                                            multiXYErrorBarSeries.lineColorSeriesNameToPaintMap())));
+                                    clientSeries.setPointColor(stringMapWithDefault(mergeColors(
+                                            multiXYErrorBarSeries.pointColorSeriesNameTointMap(),
+                                            multiXYErrorBarSeries.pointColorSeriesNameToStringMap(),
+                                            multiXYErrorBarSeries.pointColorSeriesNameToPaintMap())));
+                                    clientSeries.setLinesVisible(
+                                            boolMapWithDefault(
+                                                    multiXYErrorBarSeries.linesVisibleSeriesNameToBooleanMap()));
+                                    clientSeries.setPointsVisible(
+                                            boolMapWithDefault(
+                                                    multiXYErrorBarSeries.pointsVisibleSeriesNameToBooleanMap()));
+                                    clientSeries.setGradientVisible(
+                                            boolMapWithDefault(
+                                                    multiXYErrorBarSeries.gradientVisibleSeriesNameTobooleanMap()));
+                                    clientSeries.setPointLabelFormat(stringMapWithDefault(
+                                            multiXYErrorBarSeries.pointLabelFormatSeriesNameToStringMap()));
+                                    clientSeries.setXToolTipPattern(
+                                            stringMapWithDefault(
+                                                    multiXYErrorBarSeries.xToolTipPatternSeriesNameToStringMap()));
+                                    clientSeries.setYToolTipPattern(
+                                            stringMapWithDefault(
+                                                    multiXYErrorBarSeries.yToolTipPatternSeriesNameToStringMap()));
+                                    clientSeries.setPointLabel(stringMapWithDefault(
+                                            multiXYErrorBarSeries.pointColorSeriesNameToStringMap(),
+                                            Objects::toString));
+                                    clientSeries.setPointSize(doubleMapWithDefault(
+                                            multiXYErrorBarSeries.pointSizeSeriesNameToNumberMap(),
+                                            number -> number == null ? null : number.doubleValue()));
+
+                                    clientSeries.setPointShape(stringMapWithDefault(mergeShapes(
+                                            multiXYErrorBarSeries.pointShapeSeriesNameToStringMap(),
+                                            multiXYErrorBarSeries.pointShapeSeriesNameToShapeMap())));
                                 } else {
                                     errorList.add(
                                             "OpenAPI presently does not support series of type "

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
@@ -166,7 +166,7 @@ public class JsFigure extends HasLifecycle {
 
     private JsChart[] charts;
 
-    private String[] errors;
+    private JsArray<String> errors;
 
     private JsTable[] tables;
     private Map<Integer, JsTable> plotHandlesToTables;
@@ -203,7 +203,7 @@ public class JsFigure extends HasLifecycle {
                     .map(chartDescriptor -> new JsChart(chartDescriptor, this)).toArray(JsChart[]::new);
             JsObject.freeze(charts);
 
-            errors = JsObject.freeze(descriptor.getErrorsList().asList().toArray(new String[0]));
+            errors = JsObject.freeze(descriptor.getErrorsList().slice());
 
             return this.tableFetch.fetch(this, response);
         }).then(tableFetchData -> {
@@ -329,7 +329,7 @@ public class JsFigure extends HasLifecycle {
     }
 
     @JsProperty
-    public String[] getErrors() {
+    public JsArray<String> getErrors() {
         return errors;
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/JsFigure.java
@@ -166,6 +166,8 @@ public class JsFigure extends HasLifecycle {
 
     private JsChart[] charts;
 
+    private String[] errors;
+
     private JsTable[] tables;
     private Map<Integer, JsTable> plotHandlesToTables;
 
@@ -200,6 +202,8 @@ public class JsFigure extends HasLifecycle {
             charts = descriptor.getChartsList().asList().stream()
                     .map(chartDescriptor -> new JsChart(chartDescriptor, this)).toArray(JsChart[]::new);
             JsObject.freeze(charts);
+
+            errors = JsObject.freeze(descriptor.getErrorsList().asList().toArray(new String[0]));
 
             return this.tableFetch.fetch(this, response);
         }).then(tableFetchData -> {
@@ -324,8 +328,9 @@ public class JsFigure extends HasLifecycle {
         return charts;
     }
 
+    @JsProperty
     public String[] getErrors() {
-        return Js.uncheckedCast(descriptor.getErrorsList().slice());
+        return errors;
     }
 
     /**


### PR DESCRIPTION
- Add support for MultiXYErrorBarSeries, MultiOHLCSeries. They weren't wired up at all
- Report an error properly for MultiSeries types that are not supported
- Change the JsFigure.getErrors() to be a `@JsProperty` instead
  - Currently not listed in the JS API and not used by the Web UI at all, so I think it's a reasonable change to make - not breaking an existing documented API.
  - This should be ported to Enterprise as well. I have branch `bender_figure-errors` pushed for this, ready to open up a PR for.
- Fixes #4709 
- Tested using the code snippets in the ticket