### PR TITLE
More explicit exception message for invalid key columns

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
@@ -45,11 +45,9 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.function.LongFunction;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -90,9 +88,15 @@ public class ChunkedOperatorAggregationHelper {
             @NotNull final Collection<? extends ColumnName> groupByColumns) {
         final String[] keyNames = groupByColumns.stream().map(ColumnName::name).toArray(String[]::new);
         if (!input.hasColumns(keyNames)) {
+            final Set<String> colNames = input.getColumnSourceMap().keySet();
+            final String[] missingColumns = Arrays.stream(keyNames)
+                    .filter(Predicate.not(colNames::contains))
+                    .toArray(String[]::new);;
+
             throw new IllegalArgumentException("aggregation: not all group-by columns " + Arrays.toString(keyNames)
                     + " are present in input table with columns "
-                    + Arrays.toString(input.getDefinition().getColumnNamesArray()));
+                    + Arrays.toString(input.getDefinition().getColumnNamesArray()) + ". Missing columns: "
+                    + Arrays.toString(missingColumns));
         }
         if (initialKeys != null) {
             if (keyNames.length == 0) {
@@ -100,9 +104,15 @@ public class ChunkedOperatorAggregationHelper {
                         "aggregation: initial groups must not be specified if no group-by columns are specified");
             }
             if (!initialKeys.hasColumns(keyNames)) {
+                final Set<String> colNames = input.getColumnSourceMap().keySet();
+                final String[] missingColumns = Arrays.stream(keyNames)
+                        .filter(Predicate.not(colNames::contains))
+                        .toArray(String[]::new);;
+
                 throw new IllegalArgumentException("aggregation: not all group-by columns " + Arrays.toString(keyNames)
                         + " are present in initial groups table with columns "
-                        + Arrays.toString(initialKeys.getDefinition().getColumnNamesArray()));
+                        + Arrays.toString(initialKeys.getDefinition().getColumnNamesArray()) + ". Missing columns: "
+                        + Arrays.toString(missingColumns));
             }
             for (final String keyName : keyNames) {
                 final ColumnDefinition<?> inputDef = input.getDefinition().getColumn(keyName);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -74,7 +74,7 @@ import static io.deephaven.engine.testutil.TstUtils.*;
 import static io.deephaven.engine.util.TableTools.*;
 import static io.deephaven.util.QueryConstants.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.*;
 
 @Category(OutOfBandTest.class)
 public class QueryTableAggregationTest {
@@ -3832,6 +3832,22 @@ public class QueryTableAggregationTest {
         });
         TestCase.assertEquals(1, aggregated.size());
         assertTableEquals(expectedEmpty, aggregated);
+    }
+
+    @Test
+    public void testKeyColumnMissing() {
+        final Table data = testTable(col("S", "A", "B", "C", "D"), col("I", 10, 20, 30, 40));
+        try {
+            final Table agg = data.selectDistinct("NonExistentCol");
+            fail("Should have thrown an exception");
+        } catch (Exception ex) {
+            io.deephaven.base.verify.Assert.instanceOf(ex, "ex", IllegalArgumentException.class);
+            io.deephaven.base.verify.Assert.assertion(
+                    ex.getMessage().contains("Missing columns: [NonExistentCol]"),
+                    "ex.getMessage().contains(\"Missing columns: [NonExistentCol]\")",
+                    ex.getMessage(),
+                    "ex.getMessage()");
+        }
     }
 
     @Test


### PR DESCRIPTION
If you try to run an aggregation where one or more of your agg keys is missing from the table, we should tell you which key columns are missing (rather than just listing the ones you tried to use and the columns that are actually present and letting you figure out what's missing on your own).