### PR TITLE
ExportObject: Add onSuccess Callback for use in TableService#batch

### DIFF
--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -166,7 +166,7 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
 
         final SessionState session = sessionService.getCurrentSession();
 
-        final SessionState.ExportObject<HierarchicalTable> inputHierarchicalTableExport = ticketRouter.resolve(
+        final SessionState.ExportObject<HierarchicalTable<?>> inputHierarchicalTableExport = ticketRouter.resolve(
                 session, request.getInputHierarchicalTableId(), "apply.inputHierarchicalTableId");
 
         session.newExport(request.getResultHierarchicalTableId(), "apply.resultHierarchicalTableId")

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -822,7 +822,7 @@ public class SessionState {
                     errorHandler.onError(state, errorId, toReport, failedDependencyLogIdentity);
                 } catch (final Throwable err) {
                     // this is a serious error; crash the jvm to ensure that we don't miss it
-                    log.error().append("Unexpected error while reporting failure: ").append(err).endl();
+                    log.error().append("Unexpected error while reporting ExportObject failure: ").append(err).endl();
                     ProcessEnvironment.getGlobalFatalErrorReporter().reportAsync(
                             "Unexpected error while reporting ExportObject failure", err);
                 }
@@ -834,7 +834,7 @@ public class SessionState {
                     successHandler.accept(result);
                 } catch (final Throwable err) {
                     // this is a serious error; crash the jvm to ensure that we don't miss it
-                    log.error().append("Unexpected error while reporting success: ").append(err).endl();
+                    log.error().append("Unexpected error while reporting ExportObject success: ").append(err).endl();
                     ProcessEnvironment.getGlobalFatalErrorReporter().reportAsync(
                             "Unexpected error while reporting ExportObject success", err);
                 }

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -825,6 +825,7 @@ public class SessionState {
                 } catch (final Exception err) {
                     log.error().append("Unexpected error while reporting success: ").append(err).endl();
                 }
+                successHandler = null;
             }
 
             if (isNowExported || isExportStateTerminal(state)) {
@@ -834,6 +835,7 @@ public class SessionState {
                 parents = Collections.emptyList();
                 exportMain = null;
                 errorHandler = null;
+                successHandler = null;
             }
 
             if ((isNowExported && isNonExport()) || isExportStateTerminal(state)) {

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -544,14 +544,12 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                         .build();
                 safelyOnNext(responseObserver, response);
                 onOneResolved.run();
-            }).submit(() -> {
-                final Table table = exportBuilder.doExport();
+            }).onSuccess(table -> {
                 final ExportedTableCreationResponse response =
                         ExportUtil.buildTableCreationResponse(resultId, table);
                 safelyOnNext(responseObserver, response);
                 onOneResolved.run();
-                return table;
-            });
+            }).submit(exportBuilder::doExport);
         }
     }
 


### PR DESCRIPTION
Fixes #4754.