### PR TITLE
Correct EmStd empty table initialiation error.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/emstd/BasePrimitiveEmStdOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/emstd/BasePrimitiveEmStdOperator.java
@@ -135,8 +135,14 @@ public abstract class BasePrimitiveEmStdOperator extends BaseDoubleUpdateByOpera
         if (firstUnmodifiedKey != NULL_ROW_KEY) {
             ctx.curVal = outputSource.getDouble(firstUnmodifiedKey);
             ctx.curEma = emaSource.getDouble(firstUnmodifiedKey);
-            if (ctx.curVal == Double.NaN) {
-                ctx.curVariance = outputSource.getDouble(firstUnmodifiedKey);
+            if (ctx.curEma != NULL_DOUBLE
+                    && !Double.isNaN(ctx.curEma)
+                    && Double.isNaN(ctx.curVal)) {
+                // When we have a valid EMA, but the previous em_std value is NaN, we need to un-poison variance
+                // (by setting to 0.0) to allow the new variance to be computed properly.
+                // NOTE: this case can only exist between the first and second rows after initialization or a RESET
+                // caused by the {@link OperationControl control}.
+                ctx.curVariance = 0.0;
             } else if (ctx.curVal == NULL_DOUBLE) {
                 ctx.curVariance = 0.0;
             } else {


### PR DESCRIPTION
When the following code is executed in a single IDE call, the output from the std operations is incorrect (`NaN` instead of computed values):
```from deephaven.updateby import ema_time, emstd_time
from deephaven.plot.figure import Figure
from deephaven.time import to_j_instant
from deephaven import time_table
from deephaven import read_csv

crypto_prices = read_csv("https://media.githubusercontent.com/media/deephaven/examples/main/CryptoCurrencyHistory/CSV/crypto_sept7.csv").\
    sort(["dateTime"]).\
    select(["dateTime", "Coin", "Price = close"])

start_time = to_j_instant("2021-09-07T00:00:00 ET")

tt = time_table("PT1s").update(["dateTime = start_time + i * MINUTE"])

crypto_live = tt.join(table=crypto_prices, on=["dateTime"]).drop_columns(["Timestamp"])

bollinger_ops = [
    ema_time(ts_col="dateTime", decay_time="PT20m", cols=["EMA = Price"]),
    emstd_time(ts_col="dateTime", decay_time="PT20m", cols=["EMStd = Price"])
]

crypto_bollinger_live = crypto_live.update_by(
    ops=bollinger_ops,
    by=["Coin"]
).update_view([
    "UpperBand = EMA + 5 * EMStd",
    "LowerBand = EMA - 5 * EMStd"
]).reverse()

bitcoin_bollinger_live = crypto_bollinger_live.where(["Coin == `BTC`"])

exponential_bollinger_plot = Figure().\
    plot_xy(series_name="Price", t=bitcoin_bollinger_live, x="dateTime", y="Price").\
    plot_xy(series_name="EMA", t=bitcoin_bollinger_live, x="dateTime", y="EMA").\
    plot_xy(series_name="Upper Band", t=bitcoin_bollinger_live, x="dateTime", y="UpperBand").\
    plot_xy(series_name="Lower Band", t=bitcoin_bollinger_live, x="dateTime", y="LowerBand").\
    show()
```
The bug is that the initialization of the `EmStd` operator from an empty table (followed by single row appends) is incorrect when compared to a populated table with 2 or more rows.

This PR corrects the problem by detecting when an update occurs on a single row table and correctly initializing the intermediate values used for the EmStd operation.