### PR TITLE
C++ Client: improve proto build script test for missing envars

### DIFF
--- a/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
+++ b/proto/proto-backplane-grpc/src/main/proto/build-cpp-protos.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-if [ -z "$PROTOC_BIN" ] && [ -z "$DHCPP" ]; then
+if [ -z ${PROTOC_BIN:+x} ] && [ -z ${DHCPP:+x} ]; then
     echo "$0: At least one of the environment variables 'PROTOC_BIN' and 'DHCPP' must be defined, aborting." 1>&2
     exit 1
 fi


### PR DESCRIPTION
Expected behavior: when the envars are unset, our message is printed.

Actual behavior: because of `set -u`  the intended error message never gets printed. Instead we get this shell error
```
$ ./build-cpp-protos.sh 
./build-cpp-protos.sh: line 5: PROTOC_BIN: unbound variable
```