### PR TITLE
Update protoc and cpp client base images.

### DIFF
--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -37,7 +37,7 @@ on them anymore so we do notguarantee they are current for those platforms.
    Get the `build-dependencies.sh` script from Deephaven's base images repository
    at the correct version.
    You can download it directly from the link
-   https://github.com/deephaven/deephaven-base-images/raw/23c18c77e4a2431ef7403dd3c96336bd3ecf77d3/cpp-client/build-dependencies.sh
+   https://github.com/deephaven/deephaven-base-images/raw/47f51e769612785c6f320302a3f4f52bc0cff187/cpp-client/build-dependencies.sh
    (this script is also used from our automated tools, to generate a docker image to
    support tests runs; that's why it lives in a separate repo).
    The script downloads, builds and installs the dependent libraries
@@ -64,7 +64,7 @@ on them anymore so we do notguarantee they are current for those platforms.
    # If the directory already exists from a previous attempt, ensure is clean/empty
    mkdir -p $DHCPP
    cd $DHCPP
-   wget https://github.com/deephaven/deephaven-base-images/raw/23c18c77e4a2431ef7403dd3c96336bd3ecf77d3/cpp-client/build-dependencies.sh
+   wget https://github.com/deephaven/deephaven-base-images/raw/47f51e769612785c6f320302a3f4f52bc0cff187/cpp-client/build-dependencies.sh
    chmod +x ./build-dependencies.sh
    # Maybe edit build-dependencies.sh to reflect choices of build tools and build target, if you
    # want anything different than defaults; defaults are tested to work,

--- a/docker/registry/cpp-clients-multi-base/gradle.properties
+++ b/docker/registry/cpp-clients-multi-base/gradle.properties
@@ -1,4 +1,4 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/cpp-clients-multi-base:latest
-deephaven.registry.imageId=ghcr.io/deephaven/cpp-clients-multi-base@sha256:873298d3be934383a84fdc9c2300c23de31db3ea58fbd4648cc70337c107a50d
+deephaven.registry.imageId=ghcr.io/deephaven/cpp-clients-multi-base@sha256:e9d3cbd9cf5f95162e559a8e4b78fec20ddbc559048d8b0167db161f8b748d55
 deephaven.registry.platform=linux/amd64

--- a/docker/registry/protoc-base/gradle.properties
+++ b/docker/registry/protoc-base/gradle.properties
@@ -1,5 +1,5 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/protoc-base:latest
-deephaven.registry.imageId=ghcr.io/deephaven/protoc-base@sha256:7e6e2ad289e71824b8c72907e38cffe7458c2888aa937e9c8828ab865513e96c
+deephaven.registry.imageId=ghcr.io/deephaven/protoc-base@sha256:9e72f4456f4d950c5cb111eab8d601c9653b159221ea3fb6979dbacc3097f06c
 # TODO(deephaven-base-images#54): arm64 native image for cpp-client-base
 deephaven.registry.platform=linux/amd64

--- a/proto/proto-backplane-grpc/Dockerfile
+++ b/proto/proto-backplane-grpc/Dockerfile
@@ -12,7 +12,7 @@ RUN set -eux; \
   mkdir -p /generated/python; \
   mkdir -p /generated/cpp; \
   /opt/protoc/bin/protoc \
-    --plugin=protoc-gen-grpc=/opt/protoc-gen-grpc-java \
+    --plugin=protoc-gen-grpc=/opt/java/bin/protoc-gen-grpc-java \
     --java_out=/generated/java \
     --grpc_out=/generated/grpc \
     -I/dependencies \
@@ -64,9 +64,9 @@ RUN set -eux; \
     /includes/deephaven/proto/hierarchicaltable.proto \
     /includes/deephaven/proto/storage.proto; \
   /opt/protoc/bin/protoc \
-    --plugin=protoc-gen-go=/opt/protoc-gen-go \
-    --plugin=protoc-gen-go-grpc=/opt/protoc-gen-go-grpc \
-    --plugin=protoc-gen-cpp_grpc=/opt/cpp/grpc_cpp_plugin \
+    --plugin=protoc-gen-go=/opt/go/bin/protoc-gen-go \
+    --plugin=protoc-gen-go-grpc=/opt/go/bin/protoc-gen-go-grpc \
+    --plugin=protoc-gen-cpp_grpc=/opt/deephaven/bin/grpc_cpp_plugin \
     --go_out=/generated/go \
     --go-grpc_out=/generated/go \
     --go_opt=module=github.com/deephaven/deephaven-core/go \


### PR DESCRIPTION
This should fix the issue with the protoc image generation that was introduced in the R related refactor for deephaven-base-images.

We are also updating the cpp image to include the change in build-dependencies.sh (and link to it from the cpp-client/README) that allows for customizing the github URL (per Raffi's request).
