### PR TITLE
Bump images post 0.30.0 release

### DIFF
--- a/docker/registry/go/gradle.properties
+++ b/docker/registry/go/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=golang:1
-deephaven.registry.imageId=golang@sha256:a0e3e6859220ee48340c5926794ce87a891a1abb51530573c694317bf8f72543
+deephaven.registry.imageId=golang@sha256:81cd210ae58a6529d832af2892db822b30d84f817a671b8e1c15cff0b271a3db

--- a/docker/registry/python/gradle.properties
+++ b/docker/registry/python/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=python:3.10
-deephaven.registry.imageId=python@sha256:74cdd039dc36f6476dd5dfdbc187830e0c0f760a1bdfc73d186060ef4c4bd78f
+deephaven.registry.imageId=python@sha256:eac7369136625549bc3f7461fe072b1030f538ea20d6291e9b56896d6a40559c

--- a/docker/registry/server-base/gradle.properties
+++ b/docker/registry/server-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:89b11b535ed67027d4370a95fd37d348ca472ee0ee987aea6804c6ee4620fbd2
+deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:b02de3d96469d38a2ba5999f04a6d99e0c5f5e5e34482e57d47bd4bb64108a7c

--- a/docker/registry/slim-base/gradle.properties
+++ b/docker/registry/slim-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-slim-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:9e8b61362bb60e9797c9939b4955c5a3b01a228e2d1b3b2d9f461c0729c805a5
+deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:5d9eb6e5c3507d1d463720bb61c4ea62b98cf48a482c8c8f3faeaaf01b3c5f1f

--- a/docker/server-jetty/src/main/server-jetty/requirements.txt
+++ b/docker/server-jetty/src/main/server-jetty/requirements.txt
@@ -1,18 +1,18 @@
-adbc-driver-manager==0.5.1
-adbc-driver-postgresql==0.5.1
-connectorx==0.3.1; platform.machine == 'x86_64'
+adbc-driver-manager==0.8.0
+adbc-driver-postgresql==0.8.0
+connectorx==0.3.2; platform.machine == 'x86_64'
 deephaven-plugin==0.5.0
 java-utilities==0.2.0
 jedi==0.18.2
 jpy==0.14.0
-llvmlite==0.40.1
-numba==0.57.1
-numpy==1.24.4
-pandas==2.0.3
+llvmlite==0.41.1
+numba==0.58.1
+numpy==1.26.1
+pandas==2.1.2
 parso==0.8.3
-pyarrow==12.0.1
+pyarrow==13.0.0
 python-dateutil==2.8.2
-pytz==2023.3
+pytz==2023.3.post1
 six==1.16.0
-turbodbc==4.6.0
+turbodbc==4.7.0
 tzdata==2023.3

--- a/docker/server/src/main/server-netty/requirements.txt
+++ b/docker/server/src/main/server-netty/requirements.txt
@@ -1,18 +1,18 @@
-adbc-driver-manager==0.5.1
-adbc-driver-postgresql==0.5.1
-connectorx==0.3.1; platform.machine == 'x86_64'
+adbc-driver-manager==0.8.0
+adbc-driver-postgresql==0.8.0
+connectorx==0.3.2; platform.machine == 'x86_64'
 deephaven-plugin==0.5.0
 java-utilities==0.2.0
 jedi==0.18.2
 jpy==0.14.0
-llvmlite==0.40.1
-numba==0.57.1
-numpy==1.24.4
-pandas==2.0.3
+llvmlite==0.41.1
+numba==0.58.1
+numpy==1.26.1
+pandas==2.1.2
 parso==0.8.3
-pyarrow==12.0.1
+pyarrow==13.0.0
 python-dateutil==2.8.2
-pytz==2023.3
+pytz==2023.3.post1
 six==1.16.0
-turbodbc==4.6.0
+turbodbc==4.7.0
 tzdata==2023.3

--- a/py/jpy-integration/build.gradle
+++ b/py/jpy-integration/build.gradle
@@ -117,7 +117,7 @@ Closure<TaskProvider<Task>> gradleTestInDocker = { String taskName, SourceSet so
   def gradleWrapper = tasks.register("${taskName}GradleInit", Wrapper.class) { wrapper ->
     wrapper.scriptFile "${buildDir}/template-project/gradlew"
     wrapper.jarFile "${buildDir}/template-project/gradle/wrapper/gradle-wrapper.jar"
-    wrapper.gradleVersion '7.2'
+    wrapper.gradleVersion '8.4'
   }
   return Docker.registerDockerTask(project, taskName) {
     copyIn {

--- a/python-engine-test/build.gradle
+++ b/python-engine-test/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 def gradleWrapper = tasks.register("dockerGradleInit", Wrapper.class) { wrapper ->
   wrapper.scriptFile "${buildDir}/template-project/gradlew"
   wrapper.jarFile "${buildDir}/template-project/gradle/wrapper/gradle-wrapper.jar"
-  wrapper.gradleVersion '7.2'
+  wrapper.gradleVersion '8.4'
 }
 
 tasks.getByName('check').dependsOn Docker.registerDockerTask(project, 'test-in-docker') {


### PR DESCRIPTION
Update some unit testing gradle wrapper versions to ensure inner-gradle projects works with OpenJDK 21

* https://github.com/deephaven/deephaven-server-docker/pull/69
* https://github.com/deephaven/deephaven-server-docker/pull/70

Not updating cpp or protoc base, see

* https://github.com/deephaven/deephaven-base-images/pull/102
* https://github.com/deephaven/deephaven-core/pull/4805