### PR TITLE
`TableServiceAsyncTest`: Eliminate Compiler Overhead Variance; Close `QueryCompiler`'s `JavaFileManager`

### DIFF
--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryCompiler.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryCompiler.java
@@ -697,7 +697,7 @@ public class QueryCompiler {
         final String classPathAsString = getClassPath() + File.pathSeparator + getJavaClassPath();
         final List<String> compilerOptions = Arrays.asList("-d", tempDirAsString, "-cp", classPathAsString);
 
-        final StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+        final JavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
 
         boolean result = false;
         boolean exceptionThrown = false;

--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryCompiler.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryCompiler.java
@@ -683,22 +683,19 @@ public class QueryCompiler {
         }
     }
 
-    private static JavaCompiler JAVA_COMPILER = null;
+    private static volatile JavaCompiler JAVA_COMPILER = null;
 
     private static JavaCompiler getJavaCompiler() {
-        JavaCompiler localCompiler = JAVA_COMPILER;
-        if (localCompiler != null) {
-            return localCompiler;
+        JavaCompiler localCompiler;
+        if ((localCompiler = JAVA_COMPILER) == null) {
+            synchronized (QueryCompiler.class) {
+                if ((localCompiler = JAVA_COMPILER) == null) {
+                    localCompiler = JAVA_COMPILER = ToolProvider.getSystemJavaCompiler();
+                }
+            }
         }
-        synchronized (QueryCompiler.class) {
-            localCompiler = JAVA_COMPILER;
-            if (localCompiler != null) {
-                return localCompiler;
-            }
-            localCompiler = JAVA_COMPILER = ToolProvider.getSystemJavaCompiler();
-            if (localCompiler == null) {
-                throw new RuntimeException("No Java compiler provided - are you using a JRE instead of a JDK?");
-            }
+        if (localCompiler == null) {
+            throw new RuntimeException("No Java compiler provided - are you using a JRE instead of a JDK?");
         }
         return localCompiler;
     }
@@ -707,21 +704,15 @@ public class QueryCompiler {
      * While the JavaFileManager should be closed to clean up resources, using a singleton avoids repeated processing of
      * the classpath, which is <b>very</b> expensive.
      */
-    private static JavaFileManager JAVA_FILE_MANAGER = null;
+    private static volatile JavaFileManager JAVA_FILE_MANAGER = null;
 
     private static JavaFileManager getJavaFileManager() {
-        JavaFileManager localManager = JAVA_FILE_MANAGER;
-        if (localManager != null) {
-            return localManager;
-        }
-        synchronized (QueryCompiler.class) {
-            localManager = JAVA_FILE_MANAGER;
-            if (localManager != null) {
-                return localManager;
-            }
-            localManager = JAVA_FILE_MANAGER = getJavaCompiler().getStandardFileManager(null, null, null);
-            if (localManager == null) {
-                throw new RuntimeException("No Java compiler provided - are you using a JRE instead of a JDK?");
+        JavaFileManager localManager;
+        if ((localManager = JAVA_FILE_MANAGER) == null) {
+            synchronized (QueryCompiler.class) {
+                if ((localManager = JAVA_FILE_MANAGER) == null) {
+                    localManager = JAVA_FILE_MANAGER = getJavaCompiler().getStandardFileManager(null, null, null);
+                }
             }
         }
         return localManager;

--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryCompiler.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryCompiler.java
@@ -113,7 +113,7 @@ public class QueryCompiler {
         try {
             urls[0] = (classDestination.toURI().toURL());
         } catch (MalformedURLException e) {
-            throw new RuntimeException("", e);
+            throw new UncheckedDeephavenException(e);
         }
         this.ucl = new WritableURLClassLoader(urls, parentClassLoaderToUse);
 
@@ -183,7 +183,8 @@ public class QueryCompiler {
         ensureDirectories(parentDir,
                 () -> "Unable to create missing destination directory " + parentDir.getAbsolutePath());
         if (!destinationFile.createNewFile()) {
-            throw new RuntimeException("Unable to create destination file " + destinationFile.getAbsolutePath());
+            throw new UncheckedDeephavenException(
+                    "Unable to create destination file " + destinationFile.getAbsolutePath());
         }
         final ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream(data.length);
         byteOutStream.write(data, 0, data.length);
@@ -274,7 +275,7 @@ public class QueryCompiler {
         // (and therefore mkdirs() would return false), but still get the directory we need (and therefore exists()
         // would return true)
         if (!file.mkdirs() && !file.isDirectory()) {
-            throw new RuntimeException(runtimeErrMsg.get());
+            throw new UncheckedDeephavenException(runtimeErrMsg.get());
         }
     }
 
@@ -396,7 +397,7 @@ public class QueryCompiler {
         try {
             ucl.addURL(classSourceDirectory.toURI().toURL());
         } catch (MalformedURLException e) {
-            throw new RuntimeException("", e);
+            throw new UncheckedDeephavenException(e);
         }
     }
 
@@ -425,7 +426,7 @@ public class QueryCompiler {
         try {
             digest = MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Unable to create SHA-256 hashing digest", e);
+            throw new UncheckedDeephavenException("Unable to create SHA-256 hashing digest", e);
         }
         final String basicHashText =
                 ByteUtils.byteArrToHex(digest.digest(classBody.getBytes(StandardCharsets.UTF_8)));
@@ -645,7 +646,8 @@ public class QueryCompiler {
 
         final String[] splitPackageName = packageName.split("\\.");
         if (splitPackageName.length == 0) {
-            throw new RuntimeException(String.format("packageName %s expected to have at least one .", packageName));
+            throw new UncheckedDeephavenException(String.format(
+                    "packageName %s expected to have at least one .", packageName));
         }
         final String[] truncatedSplitPackageName = Arrays.copyOf(splitPackageName, splitPackageName.length - 1);
 
@@ -689,7 +691,7 @@ public class QueryCompiler {
 
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         if (compiler == null) {
-            throw new RuntimeException("No Java compiler provided - are you using a JRE instead of a JDK?");
+            throw new UncheckedDeephavenException("No Java compiler provided - are you using a JRE instead of a JDK?");
         }
 
         final String classPathAsString = getClassPath() + File.pathSeparator + getJavaClassPath();
@@ -707,7 +709,7 @@ public class QueryCompiler {
                     null,
                     Collections.singletonList(new JavaSourceFromString(fqClassName, finalCode)))
                     .call();
-        } catch (final Exception err) {
+        } catch (final Throwable err) {
             exceptionThrown = true;
             throw err;
         } finally {
@@ -721,7 +723,7 @@ public class QueryCompiler {
             }
         }
         if (!result) {
-            throw new RuntimeException("Error compiling class " + fqClassName + ":\n" + compilerOutput);
+            throw new UncheckedDeephavenException("Error compiling class " + fqClassName + ":\n" + compilerOutput);
         }
         // The above has compiled into e.g.
         // /tmp/workspace/cache/classes/temporaryCompilationDirectory12345/io/deephaven/test/cm12862183232603186v52_0/{various
@@ -753,7 +755,7 @@ public class QueryCompiler {
     private Pair<Boolean, String> tryCompile(File basePath, Collection<File> javaFiles) throws IOException {
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         if (compiler == null) {
-            throw new RuntimeException("No Java compiler provided - are you using a JRE instead of a JDK?");
+            throw new UncheckedDeephavenException("No Java compiler provided - are you using a JRE instead of a JDK?");
         }
 
         final File outputDirectory = Files.createTempDirectory("temporaryCompilationDirectory").toFile();
@@ -844,7 +846,7 @@ public class QueryCompiler {
                     }
                 }
             } catch (IOException e) {
-                throw new RuntimeException("Error extract manifest file from " + javaClasspath + ".\n", e);
+                throw new UncheckedIOException("Error extract manifest file from " + javaClasspath + ".\n", e);
             }
         }
         return javaClasspath;

--- a/java-client/session-dagger/src/test/java/io/deephaven/client/impl/TableServiceAsyncTest.java
+++ b/java-client/session-dagger/src/test/java/io/deephaven/client/impl/TableServiceAsyncTest.java
@@ -88,7 +88,7 @@ public class TableServiceAsyncTest extends DeephavenSessionTestBase {
     private void checkSucceeded(TableHandle x, int chainLength) {
         assertThat(x.isSuccessful()).isTrue();
         try (final SafeCloseable ignored = getExecutionContext().open()) {
-            final Table result = getSession(session.getCurrentToken()).<Table>getExport(x.exportId().id()).get();
+            final Table result = serverSessionState.<Table>getExport(x.exportId().id()).get();
             ExecutionContext.getContext().getQueryScope().putParam("ChainLength", chainLength);
             final Table expected = TableTools.emptyTable(CHAIN_ROWS).update("Current = ii - 1 + ChainLength");
             TstUtils.assertTableEquals(expected, result);

--- a/java-client/session-dagger/src/test/java/io/deephaven/client/impl/TableServiceAsyncTest.java
+++ b/java-client/session-dagger/src/test/java/io/deephaven/client/impl/TableServiceAsyncTest.java
@@ -5,7 +5,12 @@ package io.deephaven.client.impl;
 
 import io.deephaven.client.DeephavenSessionTestBase;
 import io.deephaven.client.impl.TableService.TableHandleFuture;
+import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.TstUtils;
+import io.deephaven.engine.util.TableTools;
 import io.deephaven.qst.table.TableSpec;
+import io.deephaven.util.SafeCloseable;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -27,7 +32,7 @@ public class TableServiceAsyncTest extends DeephavenSessionTestBase {
         final List<TableSpec> longChain = createLongChain();
         final TableSpec longChainLast = longChain.get(longChain.size() - 1);
         try (final TableHandle handle = get(session.executeAsync(longChainLast))) {
-            checkSucceeded(handle);
+            checkSucceeded(handle, CHAIN_OPS);
         }
     }
 
@@ -36,9 +41,10 @@ public class TableServiceAsyncTest extends DeephavenSessionTestBase {
         final List<TableSpec> longChain = createLongChain();
         final List<? extends TableHandleFuture> futures = session.executeAsync(longChain);
         try {
+            int chainLength = 0;
             for (final TableHandleFuture future : futures) {
                 try (final TableHandle handle = get(future)) {
-                    checkSucceeded(handle);
+                    checkSucceeded(handle, ++chainLength);
                 }
             }
         } catch (final Throwable t) {
@@ -55,7 +61,7 @@ public class TableServiceAsyncTest extends DeephavenSessionTestBase {
         // Cancel or close all but the last one
         TableService.TableHandleFuture.cancelOrClose(futures.subList(0, futures.size() - 1), true);
         try (final TableHandle lastHandle = get(futures.get(futures.size() - 1))) {
-            checkSucceeded(lastHandle);
+            checkSucceeded(lastHandle, CHAIN_OPS);
         }
     }
 
@@ -68,7 +74,7 @@ public class TableServiceAsyncTest extends DeephavenSessionTestBase {
         try (final TableHandle ignored = get(tableService.executeAsync(longChainLast))) {
             for (int i = 0; i < 1000; ++i) {
                 try (final TableHandle handle = get(tableService.executeAsync(longChainLast))) {
-                    checkSucceeded(handle);
+                    checkSucceeded(handle, CHAIN_OPS);
                 }
             }
         }
@@ -79,25 +85,30 @@ public class TableServiceAsyncTest extends DeephavenSessionTestBase {
         return future.getOrCancel(GETTIME);
     }
 
-    private static void checkSucceeded(TableHandle x) {
+    private void checkSucceeded(TableHandle x, int chainLength) {
         assertThat(x.isSuccessful()).isTrue();
+        try (final SafeCloseable ignored = getExecutionContext().open()) {
+            final Table result = getSession(session.getCurrentToken()).<Table>getExport(x.exportId().id()).get();
+            ExecutionContext.getContext().getQueryScope().putParam("ChainLength", chainLength);
+            final Table expected = TableTools.emptyTable(CHAIN_ROWS).update("Current = ii - 1 + ChainLength");
+            TstUtils.assertTableEquals(expected, result);
+        }
     }
 
     private static List<TableSpec> createLongChain() {
         return createLongChain(CHAIN_OPS, CHAIN_ROWS);
     }
 
-    private static List<TableSpec> createLongChain(int numColumns, int numRows) {
-        final List<TableSpec> longChain = new ArrayList<>(numColumns);
-        for (int i = 0; i < numColumns; ++i) {
+    private static List<TableSpec> createLongChain(int chainLength, int numRows) {
+        final List<TableSpec> longChain = new ArrayList<>(chainLength);
+        for (int i = 0; i < chainLength; ++i) {
             if (i == 0) {
-                longChain.add(TableSpec.empty(numRows).view("I_0=ii"));
+                longChain.add(TableSpec.empty(numRows).view("Current = ii"));
             } else {
-                // create a chain using the previous table even though we don't need the data
                 final TableSpec prev = longChain.get(i - 1);
-                // to avoid timeouts due to compilation variance reuse the same expression, including the destination
-                // column which shows up in the generated formula's FormulaEvaluationException
-                longChain.add(prev.updateView("I_1 = 1 + I_0"));
+                // Note: it's important that this formula is constant with respect to "i", otherwise we'll spend a lot
+                // of time compiling formulas
+                longChain.add(prev.updateView("Current = 1 + Current"));
             }
         }
         return longChain;

--- a/java-client/session-dagger/src/test/java/io/deephaven/client/impl/TableServiceAsyncTest.java
+++ b/java-client/session-dagger/src/test/java/io/deephaven/client/impl/TableServiceAsyncTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TableServiceAsyncTest extends DeephavenSessionTestBase {
 
     private static final Duration GETTIME = Duration.ofSeconds(15);
-    private static final int CHAIN_OPS = 50;
+    private static final int CHAIN_OPS = 250;
     private static final int CHAIN_ROWS = 1000;
 
     @Test(timeout = 20000)
@@ -93,8 +93,11 @@ public class TableServiceAsyncTest extends DeephavenSessionTestBase {
             if (i == 0) {
                 longChain.add(TableSpec.empty(numRows).view("I_0=ii"));
             } else {
+                // create a chain using the previous table even though we don't need the data
                 final TableSpec prev = longChain.get(i - 1);
-                longChain.add(prev.updateView("I_" + i + " = 1 + I_" + (i - 1)));
+                // to avoid timeouts due to compilation variance reuse the same expression, including the destination
+                // column which shows up in the generated formula's FormulaEvaluationException
+                longChain.add(prev.updateView("I_1 = 1 + I_0"));
             }
         }
         return longChain;

--- a/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
@@ -59,7 +59,7 @@ public final class BearerHandler extends CallCredentials implements ClientInterc
     }
 
     @VisibleForTesting
-    UUID getCurrentToken() {
+    public UUID getCurrentToken() {
         return UUID.fromString(bearerToken);
     }
 

--- a/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/BearerHandler.java
@@ -1,5 +1,6 @@
 package io.deephaven.client.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -14,6 +15,7 @@ import io.grpc.Status;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 
 import static io.deephaven.client.impl.Authentication.AUTHORIZATION_HEADER;
@@ -54,6 +56,11 @@ public final class BearerHandler extends CallCredentials implements ClientInterc
         if (!Objects.equals(localBearerToken, bearerToken)) {
             this.bearerToken = Objects.requireNonNull(bearerToken);
         }
+    }
+
+    @VisibleForTesting
+    UUID getCurrentToken() {
+        return UUID.fromString(bearerToken);
     }
 
     private void handleMetadata(Metadata metadata) {

--- a/java-client/session/src/main/java/io/deephaven/client/impl/Session.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/Session.java
@@ -3,10 +3,8 @@
  */
 package io.deephaven.client.impl;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.deephaven.proto.DeephavenChannel;
 
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -23,12 +21,6 @@ public interface Session
      */
     @Override
     void close();
-
-    /**
-     * Returns the current auth token.
-     */
-    @VisibleForTesting
-    UUID getCurrentToken();
 
     /**
      * Closes the session.

--- a/java-client/session/src/main/java/io/deephaven/client/impl/Session.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/Session.java
@@ -3,8 +3,10 @@
  */
 package io.deephaven.client.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.deephaven.proto.DeephavenChannel;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -21,6 +23,12 @@ public interface Session
      */
     @Override
     void close();
+
+    /**
+     * Returns the current auth token.
+     */
+    @VisibleForTesting
+    UUID getCurrentToken();
 
     /**
      * Closes the session.

--- a/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -124,18 +123,13 @@ public final class SessionImpl extends SessionBase {
                 pingFrequency.toNanos(), pingFrequency.toNanos(), TimeUnit.NANOSECONDS);
     }
 
-    // exposed for Flight
-    BearerHandler _hackBearerHandler() {
+    // exposed for Flight and testing
+    public BearerHandler _hackBearerHandler() {
         return bearerHandler;
     }
 
     private ExportStates newExportStates() {
         return new ExportStates(this, bearerChannel.session(), bearerChannel.table(), exportTicketCreator);
-    }
-
-    @Override
-    public UUID getCurrentToken() {
-        return bearerHandler.getCurrentToken();
     }
 
     @Override

--- a/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -130,6 +131,11 @@ public final class SessionImpl extends SessionBase {
 
     private ExportStates newExportStates() {
         return new ExportStates(this, bearerChannel.session(), bearerChannel.table(), exportTicketCreator);
+    }
+
+    @Override
+    public UUID getCurrentToken() {
+        return bearerHandler.getCurrentToken();
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
+++ b/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
@@ -98,7 +98,7 @@ public class DeephavenApiServer {
     }
 
     @VisibleForTesting
-    SessionService sessionService() {
+    public SessionService sessionService() {
         return sessionService;
     }
 

--- a/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
+++ b/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
@@ -24,13 +24,11 @@ import io.deephaven.server.log.LogModule;
 import io.deephaven.server.plugin.js.JsPluginNoopConsumerModule;
 import io.deephaven.server.runner.scheduler.SchedulerDelegatingImplModule;
 import io.deephaven.server.session.ObfuscatingErrorTransformerModule;
-import io.deephaven.server.session.SessionState;
 import io.deephaven.server.util.Scheduler;
 import io.deephaven.util.SafeCloseable;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.testing.GrpcCleanupRule;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -42,7 +40,6 @@ import javax.inject.Singleton;
 import java.io.PrintStream;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -174,10 +171,6 @@ public abstract class DeephavenApiServerTestBase {
 
     public ScriptSession getScriptSession() {
         return scriptSessionProvider.get();
-    }
-
-    public SessionState getSession(@NotNull final UUID token) {
-        return server.sessionService().getSessionForToken(token);
     }
 
     public ExecutionContext getExecutionContext() {


### PR DESCRIPTION
Fixes #4798.
Follow up work #4814.

Whenever I could catch a timeout in the debugger the server was not blocked, always making progress, but spending time in compilation. I've eliminated the need to recompile formulas for each operation in the chain and added some validation that the data in the result tables are as expected.

While testing ways to reproduce and/or fix the original issue, I discovered that the `JavaFileManager` that we're creating on every compilation request opened file handles for many of the jars on my classpath. After around 50'ish queries the `QueryCompiler` broke complaining of `Too many open files`. Running a quick `lsof | cut | sort | uniq -c` showed 40+ open file handles each on many of the jars on my classpath. I've done the bare minimum in this PR, will write a follow up issue, and discuss via team-slack.

Multiplexed this PR's Check CI here: https://github.com/nbauernfeind/deephaven-core/actions/runs/6830355652
Multiplexed current main's Check CI here: https://github.com/nbauernfeind/deephaven-core/actions/runs/6830357421/
(I expect to see a failure or three in the current main and none for this PR as it's hard to tell if the issue has been fixed.)