### PR TITLE
Add TableDefinition column name helpers

### DIFF
--- a/Plot/src/main/java/io/deephaven/plot/util/ArgumentValidations.java
+++ b/Plot/src/main/java/io/deephaven/plot/util/ArgumentValidations.java
@@ -841,7 +841,7 @@ public class ArgumentValidations {
         assertNotNull(t, "t", plotInfo);
         assertNotNull(cols, "cols", plotInfo);
         for (String c : cols) {
-            if (!t.getColumnSourceMap().containsKey(c)) {
+            if (!t.hasColumns(c)) {
                 throw new PlotIllegalArgumentException("Column " + c + " could not be found in table.", plotInfo);
             }
         }

--- a/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
@@ -305,12 +305,25 @@ public class TableDefinition implements LogOutputAppendable {
     }
 
     /**
+     * Check this definition to ensure that {@code columnName} is present.
+     *
+     * @param columnName The column name to check
+     * @throws NoSuchColumnException If {@code columnName} is missing
+     */
+    public final void checkColumn(@NotNull String columnName) {
+        final Set<String> columnNames = getColumnNameSet();
+        if (!columnNames.contains(columnName)) {
+            throw new NoSuchColumnException(columnNames, columnName);
+        }
+    }
+
+    /**
      * Check this definition to ensure that all {@code columns} are present.
      *
      * @param columns The column names to check
-     * @throws NoSuchColumnException If any columns were missing
+     * @throws NoSuchColumnException If any {@code columns} were missing
      */
-    public final void checkAvailableColumns(@NotNull Collection<String> columns) {
+    public final void checkColumns(@NotNull Collection<String> columns) {
         final Set<String> columnNames = getColumnNameSet();
         final List<String> missingColumns = columns
                 .stream()

--- a/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
@@ -310,7 +310,7 @@ public class TableDefinition implements LogOutputAppendable {
      * @param columnName The column name to check
      * @throws NoSuchColumnException If {@code columnName} is missing
      */
-    public final void checkColumn(@NotNull String columnName) {
+    public final void checkHasColumn(@NotNull String columnName) {
         final Set<String> columnNames = getColumnNameSet();
         if (!columnNames.contains(columnName)) {
             throw new NoSuchColumnException(columnNames, columnName);
@@ -323,7 +323,7 @@ public class TableDefinition implements LogOutputAppendable {
      * @param columns The column names to check
      * @throws NoSuchColumnException If any {@code columns} were missing
      */
-    public final void checkColumns(@NotNull Collection<String> columns) {
+    public final void checkHasColumns(@NotNull Collection<String> columns) {
         final Set<String> columnNames = getColumnNameSet();
         final List<String> missingColumns = columns
                 .stream()

--- a/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/TableDefinition.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Map.Entry;
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -311,10 +310,7 @@ public class TableDefinition implements LogOutputAppendable {
      * @throws NoSuchColumnException If {@code columnName} is missing
      */
     public final void checkHasColumn(@NotNull String columnName) {
-        final Set<String> columnNames = getColumnNameSet();
-        if (!columnNames.contains(columnName)) {
-            throw new NoSuchColumnException(columnNames, columnName);
-        }
+        NoSuchColumnException.throwIf(getColumnNameSet(), columnName);
     }
 
     /**
@@ -324,14 +320,7 @@ public class TableDefinition implements LogOutputAppendable {
      * @throws NoSuchColumnException If any {@code columns} were missing
      */
     public final void checkHasColumns(@NotNull Collection<String> columns) {
-        final Set<String> columnNames = getColumnNameSet();
-        final List<String> missingColumns = columns
-                .stream()
-                .filter(Predicate.not(columnNames::contains))
-                .collect(Collectors.toList());
-        if (!missingColumns.isEmpty()) {
-            throw new NoSuchColumnException(columnNames, missingColumns);
-        }
+        NoSuchColumnException.throwIf(getColumnNameSet(), columns);
     }
 
     /**

--- a/engine/api/src/main/java/io/deephaven/engine/table/impl/NoSuchColumnException.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/impl/NoSuchColumnException.java
@@ -5,30 +5,117 @@ package io.deephaven.engine.table.impl;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Exception thrown when a column is not found.
  */
 public class NoSuchColumnException extends IllegalArgumentException {
+
+    public static final String DELIMITER = ", ";
+
+    public static final String DEFAULT_FORMAT_STR = "Unknown column names [%s], available column names are [%s]";
+
+    public enum Type {
+        MISSING, AVAILABLE, REQUESTED
+    }
+
     /**
-     * Thrown when an operation can not find a required column.
+     * Equivalent to {@code throwIf(available, Collections.singleton(requested))}.
+     *
+     * @param available the available columns
+     * @param requested the requested columns
+     * @see #throwIf(Set, Collection)
+     */
+    public static void throwIf(Set<String> available, String requested) {
+        throwIf(available, Collections.singleton(requested));
+    }
+
+    /**
+     * Equivalent to {@code throwIf(available, requested, DEFAULT_FORMAT_STR, Type.MISSING, Type.AVAILABLE)} where
+     * {@code DEFAULT_FORMAT_STR} is {@value DEFAULT_FORMAT_STR}.
+     *
+     * @param available the available columns
+     * @param requested the requested columns
+     * @see #throwIf(Set, Collection, String, Type...)
+     */
+    public static void throwIf(Set<String> available, Collection<String> requested) {
+        throwIf(available, requested, DEFAULT_FORMAT_STR, Type.MISSING, Type.AVAILABLE);
+    }
+
+    /**
+     * Throws a {@link NoSuchColumnException} if any name from {@code requested} is not in {@code available}. The
+     * message will be constructed by {@link String#join(CharSequence, Iterable) joining} the respective collection with
+     * {@value DELIMITER} and presenting them to {@link String#format(String, Object...) format} in {@code types} order.
+     *
+     * @param available the available columns
+     * @param requested the requested columns
+     * @param formatStr the format string
+     * @param types the collection types order for formatting
+     */
+    public static void throwIf(Set<String> available, Collection<String> requested, String formatStr, Type... types) {
+        final List<String> missing = requested
+                .stream()
+                .filter(Predicate.not(available::contains))
+                .collect(Collectors.toList());
+        if (!missing.isEmpty()) {
+            final Object[] formatArgs = new Object[types.length];
+            for (int i = 0; i < types.length; ++i) {
+                switch (types[i]) {
+                    case MISSING:
+                        formatArgs[i] = String.join(DELIMITER, missing);
+                        break;
+                    case AVAILABLE:
+                        formatArgs[i] = String.join(DELIMITER, available);
+                        break;
+                    case REQUESTED:
+                        formatArgs[i] = String.join(DELIMITER, requested);
+                        break;
+                    default:
+                        throw new IllegalStateException("Unexpected case " + types[i]);
+                }
+            }
+            throw new NoSuchColumnException(String.format(formatStr, formatArgs));
+        }
+    }
+
+    /**
+     * Thrown when an operation can not find a required column(s).
+     *
+     * <p>
+     * Callers may prefer to use {@link #throwIf(Set, Collection, String, Type...)} when applicable.
+     *
+     * @param message the message
+     */
+    public NoSuchColumnException(String message) {
+        super(message);
+    }
+
+    /**
+     * Thrown when an operation can not find a required column(s).
+     *
+     * <p>
+     * Callers may prefer to use {@link #throwIf(Set, Collection)} when applicable.
      *
      * @param presentColumns the column names present in the table
-     * @param requestedColumns the request column names that were not found
+     * @param missingColumns the request column names that were not found
      */
-    public NoSuchColumnException(Collection<String> presentColumns, Collection<String> requestedColumns) {
-        super(String.format("Unknown column names [%s], available column names are [%s]",
-                String.join(",", requestedColumns),
-                String.join(",", presentColumns)));
+    public NoSuchColumnException(Collection<String> presentColumns, Collection<String> missingColumns) {
+        this(String.format(DEFAULT_FORMAT_STR,
+                String.join(DELIMITER, missingColumns),
+                String.join(DELIMITER, presentColumns)));
     }
 
     /**
      * Thrown when an operation can not find a required column.
      *
      * @param presentColumns the column names present in the table
-     * @param requestedColumn the request column name that was not found
+     * @param missingColumn the request column name that was not found
      */
-    public NoSuchColumnException(Collection<String> presentColumns, String requestedColumn) {
-        this(presentColumns, Collections.singleton(requestedColumn));
+    public NoSuchColumnException(Collection<String> presentColumns, String missingColumn) {
+        this(presentColumns, Collections.singleton(missingColumn));
     }
 }

--- a/engine/api/src/main/java/io/deephaven/engine/table/impl/NoSuchColumnException.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/impl/NoSuchColumnException.java
@@ -17,8 +17,9 @@ public class NoSuchColumnException extends IllegalArgumentException {
      * @param requestedColumns the request column names that were not found
      */
     public NoSuchColumnException(Collection<String> presentColumns, Collection<String> requestedColumns) {
-        super("Unknown column names [" + String.join(",", requestedColumns)
-                + "], available column names are [" + String.join(",", presentColumns) + "]");
+        super(String.format("Unknown column names [%s], available column names are [%s]",
+                String.join(",", requestedColumns),
+                String.join(",", presentColumns)));
     }
 
     /**

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/SortBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/SortBenchmark.java
@@ -138,7 +138,8 @@ public class SortBenchmark {
         mcsWithSortColumn = inputTable.newModifiedColumnSet(sortCol);
         MutableInt ci = new MutableInt();
         final String[] sortColumns = new String[inputTable.numColumns() - 1];
-        inputTable.getColumnSourceMap().keySet().forEach(columnName -> {
+
+        inputTable.getDefinition().getColumnNameSet().forEach(columnName -> {
             if (!columnName.equals(sortCol)) {
                 sortColumns[ci.intValue()] = columnName;
                 ci.increment();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -1021,7 +1021,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
     @Override
     public final void checkAvailableColumns(@NotNull final Collection<String> columns) {
-        getDefinition().checkAvailableColumns(columns);
+        getDefinition().checkColumns(columns);
     }
 
     public void copySortableColumns(

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -1021,7 +1021,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
     @Override
     public final void checkAvailableColumns(@NotNull final Collection<String> columns) {
-        getDefinition().checkColumns(columns);
+        getDefinition().checkHasColumns(columns);
     }
 
     public void copySortableColumns(

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -1020,13 +1020,8 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
     }
 
     @Override
-    public void checkAvailableColumns(@NotNull final Collection<String> columns) {
-        final Map<String, ? extends ColumnSource<?>> sourceMap = getColumnSourceMap();
-        final String[] missingColumns =
-                columns.stream().filter(col -> !sourceMap.containsKey(col)).toArray(String[]::new);
-        if (missingColumns.length > 0) {
-            throw new NoSuchColumnException(sourceMap.keySet(), Arrays.asList(missingColumns));
-        }
+    public final void checkAvailableColumns(@NotNull final Collection<String> columns) {
+        getDefinition().checkAvailableColumns(columns);
     }
 
     public void copySortableColumns(
@@ -1109,9 +1104,9 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         }
 
         // Now go through the other columns in the table and add them if they were unchanged
-        final Map<String, ? extends ColumnSource<?>> sourceMap = destination.getColumnSourceMap();
+        final Set<String> destKeys = destination.getDefinition().getColumnNameSet();
         for (String col : currentSortableSet) {
-            if (sourceMap.containsKey(col)) {
+            if (destKeys.contains(col)) {
                 newSortableSet.add(col);
             }
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -1058,7 +1058,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         // Process the original set of sortable columns, adding them to the new set if one of the below
         // 1) The column exists in the new table and was not renamed in any way but the Identity (C1 = C1)
         // 2) The column does not exist in the new table, but was renamed to another (C2 = C1)
-        final Set<String> resultColumnNames = destination.getDefinition().getColumnNameMap().keySet();
+        final Set<String> resultColumnNames = destination.getDefinition().getColumnNameSet();
         for (final String columnName : currentSortableColumns) {
             // Only add it to the set of sortable columns if it hasn't changed in an unknown way
             final String maybeRenamedColumn = columnMapping.get(columnName);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BucketingContext.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BucketingContext.java
@@ -20,6 +20,7 @@ import io.deephaven.util.type.TypeUtils;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.deephaven.engine.table.impl.MatchPair.matchString;
@@ -41,8 +42,11 @@ class BucketingContext implements SafeCloseable {
 
     BucketingContext(final String listenerPrefix, final QueryTable leftTable, final QueryTable rightTable,
             MatchPair[] columnsToMatch, MatchPair[] columnsToAdd, JoinControl control) {
-        final List<String> conflicts = Arrays.stream(columnsToAdd).map(MatchPair::leftColumn)
-                .filter(cn -> leftTable.getColumnSourceMap().containsKey(cn)).collect(Collectors.toList());
+        final Set<String> leftKeys = leftTable.getDefinition().getColumnNameSet();
+        final List<String> conflicts = Arrays.stream(columnsToAdd)
+                .map(MatchPair::leftColumn)
+                .filter(leftKeys::contains)
+                .collect(Collectors.toList());
         if (!conflicts.isEmpty()) {
             throw new RuntimeException("Conflicting column names " + conflicts);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/CrossJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/CrossJoinHelper.java
@@ -195,7 +195,7 @@ public class CrossJoinHelper {
                 jsm.startTrackingPrevValues();
                 final ModifiedColumnSet.Transformer leftTransformer = leftTable.newModifiedColumnSetTransformer(
                         resultTable,
-                        leftTable.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                        leftTable.getDefinition().getColumnNamesArray());
 
                 leftTable.addUpdateListener(new BaseTable.ListenerImpl(bucketingContext.listenerDescription,
                         leftTable, resultTable) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/CrossJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/CrossJoinHelper.java
@@ -195,7 +195,7 @@ public class CrossJoinHelper {
                 jsm.startTrackingPrevValues();
                 final ModifiedColumnSet.Transformer leftTransformer = leftTable.newModifiedColumnSetTransformer(
                         resultTable,
-                        leftTable.getColumnSourceMap().keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                        leftTable.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
 
                 leftTable.addUpdateListener(new BaseTable.ListenerImpl(bucketingContext.listenerDescription,
                         leftTable, resultTable) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1787,7 +1787,7 @@ public class QueryTable extends BaseTable<QueryTable> {
 
                             copyAttributes(resultTable, CopyAttributeOperation.DropColumns);
                             copySortableColumns(resultTable,
-                                    resultTable.getDefinition().getColumnNameMap()::containsKey);
+                                    resultTable.getDefinition().getColumnNameSet()::contains);
                             maybeCopyColumnDescriptions(resultTable);
 
                             if (snapshotControl != null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1772,7 +1772,7 @@ public class QueryTable extends BaseTable<QueryTable> {
             return memoizeResult(MemoizedOperationKey.dropColumns(columnNames), () -> QueryPerformanceRecorder
                     .withNugget("dropColumns(" + Arrays.toString(columnNames) + ")", sizeForInstrumentation(), () -> {
                         final Mutable<Table> result = new MutableObject<>();
-                        definition.checkColumns(Arrays.asList(columnNames));
+                        definition.checkHasColumns(Arrays.asList(columnNames));
                         final Map<String, ColumnSource<?>> newColumns = new LinkedHashMap<>(columns);
                         for (String columnName : columnNames) {
                             newColumns.remove(columnName);
@@ -1793,8 +1793,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                             if (snapshotControl != null) {
                                 final ModifiedColumnSet.Transformer mcsTransformer =
                                         newModifiedColumnSetTransformer(resultTable,
-                                                resultTable.getDefinition().getColumnNameSet()
-                                                        .toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                                                resultTable.getDefinition().getColumnNamesArray());
                                 final ListenerImpl listener = new ListenerImpl(
                                         "dropColumns(" + Arrays.deepToString(columnNames) + ')', this, resultTable) {
                                     @Override
@@ -2393,7 +2392,7 @@ public class QueryTable extends BaseTable<QueryTable> {
 
         // Use the given columns (if specified); otherwise an empty array means all of my columns
         final String[] useStampColumns = stampColumns.length == 0
-                ? definition.getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY)
+                ? definition.getColumnNamesArray()
                 : stampColumns;
 
         final Map<String, ColumnSource<?>> triggerColumns = new LinkedHashMap<>();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1772,7 +1772,7 @@ public class QueryTable extends BaseTable<QueryTable> {
             return memoizeResult(MemoizedOperationKey.dropColumns(columnNames), () -> QueryPerformanceRecorder
                     .withNugget("dropColumns(" + Arrays.toString(columnNames) + ")", sizeForInstrumentation(), () -> {
                         final Mutable<Table> result = new MutableObject<>();
-                        definition.checkAvailableColumns(Arrays.asList(columnNames));
+                        definition.checkColumns(Arrays.asList(columnNames));
                         final Map<String, ColumnSource<?>> newColumns = new LinkedHashMap<>(columns);
                         for (String columnName : columnNames) {
                             newColumns.remove(columnName);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1772,14 +1772,7 @@ public class QueryTable extends BaseTable<QueryTable> {
             return memoizeResult(MemoizedOperationKey.dropColumns(columnNames), () -> QueryPerformanceRecorder
                     .withNugget("dropColumns(" + Arrays.toString(columnNames) + ")", sizeForInstrumentation(), () -> {
                         final Mutable<Table> result = new MutableObject<>();
-
-                        final Set<String> existingColumns = new HashSet<>(definition.getColumnNames());
-                        final Set<String> columnNamesToDrop = new HashSet<>(Arrays.asList(columnNames));
-                        if (!existingColumns.containsAll(columnNamesToDrop)) {
-                            columnNamesToDrop.removeAll(existingColumns);
-                            throw new RuntimeException("Unknown columns: " + columnNamesToDrop
-                                    + ", available columns = " + getColumnSourceMap().keySet());
-                        }
+                        definition.checkAvailableColumns(Arrays.asList(columnNames));
                         final Map<String, ColumnSource<?>> newColumns = new LinkedHashMap<>(columns);
                         for (String columnName : columnNames) {
                             newColumns.remove(columnName);
@@ -1800,7 +1793,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                             if (snapshotControl != null) {
                                 final ModifiedColumnSet.Transformer mcsTransformer =
                                         newModifiedColumnSetTransformer(resultTable,
-                                                resultTable.getColumnSourceMap().keySet()
+                                                resultTable.getDefinition().getColumnNameSet()
                                                         .toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
                                 final ListenerImpl listener = new ListenerImpl(
                                         "dropColumns(" + Arrays.deepToString(columnNames) + ')', this, resultTable) {
@@ -2400,7 +2393,7 @@ public class QueryTable extends BaseTable<QueryTable> {
 
         // Use the given columns (if specified); otherwise an empty array means all of my columns
         final String[] useStampColumns = stampColumns.length == 0
-                ? getColumnSourceMap().keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY)
+                ? definition.getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY)
                 : stampColumns;
 
         final Map<String, ColumnSource<?>> triggerColumns = new LinkedHashMap<>();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -355,7 +355,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     public <T> ColumnSource<T> getColumnSource(String sourceName) {
         final ColumnSource<?> columnSource = columns.get(sourceName);
         if (columnSource == null) {
-            throw new NoSuchColumnException(columns.keySet(), Collections.singletonList(sourceName));
+            throw new NoSuchColumnException(columns.keySet(), sourceName);
         }
         // noinspection unchecked
         return (ColumnSource<T>) columnSource;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/RedefinableTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/RedefinableTable.java
@@ -84,15 +84,8 @@ public abstract class RedefinableTable<IMPL_TYPE extends RedefinableTable<IMPL_T
         if (columnNames == null || columnNames.length == 0) {
             return this;
         }
-
         final Set<String> columnNamesToDrop = new HashSet<>(Arrays.asList(columnNames));
-        final Set<String> existingColumns = new HashSet<>(definition.getColumnNames());
-        if (!existingColumns.containsAll(columnNamesToDrop)) {
-            columnNamesToDrop.removeAll(existingColumns);
-            throw new RuntimeException("Unknown columns: " + columnNamesToDrop.toString() + ", available columns = "
-                    + getColumnSourceMap().keySet());
-        }
-
+        definition.checkAvailableColumns(columnNamesToDrop);
         List<ColumnDefinition<?>> resultColumns = new ArrayList<>();
         for (ColumnDefinition<?> cDef : definition.getColumns()) {
             if (!columnNamesToDrop.contains(cDef.getName())) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/RedefinableTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/RedefinableTable.java
@@ -85,7 +85,7 @@ public abstract class RedefinableTable<IMPL_TYPE extends RedefinableTable<IMPL_T
             return this;
         }
         final Set<String> columnNamesToDrop = new HashSet<>(Arrays.asList(columnNames));
-        definition.checkAvailableColumns(columnNamesToDrop);
+        definition.checkColumns(columnNamesToDrop);
         List<ColumnDefinition<?>> resultColumns = new ArrayList<>();
         for (ColumnDefinition<?> cDef : definition.getColumns()) {
             if (!columnNamesToDrop.contains(cDef.getName())) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/RedefinableTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/RedefinableTable.java
@@ -85,7 +85,7 @@ public abstract class RedefinableTable<IMPL_TYPE extends RedefinableTable<IMPL_T
             return this;
         }
         final Set<String> columnNamesToDrop = new HashSet<>(Arrays.asList(columnNames));
-        definition.checkColumns(columnNamesToDrop);
+        definition.checkHasColumns(columnNamesToDrop);
         List<ColumnDefinition<?>> resultColumns = new ArrayList<>();
         for (ColumnDefinition<?> cDef : definition.getColumns()) {
             if (!columnNamesToDrop.contains(cDef.getName())) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
@@ -98,7 +98,7 @@ public interface TableDefaults extends Table, TableOperationsDefaults<Table, Tab
         if (columnNames == null) {
             throw new IllegalArgumentException("columnNames cannot be null!");
         }
-        return getDefinition().getColumnNameMap().keySet().containsAll(columnNames);
+        return getDefinition().getColumnNameSet().containsAll(columnNames);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
@@ -61,11 +61,14 @@ public class TableUpdateValidator implements QueryTable.Operation<QueryTable> {
         this.description = description == null ? tableToValidate.getDescription() : description;
         this.tableToValidate = tableToValidate;
         this.validationMCS = tableToValidate.newModifiedColumnSet(
-                tableToValidate.getColumnSourceMap().keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                tableToValidate.getDefinition().getColumnStream().map(ColumnDefinition::getName)
+                        .toArray(String[]::new));
         Assert.neq(validationMCS, "validationMCS", ModifiedColumnSet.ALL, "ModifiedColumnSet.ALL");
         Assert.neq(validationMCS, "validationMCS", ModifiedColumnSet.EMPTY, "ModifiedColumnSet.EMPTY");
 
-        columnInfos = tableToValidate.getColumnSourceMap().keySet().stream()
+        columnInfos = tableToValidate.getDefinition()
+                .getColumnStream()
+                .map(ColumnDefinition::getName)
                 .map((name) -> new ColumnInfo(tableToValidate, name))
                 .toArray(ColumnInfo[]::new);
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
@@ -61,8 +61,7 @@ public class TableUpdateValidator implements QueryTable.Operation<QueryTable> {
         this.description = description == null ? tableToValidate.getDescription() : description;
         this.tableToValidate = tableToValidate;
         this.validationMCS = tableToValidate.newModifiedColumnSet(
-                tableToValidate.getDefinition().getColumnStream().map(ColumnDefinition::getName)
-                        .toArray(String[]::new));
+                tableToValidate.getDefinition().getColumnNamesArray());
         Assert.neq(validationMCS, "validationMCS", ModifiedColumnSet.ALL, "ModifiedColumnSet.ALL");
         Assert.neq(validationMCS, "validationMCS", ModifiedColumnSet.EMPTY, "ModifiedColumnSet.EMPTY");
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
@@ -93,7 +93,7 @@ public class ChunkedOperatorAggregationHelper {
                 throw new IllegalArgumentException(
                         "aggregation: initial groups must not be specified if no group-by columns are specified");
             }
-            initialKeys.getDefinition().checkColumns(keyNames);
+            initialKeys.getDefinition().checkHasColumns(keyNames);
             for (final String keyName : keyNames) {
                 final ColumnDefinition<?> inputDef = input.getDefinition().getColumn(keyName);
                 final ColumnDefinition<?> initialKeysDef = initialKeys.getDefinition().getColumn(keyName);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
@@ -47,7 +47,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.LongFunction;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -94,7 +93,7 @@ public class ChunkedOperatorAggregationHelper {
                 throw new IllegalArgumentException(
                         "aggregation: initial groups must not be specified if no group-by columns are specified");
             }
-            initialKeys.getDefinition().checkAvailableColumns(keyNames);
+            initialKeys.getDefinition().checkColumns(keyNames);
             for (final String keyName : keyNames) {
                 final ColumnDefinition<?> inputDef = input.getDefinition().getColumn(keyName);
                 final ColumnDefinition<?> initialKeysDef = initialKeys.getDefinition().getColumn(keyName);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
@@ -111,7 +111,7 @@ public class ChunkedOperatorAggregationHelper {
                 final ColumnDefinition<?> initialKeysDef = initialKeys.getDefinition().getColumn(keyName);
                 if (!inputDef.isCompatible(initialKeysDef)) {
                     throw new IllegalArgumentException(String.format(
-                            "aggregation: column definition mismatch between input table and initial groups table for %s input has %s, initial groups has %s",
+                            "aggregation: column definition mismatch between input table and initial groups table for %s; input has %s, initial groups has %s",
                             keyName,
                             inputDef.describeForCompatibility(),
                             initialKeysDef.describeForCompatibility()));

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
@@ -113,7 +113,7 @@ public class ChunkedOperatorAggregationHelper {
                 "by(" + aggregationContextFactory + ", " + groupByColumns + ")", snapshotControl,
                 (usePrev, beforeClockValue) -> {
                     resultHolder.setValue(aggregation(control, snapshotControl, aggregationContextFactory,
-                            input, preserveEmpty, initialKeys, keyNames, usePrev));
+                            input, preserveEmpty, initialKeys, keyNames.toArray(String[]::new), usePrev));
                     return true;
                 });
         return resultHolder.getValue();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/PartitionByChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/PartitionByChunkedOperator.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -167,11 +168,10 @@ public final class PartitionByChunkedOperator implements IterativeChunkedAggrega
             shiftDataBuilders = new ObjectArraySource<>(RowSetShiftData.SmartCoalescingBuilder.class);
 
             final Set<String> keyColumnNameSet = Arrays.stream(keyColumnNames).collect(Collectors.toSet());
-            final Set<String> unadjustedParentColumnNameSet =
-                    new LinkedHashSet<>(unadjustedParentTable.getDefinition().getColumnNames());
+            final Set<String> unadjustedParentColumnNameSet = unadjustedParentTable.getDefinition().getColumnNameSet();
             final String[] retainedResultColumnNames = parentTable.getDefinition().getColumnStream()
                     .map(ColumnDefinition::getName)
-                    .filter(cn -> !keyColumnNameSet.contains(cn))
+                    .filter(Predicate.not(keyColumnNameSet::contains))
                     .filter(unadjustedParentColumnNameSet::contains)
                     .toArray(String[]::new);
             final ModifiedColumnSet[] retainedResultModifiedColumnSets = Arrays.stream(retainedResultColumnNames)

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/HierarchicalTableImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/HierarchicalTableImpl.java
@@ -136,13 +136,8 @@ abstract class HierarchicalTableImpl<IFACE_TYPE extends HierarchicalTable<IFACE_
     }
 
     @Override
-    protected void checkAvailableColumns(@NotNull final Collection<String> columns) {
-        final Set<String> availableColumns = root.getDefinition().getColumnNameMap().keySet();
-        final List<String> missingColumns =
-                columns.stream().filter(column -> !availableColumns.contains(column)).collect(Collectors.toList());
-        if (!missingColumns.isEmpty()) {
-            throw new NoSuchColumnException(availableColumns, missingColumns);
-        }
+    protected final void checkAvailableColumns(@NotNull final Collection<String> columns) {
+        root.getDefinition().checkAvailableColumns(columns);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/HierarchicalTableImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/HierarchicalTableImpl.java
@@ -137,7 +137,7 @@ abstract class HierarchicalTableImpl<IFACE_TYPE extends HierarchicalTable<IFACE_
 
     @Override
     protected final void checkAvailableColumns(@NotNull final Collection<String> columns) {
-        root.getDefinition().checkAvailableColumns(columns);
+        root.getDefinition().checkColumns(columns);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/HierarchicalTableImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/HierarchicalTableImpl.java
@@ -137,7 +137,7 @@ abstract class HierarchicalTableImpl<IFACE_TYPE extends HierarchicalTable<IFACE_
 
     @Override
     protected final void checkAvailableColumns(@NotNull final Collection<String> columns) {
-        root.getDefinition().checkColumns(columns);
+        root.getDefinition().checkHasColumns(columns);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/RollupTableImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/RollupTableImpl.java
@@ -465,7 +465,7 @@ public class RollupTableImpl extends HierarchicalTableImpl<RollupTable, RollupTa
                 source.getAttributes(ak -> shouldCopyAttribute(ak, CopyAttributeOperation.Rollup)),
                 source, aggregations, includeConstituents, groupByColumns,
                 levelTables, levelRowLookups, levelNodeTableSources, null, null, null, null, null);
-        source.copySortableColumns(result, baseLevel.getDefinition().getColumnNameMap()::containsKey);
+        source.copySortableColumns(result, baseLevel.getDefinition().getColumnNameSet()::contains);
         result.setColumnDescriptions(AggregationDescriptions.of(aggregations));
         return result;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
@@ -1403,9 +1403,8 @@ public class ConstructSnapshot {
         }
 
         LongSizedDataStructure.intSize("construct snapshot", snapshot.rowsIncluded.size());
-
-        final Map<String, ? extends ColumnSource<?>> sourceMap = table.getColumnSourceMap();
-        final String[] columnSources = sourceMap.keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
+        final String[] columnSources =
+                table.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
 
         snapshot.dataColumns = new Object[columnSources.length];
         try (final SharedContext sharedContext =
@@ -1480,8 +1479,8 @@ public class ConstructSnapshot {
             snapshot.rowsIncluded = snapshot.rowsAdded.copy();
         }
 
-        final Map<String, ? extends ColumnSource<?>> sourceMap = table.getColumnSourceMap();
-        final String[] columnSources = sourceMap.keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
+        final String[] columnSources =
+                table.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
 
         try (final SharedContext sharedContext =
                 (columnSources.length > 1) ? SharedContext.makeSharedContext() : null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/remote/ConstructSnapshot.java
@@ -1403,8 +1403,7 @@ public class ConstructSnapshot {
         }
 
         LongSizedDataStructure.intSize("construct snapshot", snapshot.rowsIncluded.size());
-        final String[] columnSources =
-                table.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
+        final String[] columnSources = table.getDefinition().getColumnNamesArray();
 
         snapshot.dataColumns = new Object[columnSources.length];
         try (final SharedContext sharedContext =
@@ -1479,8 +1478,7 @@ public class ConstructSnapshot {
             snapshot.rowsIncluded = snapshot.rowsAdded.copy();
         }
 
-        final String[] columnSources =
-                table.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
+        final String[] columnSources = table.getDefinition().getColumnNamesArray();
 
         try (final SharedContext sharedContext =
                 (columnSources.length > 1) ? SharedContext.makeSharedContext() : null) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
@@ -95,22 +95,7 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
 
     @Override
     public List<String> initDef(Map<String, ColumnDefinition<?>> columnDefinitionMap) {
-        final MutableObject<List<String>> missingColumnsHolder = new MutableObject<>();
-        sourceNames.forEach(name -> {
-            final ColumnDefinition<?> sourceColumnDefinition = columnDefinitionMap.get(name);
-            if (sourceColumnDefinition == null) {
-                List<String> missingColumnsList;
-                if ((missingColumnsList = missingColumnsHolder.getValue()) == null) {
-                    missingColumnsHolder.setValue(missingColumnsList = new ArrayList<>());
-                }
-                missingColumnsList.add(name);
-            }
-        });
-
-        if (missingColumnsHolder.getValue() != null) {
-            throw new NoSuchColumnException(columnDefinitionMap.keySet(), missingColumnsHolder.getValue());
-        }
-
+        NoSuchColumnException.throwIf(columnDefinitionMap.keySet(), sourceNames);
         return getColumns();
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/snapshot/SnapshotInternalListener.java
@@ -33,7 +33,7 @@ public class SnapshotInternalListener extends BaseTable.ListenerImpl {
             Map<String, SingleValueColumnSource<?>> resultTriggerColumns,
             Map<String, WritableColumnSource<?>> resultBaseColumns,
             TrackingWritableRowSet resultRowSet) {
-        super("snapshot " + result.getColumnSourceMap().keySet(), triggerTable, result);
+        super("snapshot " + result.getDefinition().getColumnNameSet(), triggerTable, result);
         this.triggerTable = triggerTable;
         this.result = result;
         this.lazySnapshot = lazySnapshot;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -1198,7 +1199,10 @@ public abstract class UpdateBy {
 
         final MutableObject<String> timestampColumnName = new MutableObject<>(null);
         // create an initial set of all source columns
-        final Set<String> preservedColumnSet = new LinkedHashSet<>(source.getColumnSourceMap().keySet());
+        final LinkedHashSet<String> preservedColumnSet = source.getDefinition()
+                .getColumnStream()
+                .map(ColumnDefinition::getName)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         final Set<String> problems = new LinkedHashSet<>();
         final Map<String, ColumnSource<?>> opResultSources = new LinkedHashMap<>();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -1189,7 +1189,7 @@ public abstract class UpdateBy {
 
         final Collection<List<ColumnUpdateOperation>> windowSpecs =
                 updateByOperatorFactory.getWindowOperatorSpecs(clauses);
-        if (windowSpecs.size() == 0) {
+        if (windowSpecs.isEmpty()) {
             throw new IllegalArgumentException("At least one operator must be specified");
         }
 
@@ -1199,7 +1199,7 @@ public abstract class UpdateBy {
 
         final MutableObject<String> timestampColumnName = new MutableObject<>(null);
         // create an initial set of all source columns
-        final LinkedHashSet<String> preservedColumnSet = new LinkedHashSet<>(source.getDefinition().getColumnNames());
+        final LinkedHashSet<String> preservedColumnSet = new LinkedHashSet<>(source.getDefinition().getColumnNameSet());
 
         final Set<String> problems = new LinkedHashSet<>();
         final Map<String, ColumnSource<?>> opResultSources = new LinkedHashMap<>();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -1199,10 +1199,7 @@ public abstract class UpdateBy {
 
         final MutableObject<String> timestampColumnName = new MutableObject<>(null);
         // create an initial set of all source columns
-        final LinkedHashSet<String> preservedColumnSet = source.getDefinition()
-                .getColumnStream()
-                .map(ColumnDefinition::getName)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        final LinkedHashSet<String> preservedColumnSet = new LinkedHashSet<>(source.getDefinition().getColumnNames());
 
         final Set<String> problems = new LinkedHashSet<>();
         final Map<String, ColumnSource<?>> opResultSources = new LinkedHashMap<>();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/DynamicTableWriter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/DynamicTableWriter.java
@@ -778,7 +778,7 @@ public final class DynamicTableWriter implements TableWriter {
         public PermissiveRowSetter<?> getSetter(final String name) {
             final PermissiveRowSetter<?> rowSetter = columnToSetter.get(name);
             if (rowSetter == null) {
-                if (table.getColumnSourceMap().containsKey(name)) {
+                if (table.hasColumns(name)) {
                     throw new RuntimeException("Column has a constant value, can not get setter " + name);
                 } else {
                     throw new RuntimeException("Unknown column name " + name);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/KeyedArrayBackedMutableTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/KeyedArrayBackedMutableTable.java
@@ -131,7 +131,7 @@ public class KeyedArrayBackedMutableTable extends BaseArrayBackedMutableTable {
     }
 
     private void startTrackingPrev() {
-        getColumnSourceMap().values().forEach(ColumnSource::startTrackingPrevValues);
+        getColumnSources().forEach(ColumnSource::startTrackingPrevValues);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/util/OuterJoinTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/OuterJoinTools.java
@@ -68,10 +68,10 @@ public class OuterJoinTools {
         // find a sentinel column name to use to identify right-side only rows
         int numAttempts = 0;
         String sentinelColumnName;
-        final Map<String, ? extends ColumnSource<?>> resultColumns = leftTable.getColumnSourceMap();
+        final Set<String> resultColumns = leftTable.getDefinition().getColumnNameSet();
         do {
             sentinelColumnName = "__sentinel_" + (numAttempts++) + "__";
-        } while (resultColumns.containsKey(sentinelColumnName));
+        } while (resultColumns.contains(sentinelColumnName));
 
         // only need match columns from the left; rename to right names and drop remaining to avoid name conflicts
         final List<SelectColumn> leftColumns = Streams.concat(

--- a/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TableTools.java
@@ -1151,7 +1151,7 @@ public class TableTools {
 
         final DataOutputStream osw = new DataOutputStream(new DigestOutputStream(new NullOutputStream(), md));
 
-        for (final ColumnSource<?> col : source.getColumnSourceMap().values()) {
+        for (final ColumnSource<?> col : source.getColumnSources()) {
             processColumnForFingerprint(source.getRowSet(), col, osw);
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/TableToolsMergeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TableToolsMergeHelper.java
@@ -115,15 +115,15 @@ public class TableToolsMergeHelper {
         if (!table.hasAttribute(Table.MERGED_TABLE_ATTRIBUTE)) {
             return false;
         }
-        Map<String, ColumnSource<?>> columnSourceMap = queryTable.getColumnSourceMap();
-        if (columnSourceMap.isEmpty()) {
+        final Collection<? extends ColumnSource<?>> columnSources = queryTable.getColumnSources();
+        if (columnSources.isEmpty()) {
             return false;
         }
-        if (!columnSourceMap.values().stream().allMatch(cs -> cs instanceof UnionColumnSource)) {
+        if (!columnSources.stream().allMatch(cs -> cs instanceof UnionColumnSource)) {
             return false;
         }
 
-        final UnionColumnSource<?> columnSource = (UnionColumnSource<?>) columnSourceMap.values().iterator().next();
+        final UnionColumnSource<?> columnSource = (UnionColumnSource<?>) columnSources.iterator().next();
         return columnSource.getUnionSourceManager().isUsingComponentsSafe();
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/util/TickSuppressor.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TickSuppressor.java
@@ -131,7 +131,7 @@ public class TickSuppressor {
                             return;
                         }
 
-                        final int columnCount = resultTable.getColumnSourceMap().size();
+                        final int columnCount = resultTable.numColumns();
                         final int chunkSize = (int) Math.min(1 << 16, downstream.modified().size());
 
                         final ChunkSource.GetContext[] getContextArray = new ChunkSource.GetContext[columnCount];

--- a/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
@@ -6,6 +6,8 @@ package io.deephaven.engine.util;
 import io.deephaven.api.agg.Aggregation;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.impl.NoSuchColumnException;
+import io.deephaven.engine.table.impl.NoSuchColumnException.Type;
 import io.deephaven.util.annotations.ScriptApi;
 import io.deephaven.util.type.EnumValue;
 import io.deephaven.util.type.TypeUtils;
@@ -546,7 +548,12 @@ public class TotalsTableBuilder {
     }
 
     private static void ensureColumnsExist(Table source, Set<String> columns) {
-        source.getDefinition().checkHasColumns(columns);
+        NoSuchColumnException.throwIf(
+                source.getDefinition().getColumnNameSet(),
+                columns,
+                "Missing columns for totals table [%s], available columns [%s]",
+                Type.MISSING,
+                Type.AVAILABLE);
     }
 
     private static String[] makeColumnFormats(Table source, TotalsTableBuilder builder) {

--- a/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
@@ -546,7 +546,7 @@ public class TotalsTableBuilder {
     }
 
     private static void ensureColumnsExist(Table source, Set<String> columns) {
-        source.getDefinition().checkColumns(columns);
+        source.getDefinition().checkHasColumns(columns);
     }
 
     private static String[] makeColumnFormats(Table source, TotalsTableBuilder builder) {

--- a/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
@@ -546,12 +546,7 @@ public class TotalsTableBuilder {
     }
 
     private static void ensureColumnsExist(Table source, Set<String> columns) {
-        if (!source.getColumnSourceMap().keySet().containsAll(columns)) {
-            final Set<String> missing = new LinkedHashSet<>(columns);
-            missing.removeAll(source.getColumnSourceMap().keySet());
-            throw new IllegalArgumentException("Missing columns for totals table " + missing + ", available columns "
-                    + source.getColumnSourceMap().keySet());
-        }
+        source.getDefinition().checkAvailableColumns(columns);
     }
 
     private static String[] makeColumnFormats(Table source, TotalsTableBuilder builder) {

--- a/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TotalsTableBuilder.java
@@ -546,7 +546,7 @@ public class TotalsTableBuilder {
     }
 
     private static void ensureColumnsExist(Table source, Set<String> columns) {
-        source.getDefinition().checkAvailableColumns(columns);
+        source.getDefinition().checkColumns(columns);
     }
 
     private static String[] makeColumnFormats(Table source, TotalsTableBuilder builder) {

--- a/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
@@ -195,7 +195,7 @@ public class WindowCheck {
             this.rowKeyToEntry = new TLongObjectHashMap<>();
 
             this.mcsTransformer = source.newModifiedColumnSetTransformer(result,
-                    source.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                    source.getDefinition().getColumnNamesArray());
             this.mcsNewColumns = result.newModifiedColumnSet(inWindowColumnName);
             this.reusableModifiedColumnSet = new ModifiedColumnSet(this.mcsNewColumns);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
@@ -195,7 +195,7 @@ public class WindowCheck {
             this.rowKeyToEntry = new TLongObjectHashMap<>();
 
             this.mcsTransformer = source.newModifiedColumnSetTransformer(result,
-                    source.getColumnSourceMap().keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                    source.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
             this.mcsNewColumns = result.newModifiedColumnSet(inWindowColumnName);
             this.reusableModifiedColumnSet = new ModifiedColumnSet(this.mcsNewColumns);
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/MultiColumnSortTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/MultiColumnSortTest.java
@@ -58,7 +58,7 @@ public class MultiColumnSortTest {
                         new BigIntegerGenerator(BigInteger.valueOf(100000), BigInteger.valueOf(100100)),
                         new BigDecimalGenerator(BigInteger.valueOf(100000), BigInteger.valueOf(100100))));
 
-        final List<String> columnNames = new ArrayList<>(table.getColumnSourceMap().keySet());
+        final List<String> columnNames = table.getDefinition().getColumnNames();
 
         doMultiColumnTest(table, SortColumn.asc(ColumnName.of("boolCol")), SortColumn.desc(ColumnName.of("Sym")));
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -3844,8 +3844,8 @@ public class QueryTableAggregationTest {
         } catch (Exception ex) {
             io.deephaven.base.verify.Assert.instanceOf(ex, "ex", IllegalArgumentException.class);
             io.deephaven.base.verify.Assert.assertion(
-                    ex.getMessage().contains("Missing columns: [NonExistentCol]"),
-                    "ex.getMessage().contains(\"Missing columns: [NonExistentCol]\")",
+                    ex.getMessage().contains("Unknown column names [NonExistentCol]"),
+                    "ex.getMessage().contains(\"Unknown column names [NonExistentCol]\")",
                     ex.getMessage(),
                     "ex.getMessage()");
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -116,12 +116,12 @@ public class QueryTableAggregationTest {
                     Arrays.stream(keySelectColumns).map(SelectColumn::getName).distinct().toArray(String[]::new);
 
             if (keyColumns.length == 0) {
-                expectedKeys = TableTools.emptyTable(adjustedInput.size() > 0 ? 1 : 0);
+                expectedKeys = TableTools.emptyTable(!adjustedInput.isEmpty() ? 1 : 0);
                 expected = adjustedInput;
             } else {
                 final Set<String> retainedColumns =
-                        new LinkedHashSet<>(adjustedInput.getDefinition().getColumnNameMap().keySet());
-                retainedColumns.removeAll(Arrays.stream(keyNames).collect(Collectors.toSet()));
+                        new LinkedHashSet<>(adjustedInput.getDefinition().getColumnNameSet());
+                Arrays.asList(keyNames).forEach(retainedColumns::remove);
                 final List<SelectColumn> allSelectColumns =
                         Stream.concat(Arrays.stream(keySelectColumns), retainedColumns.stream().map(SourceColumn::new))
                                 .collect(Collectors.toList());

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -3844,8 +3844,8 @@ public class QueryTableAggregationTest {
         } catch (Exception ex) {
             io.deephaven.base.verify.Assert.instanceOf(ex, "ex", IllegalArgumentException.class);
             io.deephaven.base.verify.Assert.assertion(
-                    ex.getMessage().contains("Unknown column names [NonExistentCol]"),
-                    "ex.getMessage().contains(\"Unknown column names [NonExistentCol]\")",
+                    ex.getMessage().contains("Missing columns: [NonExistentCol]"),
+                    "ex.getMessage().contains(\"Missing columns: [NonExistentCol]\")",
                     ex.getMessage(),
                     "ex.getMessage()");
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -887,7 +887,7 @@ public class QueryTableAggregationTest {
                         new BigDecimalGenerator(),
                         new IntGenerator()));
 
-        final Set<String> keyColumnSet = new LinkedHashSet<>(table.getDefinition().getColumnNames());
+        final Set<String> keyColumnSet = new LinkedHashSet<>(table.getDefinition().getColumnNameSet());
         keyColumnSet.remove("NonKey");
         final String[] keyColumns = keyColumnSet.toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -887,7 +887,7 @@ public class QueryTableAggregationTest {
                         new BigDecimalGenerator(),
                         new IntGenerator()));
 
-        final Set<String> keyColumnSet = new LinkedHashSet<>(table.getColumnSourceMap().keySet());
+        final Set<String> keyColumnSet = new LinkedHashSet<>(table.getDefinition().getColumnNames());
         keyColumnSet.remove("NonKey");
         final String[] keyColumns = keyColumnSet.toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -563,14 +563,14 @@ public class QueryTableTest extends QueryTableTestBase {
             table.dropColumns(Collections.singletonList("DoesNotExist"));
             fail("Expected NoSuchColumnException");
         } catch (NoSuchColumnException e) {
-            assertEquals("Unknown column names [DoesNotExist], available column names are [String,Int,Double]",
+            assertEquals("Unknown column names [DoesNotExist], available column names are [String, Int, Double]",
                     e.getMessage());
         }
         try {
             table.dropColumns(Arrays.asList("Int", "DoesNotExist"));
             fail("Expected NoSuchColumnException");
         } catch (NoSuchColumnException e) {
-            assertEquals("Unknown column names [DoesNotExist], available column names are [String,Int,Double]",
+            assertEquals("Unknown column names [DoesNotExist], available column names are [String, Int, Double]",
                     e.getMessage());
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -561,13 +561,17 @@ public class QueryTableTest extends QueryTableTestBase {
 
         try {
             table.dropColumns(Collections.singletonList("DoesNotExist"));
-        } catch (RuntimeException e) {
-            assertEquals("Unknown columns: [DoesNotExist], available columns = [String, Int, Double]", e.getMessage());
+            fail("Expected NoSuchColumnException");
+        } catch (NoSuchColumnException e) {
+            assertEquals("Unknown column names [DoesNotExist], available column names are [String,Int,Double]",
+                    e.getMessage());
         }
         try {
             table.dropColumns(Arrays.asList("Int", "DoesNotExist"));
-        } catch (RuntimeException e) {
-            assertEquals("Unknown columns: [DoesNotExist], available columns = [String, Int, Double]", e.getMessage());
+            fail("Expected NoSuchColumnException");
+        } catch (NoSuchColumnException e) {
+            assertEquals("Unknown column names [DoesNotExist], available column names are [String,Int,Double]",
+                    e.getMessage());
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/SelectOverheadLimiter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/SelectOverheadLimiter.java
@@ -131,7 +131,7 @@ public class SelectOverheadLimiter {
             {
                 inputRecorder.getValue().setMergedListener(this);
                 inputTransformer = ((QueryTable) input).newModifiedColumnSetTransformer(result,
-                        result.getColumnSourceMap().keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                        result.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
             }
 
             @Override
@@ -171,7 +171,7 @@ public class SelectOverheadLimiter {
                         new ListenerRecorder("clampSelectOverhead.flatResult()", flatResult, result);
                 flatRecorder.setMergedListener(this);
                 flatTransformer = ((QueryTable) flatResult).newModifiedColumnSetTransformer(result,
-                        result.getColumnSourceMap().keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                        result.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
 
                 flatResult.addUpdateListener(flatRecorder);
                 synchronized (recorders) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/SelectOverheadLimiter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/SelectOverheadLimiter.java
@@ -131,7 +131,7 @@ public class SelectOverheadLimiter {
             {
                 inputRecorder.getValue().setMergedListener(this);
                 inputTransformer = ((QueryTable) input).newModifiedColumnSetTransformer(result,
-                        result.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                        result.getDefinition().getColumnNamesArray());
             }
 
             @Override
@@ -171,7 +171,7 @@ public class SelectOverheadLimiter {
                         new ListenerRecorder("clampSelectOverhead.flatResult()", flatResult, result);
                 flatRecorder.setMergedListener(this);
                 flatTransformer = ((QueryTable) flatResult).newModifiedColumnSetTransformer(result,
-                        result.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY));
+                        result.getDefinition().getColumnNamesArray());
 
                 flatResult.addUpdateListener(flatRecorder);
                 synchronized (recorders) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestAggBy.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestAggBy.java
@@ -818,7 +818,7 @@ public class TestAggBy extends RefreshingTableTestCase {
         assertEquals(2.0, cs.get(0));
 
         result = dataTable.formatColumns("Doubles=Decimal(`##0.00%`)").headBy(1);
-        Set<String> columnNames = result.getColumnSourceMap().keySet();
+        List<String> columnNames = result.getDefinition().getColumnNames();
         assertEquals(3, columnNames.size()); // Additional column for formatting information of "Doubles"
         for (String colName : columnNames) {
             if (!colName.equalsIgnoreCase(doubleColName) && !colName.equalsIgnoreCase(intColName) &&

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestMoveColumns.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestMoveColumns.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.engine.table.impl;
 
+import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
 import io.deephaven.engine.util.TableTools;
@@ -149,12 +150,15 @@ public class TestMoveColumns extends RefreshingTableTestCase {
     }
 
     private void checkColumnOrder(Table t, String expectedOrder) {
-        final String order = t.getColumnSourceMap().keySet().stream().collect(Collectors.joining(""));
+        final String order = t.getDefinition()
+                .getColumnStream()
+                .map(ColumnDefinition::getName)
+                .collect(Collectors.joining(""));
         assertEquals(expectedOrder, order);
     }
 
     private void checkColumnValueOrder(Table t, String expectedOrder) {
-        final String order = t.getColumnSourceMap().values().stream().mapToInt((col) -> col.getInt(0))
+        final String order = t.getColumnSources().stream().mapToInt((col) -> col.getInt(0))
                 .mapToObj(String::valueOf).collect(Collectors.joining(""));
         assertEquals(expectedOrder, order);
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestTotalsTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestTotalsTable.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import static io.deephaven.engine.testutil.TstUtils.getTable;
 import static io.deephaven.engine.testutil.TstUtils.initColumnInfos;
@@ -61,10 +62,10 @@ public class TestTotalsTable extends RefreshingTableTestCase {
         final TotalsTableBuilder builder = new TotalsTableBuilder();
         final Table totals = ExecutionContext.getContext().getUpdateGraph().exclusiveLock().computeLocked(
                 () -> TotalsTableBuilder.makeTotalsTable(builder.applyToTable(queryTable)));
-        final Map<String, ? extends ColumnSource<?>> resultColumns = totals.getColumnSourceMap();
+        final Set<String> resultColumns = totals.getDefinition().getColumnNameSet();
         assertEquals(1, totals.size());
         assertEquals(new LinkedHashSet<>(Arrays.asList("intCol", "intCol2", "doubleCol", "doubleNullCol", "doubleCol2",
-                "floatCol", "byteCol", "shortCol")), resultColumns.keySet());
+                "floatCol", "byteCol", "shortCol")), resultColumns);
 
         assertEquals((long) Numeric.sum((int[]) DataAccessHelpers.getColumn(queryTable, "intCol").getDirect()),
                 DataAccessHelpers.getColumn(totals, "intCol").get(0));
@@ -85,7 +86,7 @@ public class TestTotalsTable extends RefreshingTableTestCase {
         final Table totals2 = ExecutionContext.getContext().getUpdateGraph().exclusiveLock().computeLocked(
                 () -> TotalsTableBuilder.makeTotalsTable(queryTable, builder));
         assertEquals(new LinkedHashSet<>(Arrays.asList("Sym", "intCol2", "byteCol")),
-                totals2.getColumnSourceMap().keySet());
+                totals2.getDefinition().getColumnNameSet());
         assertEquals(Numeric.min((byte[]) DataAccessHelpers.getColumn(queryTable, "byteCol").getDirect()),
                 DataAccessHelpers.getColumn(totals2, "byteCol").get(0));
         assertEquals(DataAccessHelpers.getColumn(queryTable, "Sym").get(0),
@@ -107,7 +108,7 @@ public class TestTotalsTable extends RefreshingTableTestCase {
             assertEquals(
                     new LinkedHashSet<>(Arrays.asList("Sym", "intCol2", "doubleCol", "doubleNullCol__Std",
                             "doubleNullCol__Count", "doubleCol2", "byteCol", "shortCol")),
-                    totals3.getColumnSourceMap().keySet());
+                    totals3.getDefinition().getColumnNameSet());
             assertEquals(
                     Numeric.max((byte[]) DataAccessHelpers.getColumn(queryTable, "byteCol").getDirect()),
                     DataAccessHelpers.getColumn(totals3, "byteCol").getByte(0));

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/indexer/TestRowSetIndexer.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/indexer/TestRowSetIndexer.java
@@ -164,8 +164,8 @@ public class TestRowSetIndexer extends RefreshingTableTestCase {
     private final ArrayList<GroupingValidator> groupingValidators = new ArrayList<>();
 
     private void addGroupingValidator(Table originalValue, String context) {
-        ArrayList<ArrayList<String>> columnSets2 = powerSet(originalValue.getColumnSourceMap().keySet());
-        ArrayList<String> columnNames = new ArrayList<>(originalValue.getColumnSourceMap().keySet());
+        ArrayList<ArrayList<String>> columnSets2 = powerSet(originalValue.getDefinition().getColumnNameSet());
+        ArrayList<String> columnNames = new ArrayList<>(originalValue.getDefinition().getColumnNameSet());
         columnSets2.add(columnNames);
         groupingValidators.add(new GroupingValidator(context, originalValue, columnSets2));
     }

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
@@ -20,6 +20,8 @@ import io.deephaven.engine.table.ElementSource;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.AbstractColumnSource;
 import io.deephaven.engine.table.impl.BaseTable;
+import io.deephaven.engine.table.impl.NoSuchColumnException;
+import io.deephaven.engine.table.impl.NoSuchColumnException.Type;
 import io.deephaven.engine.table.impl.PrevColumnSource;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.select.Formula;
@@ -173,11 +175,12 @@ public class TstUtils {
             }
         }
 
-        if (!usedNames.containsAll(table.getDefinition().getColumnNameSet())) {
-            final Set<String> expected = new LinkedHashSet<>(table.getDefinition().getColumnNameSet());
-            expected.removeAll(usedNames);
-            throw new IllegalStateException("Not all columns were populated, missing " + expected);
-        }
+        NoSuchColumnException.throwIf(
+                table.getDefinition().getColumnNameSet(),
+                usedNames,
+                "Not all columns were populated, missing [%s], available [%s]",
+                Type.MISSING,
+                Type.AVAILABLE);
 
         table.getRowSet().writableCast().insert(rowSet);
         if (table.isFlat()) {

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
@@ -176,8 +176,8 @@ public class TstUtils {
         }
 
         NoSuchColumnException.throwIf(
-                table.getDefinition().getColumnNameSet(),
                 usedNames,
+                table.getDefinition().getColumnNameSet(),
                 "Not all columns were populated, missing [%s], available [%s]",
                 Type.MISSING,
                 Type.AVAILABLE);

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/TstUtils.java
@@ -173,8 +173,8 @@ public class TstUtils {
             }
         }
 
-        if (!usedNames.containsAll(table.getColumnSourceMap().keySet())) {
-            final Set<String> expected = new LinkedHashSet<>(table.getColumnSourceMap().keySet());
+        if (!usedNames.containsAll(table.getDefinition().getColumnNameSet())) {
+            final Set<String> expected = new LinkedHashSet<>(table.getDefinition().getColumnNameSet());
             expected.removeAll(usedNames);
             throw new IllegalStateException("Not all columns were populated, missing " + expected);
         }

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/locations/TableBackedColumnLocation.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/locations/TableBackedColumnLocation.java
@@ -26,7 +26,7 @@ public final class TableBackedColumnLocation
             @NotNull final TableBackedTableLocation tableLocation,
             @NotNull final String name) {
         super(tableLocation, name);
-        columnSource = tableLocation.table().getDefinition().getColumnNameMap().containsKey(name)
+        columnSource = tableLocation.table().getDefinition().getColumnNameSet().contains(name)
                 ? ReinterpretUtils.maybeConvertToPrimitive(tableLocation.table().getColumnSource(name))
                 : null;
     }

--- a/extensions/jdbc/src/test/java/io/deephaven/jdbc/JdbcToTableAdapterTest.java
+++ b/extensions/jdbc/src/test/java/io/deephaven/jdbc/JdbcToTableAdapterTest.java
@@ -87,7 +87,7 @@ public class JdbcToTableAdapterTest {
         // check no-casing column names
         final Set<String> expectedNames = Set.of("Bool_Type", "TinyIntType", "SmallIntType", "Int_Type",
                 "Big_Int_Type", "Decimal_Type", "String_Type", "DateTime_Type");
-        Assert.assertEquals(expectedNames, result.getColumnSourceMap().keySet());
+        Assert.assertEquals(expectedNames, result.getDefinition().getColumnNameSet());
 
         // should be an empty table
         Assert.assertEquals(0, result.size());
@@ -103,7 +103,7 @@ public class JdbcToTableAdapterTest {
         // check no-casing column names
         final Set<String> expectedNames = Set.of("boolType", "tinyIntType", "smallIntType", "intType",
                 "bigIntType", "decimalType", "stringType", "datetimeType");
-        Assert.assertEquals(expectedNames, result.getColumnSourceMap().keySet());
+        Assert.assertEquals(expectedNames, result.getDefinition().getColumnNameSet());
 
         // should be an empty table
         Assert.assertEquals(0, result.size());
@@ -119,7 +119,7 @@ public class JdbcToTableAdapterTest {
         // check no-casing column names
         final Set<String> expectedNames = Set.of("bool_type", "tiny_int_type", "small_int_type", "int_type",
                 "big_int_type", "decimal_type", "string_type", "datetime_type");
-        Assert.assertEquals(expectedNames, result.getColumnSourceMap().keySet());
+        Assert.assertEquals(expectedNames, result.getDefinition().getColumnNameSet());
 
         // should be an empty table
         Assert.assertEquals(0, result.size());
@@ -135,7 +135,7 @@ public class JdbcToTableAdapterTest {
         // check no-casing column names
         final Set<String> expectedNames = Set.of("BoolType", "TinyIntType", "SmallIntType", "IntType",
                 "BigIntType", "DecimalType", "StringType", "DatetimeType");
-        Assert.assertEquals(expectedNames, result.getColumnSourceMap().keySet());
+        Assert.assertEquals(expectedNames, result.getDefinition().getColumnNameSet());
 
         // should be an empty table
         Assert.assertEquals(0, result.size());
@@ -151,7 +151,7 @@ public class JdbcToTableAdapterTest {
         // check no-casing column names
         final Set<String> expectedNames = Set.of("BOOL_TYPE", "TINY_INT_TYPE", "SMALL_INT_TYPE", "INT_TYPE",
                 "BIG_INT_TYPE", "DECIMAL_TYPE", "STRING_TYPE", "DATETIME_TYPE");
-        Assert.assertEquals(expectedNames, result.getColumnSourceMap().keySet());
+        Assert.assertEquals(expectedNames, result.getDefinition().getColumnNameSet());
 
         // should be an empty table
         Assert.assertEquals(0, result.size());
@@ -167,7 +167,7 @@ public class JdbcToTableAdapterTest {
         // check no-casing column names
         final Set<String> expectedNames = Set.of("BOOL_Z_TYPE", "TINY_Z_INT_Z_TYPE", "SMALL_Z_INT_Z_TYPE", "INT_Z_TYPE",
                 "BIG_Z_INT_Z_TYPE", "DECIMAL_Z_TYPE", "STRING_Z_TYPE", "DATETIME_Z_TYPE");
-        Assert.assertEquals(expectedNames, result.getColumnSourceMap().keySet());
+        Assert.assertEquals(expectedNames, result.getDefinition().getColumnNameSet());
 
         // should be an empty table
         Assert.assertEquals(0, result.size());

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -460,7 +460,7 @@ public final class ParquetTableReadWriteTest {
         writeReadTableTest(vectorTable, dest);
 
         // Convert the table from vector to array column
-        final Table arrayTable = vectorTable.updateView(vectorTable.getColumnSourceMap().keySet().stream()
+        final Table arrayTable = vectorTable.updateView(vectorTable.getDefinition().getColumnNameSet().stream()
                 .map(name -> name + " = " + name + ".toArray()")
                 .toArray(String[]::new));
         writeReadTableTest(arrayTable, dest);
@@ -924,7 +924,7 @@ public final class ParquetTableReadWriteTest {
         ParquetTools.writeTable(someTable, secondDataFile);
 
         Table partitionedTable = ParquetTools.readTable(parentDir).select();
-        final Set<?> columnsSet = partitionedTable.getColumnSourceMap().keySet();
+        final Set<String> columnsSet = partitionedTable.getDefinition().getColumnNameSet();
         assertTrue(columnsSet.size() == 2 && columnsSet.contains("A") && columnsSet.contains("X"));
 
         // Add an empty dot file and dot directory (with valid parquet files) in one of the partitions
@@ -1378,7 +1378,7 @@ public final class ParquetTableReadWriteTest {
         final ParquetMetadata metadata = new ParquetTableLocationKey(dest, 0, null).getMetadata();
 
         final String[] colNames =
-                inputTable.getColumnSourceMap().keySet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
+                inputTable.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
         for (int colIdx = 0; colIdx < inputTable.numColumns(); ++colIdx) {
             final String colName = colNames[colIdx];
 

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -460,7 +460,9 @@ public final class ParquetTableReadWriteTest {
         writeReadTableTest(vectorTable, dest);
 
         // Convert the table from vector to array column
-        final Table arrayTable = vectorTable.updateView(vectorTable.getDefinition().getColumnNameSet().stream()
+        final Table arrayTable = vectorTable.updateView(vectorTable.getDefinition()
+                .getColumnStream()
+                .map(ColumnDefinition::getName)
                 .map(name -> name + " = " + name + ".toArray()")
                 .toArray(String[]::new));
         writeReadTableTest(arrayTable, dest);
@@ -1377,8 +1379,7 @@ public final class ParquetTableReadWriteTest {
         // Verify that the columns have the correct statistics.
         final ParquetMetadata metadata = new ParquetTableLocationKey(dest, 0, null).getMetadata();
 
-        final String[] colNames =
-                inputTable.getDefinition().getColumnNameSet().toArray(CollectionUtil.ZERO_LENGTH_STRING_ARRAY);
+        final String[] colNames = inputTable.getDefinition().getColumnNamesArray();
         for (int colIdx = 0; colIdx < inputTable.numColumns(); ++colIdx) {
             final String colName = colNames[colIdx];
 


### PR DESCRIPTION
Adds some helper methods for on `TableDefinition#checkHasColumn`, `TableDefinition#checkHasColumns`, and `TableDefinition#getColumnNameSet`.

Additionally, fixes up call sites that were (ab)using `Table#getColumnSourceMap` to simply get the keySet. This invokes a potentially extraneous `Table#coalesce` which can be avoided in these cases.

In support of common scaffolding so https://github.com/deephaven/deephaven-core/pull/4771 won't need to call `Table#getColumnSource` for validation purposes.