### PR TITLE
change default dtype_backend for to_pandas

### DIFF
--- a/py/server/deephaven/pandas.py
+++ b/py/server/deephaven/pandas.py
@@ -112,7 +112,8 @@ _PYARROW_TO_PANDAS_TYPE_MAPPERS = {
 }
 
 
-def to_pandas(table: Table, cols: List[str] = None, dtype_backend: Literal[None, "pyarrow", "numpy_nullable"] = None,
+def to_pandas(table: Table, cols: List[str] = None,
+              dtype_backend: Literal[None, "pyarrow", "numpy_nullable"] = "numpy_nullable",
               conv_null: bool = True) -> pd.DataFrame:
     """Produces a pandas DataFrame from a table.
 
@@ -125,8 +126,8 @@ def to_pandas(table: Table, cols: List[str] = None, dtype_backend: Literal[None,
         cols (List[str]): the source column names, default is None which means include all columns
         dtype_backend (str): Which dtype_backend to use, e.g. whether a DataFrame should have NumPy arrays,
             nullable dtypes are used for all dtypes that have a nullable implementation when “numpy_nullable” is set,
-            pyarrow is used for all dtypes if “pyarrow” is set. default is None, meaning Numpy backed DataFrames with
-            no nullable dtypes.
+            pyarrow is used for all dtypes if “pyarrow” is set. None means Numpy backed DataFrames with no nullable
+            dtypes. Default is "numpy_nullable".
         conv_null (bool): When dtype_backend is not set, whether to check for Deephaven nulls in the data and
             automatically replace them with pd.NA. default is True.
 

--- a/py/server/deephaven/pandas.py
+++ b/py/server/deephaven/pandas.py
@@ -127,8 +127,9 @@ def to_pandas(table: Table, cols: List[str] = None,
         dtype_backend (str): which dtype_backend to use, e.g. whether a DataFrame should have NumPy arrays,
             nullable dtypes are used for all dtypes that have a nullable implementation when “numpy_nullable” is set,
             pyarrow is used for all dtypes if “pyarrow” is set. None means Numpy backed DataFrames with no nullable
-            dtypes. Both "numpy_nullable" and "pyarrow" automatically converts Deephaven nulls and enable the correct
-            mapping of Java String. default is "numpy_nullable".
+            dtypes. Both "numpy_nullable" and "pyarrow" automatically convert Deephaven nulls to Pandas NA and enable
+            Pandas extension types.  Extension types are needed to support types beyond NumPy's type system.  Extension
+            types support operations such as properly mapping Java Strings to Python strings. default is "numpy_nullable".
         conv_null (bool): when dtype_backend is not set, whether to check for Deephaven nulls in the data and
             automatically replace them with pd.NA. default is True.
 

--- a/py/server/deephaven/pandas.py
+++ b/py/server/deephaven/pandas.py
@@ -124,11 +124,12 @@ def to_pandas(table: Table, cols: List[str] = None,
     Args:
         table (Table): the source table
         cols (List[str]): the source column names, default is None which means include all columns
-        dtype_backend (str): Which dtype_backend to use, e.g. whether a DataFrame should have NumPy arrays,
+        dtype_backend (str): which dtype_backend to use, e.g. whether a DataFrame should have NumPy arrays,
             nullable dtypes are used for all dtypes that have a nullable implementation when “numpy_nullable” is set,
             pyarrow is used for all dtypes if “pyarrow” is set. None means Numpy backed DataFrames with no nullable
-            dtypes. Default is "numpy_nullable".
-        conv_null (bool): When dtype_backend is not set, whether to check for Deephaven nulls in the data and
+            dtypes. Both "numpy_nullable" and "pyarrow" automatically converts Deephaven nulls and enable the correct
+            mapping of Java String. default is "numpy_nullable".
+        conv_null (bool): when dtype_backend is not set, whether to check for Deephaven nulls in the data and
             automatically replace them with pd.NA. default is True.
 
     Returns:

--- a/py/server/tests/test_learn_gather.py
+++ b/py/server/tests/test_learn_gather.py
@@ -141,7 +141,7 @@ class LearnGatherTestCase(BaseTestCase):
         gatherer_colmajor = lambda rowset, colset: gather.table_to_numpy_2d(rowset, colset,
                                                                             gather.MemoryLayout.COLUMN_MAJOR, np_dtype)
 
-        array_from_table = to_pandas(source, conv_null=False).values
+        array_from_table = to_pandas(source, dtype_backend=None, conv_null=False).values
 
         gathered_rowmajor = gatherer_rowmajor(rows, cols)
         gathered_colmajor = gatherer_colmajor(rows, cols)

--- a/py/server/tests/test_pandas.py
+++ b/py/server/tests/test_pandas.py
@@ -54,7 +54,7 @@ class PandasTestCase(BaseTestCase):
         super().tearDown()
 
     def test_to_pandas_no_conv_null(self):
-        df = to_pandas(self.test_table, conv_null=False)
+        df = to_pandas(self.test_table, dtype_backend=None, conv_null=False)
         self.assertEqual(len(df.columns), len(self.test_table.columns))
         self.assertEqual(df.size, 2 * len(self.test_table.columns))
         df_series = [df[col] for col in list(df.columns)]
@@ -70,7 +70,7 @@ class PandasTestCase(BaseTestCase):
         prepared_table = self.test_table.update(
             formulas=["Long = isNull(Long_) ? Double.NaN : Long_"])
 
-        df = to_pandas(prepared_table, cols=["Boolean", "Long"], conv_null=False)
+        df = to_pandas(prepared_table, cols=["Boolean", "Long"], dtype_backend=None, conv_null=False)
         self.assertEqual(df['Long'].dtype, np.float64)
         self.assertEqual(df['Boolean'].values.dtype, np.bool_)
 
@@ -88,12 +88,12 @@ class PandasTestCase(BaseTestCase):
 
         test_table = test_table.group_by(["String"])
         df = to_pandas(test_table, cols=["String", "Doubles"])
-        self.assertEqual(df['String'].dtype, np.object_)
+        self.assertEqual(df['String'].dtype, pd.StringDtype())
         self.assertEqual(df['Doubles'].dtype, np.object_)
 
         double_series = df['Doubles']
-        self.assertEqual([1.0, 2.0], list(double_series[0].toArray()))
-        self.assertEqual([4.0, 8.0, 16.0], list(double_series[1].toArray()))
+        self.assertEqual([1.0, 2.0], list(double_series[0]))
+        self.assertEqual([4.0, 8.0, 16.0], list(double_series[1]))
 
     def test_invalid_col_name(self):
         with self.assertRaises(DHError) as cm:
@@ -114,7 +114,7 @@ class PandasTestCase(BaseTestCase):
             double_col(name="Double", data=[1.01, -1.01]),
         ]
         test_table = new_table(cols=input_cols)
-        df = to_pandas(test_table, conv_null=False)
+        df = to_pandas(test_table, dtype_backend=None, conv_null=False)
         table_from_df = to_table(df)
         self.assert_table_equals(table_from_df, test_table)
 
@@ -123,7 +123,7 @@ class PandasTestCase(BaseTestCase):
         table_with_null_bool = new_table(cols=input_cols)
         prepared_table = table_with_null_bool.update(
             formulas=["Boolean = isNull(Boolean) ? (byte)NULL_BYTE : (Boolean == true ? 1: 0)"])
-        df = to_pandas(prepared_table, conv_null=False)
+        df = to_pandas(prepared_table, dtype_backend=None, conv_null=False)
         table_from_df = to_table(df)
         self.assert_table_equals(table_from_df, prepared_table)
 
@@ -159,7 +159,7 @@ class PandasTestCase(BaseTestCase):
             pyobj_col(name="PyObj", data=[CustomClass(1, "1"), None]),
         ]
         test_table = new_table(cols=input_cols)
-        df = to_pandas(test_table)
+        df = to_pandas(test_table, dtype_backend=None)
         self.assertEqual(len(df.columns), len(test_table.columns))
         self.assertEqual(df.size, 2 * len(test_table.columns))
         test_table2 = to_table(df)

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -347,7 +347,7 @@ class ParquetTestCase(BaseTestCase):
         from_disk = read('data_from_dh.parquet')
         self.assert_table_equals(dh_table, from_disk)
 
-        df_from_disk = to_pandas(from_disk)
+        df_from_disk = to_pandas(from_disk, dtype_backend=None)
         if pandas.__version__.split('.')[0] == "1":
             df_from_pandas = pandas.read_parquet("data_from_dh.parquet", use_nullable_dtypes=True)
         else:
@@ -384,7 +384,7 @@ class ParquetTestCase(BaseTestCase):
             # Write the provided pyarrow table type-casted to the new schema
             pyarrow.parquet.write_table(pa_table.cast(new_schema), dest)
             from_disk = read(dest)
-            df_from_disk = to_pandas(from_disk)
+            df_from_disk = to_pandas(from_disk, dtype_backend=None)
             original_df = pa_table.to_pandas()
             # Compare the dataframes as strings
             self.assertTrue((df_from_disk.astype(str) == original_df.astype(str)).all().values.all())

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -347,6 +347,7 @@ class ParquetTestCase(BaseTestCase):
         from_disk = read('data_from_dh.parquet')
         self.assert_table_equals(dh_table, from_disk)
 
+        # TODO dtype_backend=None is a workaround until https://github.com/deephaven/deephaven-core/issues/4823 is fixed
         df_from_disk = to_pandas(from_disk, dtype_backend=None)
         if pandas.__version__.split('.')[0] == "1":
             df_from_pandas = pandas.read_parquet("data_from_dh.parquet", use_nullable_dtypes=True)
@@ -384,6 +385,8 @@ class ParquetTestCase(BaseTestCase):
             # Write the provided pyarrow table type-casted to the new schema
             pyarrow.parquet.write_table(pa_table.cast(new_schema), dest)
             from_disk = read(dest)
+
+            # TODO dtype_backend=None is a workaround until https://github.com/deephaven/deephaven-core/issues/4823 is fixed
             df_from_disk = to_pandas(from_disk, dtype_backend=None)
             original_df = pa_table.to_pandas()
             # Compare the dataframes as strings

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -676,7 +676,7 @@ class TableTestCase(BaseTestCase):
         self.assertIn("RuntimeError", cm.exception.compact_traceback)
 
     def verify_table_data(self, t: Table, expected: List[Any], assert_not_in: bool = False):
-        t_data = to_pandas(t).values.flatten()
+        t_data = to_pandas(t, dtype_backend=None).values.flatten()
         for s in expected:
             if assert_not_in:
                 self.assertNotIn(s, t_data)


### PR DESCRIPTION
Fixes #4810
Fixes #3149 

This is a breaking change:
1. the new default value for `dtype_backend` is `numpy_nullable`, which directs the conversion to automatically use Pandas Nullable Extension Types.
2. when `dtype_backend` is `numpy_nullable`, the conversion exports the table data into a pyarrow table as an intermediate step and then converts the pyarrow table to a Pandas Dataframe. This is a more efficient and deterministic way to convert DH data and DH nulls, however DH server still has some gaps in mapping between DH data types and Arrow types (e.g. a column of PyObject will be converted to strings, java.time.LocalDate/LocalTime to bytes). This isn't yet a problem because the unsupported data types aren't what users normally would use and there is no complaints from them so far. 