### PR TITLE
ExportObject PUBLISHING State Change Bug

### DIFF
--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -682,7 +682,11 @@ public class SessionState {
             this.errorHandler = errorHandler;
             this.successHandler = successHandler;
 
-            setState(ExportNotification.State.PENDING);
+            if (state != ExportNotification.State.PUBLISHING) {
+                setState(ExportNotification.State.PENDING);
+            } else if (dependentCount > 0) {
+                throw new IllegalStateException("published exports cannot have dependencies");
+            }
             if (dependentCount <= 0) {
                 dependentCount = 0;
                 scheduleExport();
@@ -920,7 +924,7 @@ public class SessionState {
          */
         private void scheduleExport() {
             synchronized (this) {
-                if (state != ExportNotification.State.PENDING) {
+                if (state != ExportNotification.State.PENDING && state != ExportNotification.State.PUBLISHING) {
                     return;
                 }
                 setState(ExportNotification.State.QUEUED);


### PR DESCRIPTION
In my query performance recorder change branch -- I've discovered failures around `DoPut` and `SessionService#publishTicketFromExport`. When adding the `ExportObject#onSuccess` callback, I also added some enforcement that exports move through a specific ordering. Published items "walk backward" one step to PENDING before going into QUEUED. This is unnecessary (they should never have intermediary dependencies, too -- you can always add a non-export before (it performs the publish) or after the publish (dependent on the publish)).

I have this fix in that branch, but the issue was introduced in v0.30.0.

Note that it would be inappropriate to change the enum ordering as this lives in the proto file and known by client code.