### PR TITLE
C++ Client: fix one incorrect mutex unlock, remove one needless unlock

### DIFF
--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
@@ -715,7 +715,7 @@ std::shared_ptr<Schema> TableHandleImpl::Schema() {
   std::unique_lock guard(mutex_);
   if (schema_request_sent_) {
     // Schema request already sent by someone else. So wait for the successful result or error.
-    mutex_.unlock();
+    guard.unlock();
     return schema_future_.get();
   }
 

--- a/cpp-client/deephaven/dhclient/src/server/server.cc
+++ b/cpp-client/deephaven/dhclient/src/server/server.cc
@@ -362,7 +362,6 @@ void Server::SendRpc(const std::function<grpc::Status(grpc::ClientContext *)> &c
       const char *message = "Server cancelled. All further RPCs are being rejected";
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
-    guard.unlock();
   }
 
   auto status = callback(&ctx);


### PR DESCRIPTION
The first change is an error. `guard` is managing the mutex, so we need to ask `guard` to unlock it.
The second one is extraneous. The `unlock` is at the last line of the scope. `guard` is about to unlock it on the way out anyway.