### PR TITLE
Fix URL in pkgdown file

### DIFF
--- a/R/rdeephaven/pkgdown/_pkgdown.yml
+++ b/R/rdeephaven/pkgdown/_pkgdown.yml
@@ -1,5 +1,5 @@
 ---
-url: https://deephaven.io/core/rdoc/
+url: https://deephaven.io/core/client-api/r/
 
 template:
   bootstrap: 5


### PR DESCRIPTION
The [current deployment](https://deephaven.io/core/client-api/r/) of the R client API documentation does not have some of the documents or formatting that the preview I generated has. I think this due to the `_pkgdown.yml` not being invoked correctly, which seems to result from the incorrect URL used there.