### PR TITLE
UPDATE: Change `timeTable` pydoc to match signature

### DIFF
--- a/py/server/deephaven/table_factory.py
+++ b/py/server/deephaven/table_factory.py
@@ -64,7 +64,7 @@ def time_table(period: Union[Duration, int, str, datetime.timedelta, np.timedelt
         period (Union[dtypes.Duration, int, str, datetime.timedelta, np.timedelta64, pd.Timedelta]):
             time interval between new row additions, can be expressed as an integer in nanoseconds,
             a time interval string, e.g. "PT00:00:00.001" or "PT1s", or other time duration types.
-        start_time (Union[None, str, datetime.datetime, np.datetime64], optional):
+        start_time (Union[None, Instant, int, str, datetime.datetime, np.datetime64, pd.Timestamp], optional):
             start time for adding new rows, defaults to None which means use the current time
             as the start time.
         blink_table (bool, optional): if the time table should be a blink table, defaults to False


### PR DESCRIPTION
Some of the input types for `start_time` were missing from the doc string, but were present in the method signature. I added them in.