### PR TITLE
fix: Add BigDecimal and BigInteger as numeric aggregation options

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/enums/JsAggregationOperation.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/enums/JsAggregationOperation.java
@@ -128,7 +128,9 @@ public class JsAggregationOperation {
             case "long":
             case "short":
             case "char":
-            case "byte": {
+            case "byte":
+            case "java.math.BigDecimal":
+            case "java.math.BigInteger": {
                 return true;
             }
         }


### PR DESCRIPTION
- BigDecimal and BigInteger weren't listed as numeric types, and were not getting aggregated properly
- Tested using the steps in #4877 . Items were aggregated correctly.
- Fixes #4877
