### PR TITLE
Fix github action release versioning

### DIFF
--- a/.github/scripts/gradle-properties.sh
+++ b/.github/scripts/gradle-properties.sh
@@ -48,3 +48,9 @@ org.gradle.java.installations.auto-detect=false
 org.gradle.workers.max=${MAX_WORKERS}
 org.gradle.java.installations.paths=${JAVA_INSTALL_PATHS}
 EOF
+
+# Ensure we remove the -SNAPSHOT qualifier for release branch workflows
+if [[ "${GITHUB_REF}" == refs/heads/release/v* ]];
+then
+  echo "deephavenBaseQualifier="
+fi

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -63,7 +63,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CI_AT_DEEPHAVEN_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingRequired: true
-          ORG_GRADLE_PROJECT_deephavenBaseQualifier: ""
 
       - name: Upload Artifacts
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,7 +96,7 @@ We also separate out the release branch from `upstream/main` with an empty commi
 ```shell
 $ git fetch upstream
 $ git checkout upstream/main
-$ ./gradlew printVersion -q
+$ ./gradlew printVersion -PdeephavenBaseQualifier= -q
 $ git checkout -b release/vX.Y.Z
 $ git commit --allow-empty -m "Cut for X.Y.Z"
 ```


### PR DESCRIPTION
This removes the -SNAPSHOT qualifier for all github action release branch gradle invocations. This also makes a point to update the RELEASE.md in the one place where the release manager invokes gradlew.

Follow-up fix for #4865