### PR TITLE
Add notes on releasing jsapi-types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,7 +64,11 @@ and are published as the following:
 * [C++ Client API](https://deephaven.io/core/client-api/cpp/)
 * [C++ Examples](https://deephaven.io/core/client-api/cpp-examples/)
 * [R Client API](https://deephaven.io/core/client-api/r/)
-* [TypeScript Client API](https://deephaven.io/core/client-api/javascript/)
+* [JavaScript/TypeScript Client API](https://deephaven.io/core/client-api/javascript/)
+
+### Deephaven JS API types
+The npm package `@deephaven/jsapi-types` allow TypeScript clients to use their IDE's autocomplete and compiler's typechecks.
+It is released to [npm](https://www.npmjs.com/package/@deephaven/jsapi-types).
 
 ## Release process
 
@@ -265,6 +269,7 @@ mention the version explicitly. These files are listed below:
 #
 gradle.properties
 R/rdeephaven/DESCRIPTION
+web/client-api/types/package.json
 ```
 
 This leaves the files "ready" for the next regular release, and also ensures any build done from

--- a/web/client-api/types/package-lock.json
+++ b/web/client-api/types/package-lock.json
@@ -92,6 +92,5 @@
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     }
-  },
-  "version": "1.0.0-dev0.31.0"
+  }
 }

--- a/web/client-api/types/package-lock.json
+++ b/web/client-api/types/package-lock.json
@@ -92,5 +92,6 @@
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     }
-  }
+  },
+  "version": "1.0.0-dev0.31.0"
 }

--- a/web/client-api/types/package.json
+++ b/web/client-api/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-types",
-  "version": "1.0.0-dev1",
+  "version": "1.0.0-dev0.31.0",
   "description": "Deephaven JSAPI Types",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
Note that this isn't yet part of CI, either for nightly builds or for tagged releases.