### PR TITLE
Provide JsPlugins as Singleton

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyServerModule.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyServerModule.java
@@ -15,6 +15,7 @@ import io.grpc.servlet.jakarta.ServletAdapter;
 import io.grpc.servlet.jakarta.ServletServerBuilder;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Set;
@@ -71,6 +72,7 @@ public interface JettyServerModule {
     JsPluginRegistration bindJsPlugins(JsPlugins plugins);
 
     @Provides
+    @Singleton
     static JsPlugins providesJsPluginRegistration() {
         try {
             return JsPlugins.create();


### PR DESCRIPTION
This fixes a registration issue - otherwise, the provider for JsPluginRegistration will create a new JsPlugins.

Fixes a bug introduced by #4885