### PR TITLE
C++ client: remove all Stringf/Streamf and related

### DIFF
--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
@@ -20,6 +20,7 @@
 #include "deephaven/client/client.h"
 #include "deephaven/client/utility/arrow_util.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
 
 namespace deephaven::client::utility {
 namespace internal {
@@ -209,7 +210,6 @@ const char * const TypeConverterTraits<std::optional<T>>::kDeephavenTypeName =
 template<typename T>
 TypeConverter TypeConverter::CreateNew(const std::vector<T> &values) {
   using deephaven::client::utility::OkOrThrow;
-  using deephaven::dhcore::utility::Stringf;
 
   typedef TypeConverterTraits<T> traits_t;
 
@@ -227,7 +227,7 @@ TypeConverter TypeConverter::CreateNew(const std::vector<T> &values) {
   }
   auto builder_res = builder.Finish();
   if (!builder_res.ok()) {
-    auto message = Stringf("Error building array of type %o: %o", traits_t::kDeephavenTypeName,
+    auto message = fmt::format("Error building array of type {}: {}", traits_t::kDeephavenTypeName,
         builder_res.status().ToString());
   }
   auto array = builder_res.ValueUnsafe();
@@ -237,7 +237,6 @@ TypeConverter TypeConverter::CreateNew(const std::vector<T> &values) {
 template<>
 inline TypeConverter TypeConverter::CreateNew(const std::vector<deephaven::dhcore::DateTime> &values) {
   using deephaven::client::utility::OkOrThrow;
-  using deephaven::dhcore::utility::Stringf;
 
   // TODO(kosak): put somewhere
   constexpr const char *kDeephavenTypeName = "java.time.ZonedDateTime";
@@ -255,7 +254,7 @@ inline TypeConverter TypeConverter::CreateNew(const std::vector<deephaven::dhcor
   }
   auto builder_res = builder.Finish();
   if (!builder_res.ok()) {
-    auto message = Stringf("Error building array of type %o: %o",
+    auto message = fmt::format("Error building array of type {}: {}",
         kDeephavenTypeName, builder_res.status().ToString());
   }
   auto array = builder_res.ValueUnsafe();

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
@@ -23,6 +23,8 @@
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ranges.h"
 
 using io::deephaven::proto::backplane::grpc::AddTableRequest;
 using io::deephaven::proto::backplane::grpc::AddTableResponse;
@@ -77,8 +79,6 @@ using deephaven::dhcore::ticking::TickingUpdate;
 using deephaven::dhcore::utility::GetWhat;
 using deephaven::dhcore::utility::MakeReservedVector;
 using deephaven::dhcore::utility::separatedList;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 using UpdateByOperationProto = io::deephaven::proto::backplane::grpc::UpdateByRequest::UpdateByOperation;
 
@@ -621,13 +621,12 @@ void TableHandleImpl::LookupHelper(const std::string &column_name,
     }
   }
 
-  auto render = [](std::ostream &s, ElementTypeId::Enum item) {
-    // TODO(kosak): render this as a human-readable string.
-    s << static_cast<int>(item);
-  };
-  auto message = Stringf("Column lookup for %o: Expected Arrow type: one of {%o}. Actual type %o",
-      column_name, separatedList(valid_types.begin(), valid_types.end(), ", ", render),
-      static_cast<int>(actual_type));
+  auto renderable_valid_types = MakeReservedVector<int32_t>(valid_types.size());
+  for (const auto &item : valid_types) {
+    renderable_valid_types.push_back(static_cast<int32_t>(item));
+  }
+  auto message = fmt::format("Column lookup for {}: Expected Arrow type: one of {{{}}}. Actual type {}",
+      column_name, renderable_valid_types, static_cast<int>(actual_type));
   throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
 }
 

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
@@ -11,8 +11,6 @@
 #include "deephaven/dhcore/utility/utility.h"
 
 using deephaven::client::impl::MoveVectorData;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 using deephaven::dhcore::utility::ObjectId;
 using io::deephaven::proto::backplane::grpc::CreateInputTableRequest;
 using io::deephaven::proto::backplane::grpc::EmptyTableRequest;

--- a/cpp-client/deephaven/dhclient/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/dhclient/src/subscription/subscribe_thread.cc
@@ -23,8 +23,6 @@ using deephaven::dhcore::ticking::BarrageProcessor;
 using deephaven::dhcore::ticking::TickingCallback;
 using deephaven::dhcore::utility::MakeReservedVector;
 using deephaven::dhcore::utility::separatedList;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 using deephaven::dhcore::utility::VerboseCast;
 using deephaven::client::arrowutil::ArrowInt8ColumnSource;
 using deephaven::client::arrowutil::ArrowInt16ColumnSource;
@@ -302,7 +300,7 @@ ColumnSourceAndSize ArrayToColumnSource(const arrow::Array &array) {
   const auto *list_array = VerboseCast<const arrow::ListArray *>(DEEPHAVEN_LOCATION_EXPR(&array));
 
   if (list_array->length() != 1) {
-    auto message = Stringf("Expected array of length 1, got %o", array.length());
+    auto message = fmt::format("Expected array of length 1, got {}", array.length());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 

--- a/cpp-client/deephaven/dhclient/src/update_by.cc
+++ b/cpp-client/deephaven/dhclient/src/update_by.cc
@@ -12,7 +12,6 @@
 
 using deephaven::client::impl::MoveVectorData;
 using deephaven::client::impl::UpdateByOperationImpl;
-using deephaven::dhcore::utility::Stringf;
 // typedef io::deephaven::proto::backplane::grpc::UpdateByDelta UpdateByDelta;
 using io::deephaven::proto::backplane::grpc::UpdateByEmOptions;
 
@@ -45,7 +44,7 @@ UpdateByNullBehavior convertDeltaControl(DeltaControl dc) {
     case DeltaControl::kValueDominates: return UpdateByNullBehavior::VALUE_DOMINATES;
     case DeltaControl::kZeroDominates: return UpdateByNullBehavior::ZERO_DOMINATES;
     default: {
-      auto message = Stringf("Unexpected DeltaControl %o", static_cast<int>(dc));
+      auto message = fmt::format("Unexpected DeltaControl {}", static_cast<int>(dc));
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
   }
@@ -58,7 +57,7 @@ BadDataBehaviorProtoEnum convertBadDataBehavior(BadDataBehavior bdb) {
     case BadDataBehavior::kThrow: return BadDataBehaviorProtoEnum::THROW;
     case BadDataBehavior::kPoison: return BadDataBehaviorProtoEnum::POISON;
     default: {
-      auto message = Stringf("Unexpected BadDataBehavior %o", static_cast<int>(bdb));
+      auto message = fmt::format("Unexpected BadDataBehavior {}", static_cast<int>(bdb));
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
   }
@@ -95,7 +94,7 @@ MathContextProto convertMathContext(MathContext mctx) {
       break;
     }
     default: {
-      auto message = Stringf("Unexpected MathContext %o", static_cast<int>(mctx));
+      auto message = fmt::format("Unexpected MathContext {}", static_cast<int>(mctx));
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
   }

--- a/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
@@ -4,9 +4,7 @@
 #include "deephaven/client/utility/arrow_util.h"
 
 #include <ostream>
-#include <vector>
 #include <arrow/status.h>
-#include <arrow/type.h>
 #include <arrow/flight/types.h>
 #include "deephaven/dhcore/utility/utility.h"
 
@@ -17,7 +15,7 @@ void OkOrThrow(const deephaven::dhcore::utility::DebugInfo &debug_info,
     return;
   }
 
-  auto msg = Stringf("Status: %o. Caller: %o", status, debug_info);
+  auto msg = fmt::format("Status: {}. Caller: {}", status.ToString(), debug_info);
   throw std::runtime_error(msg);
 }
 

--- a/cpp-client/deephaven/dhclient/src/utility/executor.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/executor.cc
@@ -10,8 +10,6 @@
 #include <grpc/support/log.h>
 
 using deephaven::dhcore::utility::GetWhat;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::utility {
 std::shared_ptr<Executor> Executor::Create(std::string id) {
@@ -45,7 +43,7 @@ void Executor::Invoke(std::function<void()> f) {
   std::unique_lock guard(mutex_);
   auto needs_notify = todo_.empty();
   if (cancelled_) {
-    auto message = Stringf("Executor '%o' is cancelled: ignoring Invoke()\n", id_);
+    auto message = fmt::format("Executor '{}' is cancelled: ignoring Invoke()\n", id_);
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
   todo_.push_back(std::move(f));

--- a/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
@@ -5,11 +5,11 @@
 #include "deephaven/client/utility/table_maker.h"
 #include "deephaven/client/utility/arrow_util.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
 
 using deephaven::client::TableHandle;
 using deephaven::client::utility::OkOrThrow;
 using deephaven::client::utility::ValueOrThrow;
-using deephaven::dhcore::utility::Stringf;
 
 #include <memory>
 
@@ -29,7 +29,7 @@ void TableMaker::FinishAddColumn(std::string name, internal::TypeConverter info)
     numRows_ = info.Column()->length();
   } else if (numRows_ != info.Column()->length()) {
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(
-        Stringf("Column sizes not consistent: expected %o, have %o", numRows_,
+        fmt::format("Column sizes not consistent: expected {}, have {}", numRows_,
             info.Column()->length())));
   }
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/container/row_sequence.h"
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ostream.h"
 
 namespace deephaven::dhcore::clienttable {
 /**
@@ -161,3 +163,4 @@ public:
       std::vector<std::shared_ptr<RowSequence>> row_sequences) const;
 };
 }  // namespace deephaven::dhcore::clienttable
+

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/row_sequence.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/row_sequence.h
@@ -10,6 +10,9 @@
 #include <ostream>
 #include <set>
 
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ostream.h"
+
 namespace deephaven::dhcore::container {
 class RowSequenceIterator;
 
@@ -164,3 +167,6 @@ private:
   size_t size_ = 0;
 };
 }  // namespace deephaven::dhcore::container
+
+// Add the specialization for the RowSequence formatter
+template<> struct fmt::formatter<deephaven::dhcore::container::RowSequence> : fmt::ostream_formatter {};

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -69,8 +69,7 @@ void VisitElementTypeId(ElementTypeId::Enum type_id, T *visitor) {
       break;
     }
     default: {
-      auto message = deephaven::dhcore::utility::Stringf("Unrecognized ElementTypeId %o",
-          static_cast<int>(type_id));
+      auto message = fmt::format("Unrecognized ElementTypeId {}", static_cast<int>(type_id));
       throw std::runtime_error(message);
     }
   }

--- a/cpp-client/deephaven/dhcore/src/chunk/chunk.cc
+++ b/cpp-client/deephaven/dhcore/src/chunk/chunk.cc
@@ -5,13 +5,11 @@
 #include "deephaven/dhcore/utility/utility.h"
 
 using deephaven::dhcore::chunk::Chunk;
-using deephaven::dhcore::utility::separatedList;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::dhcore::chunk {
 void Chunk::CheckSize(size_t proposed_size, std::string_view what) const {
   if (proposed_size > size_) {
-    auto message = Stringf("%o: new size > size (%o > %o)", what, proposed_size, size_);
+    auto message = fmt::format("{}: new size > size ({} > {})", what, proposed_size, size_);
     throw std::runtime_error(message);
   }
 }

--- a/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
@@ -20,11 +20,10 @@ using deephaven::dhcore::container::RowSequenceIterator;
 using deephaven::dhcore::utility::MakeReservedVector;
 using deephaven::dhcore::utility::separatedList;
 using deephaven::dhcore::utility::SimpleOstringstream;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::dhcore::clienttable {
 namespace {
-void printTableData(std::ostream &stream, const ClientTable &table,
+void PrintTableData(std::ostream &stream, const ClientTable &table,
     const std::vector<size_t> &which_cols,
     const std::vector<std::shared_ptr<RowSequence>> &row_sequences,
     bool want_headers, bool want_row_numbers, bool highlight_cells);
@@ -86,7 +85,7 @@ std::ostream &operator<<(std::ostream &s, const TableStreamAdaptor &o) {
   for (size_t i = 0; i < num_cols; ++i) {
     which_cols.push_back(i);
   }
-  printTableData(s, t, which_cols, o.row_sequences_, o.want_headers_, o.want_row_numbers_, o.highlight_cells_);
+  PrintTableData(s, t, which_cols, o.row_sequences_, o.want_headers_, o.want_row_numbers_, o.highlight_cells_);
   return s;
 }
 }  // namespace internal
@@ -187,7 +186,7 @@ private:
   std::shared_ptr<uint64_t[]> build_;
 };
 
-void printTableData(std::ostream &stream, const ClientTable &table,
+void PrintTableData(std::ostream &stream, const ClientTable &table,
     const std::vector<size_t> &which_cols,
     const std::vector<std::shared_ptr<RowSequence>> &row_sequences,
     bool want_headers, bool want_row_numbers, bool highlight_cells) {

--- a/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
@@ -3,13 +3,12 @@
  */
 #include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/utility/utility.h"
-
-using deephaven::dhcore::utility::Stringf;
+#include "deephaven/third_party/fmt/format.h"
 
 namespace deephaven::dhcore::clienttable {
 std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names, std::vector<ElementTypeId::Enum> types) {
   if (names.size() != types.size()) {
-    auto message = Stringf("Sizes differ: %o vs %o", names.size(), types.size());
+    auto message = fmt::format("Sizes differ: {} vs {}", names.size(), types.size());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
   std::map<std::string_view, size_t, std::less<>> index;
@@ -17,7 +16,7 @@ std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names, std::vect
     std::string_view sv_name = names[i];
     auto [ip, inserted] = index.insert(std::make_pair(sv_name, i));
     if (!inserted) {
-      auto message = Stringf("Duplicate column name: %o", sv_name);
+      auto message = fmt::format("Duplicate column name: {}", sv_name);
       throw std::runtime_error(message);
     }
   }
@@ -38,7 +37,7 @@ std::optional<size_t> Schema::GetColumnIndex(std::string_view name, bool strict)
   if (!strict) {
     return {};
   }
-  auto message = Stringf(R"(Column name "%o" not found)", name);
+  auto message = fmt::format(R"(Column name "{}" not found)", name);
   throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
 }
 }  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/src/column/column_source_utils.cc
+++ b/cpp-client/deephaven/dhcore/src/column/column_source_utils.cc
@@ -3,14 +3,12 @@
  */
 
 #include "deephaven/dhcore/column/column_source_utils.h"
-#include "deephaven/dhcore/utility/utility.h"
-
-using deephaven::dhcore::utility::Stringf;
+#include "deephaven/third_party/fmt/format.h"
 
 namespace deephaven::dhcore::column {
 void ColumnSourceImpls::AssertRangeValid(size_t begin, size_t end, size_t size) {
   if (begin > end || (end - begin) > size) {
-    auto message = Stringf("range [%o,%o) with size %o is invalid", begin, end, size);
+    auto message = fmt::format("range [{},{}) with size {} is invalid", begin, end, size);
     throw std::runtime_error(message);
   }
 }

--- a/cpp-client/deephaven/dhcore/src/container/row_sequence.cc
+++ b/cpp-client/deephaven/dhcore/src/container/row_sequence.cc
@@ -5,8 +5,7 @@
 
 #include <optional>
 #include "deephaven/dhcore/utility/utility.h"
-
-using deephaven::dhcore::utility::Stringf;
+#include "deephaven/third_party/fmt/format.h"
 
 namespace deephaven::dhcore::container {
 namespace {
@@ -134,7 +133,7 @@ RowSequenceBuilder::~RowSequenceBuilder() = default;
 
 void RowSequenceBuilder::AddInterval(uint64_t begin, uint64_t end) {
   if (begin > end) {
-    auto message = Stringf("Malformed range [%o,%o)", begin, end);
+    auto message = fmt::format("Malformed range [{},{})", begin, end);
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 

--- a/cpp-client/deephaven/dhcore/src/ticking/barrage_processor.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/barrage_processor.cc
@@ -16,6 +16,9 @@
 #include "deephaven/dhcore/ticking/immer_table_state.h"
 #include "deephaven/dhcore/ticking/index_decoder.h"
 #include "deephaven/flatbuf/Barrage_generated.h"
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ostream.h"
+#include "deephaven/third_party/fmt/ranges.h"
 
 using deephaven::dhcore::chunk::AnyChunk;
 using deephaven::dhcore::chunk::ChunkMaker;
@@ -29,8 +32,6 @@ using deephaven::dhcore::clienttable::Schema;
 using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::utility::MakeReservedVector;
 using deephaven::dhcore::utility::separatedList;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 using io::deephaven::barrage::flatbuf::BarrageMessageType;
 using io::deephaven::barrage::flatbuf::BarrageMessageWrapper;
@@ -234,7 +235,7 @@ BarrageProcessorImpl::ProcessNextChunk(const std::vector<std::shared_ptr<ColumnS
     case State::kBuildingResult:
       return buildingResult_.ProcessNextChunk(this, sources, begins, ends, metadata, metadata_size);
     default: {
-      auto message = Stringf("Unknown state %o", static_cast<int>(state_));
+      auto message = fmt::format("Unknown state {}", static_cast<int>(state_));
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
   }
@@ -257,7 +258,7 @@ std::optional<TickingUpdate> AwaitingMetadata::ProcessNextChunk(BarrageProcessor
   const auto *barrage_wrapper = flatbuffers::GetRoot<BarrageMessageWrapper>(metadata);
 
   if (barrage_wrapper->magic() != BarrageProcessor::kDeephavenMagicNumber) {
-    auto message = Stringf("Expected magic number %o, got %o",
+    auto message = fmt::format("Expected magic number {}, got {}",
         BarrageProcessor::kDeephavenMagicNumber,
         barrage_wrapper->magic());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
@@ -265,8 +266,9 @@ std::optional<TickingUpdate> AwaitingMetadata::ProcessNextChunk(BarrageProcessor
 
   if (barrage_wrapper->msg_type() !=
       BarrageMessageType::BarrageMessageType_BarrageUpdateMetadata) {
-    auto message = Stringf("Expected Barrage Message Type %o, got %o",
-        BarrageMessageType::BarrageMessageType_BarrageUpdateMetadata, barrage_wrapper->msg_type());
+    auto message = fmt::format("Expected Barrage Message Type {}, got {}",
+        static_cast<int>(BarrageMessageType::BarrageMessageType_BarrageUpdateMetadata),
+        static_cast<int>(barrage_wrapper->msg_type()));
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 
@@ -283,8 +285,11 @@ std::optional<TickingUpdate> AwaitingMetadata::ProcessNextChunk(BarrageProcessor
   auto shift_dest_index = IndexDecoder::ReadExternalCompressedDelta(&di_three_shift_indices);
   auto added_rows = IndexDecoder::ReadExternalCompressedDelta(&di_added);
 
-//  streamf(std::cout, "adds=%o, removes=%o, ss=%o, %se=%o, sd=%o\n", *addedRows, *removedRows,
-//      *shiftStartIndex, *shiftEndIndex, *shiftDestIndex);
+  // Disabled because it's too verbose
+  if (false) {
+    fmt::print(std::cout, "adds={}, removes={}, ss={}, %se={}, sd={}\n", *added_rows, *removed_rows,
+        *shift_start_index, *shift_end_index, *shift_dest_index);
+  }
 
   const auto &mod_column_nodes = *bmd->mod_column_nodes();
 
@@ -392,7 +397,7 @@ std::optional<TickingUpdate> AwaitingAdds::ProcessNextChunk(BarrageProcessorImpl
   for (size_t i = 1; i != num_sources; ++i) {
     auto this_size = ends[i] - begins[i];
     if (this_size != chunk_size) {
-      auto message = Stringf("Chunks have inconsistent sizes: %o vs %o", this_size, chunk_size);
+      auto message = fmt::format("Chunks have inconsistent sizes: {} vs {}", this_size, chunk_size);
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
   }
@@ -475,7 +480,7 @@ std::optional<TickingUpdate> AwaitingModifies::ProcessNextChunk(BarrageProcessor
 
   auto num_sources = sources.size();
   if (num_sources > modified_rows_remaining_.size()) {
-    auto message = Stringf("Number of sources (%o) greater than expected (%o)", num_sources,
+    auto message = fmt::format("Number of sources ({}) greater than expected ({})", num_sources,
                            modified_rows_remaining_.size());
     throw std::runtime_error(message);
   }
@@ -485,7 +490,7 @@ std::optional<TickingUpdate> AwaitingModifies::ProcessNextChunk(BarrageProcessor
     auto num_rows_available = ends[i] - begins[i];
 
     if (num_rows_available > num_rows_remaining) {
-      auto message = Stringf("col %o: numRowsAvailable > numRowsRemaining (%o > %o)",
+      auto message = fmt::format("col {}: numRowsAvailable > numRowsRemaining ({} > {})",
                              i, num_rows_available, num_rows_remaining);
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
@@ -534,9 +539,9 @@ std::optional<TickingUpdate> BuildingResult::ProcessNextChunk(BarrageProcessorIm
     const std::vector<std::shared_ptr<ColumnSource>> &/*sources*/,
     std::vector<size_t> *beginsp, const std::vector<size_t> &ends, const void */*metadata*/, size_t /*metadataSize*/) {
   if (*beginsp != ends) {
-    auto message = Stringf(
-        "Barrage logic is done processing but there is leftover caller-provided data. begins = [%o]. ends=[%o]",
-        separatedList(beginsp->begin(), beginsp->end()), separatedList(ends.begin(), ends.end()));
+    auto message = fmt::format(
+        "Barrage logic is done processing but there is leftover caller-provided data. begins = [{}]. ends=[{}]",
+        *beginsp, ends);
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
   auto *aa = &owner->awaitingAdds_;
@@ -558,7 +563,7 @@ bool AllEmpty(const std::vector<std::shared_ptr<RowSequence>> &row_sequences) {
 
 void AssertAllSame(size_t val0, size_t val1, size_t val2) {
   if (val0 != val1 || val0 != val2) {
-    auto message = Stringf("Sizes differ: %o vs %o vs %o", val0, val1, val2);
+    auto message = fmt::format("Sizes differ: {} vs {} vs {}", val0, val1, val2);
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 }

--- a/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
@@ -14,6 +14,7 @@
 #include "deephaven/dhcore/ticking/shift_processor.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
 
 using deephaven::dhcore::ElementTypeId;
 using deephaven::dhcore::VisitElementTypeId;
@@ -33,8 +34,6 @@ using deephaven::dhcore::immerutil::NumericAbstractFlexVector;
 using deephaven::dhcore::clienttable::Schema;
 using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::utility::MakeReservedVector;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::dhcore::ticking {
 namespace {
@@ -98,9 +97,9 @@ void ImmerTableState::AddData(const std::vector<std::shared_ptr<ColumnSource>> &
   auto ncols = src.size();
   auto nrows = rows_to_add_index_space.Size();
     AssertAllSame(src.size(), begins.size(), ends.size());
-    AssertLeq(ncols, flexVectors_.size(), "More columns provided than was expected (%o vs %o)");
+    AssertLeq(ncols, flexVectors_.size(), "More columns provided than was expected ({} vs {})");
   for (size_t i = 0; i != ncols; ++i) {
-      AssertLeq(nrows, ends[i] - begins[i], "Sources contain insufficient data (%o vs %o)");
+      AssertLeq(nrows, ends[i] - begins[i], "Sources contain insufficient data ({} vs {})");
   }
   auto added_data = MakeReservedVector<std::unique_ptr<AbstractFlexVectorBase>>(ncols);
   for (size_t i = 0; i != ncols; ++i) {
@@ -158,7 +157,7 @@ void ImmerTableState::ModifyData(size_t col_num, const ColumnSource &src, size_t
     const RowSequence &rows_to_modify) {
   auto nrows = rows_to_modify.Size();
   auto source_size = end - begin;
-    AssertLeq(nrows, source_size, "Insufficient data in source");
+    AssertLeq(nrows, source_size, "Insufficient data in source ({} vs {})");
   auto modified_data = MakeFlexVectorFromColumnSource(src, begin, begin + nrows);
 
   auto &fv = flexVectors_[col_num];
@@ -289,7 +288,7 @@ std::unique_ptr<AbstractFlexVectorBase> MakeFlexVectorFromColumnSource(const Col
 
 void AssertAllSame(size_t val0, size_t val1, size_t val2) {
   if (val0 != val1 || val0 != val2) {
-    auto message = Stringf("Sizes differ: %o vs %o vs %o", val0, val1, val2);
+    auto message = fmt::format("Sizes differ: {} vs {} vs {}", val0, val1, val2);
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 }
@@ -298,7 +297,7 @@ void AssertLeq(size_t lhs, size_t rhs, const char *format) {
   if (lhs <= rhs) {
     return;
   }
-  auto message = Stringf(format, lhs, rhs);
+  auto message = fmt::format(format, lhs, rhs);
   throw std::runtime_error(message);
 }
 }  // namespace

--- a/cpp-client/deephaven/dhcore/src/ticking/index_decoder.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/index_decoder.cc
@@ -3,14 +3,13 @@
  */
 #include "deephaven/dhcore/ticking/index_decoder.h"
 
-#include <cstdlib>
 #include <memory>
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
 
 using deephaven::dhcore::container::RowSequence;
 using deephaven::dhcore::container::RowSequenceBuilder;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::dhcore::ticking {
 namespace {
@@ -94,7 +93,7 @@ std::shared_ptr<RowSequence> IndexDecoder::ReadExternalCompressedDelta(DataInput
       }
 
       default: {
-        auto message = Stringf("Bad command: %o", command);
+        auto message = fmt::format("Bad command: {}", command);
         throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
       }
     }
@@ -116,7 +115,7 @@ int64_t DataInput::ReadValue(int command) {
       return ReadByte();
     }
     default: {
-      auto message = Stringf("Bad command: %o", command);
+      auto message = fmt::format("Bad command: {}", command);
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
   }

--- a/cpp-client/deephaven/dhcore/src/ticking/shift_processor.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/shift_processor.cc
@@ -3,6 +3,8 @@
  */
 #include "deephaven/dhcore/ticking/shift_processor.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ostream.h"
 
 namespace deephaven::dhcore::subscription {
 void ShiftProcessor::ApplyShiftData(const RowSequence &first_index, const RowSequence &last_index,
@@ -20,8 +22,11 @@ void ShiftProcessor::ApplyShiftData(const RowSequence &first_index, const RowSeq
   auto end_iter = last_index.GetRowSequenceIterator();
   auto dest_iter = dest_index.GetRowSequenceIterator();
   auto show_message = [](size_t first, size_t last, size_t dest) {
-//    const char *which = dest >= last ? "positive" : "negative";
-//    streamf(std::cerr, "Processing %o shift src [%o..%o] dest %o\n", which, first, last, dest);
+    // Disabled because it's too verbose
+    if (false) {
+      const char *which = dest >= last ? "positive" : "negative";
+      fmt::print(std::cerr, "Processing {} shift src [{}..{}] dest {}\n", which, first, last, dest);
+    }
   };
   {
     uint64_t first;

--- a/cpp-client/deephaven/dhcore/src/ticking/space_mapper.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/space_mapper.cc
@@ -3,33 +3,14 @@
  */
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/ticking/space_mapper.h"
-
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
 
 using deephaven::dhcore::container::RowSequence;
 using deephaven::dhcore::container::RowSequenceBuilder;
 using deephaven::dhcore::utility::separatedList;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::dhcore::ticking {
-namespace {
-// We make an "iterator" that refers to a point in a numeric range.
-// This is useful because we can use the "range" version of boost::multiset::insert, which
-// uses hints internally and should be somewhat faster for inserting contiguous values.
-struct SimpleRangeIterator {
-  explicit SimpleRangeIterator(uint64_t value) : value_(value) {}
-
-  uint64_t operator*() const { return value_; }
-
-  SimpleRangeIterator &operator++() {
-    ++value_;
-    return *this;
-  }
-
-  uint64_t value_;
-};
-}
 SpaceMapper::SpaceMapper() = default;
 SpaceMapper::~SpaceMapper() = default;
 
@@ -39,7 +20,7 @@ uint64_t SpaceMapper::AddRange(uint64_t begin_key, uint64_t end_key) {
   auto initial_size = set_.cardinality();
   set_.addRange(begin_key, end_key);
   if (set_.cardinality() != initial_size + size) {
-    auto message = Stringf("Some elements of [%o,%o) were already in the set", begin_key,
+    auto message = fmt::format("Some elements of [{},{}) were already in the set", begin_key,
         end_key);
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
@@ -78,7 +59,7 @@ std::shared_ptr<RowSequence> SpaceMapper::ConvertKeysToIndices(const RowSequence
   auto convert_interval = [this, &builder](uint64_t begin_key, uint64_t end_key) {
     auto beginp = set_.begin();
     if (!beginp.move(begin_key)) {
-      auto message = Stringf("begin key %o is not in the src map", begin_key);
+      auto message = fmt::format("begin key {} is not in the src map", begin_key);
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
     auto next_rank = ZeroBasedRank(begin_key);
@@ -86,7 +67,7 @@ std::shared_ptr<RowSequence> SpaceMapper::ConvertKeysToIndices(const RowSequence
     auto currentp = beginp;
     for (auto current_key = begin_key; current_key != end_key; ++current_key) {
       if (current_key != *currentp) {
-        auto message = Stringf("Current key %o is in not the src map", current_key);
+        auto message = fmt::format("Current key {} is in not the src map", current_key);
         throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
       }
       ++currentp;

--- a/cpp-client/deephaven/dhcore/src/utility/utility.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility.cc
@@ -3,13 +3,13 @@
  */
 #include "deephaven/dhcore/utility/utility.h"
 
-#include <ctime>
 #include <ostream>
 #include <string>
 #include <vector>
 
 #include "deephaven/third_party/fmt/chrono.h"
 #include "deephaven/third_party/fmt/core.h"
+#include "deephaven/third_party/fmt/ostream.h"
 
 #ifdef __GNUG__
 #include <cstdlib>
@@ -59,16 +59,12 @@ std::string Base64Encode(const std::string &input_buffer) {
   return encoded_string;
 }
 
-namespace {
-void dumpTillPercentOrEnd(std::ostream &result, const char **fmt);
-}  // namespace
-
 void AssertLessEq(size_t lhs, size_t rhs, std::string_view context, std::string_view lhs_text,
     std::string_view rhs_text) {
   if (lhs <= rhs) {
     return;
   }
-  auto message = Stringf("%o: assertion failed: %o <= %o (%o <= %o)",
+  auto message = fmt::format("{}: assertion failed: {} <= {} ({} <= {})",
       context, lhs, rhs, lhs_text, rhs_text);
 }
 
@@ -91,84 +87,24 @@ std::streamsize SimpleOstringstream::xsputn(const char *s, std::streamsize n) {
   return n;
 }
 
-std::ostream &Streamf(std::ostream &s, const char *fmt) {
-  while (deephaven::dhcore::utility::internal::DumpFormat(s, &fmt, false)) {
-    s << "[ extra format placeholder ]";
-  }
-  return s;
-}
-
-namespace internal {
-bool DumpFormat(std::ostream &result, const char **fmt, bool placeholder_expected) {
-  // If you escape this loop via break, then you have not found a placeholder.
-  // However, if you escape it via "return true", you have.
-  while (true) {
-    // The easy part: dump till you hit a %
-    dumpTillPercentOrEnd(result, fmt);
-
-    // now our cursor is left at a % or a NUL
-    char ch = **fmt;
-    if (ch == 0) {
-      // End of string, and no placeholder found. break.
-      break;
-    }
-
-    // cursor is at %. Next character is NUL, o (our placeholder), or other char
-    ++(*fmt);
-    ch = **fmt;
-    if (ch == 0) {
-      // Trailing %. A mistake? Hmm, just print it. Now at end of string, so break, with no
-      // placeholder found.
-      result << '%';
-      break;
-    }
-
-    // Character following % is not NUL, so it is either o (our placeholder), or some other
-    // char which should be treated as an "escaped" char. In either case, advance the caller's
-    // pointer and then deal with either a placeholder or escaped char.
-    ++(*fmt);
-    if (ch == 'o') {
-      // Found a placeholder!
-      return true;
-    }
-
-    // escaped char.
-    result << ch;
-  }
-  if (placeholder_expected) {
-    result << "[ insufficient placeholders ]";
-  }
-  return false;
-}
-}  // namespace internal
-
-std::shared_ptr<std::vector<std::shared_ptr<std::string>>>
-StringVecToShared(std::vector<std::string> src) {
-  auto result = std::make_shared<std::vector<std::shared_ptr<std::string>>>();
-  result->reserve(src.size());
-  for (auto &s: src) {
-    result->push_back(std::make_shared<std::string>(std::move(s)));
-  }
-  return result;
-}
-
 DebugInfo::DebugInfo(const char *func, const char *file, size_t line, const char *args) :
     func_(func), file_(file), line_(line), args_(args) {}
 
 std::ostream &operator<<(std::ostream &s, const DebugInfo &o) {
-  return Streamf(s, "%o@%o:%o args=(%o))", o.func_, o.file_, o.line_, o.args_);
+  fmt::print(s, "{}@{}:{} args=({}))", o.func_, o.file_, o.line_, o.args_);
+  return s;
 }
 
 namespace internal {
 void TrueOrThrowHelper(const DebugInfo &debug_info) {
-  auto message = Stringf("Assertion failed: %o", debug_info);
+  auto message = fmt::format("Assertion failed: {}", debug_info);
   throw std::runtime_error(message);
 }
 }  // namespace internal
 
 std::string FormatDebugString(const char *func, const char *file, size_t line,
     const std::string &message) {
-  return Stringf("%o@%o:%o: %o", func, file, line, message);
+  return fmt::format("{}@{}:{}: {}", func, file, line, message);
 }
 
 std::string GetWhat(std::exception_ptr eptr) {
@@ -180,25 +116,6 @@ std::string GetWhat(std::exception_ptr eptr) {
     return "Some exception thrown, but could not get message";
   }
 }
-
-namespace {
-void dumpTillPercentOrEnd(std::ostream &result, const char **fmt) {
-  const char *start = *fmt;
-  const char *p = start;
-  while (true) {
-    char ch = *p;
-    if (ch == '\0' || ch == '%') {
-      break;
-    }
-    ++p;
-  }
-  if (p == start) {
-    return;
-  }
-  result.write(start, p - start);
-  *fmt = p;
-}
-}  // namespace
 
 std::string EpochMillisToStr(int64_t epoch_millis) {
   std::chrono::milliseconds ms(epoch_millis);
@@ -245,10 +162,4 @@ std::string demangle(const char* name) {
 std::string ObjectId(const std::string &class_short_name, void *this_ptr) {
   return fmt::format("{}({})", class_short_name, this_ptr);
 }
-
-std::string
-ThreadIdToString(std::thread::id tid) {
-  return Stringf("%o", tid);
-}
-
 }  // namespace deephaven::dhcore::utility

--- a/cpp-client/deephaven/tests/add_drop_test.cc
+++ b/cpp-client/deephaven/tests/add_drop_test.cc
@@ -4,8 +4,6 @@
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"
 
-using deephaven::dhcore::utility::Streamf;
-
 namespace deephaven::client::tests {
 
 TEST_CASE("Drop all columns", "[adddrop]") {

--- a/cpp-client/deephaven/tests/aggregates_test.cc
+++ b/cpp-client/deephaven/tests/aggregates_test.cc
@@ -17,8 +17,6 @@ using deephaven::client::TableHandleManager;
 using deephaven::client::TableHandle;
 using deephaven::client::SortPair;
 using deephaven::dhcore::DeephavenConstants;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::tests {
 TEST_CASE("Various Aggregates", "[aggregates]") {

--- a/cpp-client/deephaven/tests/input_table_test.cc
+++ b/cpp-client/deephaven/tests/input_table_test.cc
@@ -6,7 +6,6 @@
 #include "deephaven/dhcore/utility/utility.h"
 
 using deephaven::client::utility::TableMaker;
-using deephaven::dhcore::utility::Streamf;
 
 namespace deephaven::client::tests {
 TEST_CASE("Input Table: append", "[input_table]") {

--- a/cpp-client/deephaven/tests/join_test.cc
+++ b/cpp-client/deephaven/tests/join_test.cc
@@ -3,12 +3,12 @@
  */
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"
+#include "deephaven/third_party/fmt/format.h"
 
 using deephaven::client::TableHandleManager;
 using deephaven::client::TableHandle;
 using deephaven::client::utility::TableMaker;
 using deephaven::dhcore::DateTime;
-using deephaven::dhcore::utility::Streamf;
 
 namespace deephaven::client::tests {
 TEST_CASE("Join", "[join]") {
@@ -101,7 +101,7 @@ TEST_CASE("Aj", "[join]") {
         DateTime::Parse("2021-04-05T16:30:00-0500")
     };
     for (const auto &ts : timestamp_data) {
-      Streamf(std::cout, "%o - %o\n", ts, ts.Nanos());
+      fmt::print(std::cout, "{} - {}\n", ts, ts.Nanos());
 
     }
     std::vector<double> price_data = {2.5, 3.7, 3.0, 100.50, 110};
@@ -197,7 +197,7 @@ TEST_CASE("Raj", "[join]") {
         DateTime::Parse("2021-04-05T16:30:00-0500")
     };
     for (const auto &ts : timestamp_data) {
-      Streamf(std::cout, "%o - %o\n", ts, ts.Nanos());
+      fmt::print(std::cout, "{} - {}\n", ts, ts.Nanos());
 
     }
     std::vector<double> price_data = {2.5, 3.7, 3.0, 100.50, 110};

--- a/cpp-client/deephaven/tests/lastby_test.cc
+++ b/cpp-client/deephaven/tests/lastby_test.cc
@@ -6,8 +6,6 @@
 
 using deephaven::client::TableHandleManager;
 using deephaven::client::TableHandle;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::tests {
 TEST_CASE("Last By", "[lastby]") {

--- a/cpp-client/deephaven/tests/new_table_test.cc
+++ b/cpp-client/deephaven/tests/new_table_test.cc
@@ -12,8 +12,6 @@ using deephaven::client::TableHandle;
 using deephaven::client::SortPair;
 using deephaven::client::utility::TableMaker;
 using deephaven::dhcore::DeephavenConstants;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::tests {
 TEST_CASE("New Table", "[newtable]") {

--- a/cpp-client/deephaven/tests/select_test.cc
+++ b/cpp-client/deephaven/tests/select_test.cc
@@ -7,13 +7,12 @@
 #include "deephaven/client/client.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
 
 using deephaven::client::Client;
 using deephaven::client::TableHandle;
 using deephaven::client::utility::TableMaker;
 using deephaven::dhcore::DeephavenConstants;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::tests {
 TEST_CASE("Support all types", "[select]") {
@@ -26,21 +25,21 @@ TEST_CASE("Support all types", "[select]") {
   std::vector<int32_t> int_data;
   std::vector<int64_t> long_data;
   std::vector<float> float_data;
-  std::vector<double> doubleData;
-  std::vector<std::string> stringData;
+  std::vector<double> double_data;
+  std::vector<std::string> string_data;
 
-  const int startValue = -8;
-  const int endValue = 8;
-  for (auto i = startValue; i != endValue; ++i) {
+  const int start_value = -8;
+  const int end_value = 8;
+  for (auto i = start_value; i != end_value; ++i) {
     bool_data.push_back((i % 2) == 0);
     char_data.push_back(i * 10);
     byte_data.push_back(i * 11);
     short_data.push_back(i * 1000);
     int_data.push_back(i * 1'000'000);
-    long_data.push_back(static_cast<long>(i) * 1'000'000'000);
+    long_data.push_back(static_cast<int64_t>(i) * 1'000'000'000);
     float_data.push_back(i * 123.456F);
-    doubleData.push_back(i * 987654.321);
-    stringData.push_back(Stringf("test %o", i));
+    double_data.push_back(i * 987654.321);
+    string_data.push_back(fmt::format("test {}", i));
   }
 
   TableMaker maker;
@@ -51,8 +50,8 @@ TEST_CASE("Support all types", "[select]") {
   maker.AddColumn("intData", int_data);
   maker.AddColumn("longData", long_data);
   maker.AddColumn("floatData", float_data);
-  maker.AddColumn("doubleData", doubleData);
-  maker.AddColumn("stringData", stringData);
+  maker.AddColumn("doubleData", double_data);
+  maker.AddColumn("stringData", string_data);
 
   auto t = maker.MakeTable(tm.Client().GetManager());
 
@@ -67,8 +66,8 @@ TEST_CASE("Support all types", "[select]") {
       "intData", int_data,
       "longData", long_data,
       "floatData", float_data,
-      "doubleData", doubleData,
-      "stringData", stringData
+      "doubleData", double_data,
+      "stringData", string_data
   );
 }
 
@@ -218,7 +217,7 @@ TEST_CASE("Simple 'Where' with syntax error", "[select]") {
     std::cout << t1.Stream(true) << '\n';
   } catch (const std::exception &e) {
     // Expected
-    Streamf(std::cerr, "Caught *expected* exception %o\n", e.what());
+    fmt::print(std::cerr, "Caught *expected* exception {}\n", e.what());
     return;
   }
   throw std::runtime_error("Expected a failure, but didn't experience one");

--- a/cpp-client/deephaven/tests/test_util.cc
+++ b/cpp-client/deephaven/tests/test_util.cc
@@ -2,16 +2,16 @@
  * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
  */
 #include "test_util.h"
+#include <cstdlib>
 #include "deephaven/client/utility/table_maker.h"
 #include "deephaven/dhcore/utility/utility.h"
-#include <cstdlib>
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ostream.h"
 
 using deephaven::client::TableHandle;
 using deephaven::client::utility::OkOrThrow;
 using deephaven::client::utility::TableMaker;
 using deephaven::client::utility::ValueOrThrow;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::tests {
 ColumnNamesForTests::ColumnNamesForTests() : importDate_("ImportDate"), ticker_("Ticker"),
@@ -120,7 +120,7 @@ Client TableMakerForTests::CreateClient(const ClientOptions &options) {
   std::string host = (hostptr == nullptr) ? "localhost" : hostptr;
   std::string port = (portptr == nullptr) ? "10000" : portptr;
   std::string connection_string(host + ":" + port);
-  Streamf(std::cerr, "Connecting to %o\n", connection_string);
+  fmt::print(std::cerr, "Connecting to {}\n", connection_string);
   auto client = Client::Connect(connection_string, options);
   return client;
 }
@@ -143,7 +143,7 @@ void CompareTableHelper(int depth, const std::shared_ptr<arrow::Table> &table,
   auto column = table->column(depth);
 
   if (field->name() != column_name) {
-    auto message = Stringf("Column %o: Expected column name %o, have %o", depth, column_name,
+    auto message = fmt::format("Column {}: Expected column name {}, have {}", depth, column_name,
         field->name());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
@@ -154,13 +154,13 @@ void CompareTableHelper(int depth, const std::shared_ptr<arrow::Table> &table,
   }
 
   if (column->length() != chunked_data.length()) {
-    auto message = Stringf("Column %o: Expected length %o, got %o", depth, chunked_data.length(),
+    auto message = fmt::format("Column {}: Expected length {}, got {}", depth, chunked_data.length(),
         column->length());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 
   if (!column->type()->Equals(chunked_data.type())) {
-    auto message = Stringf("Column %o: Expected type %o, got %o", depth,
+    auto message = fmt::format("Column {}: Expected type {}, got {}", depth,
         chunked_data.type()->ToString(), column->type()->ToString());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
@@ -192,7 +192,7 @@ void CompareTableHelper(int depth, const std::shared_ptr<arrow::Table> &table,
     const auto r_item = ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(r_chunk->GetScalar(r_chunk_index)));
 
     if (!l_item->Equals(*r_item)) {
-      auto message = Stringf("Column %o: Columns differ at element %o: %o vs %o",
+      auto message = fmt::format("Column {}: Columns differ at element {}: {} vs {}",
           depth, element_index, l_item->ToString(), r_item->ToString());
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
@@ -213,7 +213,7 @@ std::shared_ptr<arrow::Table> BasicValidate(const deephaven::client::TableHandle
 
   auto &arrow_table = *table_res;
   if (expected_columns != arrow_table->num_columns()) {
-    auto message = Stringf("Expected %o columns, but Table actually has %o columns",
+    auto message = fmt::format("Expected {} columns, but Table actually has {} columns",
         expected_columns, arrow_table->num_columns());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }

--- a/cpp-client/deephaven/tests/ticking_test.cc
+++ b/cpp-client/deephaven/tests/ticking_test.cc
@@ -13,8 +13,6 @@ using deephaven::client::Client;
 using deephaven::client::TableHandle;
 using deephaven::client::utility::TableMaker;
 using deephaven::dhcore::chunk::Int64Chunk;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::tests {
 class CommonBase : public deephaven::dhcore::ticking::TickingCallback {

--- a/cpp-client/deephaven/tests/validation_test.cc
+++ b/cpp-client/deephaven/tests/validation_test.cc
@@ -4,13 +4,14 @@
 #include "tests/third_party/catch.hpp"
 #include "tests/test_util.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ostream.h"
+#include "deephaven/third_party/fmt/ranges.h"
 
 using deephaven::client::TableHandleManager;
 using deephaven::client::TableHandle;
 using deephaven::dhcore::utility::SimpleOstringstream;
 using deephaven::dhcore::utility::separatedList;
-using deephaven::dhcore::utility::Streamf;
-using deephaven::dhcore::utility::Stringf;
 
 namespace deephaven::client::tests {
 namespace {
@@ -64,19 +65,19 @@ void TestWheresHelper(std::string_view what, const TableHandle &table,
     const std::vector<std::string> &good_wheres) {
   for (const auto &bw : bad_wheres) {
     try {
-      Streamf(std::cerr, "Trying %o %o\n", what, bw);
+      fmt::print(std::cerr, "Trying {} {}\n", what, bw);
       (void)table.Where(bw);
     } catch (const std::exception &e) {
-      Streamf(std::cerr, "%o: %o: Failed *as expected* with: %o\n", what, bw, e.what());
+      fmt::print(std::cerr, "{}: {}: Failed *as expected* with: {}\n", what, bw, e.what());
       continue;
     }
 
-    throw std::runtime_error(Stringf("%o: %o: Expected to fail, but succeeded", what, bw));
+    throw std::runtime_error(fmt::format("{}: {}: Expected to fail, but succeeded", what, bw));
   }
 
   for (const auto &gw : good_wheres) {
     (void)table.Where(gw);
-    Streamf(std::cerr, "%o: %o: Succeeded as expected\n", what, gw);
+    fmt::print(std::cerr, "{}: {}: Succeeded as expected\n", what, gw);
   }
 }
 
@@ -106,17 +107,16 @@ void TestSelectsHelper(std::string_view what, const TableHandle &table,
     try {
       (void)table.Select(bs);
     } catch (const std::exception &e) {
-      Streamf(std::cerr, "%o: %o: Failed as expected with: %o\n", what, selection.str(), e.what());
+      fmt::print(std::cerr, "{}: {}: Failed as expected with: {}\n", what, selection.str(), e.what());
       continue;
     }
-    throw std::runtime_error(Stringf("%o: %o: Expected to fail, but succeeded",
+    throw std::runtime_error(fmt::format("{}: {}: Expected to fail, but succeeded",
         what, selection.str()));
   }
 
   for (const auto &gs : good_selects) {
     (void)table.Select(gs);
-    Streamf(std::cerr, "%o: %o: Succeeded as expected\n", what,
-        separatedList(gs.begin(), gs.end()));
+    fmt::print(std::cerr, "{}: {}: Succeeded as expected\n", what, gs);
   }
 }
 }  // namespace


### PR DESCRIPTION
We are standardizing on the "fmt" package now.

Also: There is a `ThreadIdToString` method that I didn't see any usages of so I removed it.
Is this something that we use perhaps elsewhere like DnD? If so, let me know and I'll add it back in a fmt-aware form.
