### PR TITLE
fix: Clean up how objects are managed when they are fetched

### DIFF
--- a/plugin/hierarchicaltable/src/main/java/io/deephaven/hierarchicaltable/HierarchicalTableTypePlugin.java
+++ b/plugin/hierarchicaltable/src/main/java/io/deephaven/hierarchicaltable/HierarchicalTableTypePlugin.java
@@ -45,6 +45,7 @@ public class HierarchicalTableTypePlugin extends ObjectTypeBase.FetchOnly {
                 .setSnapshotSchema(BarrageUtil.schemaBytes(
                         fbb -> HierarchicalTableSchemaUtil.makeSchemaPayload(fbb, hierarchicalTable)))
                 .build();
+        exporter.reference(object);
 
         result.writeTo(out);
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -108,7 +108,14 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
             this.columns = JsObject.freeze(columns);
             this.keyColumns = JsObject.freeze(keyColumns);
 
-            return w.getExportedObjects()[0].fetch();
+
+            Promise<?> promise = w.getExportedObjects()[0].fetch();
+            promise.then(ignore -> {
+                // We only need to keep the widget open long enough to get the exported objects
+                w.close();
+                return null;
+            });
+            return promise;
         }).then(result -> {
             keys = (JsTable) result;
             // TODO(deephaven-core#3604) in case of a new session, we should do a full refetch
@@ -308,6 +315,8 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
      * will not affect tables in use.
      */
     public void close() {
+        widget.close();
+
         if (keys != null) {
             keys.close();
         }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -308,8 +308,6 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
      * will not affect tables in use.
      */
     public void close() {
-        widget.close();
-
         if (keys != null) {
             keys.close();
         }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -108,14 +108,7 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
             this.columns = JsObject.freeze(columns);
             this.keyColumns = JsObject.freeze(keyColumns);
 
-
-            Promise<?> promise = w.getExportedObjects()[0].fetch(true);
-            promise.then(ignore -> {
-                // We only need to keep the widget open long enough to get the exported objects
-                w.close();
-                return null;
-            });
-            return promise;
+            return w.getExportedObjects()[0].fetch(true);
         }).then(result -> {
             keys = (JsTable) result;
             // TODO(deephaven-core#3604) in case of a new session, we should do a full refetch

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -109,7 +109,7 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
             this.keyColumns = JsObject.freeze(keyColumns);
 
 
-            Promise<?> promise = w.getExportedObjects()[0].fetch();
+            Promise<?> promise = w.getExportedObjects()[0].fetch(true);
             promise.then(ignore -> {
                 // We only need to keep the widget open long enough to get the exported objects
                 w.close();

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -760,7 +760,7 @@ public class WorkerConnection {
     }
 
     /**
-     * Export a table from the provided ticket
+     * Export a table from the provided ticket.
      * 
      * @param ticket Ticket of the table to export
      * @param fetchSummary Description for the fetch. Used for logging and errors.
@@ -809,7 +809,7 @@ public class WorkerConnection {
     }
 
     /**
-     * Retrieve an object from it's definition
+     * Retrieve an object from its definition.
      * 
      * @param definition Variable definition to get
      * @return The object requested

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -946,6 +946,7 @@ public class WorkerConnection {
                                 legacyResponse.setTypedExportIdsList(Arrays.stream(widget.getExportedObjects())
                                         .map(JsWidgetExportedObject::typedTicket).toArray(TypedTicket[]::new));
                                 c.apply(null, legacyResponse);
+                                widget.close();
                                 return null;
                             }, error -> {
                                 c.apply(error, null);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1088,8 +1088,8 @@ public class WorkerConnection {
      */
     public Promise<JsWidget> getWidget(TypedTicket typedTicket, boolean refetch) {
         return whenServerReady("get a widget")
-                .then(response -> Promise.resolve(new JsWidget(this, typedTicket)))
-                .then(widget -> {
+                .then(response -> {
+                    JsWidget widget = new JsWidget(this, typedTicket);
                     if (refetch) {
                         return widget.refetch();
                     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -991,7 +991,6 @@ public class WorkerConnection {
                     Arrays.stream(widget.getExportedObjects()).map(JsWidgetExportedObject::takeTicket)
                             .toArray(TypedTicket[]::new));
             c.apply(null, legacyResponse);
-            widget.close();
             return null;
         }, error -> {
             c.apply(error, null);
@@ -1021,10 +1020,6 @@ public class WorkerConnection {
      */
     private Promise<JsTable> getPandasTable(JsWidget widget) {
         TypedTicket typedTicket = widget.getExportedObjects()[0].takeTicket();
-
-        // We don't need to keep the original widget open, we can just close it right away
-        widget.close();
-
         return getTable(typedTicket, "table for pandas").then(table -> {
             // TODO(deephaven-core#3604) if using a new session don't attempt a reconnect
             // never attempt a reconnect, since we might have a different widget schema entirely

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1077,7 +1077,7 @@ public class WorkerConnection {
      * Retrieve a widget using a ticket. Does not create a new ticket.
      * 
      * @param typedTicket Ticket to fetch
-     * @param refetch Whether to refetch the widget. If false, you must ensure you call {@JsWidget#refetch()} before
+     * @param refetch Whether to refetch the widget. If false, you must ensure you call {@link JsWidget#refetch()} before
      *        using the widget.
      * @return Promise of the widget
      */

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1077,8 +1077,8 @@ public class WorkerConnection {
      * Retrieve a widget using a ticket. Does not create a new ticket.
      * 
      * @param typedTicket Ticket to fetch
-     * @param reexport Whether to re-export the widget. If false, you must ensure you call {@link JsWidget#refetch()} before
-     *        using the widget.
+     * @param reexport Whether to re-export the widget. If false, you must ensure you call {@link JsWidget#refetch()}
+     *        before using the widget.
      * @return Promise of the widget
      */
     private Promise<JsWidget> getExportedWidget(TypedTicket typedTicket, boolean reexport) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -759,7 +759,7 @@ public class WorkerConnection {
         });
     }
 
-    public Promise<?> getObject(TypedTicket typedTicket) {
+    public Promise<?> getObject(TypedTicket typedTicket, boolean exportNew) {
         return getObject(
                 new JsVariableDefinition(typedTicket.getType(), null, typedTicket.getTicket().getTicket_asB64(), null));
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1000,7 +1000,8 @@ public class WorkerConnection {
     }
 
     private Promise<JsFigure> getFigure(Promise<JsWidget> widgetPromise) {
-        return whenServerReady("get a figure").then(server -> new JsFigure(this, getWidgetFigureFetch(widgetPromise)).refetch());
+        return whenServerReady("get a figure")
+                .then(server -> new JsFigure(this, getWidgetFigureFetch(widgetPromise)).refetch());
 
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -760,7 +760,7 @@ public class WorkerConnection {
     }
 
     /**
-     * Export a table from the provided ticket.
+     * Export a table from the provided ticket. Intended for server-side exports only.
      * 
      * @param ticket Ticket of the table to export
      * @param fetchSummary Description for the fetch. Used for logging and errors.

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -779,7 +779,7 @@ public class WorkerConnection {
     }
 
     /**
-     * Get an object from it's ticket
+     * Get an object from its ticket.
      * 
      * @param typedTicket Ticket to get the object for
      * @return The object requested

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -979,8 +979,7 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
 
         connection.unregisterSimpleReconnectable(this);
 
-        // Presently it is never necessary to release widget tickets, since they can't be export tickets.
-        // connection.releaseTicket(widget.getTicket());
+        connection.releaseTicket(widget.getTicket());
 
         if (filteredTable != null) {
             filteredTable.release();

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -979,8 +979,6 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
 
         connection.unregisterSimpleReconnectable(this);
 
-        connection.releaseTicket(widget.getTicket());
-
         if (filteredTable != null) {
             filteredTable.release();
             filteredTable = null;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -86,7 +86,7 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
     }
 
     /**
-     * Also closes all the exported objects that the widget still owns
+     * Closes all the exported objects that the widget still owns.
      */
     private void closeExportedObjects() {
         for (int i = 0; i < exportedObjects.length; i++) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -132,9 +132,10 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
             messageStream.onStatus(status -> {
                 if (!status.isOk()) {
                     reject.onInvoke(status.getDetails());
-                    fireEvent(EVENT_CLOSE);
-                    closeStream();
                 }
+                fireEvent(EVENT_CLOSE);
+                closeStream();
+                connection.releaseTicket(getTicket());
             });
             messageStream.onEnd(status -> {
                 closeStream();

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -91,7 +91,7 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
     private void closeExportedObjects() {
         for (int i = 0; i < exportedObjects.length; i++) {
             JsWidgetExportedObject exportedObject = exportedObjects.getAt(i);
-            if (exportedObject.isTicketOwner()) {
+            if (exportedObject.isOwner()) {
                 exportedObject.close();
             }
         }
@@ -115,7 +115,6 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
 
             messageStream = streamFactory.get();
             messageStream.onData(res -> {
-
                 JsArray<JsWidgetExportedObject> responseObjects = res.getData().getExportedReferencesList()
                         .map((p0, p1, p2) -> new JsWidgetExportedObject(connection, p0));
                 if (!hasFetched) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -135,6 +135,9 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
                 }
                 fireEvent(EVENT_CLOSE);
                 closeStream();
+
+                // We can release the ticket here because the widget can no longer be used at this point after the server has closed it.
+                // As a result, fetch-only widgets do not need to be closed, as the server closes them right away.
                 connection.releaseTicket(getTicket());
             });
             messageStream.onEnd(status -> {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -86,12 +86,25 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
     }
 
     /**
+     * Also closes all the exported objects that the widget still owns
+     */
+    private void closeExportedObjects() {
+        for (int i = 0; i < exportedObjects.length; i++) {
+            JsWidgetExportedObject exportedObject = exportedObjects.getAt(i);
+            if (exportedObject.isTicketOwner()) {
+                exportedObject.close();
+            }
+        }
+    }
+
+    /**
      * Ends the client connection to the server.
      */
     @JsMethod
     public void close() {
         suppressEvents();
         closeStream();
+        closeExportedObjects();
         connection.releaseTicket(getTicket());
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -136,7 +136,8 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
                 fireEvent(EVENT_CLOSE);
                 closeStream();
 
-                // We can release the ticket here because the widget can no longer be used at this point after the server has closed it.
+                // We can release the ticket here because the widget can no longer be used at this point after the
+                // server has closed it.
                 // As a result, fetch-only widgets do not need to be closed, as the server closes them right away.
                 connection.releaseTicket(getTicket());
             });

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -73,7 +73,6 @@ public class JsWidgetExportedObject implements ServerObject {
      * Fetches the object from the server.
      * 
      * @param takeOwnership Whether to take ownership of the object. Defaults to false.
-     *
      * @return a promise that resolves to the object
      */
     @JsMethod

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -80,6 +80,7 @@ public class JsWidgetExportedObject implements ServerObject {
         if (takeOwnership == null) {
             takeOwnership = false;
         }
+        verifyIsOwner();
         if (takeOwnership) {
             return this.connection.getObject(takeTicket());
         }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -51,7 +51,7 @@ public class JsWidgetExportedObject implements ServerObject {
     }
 
     public Promise<?> fetch() {
-        return fetch(false);
+        return fetch(true);
     }
 
     private void verifyIsOwner() {
@@ -72,7 +72,7 @@ public class JsWidgetExportedObject implements ServerObject {
     /**
      * Fetches the object from the server.
      * 
-     * @param takeOwnership Whether to take ownership of the object. Defaults to false.
+     * @param takeOwnership Whether to take ownership of the object. Defaults to true.
      * @return a promise that resolves to the object
      */
     @JsMethod
@@ -82,7 +82,7 @@ public class JsWidgetExportedObject implements ServerObject {
         }
         verifyIsOwner();
         if (takeOwnership) {
-            return this.connection.getObject(takeTicket());
+            return this.connection.getExportedObject(takeTicket());
         }
         return this.connection.getObject(
                 new JsVariableDefinition(ticket.getType(), null, ticket.getTicket().getTicket_asB64(), null));

--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
@@ -130,12 +130,12 @@ public class IdeSession extends HasEventHandling {
      */
     public Promise<JsTreeTable> getTreeTable(String name) {
         return connection.getVariableDefinition(name, JsVariableType.HIERARCHICALTABLE)
-                .then(connection::getTreeTable);
+                .then(connection::getHierarchicalTable);
     }
 
     public Promise<JsTreeTable> getHierarchicalTable(String name) {
         return connection.getVariableDefinition(name, JsVariableType.HIERARCHICALTABLE)
-                .then(connection::getTreeTable);
+                .then(connection::getHierarchicalTable);
     }
 
     public Promise<?> getObject(@TsTypeRef(JsVariableDescriptor.class) JsPropertyMap<Object> definitionObject) {


### PR DESCRIPTION
- Clean up memory leak in JsPartitionedTable, JsFigure, PandasTable with widgets not being closed after being used
- Add a `takeTicket` method to JsWidgetExportedObject to make it clear when ownership of the ticket has been passed on
- Close exported objects that are still owned when closing a widget
- Tested using the steps and scripts provided in the ticket, as well as testing with creating some tables and opening/closing them in the UI
- Fixes #4903
