### PR TITLE
fix: Add BigInteger and BigDecimal types to MatchFilter.java

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
@@ -19,6 +19,8 @@ import io.deephaven.engine.rowset.RowSet;
 import org.jetbrains.annotations.NotNull;
 import org.jpy.PyObject;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.*;
 
@@ -281,6 +283,22 @@ public class MatchFilter extends WhereFilterImpl {
                             }
                         }
                         return str.charAt(0);
+                    }
+                };
+            }
+            if (cls == BigDecimal.class) {
+                return new ColumnTypeConvertor() {
+                    @Override
+                    Object convertStringLiteral(String str) {
+                        return new BigDecimal(str);
+                    }
+                };
+            }
+            if (cls == BigInteger.class) {
+                return new ColumnTypeConvertor() {
+                    @Override
+                    Object convertStringLiteral(String str) {
+                        return new BigInteger(str);
                     }
                 };
             }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterFactoryTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterFactoryTest.java
@@ -239,6 +239,84 @@ public class WhereFilterFactoryTest extends RefreshingTableTestCase {
         assertEquals(0, idx.size());
     }
 
+    public void testBigDecimal() {
+        BigDecimal a = new BigDecimal("-914.9539"); // not in the table
+
+        BigDecimal b = new BigDecimal("618.2686");
+        BigDecimal c = new BigDecimal("89.3824");
+        BigDecimal d = new BigDecimal("-471.0881");
+        Table t = TableTools.newTable(TableTools.col("BigDecimal", b, c, d));
+        // match one item
+        WhereFilter f = WhereFilterFactory.getExpression("BigDecimal = " + b);
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        RowSet idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(1, idx.size());
+        assertEquals(b, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
+        // match one of two items
+        f = WhereFilterFactory.getExpression("BigDecimal in " + a + ", " + b + "");
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(1, idx.size());
+        assertEquals(b, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
+
+        // match two of two items
+        f = WhereFilterFactory.getExpression("BigDecimal in " + c + ", " + d);
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(2, idx.size());
+        assertEquals(c, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
+        assertEquals(d, DataAccessHelpers.getColumn(t, 0).get(idx.lastRowKey()));
+
+        // match zero of one item
+        f = WhereFilterFactory.getExpression("BigDecimal == " + a);
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(0, idx.size());
+    }
+
+    public void testBigIntegerl() {
+        BigInteger a = new BigInteger("-914"); // not in the table
+
+        BigInteger b = new BigInteger("618");
+        BigInteger c = new BigInteger("89");
+        BigInteger d = new BigInteger("-471");
+        Table t = TableTools.newTable(TableTools.col("BigInteger", b, c, d));
+        // match one item
+        WhereFilter f = WhereFilterFactory.getExpression("BigInteger = " + b);
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        RowSet idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(1, idx.size());
+        assertEquals(b, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
+        // match one of two items
+        f = WhereFilterFactory.getExpression("BigInteger in " + a + ", " + b + "");
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(1, idx.size());
+        assertEquals(b, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
+
+        // match two of two items
+        f = WhereFilterFactory.getExpression("BigInteger in " + c + ", " + d);
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(2, idx.size());
+        assertEquals(c, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
+        assertEquals(d, DataAccessHelpers.getColumn(t, 0).get(idx.lastRowKey()));
+
+        // match zero of one item
+        f = WhereFilterFactory.getExpression("BigInteger == " + a);
+        f.init(t.getDefinition());
+        assertEquals(MatchFilter.class, f.getClass());
+        idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);
+        assertEquals(0, idx.size());
+    }
+
     public void testTypeInference() {
         checkResult("1", true, true, true, true, true, true, false, true, true, (byte) 1, (short) 1, 1, 1,
                 new BigInteger("1"), 1.0, new BigDecimal("1"), '1');

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterFactoryTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterFactoryTest.java
@@ -293,7 +293,7 @@ public class WhereFilterFactoryTest extends RefreshingTableTestCase {
         assertEquals(1, idx.size());
         assertEquals(b, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
         // match one of two items
-        f = WhereFilterFactory.getExpression("BigInteger in " + a + ", " + b + "");
+        f = WhereFilterFactory.getExpression("BigInteger in " + a + ", " + b);
         f.init(t.getDefinition());
         assertEquals(MatchFilter.class, f.getClass());
         idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterFactoryTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/WhereFilterFactoryTest.java
@@ -254,7 +254,7 @@ public class WhereFilterFactoryTest extends RefreshingTableTestCase {
         assertEquals(1, idx.size());
         assertEquals(b, DataAccessHelpers.getColumn(t, 0).get(idx.firstRowKey()));
         // match one of two items
-        f = WhereFilterFactory.getExpression("BigDecimal in " + a + ", " + b + "");
+        f = WhereFilterFactory.getExpression("BigDecimal in " + a + ", " + b);
         f.init(t.getDefinition());
         assertEquals(MatchFilter.class, f.getClass());
         idx = f.filter(t.getRowSet().copy(), t.getRowSet(), t, false);


### PR DESCRIPTION
Added cases for `java.math.BigDecimal` and `java.math.BigInteger` to `MatchFilter.java`.

Fixes #4911.