### PR TITLE
Exclude always ignored package.json files

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/CopyHelper.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/CopyHelper.java
@@ -11,24 +11,33 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 class CopyHelper {
-    static void copyRecursive(Path src, Path dst) throws IOException {
+    static void copyRecursive(Path src, Path dst, Predicate<Path> includeDir, Predicate<Path> includeFile)
+            throws IOException {
         Files.createDirectories(dst.getParent());
-        Files.walkFileTree(src, new CopyRecursiveVisitor(src, dst));
+        Files.walkFileTree(src, new CopyRecursiveVisitor(src, dst, includeDir, includeFile));
     }
 
     private static class CopyRecursiveVisitor extends SimpleFileVisitor<Path> {
         private final Path src;
         private final Path dst;
+        private final Predicate<Path> includeDir;
+        private final Predicate<Path> includeFile;
 
-        public CopyRecursiveVisitor(Path src, Path dst) {
+        public CopyRecursiveVisitor(Path src, Path dst, Predicate<Path> includeDir, Predicate<Path> includeFile) {
             this.src = Objects.requireNonNull(src);
             this.dst = Objects.requireNonNull(dst);
+            this.includeDir = Objects.requireNonNull(includeDir);
+            this.includeFile = Objects.requireNonNull(includeFile);
         }
 
         @Override
         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+            if (!includeDir.test(dir)) {
+                return FileVisitResult.SKIP_SUBTREE;
+            }
             // Note: toString() necessary for src/dst that don't share the same root FS
             Files.copy(dir, dst.resolve(src.relativize(dir).toString()), StandardCopyOption.COPY_ATTRIBUTES);
             return FileVisitResult.CONTINUE;
@@ -36,6 +45,9 @@ class CopyHelper {
 
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            if (!includeFile.test(file)) {
+                return FileVisitResult.CONTINUE;
+            }
             // Note: toString() necessary for src/dst that don't share the same root FS
             Files.copy(file, dst.resolve(src.relativize(file).toString()), StandardCopyOption.COPY_ATTRIBUTES);
             return FileVisitResult.CONTINUE;


### PR DESCRIPTION
Potential workaround / solution to #4817

Does not effect "production".

May be less-than-ideal if we can find jetty solution that could be fully served from disk (as opposed to the copy approach we have now).