### PR TITLE
feat: Add `getVariableDefinition` method

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeConnection.java
@@ -16,6 +16,7 @@ import io.deephaven.web.client.api.QueryConnectable;
 import io.deephaven.web.client.api.WorkerConnection;
 import io.deephaven.web.client.api.barrage.stream.ResponseStreamWrapper;
 import io.deephaven.web.client.api.console.JsVariableChanges;
+import io.deephaven.web.client.api.console.JsVariableDefinition;
 import io.deephaven.web.client.api.console.JsVariableDescriptor;
 import io.deephaven.web.client.fu.JsLog;
 import io.deephaven.web.shared.data.ConnectToken;
@@ -130,9 +131,28 @@ public class IdeConnection extends QueryConnectable<IdeConnection> {
         }
     }
 
+    /**
+     * Gets an object from the server, given a definition object. The definition object you can get:
+     * - From {@link #getVariableDefinition(String)}, or
+     * - Returned from a {@link #subscribeToFieldUpdates(JsConsumer)} callback, or
+     * - Created manually, see {@link JsVariableDefinition}
+     * @param definitionObject A VariableDefinition object. See {@link JsVariableDefinition}
+     * @return Promise that will resolve to the object being fetched
+     */
     public Promise<?> getObject(@TsTypeRef(JsVariableDescriptor.class) JsPropertyMap<Object> definitionObject) {
         WorkerConnection conn = connection.get();
         return onConnected().then(e -> conn.getJsObject(definitionObject));
+    }
+
+    /**
+     * Gets a variable definition from the server, given a name. Can be used to get the type of the variable, and then
+     * use {@link #getObject(JsPropertyMap)} to get the actual object by passing in the definition returned from this.
+     * @param name Name of the variable to get the definition for
+     * @return Promise that will resolve to the variable definition, or reject if it is not found.
+     */
+    public Promise<JsVariableDefinition> getVariableDefinition(String name) {
+        WorkerConnection conn = connection.get();
+        return onConnected().then(e -> conn.getVariableDefinition(name, null));
     }
 
     public JsRunnable subscribeToFieldUpdates(JsConsumer<JsVariableChanges> callback) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
@@ -16,6 +16,7 @@ import io.deephaven.web.client.api.*;
 import io.deephaven.web.client.api.barrage.stream.BiDiStream;
 import io.deephaven.web.client.api.console.JsCommandResult;
 import io.deephaven.web.client.api.console.JsVariableChanges;
+import io.deephaven.web.client.api.console.JsVariableDefinition;
 import io.deephaven.web.client.api.console.JsVariableDescriptor;
 import io.deephaven.web.client.api.console.JsVariableType;
 import io.deephaven.web.client.api.tree.JsTreeTable;
@@ -136,6 +137,10 @@ public class IdeSession extends HasEventHandling {
     public Promise<JsTreeTable> getHierarchicalTable(String name) {
         return connection.getVariableDefinition(name, JsVariableType.HIERARCHICALTABLE)
                 .then(connection::getTreeTable);
+    }
+
+    public Promise<JsVariableDefinition> getVariableDefinition(String name) {
+        return connection.getVariableDefinition(name, null);
     }
 
     public Promise<?> getObject(@TsTypeRef(JsVariableDescriptor.class) JsPropertyMap<Object> definitionObject) {


### PR DESCRIPTION
- In cases of embedded widgets, we want to be able to just fetch the widget by just name, as we may not have type
- We already have a utility method doing this in JS: https://github.com/deephaven/web-client-ui/blob/4c0200e71e350fcf5261b0cc28440cb798bec207/packages/jsapi-utils/src/ConnectionUtils.ts#L18
- Figure we should just expose the getVariableDefinition, since it's doing the exact same thing
