### PR TITLE
Fix JS client leaking exported references, clarify dh.Widget API

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -314,6 +314,8 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
         if (subscription != null) {
             subscription.close();
         }
+
+        widget.close();
     }
 
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsVariableDefinition.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsVariableDefinition.java
@@ -28,6 +28,10 @@ public class JsVariableDefinition {
     private final String applicationName;
 
     public JsVariableDefinition(String type, String title, String id, String description) {
+        // base64('s/') ==> 'cy8'
+        if (!id.startsWith("cy8")) {
+            throw new IllegalArgumentException("Cannot create a VariableDefinition from a non-scope ticket");
+        }
         this.type = type;
         this.title = title == null ? JS_UNAVAILABLE : title;
         this.id = id;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsVariableDefinition.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsVariableDefinition.java
@@ -12,8 +12,8 @@ import jsinterop.annotations.JsProperty;
 /**
  * A format to describe a variable available to be read from the server. Application fields are optional, and only
  * populated when a variable is provided by application mode.
- *
- * APIs which take a VariableDefinition` must at least be provided an object with a <b>type</b> and <b>id</b> field.
+ * <p>
+ * APIs which take a VariableDefinition must at least be provided an object with a <b>type</b> and <b>id</b> field.
  */
 @TsInterface
 @TsName(namespace = "dh.ide", name = "VariableDefinition")

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -978,10 +978,8 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
         JsLog.debug("Closing tree table", this);
 
         connection.unregisterSimpleReconnectable(this);
-        connection.releaseTicket(widget.getTicket());
 
-        // Presently it is never necessary to release widget tickets, since they can't be export tickets.
-        // connection.releaseTicket(widget.getTicket());
+        connection.releaseTicket(widget.getTicket());
 
         if (filteredTable != null) {
             filteredTable.release();

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -978,6 +978,7 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
         JsLog.debug("Closing tree table", this);
 
         connection.unregisterSimpleReconnectable(this);
+        connection.releaseTicket(widget.getTicket());
 
         // Presently it is never necessary to release widget tickets, since they can't be export tickets.
         // connection.releaseTicket(widget.getTicket());

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -4,7 +4,6 @@
 package io.deephaven.web.client.api.widget;
 
 import com.vertispan.tsdefs.annotations.TsName;
-import com.vertispan.tsdefs.annotations.TsTypeRef;
 import com.vertispan.tsdefs.annotations.TsUnion;
 import com.vertispan.tsdefs.annotations.TsUnionMember;
 import elemental2.core.ArrayBuffer;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -218,6 +218,10 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
         return new String(Js.uncheckedCast(response.getData().getPayload_asU8()), StandardCharsets.UTF_8);
     }
 
+    /**
+     * @return the exported objects sent in the initial message from the server. The client is responsible for closing
+     *         them when finished using them.
+     */
     @Override
     @JsProperty
     public JsWidgetExportedObject[] getExportedObjects() {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -34,15 +34,57 @@ import java.util.function.Supplier;
 /**
  * A Widget represents a server side object that sends one or more responses to the client. The client can then
  * interpret these responses to see what to render, or how to respond.
- *
+ * <p>
  * Most custom object types result in a single response being sent to the client, often with other exported objects, but
  * some will have streamed responses, and allow the client to send follow-up requests of its own. This class's API is
  * backwards compatible, but as such does not offer a way to tell the difference between a streaming or non-streaming
  * object type, the client code that handles the payloads is expected to know what to expect. See
- * dh.WidgetMessageDetails for more information.
- *
+ * {@link WidgetMessageDetails} for more information.
+ * <p>
  * When the promise that returns this object resolves, it will have the first response assigned to its fields. Later
- * responses from the server will be emitted as "message" events. When the connection with the server ends
+ * responses from the server will be emitted as "message" events. When the connection with the server ends, the "close"
+ * event will be emitted. In this way, the connection will behave roughly in the same way as a WebSocket - either side
+ * can close, and after close no more messages will be processed. There can be some latency in closing locally while
+ * remote messages are still pending - it is up to implementations of plugins to handle this case.
+ * <p>
+ * Also like WebSockets, the plugin API doesn't define how to serialize messages, and just handles any binary payloads.
+ * What it does handle however, is allowing those messages to include references to server-side objects with those
+ * payloads. Those server side objects might be tables or other built-in types in the Deephaven JS API, or could be
+ * objects usable through their own plugins. They also might have no plugin at all, allowing the client to hold a
+ * reference to them and pass them back to the server, either to the current plugin instance, or through another API.
+ * The {@code Widget} type does not specify how those objects should be used or their lifecycle, but leaves that
+ * entirely to the plugin. Messages will arrive in the order they were sent.
+ * <p>
+ * This can suggest several patterns for how plugins operate:
+ * <ul>
+ * <li>The plugin merely exists to transport some other object to the client. This can be useful for objects which can
+ * easily be translated to some other type (like a Table) when the user clicks on it. An example of this is
+ * {@code pandas.DataFrame} will result in a widget that only contains a static
+ * {@link io.deephaven.web.client.api.JsTable}. Presently, the widget is immediately closed, and only the Table is
+ * provided to the JS API consumer.</li>
+ * <li>The plugin provides references to Tables and other objects, and those objects can live longer than the object
+ * which provided them. One concrete example of this could have been
+ * {@link io.deephaven.web.client.api.JsPartitionedTable} when fetching constituent tables, but it was implemented
+ * before bidirectional plugins were implemented. Another example of this is plugins that serve as a "factory", giving
+ * the user access to table manipulation/creation methods not supported by gRPC or the JS API.</li>
+ * <li>The plugin provides reference to Tables and other objects that only make sense within the context of the widget
+ * instance, so when the widget goes away, those objects should be released as well. This is also an example of
+ * {@link io.deephaven.web.client.api.JsPartitionedTable}, as the partitioned table tracks creation of new keys through
+ * an internal table instance.</li>
+ * </ul>
+ *
+ * Handling server objects in messages also has more than one potential pattern that can be used:
+ * <ul>
+ * <li>One object per message - the message clearly is about that message, no other details required.</li>
+ * <li>Objects indexed within their message - as each message comes with a list of objects, those objects can be
+ * referenced within the payload by index. This is roughly how {@link io.deephaven.web.client.api.widget.plot.JsFigure}
+ * behaves, where the figure descriptor schema includes an index for each created series, describing which table should
+ * be used, which columns should be mapped to each axis.</li>
+ * <li>Objects indexed since widget creation - each message would append its objects to a list created when the widget
+ * was first made, and any new exports that arrive in a new message would be appended to that list. Then, subsequent
+ * messages can reference objects already sent. This imposes a limitation where the client cannot release any exports
+ * without the server somehow signaling that it will never reference that export again.</li>
+ * </ul>
  */
 // TODO consider reconnect support? This is somewhat tricky without understanding the semantics of the widget
 @TsName(namespace = "dh", name = "Widget")
@@ -120,9 +162,10 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
             messageStream.onStatus(status -> {
                 if (!status.isOk()) {
                     reject.onInvoke(status.getDetails());
-                    fireEvent(EVENT_CLOSE);
-                    closeStream();
                 }
+                fireEvent(EVENT_CLOSE);
+                closeStream();
+                connection.releaseTicket(getTicket());
             });
             messageStream.onEnd(status -> {
                 closeStream();
@@ -226,8 +269,7 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
      * @param references an array of objects that can be safely sent to the server
      */
     @JsMethod
-    public void sendMessage(MessageUnion msg,
-            @JsOptional JsArray<@TsTypeRef(ServerObject.Union.class) ServerObject> references) {
+    public void sendMessage(MessageUnion msg, @JsOptional JsArray<ServerObject.Union> references) {
         if (messageStream == null) {
             return;
         }
@@ -249,7 +291,7 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
         }
 
         for (int i = 0; references != null && i < references.length; i++) {
-            ServerObject reference = references.getAt(i);
+            ServerObject reference = references.getAt(i).asServerObject();
             data.addReferences(reference.typedTicket());
         }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -74,7 +74,7 @@ import java.util.function.Supplier;
  *
  * Handling server objects in messages also has more than one potential pattern that can be used:
  * <ul>
- * <li>One object per message - the message clearly is about that message, no other details required.</li>
+ * <li>One object per message - the message clearly is about that object, no other details required.</li>
  * <li>Objects indexed within their message - as each message comes with a list of objects, those objects can be
  * referenced within the payload by index. This is roughly how {@link io.deephaven.web.client.api.widget.plot.JsFigure}
  * behaves, where the figure descriptor schema includes an index for each created series, describing which table should

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -16,7 +16,6 @@ import io.deephaven.web.client.api.JsLazy;
 import io.deephaven.web.client.api.JsTable;
 import io.deephaven.web.client.api.ServerObject;
 import io.deephaven.web.client.api.WorkerConnection;
-import io.deephaven.web.client.api.console.JsVariableDefinition;
 import io.deephaven.web.client.api.console.JsVariableType;
 import io.deephaven.web.client.state.ClientTableState;
 import jsinterop.annotations.JsMethod;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -53,8 +53,7 @@ public class JsWidgetExportedObject implements ServerObject {
                     return Promise.resolve(table);
                 });
             } else {
-                return this.connection.getObject(
-                        new JsVariableDefinition(ticket.getType(), null, ticket.getTicket().getTicket_asB64(), null));
+                return this.connection.getObject(ticket);
             }
         });
     }
@@ -75,6 +74,7 @@ public class JsWidgetExportedObject implements ServerObject {
     /**
      * Exports another copy of this reference, allowing it to be fetched separately. Results in rejection if the ticket
      * was already closed (either by calling {@link #close()} or closing the object returned from {@link #fetch()}).
+     *
      * @return a promise returning a reexported copy of this object, still referencing the same server-side object.
      */
     @JsMethod

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -6,9 +6,12 @@ package io.deephaven.web.client.api.widget;
 import com.vertispan.tsdefs.annotations.TsInterface;
 import com.vertispan.tsdefs.annotations.TsName;
 import elemental2.promise.Promise;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.session_pb.ExportRequest;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.table_pb.ExportedTableCreationResponse;
+import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.Ticket;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.proto.ticket_pb.TypedTicket;
 import io.deephaven.web.client.api.Callbacks;
+import io.deephaven.web.client.api.JsLazy;
 import io.deephaven.web.client.api.JsTable;
 import io.deephaven.web.client.api.ServerObject;
 import io.deephaven.web.client.api.WorkerConnection;
@@ -19,8 +22,7 @@ import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
 
 /**
- * Represents a server-side object that may not yet have been fetched by the client. Does not memoize its result, so
- * fetch() should only be called once, and calling close() on this object will also close the result of the fetch.
+ * Represents a server-side object that may not yet have been fetched by the client.
  */
 @TsInterface
 @TsName(namespace = "dh", name = "WidgetExportedObject")
@@ -29,9 +31,32 @@ public class JsWidgetExportedObject implements ServerObject {
 
     private final TypedTicket ticket;
 
+    private final JsLazy<Promise<?>> fetched;
+
     public JsWidgetExportedObject(WorkerConnection connection, TypedTicket ticket) {
         this.connection = connection;
         this.ticket = ticket;
+        this.fetched = JsLazy.of(() -> {
+            if (getType() == null) {
+                return Promise.reject("Exported object has no type, can't be fetched");
+            }
+            if (getType().equals(JsVariableType.TABLE)) {
+                return Callbacks.<ExportedTableCreationResponse, Object>grpcUnaryPromise(c -> {
+                    connection.tableServiceClient().getExportedTableCreationResponse(ticket.getTicket(),
+                            connection.metadata(),
+                            c::apply);
+                }).then(etcr -> {
+                    ClientTableState cts = connection.newStateFromUnsolicitedTable(etcr, "table for widget");
+                    JsTable table = new JsTable(connection, cts);
+                    // never attempt a reconnect, since we might have a different widget schema entirely
+                    table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
+                    return Promise.resolve(table);
+                });
+            } else {
+                return this.connection.getObject(
+                        new JsVariableDefinition(ticket.getType(), null, ticket.getTicket().getTicket_asB64(), null));
+            }
+        });
     }
 
     @JsProperty
@@ -47,32 +72,55 @@ public class JsWidgetExportedObject implements ServerObject {
         return typedTicket;
     }
 
+    /**
+     * Exports another copy of this reference, allowing it to be fetched separately. Results in rejection if the ticket
+     * was already closed (either by calling {@link #close()} or closing the object returned from {@link #fetch()}).
+     * @return a promise returning a reexported copy of this object, still referencing the same server-side object.
+     */
+    public Promise<JsWidgetExportedObject> reexport() {
+        Ticket reexportedTicket = connection.getConfig().newTicket();
+        return Callbacks.grpcUnaryPromise(c -> {
+            ExportRequest req = new ExportRequest();
+            req.setSourceId(ticket.getTicket());
+            req.setResultId(reexportedTicket);
+            connection.sessionServiceClient().exportFromTicket(req, connection.metadata(), c::apply);
+        }).then(success -> {
+            TypedTicket typedTicket = new TypedTicket();
+            typedTicket.setTicket(reexportedTicket);
+            typedTicket.setType(ticket.getType());
+            return Promise.resolve(new JsWidgetExportedObject(connection, typedTicket));
+        });
+    }
+
+
+    // Could also return Promise<JsWidgetExportedObject> - perhaps if we make it have a `boolean refetch` arg?
+    // /**
+    // * Returns a copy of this widget, so that any later {@link #fetch()} will always return a fresh instance.
+    // * @return
+    // */
+    // public JsWidgetExportedObject copy() {
+    // return new JsWidgetExportedObject(connection, ticket);
+    // }
+
+    /**
+     * Returns a promise that will fetch the object represented by this reference. Multiple calls to this will return
+     * the same instance.
+     * 
+     * @return a promise that will resolve to a client side object that represents the reference on the server.
+     */
     @JsMethod
     public Promise<?> fetch() {
-        if (getType().equals(JsVariableType.TABLE)) {
-            return Callbacks.<ExportedTableCreationResponse, Object>grpcUnaryPromise(c -> {
-                connection.tableServiceClient().getExportedTableCreationResponse(ticket.getTicket(),
-                        connection.metadata(),
-                        c::apply);
-            }).then(etcr -> {
-                ClientTableState cts = connection.newStateFromUnsolicitedTable(etcr, "table for widget");
-                JsTable table = new JsTable(connection, cts);
-                // never attempt a reconnect, since we might have a different widget schema entirely
-                table.addEventListener(JsTable.EVENT_DISCONNECT, ignore -> table.close());
-                return Promise.resolve(table);
-            });
-        } else {
-            return this.connection.getObject(
-                    new JsVariableDefinition(ticket.getType(), null, ticket.getTicket().getTicket_asB64(), null));
-        }
+        return fetched.get();
     }
 
     /**
-     * Releases the server-side resources associated with this object, regardless of whether or not other client-side
-     * objects exist that also use that object.
+     * Releases the server-side resources associated with this object, regardless of whether other client-side objects
+     * exist that also use that object. Should not be called after fetch() has been invoked.
      */
     @JsMethod
     public void close() {
-        connection.releaseTicket(ticket.getTicket());
+        if (!fetched.isAvailable()) {
+            connection.releaseTicket(ticket.getTicket());
+        }
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidgetExportedObject.java
@@ -77,6 +77,7 @@ public class JsWidgetExportedObject implements ServerObject {
      * was already closed (either by calling {@link #close()} or closing the object returned from {@link #fetch()}).
      * @return a promise returning a reexported copy of this object, still referencing the same server-side object.
      */
+    @JsMethod
     public Promise<JsWidgetExportedObject> reexport() {
         Ticket reexportedTicket = connection.getConfig().newTicket();
         return Callbacks.grpcUnaryPromise(c -> {
@@ -98,6 +99,7 @@ public class JsWidgetExportedObject implements ServerObject {
     // * Returns a copy of this widget, so that any later {@link #fetch()} will always return a fresh instance.
     // * @return
     // */
+    // @JsMethod
     // public JsWidgetExportedObject copy() {
     // return new JsWidgetExportedObject(connection, ticket);
     // }

--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeSession.java
@@ -130,12 +130,12 @@ public class IdeSession extends HasEventHandling {
      */
     public Promise<JsTreeTable> getTreeTable(String name) {
         return connection.getVariableDefinition(name, JsVariableType.HIERARCHICALTABLE)
-                .then(connection::getTreeTable);
+                .then(connection::getHierarchicalTable);
     }
 
     public Promise<JsTreeTable> getHierarchicalTable(String name) {
         return connection.getVariableDefinition(name, JsVariableType.HIERARCHICALTABLE)
-                .then(connection::getTreeTable);
+                .then(connection::getHierarchicalTable);
     }
 
     public Promise<?> getObject(@TsTypeRef(JsVariableDescriptor.class) JsPropertyMap<Object> definitionObject) {


### PR DESCRIPTION
This PR is an update to https://github.com/deephaven/deephaven-core/pull/4909.

JsPartitionedTable, JsFigure, PandasTable were previously being leaked even with correct usage, ensure that those are released when client code calls close(). Additionally, partitioned tables would be re-exported unnecessarily, but only the re-export was released, leaking the original reference.

Widget and WidgetExportedObject had documentation indicating how to consume exported objects, but these rules were not enforced. The rules have changed to be more consistent and are enforced, which should avoid later confusion, and new documentation added to propose potential patterns to follow when authoring plugins.

Fixes #4903 