### PR TITLE
fix: LongWrapper comparison through value instead of object

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/LongWrapper.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/LongWrapper.java
@@ -41,4 +41,16 @@ public class LongWrapper {
     public String toString() {
         return String.valueOf(value);
     }
+
+    @JsIgnore
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof LongWrapper && ((LongWrapper) obj).value == value;
+    }
+
+    @JsIgnore
+    @Override
+    public int hashCode() {
+        return Long.hashCode(value);
+    }
 }


### PR DESCRIPTION
While working with tables partitioned by a column of `Long` types, I was unable to get constituent tables using `LongWrapper` objects obtained from the `keyTable` since there was no override of `LongWrapper`'s `equals` function.

This change adds an `equals` and `hashCode` function to `LongWrapper` so that comparisons are done on the `Long` value field of the objects instead of on the addresses of the objects.