### PR TITLE
Docs CI V2 Rework For Old Rsync

### DIFF
--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -10,14 +10,7 @@ jobs:
   makedirs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-22.04
-    concurrency:
-      group: makdirs-${{ github.workflow }}-${{ github.ref }}
-      # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Make Directories
         run: |
           mkdir -p tmp-deephaven-core-v2/${{ github.ref_name }}/
@@ -40,14 +33,7 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v') }}
     needs: [javadoc, typedoc, pydoc, cppdoc, rdoc]
     runs-on: ubuntu-22.04
-    concurrency:
-      group: symlink-${{ github.workflow }}-${{ github.ref }}
-      # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Make Symlinks
         run: |
           mkdir -p tmp-deephaven-core-v2/symlinks

--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    branches: [ '**', 'release/v*' ] 
+    branches: [ 'main', 'release/v*' ] 
 
 jobs:
   makedirs:

--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   makedirs:
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Make Directories
+        if: ${{ github.event_name == 'push' }}
         run: |
           mkdir -p tmp-deephaven-core-v2/${{ github.ref_name }}/
           cd tmp-deephaven-core-v2/${{ github.ref_name }}/
@@ -20,6 +20,7 @@ jobs:
           mkdir -p javascript python cpp-examples cpp r
           
       - name: Deploy Directories
+        if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
           switches: -rlptDvz

--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    branches: [ 'main', 'release/v*' ] 
+    branches: [ 'main', 'release/v*' ]
 
 jobs:
   makedirs:

--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -7,6 +7,35 @@ on:
     branches: [ 'main', 'release/v*' ]
 
 jobs:
+  makedirs:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: makdirs-${{ github.workflow }}-${{ github.ref }}
+      # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make Directories
+        run: |
+          mkdir -p tmp-deephaven-core-v2/${{ github.ref_name }}/
+          cd tmp-deephaven-core-v2/${{ github.ref_name }}/
+          mkdir -p javadoc pydoc client-api
+          cd client-api
+          mkdir -p javascript python cpp-examples cpp r
+          
+      - name: Deploy Directories
+        uses: burnett01/rsync-deployments@5.2
+        with:
+          switches: -rlptDvz
+          path: tmp-deephaven-core-v2/
+          remote_path: deephaven-core-v2/
+          remote_host: ${{ secrets.DOCS_HOST }}
+          remote_port: ${{ secrets.DOCS_PORT }}
+          remote_user: ${{ secrets.DOCS_USER }}
+          remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
   symlink:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v') }}
     needs: [javadoc, typedoc, pydoc, cppdoc, rdoc]
@@ -21,7 +50,7 @@ jobs:
 
       - name: Make Symlinks
         run: |
-          mkdir -p tmp-deephaven-core-v2/symlinks;
+          mkdir -p tmp-deephaven-core-v2/symlinks
           cd tmp-deephaven-core-v2/symlinks
           ln -s ../${{ github.ref_name }} latest
           ln -s ../main next
@@ -37,6 +66,7 @@ jobs:
           remote_user: ${{ secrets.DOCS_USER }}
           remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
   javadoc:
+    needs: [makedirs]
     runs-on: ubuntu-22.04
     concurrency:
       group: javadoc-${{ github.workflow }}-${{ github.ref }}
@@ -90,7 +120,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -rlptDvz --mkpath --delete
+          switches: -rlptDvz --delete
           path: combined-javadoc/build/docs/javadoc/
           remote_path: deephaven-core-v2/${{ github.ref_name }}/javadoc/
           remote_host: ${{ secrets.DOCS_HOST }}
@@ -99,6 +129,7 @@ jobs:
           remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
 
   typedoc:
+    needs: [makedirs]
     runs-on: ubuntu-22.04
     concurrency:
       group: typedoc-${{ github.workflow }}-${{ github.ref }}
@@ -147,7 +178,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -rlptDvz --mkpath --delete
+          switches: -rlptDvz --delete
           path: web/client-api/types/build/documentation/
           remote_path: deephaven-core-v2/${{ github.ref_name }}/client-api/javascript/
           remote_host: ${{ secrets.DOCS_HOST }}
@@ -156,6 +187,7 @@ jobs:
           remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
 
   pydoc:
+    needs: [makedirs]
     runs-on: ubuntu-22.04
     concurrency:
       group: pydoc-${{ github.workflow }}-${{ github.ref }}
@@ -216,7 +248,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -rlptDvz --mkpath --delete
+          switches: -rlptDvz --delete
           path: sphinx/build/docs/
           remote_path: deephaven-core-v2/${{ github.ref_name }}/pydoc/
           remote_host: ${{ secrets.DOCS_HOST }}
@@ -228,7 +260,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -rlptDvz --mkpath --delete
+          switches: -rlptDvz --delete
           path: sphinx/build/pyclient-docs/
           remote_path: deephaven-core-v2/${{ github.ref_name }}/client-api/python/
           remote_host: ${{ secrets.DOCS_HOST }}
@@ -245,6 +277,7 @@ jobs:
           if-no-files-found: ignore
 
   cppdoc:
+    needs: [makedirs]
     runs-on: ubuntu-22.04
     concurrency:
       group: cppdoc-${{ github.workflow }}-${{ github.ref }}
@@ -298,7 +331,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -rlptDvz --mkpath --delete
+          switches: -rlptDvz --delete
           path: sphinx/build/cppClientDocs/
           remote_path: deephaven-core-v2/${{ github.ref_name }}/client-api/cpp/
           remote_host: ${{ secrets.DOCS_HOST }}
@@ -310,7 +343,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -rlptDvz --mkpath --delete
+          switches: -rlptDvz --delete
           path: sphinx/build/cppExamplesDocs/
           remote_path: deephaven-core-v2/${{ github.ref_name }}/client-api/cpp-examples/
           remote_host: ${{ secrets.DOCS_HOST }}
@@ -319,6 +352,7 @@ jobs:
           remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
 
   rdoc:
+    needs: [makedirs]
     runs-on: ubuntu-22.04
     concurrency:
       group: rdoc-${{ github.workflow }}-${{ github.ref }}
@@ -365,7 +399,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -rlptDvz --mkpath --delete
+          switches: -rlptDvz --delete
           path: R/rdeephaven/docs/
           remote_path: deephaven-core-v2/${{ github.ref_name }}/client-api/r/
           remote_host: ${{ secrets.DOCS_HOST }}

--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Make Directories
-        if: ${{ github.event_name == 'push' }}
         run: |
           mkdir -p tmp-deephaven-core-v2/${{ github.ref_name }}/
           cd tmp-deephaven-core-v2/${{ github.ref_name }}/

--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    branches: [ '**', 'release/v*' ]
+    branches: [ '**', 'release/v*' ] 
 
 jobs:
   makedirs:

--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    branches: [ 'main', 'release/v*' ]
+    branches: [ '**', 'release/v*' ]
 
 jobs:
   makedirs:


### PR DESCRIPTION
The original Docs CI V2 did not take into account that the deephaven.io production server uses an older version of Ubuntu (18.04) with an older version of rsync (3.1.2).  So there were errors on a new-ish option (--mkpath) for creating the release/v* destination directory.

- Added a step to make _deephaven-core-v2/*_ directories with _rsync_ without "--delete"
- Removed "--mkpath" option on all jobs
- Added "needs" to doc deploy jobs to ensure _makedirs_ happens first
- Removed unnecessary _actions/checkout_
- Removed unnecessary _concurrency_