### PR TITLE
Revert change auto-releasing fetch only widgets

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -164,7 +164,6 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
                 }
                 fireEvent(EVENT_CLOSE);
                 closeStream();
-                connection.releaseTicket(getTicket());
             });
             messageStream.onEnd(status -> {
                 closeStream();


### PR DESCRIPTION
This was discussed as being wrong in an earlier revision of the patch, but accidentally made it into the final revision.

Follow-up for #4939