### PR TITLE
Disable Parallel Where for ConditionFilter

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ConditionFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ConditionFilter.java
@@ -611,4 +611,10 @@ public class ConditionFilter extends AbstractConditionFilter {
     public ConditionFilter renameFilter(Map<String, String> renames) {
         return new ConditionFilter(formula, renames);
     }
+
+    @Override
+    public boolean permitParallelization() {
+        // TODO (https://github.com/deephaven/deephaven-core/issues/4896): Assume statelessness by default.
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes #4959 by disabling parallel where for formulas. There is follow up work (#4896) to assume stateless-ness by default; so this is just a bandaid.

I validated with the provided query.