### PR TITLE
Address dependency and liveness issues in KafkaTools.StreamPartitionedTable

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SourcePartitionedTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SourcePartitionedTable.java
@@ -171,7 +171,7 @@ public class SourcePartitionedTable extends PartitionedTableImpl {
             }
 
             if (refreshCombiner != null) {
-                result.getUpdateGraph().addSource(refreshCombiner);
+                refreshCombiner.install();
             }
         }
 

--- a/engine/table/src/main/java/io/deephaven/stream/StreamToBlinkTableAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/stream/StreamToBlinkTableAdapter.java
@@ -7,6 +7,7 @@ import gnu.trove.list.array.TLongArrayList;
 import io.deephaven.base.log.LogOutput;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.ModifiedColumnSet;
@@ -167,6 +168,10 @@ public class StreamToBlinkTableAdapter
                     setAttribute(e.getKey(), e.getValue());
                 }
                 addParentReference(StreamToBlinkTableAdapter.this);
+                // Ensure that the UpdateSourceRegistrar remains alive while the blink table does.
+                if (updateSourceRegistrar instanceof LivenessReferent) {
+                    manage((LivenessReferent) updateSourceRegistrar);
+                }
             }
 
             @Override

--- a/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateSourceCombiner.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/updategraph/UpdateSourceCombiner.java
@@ -23,6 +23,14 @@ public class UpdateSourceCombiner extends LivenessArtifact implements Runnable, 
         this.updateGraph = updateGraph;
     }
 
+    /**
+     * Add this UpdateSourceCombiner to the {@link UpdateGraph update graph} passed at construction. This should only be
+     * done once.
+     */
+    public void install() {
+        updateGraph.addSource(this);
+    }
+
     @Override
     public void run() {
         combinedTables.forEachValidReference(Runnable::run);

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/KafkaTools.java
@@ -1495,7 +1495,7 @@ public class KafkaTools {
              * loss for blink or ring tables.
              */
             refreshCombiner = new UpdateSourceCombiner(table().getUpdateGraph());
-            manage(refreshCombiner);
+            table().manage(refreshCombiner);
             refreshCombiner.addSource(this);
             refreshCombiner.install();
 
@@ -1551,6 +1551,10 @@ public class KafkaTools {
                     ArrayBackedColumnSource.getMemoryColumnSource(int.class, null));
             resultSources.put(CONSTITUENT_COLUMN_NAME,
                     ArrayBackedColumnSource.getMemoryColumnSource(Table.class, null));
+            /*
+             * This is subtle, but this QueryTable is an inner class of StreamPartitionedTable, and so it will have a
+             * hard-ref to this, which will keep this reachable for the UpdateSourceCombiner.
+             */
             // noinspection resource
             return new QueryTable(RowSetFactory.empty().toTracking(), resultSources) {
                 {


### PR DESCRIPTION
Fixes #4952 

* Address dependency satisfaction issue for KafkaTools.StreamPartitionedTable when used with append-only or ring constituents
* Address liveness and reachability issues for the UpdateSourceCombiner and reachability issues for StreamPartitionedQueryTable