### PR TITLE
`HashedRunFinder` run-finding improvements

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/HashedRunFinder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/HashedRunFinder.java
@@ -72,9 +72,8 @@ public class HashedRunFinder {
 
         for (int chunkPosition = 0; chunkPosition < size; ++chunkPosition) {
             final int outputPosition = outputPositions.get(chunkPosition);
-            // Increase the chance of hash collision, but reduce the linear probing needed in pathological cases.
-            int hashSlot = (outputPosition * 2) & context.tableMask;
-
+            int hashSlot = outputPosition & context.tableMask;
+            int probeOffset = 0;
             do {
                 final int baseSlot = hashSlot * 3;
                 if (context.table.get(baseSlot) == UNUSED_HASH_TABLE_VALUE) {
@@ -93,8 +92,8 @@ public class HashedRunFinder {
                     overflowPointer += 2;
                     break;
                 } else {
-                    // linear probe
-                    hashSlot = (hashSlot + 1) & context.tableMask;
+                    // quadratic probing to prevent excessive clustering
+                    hashSlot = (hashSlot + (++probeOffset * probeOffset)) & context.tableMask;
                 }
             } while (true);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/HashedRunFinder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/HashedRunFinder.java
@@ -3,13 +3,13 @@
  */
 package io.deephaven.engine.table.impl.by;
 
-import io.deephaven.base.MathUtil;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.WritableIntChunk;
 import io.deephaven.chunk.attributes.ChunkLengths;
 import io.deephaven.chunk.attributes.ChunkPositions;
 import io.deephaven.engine.rowset.chunkattributes.RowKeys;
 import io.deephaven.engine.table.impl.util.ChunkUtils;
+import io.deephaven.hash.PrimeFinder;
 import io.deephaven.util.SafeCloseable;
 
 /**
@@ -21,7 +21,6 @@ public class HashedRunFinder {
 
     public static class HashedRunContext implements SafeCloseable {
         final int tableSize;
-        final int tableMask;
 
         // the hash table is [outputPosition, position, overflow]
         // the overflow is only [position, overflow]
@@ -31,14 +30,12 @@ public class HashedRunFinder {
         public HashedRunContext(int size) {
             if (size == 0) {
                 tableSize = 0;
-                tableMask = 0;
                 table = null;
                 overflow = null;
                 return;
             }
-            // load factor of half, rounded up
-            tableSize = 1 << MathUtil.ceilLog2(size * 2);
-            tableMask = tableSize - 1;
+            // load factor of 75%, rounded up to nearest prime for double hashing
+            tableSize = PrimeFinder.nextPrime((int) (size / 0.75));
             table = WritableIntChunk.makeWritableChunk(tableSize * 3);
             overflow = WritableIntChunk.makeWritableChunk((size - 1) * 2);
             table.fillWithValue(0, table.size(), UNUSED_HASH_TABLE_VALUE);
@@ -72,8 +69,8 @@ public class HashedRunFinder {
 
         for (int chunkPosition = 0; chunkPosition < size; ++chunkPosition) {
             final int outputPosition = outputPositions.get(chunkPosition);
-            int hashSlot = outputPosition & context.tableMask;
-            int probeOffset = 0;
+            int hashSlot = outputPosition % context.tableSize;
+            int probe = 0;
             do {
                 final int baseSlot = hashSlot * 3;
                 if (context.table.get(baseSlot) == UNUSED_HASH_TABLE_VALUE) {
@@ -92,8 +89,14 @@ public class HashedRunFinder {
                     overflowPointer += 2;
                     break;
                 } else {
-                    // quadratic probing to prevent excessive clustering
-                    hashSlot = (hashSlot + (++probeOffset * probeOffset)) & context.tableMask;
+                    if (probe == 0) {
+                        // double hashing
+                        probe = 1 + (outputPosition % (context.tableSize - 2));
+                    }
+                    hashSlot -= probe;
+                    if (hashSlot < 0) {
+                        hashSlot += context.tableSize;
+                    }
                 }
             } while (true);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/HashedRunFinder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/HashedRunFinder.java
@@ -72,7 +72,8 @@ public class HashedRunFinder {
 
         for (int chunkPosition = 0; chunkPosition < size; ++chunkPosition) {
             final int outputPosition = outputPositions.get(chunkPosition);
-            int hashSlot = outputPosition & context.tableMask;
+            // Increase the chance of hash collision, but reduce the linear probing needed in pathological cases.
+            int hashSlot = (outputPosition * 2) & context.tableMask;
 
             do {
                 final int baseSlot = hashSlot * 3;


### PR DESCRIPTION
I compared a few strategies for run-finding: 

- Linear Probe Hashing (default)
- Sorted
- No Run Finding
- Quadratic Probe Hashing
- Double Hash Hashing

Here are the results:
![image](https://github.com/deephaven/deephaven-core/assets/4204632/41dccdb1-a1f8-4b75-8b80-80148cb4e553)

