### PR TITLE
Include column name in errors when creating InputColumn

### DIFF
--- a/py/server/deephaven/column.py
+++ b/py/server/deephaven/column.py
@@ -73,7 +73,7 @@ class InputColumn(Column):
                 else:
                     self.j_column = _JColumn.of(self.j_column_header, dtypes.array(self.data_type, self.input_data))
         except Exception as e:
-            raise DHError(e, "failed to create an InputColumn.") from e
+            raise DHError(e, f"failed to create an InputColumn ({self.name}).") from e
 
 
 def bool_col(name: str, data: Sequence) -> InputColumn:


### PR DESCRIPTION
Fixes #4392 

```
from deephaven import new_table
from deephaven.column import *

source = new_table([
   string_col("StringVal", ["Alpha", "Bravo", "Charlie"]),
   char_col("CharVal", ["A", "B", "C"]),
   byte_col("ByteVal", [10, 20, 30]),
   short_col("ShortVal", [100, 200, 300]),
   int_col("IntVal", [1_000_000, 2_000_000, 3_000_000]),
   long_col("LongVal", [4_000_000_000, 5_000_000_000, 6_000_000_000]),
   float_col("FloatVal", [1.1, 1.2, 1.3]),
   double_col("DoubleVal", [2.1, 2.2, 2.3])
])
```
now produces:
```
-Scheduler-Serial-1 | .c.ConsoleServiceGrpcImpl | Error running script: java.lang.RuntimeException: Error in Python interpreter:
Type: <class 'deephaven.dherror.DHError'>
Value: failed to create an InputColumn (CharVal). : TypeError: 'str' object cannot be interpreted as an integer
Traceback (most recent call last):
  File "/opt/deephaven/venv/lib/python3.10/site-packages/deephaven/dtypes.py", line 300, in array
    return jpy.array(dtype.j_type, seq)
TypeError: 'str' object cannot be interpreted as an integer

The above exception was the direct cause of the following exception:

```