### PR TITLE
Flight: Disable Batching Static Tables

### DIFF
--- a/java-client/flight-dagger/src/test/java/io/deephaven/client/DeephavenFlightSessionTest.java
+++ b/java-client/flight-dagger/src/test/java/io/deephaven/client/DeephavenFlightSessionTest.java
@@ -29,13 +29,13 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DeephavenFlightSessionTest extends DeephavenFlightSessionTestBase {
-    public static <T extends TableOperations<T, T>> T i32768(TableCreator<T> c) {
-        return c.emptyTable(32768).view("I=i");
+    public static <T extends TableOperations<T, T>> T i132768(TableCreator<T> c) {
+        return c.emptyTable(132768).view("I=i");
     }
 
     @Test
     public void getSchema() throws Exception {
-        final TableSpec table = i32768(TableCreatorImpl.INSTANCE);
+        final TableSpec table = i132768(TableCreatorImpl.INSTANCE);
         try (final TableHandle handle = flightSession.session().execute(table)) {
             final Schema schema = flightSession.schema(handle.export());
             final Schema expected = new Schema(Collections.singletonList(
@@ -46,14 +46,17 @@ public class DeephavenFlightSessionTest extends DeephavenFlightSessionTestBase {
 
     @Test
     public void getStream() throws Exception {
-        final TableSpec table = i32768(TableCreatorImpl.INSTANCE);
+        final TableSpec table = i132768(TableCreatorImpl.INSTANCE);
         try (final TableHandle handle = flightSession.session().execute(table);
                 final FlightStream stream = flightSession.stream(handle)) {
             int numRows = 0;
+            int flightCount = 0;
             while (stream.next()) {
+                ++flightCount;
                 numRows += stream.getRoot().getRowCount();
             }
-            Assert.assertEquals(32768, numRows);
+            Assert.assertEquals(1, flightCount);
+            Assert.assertEquals(132768, numRows);
         }
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -21,7 +21,6 @@ import io.deephaven.javascript.proto.dhinternal.io.deephaven.barrage.flatbuf.bar
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.barrage.flatbuf.barrage_generated.io.deephaven.barrage.flatbuf.BarrageMessageWrapper;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.barrage.flatbuf.barrage_generated.io.deephaven.barrage.flatbuf.BarrageSnapshotOptions;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.barrage.flatbuf.barrage_generated.io.deephaven.barrage.flatbuf.BarrageSnapshotRequest;
-import io.deephaven.javascript.proto.dhinternal.io.deephaven.barrage.flatbuf.barrage_generated.io.deephaven.barrage.flatbuf.BarrageSubscriptionRequest;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.barrage.flatbuf.barrage_generated.io.deephaven.barrage.flatbuf.BarrageUpdateMetadata;
 import io.deephaven.javascript.proto.dhinternal.io.deephaven.barrage.flatbuf.barrage_generated.io.deephaven.barrage.flatbuf.ColumnConversionMode;
 import io.deephaven.web.client.api.Callbacks;
@@ -36,6 +35,7 @@ import io.deephaven.web.client.api.barrage.def.ColumnDefinition;
 import io.deephaven.web.client.api.barrage.stream.BiDiStream;
 import io.deephaven.web.client.fu.JsLog;
 import io.deephaven.web.client.state.ClientTableState;
+import io.deephaven.web.shared.data.Range;
 import io.deephaven.web.shared.data.TableSnapshot;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsNullable;
@@ -45,6 +45,7 @@ import jsinterop.base.Js;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.Iterator;
 
 import static io.deephaven.web.client.api.barrage.WebBarrageUtils.makeUint8ArrayFromBitset;
 import static io.deephaven.web.client.api.barrage.WebBarrageUtils.serializeRanges;
@@ -320,14 +321,14 @@ public class TableViewportSubscription extends HasEventHandling {
                         new FlightData());
 
                 Builder doGetRequest = new Builder(1024);
-                double columnsOffset = BarrageSubscriptionRequest.createColumnsVector(doGetRequest,
+                double columnsOffset = BarrageSnapshotRequest.createColumnsVector(doGetRequest,
                         makeUint8ArrayFromBitset(columnBitset));
-                double viewportOffset = BarrageSubscriptionRequest.createViewportVector(doGetRequest, serializeRanges(
+                double viewportOffset = BarrageSnapshotRequest.createViewportVector(doGetRequest, serializeRanges(
                         Collections.singleton(rows.getRange())));
                 double serializationOptionsOffset = BarrageSnapshotOptions
                         .createBarrageSnapshotOptions(doGetRequest, ColumnConversionMode.Stringify, true, 0, 0);
                 double tableTicketOffset =
-                        BarrageSubscriptionRequest.createTicketVector(doGetRequest, state.getHandle().getTicket());
+                        BarrageSnapshotRequest.createTicketVector(doGetRequest, state.getHandle().getTicket());
                 BarrageSnapshotRequest.startBarrageSnapshotRequest(doGetRequest);
                 BarrageSnapshotRequest.addTicket(doGetRequest, tableTicketOffset);
                 BarrageSnapshotRequest.addColumns(doGetRequest, columnsOffset);
@@ -365,7 +366,24 @@ public class TableViewportSubscription extends HasEventHandling {
                             WebBarrageUtils.typedArrayToLittleEndianByteBuffer(flightData.getDataBody_asU8()), update,
                             true,
                             columnTypes);
-                    callback.onSuccess(snapshot);
+
+                    // TODO deephaven-core(#188) this check no longer makes sense
+                    Iterator<Range> rangeIterator = rows.getRange().rangeIterator();
+                    long expectedCount = 0;
+                    while (rangeIterator.hasNext()) {
+                        Range range = rangeIterator.next();
+                        if (range.getFirst() >= snapshot.getTableSize()) {
+                            break;
+                        }
+                        long end = Math.min(range.getLast(), snapshot.getTableSize());
+                        expectedCount += end - range.getFirst() + 1;
+                    }
+                    if (expectedCount != snapshot.getIncludedRows().size()) {
+                        callback.onFailure("Server did not send expected number of rows, expected " + expectedCount
+                                + ", actual " + snapshot.getIncludedRows().size());
+                    } else {
+                        callback.onSuccess(snapshot);
+                    }
                 });
                 stream.onStatus(status -> {
                     if (!status.isOk()) {


### PR DESCRIPTION
The jsapi cannot handle multiple batches on static tables; note that refreshing tables are already disabled in this regard. 

We'll have to disable batching static tables until after #188 is completed.