### PR TITLE
Adjust parameters for floating point tests

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/BucketedPartitionedUpdateByManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/BucketedPartitionedUpdateByManager.java
@@ -102,12 +102,6 @@ class BucketedPartitionedUpdateByManager extends UpdateBy {
         }, source::isRefreshing, DynamicNode::isRefreshing);
 
         if (source.isRefreshing()) {
-            // this is a refreshing source, we will need a listener
-            sourceListener = newUpdateByListener();
-            source.addUpdateListener(sourceListener);
-            // result will depend on listener
-            result.addParentReference(sourceListener);
-
             // create input and output modified column sets
             forAllOperators(op -> {
                 op.createInputModifiedColumnSet(source);
@@ -121,6 +115,12 @@ class BucketedPartitionedUpdateByManager extends UpdateBy {
             transformFailureListener = new TransformFailureListener(transformedTable);
             transformedTable.addUpdateListener(transformFailureListener);
             result.addParentReference(transformFailureListener);
+
+            // this is a refreshing source, we will need a listener
+            sourceListener = newUpdateByListener();
+            source.addUpdateListener(sourceListener);
+            // result will depend on listener
+            result.addParentReference(sourceListener);
         } else {
             sourceListener = null;
             mcsTransformer = null;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
@@ -58,12 +58,6 @@ public class ZeroKeyUpdateByManager extends UpdateBy {
         if (source.isRefreshing()) {
             result = new QueryTable(source.getRowSet(), resultSources);
 
-            // this is a refreshing source, we will need a listener
-            sourceListener = newUpdateByListener();
-            source.addUpdateListener(sourceListener);
-            // result will depend on listener
-            result.addParentReference(sourceListener);
-
             // create input and output modified column sets
             forAllOperators(op -> {
                 op.createInputModifiedColumnSet(source);
@@ -80,6 +74,12 @@ public class ZeroKeyUpdateByManager extends UpdateBy {
 
             // result will depend on zeroKeyUpdateBy
             result.addParentReference(zeroKeyUpdateBy.result);
+
+            // this is a refreshing source, we will need a listener
+            sourceListener = newUpdateByListener();
+            source.addUpdateListener(sourceListener);
+            // result will depend on listener
+            result.addParentReference(sourceListener);
         } else {
             zeroKeyUpdateBy = new UpdateByBucketHelper(bucketDescription, source, windows, resultSources,
                     timestampColumnName, control, (oe, se) -> {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -2791,8 +2791,7 @@ public class QueryTableAggregationTest {
         final QueryTable queryTable = getTable(size, random,
                 columnInfos = initColumnInfos(new String[] {"Sym", "doubleCol", "longCol"},
                         new SetGenerator<>("a", "b", "c", "d"),
-                        // TODO (deephaven-core#4743) verify this change in range
-                        new DoubleGenerator(0, 10000, 0.05, 0.05),
+                        new DoubleGenerator(10.1, 20.1, 0.05, 0.05),
                         new LongGenerator(0, 1_000_000_000L)));
 
         final Collection<? extends Aggregation> aggregations = List.of(

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/BaseUpdateByTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/BaseUpdateByTest.java
@@ -68,8 +68,7 @@ public class BaseUpdateByTest {
                 new ShortGenerator((short) -6000, (short) 65535, .1),
                 new IntGenerator(10, 100, .1),
                 new LongGenerator(10, 100, .1),
-                // TODO (deephaven-core#4743) verify this change in range
-                new FloatGenerator(0, 100, .1),
+                new FloatGenerator(10.1F, 20.1F, .1),
                 new DoubleGenerator(10.1, 20.1, .1),
                 new BooleanGenerator(.5, .1),
                 new BigIntegerGenerator(new BigInteger("-10"), new BigInteger("10"), .1),


### PR DESCRIPTION
Analyzed test sensitivity and changes made during the datagen updates (#4735) and verified the changes are correct and do not mask inaccuracies in the operations being tested.

Using floating point values with varying magnitudes increases floating point error, pushing it beyond the "acceptable" level of error in these tests.  Adjusting the tests to produce random values clustered within the same magnitude reduces the final error and allows these tests to pass.

Closes #4743.