### PR TITLE
Fix pydeephaven-ticking package name and link

### DIFF
--- a/py/client/docs/source/examples.rst
+++ b/py/client/docs/source/examples.rst
@@ -182,10 +182,10 @@ Execute a script server side
 Subscribe to a ticking table
 ############################
 
-The `pydeephaven_ticking` package can be used to subscribe to ticking tables. This is useful for getting asynchronous callbacks when
+The `pydeephaven-ticking` package can be used to subscribe to ticking tables. This is useful for getting asynchronous callbacks when
 they change. The package maintains a complete local copy of the table and notifies callers when the table changes.
 
-Note that `pydeephaven_ticking` must be built before running this example; find build instructions <ahref='https://github.com/deephaven/deephaven-core/tree/main/py/client-ticking#readme'>here</a>
+Note that `pydeephaven-ticking` must be built before running this example. Build instructions are available <a href='https://github.com/deephaven/deephaven-core/tree/main/py/client-ticking#readme'>here</a>.
 
 The listener can be specified either as a python function or as an implementation of the TableListener abstract base class. In the
 case of implementing


### PR DESCRIPTION
Fix a broken `<a href`, and update the documentation to use the package name (`pydeephaven-ticking`) instead of the module name (`pydeephaven_ticking`).