### PR TITLE
Fix Server-Side ABORT That Should be CANCELLED

### DIFF
--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
@@ -145,7 +145,7 @@ public class ApplicationServiceGrpcImpl extends ApplicationServiceGrpc.Applicati
 
     synchronized void remove(Subscription sub) {
         if (subscriptions.remove(sub)) {
-            sub.notifyObserverAborted();
+            sub.notifyObserverCancelled();
         }
     }
 
@@ -250,8 +250,8 @@ public class ApplicationServiceGrpcImpl extends ApplicationServiceGrpc.Applicati
         }
 
         // must be sync wrt parent
-        private void notifyObserverAborted() {
-            GrpcUtil.safelyError(observer, Code.ABORTED, "subscription cancelled");
+        private void notifyObserverCancelled() {
+            GrpcUtil.safelyError(observer, Code.CANCELLED, "subscription cancelled");
         }
     }
 


### PR DESCRIPTION
This fixes a spurious `ApplicationExampleTest` failure.

The issue is that the client CANCELs. The local client "cancel" task gets put into a queue as well as the "abort" task created from the server response. Given the threading model, and local execution, these can race causing a rare failure.