### PR TITLE
Add dependency on jpy>=0.15.0

### DIFF
--- a/docker/registry/server-base/gradle.properties
+++ b/docker/registry/server-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:8f9b993a4ce7c78b50b869be840241a0a9d19d3f4f35601f20cd05475abd5753
+deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:005bb15db3be4cc3b106dac86574a593c96e989d338f9e618e83b5f282050ae2

--- a/docker/server-jetty/src/main/server-jetty/requirements.txt
+++ b/docker/server-jetty/src/main/server-jetty/requirements.txt
@@ -1,18 +1,18 @@
-adbc-driver-manager==0.8.0
-adbc-driver-postgresql==0.8.0
+adbc-driver-manager==0.9.0
+adbc-driver-postgresql==0.9.0
 connectorx==0.3.2; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
 java-utilities==0.2.0
 jedi==0.18.2
-jpy==0.14.0
+jpy==0.15.0
 llvmlite==0.41.1
 numba==0.58.1
-numpy==1.26.2
+numpy==1.26.3
 pandas==2.1.4
 parso==0.8.3
-pyarrow==14.0.1
+pyarrow==14.0.2
 python-dateutil==2.8.2
 pytz==2023.3.post1
 six==1.16.0
 turbodbc==4.8.0
-tzdata==2023.3
+tzdata==2023.4

--- a/docker/server/src/main/server-netty/requirements.txt
+++ b/docker/server/src/main/server-netty/requirements.txt
@@ -1,18 +1,18 @@
-adbc-driver-manager==0.8.0
-adbc-driver-postgresql==0.8.0
+adbc-driver-manager==0.9.0
+adbc-driver-postgresql==0.9.0
 connectorx==0.3.2; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
 java-utilities==0.2.0
 jedi==0.18.2
-jpy==0.14.0
+jpy==0.15.0
 llvmlite==0.41.1
 numba==0.58.1
-numpy==1.26.2
+numpy==1.26.3
 pandas==2.1.4
 parso==0.8.3
-pyarrow==14.0.1
+pyarrow==14.0.2
 python-dateutil==2.8.2
 pytz==2023.3.post1
 six==1.16.0
 turbodbc==4.8.0
-tzdata==2023.3
+tzdata==2023.4

--- a/py/server/setup.py
+++ b/py/server/setup.py
@@ -51,11 +51,12 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     keywords='Deephaven Development',
     python_requires='>=3.8',
     install_requires=[
-        'jpy>=0.14.0',
+        'jpy>=0.15.0',
         'deephaven-plugin>=0.6.0',
         'numpy',
         'pandas>=1.5.0',


### PR DESCRIPTION
Enables Python 3.12 support, bumps the base images to pickup jpy>=0.15.0

https://github.com/jpy-consortium/jpy/releases/tag/v0.15.0