### PR TITLE
Python test workflow improvements

### DIFF
--- a/Integrations/build.gradle
+++ b/Integrations/build.gradle
@@ -48,7 +48,15 @@ SourceSet test = java.sourceSets.maybeCreate('test')
 
 def runInDocker = { String name, String sourcePath, def command, Closure addConfig = {} ->
     Docker.registerDockerTask(project, name) {
+        final String JPY_SOURCE_PATH = project.hasProperty("customJpy") ? project.property("customJpy") : null
+
         copyIn {
+            if (JPY_SOURCE_PATH != null) {
+                from (JPY_SOURCE_PATH) {
+                    into 'custom_jpy'
+                }
+            }
+
             from(sourcePath) {
                 into 'python'
             }
@@ -91,6 +99,19 @@ def runInDocker = { String name, String sourcePath, def command, Closure addConf
             // copy in the contents that we do expect to change as the project updates
             copyFile 'python', '/python'
             copyFile 'classpath', '/classpath'
+
+            if (JPY_SOURCE_PATH != null) {
+                runCommand 'apt-get update && apt-get install -y build-essential python3-dev maven'
+
+                copyFile "custom_jpy", '/custom_jpy'
+                runCommand '''set -eux; \\
+                cd /custom_jpy; \\
+                rm -rf dist; \\
+                python3 setup.py build maven bdist_wheel; \\
+                pip3 install /custom_jpy/dist/*.whl; \\
+                cd ..;
+                '''
+            }
         }
 
         if (command instanceof List) {


### PR DESCRIPTION
- Support for running only select Python tests (with `-PpyTestFiles=test_file1.py,test_file2.py`).
- Support for running Python tests using local jpy sources (with `-PcustomJpy=/path/to/jpy_sources`). The `customJpy` dir is copied into the container and the wheel is built there.