### PR TITLE
Calendar API changes so that methods accepting strings return strings

### DIFF
--- a/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
+++ b/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
@@ -433,8 +433,7 @@ public class DateTimeUtils {
         synchronized void update(final long currentTimeMillis) {
             date = toLocalDate(epochMillisToInstant(currentTimeMillis), timeZone);
             str = formatDate(date);
-            valueExpirationTimeMillis =
-                    epochMillis(atMidnight(epochMillisToZonedDateTime(currentTimeMillis, timeZone)).plusDays(1));
+            valueExpirationTimeMillis = epochMillis(date.plusDays(1).atStartOfDay(timeZone));
         }
     }
 
@@ -449,6 +448,10 @@ public class DateTimeUtils {
 
     private static final KeyedObjectHashMap<ZoneId, CachedCurrentDate> cachedCurrentDates =
             new KeyedObjectHashMap<>(new CachedDateKey<>());
+
+    private static CachedCurrentDate getCachedCurrentDate(@NotNull final ZoneId timeZone) {
+        return cachedCurrentDates.putIfAbsent(timeZone, CachedCurrentDate::new);
+    }
 
     /**
      * Provides the current date string according to the {@link #currentClock() current clock}. Under most
@@ -468,7 +471,7 @@ public class DateTimeUtils {
             return null;
         }
 
-        return cachedCurrentDates.putIfAbsent(timeZone, CachedCurrentDate::new).getStr();
+        return getCachedCurrentDate(timeZone).getStr();
     }
 
     /**
@@ -485,6 +488,7 @@ public class DateTimeUtils {
     @ScriptApi
     @NotNull
     public static String today() {
+        //noinspection ConstantConditions
         return today(DateTimeUtils.timeZone());
     }
 
@@ -506,7 +510,7 @@ public class DateTimeUtils {
             return null;
         }
 
-        return cachedCurrentDates.putIfAbsent(timeZone, CachedCurrentDate::new).getLocalDate();
+        return getCachedCurrentDate(timeZone).getLocalDate();
     }
 
     /**
@@ -523,6 +527,7 @@ public class DateTimeUtils {
     @ScriptApi
     @NotNull
     public static LocalDate todayLocalDate() {
+        //noinspection ConstantConditions
         return todayLocalDate(DateTimeUtils.timeZone());
     }
 

--- a/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
+++ b/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
@@ -488,7 +488,7 @@ public class DateTimeUtils {
     @ScriptApi
     @NotNull
     public static String today() {
-        //noinspection ConstantConditions
+        // noinspection ConstantConditions
         return today(DateTimeUtils.timeZone());
     }
 
@@ -527,7 +527,7 @@ public class DateTimeUtils {
     @ScriptApi
     @NotNull
     public static LocalDate todayLocalDate() {
-        //noinspection ConstantConditions
+        // noinspection ConstantConditions
         return todayLocalDate(DateTimeUtils.timeZone());
     }
 

--- a/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
@@ -1214,14 +1214,15 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the dates are not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate[] businessDates(final String start, final String end, final boolean startInclusive,
+    public String[] businessDates(final String start, final String end, final boolean startInclusive,
             final boolean endInclusive) {
         if (start == null || end == null) {
             return null;
         }
 
-        return businessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
+        final LocalDate[] dates = businessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
                 endInclusive);
+        return dates == null ? null : Arrays.stream(dates).map(DateTimeUtils::formatDate).toArray(String[]::new);
     }
 
     /**
@@ -1287,7 +1288,7 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the dates are not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate[] businessDates(final String start, final String end) {
+    public String[] businessDates(final String start, final String end) {
         return businessDates(start, end, true, true);
     }
 
@@ -1357,14 +1358,15 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the dates are not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate[] nonBusinessDates(final String start, final String end, final boolean startInclusive,
+    public String[] nonBusinessDates(final String start, final String end, final boolean startInclusive,
             final boolean endInclusive) {
         if (start == null || end == null) {
             return null;
         }
 
-        return nonBusinessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
+        final LocalDate[] dates = nonBusinessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
                 endInclusive);
+        return dates == null ? null : Arrays.stream(dates).map(DateTimeUtils::formatDate).toArray(String[]::new);
     }
 
     /**
@@ -1430,7 +1432,7 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the dates are not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate[] nonBusinessDates(final String start, final String end) {
+    public String[] nonBusinessDates(final String start, final String end) {
         return nonBusinessDates(start, end, true, true);
     }
 
@@ -1748,12 +1750,13 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the date is not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate plusBusinessDays(final String date, final int days) {
+    public String plusBusinessDays(final String date, final int days) {
         if (date == null || days == NULL_INT) {
             return null;
         }
 
-        return plusBusinessDays(DateTimeUtils.parseLocalDate(date), days);
+        final LocalDate d = plusBusinessDays(DateTimeUtils.parseLocalDate(date), days);
+        return d == null ? null : d.toString();
     }
 
     /**
@@ -1840,7 +1843,7 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the date is not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate minusBusinessDays(final String date, final int days) {
+    public String minusBusinessDays(final String date, final int days) {
         if (date == null || days == NULL_INT) {
             return null;
         }
@@ -1939,12 +1942,13 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the date is not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate plusNonBusinessDays(final String date, final int days) {
+    public String plusNonBusinessDays(final String date, final int days) {
         if (date == null || days == NULL_INT) {
             return null;
         }
 
-        return this.plusNonBusinessDays(DateTimeUtils.parseLocalDate(date), days);
+        final LocalDate d = this.plusNonBusinessDays(DateTimeUtils.parseLocalDate(date), days);
+        return d == null ? null : d.toString();
     }
 
     /**
@@ -2034,7 +2038,7 @@ public class BusinessCalendar extends Calendar {
      * @throws InvalidDateException if the date is not in the valid range
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate minusNonBusinessDays(final String date, final int days) {
+    public String minusNonBusinessDays(final String date, final int days) {
         if (date == null || days == NULL_INT) {
             return null;
         }

--- a/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
@@ -165,6 +165,7 @@ public class BusinessCalendar extends Calendar {
 
     // region Getters
 
+    //TODO: should there be a string equivalent?
     /**
      * Returns the first valid date for the business calendar.
      *
@@ -174,6 +175,7 @@ public class BusinessCalendar extends Calendar {
         return firstValidDate;
     }
 
+    //TODO: should there be a string equivalent?
     /**
      * Returns the last valid date for the business calendar.
      *
@@ -2095,6 +2097,7 @@ public class BusinessCalendar extends Calendar {
         return plusNonBusinessDays(time, -days);
     }
 
+    //TODO: should there be a string equivalent?
     /**
      * Adds a specified number of business days to the current date. Adding negative days is equivalent to subtracting
      * days.
@@ -2112,6 +2115,7 @@ public class BusinessCalendar extends Calendar {
         return plusBusinessDays(calendarDate(), days);
     }
 
+    //TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of business days from the current date. Subtracting negative days is equivalent to
      * adding days.
@@ -2129,6 +2133,7 @@ public class BusinessCalendar extends Calendar {
         return minusBusinessDays(calendarDate(), days);
     }
 
+    //TODO: should there be a string equivalent?
     /**
      * Adds a specified number of non-business days to the current date. Adding negative days is equivalent to
      * subtracting days.
@@ -2146,6 +2151,7 @@ public class BusinessCalendar extends Calendar {
         return this.plusNonBusinessDays(calendarDate(), days);
     }
 
+    //TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of non-business days to the current date. Subtracting negative days is equivalent to
      * adding days.

--- a/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
@@ -165,7 +165,7 @@ public class BusinessCalendar extends Calendar {
 
     // region Getters
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Returns the first valid date for the business calendar.
      *
@@ -175,7 +175,7 @@ public class BusinessCalendar extends Calendar {
         return firstValidDate;
     }
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Returns the last valid date for the business calendar.
      *
@@ -1222,8 +1222,9 @@ public class BusinessCalendar extends Calendar {
             return null;
         }
 
-        final LocalDate[] dates = businessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
-                endInclusive);
+        final LocalDate[] dates =
+                businessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
+                        endInclusive);
         return dates == null ? null : Arrays.stream(dates).map(DateTimeUtils::formatDate).toArray(String[]::new);
     }
 
@@ -1366,8 +1367,9 @@ public class BusinessCalendar extends Calendar {
             return null;
         }
 
-        final LocalDate[] dates = nonBusinessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
-                endInclusive);
+        final LocalDate[] dates =
+                nonBusinessDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
+                        endInclusive);
         return dates == null ? null : Arrays.stream(dates).map(DateTimeUtils::formatDate).toArray(String[]::new);
     }
 
@@ -2097,7 +2099,7 @@ public class BusinessCalendar extends Calendar {
         return plusNonBusinessDays(time, -days);
     }
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Adds a specified number of business days to the current date. Adding negative days is equivalent to subtracting
      * days.
@@ -2115,7 +2117,7 @@ public class BusinessCalendar extends Calendar {
         return plusBusinessDays(calendarDate(), days);
     }
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of business days from the current date. Subtracting negative days is equivalent to
      * adding days.
@@ -2133,7 +2135,7 @@ public class BusinessCalendar extends Calendar {
         return minusBusinessDays(calendarDate(), days);
     }
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Adds a specified number of non-business days to the current date. Adding negative days is equivalent to
      * subtracting days.
@@ -2151,7 +2153,7 @@ public class BusinessCalendar extends Calendar {
         return this.plusNonBusinessDays(calendarDate(), days);
     }
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of non-business days to the current date. Subtracting negative days is equivalent to
      * adding days.

--- a/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/BusinessCalendar.java
@@ -165,7 +165,6 @@ public class BusinessCalendar extends Calendar {
 
     // region Getters
 
-    // TODO: should there be a string equivalent?
     /**
      * Returns the first valid date for the business calendar.
      *
@@ -175,7 +174,6 @@ public class BusinessCalendar extends Calendar {
         return firstValidDate;
     }
 
-    // TODO: should there be a string equivalent?
     /**
      * Returns the last valid date for the business calendar.
      *
@@ -2099,7 +2097,6 @@ public class BusinessCalendar extends Calendar {
         return plusNonBusinessDays(time, -days);
     }
 
-    // TODO: should there be a string equivalent?
     /**
      * Adds a specified number of business days to the current date. Adding negative days is equivalent to subtracting
      * days.
@@ -2117,7 +2114,6 @@ public class BusinessCalendar extends Calendar {
         return plusBusinessDays(calendarDate(), days);
     }
 
-    // TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of business days from the current date. Subtracting negative days is equivalent to
      * adding days.
@@ -2135,7 +2131,6 @@ public class BusinessCalendar extends Calendar {
         return minusBusinessDays(calendarDate(), days);
     }
 
-    // TODO: should there be a string equivalent?
     /**
      * Adds a specified number of non-business days to the current date. Adding negative days is equivalent to
      * subtracting days.
@@ -2153,7 +2148,6 @@ public class BusinessCalendar extends Calendar {
         return this.plusNonBusinessDays(calendarDate(), days);
     }
 
-    // TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of non-business days to the current date. Subtracting negative days is equivalent to
      * adding days.

--- a/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
@@ -90,6 +90,7 @@ public class Calendar {
 
     // region Now
 
+    //TODO: should there be a string equivalent?
     /**
      * The current date for the calendar.
      *
@@ -118,6 +119,7 @@ public class Calendar {
         return DateTimeUtils.dayOfWeek(date);
     }
 
+    //TODO: should this return a String?
     /**
      * The current day of the week for the calendar.
      *
@@ -395,6 +397,7 @@ public class Calendar {
         return plusDays(time, -days);
     }
 
+    //TODO: should there be a string equivalent?
     /**
      * Adds a specified number of days to the current date. Adding negative days is equivalent to subtracting days.
      *
@@ -406,6 +409,7 @@ public class Calendar {
         return plusDays(calendarDate(), days);
     }
 
+    //TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of days from the current date. Subtracting negative days is equivalent to adding
      * days.

--- a/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
@@ -10,6 +10,7 @@ import io.deephaven.time.DateTimeUtils;
 import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static io.deephaven.util.QueryConstants.NULL_INT;
@@ -258,12 +259,13 @@ public class Calendar {
      *         {@link io.deephaven.util.QueryConstants#NULL_INT}.
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate plusDays(final String date, final int days) {
+    public String plusDays(final String date, final int days) {
         if (date == null || days == NULL_INT) {
             return null;
         }
 
-        return plusDays(DateTimeUtils.parseLocalDate(date), days);
+        final LocalDate d = plusDays(DateTimeUtils.parseLocalDate(date), days);
+        return d == null ? null : d.toString();
     }
 
     /**
@@ -339,12 +341,13 @@ public class Calendar {
      *         {@link io.deephaven.util.QueryConstants#NULL_INT}.
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate minusDays(final String date, final int days) {
+    public String minusDays(final String date, final int days) {
         if (date == null || days == NULL_INT) {
             return null;
         }
 
-        return minusDays(DateTimeUtils.parseLocalDate(date), days);
+        final LocalDate d = minusDays(DateTimeUtils.parseLocalDate(date), days);
+        return d == null ? null : d.toString();
     }
 
     /**
@@ -457,14 +460,15 @@ public class Calendar {
      * @return dates between {@code start} and {@code end}, or {@code null} if any input is {@code null}.
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate[] calendarDates(final String start, final String end, final boolean startInclusive,
+    public String[] calendarDates(final String start, final String end, final boolean startInclusive,
             final boolean endInclusive) {
         if (start == null || end == null) {
             return null;
         }
 
-        return calendarDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
+        final LocalDate[] dates = calendarDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
                 endInclusive);
+        return dates == null ? null : Arrays.stream(dates).map(DateTimeUtils::formatDate).toArray(String[]::new);
     }
 
     /**
@@ -528,7 +532,7 @@ public class Calendar {
      *         any input is {@code null}.
      * @throws DateTimeUtils.DateTimeParseException if the string cannot be parsed
      */
-    public LocalDate[] calendarDates(final String start, final String end) {
+    public String[] calendarDates(final String start, final String end) {
         return calendarDates(start, end, true, true);
     }
 

--- a/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
@@ -90,7 +90,7 @@ public class Calendar {
 
     // region Now
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * The current date for the calendar.
      *
@@ -119,7 +119,7 @@ public class Calendar {
         return DateTimeUtils.dayOfWeek(date);
     }
 
-    //TODO: should this return a String?
+    // TODO: should this return a String?
     /**
      * The current day of the week for the calendar.
      *
@@ -397,7 +397,7 @@ public class Calendar {
         return plusDays(time, -days);
     }
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Adds a specified number of days to the current date. Adding negative days is equivalent to subtracting days.
      *
@@ -409,7 +409,7 @@ public class Calendar {
         return plusDays(calendarDate(), days);
     }
 
-    //TODO: should there be a string equivalent?
+    // TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of days from the current date. Subtracting negative days is equivalent to adding
      * days.
@@ -470,8 +470,9 @@ public class Calendar {
             return null;
         }
 
-        final LocalDate[] dates = calendarDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
-                endInclusive);
+        final LocalDate[] dates =
+                calendarDates(DateTimeUtils.parseLocalDate(start), DateTimeUtils.parseLocalDate(end), startInclusive,
+                        endInclusive);
         return dates == null ? null : Arrays.stream(dates).map(DateTimeUtils::formatDate).toArray(String[]::new);
     }
 

--- a/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/Calendar.java
@@ -90,7 +90,6 @@ public class Calendar {
 
     // region Now
 
-    // TODO: should there be a string equivalent?
     /**
      * The current date for the calendar.
      *
@@ -119,7 +118,6 @@ public class Calendar {
         return DateTimeUtils.dayOfWeek(date);
     }
 
-    // TODO: should this return a String?
     /**
      * The current day of the week for the calendar.
      *
@@ -397,7 +395,6 @@ public class Calendar {
         return plusDays(time, -days);
     }
 
-    // TODO: should there be a string equivalent?
     /**
      * Adds a specified number of days to the current date. Adding negative days is equivalent to subtracting days.
      *
@@ -409,7 +406,6 @@ public class Calendar {
         return plusDays(calendarDate(), days);
     }
 
-    // TODO: should there be a string equivalent?
     /**
      * Subtracts a specified number of days from the current date. Subtracting negative days is equivalent to adding
      * days.

--- a/engine/time/src/main/java/io/deephaven/time/calendar/StaticCalendarMethods.java
+++ b/engine/time/src/main/java/io/deephaven/time/calendar/StaticCalendarMethods.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class StaticCalendarMethods {
     /** @see io.deephaven.time.calendar.BusinessCalendar#businessDates(java.lang.String,java.lang.String) */
-    public static  java.time.LocalDate[] businessDates( java.lang.String start, java.lang.String end ) {return Calendars.calendar().businessDates( start, end );}
+    public static  java.lang.String[] businessDates( java.lang.String start, java.lang.String end ) {return Calendars.calendar().businessDates( start, end );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#businessDates(java.time.Instant,java.time.Instant) */
     public static  java.time.LocalDate[] businessDates( java.time.Instant start, java.time.Instant end ) {return Calendars.calendar().businessDates( start, end );}
@@ -43,7 +43,7 @@ public class StaticCalendarMethods {
     public static  java.time.LocalDate[] businessDates( java.time.ZonedDateTime start, java.time.ZonedDateTime end ) {return Calendars.calendar().businessDates( start, end );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#businessDates(java.lang.String,java.lang.String,boolean,boolean) */
-    public static  java.time.LocalDate[] businessDates( java.lang.String start, java.lang.String end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().businessDates( start, end, startInclusive, endInclusive );}
+    public static  java.lang.String[] businessDates( java.lang.String start, java.lang.String end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().businessDates( start, end, startInclusive, endInclusive );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#businessDates(java.time.Instant,java.time.Instant,boolean,boolean) */
     public static  java.time.LocalDate[] businessDates( java.time.Instant start, java.time.Instant end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().businessDates( start, end, startInclusive, endInclusive );}
@@ -58,7 +58,7 @@ public class StaticCalendarMethods {
     public static  java.time.LocalDate calendarDate( ) {return Calendars.calendar().calendarDate( );}
 
     /** @see io.deephaven.time.calendar.Calendar#calendarDates(java.lang.String,java.lang.String) */
-    public static  java.time.LocalDate[] calendarDates( java.lang.String start, java.lang.String end ) {return Calendars.calendar().calendarDates( start, end );}
+    public static  java.lang.String[] calendarDates( java.lang.String start, java.lang.String end ) {return Calendars.calendar().calendarDates( start, end );}
 
     /** @see io.deephaven.time.calendar.Calendar#calendarDates(java.time.Instant,java.time.Instant) */
     public static  java.time.LocalDate[] calendarDates( java.time.Instant start, java.time.Instant end ) {return Calendars.calendar().calendarDates( start, end );}
@@ -70,7 +70,7 @@ public class StaticCalendarMethods {
     public static  java.time.LocalDate[] calendarDates( java.time.ZonedDateTime start, java.time.ZonedDateTime end ) {return Calendars.calendar().calendarDates( start, end );}
 
     /** @see io.deephaven.time.calendar.Calendar#calendarDates(java.lang.String,java.lang.String,boolean,boolean) */
-    public static  java.time.LocalDate[] calendarDates( java.lang.String start, java.lang.String end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().calendarDates( start, end, startInclusive, endInclusive );}
+    public static  java.lang.String[] calendarDates( java.lang.String start, java.lang.String end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().calendarDates( start, end, startInclusive, endInclusive );}
 
     /** @see io.deephaven.time.calendar.Calendar#calendarDates(java.time.Instant,java.time.Instant,boolean,boolean) */
     public static  java.time.LocalDate[] calendarDates( java.time.Instant start, java.time.Instant end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().calendarDates( start, end, startInclusive, endInclusive );}
@@ -271,7 +271,7 @@ public class StaticCalendarMethods {
     public static  boolean isLastBusinessDayOfYear( java.time.ZonedDateTime time ) {return Calendars.calendar().isLastBusinessDayOfYear( time );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#minusBusinessDays(java.lang.String,int) */
-    public static  java.time.LocalDate minusBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().minusBusinessDays( date, days );}
+    public static  java.lang.String minusBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().minusBusinessDays( date, days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#minusBusinessDays(java.time.Instant,int) */
     public static  java.time.Instant minusBusinessDays( java.time.Instant time, int days ) {return Calendars.calendar().minusBusinessDays( time, days );}
@@ -283,7 +283,7 @@ public class StaticCalendarMethods {
     public static  java.time.ZonedDateTime minusBusinessDays( java.time.ZonedDateTime time, int days ) {return Calendars.calendar().minusBusinessDays( time, days );}
 
     /** @see io.deephaven.time.calendar.Calendar#minusDays(java.lang.String,int) */
-    public static  java.time.LocalDate minusDays( java.lang.String date, int days ) {return Calendars.calendar().minusDays( date, days );}
+    public static  java.lang.String minusDays( java.lang.String date, int days ) {return Calendars.calendar().minusDays( date, days );}
 
     /** @see io.deephaven.time.calendar.Calendar#minusDays(java.time.Instant,int) */
     public static  java.time.Instant minusDays( java.time.Instant time, int days ) {return Calendars.calendar().minusDays( time, days );}
@@ -295,7 +295,7 @@ public class StaticCalendarMethods {
     public static  java.time.ZonedDateTime minusDays( java.time.ZonedDateTime time, int days ) {return Calendars.calendar().minusDays( time, days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#minusNonBusinessDays(java.lang.String,int) */
-    public static  java.time.LocalDate minusNonBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().minusNonBusinessDays( date, days );}
+    public static  java.lang.String minusNonBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().minusNonBusinessDays( date, days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#minusNonBusinessDays(java.time.Instant,int) */
     public static  java.time.Instant minusNonBusinessDays( java.time.Instant time, int days ) {return Calendars.calendar().minusNonBusinessDays( time, days );}
@@ -307,7 +307,7 @@ public class StaticCalendarMethods {
     public static  java.time.ZonedDateTime minusNonBusinessDays( java.time.ZonedDateTime time, int days ) {return Calendars.calendar().minusNonBusinessDays( time, days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#nonBusinessDates(java.lang.String,java.lang.String) */
-    public static  java.time.LocalDate[] nonBusinessDates( java.lang.String start, java.lang.String end ) {return Calendars.calendar().nonBusinessDates( start, end );}
+    public static  java.lang.String[] nonBusinessDates( java.lang.String start, java.lang.String end ) {return Calendars.calendar().nonBusinessDates( start, end );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#nonBusinessDates(java.time.Instant,java.time.Instant) */
     public static  java.time.LocalDate[] nonBusinessDates( java.time.Instant start, java.time.Instant end ) {return Calendars.calendar().nonBusinessDates( start, end );}
@@ -319,7 +319,7 @@ public class StaticCalendarMethods {
     public static  java.time.LocalDate[] nonBusinessDates( java.time.ZonedDateTime start, java.time.ZonedDateTime end ) {return Calendars.calendar().nonBusinessDates( start, end );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#nonBusinessDates(java.lang.String,java.lang.String,boolean,boolean) */
-    public static  java.time.LocalDate[] nonBusinessDates( java.lang.String start, java.lang.String end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().nonBusinessDates( start, end, startInclusive, endInclusive );}
+    public static  java.lang.String[] nonBusinessDates( java.lang.String start, java.lang.String end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().nonBusinessDates( start, end, startInclusive, endInclusive );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#nonBusinessDates(java.time.Instant,java.time.Instant,boolean,boolean) */
     public static  java.time.LocalDate[] nonBusinessDates( java.time.Instant start, java.time.Instant end, boolean startInclusive, boolean endInclusive ) {return Calendars.calendar().nonBusinessDates( start, end, startInclusive, endInclusive );}
@@ -412,7 +412,7 @@ public class StaticCalendarMethods {
     public static  java.time.LocalDate pastNonBusinessDate( int days ) {return Calendars.calendar().pastNonBusinessDate( days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#plusBusinessDays(java.lang.String,int) */
-    public static  java.time.LocalDate plusBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().plusBusinessDays( date, days );}
+    public static  java.lang.String plusBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().plusBusinessDays( date, days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#plusBusinessDays(java.time.Instant,int) */
     public static  java.time.Instant plusBusinessDays( java.time.Instant time, int days ) {return Calendars.calendar().plusBusinessDays( time, days );}
@@ -424,7 +424,7 @@ public class StaticCalendarMethods {
     public static  java.time.ZonedDateTime plusBusinessDays( java.time.ZonedDateTime time, int days ) {return Calendars.calendar().plusBusinessDays( time, days );}
 
     /** @see io.deephaven.time.calendar.Calendar#plusDays(java.lang.String,int) */
-    public static  java.time.LocalDate plusDays( java.lang.String date, int days ) {return Calendars.calendar().plusDays( date, days );}
+    public static  java.lang.String plusDays( java.lang.String date, int days ) {return Calendars.calendar().plusDays( date, days );}
 
     /** @see io.deephaven.time.calendar.Calendar#plusDays(java.time.Instant,int) */
     public static  java.time.Instant plusDays( java.time.Instant time, int days ) {return Calendars.calendar().plusDays( time, days );}
@@ -436,7 +436,7 @@ public class StaticCalendarMethods {
     public static  java.time.ZonedDateTime plusDays( java.time.ZonedDateTime time, int days ) {return Calendars.calendar().plusDays( time, days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#plusNonBusinessDays(java.lang.String,int) */
-    public static  java.time.LocalDate plusNonBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().plusNonBusinessDays( date, days );}
+    public static  java.lang.String plusNonBusinessDays( java.lang.String date, int days ) {return Calendars.calendar().plusNonBusinessDays( date, days );}
 
     /** @see io.deephaven.time.calendar.BusinessCalendar#plusNonBusinessDays(java.time.Instant,int) */
     public static  java.time.Instant plusNonBusinessDays( java.time.Instant time, int days ) {return Calendars.calendar().plusNonBusinessDays( time, days );}

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
@@ -1503,29 +1503,29 @@ public class TestBusinessCalendar extends TestCalendar {
     }
 
     public void testFutureBusinessDate() {
-        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(), 3), bCalendar.futureBusinessDate(3));
-        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(), -3), bCalendar.futureBusinessDate(-3));
+        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3), bCalendar.futureBusinessDate(3));
+        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3), bCalendar.futureBusinessDate(-3));
         assertNull(bCalendar.futureBusinessDate(NULL_INT));
     }
 
     public void testPastBusinessDate() {
-        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(), 3), bCalendar.pastBusinessDate(3));
-        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(), -3), bCalendar.pastBusinessDate(-3));
+        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3), bCalendar.pastBusinessDate(3));
+        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3), bCalendar.pastBusinessDate(-3));
         assertNull(bCalendar.pastBusinessDate(NULL_INT));
     }
 
     public void testFutureNonBusinessDate() {
-        assertEquals(bCalendar.plusNonBusinessDays(DateTimeUtils.todayLocalDate(), 3),
+        assertEquals(bCalendar.plusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
                 bCalendar.futureNonBusinessDate(3));
-        assertEquals(bCalendar.plusNonBusinessDays(DateTimeUtils.todayLocalDate(), -3),
+        assertEquals(bCalendar.plusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
                 bCalendar.futureNonBusinessDate(-3));
         assertNull(bCalendar.futureNonBusinessDate(NULL_INT));
     }
 
     public void testPastNonBusinessDate() {
-        assertEquals(bCalendar.minusNonBusinessDays(DateTimeUtils.todayLocalDate(), 3),
+        assertEquals(bCalendar.minusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
                 bCalendar.pastNonBusinessDate(3));
-        assertEquals(bCalendar.minusNonBusinessDays(DateTimeUtils.todayLocalDate(), -3),
+        assertEquals(bCalendar.minusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
                 bCalendar.pastNonBusinessDate(-3));
         assertNull(bCalendar.pastNonBusinessDate(NULL_INT));
     }

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
@@ -644,14 +644,17 @@ public class TestBusinessCalendar extends TestCalendar {
         };
 
         assertEquals(bus, bCalendar.businessDates(start, end));
-        assertEquals(Arrays.stream(bus).map(DateTimeUtils::formatDate).toArray(String[]::new), bCalendar.businessDates(start.toString(), end.toString()));
+        assertEquals(Arrays.stream(bus).map(DateTimeUtils::formatDate).toArray(String[]::new),
+                bCalendar.businessDates(start.toString(), end.toString()));
         assertEquals(bus,
                 bCalendar.businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone)));
         assertEquals(bus, bCalendar.businessDates(start.atTime(1, 24).atZone(timeZone).toInstant(),
                 end.atTime(1, 24).atZone(timeZone).toInstant()));
 
         assertEquals(Arrays.copyOfRange(bus, 0, bus.length - 1), bCalendar.businessDates(start, end, true, false));
-        assertEquals(Arrays.stream(Arrays.copyOfRange(bus, 0, bus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
+        assertEquals(
+                Arrays.stream(Arrays.copyOfRange(bus, 0, bus.length - 1)).map(DateTimeUtils::formatDate)
+                        .toArray(String[]::new),
                 bCalendar.businessDates(start.toString(), end.toString(), true, false));
         assertEquals(Arrays.copyOfRange(bus, 0, bus.length - 1), bCalendar
                 .businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone), true, false));
@@ -660,7 +663,9 @@ public class TestBusinessCalendar extends TestCalendar {
                         end.atTime(1, 24).atZone(timeZone).toInstant(), true, false));
 
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length), bCalendar.businessDates(start, end, false, true));
-        assertEquals(Arrays.stream(Arrays.copyOfRange(bus, 1, bus.length)).map(DateTimeUtils::formatDate).toArray(String[]::new),
+        assertEquals(
+                Arrays.stream(Arrays.copyOfRange(bus, 1, bus.length)).map(DateTimeUtils::formatDate)
+                        .toArray(String[]::new),
                 bCalendar.businessDates(start.toString(), end.toString(), false, true));
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length), bCalendar
                 .businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone), false, true));
@@ -669,7 +674,9 @@ public class TestBusinessCalendar extends TestCalendar {
                         end.atTime(1, 24).atZone(timeZone).toInstant(), false, true));
 
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length - 1), bCalendar.businessDates(start, end, false, false));
-        assertEquals(Arrays.stream(Arrays.copyOfRange(bus, 1, bus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
+        assertEquals(
+                Arrays.stream(Arrays.copyOfRange(bus, 1, bus.length - 1)).map(DateTimeUtils::formatDate)
+                        .toArray(String[]::new),
                 bCalendar.businessDates(start.toString(), end.toString(), false, false));
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length - 1), bCalendar
                 .businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone), false, false));
@@ -779,7 +786,8 @@ public class TestBusinessCalendar extends TestCalendar {
         // };
 
         assertEquals(nonBus, bCalendar.nonBusinessDates(start, end));
-        assertEquals(Arrays.stream(nonBus).map(DateTimeUtils::formatDate).toArray(String[]::new), bCalendar.nonBusinessDates(start.toString(), end.toString()));
+        assertEquals(Arrays.stream(nonBus).map(DateTimeUtils::formatDate).toArray(String[]::new),
+                bCalendar.nonBusinessDates(start.toString(), end.toString()));
         assertEquals(nonBus,
                 bCalendar.nonBusinessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone)));
         assertEquals(nonBus, bCalendar.nonBusinessDates(start.atTime(1, 24).atZone(timeZone).toInstant(),
@@ -787,7 +795,9 @@ public class TestBusinessCalendar extends TestCalendar {
 
         assertEquals(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0], nonBus[nonBus.length - 1], true, false));
-        assertEquals(Arrays.stream(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
+        assertEquals(
+                Arrays.stream(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1)).map(DateTimeUtils::formatDate)
+                        .toArray(String[]::new),
                 bCalendar.nonBusinessDates(nonBus[0].toString(), nonBus[nonBus.length - 1].toString(), true, false));
         assertEquals(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0].atTime(1, 24).atZone(timeZone),
@@ -798,7 +808,9 @@ public class TestBusinessCalendar extends TestCalendar {
 
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length),
                 bCalendar.nonBusinessDates(nonBus[0], nonBus[nonBus.length - 1], false, true));
-        assertEquals(Arrays.stream(Arrays.copyOfRange(nonBus, 1, nonBus.length)).map(DateTimeUtils::formatDate).toArray(String[]::new),
+        assertEquals(
+                Arrays.stream(Arrays.copyOfRange(nonBus, 1, nonBus.length)).map(DateTimeUtils::formatDate)
+                        .toArray(String[]::new),
                 bCalendar.nonBusinessDates(nonBus[0].toString(), nonBus[nonBus.length - 1].toString(), false, true));
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length),
                 bCalendar.nonBusinessDates(nonBus[0].atTime(1, 24).atZone(timeZone),
@@ -809,7 +821,9 @@ public class TestBusinessCalendar extends TestCalendar {
 
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0], nonBus[nonBus.length - 1], false, false));
-        assertEquals(Arrays.stream(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
+        assertEquals(
+                Arrays.stream(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1)).map(DateTimeUtils::formatDate)
+                        .toArray(String[]::new),
                 bCalendar.nonBusinessDates(nonBus[0].toString(), nonBus[nonBus.length - 1].toString(), false, false));
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0].atTime(1, 24).atZone(timeZone),

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
@@ -1503,14 +1503,18 @@ public class TestBusinessCalendar extends TestCalendar {
     }
 
     public void testFutureBusinessDate() {
-        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3), bCalendar.futureBusinessDate(3));
-        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3), bCalendar.futureBusinessDate(-3));
+        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
+                bCalendar.futureBusinessDate(3));
+        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
+                bCalendar.futureBusinessDate(-3));
         assertNull(bCalendar.futureBusinessDate(NULL_INT));
     }
 
     public void testPastBusinessDate() {
-        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3), bCalendar.pastBusinessDate(3));
-        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3), bCalendar.pastBusinessDate(-3));
+        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
+                bCalendar.pastBusinessDate(3));
+        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
+                bCalendar.pastBusinessDate(-3));
         assertNull(bCalendar.pastBusinessDate(NULL_INT));
     }
 

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
@@ -1503,33 +1503,33 @@ public class TestBusinessCalendar extends TestCalendar {
     }
 
     public void testFutureBusinessDate() {
-        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
+        assertEquals(bCalendar.plusBusinessDays(bCalendar.calendarDate(), 3),
                 bCalendar.futureBusinessDate(3));
-        assertEquals(bCalendar.plusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
+        assertEquals(bCalendar.plusBusinessDays(bCalendar.calendarDate(), -3),
                 bCalendar.futureBusinessDate(-3));
         assertNull(bCalendar.futureBusinessDate(NULL_INT));
     }
 
     public void testPastBusinessDate() {
-        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
+        assertEquals(bCalendar.minusBusinessDays(bCalendar.calendarDate(), 3),
                 bCalendar.pastBusinessDate(3));
-        assertEquals(bCalendar.minusBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
+        assertEquals(bCalendar.minusBusinessDays(bCalendar.calendarDate(), -3),
                 bCalendar.pastBusinessDate(-3));
         assertNull(bCalendar.pastBusinessDate(NULL_INT));
     }
 
     public void testFutureNonBusinessDate() {
-        assertEquals(bCalendar.plusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
+        assertEquals(bCalendar.plusNonBusinessDays(bCalendar.calendarDate(), 3),
                 bCalendar.futureNonBusinessDate(3));
-        assertEquals(bCalendar.plusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
+        assertEquals(bCalendar.plusNonBusinessDays(bCalendar.calendarDate(), -3),
                 bCalendar.futureNonBusinessDate(-3));
         assertNull(bCalendar.futureNonBusinessDate(NULL_INT));
     }
 
     public void testPastNonBusinessDate() {
-        assertEquals(bCalendar.minusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), 3),
+        assertEquals(bCalendar.minusNonBusinessDays(bCalendar.calendarDate(), 3),
                 bCalendar.pastNonBusinessDate(3));
-        assertEquals(bCalendar.minusNonBusinessDays(DateTimeUtils.todayLocalDate(bCalendar.timeZone()), -3),
+        assertEquals(bCalendar.minusNonBusinessDays(bCalendar.calendarDate(), -3),
                 bCalendar.pastNonBusinessDate(-3));
         assertNull(bCalendar.pastNonBusinessDate(NULL_INT));
     }

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestBusinessCalendar.java
@@ -3,7 +3,6 @@
  */
 package io.deephaven.time.calendar;
 
-import io.deephaven.base.verify.RequirementFailure;
 import io.deephaven.time.DateTimeUtils;
 
 import java.time.*;
@@ -645,14 +644,14 @@ public class TestBusinessCalendar extends TestCalendar {
         };
 
         assertEquals(bus, bCalendar.businessDates(start, end));
-        assertEquals(bus, bCalendar.businessDates(start.toString(), end.toString()));
+        assertEquals(Arrays.stream(bus).map(DateTimeUtils::formatDate).toArray(String[]::new), bCalendar.businessDates(start.toString(), end.toString()));
         assertEquals(bus,
                 bCalendar.businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone)));
         assertEquals(bus, bCalendar.businessDates(start.atTime(1, 24).atZone(timeZone).toInstant(),
                 end.atTime(1, 24).atZone(timeZone).toInstant()));
 
         assertEquals(Arrays.copyOfRange(bus, 0, bus.length - 1), bCalendar.businessDates(start, end, true, false));
-        assertEquals(Arrays.copyOfRange(bus, 0, bus.length - 1),
+        assertEquals(Arrays.stream(Arrays.copyOfRange(bus, 0, bus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
                 bCalendar.businessDates(start.toString(), end.toString(), true, false));
         assertEquals(Arrays.copyOfRange(bus, 0, bus.length - 1), bCalendar
                 .businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone), true, false));
@@ -661,7 +660,7 @@ public class TestBusinessCalendar extends TestCalendar {
                         end.atTime(1, 24).atZone(timeZone).toInstant(), true, false));
 
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length), bCalendar.businessDates(start, end, false, true));
-        assertEquals(Arrays.copyOfRange(bus, 1, bus.length),
+        assertEquals(Arrays.stream(Arrays.copyOfRange(bus, 1, bus.length)).map(DateTimeUtils::formatDate).toArray(String[]::new),
                 bCalendar.businessDates(start.toString(), end.toString(), false, true));
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length), bCalendar
                 .businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone), false, true));
@@ -670,7 +669,7 @@ public class TestBusinessCalendar extends TestCalendar {
                         end.atTime(1, 24).atZone(timeZone).toInstant(), false, true));
 
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length - 1), bCalendar.businessDates(start, end, false, false));
-        assertEquals(Arrays.copyOfRange(bus, 1, bus.length - 1),
+        assertEquals(Arrays.stream(Arrays.copyOfRange(bus, 1, bus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
                 bCalendar.businessDates(start.toString(), end.toString(), false, false));
         assertEquals(Arrays.copyOfRange(bus, 1, bus.length - 1), bCalendar
                 .businessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone), false, false));
@@ -780,7 +779,7 @@ public class TestBusinessCalendar extends TestCalendar {
         // };
 
         assertEquals(nonBus, bCalendar.nonBusinessDates(start, end));
-        assertEquals(nonBus, bCalendar.nonBusinessDates(start.toString(), end.toString()));
+        assertEquals(Arrays.stream(nonBus).map(DateTimeUtils::formatDate).toArray(String[]::new), bCalendar.nonBusinessDates(start.toString(), end.toString()));
         assertEquals(nonBus,
                 bCalendar.nonBusinessDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone)));
         assertEquals(nonBus, bCalendar.nonBusinessDates(start.atTime(1, 24).atZone(timeZone).toInstant(),
@@ -788,7 +787,7 @@ public class TestBusinessCalendar extends TestCalendar {
 
         assertEquals(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0], nonBus[nonBus.length - 1], true, false));
-        assertEquals(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1),
+        assertEquals(Arrays.stream(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
                 bCalendar.nonBusinessDates(nonBus[0].toString(), nonBus[nonBus.length - 1].toString(), true, false));
         assertEquals(Arrays.copyOfRange(nonBus, 0, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0].atTime(1, 24).atZone(timeZone),
@@ -799,7 +798,7 @@ public class TestBusinessCalendar extends TestCalendar {
 
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length),
                 bCalendar.nonBusinessDates(nonBus[0], nonBus[nonBus.length - 1], false, true));
-        assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length),
+        assertEquals(Arrays.stream(Arrays.copyOfRange(nonBus, 1, nonBus.length)).map(DateTimeUtils::formatDate).toArray(String[]::new),
                 bCalendar.nonBusinessDates(nonBus[0].toString(), nonBus[nonBus.length - 1].toString(), false, true));
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length),
                 bCalendar.nonBusinessDates(nonBus[0].atTime(1, 24).atZone(timeZone),
@@ -810,7 +809,7 @@ public class TestBusinessCalendar extends TestCalendar {
 
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0], nonBus[nonBus.length - 1], false, false));
-        assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1),
+        assertEquals(Arrays.stream(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1)).map(DateTimeUtils::formatDate).toArray(String[]::new),
                 bCalendar.nonBusinessDates(nonBus[0].toString(), nonBus[nonBus.length - 1].toString(), false, false));
         assertEquals(Arrays.copyOfRange(nonBus, 1, nonBus.length - 1),
                 bCalendar.nonBusinessDates(nonBus[0].atTime(1, 24).atZone(timeZone),
@@ -1104,7 +1103,7 @@ public class TestBusinessCalendar extends TestCalendar {
         Instant i = z.toInstant();
 
         assertEquals(d, bCalendar.plusBusinessDays(d, 0));
-        assertEquals(d, bCalendar.plusBusinessDays(s, 0));
+        assertEquals(d.toString(), bCalendar.plusBusinessDays(s, 0));
         assertEquals(z.withZoneSameInstant(timeZone), bCalendar.plusBusinessDays(z, 0));
         assertEquals(i, bCalendar.plusBusinessDays(i, 0));
 
@@ -1112,7 +1111,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i2 = d2.atTime(6, 24).atZone(timeZone2).toInstant();
         final ZonedDateTime z2 = d2.atTime(6, 24).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d2, bCalendar.plusBusinessDays(d, 1));
-        assertEquals(d2, bCalendar.plusBusinessDays(s, 1));
+        assertEquals(d2.toString(), bCalendar.plusBusinessDays(s, 1));
         assertEquals(z2, bCalendar.plusBusinessDays(z, 1));
         assertEquals(i2, bCalendar.plusBusinessDays(i, 1));
 
@@ -1120,7 +1119,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i3 = d3.atTime(6, 24).atZone(timeZone2).toInstant();
         final ZonedDateTime z3 = d3.atTime(6, 24).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d3, bCalendar.plusBusinessDays(d, 2));
-        assertEquals(d3, bCalendar.plusBusinessDays(s, 2));
+        assertEquals(d3.toString(), bCalendar.plusBusinessDays(s, 2));
         assertEquals(z3, bCalendar.plusBusinessDays(z, 2));
         assertEquals(i3, bCalendar.plusBusinessDays(i, 2));
 
@@ -1128,7 +1127,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i4 = d4.atTime(6, 24).atZone(timeZone2).toInstant();
         final ZonedDateTime z4 = d4.atTime(6, 24).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d4, bCalendar.plusBusinessDays(d, 7));
-        assertEquals(d4, bCalendar.plusBusinessDays(s, 7));
+        assertEquals(d4.toString(), bCalendar.plusBusinessDays(s, 7));
         assertEquals(z4, bCalendar.plusBusinessDays(z, 7));
         assertEquals(i4, bCalendar.plusBusinessDays(i, 7));
 
@@ -1138,7 +1137,7 @@ public class TestBusinessCalendar extends TestCalendar {
         i = z.toInstant();
 
         assertEquals(d, bCalendar.plusBusinessDays(d, 0));
-        assertEquals(d, bCalendar.plusBusinessDays(s, 0));
+        assertEquals(d.toString(), bCalendar.plusBusinessDays(s, 0));
         assertEquals(z.withZoneSameInstant(timeZone), bCalendar.plusBusinessDays(z, 0));
         assertEquals(i, bCalendar.plusBusinessDays(i, 0));
 
@@ -1146,7 +1145,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i5 = d5.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z5 = d5.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d5, bCalendar.plusBusinessDays(d, -1));
-        assertEquals(d5, bCalendar.plusBusinessDays(s, -1));
+        assertEquals(d5.toString(), bCalendar.plusBusinessDays(s, -1));
         assertEquals(z5, bCalendar.plusBusinessDays(z, -1));
         assertEquals(i5, bCalendar.plusBusinessDays(i, -1));
 
@@ -1154,7 +1153,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i6 = d6.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z6 = d6.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d6, bCalendar.plusBusinessDays(d, -2));
-        assertEquals(d6, bCalendar.plusBusinessDays(s, -2));
+        assertEquals(d6.toString(), bCalendar.plusBusinessDays(s, -2));
         assertEquals(z6, bCalendar.plusBusinessDays(z, -2));
         assertEquals(i6, bCalendar.plusBusinessDays(i, -2));
 
@@ -1162,7 +1161,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i7 = d7.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z7 = d7.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d7, bCalendar.plusBusinessDays(d, -7));
-        assertEquals(d7, bCalendar.plusBusinessDays(s, -7));
+        assertEquals(d7.toString(), bCalendar.plusBusinessDays(s, -7));
         assertEquals(z7, bCalendar.plusBusinessDays(z, -7));
         assertEquals(i7, bCalendar.plusBusinessDays(i, -7));
 
@@ -1209,7 +1208,7 @@ public class TestBusinessCalendar extends TestCalendar {
         Instant i = z.toInstant();
 
         assertEquals(d, bCalendar.minusBusinessDays(d, 0));
-        assertEquals(d, bCalendar.minusBusinessDays(s, 0));
+        assertEquals(d.toString(), bCalendar.minusBusinessDays(s, 0));
         assertEquals(z.withZoneSameInstant(timeZone), bCalendar.minusBusinessDays(z, 0));
         assertEquals(i, bCalendar.minusBusinessDays(i, 0));
 
@@ -1217,7 +1216,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i1 = d1.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z1 = d1.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d1, bCalendar.minusBusinessDays(d, -1));
-        assertEquals(d1, bCalendar.minusBusinessDays(s, -1));
+        assertEquals(d1.toString(), bCalendar.minusBusinessDays(s, -1));
         assertEquals(z1, bCalendar.minusBusinessDays(z, -1));
         assertEquals(i1, bCalendar.minusBusinessDays(i, -1));
 
@@ -1225,7 +1224,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i2 = d2.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z2 = d2.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d2, bCalendar.minusBusinessDays(d, -2));
-        assertEquals(d2, bCalendar.minusBusinessDays(s, -2));
+        assertEquals(d2.toString(), bCalendar.minusBusinessDays(s, -2));
         assertEquals(z2, bCalendar.minusBusinessDays(z, -2));
         assertEquals(i2, bCalendar.minusBusinessDays(i, -2));
 
@@ -1233,7 +1232,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i3 = d3.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z3 = d3.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d3, bCalendar.minusBusinessDays(d, -7));
-        assertEquals(d3, bCalendar.minusBusinessDays(s, -7));
+        assertEquals(d3.toString(), bCalendar.minusBusinessDays(s, -7));
         assertEquals(z3, bCalendar.minusBusinessDays(z, -7));
         assertEquals(i3, bCalendar.minusBusinessDays(i, -7));
 
@@ -1243,7 +1242,7 @@ public class TestBusinessCalendar extends TestCalendar {
         i = z.toInstant();
 
         assertEquals(d, bCalendar.minusBusinessDays(d, 0));
-        assertEquals(d, bCalendar.minusBusinessDays(s, 0));
+        assertEquals(d.toString(), bCalendar.minusBusinessDays(s, 0));
         assertEquals(z.withZoneSameInstant(timeZone), bCalendar.minusBusinessDays(z, 0));
         assertEquals(i, bCalendar.minusBusinessDays(i, 0));
 
@@ -1251,7 +1250,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i4 = d4.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z4 = d4.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d4, bCalendar.minusBusinessDays(d, 1));
-        assertEquals(d4, bCalendar.minusBusinessDays(s, 1));
+        assertEquals(d4.toString(), bCalendar.minusBusinessDays(s, 1));
         assertEquals(z4, bCalendar.minusBusinessDays(z, 1));
         assertEquals(i4, bCalendar.minusBusinessDays(i, 1));
 
@@ -1259,7 +1258,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i5 = d5.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z5 = d5.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d5, bCalendar.minusBusinessDays(d, 2));
-        assertEquals(d5, bCalendar.minusBusinessDays(s, 2));
+        assertEquals(d5.toString(), bCalendar.minusBusinessDays(s, 2));
         assertEquals(z5, bCalendar.minusBusinessDays(z, 2));
         assertEquals(i5, bCalendar.minusBusinessDays(i, 2));
 
@@ -1267,7 +1266,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i6 = d6.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z6 = d6.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d6, bCalendar.minusBusinessDays(d, 7));
-        assertEquals(d6, bCalendar.minusBusinessDays(s, 7));
+        assertEquals(d6.toString(), bCalendar.minusBusinessDays(s, 7));
         assertEquals(z6, bCalendar.minusBusinessDays(z, 7));
         assertEquals(i6, bCalendar.minusBusinessDays(i, 7));
 
@@ -1322,7 +1321,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i1 = d1.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z1 = d1.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d1, bCalendar.plusNonBusinessDays(d, 1));
-        assertEquals(d1, bCalendar.plusNonBusinessDays(s, 1));
+        assertEquals(d1.toString(), bCalendar.plusNonBusinessDays(s, 1));
         assertEquals(z1, bCalendar.plusNonBusinessDays(z, 1));
         assertEquals(i1, bCalendar.plusNonBusinessDays(i, 1));
 
@@ -1330,7 +1329,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i2 = d2.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z2 = d2.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d2, bCalendar.plusNonBusinessDays(d, 2));
-        assertEquals(d2, bCalendar.plusNonBusinessDays(s, 2));
+        assertEquals(d2.toString(), bCalendar.plusNonBusinessDays(s, 2));
         assertEquals(z2, bCalendar.plusNonBusinessDays(z, 2));
         assertEquals(i2, bCalendar.plusNonBusinessDays(i, 2));
 
@@ -1338,7 +1337,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i3 = d3.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z3 = d3.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d3, bCalendar.plusNonBusinessDays(d, 4));
-        assertEquals(d3, bCalendar.plusNonBusinessDays(s, 4));
+        assertEquals(d3.toString(), bCalendar.plusNonBusinessDays(s, 4));
         assertEquals(z3, bCalendar.plusNonBusinessDays(z, 4));
         assertEquals(i3, bCalendar.plusNonBusinessDays(i, 4));
 
@@ -1356,7 +1355,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i4 = d4.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z4 = d4.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d4, bCalendar.plusNonBusinessDays(d, -1));
-        assertEquals(d4, bCalendar.plusNonBusinessDays(s, -1));
+        assertEquals(d4.toString(), bCalendar.plusNonBusinessDays(s, -1));
         assertEquals(z4, bCalendar.plusNonBusinessDays(z, -1));
         assertEquals(i4, bCalendar.plusNonBusinessDays(i, -1));
 
@@ -1364,7 +1363,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i5 = d5.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z5 = d5.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d5, bCalendar.plusNonBusinessDays(d, -2));
-        assertEquals(d5, bCalendar.plusNonBusinessDays(s, -2));
+        assertEquals(d5.toString(), bCalendar.plusNonBusinessDays(s, -2));
         assertEquals(z5, bCalendar.plusNonBusinessDays(z, -2));
         assertEquals(i5, bCalendar.plusNonBusinessDays(i, -2));
 
@@ -1372,7 +1371,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i6 = d6.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z6 = d6.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d6, bCalendar.plusNonBusinessDays(d, -4));
-        assertEquals(d6, bCalendar.plusNonBusinessDays(s, -4));
+        assertEquals(d6.toString(), bCalendar.plusNonBusinessDays(s, -4));
         assertEquals(z6, bCalendar.plusNonBusinessDays(z, -4));
         assertEquals(i6, bCalendar.plusNonBusinessDays(i, -4));
 
@@ -1427,7 +1426,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i1 = d1.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z1 = d1.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d1, bCalendar.minusNonBusinessDays(d, -1));
-        assertEquals(d1, bCalendar.minusNonBusinessDays(s, -1));
+        assertEquals(d1.toString(), bCalendar.minusNonBusinessDays(s, -1));
         assertEquals(z1, bCalendar.minusNonBusinessDays(z, -1));
         assertEquals(i1, bCalendar.minusNonBusinessDays(i, -1));
 
@@ -1435,7 +1434,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i2 = d2.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z2 = d2.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d2, bCalendar.minusNonBusinessDays(d, -2));
-        assertEquals(d2, bCalendar.minusNonBusinessDays(s, -2));
+        assertEquals(d2.toString(), bCalendar.minusNonBusinessDays(s, -2));
         assertEquals(z2, bCalendar.minusNonBusinessDays(z, -2));
         assertEquals(i2, bCalendar.minusNonBusinessDays(i, -2));
 
@@ -1443,7 +1442,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i3 = d3.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z3 = d3.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d3, bCalendar.minusNonBusinessDays(d, -4));
-        assertEquals(d3, bCalendar.minusNonBusinessDays(s, -4));
+        assertEquals(d3.toString(), bCalendar.minusNonBusinessDays(s, -4));
         assertEquals(z3, bCalendar.minusNonBusinessDays(z, -4));
         assertEquals(i3, bCalendar.minusNonBusinessDays(i, -4));
 
@@ -1461,7 +1460,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i4 = d4.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z4 = d4.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d4, bCalendar.minusNonBusinessDays(d, 1));
-        assertEquals(d4, bCalendar.minusNonBusinessDays(s, 1));
+        assertEquals(d4.toString(), bCalendar.minusNonBusinessDays(s, 1));
         assertEquals(z4, bCalendar.minusNonBusinessDays(z, 1));
         assertEquals(i4, bCalendar.minusNonBusinessDays(i, 1));
 
@@ -1469,7 +1468,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i5 = d5.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z5 = d5.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d5, bCalendar.minusNonBusinessDays(d, 2));
-        assertEquals(d5, bCalendar.minusNonBusinessDays(s, 2));
+        assertEquals(d5.toString(), bCalendar.minusNonBusinessDays(s, 2));
         assertEquals(z5, bCalendar.minusNonBusinessDays(z, 2));
         assertEquals(i5, bCalendar.minusNonBusinessDays(i, 2));
 
@@ -1477,7 +1476,7 @@ public class TestBusinessCalendar extends TestCalendar {
         final Instant i6 = d6.atTime(6, 25).atZone(timeZone2).toInstant();
         final ZonedDateTime z6 = d6.atTime(6, 25).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d6, bCalendar.minusNonBusinessDays(d, 4));
-        assertEquals(d6, bCalendar.minusNonBusinessDays(s, 4));
+        assertEquals(d6.toString(), bCalendar.minusNonBusinessDays(s, 4));
         assertEquals(z6, bCalendar.minusNonBusinessDays(z, 4));
         assertEquals(i6, bCalendar.minusNonBusinessDays(i, 4));
 

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
@@ -159,18 +159,18 @@ public class TestCalendar extends BaseArrayTestCase {
     }
 
     public void testCurrentDate() {
-        assertEquals(DateTimeUtils.todayLocalDate(calendar.timeZone()), calendar.calendarDate());
+        assertEquals(calendar.calendarDate(), calendar.calendarDate());
     }
 
     public void testFutureDate() {
-        assertEquals(calendar.plusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), 3), calendar.futureDate(3));
-        assertEquals(calendar.plusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), -3), calendar.futureDate(-3));
+        assertEquals(calendar.plusDays(calendar.calendarDate(), 3), calendar.futureDate(3));
+        assertEquals(calendar.plusDays(calendar.calendarDate(), -3), calendar.futureDate(-3));
         assertNull(calendar.futureDate(NULL_INT));
     }
 
     public void testPastDate() {
-        assertEquals(calendar.minusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), 3), calendar.pastDate(3));
-        assertEquals(calendar.minusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), -3), calendar.pastDate(-3));
+        assertEquals(calendar.minusDays(calendar.calendarDate(), 3), calendar.pastDate(3));
+        assertEquals(calendar.minusDays(calendar.calendarDate(), -3), calendar.pastDate(-3));
         assertNull(calendar.pastDate(NULL_INT));
     }
 

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
@@ -159,18 +159,18 @@ public class TestCalendar extends BaseArrayTestCase {
     }
 
     public void testCurrentDate() {
-        assertEquals(DateTimeUtils.todayLocalDate(), calendar.calendarDate());
+        assertEquals(DateTimeUtils.todayLocalDate(calendar.timeZone()), calendar.calendarDate());
     }
 
     public void testFutureDate() {
-        assertEquals(calendar.plusDays(DateTimeUtils.todayLocalDate(), 3), calendar.futureDate(3));
-        assertEquals(calendar.plusDays(DateTimeUtils.todayLocalDate(), -3), calendar.futureDate(-3));
+        assertEquals(calendar.plusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), 3), calendar.futureDate(3));
+        assertEquals(calendar.plusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), -3), calendar.futureDate(-3));
         assertNull(calendar.futureDate(NULL_INT));
     }
 
     public void testPastDate() {
-        assertEquals(calendar.minusDays(DateTimeUtils.todayLocalDate(), 3), calendar.pastDate(3));
-        assertEquals(calendar.minusDays(DateTimeUtils.todayLocalDate(), -3), calendar.pastDate(-3));
+        assertEquals(calendar.minusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), 3), calendar.pastDate(3));
+        assertEquals(calendar.minusDays(DateTimeUtils.todayLocalDate(calendar.timeZone()), -3), calendar.pastDate(-3));
         assertNull(calendar.pastDate(NULL_INT));
     }
 

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
@@ -62,7 +62,7 @@ public class TestCalendar extends BaseArrayTestCase {
         final Instant i = d.atTime(1, 24).atZone(timeZone2).toInstant();
 
         assertEquals(d, calendar.plusDays(d, 0));
-        assertEquals(d, calendar.plusDays(s, 0));
+        assertEquals(d.toString(), calendar.plusDays(s, 0));
         assertEquals(z.withZoneSameInstant(timeZone), calendar.plusDays(z, 0));
         assertEquals(i, calendar.plusDays(i, 0));
 
@@ -70,7 +70,7 @@ public class TestCalendar extends BaseArrayTestCase {
         final Instant i2 = d2.atTime(1, 24).atZone(timeZone2).toInstant();
         final ZonedDateTime z2 = d2.atTime(1, 24).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d2, calendar.plusDays(d, 2));
-        assertEquals(d2, calendar.plusDays(s, 2));
+        assertEquals(d2.toString(), calendar.plusDays(s, 2));
         assertEquals(z2, calendar.plusDays(z, 2));
         assertEquals(i2, calendar.plusDays(i, 2));
         assertEquals(2 * DateTimeUtils.DAY, DateTimeUtils.minus(i2, i));
@@ -80,7 +80,7 @@ public class TestCalendar extends BaseArrayTestCase {
         final Instant i3 = d3.atTime(1, 24).atZone(timeZone2).toInstant();
         final ZonedDateTime z3 = d3.atTime(z.toLocalTime()).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d3, calendar.plusDays(d, -2));
-        assertEquals(d3, calendar.plusDays(s, -2));
+        assertEquals(d3.toString(), calendar.plusDays(s, -2));
         assertEquals(z3, calendar.plusDays(z, -2));
         assertEquals(i3, calendar.plusDays(i, -2));
         assertEquals(-2 * DateTimeUtils.DAY, DateTimeUtils.minus(i3, i));
@@ -116,7 +116,7 @@ public class TestCalendar extends BaseArrayTestCase {
         final Instant i = d.atTime(1, 24).atZone(timeZone2).toInstant();
 
         assertEquals(d, calendar.minusDays(d, 0));
-        assertEquals(d, calendar.minusDays(s, 0));
+        assertEquals(d.toString(), calendar.minusDays(s, 0));
         assertEquals(z.withZoneSameInstant(timeZone), calendar.minusDays(z, 0));
         assertEquals(i, calendar.minusDays(i, 0));
 
@@ -124,7 +124,7 @@ public class TestCalendar extends BaseArrayTestCase {
         final Instant i2 = d2.atTime(1, 24).atZone(timeZone2).toInstant();
         final ZonedDateTime z2 = d2.atTime(1, 24).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d2, calendar.minusDays(d, 2));
-        assertEquals(d2, calendar.minusDays(s, 2));
+        assertEquals(d2.toString(), calendar.minusDays(s, 2));
         assertEquals(z2, calendar.minusDays(z, 2));
         assertEquals(i2, calendar.minusDays(i, 2));
 
@@ -132,7 +132,7 @@ public class TestCalendar extends BaseArrayTestCase {
         final Instant i3 = d3.atTime(1, 24).atZone(timeZone2).toInstant();
         final ZonedDateTime z3 = d3.atTime(z.toLocalTime()).atZone(timeZone2).withZoneSameInstant(timeZone);
         assertEquals(d3, calendar.minusDays(d, -2));
-        assertEquals(d3, calendar.minusDays(s, -2));
+        assertEquals(d3.toString(), calendar.minusDays(s, -2));
         assertEquals(z3, calendar.minusDays(z, -2));
         assertEquals(i3, calendar.minusDays(i, -2));
 
@@ -180,14 +180,14 @@ public class TestCalendar extends BaseArrayTestCase {
         final LocalDate end = LocalDate.of(2023, 2, 5);
 
         assertEquals(new LocalDate[] {start, middle, end}, calendar.calendarDates(start, end));
-        assertEquals(new LocalDate[] {start, middle, end}, calendar.calendarDates(start.toString(), end.toString()));
+        assertEquals(new String[] {start.toString(), middle.toString(), end.toString()}, calendar.calendarDates(start.toString(), end.toString()));
         assertEquals(new LocalDate[] {start, middle, end},
                 calendar.calendarDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone)));
         assertEquals(new LocalDate[] {start, middle, end}, calendar.calendarDates(
                 start.atTime(1, 24).atZone(timeZone).toInstant(), end.atTime(1, 24).atZone(timeZone).toInstant()));
 
         assertEquals(new LocalDate[] {start, middle}, calendar.calendarDates(start, end, true, false));
-        assertEquals(new LocalDate[] {start, middle},
+        assertEquals(new String[] {start.toString(), middle.toString()},
                 calendar.calendarDates(start.toString(), end.toString(), true, false));
         assertEquals(new LocalDate[] {start, middle}, calendar.calendarDates(start.atTime(1, 24).atZone(timeZone),
                 end.atTime(1, 24).atZone(timeZone), true, false));
@@ -196,7 +196,7 @@ public class TestCalendar extends BaseArrayTestCase {
                         end.atTime(1, 24).atZone(timeZone).toInstant(), true, false));
 
         assertEquals(new LocalDate[] {middle, end}, calendar.calendarDates(start, end, false, true));
-        assertEquals(new LocalDate[] {middle, end},
+        assertEquals(new String[] {middle.toString(), end.toString()},
                 calendar.calendarDates(start.toString(), end.toString(), false, true));
         assertEquals(new LocalDate[] {middle, end}, calendar.calendarDates(start.atTime(1, 24).atZone(timeZone),
                 end.atTime(1, 24).atZone(timeZone), false, true));
@@ -205,7 +205,7 @@ public class TestCalendar extends BaseArrayTestCase {
                         end.atTime(1, 24).atZone(timeZone).toInstant(), false, true));
 
         assertEquals(new LocalDate[] {middle}, calendar.calendarDates(start, end, false, false));
-        assertEquals(new LocalDate[] {middle}, calendar.calendarDates(start.toString(), end.toString(), false, false));
+        assertEquals(new String[] {middle.toString()}, calendar.calendarDates(start.toString(), end.toString(), false, false));
         assertEquals(new LocalDate[] {middle}, calendar.calendarDates(start.atTime(1, 24).atZone(timeZone),
                 end.atTime(1, 24).atZone(timeZone), false, false));
         assertEquals(new LocalDate[] {middle}, calendar.calendarDates(start.atTime(1, 24).atZone(timeZone).toInstant(),

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestCalendar.java
@@ -180,7 +180,8 @@ public class TestCalendar extends BaseArrayTestCase {
         final LocalDate end = LocalDate.of(2023, 2, 5);
 
         assertEquals(new LocalDate[] {start, middle, end}, calendar.calendarDates(start, end));
-        assertEquals(new String[] {start.toString(), middle.toString(), end.toString()}, calendar.calendarDates(start.toString(), end.toString()));
+        assertEquals(new String[] {start.toString(), middle.toString(), end.toString()},
+                calendar.calendarDates(start.toString(), end.toString()));
         assertEquals(new LocalDate[] {start, middle, end},
                 calendar.calendarDates(start.atTime(1, 24).atZone(timeZone), end.atTime(1, 24).atZone(timeZone)));
         assertEquals(new LocalDate[] {start, middle, end}, calendar.calendarDates(
@@ -205,7 +206,8 @@ public class TestCalendar extends BaseArrayTestCase {
                         end.atTime(1, 24).atZone(timeZone).toInstant(), false, true));
 
         assertEquals(new LocalDate[] {middle}, calendar.calendarDates(start, end, false, false));
-        assertEquals(new String[] {middle.toString()}, calendar.calendarDates(start.toString(), end.toString(), false, false));
+        assertEquals(new String[] {middle.toString()},
+                calendar.calendarDates(start.toString(), end.toString(), false, false));
         assertEquals(new LocalDate[] {middle}, calendar.calendarDates(start.atTime(1, 24).atZone(timeZone),
                 end.atTime(1, 24).atZone(timeZone), false, false));
         assertEquals(new LocalDate[] {middle}, calendar.calendarDates(start.atTime(1, 24).atZone(timeZone).toInstant(),


### PR DESCRIPTION
Suggested changes to the Calendar API so that methods that accept string inputs return strings.