### PR TITLE
Fix mismatched list and count in docs

### DIFF
--- a/py/client-ticking/README.md
+++ b/py/client-ticking/README.md
@@ -8,8 +8,8 @@ create a thin wrapper around the Deephaven native C++ library.
 ## Prerequisites
 
 Before installing this library, you will need to install the Deephaven Core C++ library and the
-pydeephaven python package. All three packages (Deephaven Core C++, pydeephaven, Deephaven Core,
-and pydeephaven-ticking) are present in the Deephaven Core github repository. We assume you
+pydeephaven python package. All four packages (Deephaven Core C++, pydeephaven, Deephaven Core,
+and pydeephaven-ticking) are present in the Deephaven Core GitHub repository. We assume you
 have checked out this repository at the location specified by `${DHROOT}`.
 
 ### Installing Deephaven Core


### PR DESCRIPTION
Fixes a place where the Python docs say "all **three** packages" and then proceed to list **four** packages.