### PR TITLE
fix: Mark JsPartitionedTable.getTable as nullable

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -169,8 +169,8 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
         }
         final List<Object> keyList = Js.<JsArray<Object>>uncheckedCast(key).asList();
         if (!knownKeys.contains(keyList)) {
-            // key doesn't even exist
-            return Promise.reject("Key not found");
+            // key doesn't even exist, just hand back a null table
+            return Promise.resolve((JsTable) null);
         }
         final String[] columnNames = descriptor.getKeyColumnNamesList().asArray(new String[0]);
         final String[] columnTypes = keyColumnTypes.toArray(new String[0]);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -169,8 +169,8 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
         }
         final List<Object> keyList = Js.<JsArray<Object>>uncheckedCast(key).asList();
         if (!knownKeys.contains(keyList)) {
-            // key doesn't even exist, just hand back a null table
-            return Promise.resolve((JsTable) null);
+            // key doesn't even exist
+            return Promise.reject("Key not found");
         }
         final String[] columnNames = descriptor.getKeyColumnNamesList().asArray(new String[0]);
         final String[] columnTypes = keyColumnTypes.toArray(new String[0]);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -24,6 +24,7 @@ import io.deephaven.web.client.state.ClientTableState;
 import io.deephaven.web.shared.data.RangeSet;
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsNullable;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
@@ -157,12 +158,12 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
     }
 
     /**
-     * Fetch the table with the given key.
+     * Fetch the table with the given key. If the key does not exist, returns `null`.
      *
      * @param key The key to fetch. An array of values for each key column, in the same order as the key columns are.
-     * @return Promise of dh.Table
+     * @return Promise of dh.Table, or `null` if the key does not exist.
      */
-    public Promise<JsTable> getTable(Object key) {
+    public Promise<@JsNullable JsTable> getTable(Object key) {
         // Wrap non-arrays in an array so we are consistent with how we track keys
         if (!JsArray.isArray(key)) {
             key = JsArray.of(key);


### PR DESCRIPTION
- JsPartitionedTable.getTable returns `null` if the key is not found, as the table may not exist yet.