### PR TITLE
Chunk pools should be easier to emulate in GWT

### DIFF
--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableBooleanChunk.java
@@ -23,7 +23,7 @@ public class ResettableBooleanChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableBooleanChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getBooleanChunkPool().takeResettableBooleanChunk();
+            return MultiChunkPool.forThisThread().takeResettableBooleanChunk();
         }
         return new ResettableBooleanChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableBooleanChunk<ATTR_UPPER extends Any>
         return new ResettableBooleanChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getBooleanChunkPool().giveResettableBooleanChunk(this);
+                MultiChunkPool.forThisThread().giveResettableBooleanChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableBooleanChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for boolean data.
  */
-public final class ResettableBooleanChunk<ATTR_UPPER extends Any>
+public class ResettableBooleanChunk<ATTR_UPPER extends Any>
         extends BooleanChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -29,7 +29,12 @@ public final class ResettableBooleanChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableBooleanChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableBooleanChunk<>();
+        return new ResettableBooleanChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getBooleanChunkPool().giveResettableBooleanChunk(this);
+            }
+        };
     }
 
     private ResettableBooleanChunk(boolean[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableBooleanChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getBooleanChunkPool().giveResettableBooleanChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableByteChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for byte data.
  */
-public final class ResettableByteChunk<ATTR_UPPER extends Any>
+public class ResettableByteChunk<ATTR_UPPER extends Any>
         extends ByteChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -29,7 +29,12 @@ public final class ResettableByteChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableByteChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableByteChunk<>();
+        return new ResettableByteChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getByteChunkPool().giveResettableByteChunk(this);
+            }
+        };
     }
 
     private ResettableByteChunk(byte[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableByteChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getByteChunkPool().giveResettableByteChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableByteChunk.java
@@ -23,7 +23,7 @@ public class ResettableByteChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableByteChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getByteChunkPool().takeResettableByteChunk();
+            return MultiChunkPool.forThisThread().takeResettableByteChunk();
         }
         return new ResettableByteChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableByteChunk<ATTR_UPPER extends Any>
         return new ResettableByteChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getByteChunkPool().giveResettableByteChunk(this);
+                MultiChunkPool.forThisThread().giveResettableByteChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableCharChunk.java
@@ -12,7 +12,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for char data.
  */
-public final class ResettableCharChunk<ATTR_UPPER extends Any>
+public class ResettableCharChunk<ATTR_UPPER extends Any>
         extends CharChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -24,7 +24,12 @@ public final class ResettableCharChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableCharChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableCharChunk<>();
+        return new ResettableCharChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getCharChunkPool().giveResettableCharChunk(this);
+            }
+        };
     }
 
     private ResettableCharChunk(char[] data, int offset, int capacity) {
@@ -79,8 +84,5 @@ public final class ResettableCharChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getCharChunkPool().giveResettableCharChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableCharChunk.java
@@ -18,7 +18,7 @@ public class ResettableCharChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableCharChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getCharChunkPool().takeResettableCharChunk();
+            return MultiChunkPool.forThisThread().takeResettableCharChunk();
         }
         return new ResettableCharChunk<>();
     }
@@ -27,7 +27,7 @@ public class ResettableCharChunk<ATTR_UPPER extends Any>
         return new ResettableCharChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getCharChunkPool().giveResettableCharChunk(this);
+                MultiChunkPool.forThisThread().giveResettableCharChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableDoubleChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for double data.
  */
-public final class ResettableDoubleChunk<ATTR_UPPER extends Any>
+public class ResettableDoubleChunk<ATTR_UPPER extends Any>
         extends DoubleChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -29,7 +29,12 @@ public final class ResettableDoubleChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableDoubleChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableDoubleChunk<>();
+        return new ResettableDoubleChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getDoubleChunkPool().giveResettableDoubleChunk(this);
+            }
+        };
     }
 
     private ResettableDoubleChunk(double[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableDoubleChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getDoubleChunkPool().giveResettableDoubleChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableDoubleChunk.java
@@ -23,7 +23,7 @@ public class ResettableDoubleChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableDoubleChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getDoubleChunkPool().takeResettableDoubleChunk();
+            return MultiChunkPool.forThisThread().takeResettableDoubleChunk();
         }
         return new ResettableDoubleChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableDoubleChunk<ATTR_UPPER extends Any>
         return new ResettableDoubleChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getDoubleChunkPool().giveResettableDoubleChunk(this);
+                MultiChunkPool.forThisThread().giveResettableDoubleChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableFloatChunk.java
@@ -23,7 +23,7 @@ public class ResettableFloatChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableFloatChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getFloatChunkPool().takeResettableFloatChunk();
+            return MultiChunkPool.forThisThread().takeResettableFloatChunk();
         }
         return new ResettableFloatChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableFloatChunk<ATTR_UPPER extends Any>
         return new ResettableFloatChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getFloatChunkPool().giveResettableFloatChunk(this);
+                MultiChunkPool.forThisThread().giveResettableFloatChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableFloatChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for float data.
  */
-public final class ResettableFloatChunk<ATTR_UPPER extends Any>
+public class ResettableFloatChunk<ATTR_UPPER extends Any>
         extends FloatChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -29,7 +29,12 @@ public final class ResettableFloatChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableFloatChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableFloatChunk<>();
+        return new ResettableFloatChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getFloatChunkPool().giveResettableFloatChunk(this);
+            }
+        };
     }
 
     private ResettableFloatChunk(float[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableFloatChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getFloatChunkPool().giveResettableFloatChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableIntChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for int data.
  */
-public final class ResettableIntChunk<ATTR_UPPER extends Any>
+public class ResettableIntChunk<ATTR_UPPER extends Any>
         extends IntChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -29,7 +29,12 @@ public final class ResettableIntChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableIntChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableIntChunk<>();
+        return new ResettableIntChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getIntChunkPool().giveResettableIntChunk(this);
+            }
+        };
     }
 
     private ResettableIntChunk(int[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableIntChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getIntChunkPool().giveResettableIntChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableIntChunk.java
@@ -23,7 +23,7 @@ public class ResettableIntChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableIntChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getIntChunkPool().takeResettableIntChunk();
+            return MultiChunkPool.forThisThread().takeResettableIntChunk();
         }
         return new ResettableIntChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableIntChunk<ATTR_UPPER extends Any>
         return new ResettableIntChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getIntChunkPool().giveResettableIntChunk(this);
+                MultiChunkPool.forThisThread().giveResettableIntChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableLongChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for long data.
  */
-public final class ResettableLongChunk<ATTR_UPPER extends Any>
+public class ResettableLongChunk<ATTR_UPPER extends Any>
         extends LongChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -29,7 +29,12 @@ public final class ResettableLongChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableLongChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableLongChunk<>();
+        return new ResettableLongChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getLongChunkPool().giveResettableLongChunk(this);
+            }
+        };
     }
 
     private ResettableLongChunk(long[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableLongChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getLongChunkPool().giveResettableLongChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableLongChunk.java
@@ -23,7 +23,7 @@ public class ResettableLongChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableLongChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getLongChunkPool().takeResettableLongChunk();
+            return MultiChunkPool.forThisThread().takeResettableLongChunk();
         }
         return new ResettableLongChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableLongChunk<ATTR_UPPER extends Any>
         return new ResettableLongChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getLongChunkPool().giveResettableLongChunk(this);
+                MultiChunkPool.forThisThread().giveResettableLongChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableObjectChunk.java
@@ -17,19 +17,24 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for Object data.
  */
-public final class ResettableObjectChunk<T, ATTR_UPPER extends Any>
+public class ResettableObjectChunk<T, ATTR_UPPER extends Any>
         extends ObjectChunk<T, ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
     public static <T, ATTR_BASE extends Any> ResettableObjectChunk<T, ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getObjectChunkPool().takeResettableObjectChunk();
+            return MultiChunkPool.forThisThread().takeResettableObjectChunk();
         }
         return new ResettableObjectChunk<>();
     }
 
     public static <T, ATTR_BASE extends Any> ResettableObjectChunk<T, ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableObjectChunk<>();
+        return new ResettableObjectChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getObjectChunkPool().giveResettableObjectChunk(this);
+            }
+        };
     }
 
     private ResettableObjectChunk(T[] data, int offset, int capacity) {
@@ -87,8 +92,5 @@ public final class ResettableObjectChunk<T, ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getObjectChunkPool().giveResettableObjectChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableObjectChunk.java
@@ -32,7 +32,7 @@ public class ResettableObjectChunk<T, ATTR_UPPER extends Any>
         return new ResettableObjectChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getObjectChunkPool().giveResettableObjectChunk(this);
+                MultiChunkPool.forThisThread().giveResettableObjectChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableShortChunk.java
@@ -23,7 +23,7 @@ public class ResettableShortChunk<ATTR_UPPER extends Any>
 
     public static <ATTR_BASE extends Any> ResettableShortChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getShortChunkPool().takeResettableShortChunk();
+            return MultiChunkPool.forThisThread().takeResettableShortChunk();
         }
         return new ResettableShortChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableShortChunk<ATTR_UPPER extends Any>
         return new ResettableShortChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getShortChunkPool().giveResettableShortChunk(this);
+                MultiChunkPool.forThisThread().giveResettableShortChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableShortChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableReadOnlyChunk} implementation for short data.
  */
-public final class ResettableShortChunk<ATTR_UPPER extends Any>
+public class ResettableShortChunk<ATTR_UPPER extends Any>
         extends ShortChunk<ATTR_UPPER>
         implements ResettableReadOnlyChunk<ATTR_UPPER> {
 
@@ -29,7 +29,12 @@ public final class ResettableShortChunk<ATTR_UPPER extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableShortChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableShortChunk<>();
+        return new ResettableShortChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getShortChunkPool().giveResettableShortChunk(this);
+            }
+        };
     }
 
     private ResettableShortChunk(short[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableShortChunk<ATTR_UPPER extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getShortChunkPool().giveResettableShortChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableBooleanChunk.java
@@ -86,8 +86,4 @@ public class ResettableWritableBooleanChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableBooleanChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableBooleanChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for boolean data.
  */
-public final class ResettableWritableBooleanChunk<ATTR_BASE extends Any>
+public class ResettableWritableBooleanChunk<ATTR_BASE extends Any>
         extends WritableBooleanChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableBooleanChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableBooleanChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableBooleanChunk<>();
+        return new ResettableWritableBooleanChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getBooleanChunkPool().giveResettableWritableBooleanChunk(this);
+            }
+        };
     }
 
     private ResettableWritableBooleanChunk(boolean[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableWritableBooleanChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getBooleanChunkPool().giveResettableWritableBooleanChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableBooleanChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableBooleanChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableBooleanChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getBooleanChunkPool().takeResettableWritableBooleanChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableBooleanChunk();
         }
         return new ResettableWritableBooleanChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableBooleanChunk<ATTR_BASE extends Any>
         return new ResettableWritableBooleanChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getBooleanChunkPool().giveResettableWritableBooleanChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableBooleanChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableByteChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for byte data.
  */
-public final class ResettableWritableByteChunk<ATTR_BASE extends Any>
+public class ResettableWritableByteChunk<ATTR_BASE extends Any>
         extends WritableByteChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableByteChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableByteChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableByteChunk<>();
+        return new ResettableWritableByteChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getByteChunkPool().giveResettableWritableByteChunk(this);
+            }
+        };
     }
 
     private ResettableWritableByteChunk(byte[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableWritableByteChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getByteChunkPool().giveResettableWritableByteChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableByteChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableByteChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableByteChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getByteChunkPool().takeResettableWritableByteChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableByteChunk();
         }
         return new ResettableWritableByteChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableByteChunk<ATTR_BASE extends Any>
         return new ResettableWritableByteChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getByteChunkPool().giveResettableWritableByteChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableByteChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableByteChunk.java
@@ -86,8 +86,4 @@ public class ResettableWritableByteChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableByteChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableCharChunk.java
@@ -12,7 +12,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for char data.
  */
-public final class ResettableWritableCharChunk<ATTR_BASE extends Any>
+public class ResettableWritableCharChunk<ATTR_BASE extends Any>
         extends WritableCharChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -24,7 +24,12 @@ public final class ResettableWritableCharChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableCharChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableCharChunk<>();
+        return new ResettableWritableCharChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getCharChunkPool().giveResettableWritableCharChunk(this);
+            }
+        };
     }
 
     private ResettableWritableCharChunk(char[] data, int offset, int capacity) {
@@ -79,8 +84,5 @@ public final class ResettableWritableCharChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getCharChunkPool().giveResettableWritableCharChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableCharChunk.java
@@ -81,8 +81,4 @@ public class ResettableWritableCharChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableCharChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableCharChunk.java
@@ -18,7 +18,7 @@ public class ResettableWritableCharChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableCharChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getCharChunkPool().takeResettableWritableCharChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableCharChunk();
         }
         return new ResettableWritableCharChunk<>();
     }
@@ -27,7 +27,7 @@ public class ResettableWritableCharChunk<ATTR_BASE extends Any>
         return new ResettableWritableCharChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getCharChunkPool().giveResettableWritableCharChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableCharChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableDoubleChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for double data.
  */
-public final class ResettableWritableDoubleChunk<ATTR_BASE extends Any>
+public class ResettableWritableDoubleChunk<ATTR_BASE extends Any>
         extends WritableDoubleChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableDoubleChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableDoubleChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableDoubleChunk<>();
+        return new ResettableWritableDoubleChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getDoubleChunkPool().giveResettableWritableDoubleChunk(this);
+            }
+        };
     }
 
     private ResettableWritableDoubleChunk(double[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableWritableDoubleChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getDoubleChunkPool().giveResettableWritableDoubleChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableDoubleChunk.java
@@ -86,8 +86,4 @@ public class ResettableWritableDoubleChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableDoubleChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableDoubleChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableDoubleChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableDoubleChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getDoubleChunkPool().takeResettableWritableDoubleChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableDoubleChunk();
         }
         return new ResettableWritableDoubleChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableDoubleChunk<ATTR_BASE extends Any>
         return new ResettableWritableDoubleChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getDoubleChunkPool().giveResettableWritableDoubleChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableDoubleChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableFloatChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for float data.
  */
-public final class ResettableWritableFloatChunk<ATTR_BASE extends Any>
+public class ResettableWritableFloatChunk<ATTR_BASE extends Any>
         extends WritableFloatChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableFloatChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableFloatChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableFloatChunk<>();
+        return new ResettableWritableFloatChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getFloatChunkPool().giveResettableWritableFloatChunk(this);
+            }
+        };
     }
 
     private ResettableWritableFloatChunk(float[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableWritableFloatChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getFloatChunkPool().giveResettableWritableFloatChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableFloatChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableFloatChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableFloatChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getFloatChunkPool().takeResettableWritableFloatChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableFloatChunk();
         }
         return new ResettableWritableFloatChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableFloatChunk<ATTR_BASE extends Any>
         return new ResettableWritableFloatChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getFloatChunkPool().giveResettableWritableFloatChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableFloatChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableFloatChunk.java
@@ -86,8 +86,4 @@ public class ResettableWritableFloatChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableFloatChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableIntChunk.java
@@ -86,8 +86,4 @@ public class ResettableWritableIntChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableIntChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableIntChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableIntChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableIntChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getIntChunkPool().takeResettableWritableIntChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableIntChunk();
         }
         return new ResettableWritableIntChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableIntChunk<ATTR_BASE extends Any>
         return new ResettableWritableIntChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getIntChunkPool().giveResettableWritableIntChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableIntChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableIntChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for int data.
  */
-public final class ResettableWritableIntChunk<ATTR_BASE extends Any>
+public class ResettableWritableIntChunk<ATTR_BASE extends Any>
         extends WritableIntChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableIntChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableIntChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableIntChunk<>();
+        return new ResettableWritableIntChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getIntChunkPool().giveResettableWritableIntChunk(this);
+            }
+        };
     }
 
     private ResettableWritableIntChunk(int[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableWritableIntChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getIntChunkPool().giveResettableWritableIntChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableLongChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableLongChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableLongChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getLongChunkPool().takeResettableWritableLongChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableLongChunk();
         }
         return new ResettableWritableLongChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableLongChunk<ATTR_BASE extends Any>
         return new ResettableWritableLongChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getLongChunkPool().giveResettableWritableLongChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableLongChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableLongChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for long data.
  */
-public final class ResettableWritableLongChunk<ATTR_BASE extends Any>
+public class ResettableWritableLongChunk<ATTR_BASE extends Any>
         extends WritableLongChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableLongChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableLongChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableLongChunk<>();
+        return new ResettableWritableLongChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getLongChunkPool().giveResettableWritableLongChunk(this);
+            }
+        };
     }
 
     private ResettableWritableLongChunk(long[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableWritableLongChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getLongChunkPool().giveResettableWritableLongChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableLongChunk.java
@@ -86,8 +86,4 @@ public class ResettableWritableLongChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableLongChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableObjectChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableObjectChunk<T, ATTR_BASE extends Any>
 
     public static <T, ATTR_BASE extends Any> ResettableWritableObjectChunk<T, ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getObjectChunkPool().takeResettableWritableObjectChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableObjectChunk();
         }
         return new ResettableWritableObjectChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableObjectChunk<T, ATTR_BASE extends Any>
         return new ResettableWritableObjectChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getObjectChunkPool().giveResettableWritableObjectChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableObjectChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableObjectChunk.java
@@ -89,8 +89,4 @@ public class ResettableWritableObjectChunk<T, ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableObjectChunk<T, ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableObjectChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for Object data.
  */
-public final class ResettableWritableObjectChunk<T, ATTR_BASE extends Any>
+public class ResettableWritableObjectChunk<T, ATTR_BASE extends Any>
         extends WritableObjectChunk<T, ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableObjectChunk<T, ATTR_BASE extends Any>
     }
 
     public static <T, ATTR_BASE extends Any> ResettableWritableObjectChunk<T, ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableObjectChunk<>();
+        return new ResettableWritableObjectChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getObjectChunkPool().giveResettableWritableObjectChunk(this);
+            }
+        };
     }
 
     private ResettableWritableObjectChunk(T[] data, int offset, int capacity) {
@@ -87,8 +92,5 @@ public final class ResettableWritableObjectChunk<T, ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getObjectChunkPool().giveResettableWritableObjectChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableShortChunk.java
@@ -86,8 +86,4 @@ public class ResettableWritableShortChunk<ATTR_BASE extends Any>
         //noinspection unchecked
         return (WritableShortChunk<ATTR>) this;
     }
-
-    @Override
-    public void close() {
-    }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableShortChunk.java
@@ -17,7 +17,7 @@ import static io.deephaven.chunk.util.pools.ChunkPoolConstants.POOL_RESETTABLE_C
 /**
  * {@link ResettableWritableChunk} implementation for short data.
  */
-public final class ResettableWritableShortChunk<ATTR_BASE extends Any>
+public class ResettableWritableShortChunk<ATTR_BASE extends Any>
         extends WritableShortChunk<ATTR_BASE>
         implements ResettableWritableChunk<ATTR_BASE> {
 
@@ -29,7 +29,12 @@ public final class ResettableWritableShortChunk<ATTR_BASE extends Any>
     }
 
     public static <ATTR_BASE extends Any> ResettableWritableShortChunk<ATTR_BASE> makeResettableChunkForPool() {
-        return new ResettableWritableShortChunk<>();
+        return new ResettableWritableShortChunk<>() {
+            @Override
+            public void close() {
+                MultiChunkPool.forThisThread().getShortChunkPool().giveResettableWritableShortChunk(this);
+            }
+        };
     }
 
     private ResettableWritableShortChunk(short[] data, int offset, int capacity) {
@@ -84,8 +89,5 @@ public final class ResettableWritableShortChunk<ATTR_BASE extends Any>
 
     @Override
     public void close() {
-        if (POOL_RESETTABLE_CHUNKS) {
-            MultiChunkPool.forThisThread().getShortChunkPool().giveResettableWritableShortChunk(this);
-        }
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ResettableWritableShortChunk.java
@@ -23,7 +23,7 @@ public class ResettableWritableShortChunk<ATTR_BASE extends Any>
 
     public static <ATTR_BASE extends Any> ResettableWritableShortChunk<ATTR_BASE> makeResettableChunk() {
         if (POOL_RESETTABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getShortChunkPool().takeResettableWritableShortChunk();
+            return MultiChunkPool.forThisThread().takeResettableWritableShortChunk();
         }
         return new ResettableWritableShortChunk<>();
     }
@@ -32,7 +32,7 @@ public class ResettableWritableShortChunk<ATTR_BASE extends Any>
         return new ResettableWritableShortChunk<>() {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getShortChunkPool().giveResettableWritableShortChunk(this);
+                MultiChunkPool.forThisThread().giveResettableWritableShortChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableBooleanChunk.java
@@ -42,7 +42,7 @@ public class WritableBooleanChunk<ATTR extends Any> extends BooleanChunk<ATTR> i
 
     public static <ATTR extends Any> WritableBooleanChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getBooleanChunkPool().takeWritableBooleanChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableBooleanChunk(size);
         }
         return new WritableBooleanChunk<>(makeArray(size), 0, size);
     }
@@ -52,7 +52,7 @@ public class WritableBooleanChunk<ATTR extends Any> extends BooleanChunk<ATTR> i
         return new WritableBooleanChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getBooleanChunkPool().giveWritableBooleanChunk(this);
+                MultiChunkPool.forThisThread().giveWritableBooleanChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableBooleanChunk.java
@@ -47,9 +47,8 @@ public class WritableBooleanChunk<ATTR extends Any> extends BooleanChunk<ATTR> i
         return new WritableBooleanChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableBooleanChunk makeWritableChunkForPool(int size) {
-        return new WritableBooleanChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableBooleanChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableBooleanChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableBooleanChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableByteChunk.java
@@ -45,7 +45,7 @@ public class WritableByteChunk<ATTR extends Any> extends ByteChunk<ATTR> impleme
 
     public static <ATTR extends Any> WritableByteChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getByteChunkPool().takeWritableByteChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableByteChunk(size);
         }
         return new WritableByteChunk<>(makeArray(size), 0, size);
     }
@@ -55,7 +55,7 @@ public class WritableByteChunk<ATTR extends Any> extends ByteChunk<ATTR> impleme
         return new WritableByteChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getByteChunkPool().giveWritableByteChunk(this);
+                MultiChunkPool.forThisThread().giveWritableByteChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableByteChunk.java
@@ -50,9 +50,8 @@ public class WritableByteChunk<ATTR extends Any> extends ByteChunk<ATTR> impleme
         return new WritableByteChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableByteChunk makeWritableChunkForPool(int size) {
-        return new WritableByteChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableByteChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableByteChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableByteChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java
@@ -40,7 +40,7 @@ public class WritableCharChunk<ATTR extends Any> extends CharChunk<ATTR> impleme
 
     public static <ATTR extends Any> WritableCharChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getCharChunkPool().takeWritableCharChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableCharChunk(size);
         }
         return new WritableCharChunk<>(makeArray(size), 0, size);
     }
@@ -50,7 +50,7 @@ public class WritableCharChunk<ATTR extends Any> extends CharChunk<ATTR> impleme
         return new WritableCharChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getCharChunkPool().giveWritableCharChunk(this);
+                MultiChunkPool.forThisThread().giveWritableCharChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java
@@ -45,9 +45,8 @@ public class WritableCharChunk<ATTR extends Any> extends CharChunk<ATTR> impleme
         return new WritableCharChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableCharChunk makeWritableChunkForPool(int size) {
-        return new WritableCharChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableCharChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableCharChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableCharChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableDoubleChunk.java
@@ -50,9 +50,8 @@ public class WritableDoubleChunk<ATTR extends Any> extends DoubleChunk<ATTR> imp
         return new WritableDoubleChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableDoubleChunk makeWritableChunkForPool(int size) {
-        return new WritableDoubleChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableDoubleChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableDoubleChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableDoubleChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableDoubleChunk.java
@@ -45,7 +45,7 @@ public class WritableDoubleChunk<ATTR extends Any> extends DoubleChunk<ATTR> imp
 
     public static <ATTR extends Any> WritableDoubleChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getDoubleChunkPool().takeWritableDoubleChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableDoubleChunk(size);
         }
         return new WritableDoubleChunk<>(makeArray(size), 0, size);
     }
@@ -55,7 +55,7 @@ public class WritableDoubleChunk<ATTR extends Any> extends DoubleChunk<ATTR> imp
         return new WritableDoubleChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getDoubleChunkPool().giveWritableDoubleChunk(this);
+                MultiChunkPool.forThisThread().giveWritableDoubleChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableFloatChunk.java
@@ -45,7 +45,7 @@ public class WritableFloatChunk<ATTR extends Any> extends FloatChunk<ATTR> imple
 
     public static <ATTR extends Any> WritableFloatChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getFloatChunkPool().takeWritableFloatChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableFloatChunk(size);
         }
         return new WritableFloatChunk<>(makeArray(size), 0, size);
     }
@@ -55,7 +55,7 @@ public class WritableFloatChunk<ATTR extends Any> extends FloatChunk<ATTR> imple
         return new WritableFloatChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getFloatChunkPool().giveWritableFloatChunk(this);
+                MultiChunkPool.forThisThread().giveWritableFloatChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableFloatChunk.java
@@ -50,9 +50,8 @@ public class WritableFloatChunk<ATTR extends Any> extends FloatChunk<ATTR> imple
         return new WritableFloatChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableFloatChunk makeWritableChunkForPool(int size) {
-        return new WritableFloatChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableFloatChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableFloatChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableFloatChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableIntChunk.java
@@ -45,7 +45,7 @@ public class WritableIntChunk<ATTR extends Any> extends IntChunk<ATTR> implement
 
     public static <ATTR extends Any> WritableIntChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getIntChunkPool().takeWritableIntChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableIntChunk(size);
         }
         return new WritableIntChunk<>(makeArray(size), 0, size);
     }
@@ -55,7 +55,7 @@ public class WritableIntChunk<ATTR extends Any> extends IntChunk<ATTR> implement
         return new WritableIntChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getIntChunkPool().giveWritableIntChunk(this);
+                MultiChunkPool.forThisThread().giveWritableIntChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableIntChunk.java
@@ -50,9 +50,8 @@ public class WritableIntChunk<ATTR extends Any> extends IntChunk<ATTR> implement
         return new WritableIntChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableIntChunk makeWritableChunkForPool(int size) {
-        return new WritableIntChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableIntChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableIntChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableIntChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableLongChunk.java
@@ -50,9 +50,8 @@ public class WritableLongChunk<ATTR extends Any> extends LongChunk<ATTR> impleme
         return new WritableLongChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableLongChunk makeWritableChunkForPool(int size) {
-        return new WritableLongChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableLongChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableLongChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableLongChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableLongChunk.java
@@ -45,7 +45,7 @@ public class WritableLongChunk<ATTR extends Any> extends LongChunk<ATTR> impleme
 
     public static <ATTR extends Any> WritableLongChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getLongChunkPool().takeWritableLongChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableLongChunk(size);
         }
         return new WritableLongChunk<>(makeArray(size), 0, size);
     }
@@ -55,7 +55,7 @@ public class WritableLongChunk<ATTR extends Any> extends LongChunk<ATTR> impleme
         return new WritableLongChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getLongChunkPool().giveWritableLongChunk(this);
+                MultiChunkPool.forThisThread().giveWritableLongChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableObjectChunk.java
@@ -45,7 +45,7 @@ public class WritableObjectChunk<T, ATTR extends Any> extends ObjectChunk<T, ATT
 
     public static <T, ATTR extends Any> WritableObjectChunk<T, ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getObjectChunkPool().takeWritableObjectChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableObjectChunk(size);
         }
         return new WritableObjectChunk<>(makeArray(size), 0, size);
     }
@@ -55,7 +55,7 @@ public class WritableObjectChunk<T, ATTR extends Any> extends ObjectChunk<T, ATT
         return new WritableObjectChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getObjectChunkPool().giveWritableObjectChunk(this);
+                MultiChunkPool.forThisThread().giveWritableObjectChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableObjectChunk.java
@@ -50,9 +50,8 @@ public class WritableObjectChunk<T, ATTR extends Any> extends ObjectChunk<T, ATT
         return new WritableObjectChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableObjectChunk makeWritableChunkForPool(int size) {
-        return new WritableObjectChunk(makeArray(size), 0, size) {
+    public static <T, ATTR extends Any> WritableObjectChunk<T, ATTR> makeWritableChunkForPool(int size) {
+        return new WritableObjectChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableObjectChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableShortChunk.java
@@ -50,9 +50,8 @@ public class WritableShortChunk<ATTR extends Any> extends ShortChunk<ATTR> imple
         return new WritableShortChunk<>(makeArray(size), 0, size);
     }
 
-    @SuppressWarnings("rawtypes")
-    public static WritableShortChunk makeWritableChunkForPool(int size) {
-        return new WritableShortChunk(makeArray(size), 0, size) {
+    public static <ATTR extends Any> WritableShortChunk<ATTR> makeWritableChunkForPool(int size) {
+        return new WritableShortChunk<>(makeArray(size), 0, size) {
             @Override
             public void close() {
                 MultiChunkPool.forThisThread().giveWritableShortChunk(this);

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableShortChunk.java
@@ -45,7 +45,7 @@ public class WritableShortChunk<ATTR extends Any> extends ShortChunk<ATTR> imple
 
     public static <ATTR extends Any> WritableShortChunk<ATTR> makeWritableChunk(int size) {
         if (POOL_WRITABLE_CHUNKS) {
-            return MultiChunkPool.forThisThread().getShortChunkPool().takeWritableShortChunk(size);
+            return MultiChunkPool.forThisThread().takeWritableShortChunk(size);
         }
         return new WritableShortChunk<>(makeArray(size), 0, size);
     }
@@ -55,7 +55,7 @@ public class WritableShortChunk<ATTR extends Any> extends ShortChunk<ATTR> imple
         return new WritableShortChunk(makeArray(size), 0, size) {
             @Override
             public void close() {
-                MultiChunkPool.forThisThread().getShortChunkPool().giveWritableShortChunk(this);
+                MultiChunkPool.forThisThread().giveWritableShortChunk(this);
             }
         };
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkPool.java
@@ -1,6 +1,3 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkPool and regenerate
@@ -8,135 +5,59 @@
  */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableBooleanChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableBooleanChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface BooleanChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of booleans.
- */
-@SuppressWarnings("rawtypes")
-public final class BooleanChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableBooleanChunk(capacity);
+            }
 
-    private final WritableBooleanChunk<Any> EMPTY = WritableBooleanChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_BOOLEAN_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableBooleanChunk(writableChunk.asWritableBooleanChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableBooleanChunk}s.
-     */
-    private final SegmentedSoftPool<WritableBooleanChunk>[] writableBooleanChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableBooleanChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableBooleanChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableBooleanChunk> resettableBooleanChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableBooleanChunk(resettableChunk.asResettableBooleanChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableBooleanChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableBooleanChunk> resettableWritableBooleanChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableBooleanChunk();
+            }
 
-    BooleanChunkPool() {
-        //noinspection unchecked
-        writableBooleanChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableBooleanChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableBooleanChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableBooleanChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableBooleanChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableBooleanChunk::makeResettableChunkForPool),
-                ResettableBooleanChunk::clear
-        );
-        resettableWritableBooleanChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableBooleanChunk::makeResettableChunkForPool),
-                ResettableWritableBooleanChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableBooleanChunk(resettableWritableChunk.asResettableWritableBooleanChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableBooleanChunk<ATTR> takeWritableBooleanChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableBooleanChunk(capacity);
-    }
+    void giveWritableBooleanChunk(@NotNull WritableBooleanChunk<?> writableBooleanChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableBooleanChunk(writableChunk.asWritableBooleanChunk());
-    }
+    <ATTR extends Any> ResettableBooleanChunk<ATTR> takeResettableBooleanChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableBooleanChunk();
-    }
+    void giveResettableBooleanChunk(@NotNull ResettableBooleanChunk resettableBooleanChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableBooleanChunk(resettableChunk.asResettableBooleanChunk());
-    }
+    <ATTR extends Any> ResettableWritableBooleanChunk<ATTR> takeResettableWritableBooleanChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableBooleanChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableBooleanChunk(resettableWritableChunk.asResettableWritableBooleanChunk());
-    }
-
-    public <ATTR extends Any> WritableBooleanChunk<ATTR> takeWritableBooleanChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableBooleanChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableBooleanChunk result = writableBooleanChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableBooleanChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableBooleanChunk(@NotNull final WritableBooleanChunk<?> writableBooleanChunk) {
-        if (writableBooleanChunk == EMPTY || writableBooleanChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableBooleanChunk);
-        final int capacity = writableBooleanChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableBooleanChunks[poolIndexForGive].give(writableBooleanChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableBooleanChunk<ATTR> takeResettableBooleanChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableBooleanChunks.take());
-    }
-
-    public void giveResettableBooleanChunk(@NotNull final ResettableBooleanChunk resettableBooleanChunk) {
-        resettableBooleanChunks.give(ChunkPoolReleaseTracking.onGive(resettableBooleanChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableBooleanChunk<ATTR> takeResettableWritableBooleanChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableBooleanChunks.take());
-    }
-
-    public void giveResettableWritableBooleanChunk(@NotNull final ResettableWritableBooleanChunk resettableWritableBooleanChunk) {
-        resettableWritableBooleanChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableBooleanChunk));
-    }
+    void giveResettableWritableBooleanChunk(@NotNull ResettableWritableBooleanChunk resettableWritableBooleanChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkPool.java
@@ -16,48 +16,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface BooleanChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableBooleanChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableBooleanChunk(writableChunk.asWritableBooleanChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableBooleanChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableBooleanChunk(resettableChunk.asResettableBooleanChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableBooleanChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableBooleanChunk(resettableWritableChunk.asResettableWritableBooleanChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableBooleanChunk<ATTR> takeWritableBooleanChunk(int capacity);
 
     void giveWritableBooleanChunk(@NotNull WritableBooleanChunk<?> writableBooleanChunk);
 
     <ATTR extends Any> ResettableBooleanChunk<ATTR> takeResettableBooleanChunk();
 
-    void giveResettableBooleanChunk(@NotNull ResettableBooleanChunk resettableBooleanChunk);
+    void giveResettableBooleanChunk(@NotNull ResettableBooleanChunk<?> resettableBooleanChunk);
 
     <ATTR extends Any> ResettableWritableBooleanChunk<ATTR> takeResettableWritableBooleanChunk();
 
-    void giveResettableWritableBooleanChunk(@NotNull ResettableWritableBooleanChunk resettableWritableBooleanChunk);
+    void giveResettableWritableBooleanChunk(@NotNull ResettableWritableBooleanChunk<?> resettableWritableBooleanChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkSoftPool.java
@@ -64,6 +64,41 @@ public final class BooleanChunkSoftPool implements BooleanChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableBooleanChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableBooleanChunk(writableChunk.asWritableBooleanChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableBooleanChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableBooleanChunk(resettableChunk.asResettableBooleanChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableBooleanChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableBooleanChunk(resettableWritableChunk.asResettableWritableBooleanChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableBooleanChunk<ATTR> takeWritableBooleanChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/BooleanChunkSoftPool.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkSoftPool and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of booleans.
+ */
+@SuppressWarnings("rawtypes")
+public final class BooleanChunkSoftPool implements BooleanChunkPool {
+
+    private final WritableBooleanChunk<Any> EMPTY = WritableBooleanChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_BOOLEAN_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableBooleanChunk}s.
+     */
+    private final SegmentedSoftPool<WritableBooleanChunk>[] writableBooleanChunks;
+
+    /**
+     * Sub-pool of {@link ResettableBooleanChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableBooleanChunk> resettableBooleanChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableBooleanChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableBooleanChunk> resettableWritableBooleanChunks;
+
+    BooleanChunkSoftPool() {
+        //noinspection unchecked
+        writableBooleanChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableBooleanChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableBooleanChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableBooleanChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableBooleanChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableBooleanChunk::makeResettableChunkForPool),
+                ResettableBooleanChunk::clear
+        );
+        resettableWritableBooleanChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableBooleanChunk::makeResettableChunkForPool),
+                ResettableWritableBooleanChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableBooleanChunk<ATTR> takeWritableBooleanChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableBooleanChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableBooleanChunk result = writableBooleanChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableBooleanChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableBooleanChunk(@NotNull final WritableBooleanChunk<?> writableBooleanChunk) {
+        if (writableBooleanChunk == EMPTY || writableBooleanChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableBooleanChunk);
+        final int capacity = writableBooleanChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableBooleanChunks[poolIndexForGive].give(writableBooleanChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableBooleanChunk<ATTR> takeResettableBooleanChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableBooleanChunks.take());
+    }
+
+    @Override
+    public void giveResettableBooleanChunk(@NotNull final ResettableBooleanChunk resettableBooleanChunk) {
+        resettableBooleanChunks.give(ChunkPoolReleaseTracking.onGive(resettableBooleanChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableBooleanChunk<ATTR> takeResettableWritableBooleanChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableBooleanChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableBooleanChunk(@NotNull final ResettableWritableBooleanChunk resettableWritableBooleanChunk) {
+        resettableWritableBooleanChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableBooleanChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkPool.java
@@ -16,48 +16,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface ByteChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableByteChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableByteChunk(writableChunk.asWritableByteChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableByteChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableByteChunk(resettableChunk.asResettableByteChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableByteChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableByteChunk(resettableWritableChunk.asResettableWritableByteChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableByteChunk<ATTR> takeWritableByteChunk(int capacity);
 
     void giveWritableByteChunk(@NotNull WritableByteChunk<?> writableByteChunk);
 
     <ATTR extends Any> ResettableByteChunk<ATTR> takeResettableByteChunk();
 
-    void giveResettableByteChunk(@NotNull ResettableByteChunk resettableByteChunk);
+    void giveResettableByteChunk(@NotNull ResettableByteChunk<?> resettableByteChunk);
 
     <ATTR extends Any> ResettableWritableByteChunk<ATTR> takeResettableWritableByteChunk();
 
-    void giveResettableWritableByteChunk(@NotNull ResettableWritableByteChunk resettableWritableByteChunk);
+    void giveResettableWritableByteChunk(@NotNull ResettableWritableByteChunk<?> resettableWritableByteChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkPool.java
@@ -1,6 +1,3 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkPool and regenerate
@@ -8,135 +5,59 @@
  */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableByteChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableByteChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableByteChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface ByteChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of bytes.
- */
-@SuppressWarnings("rawtypes")
-public final class ByteChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableByteChunk(capacity);
+            }
 
-    private final WritableByteChunk<Any> EMPTY = WritableByteChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_BYTE_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableByteChunk(writableChunk.asWritableByteChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableByteChunk}s.
-     */
-    private final SegmentedSoftPool<WritableByteChunk>[] writableByteChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableByteChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableByteChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableByteChunk> resettableByteChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableByteChunk(resettableChunk.asResettableByteChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableByteChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableByteChunk> resettableWritableByteChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableByteChunk();
+            }
 
-    ByteChunkPool() {
-        //noinspection unchecked
-        writableByteChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableByteChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableByteChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableByteChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableByteChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableByteChunk::makeResettableChunkForPool),
-                ResettableByteChunk::clear
-        );
-        resettableWritableByteChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableByteChunk::makeResettableChunkForPool),
-                ResettableWritableByteChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableByteChunk(resettableWritableChunk.asResettableWritableByteChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableByteChunk<ATTR> takeWritableByteChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableByteChunk(capacity);
-    }
+    void giveWritableByteChunk(@NotNull WritableByteChunk<?> writableByteChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableByteChunk(writableChunk.asWritableByteChunk());
-    }
+    <ATTR extends Any> ResettableByteChunk<ATTR> takeResettableByteChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableByteChunk();
-    }
+    void giveResettableByteChunk(@NotNull ResettableByteChunk resettableByteChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableByteChunk(resettableChunk.asResettableByteChunk());
-    }
+    <ATTR extends Any> ResettableWritableByteChunk<ATTR> takeResettableWritableByteChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableByteChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableByteChunk(resettableWritableChunk.asResettableWritableByteChunk());
-    }
-
-    public <ATTR extends Any> WritableByteChunk<ATTR> takeWritableByteChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableByteChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableByteChunk result = writableByteChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableByteChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableByteChunk(@NotNull final WritableByteChunk<?> writableByteChunk) {
-        if (writableByteChunk == EMPTY || writableByteChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableByteChunk);
-        final int capacity = writableByteChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableByteChunks[poolIndexForGive].give(writableByteChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableByteChunk<ATTR> takeResettableByteChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableByteChunks.take());
-    }
-
-    public void giveResettableByteChunk(@NotNull final ResettableByteChunk resettableByteChunk) {
-        resettableByteChunks.give(ChunkPoolReleaseTracking.onGive(resettableByteChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableByteChunk<ATTR> takeResettableWritableByteChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableByteChunks.take());
-    }
-
-    public void giveResettableWritableByteChunk(@NotNull final ResettableWritableByteChunk resettableWritableByteChunk) {
-        resettableWritableByteChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableByteChunk));
-    }
+    void giveResettableWritableByteChunk(@NotNull ResettableWritableByteChunk resettableWritableByteChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkSoftPool.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkSoftPool and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of bytes.
+ */
+@SuppressWarnings("rawtypes")
+public final class ByteChunkSoftPool implements ByteChunkPool {
+
+    private final WritableByteChunk<Any> EMPTY = WritableByteChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_BYTE_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableByteChunk}s.
+     */
+    private final SegmentedSoftPool<WritableByteChunk>[] writableByteChunks;
+
+    /**
+     * Sub-pool of {@link ResettableByteChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableByteChunk> resettableByteChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableByteChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableByteChunk> resettableWritableByteChunks;
+
+    ByteChunkSoftPool() {
+        //noinspection unchecked
+        writableByteChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableByteChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableByteChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableByteChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableByteChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableByteChunk::makeResettableChunkForPool),
+                ResettableByteChunk::clear
+        );
+        resettableWritableByteChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableByteChunk::makeResettableChunkForPool),
+                ResettableWritableByteChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableByteChunk<ATTR> takeWritableByteChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableByteChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableByteChunk result = writableByteChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableByteChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableByteChunk(@NotNull final WritableByteChunk<?> writableByteChunk) {
+        if (writableByteChunk == EMPTY || writableByteChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableByteChunk);
+        final int capacity = writableByteChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableByteChunks[poolIndexForGive].give(writableByteChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableByteChunk<ATTR> takeResettableByteChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableByteChunks.take());
+    }
+
+    @Override
+    public void giveResettableByteChunk(@NotNull final ResettableByteChunk resettableByteChunk) {
+        resettableByteChunks.give(ChunkPoolReleaseTracking.onGive(resettableByteChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableByteChunk<ATTR> takeResettableWritableByteChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableByteChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableByteChunk(@NotNull final ResettableWritableByteChunk resettableWritableByteChunk) {
+        resettableWritableByteChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableByteChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ByteChunkSoftPool.java
@@ -64,6 +64,41 @@ public final class ByteChunkSoftPool implements ByteChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableByteChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableByteChunk(writableChunk.asWritableByteChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableByteChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableByteChunk(resettableChunk.asResettableByteChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableByteChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableByteChunk(resettableWritableChunk.asResettableWritableByteChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableByteChunk<ATTR> takeWritableByteChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkPool.java
@@ -11,48 +11,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface CharChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableCharChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableCharChunk(writableChunk.asWritableCharChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableCharChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableCharChunk(resettableChunk.asResettableCharChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableCharChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableCharChunk(resettableWritableChunk.asResettableWritableCharChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableCharChunk<ATTR> takeWritableCharChunk(int capacity);
 
     void giveWritableCharChunk(@NotNull WritableCharChunk<?> writableCharChunk);
 
     <ATTR extends Any> ResettableCharChunk<ATTR> takeResettableCharChunk();
 
-    void giveResettableCharChunk(@NotNull ResettableCharChunk resettableCharChunk);
+    void giveResettableCharChunk(@NotNull ResettableCharChunk<?> resettableCharChunk);
 
     <ATTR extends Any> ResettableWritableCharChunk<ATTR> takeResettableWritableCharChunk();
 
-    void giveResettableWritableCharChunk(@NotNull ResettableWritableCharChunk resettableWritableCharChunk);
+    void giveResettableWritableCharChunk(@NotNull ResettableWritableCharChunk<?> resettableWritableCharChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkPool.java
@@ -1,137 +1,58 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableCharChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableCharChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableCharChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface CharChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of chars.
- */
-@SuppressWarnings("rawtypes")
-public final class CharChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableCharChunk(capacity);
+            }
 
-    private final WritableCharChunk<Any> EMPTY = WritableCharChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_CHAR_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableCharChunk(writableChunk.asWritableCharChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableCharChunk}s.
-     */
-    private final SegmentedSoftPool<WritableCharChunk>[] writableCharChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableCharChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableCharChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableCharChunk> resettableCharChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableCharChunk(resettableChunk.asResettableCharChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableCharChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableCharChunk> resettableWritableCharChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableCharChunk();
+            }
 
-    CharChunkPool() {
-        //noinspection unchecked
-        writableCharChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableCharChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableCharChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableCharChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableCharChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableCharChunk::makeResettableChunkForPool),
-                ResettableCharChunk::clear
-        );
-        resettableWritableCharChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableCharChunk::makeResettableChunkForPool),
-                ResettableWritableCharChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableCharChunk(resettableWritableChunk.asResettableWritableCharChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableCharChunk<ATTR> takeWritableCharChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableCharChunk(capacity);
-    }
+    void giveWritableCharChunk(@NotNull WritableCharChunk<?> writableCharChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableCharChunk(writableChunk.asWritableCharChunk());
-    }
+    <ATTR extends Any> ResettableCharChunk<ATTR> takeResettableCharChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableCharChunk();
-    }
+    void giveResettableCharChunk(@NotNull ResettableCharChunk resettableCharChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableCharChunk(resettableChunk.asResettableCharChunk());
-    }
+    <ATTR extends Any> ResettableWritableCharChunk<ATTR> takeResettableWritableCharChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableCharChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableCharChunk(resettableWritableChunk.asResettableWritableCharChunk());
-    }
-
-    public <ATTR extends Any> WritableCharChunk<ATTR> takeWritableCharChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableCharChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableCharChunk result = writableCharChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableCharChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableCharChunk(@NotNull final WritableCharChunk<?> writableCharChunk) {
-        if (writableCharChunk == EMPTY || writableCharChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableCharChunk);
-        final int capacity = writableCharChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableCharChunks[poolIndexForGive].give(writableCharChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableCharChunk<ATTR> takeResettableCharChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableCharChunks.take());
-    }
-
-    public void giveResettableCharChunk(@NotNull final ResettableCharChunk resettableCharChunk) {
-        resettableCharChunks.give(ChunkPoolReleaseTracking.onGive(resettableCharChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableCharChunk<ATTR> takeResettableWritableCharChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableCharChunks.take());
-    }
-
-    public void giveResettableWritableCharChunk(@NotNull final ResettableWritableCharChunk resettableWritableCharChunk) {
-        resettableWritableCharChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableCharChunk));
-    }
+    void giveResettableWritableCharChunk(@NotNull ResettableWritableCharChunk resettableWritableCharChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkSoftPool.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of chars.
+ */
+@SuppressWarnings("rawtypes")
+public final class CharChunkSoftPool implements CharChunkPool {
+
+    private final WritableCharChunk<Any> EMPTY = WritableCharChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_CHAR_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableCharChunk}s.
+     */
+    private final SegmentedSoftPool<WritableCharChunk>[] writableCharChunks;
+
+    /**
+     * Sub-pool of {@link ResettableCharChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableCharChunk> resettableCharChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableCharChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableCharChunk> resettableWritableCharChunks;
+
+    CharChunkSoftPool() {
+        //noinspection unchecked
+        writableCharChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableCharChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableCharChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableCharChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableCharChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableCharChunk::makeResettableChunkForPool),
+                ResettableCharChunk::clear
+        );
+        resettableWritableCharChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableCharChunk::makeResettableChunkForPool),
+                ResettableWritableCharChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableCharChunk<ATTR> takeWritableCharChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableCharChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableCharChunk result = writableCharChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableCharChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableCharChunk(@NotNull final WritableCharChunk<?> writableCharChunk) {
+        if (writableCharChunk == EMPTY || writableCharChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableCharChunk);
+        final int capacity = writableCharChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableCharChunks[poolIndexForGive].give(writableCharChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableCharChunk<ATTR> takeResettableCharChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableCharChunks.take());
+    }
+
+    @Override
+    public void giveResettableCharChunk(@NotNull final ResettableCharChunk resettableCharChunk) {
+        resettableCharChunks.give(ChunkPoolReleaseTracking.onGive(resettableCharChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableCharChunk<ATTR> takeResettableWritableCharChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableCharChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableCharChunk(@NotNull final ResettableWritableCharChunk resettableWritableCharChunk) {
+        resettableWritableCharChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableCharChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkSoftPool.java
@@ -59,6 +59,41 @@ public final class CharChunkSoftPool implements CharChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableCharChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableCharChunk(writableChunk.asWritableCharChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableCharChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableCharChunk(resettableChunk.asResettableCharChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableCharChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableCharChunk(resettableWritableChunk.asResettableWritableCharChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableCharChunk<ATTR> takeWritableCharChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkPool.java
@@ -16,48 +16,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface DoubleChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableDoubleChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableDoubleChunk(writableChunk.asWritableDoubleChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableDoubleChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableDoubleChunk(resettableChunk.asResettableDoubleChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableDoubleChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableDoubleChunk(resettableWritableChunk.asResettableWritableDoubleChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableDoubleChunk<ATTR> takeWritableDoubleChunk(int capacity);
 
     void giveWritableDoubleChunk(@NotNull WritableDoubleChunk<?> writableDoubleChunk);
 
     <ATTR extends Any> ResettableDoubleChunk<ATTR> takeResettableDoubleChunk();
 
-    void giveResettableDoubleChunk(@NotNull ResettableDoubleChunk resettableDoubleChunk);
+    void giveResettableDoubleChunk(@NotNull ResettableDoubleChunk<?> resettableDoubleChunk);
 
     <ATTR extends Any> ResettableWritableDoubleChunk<ATTR> takeResettableWritableDoubleChunk();
 
-    void giveResettableWritableDoubleChunk(@NotNull ResettableWritableDoubleChunk resettableWritableDoubleChunk);
+    void giveResettableWritableDoubleChunk(@NotNull ResettableWritableDoubleChunk<?> resettableWritableDoubleChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkPool.java
@@ -1,6 +1,3 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkPool and regenerate
@@ -8,135 +5,59 @@
  */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableDoubleChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableDoubleChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableDoubleChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface DoubleChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of doubles.
- */
-@SuppressWarnings("rawtypes")
-public final class DoubleChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableDoubleChunk(capacity);
+            }
 
-    private final WritableDoubleChunk<Any> EMPTY = WritableDoubleChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_DOUBLE_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableDoubleChunk(writableChunk.asWritableDoubleChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableDoubleChunk}s.
-     */
-    private final SegmentedSoftPool<WritableDoubleChunk>[] writableDoubleChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableDoubleChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableDoubleChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableDoubleChunk> resettableDoubleChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableDoubleChunk(resettableChunk.asResettableDoubleChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableDoubleChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableDoubleChunk> resettableWritableDoubleChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableDoubleChunk();
+            }
 
-    DoubleChunkPool() {
-        //noinspection unchecked
-        writableDoubleChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableDoubleChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableDoubleChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableDoubleChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableDoubleChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableDoubleChunk::makeResettableChunkForPool),
-                ResettableDoubleChunk::clear
-        );
-        resettableWritableDoubleChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableDoubleChunk::makeResettableChunkForPool),
-                ResettableWritableDoubleChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableDoubleChunk(resettableWritableChunk.asResettableWritableDoubleChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableDoubleChunk<ATTR> takeWritableDoubleChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableDoubleChunk(capacity);
-    }
+    void giveWritableDoubleChunk(@NotNull WritableDoubleChunk<?> writableDoubleChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableDoubleChunk(writableChunk.asWritableDoubleChunk());
-    }
+    <ATTR extends Any> ResettableDoubleChunk<ATTR> takeResettableDoubleChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableDoubleChunk();
-    }
+    void giveResettableDoubleChunk(@NotNull ResettableDoubleChunk resettableDoubleChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableDoubleChunk(resettableChunk.asResettableDoubleChunk());
-    }
+    <ATTR extends Any> ResettableWritableDoubleChunk<ATTR> takeResettableWritableDoubleChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableDoubleChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableDoubleChunk(resettableWritableChunk.asResettableWritableDoubleChunk());
-    }
-
-    public <ATTR extends Any> WritableDoubleChunk<ATTR> takeWritableDoubleChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableDoubleChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableDoubleChunk result = writableDoubleChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableDoubleChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableDoubleChunk(@NotNull final WritableDoubleChunk<?> writableDoubleChunk) {
-        if (writableDoubleChunk == EMPTY || writableDoubleChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableDoubleChunk);
-        final int capacity = writableDoubleChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableDoubleChunks[poolIndexForGive].give(writableDoubleChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableDoubleChunk<ATTR> takeResettableDoubleChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableDoubleChunks.take());
-    }
-
-    public void giveResettableDoubleChunk(@NotNull final ResettableDoubleChunk resettableDoubleChunk) {
-        resettableDoubleChunks.give(ChunkPoolReleaseTracking.onGive(resettableDoubleChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableDoubleChunk<ATTR> takeResettableWritableDoubleChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableDoubleChunks.take());
-    }
-
-    public void giveResettableWritableDoubleChunk(@NotNull final ResettableWritableDoubleChunk resettableWritableDoubleChunk) {
-        resettableWritableDoubleChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableDoubleChunk));
-    }
+    void giveResettableWritableDoubleChunk(@NotNull ResettableWritableDoubleChunk resettableWritableDoubleChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkSoftPool.java
@@ -64,6 +64,41 @@ public final class DoubleChunkSoftPool implements DoubleChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableDoubleChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableDoubleChunk(writableChunk.asWritableDoubleChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableDoubleChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableDoubleChunk(resettableChunk.asResettableDoubleChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableDoubleChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableDoubleChunk(resettableWritableChunk.asResettableWritableDoubleChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableDoubleChunk<ATTR> takeWritableDoubleChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/DoubleChunkSoftPool.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkSoftPool and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of doubles.
+ */
+@SuppressWarnings("rawtypes")
+public final class DoubleChunkSoftPool implements DoubleChunkPool {
+
+    private final WritableDoubleChunk<Any> EMPTY = WritableDoubleChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_DOUBLE_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableDoubleChunk}s.
+     */
+    private final SegmentedSoftPool<WritableDoubleChunk>[] writableDoubleChunks;
+
+    /**
+     * Sub-pool of {@link ResettableDoubleChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableDoubleChunk> resettableDoubleChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableDoubleChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableDoubleChunk> resettableWritableDoubleChunks;
+
+    DoubleChunkSoftPool() {
+        //noinspection unchecked
+        writableDoubleChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableDoubleChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableDoubleChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableDoubleChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableDoubleChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableDoubleChunk::makeResettableChunkForPool),
+                ResettableDoubleChunk::clear
+        );
+        resettableWritableDoubleChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableDoubleChunk::makeResettableChunkForPool),
+                ResettableWritableDoubleChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableDoubleChunk<ATTR> takeWritableDoubleChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableDoubleChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableDoubleChunk result = writableDoubleChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableDoubleChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableDoubleChunk(@NotNull final WritableDoubleChunk<?> writableDoubleChunk) {
+        if (writableDoubleChunk == EMPTY || writableDoubleChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableDoubleChunk);
+        final int capacity = writableDoubleChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableDoubleChunks[poolIndexForGive].give(writableDoubleChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableDoubleChunk<ATTR> takeResettableDoubleChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableDoubleChunks.take());
+    }
+
+    @Override
+    public void giveResettableDoubleChunk(@NotNull final ResettableDoubleChunk resettableDoubleChunk) {
+        resettableDoubleChunks.give(ChunkPoolReleaseTracking.onGive(resettableDoubleChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableDoubleChunk<ATTR> takeResettableWritableDoubleChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableDoubleChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableDoubleChunk(@NotNull final ResettableWritableDoubleChunk resettableWritableDoubleChunk) {
+        resettableWritableDoubleChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableDoubleChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkPool.java
@@ -16,48 +16,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface FloatChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableFloatChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableFloatChunk(writableChunk.asWritableFloatChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableFloatChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableFloatChunk(resettableChunk.asResettableFloatChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableFloatChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableFloatChunk(resettableWritableChunk.asResettableWritableFloatChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableFloatChunk<ATTR> takeWritableFloatChunk(int capacity);
 
     void giveWritableFloatChunk(@NotNull WritableFloatChunk<?> writableFloatChunk);
 
     <ATTR extends Any> ResettableFloatChunk<ATTR> takeResettableFloatChunk();
 
-    void giveResettableFloatChunk(@NotNull ResettableFloatChunk resettableFloatChunk);
+    void giveResettableFloatChunk(@NotNull ResettableFloatChunk<?> resettableFloatChunk);
 
     <ATTR extends Any> ResettableWritableFloatChunk<ATTR> takeResettableWritableFloatChunk();
 
-    void giveResettableWritableFloatChunk(@NotNull ResettableWritableFloatChunk resettableWritableFloatChunk);
+    void giveResettableWritableFloatChunk(@NotNull ResettableWritableFloatChunk<?> resettableWritableFloatChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkPool.java
@@ -1,6 +1,3 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkPool and regenerate
@@ -8,135 +5,59 @@
  */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableFloatChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableFloatChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableFloatChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface FloatChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of floats.
- */
-@SuppressWarnings("rawtypes")
-public final class FloatChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableFloatChunk(capacity);
+            }
 
-    private final WritableFloatChunk<Any> EMPTY = WritableFloatChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_FLOAT_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableFloatChunk(writableChunk.asWritableFloatChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableFloatChunk}s.
-     */
-    private final SegmentedSoftPool<WritableFloatChunk>[] writableFloatChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableFloatChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableFloatChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableFloatChunk> resettableFloatChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableFloatChunk(resettableChunk.asResettableFloatChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableFloatChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableFloatChunk> resettableWritableFloatChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableFloatChunk();
+            }
 
-    FloatChunkPool() {
-        //noinspection unchecked
-        writableFloatChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableFloatChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableFloatChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableFloatChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableFloatChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableFloatChunk::makeResettableChunkForPool),
-                ResettableFloatChunk::clear
-        );
-        resettableWritableFloatChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableFloatChunk::makeResettableChunkForPool),
-                ResettableWritableFloatChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableFloatChunk(resettableWritableChunk.asResettableWritableFloatChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableFloatChunk<ATTR> takeWritableFloatChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableFloatChunk(capacity);
-    }
+    void giveWritableFloatChunk(@NotNull WritableFloatChunk<?> writableFloatChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableFloatChunk(writableChunk.asWritableFloatChunk());
-    }
+    <ATTR extends Any> ResettableFloatChunk<ATTR> takeResettableFloatChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableFloatChunk();
-    }
+    void giveResettableFloatChunk(@NotNull ResettableFloatChunk resettableFloatChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableFloatChunk(resettableChunk.asResettableFloatChunk());
-    }
+    <ATTR extends Any> ResettableWritableFloatChunk<ATTR> takeResettableWritableFloatChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableFloatChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableFloatChunk(resettableWritableChunk.asResettableWritableFloatChunk());
-    }
-
-    public <ATTR extends Any> WritableFloatChunk<ATTR> takeWritableFloatChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableFloatChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableFloatChunk result = writableFloatChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableFloatChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableFloatChunk(@NotNull final WritableFloatChunk<?> writableFloatChunk) {
-        if (writableFloatChunk == EMPTY || writableFloatChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableFloatChunk);
-        final int capacity = writableFloatChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableFloatChunks[poolIndexForGive].give(writableFloatChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableFloatChunk<ATTR> takeResettableFloatChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableFloatChunks.take());
-    }
-
-    public void giveResettableFloatChunk(@NotNull final ResettableFloatChunk resettableFloatChunk) {
-        resettableFloatChunks.give(ChunkPoolReleaseTracking.onGive(resettableFloatChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableFloatChunk<ATTR> takeResettableWritableFloatChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableFloatChunks.take());
-    }
-
-    public void giveResettableWritableFloatChunk(@NotNull final ResettableWritableFloatChunk resettableWritableFloatChunk) {
-        resettableWritableFloatChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableFloatChunk));
-    }
+    void giveResettableWritableFloatChunk(@NotNull ResettableWritableFloatChunk resettableWritableFloatChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkSoftPool.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkSoftPool and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of floats.
+ */
+@SuppressWarnings("rawtypes")
+public final class FloatChunkSoftPool implements FloatChunkPool {
+
+    private final WritableFloatChunk<Any> EMPTY = WritableFloatChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_FLOAT_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableFloatChunk}s.
+     */
+    private final SegmentedSoftPool<WritableFloatChunk>[] writableFloatChunks;
+
+    /**
+     * Sub-pool of {@link ResettableFloatChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableFloatChunk> resettableFloatChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableFloatChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableFloatChunk> resettableWritableFloatChunks;
+
+    FloatChunkSoftPool() {
+        //noinspection unchecked
+        writableFloatChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableFloatChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableFloatChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableFloatChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableFloatChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableFloatChunk::makeResettableChunkForPool),
+                ResettableFloatChunk::clear
+        );
+        resettableWritableFloatChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableFloatChunk::makeResettableChunkForPool),
+                ResettableWritableFloatChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableFloatChunk<ATTR> takeWritableFloatChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableFloatChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableFloatChunk result = writableFloatChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableFloatChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableFloatChunk(@NotNull final WritableFloatChunk<?> writableFloatChunk) {
+        if (writableFloatChunk == EMPTY || writableFloatChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableFloatChunk);
+        final int capacity = writableFloatChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableFloatChunks[poolIndexForGive].give(writableFloatChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableFloatChunk<ATTR> takeResettableFloatChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableFloatChunks.take());
+    }
+
+    @Override
+    public void giveResettableFloatChunk(@NotNull final ResettableFloatChunk resettableFloatChunk) {
+        resettableFloatChunks.give(ChunkPoolReleaseTracking.onGive(resettableFloatChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableFloatChunk<ATTR> takeResettableWritableFloatChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableFloatChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableFloatChunk(@NotNull final ResettableWritableFloatChunk resettableWritableFloatChunk) {
+        resettableWritableFloatChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableFloatChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/FloatChunkSoftPool.java
@@ -64,6 +64,41 @@ public final class FloatChunkSoftPool implements FloatChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableFloatChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableFloatChunk(writableChunk.asWritableFloatChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableFloatChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableFloatChunk(resettableChunk.asResettableFloatChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableFloatChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableFloatChunk(resettableWritableChunk.asResettableWritableFloatChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableFloatChunk<ATTR> takeWritableFloatChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkPool.java
@@ -1,6 +1,3 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkPool and regenerate
@@ -8,135 +5,59 @@
  */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableIntChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableIntChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface IntChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of ints.
- */
-@SuppressWarnings("rawtypes")
-public final class IntChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableIntChunk(capacity);
+            }
 
-    private final WritableIntChunk<Any> EMPTY = WritableIntChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_INT_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableIntChunk(writableChunk.asWritableIntChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableIntChunk}s.
-     */
-    private final SegmentedSoftPool<WritableIntChunk>[] writableIntChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableIntChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableIntChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableIntChunk> resettableIntChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableIntChunk(resettableChunk.asResettableIntChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableIntChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableIntChunk> resettableWritableIntChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableIntChunk();
+            }
 
-    IntChunkPool() {
-        //noinspection unchecked
-        writableIntChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableIntChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableIntChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableIntChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableIntChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableIntChunk::makeResettableChunkForPool),
-                ResettableIntChunk::clear
-        );
-        resettableWritableIntChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableIntChunk::makeResettableChunkForPool),
-                ResettableWritableIntChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableIntChunk(resettableWritableChunk.asResettableWritableIntChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableIntChunk<ATTR> takeWritableIntChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableIntChunk(capacity);
-    }
+    void giveWritableIntChunk(@NotNull WritableIntChunk<?> writableIntChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableIntChunk(writableChunk.asWritableIntChunk());
-    }
+    <ATTR extends Any> ResettableIntChunk<ATTR> takeResettableIntChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableIntChunk();
-    }
+    void giveResettableIntChunk(@NotNull ResettableIntChunk resettableIntChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableIntChunk(resettableChunk.asResettableIntChunk());
-    }
+    <ATTR extends Any> ResettableWritableIntChunk<ATTR> takeResettableWritableIntChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableIntChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableIntChunk(resettableWritableChunk.asResettableWritableIntChunk());
-    }
-
-    public <ATTR extends Any> WritableIntChunk<ATTR> takeWritableIntChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableIntChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableIntChunk result = writableIntChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableIntChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableIntChunk(@NotNull final WritableIntChunk<?> writableIntChunk) {
-        if (writableIntChunk == EMPTY || writableIntChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableIntChunk);
-        final int capacity = writableIntChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableIntChunks[poolIndexForGive].give(writableIntChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableIntChunk<ATTR> takeResettableIntChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableIntChunks.take());
-    }
-
-    public void giveResettableIntChunk(@NotNull final ResettableIntChunk resettableIntChunk) {
-        resettableIntChunks.give(ChunkPoolReleaseTracking.onGive(resettableIntChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableIntChunk<ATTR> takeResettableWritableIntChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableIntChunks.take());
-    }
-
-    public void giveResettableWritableIntChunk(@NotNull final ResettableWritableIntChunk resettableWritableIntChunk) {
-        resettableWritableIntChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableIntChunk));
-    }
+    void giveResettableWritableIntChunk(@NotNull ResettableWritableIntChunk resettableWritableIntChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkPool.java
@@ -16,48 +16,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface IntChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableIntChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableIntChunk(writableChunk.asWritableIntChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableIntChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableIntChunk(resettableChunk.asResettableIntChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableIntChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableIntChunk(resettableWritableChunk.asResettableWritableIntChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableIntChunk<ATTR> takeWritableIntChunk(int capacity);
 
     void giveWritableIntChunk(@NotNull WritableIntChunk<?> writableIntChunk);
 
     <ATTR extends Any> ResettableIntChunk<ATTR> takeResettableIntChunk();
 
-    void giveResettableIntChunk(@NotNull ResettableIntChunk resettableIntChunk);
+    void giveResettableIntChunk(@NotNull ResettableIntChunk<?> resettableIntChunk);
 
     <ATTR extends Any> ResettableWritableIntChunk<ATTR> takeResettableWritableIntChunk();
 
-    void giveResettableWritableIntChunk(@NotNull ResettableWritableIntChunk resettableWritableIntChunk);
+    void giveResettableWritableIntChunk(@NotNull ResettableWritableIntChunk<?> resettableWritableIntChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkSoftPool.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkSoftPool and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of ints.
+ */
+@SuppressWarnings("rawtypes")
+public final class IntChunkSoftPool implements IntChunkPool {
+
+    private final WritableIntChunk<Any> EMPTY = WritableIntChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_INT_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableIntChunk}s.
+     */
+    private final SegmentedSoftPool<WritableIntChunk>[] writableIntChunks;
+
+    /**
+     * Sub-pool of {@link ResettableIntChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableIntChunk> resettableIntChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableIntChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableIntChunk> resettableWritableIntChunks;
+
+    IntChunkSoftPool() {
+        //noinspection unchecked
+        writableIntChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableIntChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableIntChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableIntChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableIntChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableIntChunk::makeResettableChunkForPool),
+                ResettableIntChunk::clear
+        );
+        resettableWritableIntChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableIntChunk::makeResettableChunkForPool),
+                ResettableWritableIntChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableIntChunk<ATTR> takeWritableIntChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableIntChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableIntChunk result = writableIntChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableIntChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableIntChunk(@NotNull final WritableIntChunk<?> writableIntChunk) {
+        if (writableIntChunk == EMPTY || writableIntChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableIntChunk);
+        final int capacity = writableIntChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableIntChunks[poolIndexForGive].give(writableIntChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableIntChunk<ATTR> takeResettableIntChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableIntChunks.take());
+    }
+
+    @Override
+    public void giveResettableIntChunk(@NotNull final ResettableIntChunk resettableIntChunk) {
+        resettableIntChunks.give(ChunkPoolReleaseTracking.onGive(resettableIntChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableIntChunk<ATTR> takeResettableWritableIntChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableIntChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableIntChunk(@NotNull final ResettableWritableIntChunk resettableWritableIntChunk) {
+        resettableWritableIntChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableIntChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/IntChunkSoftPool.java
@@ -64,6 +64,41 @@ public final class IntChunkSoftPool implements IntChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableIntChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableIntChunk(writableChunk.asWritableIntChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableIntChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableIntChunk(resettableChunk.asResettableIntChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableIntChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableIntChunk(resettableWritableChunk.asResettableWritableIntChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableIntChunk<ATTR> takeWritableIntChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkPool.java
@@ -16,48 +16,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface LongChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableLongChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableLongChunk(writableChunk.asWritableLongChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableLongChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableLongChunk(resettableChunk.asResettableLongChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableLongChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableLongChunk(resettableWritableChunk.asResettableWritableLongChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableLongChunk<ATTR> takeWritableLongChunk(int capacity);
 
     void giveWritableLongChunk(@NotNull WritableLongChunk<?> writableLongChunk);
 
     <ATTR extends Any> ResettableLongChunk<ATTR> takeResettableLongChunk();
 
-    void giveResettableLongChunk(@NotNull ResettableLongChunk resettableLongChunk);
+    void giveResettableLongChunk(@NotNull ResettableLongChunk<?> resettableLongChunk);
 
     <ATTR extends Any> ResettableWritableLongChunk<ATTR> takeResettableWritableLongChunk();
 
-    void giveResettableWritableLongChunk(@NotNull ResettableWritableLongChunk resettableWritableLongChunk);
+    void giveResettableWritableLongChunk(@NotNull ResettableWritableLongChunk<?> resettableWritableLongChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkPool.java
@@ -1,6 +1,3 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkPool and regenerate
@@ -8,135 +5,59 @@
  */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableLongChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableLongChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface LongChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of longs.
- */
-@SuppressWarnings("rawtypes")
-public final class LongChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableLongChunk(capacity);
+            }
 
-    private final WritableLongChunk<Any> EMPTY = WritableLongChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_LONG_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableLongChunk(writableChunk.asWritableLongChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableLongChunk}s.
-     */
-    private final SegmentedSoftPool<WritableLongChunk>[] writableLongChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableLongChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableLongChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableLongChunk> resettableLongChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableLongChunk(resettableChunk.asResettableLongChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableLongChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableLongChunk> resettableWritableLongChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableLongChunk();
+            }
 
-    LongChunkPool() {
-        //noinspection unchecked
-        writableLongChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableLongChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableLongChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableLongChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableLongChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableLongChunk::makeResettableChunkForPool),
-                ResettableLongChunk::clear
-        );
-        resettableWritableLongChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableLongChunk::makeResettableChunkForPool),
-                ResettableWritableLongChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableLongChunk(resettableWritableChunk.asResettableWritableLongChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableLongChunk<ATTR> takeWritableLongChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableLongChunk(capacity);
-    }
+    void giveWritableLongChunk(@NotNull WritableLongChunk<?> writableLongChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableLongChunk(writableChunk.asWritableLongChunk());
-    }
+    <ATTR extends Any> ResettableLongChunk<ATTR> takeResettableLongChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableLongChunk();
-    }
+    void giveResettableLongChunk(@NotNull ResettableLongChunk resettableLongChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableLongChunk(resettableChunk.asResettableLongChunk());
-    }
+    <ATTR extends Any> ResettableWritableLongChunk<ATTR> takeResettableWritableLongChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableLongChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableLongChunk(resettableWritableChunk.asResettableWritableLongChunk());
-    }
-
-    public <ATTR extends Any> WritableLongChunk<ATTR> takeWritableLongChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableLongChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableLongChunk result = writableLongChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableLongChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableLongChunk(@NotNull final WritableLongChunk<?> writableLongChunk) {
-        if (writableLongChunk == EMPTY || writableLongChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableLongChunk);
-        final int capacity = writableLongChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableLongChunks[poolIndexForGive].give(writableLongChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableLongChunk<ATTR> takeResettableLongChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableLongChunks.take());
-    }
-
-    public void giveResettableLongChunk(@NotNull final ResettableLongChunk resettableLongChunk) {
-        resettableLongChunks.give(ChunkPoolReleaseTracking.onGive(resettableLongChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableLongChunk<ATTR> takeResettableWritableLongChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableLongChunks.take());
-    }
-
-    public void giveResettableWritableLongChunk(@NotNull final ResettableWritableLongChunk resettableWritableLongChunk) {
-        resettableWritableLongChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableLongChunk));
-    }
+    void giveResettableWritableLongChunk(@NotNull ResettableWritableLongChunk resettableWritableLongChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkSoftPool.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkSoftPool and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of longs.
+ */
+@SuppressWarnings("rawtypes")
+public final class LongChunkSoftPool implements LongChunkPool {
+
+    private final WritableLongChunk<Any> EMPTY = WritableLongChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_LONG_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableLongChunk}s.
+     */
+    private final SegmentedSoftPool<WritableLongChunk>[] writableLongChunks;
+
+    /**
+     * Sub-pool of {@link ResettableLongChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableLongChunk> resettableLongChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableLongChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableLongChunk> resettableWritableLongChunks;
+
+    LongChunkSoftPool() {
+        //noinspection unchecked
+        writableLongChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableLongChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableLongChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableLongChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableLongChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableLongChunk::makeResettableChunkForPool),
+                ResettableLongChunk::clear
+        );
+        resettableWritableLongChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableLongChunk::makeResettableChunkForPool),
+                ResettableWritableLongChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableLongChunk<ATTR> takeWritableLongChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableLongChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableLongChunk result = writableLongChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableLongChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableLongChunk(@NotNull final WritableLongChunk<?> writableLongChunk) {
+        if (writableLongChunk == EMPTY || writableLongChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableLongChunk);
+        final int capacity = writableLongChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableLongChunks[poolIndexForGive].give(writableLongChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableLongChunk<ATTR> takeResettableLongChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableLongChunks.take());
+    }
+
+    @Override
+    public void giveResettableLongChunk(@NotNull final ResettableLongChunk resettableLongChunk) {
+        resettableLongChunks.give(ChunkPoolReleaseTracking.onGive(resettableLongChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableLongChunk<ATTR> takeResettableWritableLongChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableLongChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableLongChunk(@NotNull final ResettableWritableLongChunk resettableWritableLongChunk) {
+        resettableWritableLongChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableLongChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/LongChunkSoftPool.java
@@ -64,6 +64,41 @@ public final class LongChunkSoftPool implements LongChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableLongChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableLongChunk(writableChunk.asWritableLongChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableLongChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableLongChunk(resettableChunk.asResettableLongChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableLongChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableLongChunk(resettableWritableChunk.asResettableWritableLongChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableLongChunk<ATTR> takeWritableLongChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/MultiChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/MultiChunkPool.java
@@ -4,6 +4,34 @@
 package io.deephaven.chunk.util.pools;
 
 import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.ResettableBooleanChunk;
+import io.deephaven.chunk.ResettableByteChunk;
+import io.deephaven.chunk.ResettableCharChunk;
+import io.deephaven.chunk.ResettableDoubleChunk;
+import io.deephaven.chunk.ResettableFloatChunk;
+import io.deephaven.chunk.ResettableIntChunk;
+import io.deephaven.chunk.ResettableLongChunk;
+import io.deephaven.chunk.ResettableObjectChunk;
+import io.deephaven.chunk.ResettableShortChunk;
+import io.deephaven.chunk.ResettableWritableBooleanChunk;
+import io.deephaven.chunk.ResettableWritableByteChunk;
+import io.deephaven.chunk.ResettableWritableCharChunk;
+import io.deephaven.chunk.ResettableWritableDoubleChunk;
+import io.deephaven.chunk.ResettableWritableFloatChunk;
+import io.deephaven.chunk.ResettableWritableIntChunk;
+import io.deephaven.chunk.ResettableWritableLongChunk;
+import io.deephaven.chunk.ResettableWritableObjectChunk;
+import io.deephaven.chunk.ResettableWritableShortChunk;
+import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.WritableByteChunk;
+import io.deephaven.chunk.WritableCharChunk;
+import io.deephaven.chunk.WritableDoubleChunk;
+import io.deephaven.chunk.WritableFloatChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.WritableObjectChunk;
+import io.deephaven.chunk.WritableShortChunk;
+import io.deephaven.chunk.attributes.Any;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -18,7 +46,8 @@ import java.util.function.Supplier;
  * This type isn't compatible with GWT, and needs to be replaced with a different class that doesn't use the soft pool
  * instances.
  */
-public final class MultiChunkPool {
+public final class MultiChunkPool implements BooleanChunkPool, ByteChunkPool, CharChunkPool, ShortChunkPool,
+        IntChunkPool, LongChunkPool, FloatChunkPool, DoubleChunkPool, ObjectChunkPool {
 
     private static final MultiChunkPool SHARED_POOL = new MultiChunkPool();
     private static final ThreadLocal<MultiChunkPool> POOL_THREAD_LOCAL = ThreadLocal.withInitial(() -> SHARED_POOL);
@@ -34,14 +63,14 @@ public final class MultiChunkPool {
     }
 
     private final BooleanChunkPool booleanChunkPool = new BooleanChunkSoftPool();
-    private final CharChunkSoftPool charChunkPool = new CharChunkSoftPool();
+    private final CharChunkPool charChunkPool = new CharChunkSoftPool();
     private final ByteChunkPool byteChunkPool = new ByteChunkSoftPool();
     private final ShortChunkPool shortChunkPool = new ShortChunkSoftPool();
     private final IntChunkPool intChunkPool = new IntChunkSoftPool();
     private final LongChunkPool longChunkPool = new LongChunkSoftPool();
     private final FloatChunkPool floatChunkPool = new FloatChunkSoftPool();
     private final DoubleChunkPool doubleChunkPool = new DoubleChunkSoftPool();
-    private final ObjectChunkSoftPool objectChunkPool = new ObjectChunkSoftPool();
+    private final ObjectChunkPool objectChunkPool = new ObjectChunkSoftPool();
 
     private final Map<ChunkType, Supplier<ChunkPool>> pools;
 
@@ -70,7 +99,7 @@ public final class MultiChunkPool {
         return booleanChunkPool;
     }
 
-    public CharChunkSoftPool getCharChunkPool() {
+    public CharChunkPool getCharChunkPool() {
         return charChunkPool;
     }
 
@@ -98,7 +127,288 @@ public final class MultiChunkPool {
         return doubleChunkPool;
     }
 
-    public ObjectChunkSoftPool getObjectChunkPool() {
+    public ObjectChunkPool getObjectChunkPool() {
         return objectChunkPool;
+    }
+
+    @Override
+    public ChunkPool asChunkPool() {
+        throw new UnsupportedOperationException(
+                "MultiChunkPool can't create a ChunkPool, call this on the specific type required");
+    }
+
+    @Override
+    public <ATTR extends Any> WritableBooleanChunk<ATTR> takeWritableBooleanChunk(int capacity) {
+        return booleanChunkPool.takeWritableBooleanChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableBooleanChunk(@NotNull WritableBooleanChunk<?> writableBooleanChunk) {
+        booleanChunkPool.giveWritableBooleanChunk(writableBooleanChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableBooleanChunk<ATTR> takeResettableBooleanChunk() {
+        return booleanChunkPool.takeResettableBooleanChunk();
+    }
+
+    @Override
+    public void giveResettableBooleanChunk(@NotNull ResettableBooleanChunk<?> resettableBooleanChunk) {
+        booleanChunkPool.giveResettableBooleanChunk(resettableBooleanChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableBooleanChunk<ATTR> takeResettableWritableBooleanChunk() {
+        return booleanChunkPool.takeResettableWritableBooleanChunk();
+    }
+
+    @Override
+    public void giveResettableWritableBooleanChunk(
+            @NotNull ResettableWritableBooleanChunk<?> resettableWritableBooleanChunk) {
+        booleanChunkPool.giveResettableWritableBooleanChunk(resettableWritableBooleanChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> WritableCharChunk<ATTR> takeWritableCharChunk(int capacity) {
+        return charChunkPool.takeWritableCharChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableCharChunk(@NotNull WritableCharChunk<?> writableCharChunk) {
+        charChunkPool.giveWritableCharChunk(writableCharChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableCharChunk<ATTR> takeResettableCharChunk() {
+        return charChunkPool.takeResettableCharChunk();
+    }
+
+    @Override
+    public void giveResettableCharChunk(@NotNull ResettableCharChunk<?> resettableCharChunk) {
+        charChunkPool.giveResettableCharChunk(resettableCharChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableCharChunk<ATTR> takeResettableWritableCharChunk() {
+        return charChunkPool.takeResettableWritableCharChunk();
+    }
+
+    @Override
+    public void giveResettableWritableCharChunk(@NotNull ResettableWritableCharChunk<?> resettableWritableCharChunk) {
+        charChunkPool.giveResettableWritableCharChunk(resettableWritableCharChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> WritableByteChunk<ATTR> takeWritableByteChunk(int capacity) {
+        return byteChunkPool.takeWritableByteChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableByteChunk(@NotNull WritableByteChunk<?> writableByteChunk) {
+        byteChunkPool.giveWritableByteChunk(writableByteChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableByteChunk<ATTR> takeResettableByteChunk() {
+        return byteChunkPool.takeResettableByteChunk();
+    }
+
+    @Override
+    public void giveResettableByteChunk(@NotNull ResettableByteChunk<?> resettableByteChunk) {
+        byteChunkPool.giveResettableByteChunk(resettableByteChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableByteChunk<ATTR> takeResettableWritableByteChunk() {
+        return byteChunkPool.takeResettableWritableByteChunk();
+    }
+
+    @Override
+    public void giveResettableWritableByteChunk(@NotNull ResettableWritableByteChunk<?> resettableWritableByteChunk) {
+        byteChunkPool.giveResettableWritableByteChunk(resettableWritableByteChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> WritableShortChunk<ATTR> takeWritableShortChunk(int capacity) {
+        return shortChunkPool.takeWritableShortChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableShortChunk(@NotNull WritableShortChunk<?> writableShortChunk) {
+        shortChunkPool.giveWritableShortChunk(writableShortChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableShortChunk<ATTR> takeResettableShortChunk() {
+        return shortChunkPool.takeResettableShortChunk();
+    }
+
+    @Override
+    public void giveResettableShortChunk(@NotNull ResettableShortChunk<?> resettableShortChunk) {
+        shortChunkPool.giveResettableShortChunk(resettableShortChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableShortChunk<ATTR> takeResettableWritableShortChunk() {
+        return shortChunkPool.takeResettableWritableShortChunk();
+    }
+
+    @Override
+    public void giveResettableWritableShortChunk(
+            @NotNull ResettableWritableShortChunk<?> resettableWritableShortChunk) {
+        shortChunkPool.giveResettableWritableShortChunk(resettableWritableShortChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> WritableIntChunk<ATTR> takeWritableIntChunk(int capacity) {
+        return intChunkPool.takeWritableIntChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableIntChunk(@NotNull WritableIntChunk<?> writableIntChunk) {
+        intChunkPool.giveWritableIntChunk(writableIntChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableIntChunk<ATTR> takeResettableIntChunk() {
+        return intChunkPool.takeResettableIntChunk();
+    }
+
+    @Override
+    public void giveResettableIntChunk(@NotNull ResettableIntChunk<?> resettableIntChunk) {
+        intChunkPool.giveResettableIntChunk(resettableIntChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableIntChunk<ATTR> takeResettableWritableIntChunk() {
+        return intChunkPool.takeResettableWritableIntChunk();
+    }
+
+    @Override
+    public void giveResettableWritableIntChunk(@NotNull ResettableWritableIntChunk<?> resettableWritableIntChunk) {
+        intChunkPool.giveResettableWritableIntChunk(resettableWritableIntChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> WritableLongChunk<ATTR> takeWritableLongChunk(int capacity) {
+        return longChunkPool.takeWritableLongChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableLongChunk(@NotNull WritableLongChunk<?> writableLongChunk) {
+        longChunkPool.giveWritableLongChunk(writableLongChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableLongChunk<ATTR> takeResettableLongChunk() {
+        return longChunkPool.takeResettableLongChunk();
+    }
+
+    @Override
+    public void giveResettableLongChunk(@NotNull ResettableLongChunk<?> resettableLongChunk) {
+        longChunkPool.giveResettableLongChunk(resettableLongChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableLongChunk<ATTR> takeResettableWritableLongChunk() {
+        return longChunkPool.takeResettableWritableLongChunk();
+    }
+
+    @Override
+    public void giveResettableWritableLongChunk(@NotNull ResettableWritableLongChunk<?> resettableWritableLongChunk) {
+        longChunkPool.giveResettableWritableLongChunk(resettableWritableLongChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> WritableFloatChunk<ATTR> takeWritableFloatChunk(int capacity) {
+        return floatChunkPool.takeWritableFloatChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableFloatChunk(@NotNull WritableFloatChunk<?> writableFloatChunk) {
+        floatChunkPool.giveWritableFloatChunk(writableFloatChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableFloatChunk<ATTR> takeResettableFloatChunk() {
+        return floatChunkPool.takeResettableFloatChunk();
+    }
+
+    @Override
+    public void giveResettableFloatChunk(@NotNull ResettableFloatChunk<?> resettableFloatChunk) {
+        floatChunkPool.giveResettableFloatChunk(resettableFloatChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableFloatChunk<ATTR> takeResettableWritableFloatChunk() {
+        return floatChunkPool.takeResettableWritableFloatChunk();
+    }
+
+    @Override
+    public void giveResettableWritableFloatChunk(
+            @NotNull ResettableWritableFloatChunk<?> resettableWritableFloatChunk) {
+        floatChunkPool.giveResettableWritableFloatChunk(resettableWritableFloatChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> WritableDoubleChunk<ATTR> takeWritableDoubleChunk(int capacity) {
+        return doubleChunkPool.takeWritableDoubleChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableDoubleChunk(@NotNull WritableDoubleChunk<?> writableDoubleChunk) {
+        doubleChunkPool.giveWritableDoubleChunk(writableDoubleChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableDoubleChunk<ATTR> takeResettableDoubleChunk() {
+        return doubleChunkPool.takeResettableDoubleChunk();
+    }
+
+    @Override
+    public void giveResettableDoubleChunk(@NotNull ResettableDoubleChunk<?> resettableDoubleChunk) {
+        doubleChunkPool.giveResettableDoubleChunk(resettableDoubleChunk);
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableDoubleChunk<ATTR> takeResettableWritableDoubleChunk() {
+        return doubleChunkPool.takeResettableWritableDoubleChunk();
+    }
+
+    @Override
+    public void giveResettableWritableDoubleChunk(
+            @NotNull ResettableWritableDoubleChunk<?> resettableWritableDoubleChunk) {
+        doubleChunkPool.giveResettableWritableDoubleChunk(resettableWritableDoubleChunk);
+    }
+
+    @Override
+    public <TYPE, ATTR extends Any> WritableObjectChunk<TYPE, ATTR> takeWritableObjectChunk(int capacity) {
+        return objectChunkPool.takeWritableObjectChunk(capacity);
+    }
+
+    @Override
+    public void giveWritableObjectChunk(@NotNull WritableObjectChunk<?, ?> writableObjectChunk) {
+        objectChunkPool.giveWritableObjectChunk(writableObjectChunk);
+    }
+
+    @Override
+    public <TYPE, ATTR extends Any> ResettableObjectChunk<TYPE, ATTR> takeResettableObjectChunk() {
+        return objectChunkPool.takeResettableObjectChunk();
+    }
+
+    @Override
+    public void giveResettableObjectChunk(@NotNull ResettableObjectChunk<?, ?> resettableObjectChunk) {
+        objectChunkPool.giveResettableObjectChunk(resettableObjectChunk);
+    }
+
+    @Override
+    public <TYPE, ATTR extends Any> ResettableWritableObjectChunk<TYPE, ATTR> takeResettableWritableObjectChunk() {
+        return objectChunkPool.takeResettableWritableObjectChunk();
+    }
+
+    @Override
+    public void giveResettableWritableObjectChunk(
+            @NotNull ResettableWritableObjectChunk<?, ?> resettableWritableObjectChunk) {
+        objectChunkPool.giveResettableWritableObjectChunk(resettableWritableObjectChunk);
     }
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/MultiChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/MultiChunkPool.java
@@ -37,14 +37,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Provides a set of per-type {@link ChunkPool}s. Normally accessed via a {@link ThreadLocal}, to allow some threads to
  * share a common pool and others to allocate their own.
- * <p>
- * This type isn't compatible with GWT, and needs to be replaced with a different class that doesn't use the soft pool
- * instances.
  */
 public final class MultiChunkPool implements BooleanChunkPool, ByteChunkPool, CharChunkPool, ShortChunkPool,
         IntChunkPool, LongChunkPool, FloatChunkPool, DoubleChunkPool, ObjectChunkPool {
@@ -72,19 +68,19 @@ public final class MultiChunkPool implements BooleanChunkPool, ByteChunkPool, Ch
     private final DoubleChunkPool doubleChunkPool = new DoubleChunkSoftPool();
     private final ObjectChunkPool objectChunkPool = new ObjectChunkSoftPool();
 
-    private final Map<ChunkType, Supplier<ChunkPool>> pools;
+    private final Map<ChunkType, ChunkPool> pools;
 
     {
-        final EnumMap<ChunkType, Supplier<ChunkPool>> tempPools = new EnumMap<>(ChunkType.class);
-        tempPools.put(ChunkType.Boolean, booleanChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Char, charChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Byte, byteChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Short, shortChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Int, intChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Long, longChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Float, floatChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Double, doubleChunkPool::asChunkPool);
-        tempPools.put(ChunkType.Object, objectChunkPool::asChunkPool);
+        final EnumMap<ChunkType, ChunkPool> tempPools = new EnumMap<>(ChunkType.class);
+        tempPools.put(ChunkType.Boolean, booleanChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Char, charChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Byte, byteChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Short, shortChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Int, intChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Long, longChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Float, floatChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Double, doubleChunkPool.asChunkPool());
+        tempPools.put(ChunkType.Object, objectChunkPool.asChunkPool());
         pools = Collections.unmodifiableMap(tempPools);
     }
 
@@ -92,7 +88,7 @@ public final class MultiChunkPool implements BooleanChunkPool, ByteChunkPool, Ch
 
     @SuppressWarnings("unused")
     public ChunkPool getChunkPool(@NotNull final ChunkType chunkType) {
-        return pools.get(chunkType).get();
+        return pools.get(chunkType);
     }
 
     public BooleanChunkPool getBooleanChunkPool() {

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkPool.java
@@ -1,140 +1,58 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableObjectChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.ResettableWritableObjectChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface ObjectChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableObjectChunk(capacity);
+            }
 
-/**
- * {@link ChunkPool} implementation for chunks of objects.
- */
-@SuppressWarnings("rawtypes")
-public final class ObjectChunkPool implements ChunkPool {
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableObjectChunk(writableChunk.asWritableObjectChunk());
+            }
 
-    private final WritableObjectChunk<?, Any> EMPTY = WritableObjectChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_OBJECT_ARRAY);
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableObjectChunk();
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableObjectChunk}s.
-     */
-    private final SegmentedSoftPool<WritableObjectChunk>[] writableObjectChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableObjectChunk(resettableChunk.asResettableObjectChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableObjectChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableObjectChunk> resettableObjectChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableObjectChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableObjectChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableObjectChunk> resettableWritableObjectChunks;
-
-    ObjectChunkPool() {
-        //noinspection unchecked
-        writableObjectChunks = (SegmentedSoftPool<WritableObjectChunk>[]) new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableObjectChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableObjectChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableObjectChunk chunk) -> {
-                        chunk.fillWithNullValue(0, chunkCapacity);
-                        chunk.setSize(chunkCapacity);
-                    }
-            );
-        }
-        resettableObjectChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableObjectChunk::makeResettableChunkForPool),
-                ResettableObjectChunk::clear
-        );
-        resettableWritableObjectChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableObjectChunk::makeResettableChunkForPool),
-                ResettableWritableObjectChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableObjectChunk(resettableWritableChunk.asResettableWritableObjectChunk());
+            }
+        };
     }
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableObjectChunk(capacity);
-    }
+    <TYPE, ATTR extends Any> WritableObjectChunk<TYPE, ATTR> takeWritableObjectChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableObjectChunk(writableChunk.asWritableObjectChunk());
-    }
+    void giveWritableObjectChunk(@NotNull WritableObjectChunk<?, ?> writableObjectChunk);
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableObjectChunk();
-    }
+    <TYPE, ATTR extends Any> ResettableObjectChunk<TYPE, ATTR> takeResettableObjectChunk();
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableObjectChunk(resettableChunk.asResettableObjectChunk());
-    }
+    void giveResettableObjectChunk(@NotNull ResettableObjectChunk<?, ?> resettableObjectChunk);
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableObjectChunk();
-    }
+    <TYPE, ATTR extends Any> ResettableWritableObjectChunk<TYPE, ATTR> takeResettableWritableObjectChunk();
 
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableObjectChunk(resettableWritableChunk.asResettableWritableObjectChunk());
-    }
-
-    public <TYPE, ATTR extends Any> WritableObjectChunk<TYPE, ATTR> takeWritableObjectChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableObjectChunk<TYPE, ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableObjectChunk result = writableObjectChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableObjectChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableObjectChunk(@NotNull final WritableObjectChunk<?, ?> writableObjectChunk) {
-        if (writableObjectChunk == EMPTY || writableObjectChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableObjectChunk);
-        final int capacity = writableObjectChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableObjectChunks[poolIndexForGive].give(writableObjectChunk);
-        }
-    }
-
-    public <TYPE, ATTR extends Any> ResettableObjectChunk<TYPE, ATTR> takeResettableObjectChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableObjectChunks.take());
-    }
-
-    public void giveResettableObjectChunk(@NotNull final ResettableObjectChunk resettableObjectChunk) {
-        resettableObjectChunks.give(ChunkPoolReleaseTracking.onGive(resettableObjectChunk));
-    }
-
-    public <TYPE, ATTR extends Any> ResettableWritableObjectChunk<TYPE, ATTR> takeResettableWritableObjectChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableObjectChunks.take());
-    }
-
-    public void giveResettableWritableObjectChunk(@NotNull final ResettableWritableObjectChunk resettableWritableObjectChunk) {
-        resettableWritableObjectChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableObjectChunk));
-    }
+    void giveResettableWritableObjectChunk(@NotNull ResettableWritableObjectChunk<?, ?> resettableWritableObjectChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkPool.java
@@ -10,39 +10,7 @@ import io.deephaven.chunk.attributes.Any;
 import org.jetbrains.annotations.NotNull;
 
 public interface ObjectChunkPool {
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableObjectChunk(capacity);
-            }
-
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableObjectChunk(writableChunk.asWritableObjectChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableObjectChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableObjectChunk(resettableChunk.asResettableObjectChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableObjectChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableObjectChunk(resettableWritableChunk.asResettableWritableObjectChunk());
-            }
-        };
-    }
+    ChunkPool asChunkPool();
 
     <TYPE, ATTR extends Any> WritableObjectChunk<TYPE, ATTR> takeWritableObjectChunk(int capacity);
 

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkSoftPool.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of objects.
+ */
+@SuppressWarnings("rawtypes")
+public final class ObjectChunkSoftPool implements ChunkPool, ObjectChunkPool {
+
+    private final WritableObjectChunk<?, Any> EMPTY = WritableObjectChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_OBJECT_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableObjectChunk}s.
+     */
+    private final SegmentedSoftPool<WritableObjectChunk>[] writableObjectChunks;
+
+    /**
+     * Sub-pool of {@link ResettableObjectChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableObjectChunk> resettableObjectChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableObjectChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableObjectChunk> resettableWritableObjectChunks;
+
+    ObjectChunkSoftPool() {
+        //noinspection unchecked
+        writableObjectChunks = (SegmentedSoftPool<WritableObjectChunk>[]) new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableObjectChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableObjectChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableObjectChunk chunk) -> {
+                        chunk.fillWithNullValue(0, chunkCapacity);
+                        chunk.setSize(chunkCapacity);
+                    }
+            );
+        }
+        resettableObjectChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableObjectChunk::makeResettableChunkForPool),
+                ResettableObjectChunk::clear
+        );
+        resettableWritableObjectChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableObjectChunk::makeResettableChunkForPool),
+                ResettableWritableObjectChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+        return takeWritableObjectChunk(capacity);
+    }
+
+    @Override
+    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+        giveWritableObjectChunk(writableChunk.asWritableObjectChunk());
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+        return takeResettableObjectChunk();
+    }
+
+    @Override
+    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+        giveResettableObjectChunk(resettableChunk.asResettableObjectChunk());
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+        return takeResettableWritableObjectChunk();
+    }
+
+    @Override
+    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+        giveResettableWritableObjectChunk(resettableWritableChunk.asResettableWritableObjectChunk());
+    }
+
+    @Override
+    public <TYPE, ATTR extends Any> WritableObjectChunk<TYPE, ATTR> takeWritableObjectChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableObjectChunk<TYPE, ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableObjectChunk result = writableObjectChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableObjectChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableObjectChunk(@NotNull final WritableObjectChunk<?, ?> writableObjectChunk) {
+        if (writableObjectChunk == EMPTY || writableObjectChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableObjectChunk);
+        final int capacity = writableObjectChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableObjectChunks[poolIndexForGive].give(writableObjectChunk);
+        }
+    }
+
+    @Override
+    public <TYPE, ATTR extends Any> ResettableObjectChunk<TYPE, ATTR> takeResettableObjectChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableObjectChunks.take());
+    }
+
+    @Override
+    public void giveResettableObjectChunk(@NotNull final ResettableObjectChunk resettableObjectChunk) {
+        resettableObjectChunks.give(ChunkPoolReleaseTracking.onGive(resettableObjectChunk));
+    }
+
+    @Override
+    public <TYPE, ATTR extends Any> ResettableWritableObjectChunk<TYPE, ATTR> takeResettableWritableObjectChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableObjectChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableObjectChunk(@NotNull final ResettableWritableObjectChunk resettableWritableObjectChunk) {
+        resettableWritableObjectChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableObjectChunk));
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ObjectChunkSoftPool.java
@@ -62,6 +62,41 @@ public final class ObjectChunkSoftPool implements ChunkPool, ObjectChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableObjectChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableObjectChunk(writableChunk.asWritableObjectChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableObjectChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableObjectChunk(resettableChunk.asResettableObjectChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableObjectChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableObjectChunk(resettableWritableChunk.asResettableWritableObjectChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
         return takeWritableObjectChunk(capacity);
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkPool.java
@@ -1,6 +1,3 @@
-/**
- * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
- */
 /*
  * ---------------------------------------------------------------------------------------------------------------------
  * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkPool and regenerate
@@ -8,135 +5,59 @@
  */
 package io.deephaven.chunk.util.pools;
 
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.ResettableShortChunk;
+import io.deephaven.chunk.ResettableReadOnlyChunk;
+import io.deephaven.chunk.ResettableWritableShortChunk;
+import io.deephaven.chunk.ResettableWritableChunk;
+import io.deephaven.chunk.WritableShortChunk;
+import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Any;
-import io.deephaven.chunk.*;
-import io.deephaven.util.datastructures.SegmentedSoftPool;
 import org.jetbrains.annotations.NotNull;
 
-import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+public interface ShortChunkPool {
 
-/**
- * {@link ChunkPool} implementation for chunks of shorts.
- */
-@SuppressWarnings("rawtypes")
-public final class ShortChunkPool implements ChunkPool {
+    default ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableShortChunk(capacity);
+            }
 
-    private final WritableShortChunk<Any> EMPTY = WritableShortChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_SHORT_ARRAY);
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableShortChunk(writableChunk.asWritableShortChunk());
+            }
 
-    /**
-     * Sub-pools by power-of-two sizes for {@link WritableShortChunk}s.
-     */
-    private final SegmentedSoftPool<WritableShortChunk>[] writableShortChunks;
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableShortChunk();
+            }
 
-    /**
-     * Sub-pool of {@link ResettableShortChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableShortChunk> resettableShortChunks;
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableShortChunk(resettableChunk.asResettableShortChunk());
+            }
 
-    /**
-     * Sub-pool of {@link ResettableWritableShortChunk}s.
-     */
-    private final SegmentedSoftPool<ResettableWritableShortChunk> resettableWritableShortChunks;
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableShortChunk();
+            }
 
-    ShortChunkPool() {
-        //noinspection unchecked
-        writableShortChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
-        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
-            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
-            final int chunkCapacity = 1 << chunkLog2Capacity;
-            writableShortChunks[pcci] = new SegmentedSoftPool<>(
-                    SUB_POOL_SEGMENT_CAPACITY,
-                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableShortChunk.makeWritableChunkForPool(chunkCapacity)),
-                    (final WritableShortChunk chunk) -> chunk.setSize(chunkCapacity)
-            );
-        }
-        resettableShortChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableShortChunk::makeResettableChunkForPool),
-                ResettableShortChunk::clear
-        );
-        resettableWritableShortChunks = new SegmentedSoftPool<>(
-                SUB_POOL_SEGMENT_CAPACITY,
-                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableShortChunk::makeResettableChunkForPool),
-                ResettableWritableShortChunk::clear
-        );
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableShortChunk(resettableWritableChunk.asResettableWritableShortChunk());
+            }
+        };
     }
+    <ATTR extends Any> WritableShortChunk<ATTR> takeWritableShortChunk(int capacity);
 
-    @Override
-    public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-        return takeWritableShortChunk(capacity);
-    }
+    void giveWritableShortChunk(@NotNull WritableShortChunk<?> writableShortChunk);
 
-    @Override
-    public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-        giveWritableShortChunk(writableChunk.asWritableShortChunk());
-    }
+    <ATTR extends Any> ResettableShortChunk<ATTR> takeResettableShortChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-        return takeResettableShortChunk();
-    }
+    void giveResettableShortChunk(@NotNull ResettableShortChunk resettableShortChunk);
 
-    @Override
-    public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-        giveResettableShortChunk(resettableChunk.asResettableShortChunk());
-    }
+    <ATTR extends Any> ResettableWritableShortChunk<ATTR> takeResettableWritableShortChunk();
 
-    @Override
-    public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-        return takeResettableWritableShortChunk();
-    }
-
-    @Override
-    public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-        giveResettableWritableShortChunk(resettableWritableChunk.asResettableWritableShortChunk());
-    }
-
-    public <ATTR extends Any> WritableShortChunk<ATTR> takeWritableShortChunk(final int capacity) {
-        if (capacity == 0) {
-            //noinspection unchecked
-            return (WritableShortChunk<ATTR>) EMPTY;
-        }
-        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
-        if (poolIndexForTake >= 0) {
-            //noinspection resource
-            final WritableShortChunk result = writableShortChunks[poolIndexForTake].take();
-            result.setSize(capacity);
-            //noinspection unchecked
-            return ChunkPoolReleaseTracking.onTake(result);
-        }
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(WritableShortChunk.makeWritableChunkForPool(capacity));
-    }
-
-    public void giveWritableShortChunk(@NotNull final WritableShortChunk<?> writableShortChunk) {
-        if (writableShortChunk == EMPTY || writableShortChunk.isAlias(EMPTY)) {
-            return;
-        }
-        ChunkPoolReleaseTracking.onGive(writableShortChunk);
-        final int capacity = writableShortChunk.capacity();
-        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
-        if (poolIndexForGive >= 0) {
-            writableShortChunks[poolIndexForGive].give(writableShortChunk);
-        }
-    }
-
-    public <ATTR extends Any> ResettableShortChunk<ATTR> takeResettableShortChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableShortChunks.take());
-    }
-
-    public void giveResettableShortChunk(@NotNull final ResettableShortChunk resettableShortChunk) {
-        resettableShortChunks.give(ChunkPoolReleaseTracking.onGive(resettableShortChunk));
-    }
-
-    public <ATTR extends Any> ResettableWritableShortChunk<ATTR> takeResettableWritableShortChunk() {
-        //noinspection unchecked
-        return ChunkPoolReleaseTracking.onTake(resettableWritableShortChunks.take());
-    }
-
-    public void giveResettableWritableShortChunk(@NotNull final ResettableWritableShortChunk resettableWritableShortChunk) {
-        resettableWritableShortChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableShortChunk));
-    }
+    void giveResettableWritableShortChunk(@NotNull ResettableWritableShortChunk resettableWritableShortChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkPool.java
@@ -16,48 +16,17 @@ import org.jetbrains.annotations.NotNull;
 
 public interface ShortChunkPool {
 
-    default ChunkPool asChunkPool() {
-        return new ChunkPool() {
-            @Override
-            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
-                return takeWritableShortChunk(capacity);
-            }
+    ChunkPool asChunkPool();
 
-            @Override
-            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
-                giveWritableShortChunk(writableChunk.asWritableShortChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
-                return takeResettableShortChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
-                giveResettableShortChunk(resettableChunk.asResettableShortChunk());
-            }
-
-            @Override
-            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
-                return takeResettableWritableShortChunk();
-            }
-
-            @Override
-            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
-                giveResettableWritableShortChunk(resettableWritableChunk.asResettableWritableShortChunk());
-            }
-        };
-    }
     <ATTR extends Any> WritableShortChunk<ATTR> takeWritableShortChunk(int capacity);
 
     void giveWritableShortChunk(@NotNull WritableShortChunk<?> writableShortChunk);
 
     <ATTR extends Any> ResettableShortChunk<ATTR> takeResettableShortChunk();
 
-    void giveResettableShortChunk(@NotNull ResettableShortChunk resettableShortChunk);
+    void giveResettableShortChunk(@NotNull ResettableShortChunk<?> resettableShortChunk);
 
     <ATTR extends Any> ResettableWritableShortChunk<ATTR> takeResettableWritableShortChunk();
 
-    void giveResettableWritableShortChunk(@NotNull ResettableWritableShortChunk resettableWritableShortChunk);
+    void giveResettableWritableShortChunk(@NotNull ResettableWritableShortChunk<?> resettableWritableShortChunk);
 }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkSoftPool.java
@@ -64,6 +64,41 @@ public final class ShortChunkSoftPool implements ShortChunkPool {
     }
 
     @Override
+    public ChunkPool asChunkPool() {
+        return new ChunkPool() {
+            @Override
+            public <ATTR extends Any> WritableChunk<ATTR> takeWritableChunk(final int capacity) {
+                return takeWritableShortChunk(capacity);
+            }
+
+            @Override
+            public <ATTR extends Any> void giveWritableChunk(@NotNull final WritableChunk<ATTR> writableChunk) {
+                giveWritableShortChunk(writableChunk.asWritableShortChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableReadOnlyChunk<ATTR> takeResettableChunk() {
+                return takeResettableShortChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableChunk(@NotNull final ResettableReadOnlyChunk<ATTR> resettableChunk) {
+                giveResettableShortChunk(resettableChunk.asResettableShortChunk());
+            }
+
+            @Override
+            public <ATTR extends Any> ResettableWritableChunk<ATTR> takeResettableWritableChunk() {
+                return takeResettableWritableShortChunk();
+            }
+
+            @Override
+            public <ATTR extends Any> void giveResettableWritableChunk(@NotNull final ResettableWritableChunk<ATTR> resettableWritableChunk) {
+                giveResettableWritableShortChunk(resettableWritableChunk.asResettableWritableShortChunk());
+            }
+        };
+    }
+
+    @Override
     public <ATTR extends Any> WritableShortChunk<ATTR> takeWritableShortChunk(final int capacity) {
         if (capacity == 0) {
             //noinspection unchecked

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkSoftPool.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/pools/ShortChunkSoftPool.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+/*
+ * ---------------------------------------------------------------------------------------------------------------------
+ * AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY - for any changes edit CharChunkSoftPool and regenerate
+ * ---------------------------------------------------------------------------------------------------------------------
+ */
+package io.deephaven.chunk.util.pools;
+
+import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.chunk.*;
+import io.deephaven.util.datastructures.SegmentedSoftPool;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.chunk.util.pools.ChunkPoolConstants.*;
+
+/**
+ * {@link ChunkPool} implementation for chunks of shorts.
+ */
+@SuppressWarnings("rawtypes")
+public final class ShortChunkSoftPool implements ShortChunkPool {
+
+    private final WritableShortChunk<Any> EMPTY = WritableShortChunk.writableChunkWrap(ArrayTypeUtils.EMPTY_SHORT_ARRAY);
+
+    /**
+     * Sub-pools by power-of-two sizes for {@link WritableShortChunk}s.
+     */
+    private final SegmentedSoftPool<WritableShortChunk>[] writableShortChunks;
+
+    /**
+     * Sub-pool of {@link ResettableShortChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableShortChunk> resettableShortChunks;
+
+    /**
+     * Sub-pool of {@link ResettableWritableShortChunk}s.
+     */
+    private final SegmentedSoftPool<ResettableWritableShortChunk> resettableWritableShortChunks;
+
+    ShortChunkSoftPool() {
+        //noinspection unchecked
+        writableShortChunks = new SegmentedSoftPool[NUM_POOLED_CHUNK_CAPACITIES];
+        for (int pcci = 0; pcci < NUM_POOLED_CHUNK_CAPACITIES; ++pcci) {
+            final int chunkLog2Capacity = pcci + SMALLEST_POOLED_CHUNK_LOG2_CAPACITY;
+            final int chunkCapacity = 1 << chunkLog2Capacity;
+            writableShortChunks[pcci] = new SegmentedSoftPool<>(
+                    SUB_POOL_SEGMENT_CAPACITY,
+                    () -> ChunkPoolInstrumentation.getAndRecord(() -> WritableShortChunk.makeWritableChunkForPool(chunkCapacity)),
+                    (final WritableShortChunk chunk) -> chunk.setSize(chunkCapacity)
+            );
+        }
+        resettableShortChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableShortChunk::makeResettableChunkForPool),
+                ResettableShortChunk::clear
+        );
+        resettableWritableShortChunks = new SegmentedSoftPool<>(
+                SUB_POOL_SEGMENT_CAPACITY,
+                () -> ChunkPoolInstrumentation.getAndRecord(ResettableWritableShortChunk::makeResettableChunkForPool),
+                ResettableWritableShortChunk::clear
+        );
+    }
+
+    @Override
+    public <ATTR extends Any> WritableShortChunk<ATTR> takeWritableShortChunk(final int capacity) {
+        if (capacity == 0) {
+            //noinspection unchecked
+            return (WritableShortChunk<ATTR>) EMPTY;
+        }
+        final int poolIndexForTake = getPoolIndexForTake(checkCapacityBounds(capacity));
+        if (poolIndexForTake >= 0) {
+            //noinspection resource
+            final WritableShortChunk result = writableShortChunks[poolIndexForTake].take();
+            result.setSize(capacity);
+            //noinspection unchecked
+            return ChunkPoolReleaseTracking.onTake(result);
+        }
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(WritableShortChunk.makeWritableChunkForPool(capacity));
+    }
+
+    @Override
+    public void giveWritableShortChunk(@NotNull final WritableShortChunk<?> writableShortChunk) {
+        if (writableShortChunk == EMPTY || writableShortChunk.isAlias(EMPTY)) {
+            return;
+        }
+        ChunkPoolReleaseTracking.onGive(writableShortChunk);
+        final int capacity = writableShortChunk.capacity();
+        final int poolIndexForGive = getPoolIndexForGive(checkCapacityBounds(capacity));
+        if (poolIndexForGive >= 0) {
+            writableShortChunks[poolIndexForGive].give(writableShortChunk);
+        }
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableShortChunk<ATTR> takeResettableShortChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableShortChunks.take());
+    }
+
+    @Override
+    public void giveResettableShortChunk(@NotNull final ResettableShortChunk resettableShortChunk) {
+        resettableShortChunks.give(ChunkPoolReleaseTracking.onGive(resettableShortChunk));
+    }
+
+    @Override
+    public <ATTR extends Any> ResettableWritableShortChunk<ATTR> takeResettableWritableShortChunk() {
+        //noinspection unchecked
+        return ChunkPoolReleaseTracking.onTake(resettableWritableShortChunks.take());
+    }
+
+    @Override
+    public void giveResettableWritableShortChunk(@NotNull final ResettableWritableShortChunk resettableWritableShortChunk) {
+        resettableWritableShortChunks.give(ChunkPoolReleaseTracking.onGive(resettableWritableShortChunk));
+    }
+}

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
@@ -97,6 +97,7 @@ public class ReplicateSourcesAndChunks {
 
         replicateFactories();
         charToAll("engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkPool.java");
+        charToAll("engine/chunk/src/main/java/io/deephaven/chunk/util/pools/CharChunkSoftPool.java");
 
         replicateChunkFillers();
 


### PR DESCRIPTION
Several changes to simplify how Chunk pooling will work in the JS API:
 - close() calls of borrowed instances should return the instance to the pool consistently
 - Separate pool implementations from interface
 - Flattened method calls required to borrow/create a chunk