### PR TITLE
Fix `Where` performance regression

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
@@ -186,7 +186,7 @@ abstract class AbstractFilterExecution {
                     final BiConsumer<WritableRowSet, WritableRowSet> onFilterComplete = (adds, mods) -> {
                         // Clean up the row sets created by the filter.
                         try (final RowSet ignored = adds;
-                             final RowSet ignored2 = mods) {
+                                final RowSet ignored2 = mods) {
                             if (addedResult != null) {
                                 synchronized (addedResult) {
                                     addedResult.insert(adds);
@@ -270,7 +270,7 @@ abstract class AbstractFilterExecution {
                     final BiConsumer<WritableRowSet, WritableRowSet> onFilterComplete = (adds, mods) -> {
                         // Clean up the row sets created by the filter.
                         try (final RowSet ignored = localAddInput.getValue();
-                             final RowSet ignored2 = localModInput.getValue()) {
+                                final RowSet ignored2 = localModInput.getValue()) {
                             // Store the output as the next filter input.
                             localAddInput.setValue(adds);
                             localModInput.setValue(mods);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
@@ -4,7 +4,6 @@ import io.deephaven.base.log.LogOutput;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.exceptions.CancellationException;
 import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderRandom;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.ModifiedColumnSet;
@@ -172,8 +171,8 @@ abstract class AbstractFilterExecution {
                 QueryTable.PARALLEL_WHERE_ROWS_PER_SEGMENT - 1) / QueryTable.PARALLEL_WHERE_ROWS_PER_SEGMENT);
         final long targetSize = (updateSize + targetSegments - 1) / targetSegments;
 
-        final RowSetBuilderRandom addedBuilder = addSize <= 0 ? null : RowSetFactory.builderRandom();
-        final RowSetBuilderRandom modifiedBuilder = modifySize <= 0 ? null : RowSetFactory.builderRandom();
+        final WritableRowSet addedResult = addSize <= 0 ? null : RowSetFactory.empty();
+        final WritableRowSet modifiedResult = modifySize <= 0 ? null : RowSetFactory.empty();
 
         jobScheduler().iterateParallel(
                 ExecutionContext.getContext(),
@@ -187,15 +186,15 @@ abstract class AbstractFilterExecution {
                     final BiConsumer<WritableRowSet, WritableRowSet> onFilterComplete = (adds, mods) -> {
                         // Clean up the row sets created by the filter.
                         try (final RowSet ignored = adds;
-                                final RowSet ignored2 = mods) {
-                            if (addedBuilder != null) {
-                                synchronized (addedBuilder) {
-                                    addedBuilder.addRowSet(adds);
+                             final RowSet ignored2 = mods) {
+                            if (addedResult != null) {
+                                synchronized (addedResult) {
+                                    addedResult.insert(adds);
                                 }
                             }
-                            if (modifiedBuilder != null) {
-                                synchronized (modifiedBuilder) {
-                                    modifiedBuilder.addRowSet(mods);
+                            if (modifiedResult != null) {
+                                synchronized (modifiedResult) {
+                                    modifiedResult.insert(mods);
                                 }
                             }
                         }
@@ -221,10 +220,7 @@ abstract class AbstractFilterExecution {
                                 modifiedInputToUse, startOffSet - addSize, endOffset - addSize,
                                 onFilterComplete, nec);
                     }
-                }, () -> onComplete.accept(
-                        addedBuilder == null ? null : addedBuilder.build(),
-                        modifiedBuilder == null ? null : modifiedBuilder.build()),
-                onError);
+                }, () -> onComplete.accept(addedResult, modifiedResult), onError);
     }
 
     public LogOutput append(LogOutput output) {
@@ -274,7 +270,7 @@ abstract class AbstractFilterExecution {
                     final BiConsumer<WritableRowSet, WritableRowSet> onFilterComplete = (adds, mods) -> {
                         // Clean up the row sets created by the filter.
                         try (final RowSet ignored = localAddInput.getValue();
-                                final RowSet ignored2 = localModInput.getValue()) {
+                             final RowSet ignored2 = localModInput.getValue()) {
                             // Store the output as the next filter input.
                             localAddInput.setValue(adds);
                             localModInput.setValue(mods);


### PR DESCRIPTION
PR #5032 introduced a serious performance issue in the `where` operations.  This PR corrects this by using `RowSet#insert()` calls instead of a `RowSetRandomBuilder` which performs much worse in this scenario.

Performance comparisons (1.2B rows, `main` is before #5032 merged):

<img width="545" alt="image" src="https://github.com/deephaven/deephaven-core/assets/4204632/62c5f9b7-2960-4053-9e33-57e6d7ff82c9">
