### PR TITLE
Use a Deque to avoid StackOverflow in ImmediateJobScheduler

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InitialFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InitialFilterExecution.java
@@ -38,7 +38,7 @@ class InitialFilterExecution extends AbstractFilterExecution {
         if (permitParallelization) {
             jobScheduler = new OperationInitializerJobScheduler();
         } else {
-            jobScheduler = ImmediateJobScheduler.INSTANCE;
+            jobScheduler = new ImmediateJobScheduler();
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1479,7 +1479,7 @@ public class QueryTable extends BaseTable<QueryTable> {
                             && analyzer.allowCrossColumnParallelization()) {
                         jobScheduler = new OperationInitializerJobScheduler();
                     } else {
-                        jobScheduler = ImmediateJobScheduler.INSTANCE;
+                        jobScheduler = new ImmediateJobScheduler();
                     }
 
                     final QueryTable resultTable;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SelectOrUpdateListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SelectOrUpdateListener.java
@@ -88,7 +88,7 @@ class SelectOrUpdateListener extends BaseTable.ListenerImpl {
         if (enableParallelUpdate) {
             jobScheduler = new UpdateGraphJobScheduler(getUpdateGraph());
         } else {
-            jobScheduler = ImmediateJobScheduler.INSTANCE;
+            jobScheduler = new ImmediateJobScheduler();
         }
 
         analyzer.applyUpdate(acquiredUpdate, toClear, updateHelper, jobScheduler, this,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/WhereListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/WhereListener.java
@@ -260,7 +260,7 @@ class WhereListener extends MergedListener {
             if (permitParallelization) {
                 jobScheduler = new UpdateGraphJobScheduler(getUpdateGraph());
             } else {
-                jobScheduler = ImmediateJobScheduler.INSTANCE;
+                jobScheduler = new ImmediateJobScheduler();
             }
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/rangejoin/RangeJoinOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/rangejoin/RangeJoinOperation.java
@@ -255,7 +255,7 @@ public class RangeJoinOperation implements QueryTable.MemoizableOperation<QueryT
         if (ExecutionContext.getContext().getOperationInitializer().canParallelize()) {
             jobScheduler = new OperationInitializerJobScheduler();
         } else {
-            jobScheduler = ImmediateJobScheduler.INSTANCE;
+            jobScheduler = new ImmediateJobScheduler();
         }
 
         final ExecutionContext executionContext = ExecutionContext.newBuilder()

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -302,7 +302,7 @@ public abstract class UpdateBy {
                 if (ExecutionContext.getContext().getOperationInitializer().canParallelize()) {
                     jobScheduler = new OperationInitializerJobScheduler();
                 } else {
-                    jobScheduler = ImmediateJobScheduler.INSTANCE;
+                    jobScheduler = new ImmediateJobScheduler();
                 }
                 executionContext = ExecutionContext.newBuilder()
                         .markSystemic().build();
@@ -331,7 +331,7 @@ public abstract class UpdateBy {
                 if (source.getUpdateGraph().parallelismFactor() > 1) {
                     jobScheduler = new UpdateGraphJobScheduler(source.getUpdateGraph());
                 } else {
-                    jobScheduler = ImmediateJobScheduler.INSTANCE;
+                    jobScheduler = new ImmediateJobScheduler();
                 }
                 executionContext = ExecutionContext.newBuilder()
                         .setUpdateGraph(result().getUpdateGraph())

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ImmediateJobScheduler.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ImmediateJobScheduler.java
@@ -44,8 +44,9 @@ public class ImmediateJobScheduler implements JobScheduler {
         }
 
         try {
-            while (!pendingJobs.isEmpty()) {
-                pendingJobs.removeLast().run();
+            Runnable job;
+            while ((job = pendingJobs.pollLast()) != null) {
+                job.run();
             }
         } finally {
             processingThread.set(null);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ImmediateJobScheduler.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ImmediateJobScheduler.java
@@ -44,9 +44,8 @@ public class ImmediateJobScheduler implements JobScheduler {
         }
 
         try {
-            Runnable job;
-            while ((job = pendingJobs.removeLast()) != null) {
-                job.run();
+            while (!pendingJobs.isEmpty()) {
+                pendingJobs.removeLast().run();
             }
         } finally {
             processingThread.set(null);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ImmediateJobScheduler.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ImmediateJobScheduler.java
@@ -3,14 +3,17 @@ package io.deephaven.engine.table.impl.util;
 import io.deephaven.base.log.LogOutputAppendable;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.impl.perf.BasePerformanceEntry;
-import io.deephaven.io.log.impl.LogOutputStringImpl;
 import io.deephaven.util.SafeCloseable;
-import io.deephaven.util.process.ProcessEnvironment;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 public class ImmediateJobScheduler implements JobScheduler {
-    public static final ImmediateJobScheduler INSTANCE = new ImmediateJobScheduler();
+
+    private final AtomicReference<Thread> processingThread = new AtomicReference<>();
+    private final Deque<Runnable> pendingJobs = new ArrayDeque<>();
 
     @Override
     public void submit(
@@ -18,15 +21,35 @@ public class ImmediateJobScheduler implements JobScheduler {
             final Runnable runnable,
             final LogOutputAppendable description,
             final Consumer<Exception> onError) {
-        // We do not need to install the update context since we are not changing thread contexts.
-        try (SafeCloseable ignored = executionContext != null ? executionContext.open() : null) {
-            runnable.run();
-        } catch (Exception e) {
-            onError.accept(e);
-        } catch (Error e) {
-            final String logMessage = new LogOutputStringImpl().append(description).append(" Error").toString();
-            ProcessEnvironment.getGlobalFatalErrorReporter().report(logMessage, e);
-            throw e;
+        final Thread localProcessingThread = processingThread.get();
+        final Thread thisThread = Thread.currentThread();
+        final boolean thisThreadIsProcessing = localProcessingThread == thisThread;
+
+        if (!thisThreadIsProcessing && !processingThread.compareAndSet(null, thisThread)) {
+            throw new IllegalCallerException("An unexpected thread submitted a job to this job scheduler");
+        }
+
+        pendingJobs.addLast(() -> {
+            // We do not need to install the update context since we are not changing thread contexts.
+            try (SafeCloseable ignored = executionContext != null ? executionContext.open() : null) {
+                runnable.run();
+            } catch (Exception e) {
+                onError.accept(e);
+            }
+        });
+
+        if (thisThreadIsProcessing) {
+            // We're already draining the queue in an ancestor stack frame
+            return;
+        }
+
+        try {
+            Runnable job;
+            while ((job = pendingJobs.removeLast()) != null) {
+                job.run();
+            }
+        } finally {
+            processingThread.set(null);
         }
     }
 


### PR DESCRIPTION
This helps avoid StackOverflowErrors during select/update operations with many layers.