### PR TITLE
Submit gradle-aware dependency information to Github

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,33 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ 'main' ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 11
+        id: setup-java-11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Set JAVA_HOME
+        run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
+
+      - name: Setup gradle properties
+        run: |
+          .github/scripts/gradle-properties.sh >> gradle.properties
+          cat gradle.properties
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3


### PR DESCRIPTION
Currently, Github automatically ingests dependency information that is an easy-to-digest form (for example, something like Python's requirements.txt).

This PR uses the Github Dependency Submission API to add our projects dependency information as known by Gradle (group id, artifact id, version, etc) to Github. This allows for better dependency graph and code security information.

There's potential to use this information in the future to enhance our PR review process, specifically calling out new dependencies (https://github.com/actions/dependency-review-action).

https://docs.github.com/en/rest/dependency-graph/dependency-submission
https://github.com/gradle/actions/blob/main/dependency-submission/README.md