### PR TITLE
Update slf4j and logback versions

### DIFF
--- a/buildSrc/src/main/groovy/Classpaths.groovy
+++ b/buildSrc/src/main/groovy/Classpaths.groovy
@@ -49,7 +49,7 @@ class Classpaths {
     static final String ARROW_VERSION = '13.0.0'
 
     static final String SLF4J_GROUP = 'org.slf4j'
-    static final String SLF4J_VERSION = '2.0.6'
+    static final String SLF4J_VERSION = '2.0.11'
 
     static final String FLATBUFFER_GROUP = 'com.google.flatbuffers'
     static final String FLATBUFFER_NAME = 'flatbuffers-java'
@@ -88,7 +88,7 @@ class Classpaths {
 
     static final String LOGBACK_GROUP = 'ch.qos.logback'
     static final String LOGBACK_NAME = 'logback-classic'
-    static final String LOGBACK_VERSION = '1.4.5'
+    static final String LOGBACK_VERSION = '1.4.14'
 
     static final String GROOVY_GROUP = 'org.codehaus.groovy'
     static final String GROOVY_VERSION = '3.0.18'


### PR DESCRIPTION
Fixes CVE-2023-6378, related to logback receiver component vulnerabilities. While our default deployment is not vulnerable, it's theoretically possible a custom logback configuration would be vulnerable.