### PR TITLE
Update avro version

### DIFF
--- a/extensions/kafka/build.gradle
+++ b/extensions/kafka/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     api project(':engine-processor')
 
-    api 'org.apache.avro:avro:1.11.2'
+    api 'org.apache.avro:avro:1.11.3'
 
     // Using io.confluent dependencies requires code in the toplevel build.gradle to add their maven repository.
     // Note: the -ccs flavor is provided by confluent as their community edition. It is equivalent to the maven central


### PR DESCRIPTION
Fixes CVE-2023-39410, which could cause a out-of-memory when reading untrusted avro data. Unlikely to be relevant in the context of Kafka.