### PR TITLE
Update xerial snappy-java version

### DIFF
--- a/extensions/parquet/compression/build.gradle
+++ b/extensions/parquet/compression/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         because 'Provides Lz4, LZO, Zstd compression support for parquet'
     }
 
-    implementation('org.xerial.snappy:snappy-java:1.1.8.4') {
+    implementation('org.xerial.snappy:snappy-java:1.1.10.5') {
         because 'Provides snappy compression for parquet, with native support for all platforms deephaven works on'
     }
 }


### PR DESCRIPTION
Fixes CVE-2023-43642, CVE-2023-34455, CVE-2023-34454, and CVE-2023-34453, which are various forms of DoS. Potentially relevant when reading untrusted parquet files.