### PR TITLE
DEEPHAVEN_VERSION must be set when installing py-client wheel

### DIFF
--- a/py/client/build.gradle
+++ b/py/client/build.gradle
@@ -111,6 +111,7 @@ def testPyClient = Docker.registerDockerTask(project, 'testPyClient') {
                       pip3 install --upgrade pip; \\
                       pip3 install -r requirements-dev.txt'''
 
+        environmentVariable 'DEEPHAVEN_VERSION', project.version
         runCommand 'pip install .'
         environmentVariable 'DH_HOST', deephavenDocker.containerName.get()
         environmentVariable 'DH_PORT', '10000'


### PR DESCRIPTION
Without this, the pip install apparently fails (silently?) and tests do not run.

Followup #4865