### PR TITLE
Ensure wildcard imports work against JRE classes

### DIFF
--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     // TODO(deephaven-core#3204): t-digest 3.3 appears to have higher errors than 3.2
     implementation 'com.tdunning:t-digest:3.2'
     implementation 'com.squareup:javapoet:1.13.0'
-    implementation 'io.github.classgraph:classgraph:4.8.154'
+    implementation 'io.github.classgraph:classgraph:4.8.165'
 
     implementation project(':plugin')
     implementation depCommonsLang3

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -557,7 +557,8 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
     }
 
     private static boolean packageIsVisibleToClassGraph(String packageImport) {
-        try (ScanResult scanResult = new ClassGraph().enableClassInfo().acceptPackages(packageImport).scan()) {
+        try (ScanResult scanResult =
+                new ClassGraph().enableClassInfo().enableSystemJarsAndModules().acceptPackages(packageImport).scan()) {
             final Optional<ClassInfo> firstClassFound = scanResult.getAllClasses().stream().findFirst();
             // force load the class so that the jvm is aware of the package
             firstClassFound.ifPresent(ClassInfo::loadClass);

--- a/engine/table/src/test/java/io/deephaven/engine/util/scripts/TestGroovyDeephavenSession.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/scripts/TestGroovyDeephavenSession.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -130,13 +131,14 @@ public class TestGroovyDeephavenSession {
 
     @Test
     public void testUnloadedWildcardPackageImport() {
-        // it's unlikely we have loaded anything from this groovy package
-        final String packageString = "groovy.time";
-
-        if (this.getClass().getClassLoader().getDefinedPackage(packageString) != null) {
-            Assert.fail("Package '" + packageString + "' is already loaded, test with a more obscure package.");
+        // Pick three packages we won't have loaded directly - a JRE package, a third party package (from a jar), and a
+        // package in the current source set
+        for (String packageString : Set.of("java.util", "groovy.time", "io.deephaven.engine.util.scripts.wontbeused")) {
+            if (this.getClass().getClassLoader().getDefinedPackage(packageString) != null) {
+                Assert.fail("Package '" + packageString + "' is already loaded, test with a more obscure package.");
+            }
+            session.evaluateScript("import " + packageString + ".*").throwIfError();
         }
-        session.evaluateScript("import " + packageString + ".*").throwIfError();
     }
 
     /**

--- a/engine/table/src/test/java/io/deephaven/engine/util/scripts/wontbeused/WontBeUsed.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/scripts/wontbeused/WontBeUsed.java
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+package io.deephaven.engine.util.scripts.wontbeused;
+
+/**
+ * Deliberately unused class so that we have a package that can be tested by
+ * {@link io.deephaven.engine.util.scripts.TestGroovyDeephavenSession}.
+ */
+public class WontBeUsed {
+}


### PR DESCRIPTION
Also updates our classgraph build, in case we were affected by Java 17+ issues.

Fixes #4994