### PR TITLE
PythonScopeJpyImpl: Disable Conversion Cache

### DIFF
--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
@@ -3,7 +3,6 @@
  */
 package io.deephaven.integrations.python;
 
-import io.deephaven.api.util.NameValidator;
 import io.deephaven.base.FileUtils;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.configuration.Configuration;
@@ -303,7 +302,7 @@ public class PythonDeephavenSession extends AbstractScriptSession<PythonSnapshot
     }
 
     @Override
-    protected Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate) {
+    protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
         final HashMap<String, Object> result = new HashMap<>();
         // note: we can't use collect(Collectors.toMap()) because we allow null values
         return PyLib.ensureGil(() -> {

--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
@@ -304,7 +304,7 @@ public class PythonDeephavenSession extends AbstractScriptSession<PythonSnapshot
     protected Map<String, Object> getAllValues() {
         return PyLib
                 .ensureGil(() -> scope.getEntries()
-                        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue)));
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     @Override
@@ -315,7 +315,7 @@ public class PythonDeephavenSession extends AbstractScriptSession<PythonSnapshot
     // TODO core#41 move this logic into the python console instance or scope like this - can go further and move
     // isWidget too
     @Override
-    public Object unwrapObject(Object object) {
+    public Object unwrapObject(@Nullable Object object) {
         if (object instanceof PyObject) {
             final PyObject pyObject = (PyObject) object;
             final Object unwrapped = module.javaify(pyObject);

--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.integrations.python;
 
+import io.deephaven.api.util.NameValidator;
 import io.deephaven.base.FileUtils;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.configuration.Configuration;
@@ -301,9 +302,10 @@ public class PythonDeephavenSession extends AbstractScriptSession<PythonSnapshot
     }
 
     @Override
-    protected Map<String, Object> getAllValues() {
+    protected Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate) {
         return PyLib
                 .ensureGil(() -> scope.getEntries()
+                        .filter(predicate)
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 

--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
@@ -300,8 +300,11 @@ public class PythonDeephavenSession extends AbstractScriptSession<PythonSnapshot
 
     @Override
     protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
-        final HashMap<String, Object> result = PyLib.ensureGil(() -> scope.getEntries()
-                .collect(HashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll));
+        final HashMap<String, Object> result = PyLib.ensureGil(
+                () -> scope.getEntriesRaw().<Map.Entry<String, PyObject>>map(
+                        e -> new AbstractMap.SimpleImmutableEntry<>(scope.convertStringKey(e.getKey()), e.getValue()))
+                        .collect(HashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()),
+                                HashMap::putAll));
 
         final Iterator<Map.Entry<String, Object>> iter = result.entrySet().iterator();
         while (iter.hasNext()) {

--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonDeephavenSession.java
@@ -42,6 +42,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -303,10 +304,14 @@ public class PythonDeephavenSession extends AbstractScriptSession<PythonSnapshot
 
     @Override
     protected Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate) {
-        return PyLib
-                .ensureGil(() -> scope.getEntries()
-                        .filter(predicate)
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        final HashMap<String, Object> result = new HashMap<>();
+        // note: we can't use collect(Collectors.toMap()) because we allow null values
+        return PyLib.ensureGil(() -> {
+            scope.getEntries()
+                    .filter(predicate)
+                    .forEach(entry -> result.put(entry.getKey(), entry.getValue()));
+            return result;
+        });
     }
 
     @Override

--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonObjectWrapper.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonObjectWrapper.java
@@ -13,6 +13,10 @@ import org.jpy.PyObject;
 public class PythonObjectWrapper {
     private static final PyModule PY_WRAPPER_MODULE = PyModule.importModule("deephaven._wrapper");
 
+    public static void init() {
+        // ensured that the class initializer runs during Jpy initialization
+    }
+
     /**
      * Unwrap a Python object to return the wrapped Java object.
      * 

--- a/Integrations/src/main/java/io/deephaven/integrations/python/PythonObjectWrapper.java
+++ b/Integrations/src/main/java/io/deephaven/integrations/python/PythonObjectWrapper.java
@@ -13,9 +13,10 @@ import org.jpy.PyObject;
 public class PythonObjectWrapper {
     private static final PyModule PY_WRAPPER_MODULE = PyModule.importModule("deephaven._wrapper");
 
-    public static void init() {
-        // ensured that the class initializer runs during Jpy initialization
-    }
+    /**
+     * Ensure that the class initializer runs.
+     */
+    public static void init() {}
 
     /**
      * Unwrap a Python object to return the wrapped Java object.

--- a/engine/context/src/main/java/io/deephaven/engine/context/EmptyQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/EmptyQueryScope.java
@@ -10,6 +10,7 @@ import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class EmptyQueryScope implements QueryScope {
@@ -48,7 +49,7 @@ public class EmptyQueryScope implements QueryScope {
     }
 
     @Override
-    public Map<String, Object> toMap() {
+    public Map<String, Object> toMap(@NotNull Predicate<Map.Entry<String, Object>> predicate) {
         return Collections.emptyMap();
     }
 

--- a/engine/context/src/main/java/io/deephaven/engine/context/PoisonedQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/PoisonedQueryScope.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class PoisonedQueryScope implements QueryScope {
@@ -53,7 +54,7 @@ public class PoisonedQueryScope implements QueryScope {
     }
 
     @Override
-    public Map<String, Object> toMap() {
+    public Map<String, Object> toMap(@NotNull Predicate<Map.Entry<String, Object>> predicate) {
         return fail();
     }
 

--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.context;
 import io.deephaven.engine.liveness.LivenessNode;
 import io.deephaven.base.log.LogOutput;
 import io.deephaven.base.log.LogOutputAppendable;
+import io.deephaven.util.annotations.FinalDefault;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +14,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Variable scope used to resolve parameter values during query execution and to expose named objects to users. Objects
@@ -137,7 +139,18 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
      *
      * @return a caller-owned mutable map with all known variables and their values.
      */
-    Map<String, Object> toMap();
+    Map<String, Object> toMap(@NotNull Predicate<Map.Entry<String, Object>> predicate);
+
+    /**
+     * Returns a mutable map with all objects in the scope. Callers may want to unwrap language-specific values using
+     * {@link #unwrapObject(Object)} before using them. This map is owned by the caller and may be mutated.
+     *
+     * @return a caller-owned mutable map with all known variables and their values.
+     */
+    @FinalDefault
+    default Map<String, Object> toMap() {
+        return toMap(entry -> true);
+    }
 
     /**
      * Removes any wrapping that exists on a scope param object so that clients can fetch them. Defaults to returning

--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
@@ -137,6 +137,7 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
      * Returns a mutable map with all objects in the scope. Callers may want to unwrap language-specific values using
      * {@link #unwrapObject(Object)} before using them. This map is owned by the caller and may be mutated.
      *
+     * @param predicate a predicate to filter the map entries
      * @return a caller-owned mutable map with all known variables and their values.
      */
     Map<String, Object> toMap(@NotNull Predicate<Map.Entry<String, Object>> predicate);
@@ -166,9 +167,9 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
     @Override
     default LogOutput append(@NotNull final LogOutput logOutput) {
         logOutput.append('{');
-        for (final String paramName : getParamNames()) {
-            final Object paramValue = readParamValue(paramName);
-            logOutput.nl().append(paramName).append("=");
+        for (final Map.Entry<String, Object> param : toMap().entrySet()) {
+            logOutput.nl().append(param.getKey()).append("=");
+            Object paramValue = param.getValue();
             if (paramValue == this) {
                 logOutput.append("this QueryScope (" + paramValue.getClass().getName() + ':'
                         + System.identityHashCode(paramValue) + ')');

--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
@@ -7,6 +7,7 @@ import io.deephaven.engine.liveness.LivenessNode;
 import io.deephaven.base.log.LogOutput;
 import io.deephaven.base.log.LogOutputAppendable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
@@ -69,8 +70,8 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
      * @return A newly-constructed array of newly-constructed Params.
      * @throws QueryScope.MissingVariableException If any of the named scope variables does not exist.
      */
-    default QueryScopeParam[] getParams(final Collection<String> names) throws MissingVariableException {
-        final QueryScopeParam[] result = new QueryScopeParam[names.size()];
+    default QueryScopeParam<?>[] getParams(final Collection<String> names) throws MissingVariableException {
+        final QueryScopeParam<?>[] result = new QueryScopeParam[names.size()];
         int pi = 0;
         for (final String name : names) {
             result[pi++] = createParam(name);
@@ -131,10 +132,10 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
     <T> void putParam(final String name, final T value);
 
     /**
-     * Returns an immutable map with all objects in the scope. Callers may want to unwrap language-specific values using
-     * {@link #unwrapObject(Object)} before using them.
+     * Returns a mutable map with all objects in the scope. Callers may want to unwrap language-specific values using
+     * {@link #unwrapObject(Object)} before using them. This map is owned by the caller and may be mutated.
      *
-     * @return an immutable map with all known variables and their values.
+     * @return a caller-owned mutable map with all known variables and their values.
      */
     Map<String, Object> toMap();
 
@@ -145,7 +146,7 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
      * @param object the scoped object
      * @return an obj which can be consumed by a client
      */
-    default Object unwrapObject(Object object) {
+    default Object unwrapObject(@Nullable Object object) {
         return object;
     }
 

--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryScopeParam.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryScopeParam.java
@@ -5,8 +5,6 @@ package io.deephaven.engine.context;
 
 public class QueryScopeParam<T> {
 
-    public static final QueryScopeParam<?>[] ZERO_LENGTH_PARAM_ARRAY = new QueryScopeParam[0];
-
     private final String name;
     private final T value;
 

--- a/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
@@ -6,9 +6,11 @@ import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.engine.updategraph.DynamicNode;
 import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -77,9 +79,11 @@ public class StandaloneQueryScope extends LivenessArtifact implements QueryScope
     }
 
     @Override
-    public Map<String, Object> toMap() {
+    public Map<String, Object> toMap(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
         return valueRetrievers.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().value));
+                .map(e -> Map.entry(e.getKey(), (Object) e.getValue().value))
+                .filter(predicate)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private static class ValueRetriever<T> {

--- a/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
@@ -6,6 +6,7 @@ import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.engine.updategraph.DynamicNode;
 import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -82,7 +83,7 @@ public class StandaloneQueryScope extends LivenessArtifact implements QueryScope
     public Map<String, Object> toMap(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
         final HashMap<String, Object> result = new HashMap<>();
         valueRetrievers.entrySet().stream()
-                .map(e -> Map.entry(e.getKey(), (Object) e.getValue().value))
+                .map(e -> ImmutablePair.of(e.getKey(), (Object) e.getValue().value))
                 .filter(predicate)
                 .forEach(e -> result.put(e.getKey(), e.getValue()));
         return result;

--- a/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
@@ -8,10 +8,10 @@ import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Map-based implementation, extending LivenessArtifact to manage the objects passed into it.
@@ -80,10 +80,12 @@ public class StandaloneQueryScope extends LivenessArtifact implements QueryScope
 
     @Override
     public Map<String, Object> toMap(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
-        return valueRetrievers.entrySet().stream()
+        final HashMap<String, Object> result = new HashMap<>();
+        valueRetrievers.entrySet().stream()
                 .map(e -> Map.entry(e.getKey(), (Object) e.getValue().value))
                 .filter(predicate)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .forEach(e -> result.put(e.getKey(), e.getValue()));
+        return result;
     }
 
     private static class ValueRetriever<T> {

--- a/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/StandaloneQueryScope.java
@@ -79,7 +79,7 @@ public class StandaloneQueryScope extends LivenessArtifact implements QueryScope
     @Override
     public Map<String, Object> toMap() {
         return valueRetrievers.entrySet().stream()
-                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().value));
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().value));
     }
 
     private static class ValueRetriever<T> {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -2758,7 +2758,7 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
                     pyCallableWrapper.addChunkArgument(
                             new ConstantChunkArgument(queryScopeVariables.get(name), argTypes[i]));
                 } else {
-                    throw new IllegalStateException("Vectorizability could not find variable by name: " + name);
+                    throw new IllegalStateException("Vectorizability check could not find variable by name: " + name);
                 }
             } else {
                 throw new IllegalStateException("Vectorizability check failed: " + n);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -86,7 +86,6 @@ import groovy.lang.Closure;
 import io.deephaven.base.Pair;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.configuration.Configuration;
-import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.context.QueryScopeParam;
 import io.deephaven.engine.table.impl.MatchPair;
 import io.deephaven.engine.table.impl.ShiftedColumnsFactory;
@@ -337,7 +336,7 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
                     // make sure the parser has no problem reparsing its own output and makes no changes to it.
                     final QueryLanguageParser validationQueryLanguageParser = new QueryLanguageParser(
                             printedSource, packageImports, classImports, staticImports, variables,
-                            variableTypeArguments, possibleParams, false, false, pyCallableWrapperImplName);
+                            variableTypeArguments, possibleParams, unboxArguments, false, pyCallableWrapperImplName);
 
                     final String reparsedSource = validationQueryLanguageParser.result.source;
                     Assert.equals(
@@ -2537,7 +2536,7 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
     private Optional<Class<?>> pyCallableReturnType(@NotNull MethodCallExpr n) {
         final PyCallableDetails pyCallableDetails = n.getData(QueryLanguageParserDataKeys.PY_CALLABLE_DETAILS);
         final String pyMethodName = pyCallableDetails.pythonMethodName;
-        final QueryScopeParam<?> queryScopeParam = possibleParams.getOrDefault(pyMethodName, null);
+        final QueryScopeParam<?> queryScopeParam = possibleParams.get(pyMethodName);
         if (queryScopeParam == null) {
             return Optional.empty();
         }
@@ -2633,7 +2632,7 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
         // Note: "paramValueRaw" needs to be the *actual PyCallableWrapper* corresponding to the method.
         // TODO: Support vectorization of instance methods of constant objects
         // ^^ i.e., create a constant for `new PyCallableWrapperImpl(pyScopeObj.getAttribute("pyMethodName"))`
-        final QueryScopeParam<?> queryScopeParam = possibleParams.getOrDefault(pyMethodName, null);
+        final QueryScopeParam<?> queryScopeParam = possibleParams.get(pyMethodName);
         if (queryScopeParam == null) {
             throw new IllegalStateException("Resolved Python function name " + pyMethodName + " not found");
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -143,8 +143,8 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
 
     private final Map<String, Class<?>> variables;
     private final Map<String, Class<?>[]> variableTypeArguments;
-    private final Set<String> columnVariables;
     private final Map<String, Object> queryScopeVariables;
+    private final Set<String> columnVariables;
 
     private final HashSet<String> variablesUsed = new HashSet<>();
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/lang/QueryLanguageParser.java
@@ -2537,10 +2537,11 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
     private Optional<Class<?>> pyCallableReturnType(@NotNull MethodCallExpr n) {
         final PyCallableDetails pyCallableDetails = n.getData(QueryLanguageParserDataKeys.PY_CALLABLE_DETAILS);
         final String pyMethodName = pyCallableDetails.pythonMethodName;
-        final Object paramValueRaw = possibleParams.getOrDefault(pyMethodName, null);
-        if (paramValueRaw == null) {
+        final QueryScopeParam<?> queryScopeParam = possibleParams.getOrDefault(pyMethodName, null);
+        if (queryScopeParam == null) {
             return Optional.empty();
         }
+        final Object paramValueRaw = queryScopeParam.getValue();
         if (!(paramValueRaw instanceof PyCallableWrapper)) {
             return Optional.empty();
         }
@@ -2632,11 +2633,11 @@ public final class QueryLanguageParser extends GenericVisitorAdapter<Class<?>, Q
         // Note: "paramValueRaw" needs to be the *actual PyCallableWrapper* corresponding to the method.
         // TODO: Support vectorization of instance methods of constant objects
         // ^^ i.e., create a constant for `new PyCallableWrapperImpl(pyScopeObj.getAttribute("pyMethodName"))`
-        final QueryScopeParam<?> paramValueParam = possibleParams.getOrDefault(pyMethodName, null);
-        if (paramValueParam == null) {
+        final QueryScopeParam<?> queryScopeParam = possibleParams.getOrDefault(pyMethodName, null);
+        if (queryScopeParam == null) {
             throw new IllegalStateException("Resolved Python function name " + pyMethodName + " not found");
         }
-        final Object paramValueRaw = paramValueParam.getValue();
+        final Object paramValueRaw = queryScopeParam.getValue();
         if (!(paramValueRaw instanceof PyCallableWrapper)) {
             throw new IllegalStateException("Resolved Python function name " + pyMethodName + " not callable");
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
@@ -148,12 +148,13 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
 
             possibleVariables.putAll(timeConversionResult.getNewVariables());
 
-            final QueryLanguageParser.Result result =
-                    new QueryLanguageParser(timeConversionResult.getConvertedFormula(),
-                            ExecutionContext.getContext().getQueryLibrary().getPackageImports(),
-                            ExecutionContext.getContext().getQueryLibrary().getClassImports(),
-                            ExecutionContext.getContext().getQueryLibrary().getStaticImports(),
-                            possibleVariables, possibleVariableParameterizedTypes, unboxArguments).getResult();
+            final QueryLanguageParser.Result result = new QueryLanguageParser(
+                    timeConversionResult.getConvertedFormula(),
+                    ExecutionContext.getContext().getQueryLibrary().getPackageImports(),
+                    ExecutionContext.getContext().getQueryLibrary().getClassImports(),
+                    ExecutionContext.getContext().getQueryLibrary().getStaticImports(),
+                    possibleVariables, possibleVariableParameterizedTypes, possibleParams, unboxArguments)
+                    .getResult();
             formulaShiftColPair = result.getFormulaShiftColPair();
             if (formulaShiftColPair != null) {
                 log.debug("Formula (after shift conversion) : " + formulaShiftColPair.getFirst());
@@ -205,8 +206,8 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
                     usedColumns.add(variable);
                 } else if (arrayColumnToFind != null && tableDefinition.getColumn(arrayColumnToFind) != null) {
                     usedColumnArrays.add(arrayColumnOuterName);
-                } else if (possibleParams.containsKey(variable)) {
-                    paramsList.add(possibleParams.get(variable));
+                } else if (result.getPossibleParams().containsKey(variable)) {
+                    paramsList.add(result.getPossibleParams().get(variable));
                 }
             }
             params = paramsList.toArray(QueryScopeParam.ZERO_LENGTH_PARAM_ARRAY);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -105,7 +105,7 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
     protected void applyUsedVariables(
             @NotNull final Map<String, ColumnDefinition<?>> columnDefinitionMap,
             @NotNull final Set<String> variablesUsed,
-            @NotNull final Map<String, QueryScopeParam<?>> possibleParams) {
+            @NotNull final Map<String, Object> possibleParams) {
         // the column definition map passed in is being mutated by the caller, so we need to make a copy
         columnDefinitions = Map.copyOf(columnDefinitionMap);
 
@@ -127,12 +127,12 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
                 if (variable.endsWith(COLUMN_SUFFIX) && columnDefinitions.get(strippedColumnName) != null) {
                     usedColumnArrays.add(strippedColumnName);
                 } else if (possibleParams.containsKey(variable)) {
-                    paramsList.add(possibleParams.get(variable));
+                    paramsList.add(new QueryScopeParam<>(variable, possibleParams.get(variable)));
                 }
             }
         }
 
-        params = paramsList.toArray(QueryScopeParam.ZERO_LENGTH_PARAM_ARRAY);
+        params = paramsList.toArray(QueryScopeParam[]::new);
     }
 
     protected void onCopy(final AbstractFormulaColumn copy) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -6,8 +6,6 @@ package io.deephaven.engine.table.impl.select;
 import io.deephaven.base.verify.Require;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.*;
-import io.deephaven.engine.context.ExecutionContext;
-import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.context.QueryScopeParam;
 import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.MatchPair;
@@ -104,15 +102,12 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
         }
     }
 
-    protected void applyUsedVariables(Map<String, ColumnDefinition<?>> columnDefinitionMap, Set<String> variablesUsed) {
+    protected void applyUsedVariables(
+            @NotNull final Map<String, ColumnDefinition<?>> columnDefinitionMap,
+            @NotNull final Set<String> variablesUsed,
+            @NotNull final Map<String, QueryScopeParam<?>> possibleParams) {
         // the column definition map passed in is being mutated by the caller, so we need to make a copy
         columnDefinitions = Map.copyOf(columnDefinitionMap);
-
-        final Map<String, QueryScopeParam<?>> possibleParams = new HashMap<>();
-        final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
-        for (QueryScopeParam<?> param : queryScope.getParams(queryScope.getParamNames())) {
-            possibleParams.put(param.getName(), param);
-        }
 
         final List<QueryScopeParam<?>> paramsList = new ArrayList<>();
         usedColumns = new ArrayList<>();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/DhFormulaColumn.java
@@ -201,7 +201,7 @@ public class DhFormulaColumn extends AbstractFormulaColumn {
             log.debug().append("Expression (after language conversion) : ").append(analyzedFormula.cookedFormulaString)
                     .endl();
 
-            applyUsedVariables(columnDefinitionMap, result.getVariablesUsed());
+            applyUsedVariables(columnDefinitionMap, result.getVariablesUsed(), result.getPossibleParams());
             returnedType = result.getType();
             if (returnedType == boolean.class) {
                 returnedType = Boolean.class;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
@@ -94,10 +94,12 @@ public class FormulaAnalyzer {
             }
         }
 
+        final Map<String, QueryScopeParam<?>> possibleVariableValues = new HashMap<>();
         final ExecutionContext context = ExecutionContext.getContext();
         final QueryScope queryScope = context.getQueryScope();
         for (QueryScopeParam<?> param : queryScope.getParams(queryScope.getParamNames())) {
             possibleVariables.put(param.getName(), QueryScopeParamTypeUtil.getDeclaredClass(param.getValue()));
+            possibleVariableValues.put(param.getName(), param);
 
             Type declaredType = QueryScopeParamTypeUtil.getDeclaredType(param.getValue());
             if (declaredType instanceof ParameterizedType) {
@@ -131,7 +133,7 @@ public class FormulaAnalyzer {
         return new QueryLanguageParser(timeConversionResult.getConvertedFormula(),
                 context.getQueryLibrary().getPackageImports(),
                 classImports, context.getQueryLibrary().getStaticImports(), possibleVariables,
-                possibleVariableParameterizedTypes)
+                possibleVariableParameterizedTypes, possibleVariableValues)
                 .getResult();
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/python/FormulaColumnPython.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/python/FormulaColumnPython.java
@@ -44,7 +44,7 @@ public class FormulaColumnPython extends AbstractFormulaColumn implements Formul
             validateColumnDefinition(columnDefinitionMap);
         } else {
             returnedType = dcf.getReturnedType();
-            applyUsedVariables(columnDefinitionMap, new LinkedHashSet<>(dcf.getColumnNames()));
+            applyUsedVariables(columnDefinitionMap, new LinkedHashSet<>(dcf.getColumnNames()), Map.of());
             formulaFactory = createKernelFormulaFactory(this);
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
@@ -25,6 +25,7 @@ import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.plugin.type.ObjectType;
 import io.deephaven.plugin.type.ObjectTypeLookup;
 import io.deephaven.util.SafeCloseable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -293,10 +294,11 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
     /**
      * Returns a mutable map with all known variables and their values. It is owned by the caller.
      *
+     * @param predicate a predicate to decide if an entry should be included in the returned map
      * @return a mutable map with all known variables and their values. As with {@link #getVariable(String)}, values may
      *         need to be unwrapped.
      */
-    protected abstract Map<String, Object> getAllValues();
+    protected abstract Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate);
 
     // -----------------------------------------------------------------------------------------------------------------
     // ScriptSession-based QueryScope implementation, with no remote scope or object reflection support
@@ -370,8 +372,8 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
         }
 
         @Override
-        public Map<String, Object> toMap() {
-            return AbstractScriptSession.this.getAllValues();
+        public Map<String, Object> toMap(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
+            return AbstractScriptSession.this.getAllValues(predicate);
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
@@ -291,10 +291,10 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
     protected abstract Object setVariable(String name, @Nullable Object value);
 
     /**
-     * Returns an immutable map with all known variables and their values.
+     * Returns a mutable map with all known variables and their values. It is owned by the caller.
      *
-     * @return an immutable map with all known variables and their values. As with {@link #getVariable(String)}, values
-     *         may need to be unwrapped.
+     * @return a mutable map with all known variables and their values. As with {@link #getVariable(String)}, values may
+     *         need to be unwrapped.
      */
     protected abstract Map<String, Object> getAllValues();
 
@@ -375,7 +375,7 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
         }
 
         @Override
-        public Object unwrapObject(Object object) {
+        public Object unwrapObject(@Nullable Object object) {
             return AbstractScriptSession.this.unwrapObject(object);
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
@@ -298,7 +298,7 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
      * @return a mutable map with all known variables and their values. As with {@link #getVariable(String)}, values may
      *         need to be unwrapped.
      */
-    protected abstract Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate);
+    protected abstract Map<String, Object> getAllValues(@NotNull Predicate<Map.Entry<String, Object>> predicate);
 
     // -----------------------------------------------------------------------------------------------------------------
     // ScriptSession-based QueryScope implementation, with no remote scope or object reflection support

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -772,9 +772,12 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
     @Override
     protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
         synchronized (bindingBackingMap) {
-            return bindingBackingMap.entrySet().stream()
+            final HashMap<String, Object> result = new HashMap<>();
+            // note: we can't use collect(Collectors.toMap()) because we allow null values
+            bindingBackingMap.entrySet().stream()
                     .filter(predicate)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .forEach(e -> result.put(e.getKey(), e.getValue()));
+            return result;
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -771,7 +771,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
     @Override
     protected Map<String, Object> getAllValues() {
         synchronized (bindingBackingMap) {
-            return Map.copyOf(bindingBackingMap);
+            return new HashMap<>(bindingBackingMap);
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -52,6 +52,7 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.codehaus.groovy.tools.GroovyClass;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.tools.JavaFileObject;
@@ -769,9 +770,11 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
     }
 
     @Override
-    protected Map<String, Object> getAllValues() {
+    protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
         synchronized (bindingBackingMap) {
-            return new HashMap<>(bindingBackingMap);
+            return bindingBackingMap.entrySet().stream()
+                    .filter(predicate)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -771,14 +771,14 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
 
     @Override
     protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
+        // note: we can't use collect(Collectors.toMap()) because we allow null values
+        final HashMap<String, Object> result = new HashMap<>();
         synchronized (bindingBackingMap) {
-            final HashMap<String, Object> result = new HashMap<>();
-            // note: we can't use collect(Collectors.toMap()) because we allow null values
             bindingBackingMap.entrySet().stream()
                     .filter(predicate)
                     .forEach(e -> result.put(e.getKey(), e.getValue()));
-            return result;
         }
+        return result;
     }
 
     public Binding getBinding() {

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -771,14 +771,11 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
 
     @Override
     protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
-        // note: we can't use collect(Collectors.toMap()) because we allow null values
-        final HashMap<String, Object> result = new HashMap<>();
         synchronized (bindingBackingMap) {
-            bindingBackingMap.entrySet().stream()
+            return bindingBackingMap.entrySet().stream()
                     .filter(predicate)
-                    .forEach(e -> result.put(e.getKey(), e.getValue()));
+                    .collect(HashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll);
         }
-        return result;
     }
 
     public Binding getBinding() {

--- a/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
@@ -3,6 +3,7 @@
  */
 package io.deephaven.engine.util;
 
+import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
@@ -92,9 +93,11 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession<AbstractSc
     }
 
     @Override
-    protected Map<String, Object> getAllValues() {
+    protected Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate) {
         synchronized (variables) {
-            return new HashMap<>(variables);
+            return variables.entrySet().stream()
+                    .filter(predicate)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
@@ -94,11 +94,14 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession<AbstractSc
 
     @Override
     protected Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate) {
+        // note: we can't use collect(Collectors.toMap()) because we allow null values
+        final HashMap<String, Object> result = new HashMap<>();
         synchronized (variables) {
-            return variables.entrySet().stream()
+            variables.entrySet().stream()
                     .filter(predicate)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .forEach(entry -> result.put(entry.getKey(), entry.getValue()));
         }
+        return result;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
@@ -7,6 +7,7 @@ import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -93,15 +94,12 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession<AbstractSc
     }
 
     @Override
-    protected Map<String, Object> getAllValues(Predicate<Map.Entry<String, Object>> predicate) {
-        // note: we can't use collect(Collectors.toMap()) because we allow null values
-        final HashMap<String, Object> result = new HashMap<>();
+    protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
         synchronized (variables) {
-            variables.entrySet().stream()
+            return variables.entrySet().stream()
                     .filter(predicate)
-                    .forEach(entry -> result.put(entry.getKey(), entry.getValue()));
+                    .collect(HashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll);
         }
-        return result;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
@@ -8,10 +8,7 @@ import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -97,7 +94,7 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession<AbstractSc
     @Override
     protected Map<String, Object> getAllValues() {
         synchronized (variables) {
-            return Map.copyOf(variables);
+            return new HashMap<>(variables);
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapperJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapperJpyImpl.java
@@ -42,6 +42,10 @@ public class PyCallableWrapperJpyImpl implements PyCallableWrapper {
         numpyType2JavaClass.put('O', Object.class);
     }
 
+    public static void init() {
+        // this is invoked to force the static initializer to run immediately after Jpy is initialized
+    }
+
     // TODO: support for vectorizing functions that return arrays
     // https://github.com/deephaven/deephaven-core/issues/4649
     private static final Set<Class<?>> vectorizableReturnTypes = Set.of(

--- a/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapperJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapperJpyImpl.java
@@ -43,7 +43,7 @@ public class PyCallableWrapperJpyImpl implements PyCallableWrapper {
     }
 
     public static void init() {
-        // this is invoked to force the static initializer to run immediately after Jpy is initialized
+        // ensured that the class initializer runs during Jpy initialization
     }
 
     // TODO: support for vectorizing functions that return arrays

--- a/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapperJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapperJpyImpl.java
@@ -42,9 +42,10 @@ public class PyCallableWrapperJpyImpl implements PyCallableWrapper {
         numpyType2JavaClass.put('O', Object.class);
     }
 
-    public static void init() {
-        // ensured that the class initializer runs during Jpy initialization
-    }
+    /**
+     * Ensure that the class initializer runs.
+     */
+    public static void init() {}
 
     // TODO: support for vectorizing functions that return arrays
     // https://github.com/deephaven/deephaven-core/issues/4649

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonEvaluatorJpy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonEvaluatorJpy.java
@@ -47,8 +47,6 @@ public class PythonEvaluatorJpy implements PythonEvaluator {
 
     private PythonEvaluatorJpy(PyDictWrapper globals) {
         this.globals = globals;
-        // forcefully load this helper class which imports python modules
-        PyCallableWrapperJpyImpl.init();
     }
 
     public PythonScopeJpyImpl getScope() {

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonEvaluatorJpy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonEvaluatorJpy.java
@@ -47,6 +47,8 @@ public class PythonEvaluatorJpy implements PythonEvaluator {
 
     private PythonEvaluatorJpy(PyDictWrapper globals) {
         this.globals = globals;
+        // forcefully load this helper class which imports python modules
+        PyCallableWrapperJpyImpl.init();
     }
 
     public PythonScopeJpyImpl getScope() {

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScope.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScope.java
@@ -6,10 +6,7 @@ package io.deephaven.engine.util;
 import org.jpy.PyDictWrapper;
 import org.jpy.PyObject;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -134,16 +131,6 @@ public interface PythonScope<PyObj> {
     }
 
     /**
-     * Equivalent to {@link #getEntriesRaw()}, where the keys have been converted via {@link #convertStringKey(Object)}
-     * but the values still need conversion via {@link #convertValue(Object)}.
-     *
-     * @return the string keys and original values
-     */
-    default Stream<Entry<String, PyObj>> getEntries() {
-        return getEntriesRaw().map(e -> new SimpleImmutableEntry<>(convertStringKey(e.getKey()), e.getValue()));
-    }
-
-    /**
      * Equivalent to {@link #getKeys()}.collect(someCollector)
      *
      * @return the string keys, as a collection
@@ -151,17 +138,6 @@ public interface PythonScope<PyObj> {
     default Collection<String> getKeysCollection() {
         return getKeys()
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Equivalent to {@link #getEntries()}.collect(someMapCollector)
-     *
-     * @return the string keys and converted values, as a map
-     */
-    default Map<String, Object> getEntriesMap() {
-        return getEntries()
-                .map(e -> new SimpleImmutableEntry<>(e.getKey(), convertValue(e.getValue())))
-                .collect(HashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 public class PythonScopeJpyImpl implements PythonScope<PyObject> {
     private static volatile boolean cacheEnabled =
             Configuration.getInstance().getBooleanForClassWithDefault(PythonScopeJpyImpl.class, "cacheEnabled", false);
+
     public static void setCacheEnabled(boolean enabled) {
         cacheEnabled = enabled;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -124,10 +124,7 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
             ret = pyObject.getObjectValue();
         }
 
-        if (ret == null && fromCache) {
-            ret = new NULL_TOKEN();
-        }
-        return ret;
+        return ret == null && fromCache ? new NULL_TOKEN() : ret;
     }
 
     public PyDictWrapper mainGlobals() {

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -98,6 +98,8 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
             return pyObject.asDict();
         } else if (pyObject.isCallable()) {
             return new PyCallableWrapperJpyImpl(pyObject);
+        } else if (pyObject.isNone()) {
+            return null;
         } else if (pyObject.isConvertible()) {
             try {
                 // these are java objects; avoid the overhead of the JNI round trip when possible

--- a/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/ScriptSession.java
@@ -118,7 +118,7 @@ public interface ScriptSession extends LivenessNode {
      * @param object the scoped object
      * @return an obj which can be consumed by a client
      */
-    default Object unwrapObject(Object object) {
+    default Object unwrapObject(@Nullable Object object) {
         return object;
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
@@ -4,6 +4,7 @@
 package io.deephaven.engine.table.impl.lang;
 
 import groovy.lang.Closure;
+import io.deephaven.api.util.NameValidator;
 import io.deephaven.base.Pair;
 import io.deephaven.base.testing.BaseArrayTestCase;
 import io.deephaven.base.verify.Assert;
@@ -3177,14 +3178,14 @@ public class TestQueryLanguageParser extends BaseArrayTestCase {
         final Map<String, Object> possibleParams;
         final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
         if (!(queryScope instanceof PoisonedQueryScope)) {
-            possibleParams = queryScope.toMap();
+            possibleParams = queryScope.toMap(NameValidator.VALID_QUERY_PARAMETER_MAP_ENTRY_PREDICATE);
         } else {
             possibleParams = null;
         }
 
         final QueryLanguageParser.Result result =
                 new QueryLanguageParser(expression, packageImports, classImports, staticImports,
-                        variables, variableParameterizedTypes, possibleParams,
+                        variables, variableParameterizedTypes, possibleParams, null,
                         true,
                         verifyIdempotence,
                         PyCallableWrapperDummyImpl.class.getName()).getResult();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
@@ -3177,7 +3177,7 @@ public class TestQueryLanguageParser extends BaseArrayTestCase {
             throws Exception {
         QueryLanguageParser.Result result =
                 new QueryLanguageParser(expression, packageImports, classImports, staticImports,
-                        variables, variableParameterizedTypes,
+                        variables, variableParameterizedTypes, null,
                         true,
                         verifyIdempotence,
                         PyCallableWrapperDummyImpl.class.getName()).getResult();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
@@ -3174,12 +3174,12 @@ public class TestQueryLanguageParser extends BaseArrayTestCase {
     private void check(String expression, String resultExpression, Class<?> resultType, String[] resultVarsUsed,
             boolean verifyIdempotence)
             throws Exception {
-        final Map<String, QueryScopeParam<?>> possibleParams = new HashMap<>();
+        final Map<String, Object> possibleParams;
         final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
         if (!(queryScope instanceof PoisonedQueryScope)) {
-            for (QueryScopeParam<?> param : queryScope.getParams(queryScope.getParamNames())) {
-                possibleParams.put(param.getName(), param);
-            }
+            possibleParams = queryScope.toMap();
+        } else {
+            possibleParams = null;
         }
 
         final QueryLanguageParser.Result result =

--- a/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeCopyModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeCopyModule.java
@@ -16,7 +16,9 @@ public interface PythonGlobalScopeCopyModule {
     @Provides
     static PythonEvaluatorJpy providePythonEvaluatorJpy() {
         try {
-            return PythonEvaluatorJpy.withGlobalCopy();
+            PythonEvaluatorJpy jpy = PythonEvaluatorJpy.withGlobalCopy();
+            PythonImportInitializer.init();
+            return jpy;
         } catch (IOException | InterruptedException | TimeoutException e) {
             throw new IllegalStateException("Unable to start a python session: ", e);
         }

--- a/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeModule.java
@@ -16,7 +16,9 @@ public interface PythonGlobalScopeModule {
     @Provides
     static PythonEvaluatorJpy providePythonEvaluatorJpy() {
         try {
-            return PythonEvaluatorJpy.withGlobals();
+            PythonEvaluatorJpy jpy = PythonEvaluatorJpy.withGlobals();
+            PythonImportInitializer.init();
+            return jpy;
         } catch (IOException | InterruptedException | TimeoutException e) {
             throw new IllegalStateException("Unable to start a python session: ", e);
         }

--- a/server/src/main/java/io/deephaven/server/console/python/PythonImportInitializer.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonImportInitializer.java
@@ -1,0 +1,17 @@
+package io.deephaven.server.console.python;
+
+import io.deephaven.engine.util.PyCallableWrapperJpyImpl;
+import io.deephaven.integrations.python.PythonObjectWrapper;
+
+public abstract class PythonImportInitializer {
+    public static void init() {
+        // ensured that these classes are initialized during Jpy initialization as they import python modules and we'd
+        // like to avoid deadlocking the GIL during class initialization
+        PythonObjectWrapper.init();
+        PyCallableWrapperJpyImpl.init();
+    }
+
+    private PythonImportInitializer() {
+        // no instances should be created
+    }
+}

--- a/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
+++ b/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
@@ -5,9 +5,8 @@ package io.deephaven.api.util;
 
 import javax.lang.model.SourceVersion;
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -97,6 +96,9 @@ public class NameValidator {
     private static final Set<String> QUERY_LANG_RESERVED_VARIABLE_NAMES =
             Stream.of("in", "not", "i", "ii", "k").collect(
                     Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+
+    public static final Predicate<Map.Entry<String, Object>> VALID_QUERY_PARAMETER_MAP_ENTRY_PREDICATE =
+            e -> isValidQueryParameterName(e.getKey());
 
     public static String validateTableName(String name) {
         return Type.TABLE.validate(name);


### PR DESCRIPTION
This fixes a memory leak discovered in #5112 via repeated runs of:

```python
import time, jpy
from deephaven import empty_table, garbage_collect

row_count = 10_000_000

begin_time = time.perf_counter_ns()
source = empty_table(row_count).update(["X = repeat(ii % 250, 100)"]) 
empty_table(1).select('Y = 1')
print('Rows / Sec:', row_count / ((time.perf_counter_ns() - begin_time) / 1_000_000_000))

Runtime = jpy.get_type('java.lang.Runtime')
print('Gigs Used Before GC:',
        (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024 / 1024)

del source;
del row_count;
del begin_time
for i in range(10):
    garbage_collect()

print('Gigs Used After GC:',
        (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024 / 1024)
del Runtime
```

Nightlies running here: https://github.com/nbauernfeind/deephaven-core/actions/runs/7833860264/