### PR TITLE
Drop Usage of `ensureGil` from PythonDeephavenSession and Copy Current Scope

### DIFF
--- a/engine/context/src/main/java/io/deephaven/engine/context/EmptyQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/EmptyQueryScope.java
@@ -5,11 +5,13 @@ package io.deephaven.engine.context;
 
 import io.deephaven.engine.liveness.LivenessReferent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -49,7 +51,7 @@ public class EmptyQueryScope implements QueryScope {
     }
 
     @Override
-    public Map<String, Object> toMap(@NotNull Predicate<Map.Entry<String, Object>> predicate) {
+    public <T> Map<String, T> toMap(@Nullable Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter) {
         return Collections.emptyMap();
     }
 

--- a/engine/context/src/main/java/io/deephaven/engine/context/EmptyQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/EmptyQueryScope.java
@@ -5,14 +5,10 @@ package io.deephaven.engine.context;
 
 import io.deephaven.engine.liveness.LivenessReferent;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class EmptyQueryScope implements QueryScope {
@@ -22,7 +18,7 @@ public class EmptyQueryScope implements QueryScope {
 
     @Override
     public Set<String> getParamNames() {
-        return Collections.emptySet();
+        return new HashSet<>();
     }
 
     @Override
@@ -51,8 +47,13 @@ public class EmptyQueryScope implements QueryScope {
     }
 
     @Override
-    public <T> Map<String, T> toMap(@Nullable Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter) {
-        return Collections.emptyMap();
+    public Map<String, Object> toMap(@NotNull ParamFilter<Object> filter) {
+        return new HashMap<>();
+    }
+
+    @Override
+    public <T> Map<String, T> toMap(@NotNull Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter) {
+        return new HashMap<>();
     }
 
     @Override

--- a/engine/context/src/main/java/io/deephaven/engine/context/PoisonedQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/PoisonedQueryScope.java
@@ -6,7 +6,6 @@ package io.deephaven.engine.context;
 import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.util.ExecutionContextRegistrationException;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.Map;
@@ -55,7 +54,12 @@ public class PoisonedQueryScope implements QueryScope {
     }
 
     @Override
-    public <T> Map<String, T> toMap(@Nullable Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter) {
+    public Map<String, Object> toMap(@NotNull ParamFilter<Object> filter) {
+        return fail();
+    }
+
+    @Override
+    public <T> Map<String, T> toMap(@NotNull Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter) {
         return fail();
     }
 

--- a/engine/context/src/main/java/io/deephaven/engine/context/PoisonedQueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/PoisonedQueryScope.java
@@ -6,11 +6,12 @@ package io.deephaven.engine.context;
 import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.util.ExecutionContextRegistrationException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class PoisonedQueryScope implements QueryScope {
@@ -54,7 +55,7 @@ public class PoisonedQueryScope implements QueryScope {
     }
 
     @Override
-    public Map<String, Object> toMap(@NotNull Predicate<Map.Entry<String, Object>> predicate) {
+    public <T> Map<String, T> toMap(@Nullable Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter) {
         return fail();
     }
 

--- a/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
+++ b/engine/context/src/main/java/io/deephaven/engine/context/QueryScope.java
@@ -6,7 +6,6 @@ package io.deephaven.engine.context;
 import io.deephaven.engine.liveness.LivenessNode;
 import io.deephaven.base.log.LogOutput;
 import io.deephaven.base.log.LogOutputAppendable;
-import io.deephaven.util.annotations.FinalDefault;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -84,7 +83,7 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
     /**
      * Get all known scope variable names.
      *
-     * @return A collection of scope variable names.
+     * @return A caller-owned mutable collection of scope variable names.
      */
     Set<String> getParamNames();
 
@@ -133,6 +132,7 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
      */
     <T> void putParam(final String name, final T value);
 
+    @FunctionalInterface
     interface ParamFilter<T> {
         boolean accept(String name, T value);
     }
@@ -144,10 +144,7 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
      * @param filter a predicate to filter the map entries
      * @return a caller-owned mutable map with all known variables and their values.
      */
-    @FinalDefault
-    default Map<String, Object> toMap(@NotNull ParamFilter<Object> filter) {
-        return toMap(null, filter);
-    }
+    Map<String, Object> toMap(@NotNull ParamFilter<Object> filter);
 
     /**
      * Returns a mutable map with all objects in the scope.
@@ -161,7 +158,7 @@ public interface QueryScope extends LivenessNode, LogOutputAppendable {
      * @param <T> the type of the mapped values
      */
     <T> Map<String, T> toMap(
-            @Nullable Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter);
+            @NotNull Function<Object, T> valueMapper, @NotNull ParamFilter<T> filter);
 
     /**
      * Removes any wrapping that exists on a scope param object so that clients can fetch them. Defaults to returning

--- a/engine/sql/src/main/java/io/deephaven/engine/sql/Sql.java
+++ b/engine/sql/src/main/java/io/deephaven/engine/sql/Sql.java
@@ -83,10 +83,8 @@ public final class Sql {
         // getVariables() is inefficient
         // See SQLTODO(catalog-reader-implementation)
         final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
-        return queryScope.toMap(wrapped -> {
-            final Object value = queryScope.unwrapObject(wrapped);
-            return value instanceof Table ? (Table) value : null;
-        }, (n, t) -> t != null);
+        // noinspection unchecked,rawtypes
+        return (Map<String, Table>) (Map) queryScope.toMap(queryScope::unwrapObject, (n, t) -> t instanceof Table);
     }
 
     private static TableHeader adapt(TableDefinition tableDef) {

--- a/engine/sql/src/main/java/io/deephaven/engine/sql/Sql.java
+++ b/engine/sql/src/main/java/io/deephaven/engine/sql/Sql.java
@@ -82,16 +82,11 @@ public final class Sql {
     private static Map<String, Table> currentScriptSessionNamedTables() {
         // getVariables() is inefficient
         // See SQLTODO(catalog-reader-implementation)
-        QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
-        final Map<String, Table> scope = queryScope
-                .toMap()
-                .entrySet()
-                .stream()
-                .map(e -> Map.entry(e.getKey(), queryScope.unwrapObject(e.getValue())))
-                .filter(e -> e.getValue() instanceof Table)
-                .collect(Collectors.toMap(Entry::getKey, e -> (Table) e.getValue()));
-
-        return scope;
+        final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
+        return queryScope.toMap(wrapped -> {
+            final Object value = queryScope.unwrapObject(wrapped);
+            return value instanceof Table ? (Table) value : null;
+        }, (n, t) -> t != null);
     }
 
     private static TableHeader adapt(TableDefinition tableDef) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractConditionFilter.java
@@ -95,7 +95,7 @@ public abstract class AbstractConditionFilter extends WhereFilterImpl {
         try {
             final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
             final Map<String, Object> queryScopeVariables = queryScope.toMap(
-                    NameValidator.VALID_QUERY_PARAMETER_MAP_ENTRY_PREDICATE);
+                    (name, value) -> NameValidator.isValidQueryParameterName(name));
             for (Map.Entry<String, Object> param : queryScopeVariables.entrySet()) {
                 possibleVariables.put(param.getKey(), QueryScopeParamTypeUtil.getDeclaredClass(param.getValue()));
                 Type declaredType = QueryScopeParamTypeUtil.getDeclaredType(param.getValue());

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/codegen/FormulaAnalyzer.java
@@ -105,7 +105,7 @@ public class FormulaAnalyzer {
 
         final ExecutionContext context = ExecutionContext.getContext();
         final Map<String, Object> queryScopeVariables = context.getQueryScope().toMap(
-                NameValidator.VALID_QUERY_PARAMETER_MAP_ENTRY_PREDICATE);
+                (name, value) -> NameValidator.isValidQueryParameterName(name));
         for (Map.Entry<String, Object> param : queryScopeVariables.entrySet()) {
             if (possibleVariables.containsKey(param.getKey())) {
                 // skip any existing matches

--- a/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/AbstractScriptSession.java
@@ -5,7 +5,6 @@ package io.deephaven.engine.util;
 
 import com.github.f4b6a3.uuid.UuidCreator;
 import io.deephaven.UncheckedDeephavenException;
-import io.deephaven.api.util.NameValidator;
 import io.deephaven.base.FileUtils;
 import io.deephaven.configuration.CacheDir;
 import io.deephaven.engine.context.*;
@@ -30,7 +29,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static io.deephaven.engine.table.Table.NON_DISPLAY_TABLE;
 
@@ -264,10 +262,9 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
     /**
      * Retrieves all variable names present in the session's scope.
      *
-     * @param allowName a predicate to decide if a name should be in the returned immutable set
-     * @return an immutable set of variable names
+     * @return a caller-owned mutable set of variable names
      */
-    protected abstract Set<String> getVariableNames(Predicate<String> allowName);
+    protected abstract Set<String> getVariableNames();
 
     /**
      * Check if the scope has the given variable name.
@@ -315,12 +312,12 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
 
         @Override
         public Set<String> getParamNames() {
-            return getVariableNames(NameValidator::isValidQueryParameterName);
+            return getVariableNames();
         }
 
         @Override
         public boolean hasParamName(String name) {
-            return NameValidator.isValidQueryParameterName(name) && hasVariable(name);
+            return hasVariable(name);
         }
 
         @Override
@@ -360,8 +357,13 @@ public abstract class AbstractScriptSession<S extends AbstractScriptSession.Snap
         }
 
         @Override
+        public Map<String, Object> toMap(@NotNull final ParamFilter<Object> filter) {
+            return AbstractScriptSession.this.getAllValues(null, filter);
+        }
+
+        @Override
         public <T> Map<String, T> toMap(
-                @Nullable final Function<Object, T> valueMapper,
+                @NotNull final Function<Object, T> valueMapper,
                 @NotNull final ParamFilter<T> filter) {
             return AbstractScriptSession.this.getAllValues(valueMapper, filter);
         }

--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -18,7 +18,6 @@ import io.deephaven.base.Pair;
 import io.deephaven.engine.context.*;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.exceptions.CancellationException;
-import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.TrackingRowSet;
 import io.deephaven.engine.table.ColumnSource;
@@ -71,7 +70,6 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -744,9 +742,9 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
     }
 
     @Override
-    protected Set<String> getVariableNames(Predicate<String> allowName) {
+    protected Set<String> getVariableNames() {
         synchronized (bindingBackingMap) {
-            return bindingBackingMap.keySet().stream().filter(allowName).collect(Collectors.toUnmodifiableSet());
+            return new HashSet<>(bindingBackingMap.keySet());
         }
     }
 
@@ -757,8 +755,6 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
 
     @Override
     protected Object setVariable(String name, @Nullable Object newValue) {
-        NameValidator.validateQueryParameterName(name);
-
         Object oldValue = bindingBackingMap.put(name, newValue);
 
         // Observe changes from this "setVariable" (potentially capturing previous or concurrent external changes from

--- a/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
@@ -3,7 +3,6 @@
  */
 package io.deephaven.engine.util;
 
-import io.deephaven.api.util.NameValidator;
 import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
@@ -11,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -94,12 +94,27 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession<AbstractSc
     }
 
     @Override
-    protected Map<String, Object> getAllValues(@NotNull final Predicate<Map.Entry<String, Object>> predicate) {
+    protected <T> Map<String, T> getAllValues(@Nullable Function<Object, T> valueMapper,
+            QueryScope.@NotNull ParamFilter<T> filter) {
+        final Map<String, T> result = new HashMap<>();
+
         synchronized (variables) {
-            return variables.entrySet().stream()
-                    .filter(predicate)
-                    .collect(HashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll);
+            for (final Map.Entry<String, Object> entry : variables.entrySet()) {
+                final String name = entry.getKey();
+                Object value = entry.getValue();
+                if (valueMapper != null) {
+                    value = valueMapper.apply(value);
+                }
+
+                // noinspection unchecked
+                if (filter.accept(name, (T) value)) {
+                    // noinspection unchecked
+                    result.put(name, (T) value);
+                }
+            }
         }
+
+        return result;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/NoLanguageDeephavenSession.java
@@ -11,8 +11,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * ScriptSession implementation that simply allows variables to be exported. This is not intended for use in user
@@ -75,9 +73,9 @@ public class NoLanguageDeephavenSession extends AbstractScriptSession<AbstractSc
     }
 
     @Override
-    protected Set<String> getVariableNames(Predicate<String> allowName) {
+    protected Set<String> getVariableNames() {
         synchronized (variables) {
-            return variables.keySet().stream().filter(allowName).collect(Collectors.toUnmodifiableSet());
+            return new HashSet<>(variables.keySet());
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScope.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScope.java
@@ -143,7 +143,12 @@ public interface PythonScope<PyObj> {
     /**
      * @return the Python's __main__ module namespace
      */
-    public PyDictWrapper mainGlobals();
+    PyDictWrapper mainGlobals();
+
+    /**
+     * @return the current scope or the main globals if no scope is set
+     */
+    PyDictWrapper currentScope();
 
     /**
      * Push the provided Python scope into the thread scope stack for subsequent operations on Tables

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScope.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScope.java
@@ -6,11 +6,7 @@ package io.deephaven.engine.util;
 import org.jpy.PyDictWrapper;
 import org.jpy.PyObject;
 
-import java.util.Collection;
-import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A collection of methods around retrieving objects from the given Python scope.
@@ -29,26 +25,6 @@ public interface PythonScope<PyObj> {
      * @return the value, or empty
      */
     Optional<PyObj> getValueRaw(String name);
-
-    /**
-     * Retrieves all keys from the give scope.
-     * <p>
-     * No conversion is done.
-     * <p>
-     * Technically, the keys can be tuples...
-     *
-     * @return the keys
-     */
-    Stream<PyObj> getKeysRaw();
-
-    /**
-     * Retrieves all keys and values from the given scope.
-     * <p>
-     * No conversion is done.
-     *
-     * @return the keys and values
-     */
-    Stream<Entry<PyObj, PyObj>> getEntriesRaw();
 
     /**
      * The helper method to turn a raw key into a string key.
@@ -118,26 +94,6 @@ public interface PythonScope<PyObj> {
         // noinspection unchecked
         return getValue(name)
                 .map(x -> (T) x);
-    }
-
-    /**
-     * Equivalent to {@link #getKeysRaw()}.map({@link #convertStringKey(Object)})
-     *
-     * @return the string keys
-     */
-    default Stream<String> getKeys() {
-        return getKeysRaw()
-                .map(this::convertStringKey);
-    }
-
-    /**
-     * Equivalent to {@link #getKeys()}.collect(someCollector)
-     *
-     * @return the string keys, as a collection
-     */
-    default Collection<String> getKeysCollection() {
-        return getKeys()
-                .collect(Collectors.toList());
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -13,10 +13,8 @@ import org.jpy.PyObject;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Stream;
 
 public class PythonScopeJpyImpl implements PythonScope<PyObject> {
     private static volatile boolean cacheEnabled =
@@ -54,16 +52,6 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
         // note: we *may* be returning Optional.of(None)
         // None is a valid PyObject, and can be in scope
         return Optional.ofNullable(currentScope().get(name));
-    }
-
-    @Override
-    public Stream<PyObject> getKeysRaw() {
-        return currentScope().keySet().stream();
-    }
-
-    @Override
-    public Stream<Entry<PyObject, PyObject>> getEntriesRaw() {
-        return currentScope().entrySet().stream();
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PythonScopeJpyImpl.java
@@ -39,7 +39,8 @@ public class PythonScopeJpyImpl implements PythonScope<PyObject> {
         this.dict = dict;
     }
 
-    private PyDictWrapper currentScope() {
+    @Override
+    public PyDictWrapper currentScope() {
         Deque<PyDictWrapper> scopeStack = threadScopeStack.get();
         if (scopeStack == null || scopeStack.isEmpty()) {
             return this.dict;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/lang/TestQueryLanguageParser.java
@@ -3178,7 +3178,7 @@ public class TestQueryLanguageParser extends BaseArrayTestCase {
         final Map<String, Object> possibleParams;
         final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
         if (!(queryScope instanceof PoisonedQueryScope)) {
-            possibleParams = queryScope.toMap(NameValidator.VALID_QUERY_PARAMETER_MAP_ENTRY_PREDICATE);
+            possibleParams = queryScope.toMap((name, value) -> NameValidator.isValidQueryParameterName(name));
         } else {
             possibleParams = null;
         }

--- a/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
+++ b/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
@@ -71,14 +71,12 @@ public class ScopeTicketResolver extends TicketResolverBase {
 
     @Override
     public void forAllFlightInfo(@Nullable final SessionState session, final Consumer<Flight.FlightInfo> visitor) {
-        QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
-        queryScope.toMap().forEach((varName, varObj) -> {
-            varObj = queryScope.unwrapObject(varObj);
-            if (varObj instanceof Table) {
-                visitor.accept(TicketRouter.getFlightInfo((Table) varObj, descriptorForName(varName),
-                        flightTicketForName(varName)));
-            }
-        });
+        final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
+        queryScope.toMap(wrapped -> {
+            final Object value = queryScope.unwrapObject(wrapped);
+            return value instanceof Table ? (Table) value : null;
+        }, (n, t) -> t != null).forEach((name, table) -> visitor
+                .accept(TicketRouter.getFlightInfo(table, descriptorForName(name), flightTicketForName(name))));
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
+++ b/server/src/main/java/io/deephaven/server/console/ScopeTicketResolver.java
@@ -72,11 +72,8 @@ public class ScopeTicketResolver extends TicketResolverBase {
     @Override
     public void forAllFlightInfo(@Nullable final SessionState session, final Consumer<Flight.FlightInfo> visitor) {
         final QueryScope queryScope = ExecutionContext.getContext().getQueryScope();
-        queryScope.toMap(wrapped -> {
-            final Object value = queryScope.unwrapObject(wrapped);
-            return value instanceof Table ? (Table) value : null;
-        }, (n, t) -> t != null).forEach((name, table) -> visitor
-                .accept(TicketRouter.getFlightInfo(table, descriptorForName(name), flightTicketForName(name))));
+        queryScope.toMap(queryScope::unwrapObject, (n, t) -> t instanceof Table).forEach((name, table) -> visitor
+                .accept(TicketRouter.getFlightInfo((Table) table, descriptorForName(name), flightTicketForName(name))));
     }
 
     @Override

--- a/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
+++ b/table-api/src/main/java/io/deephaven/api/util/NameValidator.java
@@ -6,7 +6,6 @@ package io.deephaven.api.util;
 import javax.lang.model.SourceVersion;
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -96,9 +95,6 @@ public class NameValidator {
     private static final Set<String> QUERY_LANG_RESERVED_VARIABLE_NAMES =
             Stream.of("in", "not", "i", "ii", "k").collect(
                     Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
-
-    public static final Predicate<Map.Entry<String, Object>> VALID_QUERY_PARAMETER_MAP_ENTRY_PREDICATE =
-            e -> isValidQueryParameterName(e.getKey());
 
     public static String validateTableName(String name) {
         return Type.TABLE.validate(name);


### PR DESCRIPTION
Cleans up the `toMap` interface for use in other contexts (e.g. they want all `Table` instances) and Python copies `currentScope` instead of trying to do the work under the GIL.

Also fixes #5138 by only disallowing `i`, `ii`, `k` when used as formula parameters - allowing users to name tables in their REPL these things (and observe expected UI behavior).

Also fixes #2324 which is the java-reserved-keyword version of #5138.