### PR TITLE
Ensure docs invokes typedoc with correct properties

### DIFF
--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -142,6 +142,11 @@ jobs:
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
+      - name: Setup gradle properties
+        run: |
+          .github/scripts/gradle-properties.sh >> gradle.properties
+          cat gradle.properties
+
       - name: Run typedoc on JS API
         uses: burrunan/gradle-cache-action@v1
         with:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -96,6 +96,11 @@ jobs:
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
+      - name: Setup gradle properties
+        run: |
+          .github/scripts/gradle-properties.sh >> gradle.properties
+          cat gradle.properties
+
       - name: Run typedoc on JS API
         uses: burrunan/gradle-cache-action@v1
         with:


### PR DESCRIPTION
Noticed during the release process for https://github.com/deephaven/deephaven-core/releases/tag/v0.32.1 that typedoc job did not have the correct artifact version name.