### PR TITLE
Fix unrendered HTML in py client doc

### DIFF
--- a/py/client/docs/source/examples.rst
+++ b/py/client/docs/source/examples.rst
@@ -185,7 +185,7 @@ Subscribe to a ticking table
 The `pydeephaven-ticking` package can be used to subscribe to ticking tables. This is useful for getting asynchronous callbacks when
 they change. The package maintains a complete local copy of the table and notifies callers when the table changes.
 
-Note that `pydeephaven-ticking` must be built before running this example. Build instructions are available <a href='https://github.com/deephaven/deephaven-core/tree/main/py/client-ticking#readme'>here</a>.
+Note that `pydeephaven-ticking` must be built before running this example. Build instructions are available `here https://github.com/deephaven/deephaven-core/tree/main/py/client-ticking#readme`_.
 
 The listener can be specified either as a python function or as an implementation of the TableListener abstract base class. In the
 case of implementing


### PR DESCRIPTION
Our py client docs have a link that isn't rendered properly. This should fix that.