### PR TITLE
Reduce Verbose Logging in Generators

### DIFF
--- a/Generators/src/main/java/io/deephaven/gen/AbstractBasicJavaGenerator.java
+++ b/Generators/src/main/java/io/deephaven/gen/AbstractBasicJavaGenerator.java
@@ -41,13 +41,21 @@ public abstract class AbstractBasicJavaGenerator {
      * @param skipsGen Collection of predicates to determine if a function should be skipped when generating code.
      * @throws ClassNotFoundException If a class in the imports array cannot be found.
      */
-    public AbstractBasicJavaGenerator(final String gradleTask, final String packageName, final String className,
-            final String[] imports, Predicate<Method> includeMethod, Collection<Predicate<JavaFunction>> skipsGen)
+    public AbstractBasicJavaGenerator(
+            final String gradleTask,
+            final String packageName,
+            final String className,
+            final String[] imports,
+            final Predicate<Method> includeMethod,
+            final Collection<Predicate<JavaFunction>> skipsGen,
+            final Level logLevel)
             throws ClassNotFoundException {
         this.gradleTask = gradleTask;
         this.packageName = packageName;
         this.className = className;
         this.skipsGen = skipsGen;
+
+        log.setLevel(logLevel);
 
         for (String imp : imports) {
             Class<?> c = Class.forName(imp, false, Thread.currentThread().getContextClassLoader());
@@ -158,7 +166,6 @@ public abstract class AbstractBasicJavaGenerator {
             System.exit(-1);
         }
 
-        log.setLevel(Level.WARNING);
         log.warning("Running " + gen.getClass().getSimpleName() + " assertNoChange=" + assertNoChange);
 
         final String code = gen.generateCode();

--- a/Generators/src/main/java/io/deephaven/libs/GroovyStaticImportGenerator.java
+++ b/Generators/src/main/java/io/deephaven/libs/GroovyStaticImportGenerator.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 
@@ -25,9 +26,9 @@ import java.util.stream.Collectors;
 public class GroovyStaticImportGenerator extends AbstractBasicJavaGenerator {
 
     public GroovyStaticImportGenerator(String gradleTask, String packageName, String className, String[] imports,
-            Predicate<Method> includeMethod, Collection<Predicate<JavaFunction>> skipsGen)
+            Predicate<Method> includeMethod, Collection<Predicate<JavaFunction>> skipsGen, Level logLevel)
             throws ClassNotFoundException {
-        super(gradleTask, packageName, className, imports, includeMethod, skipsGen);
+        super(gradleTask, packageName, className, imports, includeMethod, skipsGen, logLevel);
     }
 
     @Override
@@ -79,7 +80,8 @@ public class GroovyStaticImportGenerator extends AbstractBasicJavaGenerator {
                 // skipping common erasure "sum"
                 Collections.singletonList((f) -> f.getMethodName().equals("sum") && f.getParameterTypes().length == 1
                         && f.getParameterTypes()[0].getTypeName()
-                                .contains("ObjectVector<")));
+                                .contains("ObjectVector<")),
+                Level.WARNING);
 
         runCommandLine(gen, relativeFilePath, args);
     }

--- a/Generators/src/main/java/io/deephaven/libs/StaticCalendarMethodsGenerator.java
+++ b/Generators/src/main/java/io/deephaven/libs/StaticCalendarMethodsGenerator.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -24,8 +25,8 @@ public class StaticCalendarMethodsGenerator extends AbstractBasicJavaGenerator {
 
     public StaticCalendarMethodsGenerator(String gradleTask, String packageName, String className, String[] imports,
             Predicate<Method> includeMethod, Collection<Predicate<JavaFunction>> skipsGen,
-            Function<String, String> renamer) throws ClassNotFoundException {
-        super(gradleTask, packageName, className, imports, includeMethod, skipsGen);
+            Function<String, String> renamer, Level logLevel) throws ClassNotFoundException {
+        super(gradleTask, packageName, className, imports, includeMethod, skipsGen, logLevel);
         this.renamer = renamer;
     }
 
@@ -93,7 +94,8 @@ public class StaticCalendarMethodsGenerator extends AbstractBasicJavaGenerator {
                             } else {
                                 return s;
                             }
-                        });
+                        },
+                        Level.WARNING);
 
         runCommandLine(gen, relativeFilePath, args);
     }

--- a/Generators/src/main/java/io/deephaven/plot/util/GeneratePlottingConvenience.java
+++ b/Generators/src/main/java/io/deephaven/plot/util/GeneratePlottingConvenience.java
@@ -110,7 +110,7 @@ public class GeneratePlottingConvenience {
         boolean skip = skip(f, ignoreSkips);
 
         if (skip) {
-            log.warning("*** Skipping function: " + f);
+            log.info("*** Skipping function: " + f);
             return;
         }
 
@@ -167,7 +167,7 @@ public class GeneratePlottingConvenience {
             final boolean skip = skip(f, true);
 
             if (skip) {
-                log.warning("*** Skipping static function: " + f);
+                log.info("*** Skipping static function: " + f);
                 continue;
             }
 
@@ -183,7 +183,7 @@ public class GeneratePlottingConvenience {
             final boolean skip = skip(f, false);
 
             if (skip) {
-                log.warning("*** Skipping function: " + f);
+                log.info("*** Skipping function: " + f);
                 continue;
             }
 


### PR DESCRIPTION
This removes ~29k lines of logging that muddies up the Check CI log.