### PR TITLE
Add optional S3 dependency to py embedded-server

### DIFF
--- a/py/embedded-server/java-runtime/build.gradle
+++ b/py/embedded-server/java-runtime/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     if (!hasProperty('excludeSql')) {
         runtimeOnly project(':engine-sql')
     }
+
+    if (!hasProperty('excludeS3')) {
+        runtimeOnly project(':extensions-s3')
+    }
 }
 
 // making a dir here isn't optimal, but without it we need to make py-embedded-server be a java and a python

--- a/server/jetty-app-custom/build.gradle
+++ b/server/jetty-app-custom/build.gradle
@@ -46,6 +46,18 @@ if (!hasProperty('excludeClockImpl')) {
     extraJvmArgs += ['--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED']
 }
 
+if (!hasProperty('excludeSql')) {
+    dependencies {
+        runtimeOnly project(':engine-sql')
+    }
+}
+
+if (!hasProperty('excludeS3')) {
+    dependencies {
+        runtimeOnly project(':extensions-s3')
+    }
+}
+
 if (hasProperty('devCerts') || hasProperty('devMTLS')) {
     extraJvmArgs += [
             '-Dhttp.port=8443',


### PR DESCRIPTION
Also, adds overlooked sql and s3 to server-jetty-app-custom example.