### PR TITLE
Bump calcite to 1.36.0, add json-path constraint

### DIFF
--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -8,7 +8,14 @@ description = 'The Deephaven SQL parser'
 
 dependencies {
     api project(':qst')
-    implementation 'org.apache.calcite:calcite-core:1.34.0'
+    implementation 'org.apache.calcite:calcite-core:1.36.0'
+    constraints {
+        // This constraint can be removed once calcite-core has next release and we can
+        // pick up the fixed dependency transitively.
+        implementation('com.jayway.jsonpath:json-path:2.9.0') {
+            because 'json-path Out-of-bounds Write vulnerability, CVE-2023-51074'
+        }
+    }
 
     Classpaths.inheritImmutables(project)
 


### PR DESCRIPTION
https://calcite.apache.org/news/2023/07/26/release-1.35.0/
https://calcite.apache.org/news/2023/11/10/release-1.36.0/

Fixes CVE-2023-51074