### PR TITLE
Quiesce `RetainedRefrenceTracker#ensureReferencesDroppedInternal` by Disabling `CLEANUP_LOG_ENABLED` by Default

### DIFF
--- a/engine/updategraph/src/main/java/io/deephaven/engine/liveness/Liveness.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/liveness/Liveness.java
@@ -35,7 +35,7 @@ public final class Liveness {
             Configuration.getInstance().getBooleanWithDefault("Liveness.heapDump", false);
 
     static final boolean CLEANUP_LOG_ENABLED =
-            Configuration.getInstance().getBooleanWithDefault("Liveness.cleanupLogEnabled", true);
+            Configuration.getInstance().getBooleanWithDefault("Liveness.cleanupLogEnabled", false);
 
     private static final long OUTSTANDING_COUNT_LOG_INTERVAL_MILLIS = 1000L;
 

--- a/engine/updategraph/src/main/java/io/deephaven/engine/liveness/RetainedReferenceTracker.java
+++ b/engine/updategraph/src/main/java/io/deephaven/engine/liveness/RetainedReferenceTracker.java
@@ -192,11 +192,6 @@ final class RetainedReferenceTracker<TYPE extends LivenessManager> extends WeakC
         if (!OUTSTANDING_STATE_UPDATER.compareAndSet(this, OUTSTANDING, NOT_OUTSTANDING)) {
             return;
         }
-        if (Liveness.DEBUG_MODE_ENABLED || (onCleanup && Liveness.CLEANUP_LOG_ENABLED)) {
-            Liveness.log.info().append("LivenessDebug: Ensuring references dropped ")
-                    .append(onCleanup ? "(on cleanup) " : "").append("for ").append(Utils.REFERENT_FORMATTER, this)
-                    .endl();
-        }
         outstandingCount.decrementAndGet();
 
         Queue<WeakReference<? extends LivenessReferent>> pendingDropReferences = tlPendingDropReferences.get();
@@ -210,9 +205,17 @@ final class RetainedReferenceTracker<TYPE extends LivenessManager> extends WeakC
             tlPendingDropReferences.set(pendingDropReferences);
         }
 
+        int numToDrop = -pendingDropReferences.size();
         synchronized (this) {
             impl.forEach(pendingDropReferences::add);
             impl.clear();
+            numToDrop += pendingDropReferences.size();
+        }
+
+        if (numToDrop > 0 && (Liveness.DEBUG_MODE_ENABLED || (onCleanup && Liveness.CLEANUP_LOG_ENABLED))) {
+            Liveness.log.info().append("LivenessDebug: Ensuring references dropped ")
+                    .append(onCleanup ? "(on cleanup) " : "").append("for ").append(Utils.REFERENT_FORMATTER, this)
+                    .endl();
         }
 
         if (processDrops) {


### PR DESCRIPTION
Fixes #1152.

Ryan and I discussed #4575 as a better solution to this problem. In the meantime, we can disable cleanup logging by default. The other piece of work is not high priority and is not a trivial change (in terms of files touched; it is otherwise straightforward).