### PR TITLE
Fix bugs in moveColumns and renameColumns

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -413,8 +413,8 @@ public interface Table extends
     Table moveColumnsDown(String... columnsToMove);
 
     /**
-     * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
-     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * Produce a new table with the specified columns moved to the specified {@code index}. Column indices begin at 0.
+     * Columns can be renamed with the usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -327,7 +327,8 @@ public interface Table extends
     Table dropColumnFormats();
 
     /**
-     * Produce a new table with the specified columns renamed using the syntax {@code "NewColumnName=OldColumnName"}.
+     * Produce a new table with the specified columns renamed using the specified {@link Pair pairs}. The renames are
+     * simultaneous, and unordered, enabling direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
@@ -343,6 +344,7 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns renamed using the syntax {@code "NewColumnName=OldColumnName"}.
+     * The renames are simultaneous, and unordered, enabling direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
@@ -357,13 +359,8 @@ public interface Table extends
     Table renameColumns(String... pairs);
 
     /**
-     * Produce a new table with the specified columns renamed using the provided function.
-     * <p>
-     * {@link IllegalArgumentException} will be thrown:
-     * <ul>
-     * <li>if a source column is used more than once</li>
-     * <li>if a destination column is used more than once</li>
-     * </ul>
+     * Produce a new table with the specified columns renamed using the provided function. The renames are simultaneous,
+     * and unordered, enabling direct swaps between column names.
      *
      * @param renameFunction The function to apply to each column name
      * @return The new table, with the columns renamed
@@ -382,7 +379,8 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns moved to the leftmost position. Columns can be renamed with the
-     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous, and unordered, enabling
+     * direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
@@ -398,7 +396,8 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
-     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous, and unordered, enabling
+     * direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
@@ -414,7 +413,8 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns moved to the specified {@code index}. Column indices begin at 0.
-     * Columns can be renamed with the usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * Columns can be renamed with the usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are
+     * simultaneous, and unordered, enabling direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -328,7 +328,7 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns renamed using the specified {@link Pair pairs}. The renames are
-     * simultaneous, and unordered, enabling direct swaps between column names.
+     * simultaneous and unordered, enabling direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
@@ -344,7 +344,7 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns renamed using the syntax {@code "NewColumnName=OldColumnName"}.
-     * The renames are simultaneous, and unordered, enabling direct swaps between column names.
+     * The renames are simultaneous and unordered, enabling direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
@@ -359,7 +359,7 @@ public interface Table extends
     Table renameColumns(String... pairs);
 
     /**
-     * Produce a new table with the specified columns renamed using the provided function. The renames are simultaneous,
+     * Produce a new table with the specified columns renamed using the provided function. The renames are simultaneous
      * and unordered, enabling direct swaps between column names.
      *
      * @param renameFunction The function to apply to each column name
@@ -379,7 +379,7 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns moved to the leftmost position. Columns can be renamed with the
-     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous, and unordered, enabling
+     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous and unordered, enabling
      * direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
@@ -396,7 +396,7 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
-     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous, and unordered, enabling
+     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous and unordered, enabling
      * direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
@@ -414,7 +414,7 @@ public interface Table extends
     /**
      * Produce a new table with the specified columns moved to the specified {@code index}. Column indices begin at 0.
      * Columns can be renamed with the usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are
-     * simultaneous, and unordered, enabling direct swaps between column names.
+     * simultaneous and unordered, enabling direct swaps between column names.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -326,10 +326,49 @@ public interface Table extends
     @ConcurrentMethod
     Table dropColumnFormats();
 
+    /**
+     * Produce a new table with the specified columns renamed using the syntax {@code "NewColumnName=OldColumnName"}.
+     * <p>
+     * {@link IllegalArgumentException} will be thrown:
+     * <ul>
+     * <li>if a source column is used more than once</li>
+     * <li>if a destination column is used more than once</li>
+     * </ul>
+     *
+     * @param pairs The columns to rename
+     * @return The new table, with the columns renamed
+     */
+    @ConcurrentMethod
     Table renameColumns(Collection<Pair> pairs);
 
+    /**
+     * Produce a new table with the specified columns renamed using the syntax {@code "NewColumnName=OldColumnName"}.
+     * <p>
+     * {@link IllegalArgumentException} will be thrown:
+     * <ul>
+     * <li>if a source column is used more than once</li>
+     * <li>if a destination column is used more than once</li>
+     * </ul>
+     *
+     * @param pairs The columns to rename
+     * @return The new table, with the columns renamed
+     */
+    @ConcurrentMethod
     Table renameColumns(String... pairs);
 
+    /**
+     * Produce a new table with the specified columns renamed using the provided function.
+     * <p>
+     * {@link IllegalArgumentException} will be thrown:
+     * <ul>
+     * <li>if a source column is used more than once</li>
+     * <li>if a destination column is used more than once</li>
+     * </ul>
+     *
+     * @param renameFunction The function to apply to each column name
+     * @return The new table, with the columns renamed
+     */
+    @ConcurrentMethod
     Table renameAllColumns(UnaryOperator<String> renameFunction);
 
     @ConcurrentMethod
@@ -342,8 +381,14 @@ public interface Table extends
     Table formatColumnWhere(String columnName, String condition, String formula);
 
     /**
-     * Produce a new table with the specified columns moved to the leftmost position. Columns can be renamed with the
+     * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
      * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * <p>
+     * {@link IllegalArgumentException} will be thrown:
+     * <ul>
+     * <li>if a source column is used more than once</li>
+     * <li>if a destination column is used more than once</li>
+     * </ul>
      *
      * @param columnsToMove The columns to move to the left (and, optionally, to rename)
      * @return The new table, with the columns rearranged as explained above {@link #moveColumns(int, String...)}
@@ -354,6 +399,12 @@ public interface Table extends
     /**
      * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
      * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * <p>
+     * {@link IllegalArgumentException} will be thrown:
+     * <ul>
+     * <li>if a source column is used more than once</li>
+     * <li>if a destination column is used more than once</li>
+     * </ul>
      *
      * @param columnsToMove The columns to move to the right (and, optionally, to rename)
      * @return The new table, with the columns rearranged as explained above {@link #moveColumns(int, String...)}
@@ -362,8 +413,14 @@ public interface Table extends
     Table moveColumnsDown(String... columnsToMove);
 
     /**
-     * Produce a new table with the specified columns moved to the specified {@code index}. Column indices begin at 0.
-     * Columns can be renamed with the usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
+     * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
+     * <p>
+     * {@link IllegalArgumentException} will be thrown:
+     * <ul>
+     * <li>if a source column is used more than once</li>
+     * <li>if a destination column is used more than once</li>
+     * </ul>
      *
      * @param index The index to which the specified columns should be moved
      * @param columnsToMove The columns to move to the specified index (and, optionally, to rename)
@@ -371,9 +428,6 @@ public interface Table extends
      */
     @ConcurrentMethod
     Table moveColumns(int index, String... columnsToMove);
-
-    @ConcurrentMethod
-    Table moveColumns(int index, boolean moveToEnd, String... columnsToMove);
 
     // -----------------------------------------------------------------------------------------------------------------
     // Slice Operations

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -381,7 +381,7 @@ public interface Table extends
     Table formatColumnWhere(String columnName, String condition, String formula);
 
     /**
-     * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
+     * Produce a new table with the specified columns moved to the leftmost position. Columns can be renamed with the
      * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}.
      * <p>
      * {@link IllegalArgumentException} will be thrown:

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -328,10 +328,12 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns renamed using the specified {@link Pair pairs}. The renames are
-     * simultaneous and unordered, enabling direct swaps between column names.
+     * simultaneous and unordered, enabling direct swaps between column names. The resulting table retains the original
+     * column ordering after applying the specified renames.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
+     * <li>if a source column does not exist</li>
      * <li>if a source column is used more than once</li>
      * <li>if a destination column is used more than once</li>
      * </ul>
@@ -344,10 +346,12 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns renamed using the syntax {@code "NewColumnName=OldColumnName"}.
-     * The renames are simultaneous and unordered, enabling direct swaps between column names.
+     * The renames are simultaneous and unordered, enabling direct swaps between column names. The resulting table
+     * retains the original column ordering after applying the specified renames.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
+     * <li>if a source column does not exist</li>
      * <li>if a source column is used more than once</li>
      * <li>if a destination column is used more than once</li>
      * </ul>
@@ -360,7 +364,13 @@ public interface Table extends
 
     /**
      * Produce a new table with the specified columns renamed using the provided function. The renames are simultaneous
-     * and unordered, enabling direct swaps between column names.
+     * and unordered, enabling direct swaps between column names. The resulting table retains the original column
+     * ordering after applying the specified renames.
+     * <p>
+     * {@link IllegalArgumentException} will be thrown:
+     * <ul>
+     * <li>if a destination column is used more than once</li>
+     * </ul>
      *
      * @param renameFunction The function to apply to each column name
      * @return The new table, with the columns renamed
@@ -380,16 +390,17 @@ public interface Table extends
     /**
      * Produce a new table with the specified columns moved to the leftmost position. Columns can be renamed with the
      * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous and unordered, enabling
-     * direct swaps between column names.
+     * direct swaps between column names. All other columns are left in their original order.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
+     * <li>if a source column does not exist</li>
      * <li>if a source column is used more than once</li>
      * <li>if a destination column is used more than once</li>
      * </ul>
      *
      * @param columnsToMove The columns to move to the left (and, optionally, to rename)
-     * @return The new table, with the columns rearranged as explained above {@link #moveColumns(int, String...)}
+     * @return The new table, with the columns rearranged as explained above
      */
     @ConcurrentMethod
     Table moveColumnsUp(String... columnsToMove);
@@ -397,16 +408,17 @@ public interface Table extends
     /**
      * Produce a new table with the specified columns moved to the rightmost position. Columns can be renamed with the
      * usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are simultaneous and unordered, enabling
-     * direct swaps between column names.
+     * direct swaps between column names. All other columns are left in their original order.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
+     * <li>if a source column does not exist</li>
      * <li>if a source column is used more than once</li>
      * <li>if a destination column is used more than once</li>
      * </ul>
      *
      * @param columnsToMove The columns to move to the right (and, optionally, to rename)
-     * @return The new table, with the columns rearranged as explained above {@link #moveColumns(int, String...)}
+     * @return The new table, with the columns rearranged as explained above
      */
     @ConcurrentMethod
     Table moveColumnsDown(String... columnsToMove);
@@ -414,13 +426,19 @@ public interface Table extends
     /**
      * Produce a new table with the specified columns moved to the specified {@code index}. Column indices begin at 0.
      * Columns can be renamed with the usual syntax, i.e. {@code "NewColumnName=OldColumnName")}. The renames are
-     * simultaneous and unordered, enabling direct swaps between column names.
+     * simultaneous and unordered, enabling direct swaps between column names. The resulting table retains the original
+     * column ordering except for the specified columns, which are inserted at the specified index, in the order of
+     * {@code columnsToMove}, after the effects of applying any renames.
      * <p>
      * {@link IllegalArgumentException} will be thrown:
      * <ul>
+     * <li>if a source column does not exist</li>
      * <li>if a source column is used more than once</li>
      * <li>if a destination column is used more than once</li>
      * </ul>
+     * <p>
+     * Values of {@code index} outside the range of 0 to the number of columns in the table (exclusive) will be clamped
+     * to the nearest valid index.
      *
      * @param index The index to which the specified columns should be moved
      * @param columnsToMove The columns to move to the specified index (and, optionally, to rename)

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -5,6 +5,7 @@ package io.deephaven.engine.table.impl;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import io.deephaven.api.Pair;
 import io.deephaven.base.Base64;
 import io.deephaven.base.log.LogOutput;
 import io.deephaven.base.reference.SimpleReference;
@@ -1034,7 +1035,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         destination.setSortableColumns(currentSortableColumns.stream().filter(shouldCopy).collect(Collectors.toList()));
     }
 
-    void copySortableColumns(BaseTable<?> destination, Collection<io.deephaven.api.Pair> renamedColumns) {
+    void copySortableColumns(BaseTable<?> destination, Collection<Pair> renamedColumns) {
         final Collection<String> currentSortableColumns = getSortableColumns();
         if (currentSortableColumns == null) {
             return;
@@ -1047,7 +1048,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         // b) The original column exists, and has not been replaced by another. For example
         // T1 = [ Col1, Col2, Col3 ]; T1.renameColumns(Col1=Col3, Col2];
         if (renamedColumns != null) {
-            for (final io.deephaven.api.Pair pair : renamedColumns) {
+            for (final Pair pair : renamedColumns) {
                 // Only the last grouping matters.
                 columnMapping.forcePut(pair.output().name(), pair.input().name());
             }
@@ -1160,7 +1161,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
      */
     void maybeCopyColumnDescriptions(
             final BaseTable<?> destination,
-            final Collection<io.deephaven.api.Pair> renamedColumns) {
+            final Collection<Pair> renamedColumns) {
         // noinspection unchecked
         final Map<String, String> oldDescriptions =
                 (Map<String, String>) getAttribute(Table.COLUMN_DESCRIPTIONS_ATTRIBUTE);
@@ -1171,7 +1172,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         final Map<String, String> sourceDescriptions = new HashMap<>(oldDescriptions);
 
         if (renamedColumns != null) {
-            for (final io.deephaven.api.Pair pair : renamedColumns) {
+            for (final Pair pair : renamedColumns) {
                 final String desc = sourceDescriptions.remove(pair.input().name());
                 if (desc != null) {
                     sourceDescriptions.put(pair.output().name(), desc);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -1034,7 +1034,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         destination.setSortableColumns(currentSortableColumns.stream().filter(shouldCopy).collect(Collectors.toList()));
     }
 
-    void copySortableColumns(BaseTable<?> destination, MatchPair[] renamedColumns) {
+    void copySortableColumns(BaseTable<?> destination, Collection<io.deephaven.api.Pair> renamedColumns) {
         final Collection<String> currentSortableColumns = getSortableColumns();
         if (currentSortableColumns == null) {
             return;
@@ -1047,9 +1047,9 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         // b) The original column exists, and has not been replaced by another. For example
         // T1 = [ Col1, Col2, Col3 ]; T1.renameColumns(Col1=Col3, Col2];
         if (renamedColumns != null) {
-            for (MatchPair mp : renamedColumns) {
+            for (final io.deephaven.api.Pair pair : renamedColumns) {
                 // Only the last grouping matters.
-                columnMapping.forcePut(mp.leftColumn(), mp.rightColumn());
+                columnMapping.forcePut(pair.output().name(), pair.input().name());
             }
         }
 
@@ -1158,7 +1158,9 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
      * @param destination the table which shall possibly have a column-description attribute created
      * @param renamedColumns an array of the columns which have been renamed
      */
-    void maybeCopyColumnDescriptions(final BaseTable<?> destination, final MatchPair[] renamedColumns) {
+    void maybeCopyColumnDescriptions(
+            final BaseTable<?> destination,
+            final Collection<io.deephaven.api.Pair> renamedColumns) {
         // noinspection unchecked
         final Map<String, String> oldDescriptions =
                 (Map<String, String>) getAttribute(Table.COLUMN_DESCRIPTIONS_ATTRIBUTE);
@@ -1168,11 +1170,13 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         }
         final Map<String, String> sourceDescriptions = new HashMap<>(oldDescriptions);
 
-        if (renamedColumns != null && renamedColumns.length != 0) {
-            for (final MatchPair mp : renamedColumns) {
-                final String desc = sourceDescriptions.remove(mp.rightColumn());
+        if (renamedColumns != null) {
+            for (final io.deephaven.api.Pair pair : renamedColumns) {
+                final String desc = sourceDescriptions.remove(pair.input().name());
                 if (desc != null) {
-                    sourceDescriptions.put(mp.leftColumn(), desc);
+                    sourceDescriptions.put(pair.output().name(), desc);
+                } else {
+                    sourceDescriptions.remove(pair.output().name());
                 }
             }
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableAdapter.java
@@ -219,7 +219,7 @@ public interface TableAdapter extends TableDefaults {
     }
 
     @Override
-    default Table moveColumns(int index, boolean moveToEnd, String... columnsToMove) {
+    default Table moveColumns(int index, String... columnsToMove) {
         return throwUnsupported();
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableDefaults.java
@@ -243,14 +243,7 @@ public interface TableDefaults extends Table, TableOperationsDefaults<Table, Tab
     @ConcurrentMethod
     @FinalDefault
     default Table moveColumnsDown(String... columnsToMove) {
-        return moveColumns(numColumns() - columnsToMove.length, true, columnsToMove);
-    }
-
-    @Override
-    @ConcurrentMethod
-    @FinalDefault
-    default Table moveColumns(int index, String... columnsToMove) {
-        return moveColumns(index, false, columnsToMove);
+        return moveColumns(numColumns() - columnsToMove.length, columnsToMove);
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
@@ -271,8 +271,8 @@ public abstract class UncoalescedTable<IMPL_TYPE extends UncoalescedTable<IMPL_T
 
     @Override
     @ConcurrentMethod
-    public Table moveColumns(int index, boolean moveToEnd, String... columnsToMove) {
-        return coalesce().moveColumns(index, moveToEnd, columnsToMove);
+    public Table moveColumns(int index, String... columnsToMove) {
+        return coalesce().moveColumns(index, columnsToMove);
     }
 
     @Override

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestMoveColumns.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestMoveColumns.java
@@ -69,29 +69,13 @@ public class TestMoveColumns extends RefreshingTableTestCase {
         checkColumnOrder(temp, "dexab");
         checkColumnValueOrder(temp, "45123");
 
-        temp = table.moveColumns(0, "x=a", "b=x");
-        checkColumnOrder(temp, "xbcde");
-        checkColumnValueOrder(temp, "11345");
-
-        temp = table.moveColumns(0, "x=a", "y=a", "z=a");
-        checkColumnOrder(temp, "xyzbcde");
-        checkColumnValueOrder(temp, "1112345");
+        temp = table.moveColumns(0, "x=a", "d");
+        checkColumnOrder(temp, "xdbce");
+        checkColumnValueOrder(temp, "14235");
 
         temp = table.moveColumns(0, "b=a", "a=b");
         checkColumnOrder(temp, "bacde");
-        checkColumnValueOrder(temp, "11345");
-
-        temp = table.moveColumns(0, "d=c", "d=a", "x=e");
-        checkColumnOrder(temp, "dxb");
-        checkColumnValueOrder(temp, "152");
-
-        temp = table.moveColumns(0, "a=b", "a=c");
-        checkColumnOrder(temp, "ade");
-        checkColumnValueOrder(temp, "345");
-
-        temp = table.moveColumns(0, "a=b", "a=c", "a=d", "a=e");
-        checkColumnOrder(temp, "a");
-        checkColumnValueOrder(temp, "5");
+        checkColumnValueOrder(temp, "12345");
     }
 
     public void testMoveUpColumns() {
@@ -110,14 +94,6 @@ public class TestMoveColumns extends RefreshingTableTestCase {
         temp = table.moveColumnsUp("x=e");
         checkColumnOrder(temp, "xabcd");
         checkColumnValueOrder(temp, "51234");
-
-        temp = table.moveColumnsUp("x=a", "x=b");
-        checkColumnOrder(temp, "xcde");
-        checkColumnValueOrder(temp, "2345");
-
-        temp = table.moveColumnsUp("x=a", "y=a");
-        checkColumnOrder(temp, "xybcde");
-        checkColumnValueOrder(temp, "112345");
     }
 
     public void testMoveDownColumns() {
@@ -134,19 +110,11 @@ public class TestMoveColumns extends RefreshingTableTestCase {
 
         temp = table.moveColumnsDown("b=a", "a=b", "c");
         checkColumnOrder(temp, "debac");
-        checkColumnValueOrder(temp, "45113");
+        checkColumnValueOrder(temp, "45123");
 
-        temp = table.moveColumnsDown("b=a", "a=b", "c", "d=a");
-        checkColumnOrder(temp, "ebacd");
-        checkColumnValueOrder(temp, "51131");
-
-        temp = table.moveColumnsDown("x=a", "x=b");
-        checkColumnOrder(temp, "cdex");
-        checkColumnValueOrder(temp, "3452");
-
-        temp = table.moveColumnsDown("x=a", "y=a");
-        checkColumnOrder(temp, "bcdexy");
-        checkColumnValueOrder(temp, "234511");
+        temp = table.moveColumnsDown("b=a", "a=b", "c");
+        checkColumnOrder(temp, "debac");
+        checkColumnValueOrder(temp, "45123");
     }
 
     private void checkColumnOrder(Table t, String expectedOrder) {

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -665,7 +665,7 @@ class Table(JObjectWrapper):
 
     def move_columns(self, idx: int, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns method creates a new table with specified columns moved to a specific column index value.
-        Columns may be renamed with the same semantics as rename_columns. The renames are simulatenous, and unordered,
+        Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous, and unordered,
         enabling direct swaps between column names. Specifying a source or destination more than once is prohibited.
 
         Args:
@@ -686,7 +686,7 @@ class Table(JObjectWrapper):
 
     def move_columns_down(self, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns_down method creates a new table with specified columns appearing last in order, to the far
-        right. Columns may be renamed with the same semantics as rename_columns. The renames are simulatenous, and
+        right. Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous, and
         unordered, enabling direct swaps between column names. Specifying a source or destination more than once is
         prohibited.
 
@@ -707,7 +707,7 @@ class Table(JObjectWrapper):
 
     def move_columns_up(self, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns_up method creates a new table with specified columns appearing first in order, to the far
-        left. Columns may be renamed with the same semantics as rename_columns. The renames are simulatenous, and
+        left. Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous, and
         unordered, enabling direct swaps between column names. Specifying a source or destination more than once is
         prohibited.
 
@@ -728,7 +728,7 @@ class Table(JObjectWrapper):
 
     def rename_columns(self, cols: Union[str, Sequence[str]]) -> Table:
         """The rename_columns method creates a new table with the specified columns renamed. The renames are
-        simulatenous, and unordered, enabling direct swaps between column names. Specifying a source or
+        simultaneous, and unordered, enabling direct swaps between column names. Specifying a source or
          destination more than once is prohibited.
 
         Args:

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -80,11 +80,11 @@ class NodeType(Enum):
     """An enum of node types for RollupTable"""
     AGGREGATED = _JNodeType.Aggregated
     """Nodes at an aggregated (rolled up) level in the RollupTable. An aggregated level is above the constituent (
-    leaf) level. These nodes have column names and types that result from applying aggregations on the source table 
+    leaf) level. These nodes have column names and types that result from applying aggregations on the source table
     of the RollupTable. """
     CONSTITUENT = _JNodeType.Constituent
-    """Nodes at the leaf level when :meth:`~deephaven.table.Table.rollup` method is called with 
-    include_constituent=True. The constituent level is the lowest in a rollup table. These nodes have column names 
+    """Nodes at the leaf level when :meth:`~deephaven.table.Table.rollup` method is called with
+    include_constituent=True. The constituent level is the lowest in a rollup table. These nodes have column names
     and types from the source table of the RollupTable. """
 
 
@@ -734,8 +734,7 @@ class Table(JObjectWrapper):
         """
         try:
             cols = to_sequence(cols)
-            with auto_locking_ctx(self):
-                return Table(j_table=self.j_table.renameColumns(*cols))
+            return Table(j_table=self.j_table.renameColumns(*cols))
         except Exception as e:
             raise DHError(e, "table rename_columns operation failed.") from e
 

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -665,10 +665,12 @@ class Table(JObjectWrapper):
 
     def move_columns(self, idx: int, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns method creates a new table with specified columns moved to a specific column index value.
+        Columns may be renamed with the same semantics as rename_columns. The renames are simulatenous, and unordered,
+        enabling direct swaps between column names. Specifying a source or destination more than once is prohibited.
 
         Args:
             idx (int): the column index where the specified columns will be moved in the new table.
-            cols (Union[str, Sequence[str]]) : the column name(s)
+            cols (Union[str, Sequence[str]]) : the column name(s) or the column rename expr(s) as "X = Y"
 
         Returns:
             a new table
@@ -684,10 +686,12 @@ class Table(JObjectWrapper):
 
     def move_columns_down(self, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns_down method creates a new table with specified columns appearing last in order, to the far
-        right.
+        right. Columns may be renamed with the same semantics as rename_columns. The renames are simulatenous, and
+        unordered, enabling direct swaps between column names. Specifying a source or destination more than once is
+        prohibited.
 
         Args:
-            cols (Union[str, Sequence[str]]) : the column name(s)
+            cols (Union[str, Sequence[str]]) : the column name(s) or the column rename expr(s) as "X = Y"
 
         Returns:
             a new table
@@ -703,10 +707,12 @@ class Table(JObjectWrapper):
 
     def move_columns_up(self, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns_up method creates a new table with specified columns appearing first in order, to the far
-        left.
+        left. Columns may be renamed with the same semantics as rename_columns. The renames are simulatenous, and
+        unordered, enabling direct swaps between column names. Specifying a source or destination more than once is
+        prohibited.
 
         Args:
-            cols (Union[str, Sequence[str]]) : the column name(s)
+            cols (Union[str, Sequence[str]]) : the column name(s) or the column rename expr(s) as "X = Y"
 
         Returns:
             a new table
@@ -721,7 +727,9 @@ class Table(JObjectWrapper):
             raise DHError(e, "table move_columns_up operation failed.") from e
 
     def rename_columns(self, cols: Union[str, Sequence[str]]) -> Table:
-        """The rename_columns method creates a new table with the specified columns renamed.
+        """The rename_columns method creates a new table with the specified columns renamed. The renames are
+        simulatenous, and unordered, enabling direct swaps between column names. Specifying a source or
+         destination more than once is prohibited.
 
         Args:
             cols (Union[str, Sequence[str]]) : the column rename expr(s) as "X = Y"

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -665,7 +665,7 @@ class Table(JObjectWrapper):
 
     def move_columns(self, idx: int, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns method creates a new table with specified columns moved to a specific column index value.
-        Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous, and unordered,
+        Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous and unordered,
         enabling direct swaps between column names. Specifying a source or destination more than once is prohibited.
 
         Args:
@@ -686,7 +686,7 @@ class Table(JObjectWrapper):
 
     def move_columns_down(self, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns_down method creates a new table with specified columns appearing last in order, to the far
-        right. Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous, and
+        right. Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous and
         unordered, enabling direct swaps between column names. Specifying a source or destination more than once is
         prohibited.
 
@@ -707,7 +707,7 @@ class Table(JObjectWrapper):
 
     def move_columns_up(self, cols: Union[str, Sequence[str]]) -> Table:
         """The move_columns_up method creates a new table with specified columns appearing first in order, to the far
-        left. Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous, and
+        left. Columns may be renamed with the same semantics as rename_columns. The renames are simultaneous and
         unordered, enabling direct swaps between column names. Specifying a source or destination more than once is
         prohibited.
 
@@ -728,7 +728,7 @@ class Table(JObjectWrapper):
 
     def rename_columns(self, cols: Union[str, Sequence[str]]) -> Table:
         """The rename_columns method creates a new table with the specified columns renamed. The renames are
-        simultaneous, and unordered, enabling direct swaps between column names. Specifying a source or
+        simultaneous and unordered, enabling direct swaps between column names. Specifying a source or
          destination more than once is prohibited.
 
         Args:

--- a/py/server/tests/test_update_graph.py
+++ b/py/server/tests/test_update_graph.py
@@ -161,21 +161,6 @@ class UpdateGraphTestCase(BaseTestCase):
             with self.subTest(op=op):
                 result_table = left_table.aj(right_table, on="X")
 
-    def test_auto_locking_rename_columns(self):
-        with ug.shared_lock(self.test_update_graph):
-            test_table = time_table("PT00:00:00.001").update(["X=i", "Y=i%13", "Z=X*Y"])
-
-        cols_to_rename = [
-            f"{f.name + '_2'} = {f.name}" for f in test_table.columns[::2]
-        ]
-
-        with self.assertRaises(DHError) as cm:
-            result_table = test_table.rename_columns(cols_to_rename)
-        self.assertRegex(str(cm.exception), r"IllegalStateException")
-
-        ug.auto_locking = True
-        result_table = test_table.rename_columns(cols_to_rename)
-
     def test_auto_locking_ungroup(self):
         with ug.shared_lock(self.test_update_graph):
             test_table = time_table("PT00:00:00.001").update(["X=i", "Y=i%13"])

--- a/table-api/src/main/java/io/deephaven/api/Strings.java
+++ b/table-api/src/main/java/io/deephaven/api/Strings.java
@@ -116,6 +116,10 @@ public class Strings {
         return (invert ? "!" : "") + inner;
     }
 
+    public static String ofPairs(Collection<? extends Pair> pairs) {
+        return pairs.stream().map(Strings::of).collect(Collectors.joining(",", "[", "]"));
+    }
+
     public static String of(Pair pair) {
         if (pair.input().equals(pair.output())) {
             return of(pair.output());


### PR DESCRIPTION
Fixes #4824.

There were a few odd behaviors of the existing replace columns implementation. This hopefully makes behavior well defined and consistent. I've also added tests; which apparently were quite useful in extracting bugs.

I've explicitly disallowed having multiple entries for the same source or the same destination. You can lose columns by renaming some column to an existing column name; it was easy to support and there may be legitimate uses.

Nightlies: https://github.com/nbauernfeind/deephaven-core/actions/runs/8085227568