### PR TITLE
build: Add provenence flag when publishing jsapi-types

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -113,5 +113,5 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.DEEPHAVENBOT_NPM_TOKEN }}
-        run: npm publish --tag latest web/client-api/types/build/deephaven-jsapi-types-*.tgz
+        run: npm publish --provenance --tag latest web/client-api/types/build/deephaven-jsapi-types-*.tgz
         continue-on-error: true

--- a/web/client-api/types/.npmrc
+++ b/web/client-api/types/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-provenance=true


### PR DESCRIPTION
- .npmrc file is not getting used with how we publish (building the tarball first and then publishing from a different directory)
- Adding the --provenance flag should generate the provenance statements automatically: https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
- This _should_ work even publishing from the tarball, as the provenance info is generated after the tarball is created: https://github.com/npm/provenance?tab=readme-ov-file#demo-generating-signed-slsa-provenance
