### PR TITLE
fix: seek row for sorted columns

### DIFF
--- a/ClientSupport/ClientSupport.gradle
+++ b/ClientSupport/ClientSupport.gradle
@@ -12,4 +12,14 @@ dependencies {
     implementation project(':log-factory')
     implementation project(':Configuration')
     implementation depCommonsLang3
+
+    testImplementation project(':engine-test-utils')
+    Classpaths.inheritJUnitClassic(project, 'testImplementation')
+    Classpaths.inheritJUnitPlatform(project)
+    Classpaths.inheritAssertJ(project)
+
+    testRuntimeOnly project(':log-to-slf4j'),
+            project(path: ':configs'),
+            project(path: ':test-configs')
+    Classpaths.inheritSlf4j(project, 'slf4j-simple', 'testRuntimeOnly')
 }

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -58,7 +58,7 @@ public class SeekRow implements Function<Table, Long> {
                 // check prev row
                 if (startingRow != 0) {
                     final Comparable prevValue =
-                            (Comparable) table.getColumnSource(columnName).get((int) index.get((int) startingRow - 1));
+                            (Comparable) table.getColumnSource(columnName).get(index.get(startingRow - 1));
                     if (nullSafeCompare(prevValue, (Comparable) seekValue) == 0) {
                         return startingRow - 1;
                     }
@@ -70,7 +70,7 @@ public class SeekRow implements Function<Table, Long> {
                 // check next row
                 if (startingRow != index.size() - 1) {
                     final Comparable nextValue =
-                            (Comparable) table.getColumnSource(columnName).get((int) index.get((int) startingRow + 1));
+                            (Comparable) table.getColumnSource(columnName).get(index.get(startingRow + 1));
                     if (nullSafeCompare(nextValue, (Comparable) seekValue) == 0) {
                         return startingRow + 1;
                     }

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -53,7 +53,7 @@ public class SeekRow implements Function<Table, Long> {
         final Optional<SortingOrder> order = SortedColumnsAttribute.getOrderForColumn(table, columnName);
         final RowSet index = table.getRowSet();
 
-        if (!order.isEmpty()) {
+        if (order.isPresent()) {
             if (isBackward) {
                 // check prev row
                 if (startingRow != 0) {

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -51,7 +51,7 @@ public class SeekRow {
 
     @ConcurrentMethod
     public long seek(Table table) {
-        final Mutable<Long> result = new MutableObject<>(-1L);
+        final Mutable<Long> result = new MutableObject<>(null);
 
         ConstructSnapshot.callDataSnapshotFunction("SeekRow",
                 ConstructSnapshot.makeSnapshotControl(false, table.isRefreshing(), (NotificationStepSource) table),

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -146,7 +146,7 @@ public class SeekRow implements Function<Table, Long> {
      * @param table the table to check for sorted-ness
      * @param start the starting index to search
      * @param end the ending index to search
-     * @param findFirst whether to find the first or last occurence (false for last)
+     * @param findFirst whether to find the first or last occurrence (false for last)
      * @param isAscending whether the table is sorted in ascending order (false for descending)
      * @return the index of the first/last occurence of the target value, -1 if not found
      */

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -141,7 +141,7 @@ public class SeekRow implements Function<Table, Long> {
     }
 
     /**
-     * Finds the first/last occurence of the target value by using binary search
+     * Finds the first/last occurrence of the target value by using binary search
      *
      * @param table the table to check for sorted-ness
      * @param start the starting index to search

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -150,7 +150,7 @@ public class SeekRow implements Function<Table, Long> {
      * @param isAscending whether the table is sorted in ascending order (false for descending)
      * @return the index of the first/last occurence of the target value, -1 if not found
      */
-    private long findEdgeOccurence(Table table, RowSet index, long start, long end, boolean findFirst,
+    private long findEdgeOccurrence(Table table, RowSet index, long start, long end, boolean findFirst,
             boolean isAscending) {
         long result = -1;
 

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -143,7 +143,7 @@ public class SeekRow {
                     return true;
                 }));
 
-        log.info().append(result.getValue()).endl();
+        Assert.neqNull(result.getValue(), "result.getValue()");
         return result.getValue();
     }
 

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -64,7 +64,7 @@ public class SeekRow implements Function<Table, Long> {
                     }
                 }
                 // no values before, loop back around and find the last value
-                return findEdgeOccurence(table, index, startingRow, index.size() - 1, false,
+                return findEdgeOccurrence(table, index, startingRow, index.size() - 1, false,
                         order.get() == SortingOrder.Ascending);
             } else {
                 // check next row
@@ -76,7 +76,7 @@ public class SeekRow implements Function<Table, Long> {
                     }
                 }
                 // no values after, loop back around and find the first value
-                return findEdgeOccurence(table, index, 0, startingRow, true, order.get() == SortingOrder.Ascending);
+                return findEdgeOccurrence(table, index, 0, startingRow, true, order.get() == SortingOrder.Ascending);
             }
         }
 
@@ -148,7 +148,7 @@ public class SeekRow implements Function<Table, Long> {
      * @param end the ending index to search
      * @param findFirst whether to find the first or last occurrence (false for last)
      * @param isAscending whether the table is sorted in ascending order (false for descending)
-     * @return the index of the first/last occurence of the target value, -1 if not found
+     * @return the index of the first/last occurrence of the target value, -1 if not found
      */
     private long findEdgeOccurrence(Table table, RowSet index, long start, long end, boolean findFirst,
             boolean isAscending) {

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/gotorow/SeekRow.java
@@ -4,6 +4,7 @@
 package io.deephaven.clientsupport.gotorow;
 
 import io.deephaven.api.util.ConcurrentMethod;
+import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.table.ColumnSource;
@@ -116,26 +117,22 @@ public class SeekRow {
                         row = findRow(rowSet, 0, (int) startingRow);
                         if (row >= 0) {
                             result.setValue(row);
-                            log.info().append("found 1").endl();
                             return true;
                         }
                         row = findRow(rowSet, (int) startingRow, (int) rowSet.size());
                         if (row >= 0) {
                             result.setValue(row);
-                            log.info().append("found 2").endl();
                             return true;
                         }
                     } else {
                         row = findRow(rowSet, (int) startingRow + 1, (int) rowSet.size());
                         if (row >= 0) {
                             result.setValue(row);
-                            log.info().append("found 3").endl();
                             return true;
                         }
                         row = findRow(rowSet, 0, (int) startingRow + 1);
                         if (row >= 0) {
                             result.setValue(row);
-                            log.info().append("found 4").endl();
                             return true;
                         }
                     }

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -6,11 +6,13 @@ package io.deephaven.clientsupport.gotorow;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.engine.util.TableTools;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
 import static io.deephaven.engine.util.TableTools.intCol;
+import static io.deephaven.engine.util.TableTools.newTable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class SeekRowTest {
@@ -18,97 +20,288 @@ public class SeekRowTest {
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
 
+    /**
+     * Helper to verify that a given value can not be found no matter which row is started from
+     *
+     * @param t the table to search
+     * @param impossibleValue a value that isn't present in the table
+     */
+    public static void assertNotFound(int impossibleValue, Table t) {
+        // ensure we can't find values that don't exist
+        for (int i = 0; i < t.size(); i++) {
+            assertSeekPosition(t, impossibleValue, true, i, -1);
+            assertSeekPosition(t, impossibleValue, false, i, -1);
+        }
+    }
+
+    /**
+     * Helper to run SeekRow and validate that the discovered row is what was expected. Validates the
+     * {@code expectedPosition} before running, to ensure test data makes sense.
+     *
+     * @param t the table to search
+     * @param seekValue the value to search for
+     * @param seekForward true to seek forward, false to seek backward
+     * @param currentPosition the position to start searching
+     * @param expectedPosition the next expected position of the seek value
+     */
+    private static void assertSeekPosition(Table t, int seekValue, boolean seekForward, int currentPosition,
+            int expectedPosition) {
+        if (expectedPosition != -1) {
+            // Confirm that the expected position matches
+            assertEquals(seekValue, t.flatten().getColumnSource("num").getInt(expectedPosition));
+        } else {
+            // Confirm that the value actually doesn't exist
+            assertTrue(t.where("num" + "=" + seekValue).isEmpty());
+        }
+        // Actually perform the requested assertion
+        SeekRow seek = new SeekRow(currentPosition, "num", seekValue, false, false, !seekForward);
+        assertEquals(expectedPosition, seek.seek(t));
+    }
+
+    /**
+     * Helper to seek from every row in a table, and assert that a valid value can be found in a valid position from
+     * each.
+     *
+     * @param t the table to search
+     * @param seekValue the value to search for
+     * @param forwardPositions expected positions when searching forward, indexed on starting row
+     * @param backwardPositions expected positions when searching backwards, indexed on starting row
+     */
+    private static void assertSeekPositionAllRows(Table t, int seekValue, int[] forwardPositions,
+            int[] backwardPositions) {
+        assertEquals(t.size(), forwardPositions.length);
+        assertEquals(t.size(), backwardPositions.length);
+        for (int i = 0; i < t.size(); i++) {
+            // seek from the current position, confirm we get the expected position
+            assertSeekPosition(t, seekValue, true, i, forwardPositions[i]);
+            assertSeekPosition(t, seekValue, false, i, backwardPositions[i]);
+        }
+    }
+
+    /**
+     * Helper to run asserts for int rows that are already sorted at initialization
+     * 
+     * @param data the data, must be sorted in ascending order already
+     * @param seekValue the value to search for
+     * @param ascForwardPositions expected positions when searching forwards for ascending data
+     * @param ascBackwardPositions expected positions when searching backwards for ascending data
+     * @param descForwardPositions expected positions when searching forwards for descending data
+     * @param descBackwardPositions expected positions when searching backwards for descending data
+     */
+    private static void assertNaturallySorted(int[] data, int seekValue,
+            int[] ascForwardPositions, int[] ascBackwardPositions,
+            int[] descForwardPositions, int[] descBackwardPositions) {
+        // ascending tables
+        Table ascUnsorted = TableTools.newTable(intCol("num", data));
+        Table ascSorted = ascUnsorted.sort("num");
+        // reverse data to be in descending
+        for (int i = 0; i < data.length / 2; i++) {
+            int tmp = data[i];
+            data[i] = data[data.length - i - 1];
+            data[data.length - i - 1] = tmp;
+        }
+        // descending tables
+        Table descUnsorted = TableTools.newTable(intCol("num", data));
+        Table descSorted = descUnsorted.sort("num");
+
+        assertSeekPositionAllRows(ascUnsorted, seekValue, ascForwardPositions, ascBackwardPositions);
+        assertSeekPositionAllRows(ascSorted, seekValue, ascForwardPositions, ascBackwardPositions);
+        assertSeekPositionAllRows(descUnsorted, seekValue, descForwardPositions, descBackwardPositions);
+        assertSeekPositionAllRows(descSorted, seekValue, descForwardPositions, descBackwardPositions);
+    }
+
+    @Test
+    public void emptyTable() {
+        Table t = TableTools.newTable(intCol("num"));
+
+        assertSeekPosition(t, 1, true, 0, -1);
+        assertSeekPosition(t, 1, false, 0, -1);
+
+        // repeat with sorted
+        t = t.sort("num");
+        assertSeekPosition(t, 1, true, 0, -1);
+        assertSeekPosition(t, 1, false, 0, -1);
+    }
+
     @Test
     public void singleRow() {
-        Table t = TableTools.newTable(intCol("num", 1)).sort("num");
-        Assert.assertEquals(0, (long) new SeekRow(
-                0, "num", 1, false, false, true).seek(t));
-        Assert.assertEquals(0, (long) new SeekRow(
-                0, "num", 1, false, false, false).seek(t));
+        Table t = TableTools.newTable(intCol("num", 1));
+        assertSeekPosition(t, 1, true, 0, 0);
+        assertSeekPosition(t, 1, false, 0, 0);
+
+        assertSeekPosition(t, 100, false, 0, -1);
+        assertSeekPosition(t, 100, true, 0, -1);
+
+        // repeat with sorted
+        t = t.sort("num");
+        assertSeekPosition(t, 1, true, 0, 0);
+        assertSeekPosition(t, 1, false, 0, 0);
+
+        assertSeekPosition(t, 100, false, 0, -1);
+        assertSeekPosition(t, 100, true, 0, -1);
+
+        // repeat with sorted descending
+        t = t.sortDescending("num");
+        assertSeekPosition(t, 1, true, 0, 0);
+        assertSeekPosition(t, 1, false, 0, 0);
+
+        assertSeekPosition(t, 100, false, 0, -1);
+        assertSeekPosition(t, 100, true, 0, -1);
     }
 
     @Test
-    public void ascendingForward() {
-        Table t = createSortedTable(true);
-        Assert.assertEquals(3, (long) new SeekRow(
-                0, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                1, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                2, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(4, (long) new SeekRow(
-                3, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                4, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                5, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                6, "num", 3, false, false, false).seek(t));
+    public void mono1() {
+        assertNaturallySorted(
+                new int[] {1}, 1,
+                new int[] {0},
+                new int[] {0},
+                new int[] {0},
+                new int[] {0});
     }
 
     @Test
-    public void ascendingBackward() {
-        Table t = createSortedTable(true);
-        Assert.assertEquals(4, (long) new SeekRow(
-                0, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(4, (long) new SeekRow(
-                1, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(4, (long) new SeekRow(
-                2, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(4, (long) new SeekRow(
-                3, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                4, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(4, (long) new SeekRow(
-                5, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(4, (long) new SeekRow(
-                6, "num", 3, false, false, true).seek(t));
+    public void mono2() {
+        assertNaturallySorted(
+                new int[] {1, 1}, 1,
+                new int[] {1, 0},
+                new int[] {1, 0},
+                new int[] {1, 0},
+                new int[] {1, 0});
     }
 
     @Test
-    public void descendingForward() {
-        Table t = createSortedTable(false);
-        Assert.assertEquals(2, (long) new SeekRow(
-                0, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(2, (long) new SeekRow(
-                1, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                2, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(2, (long) new SeekRow(
-                3, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(2, (long) new SeekRow(
-                4, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(2, (long) new SeekRow(
-                5, "num", 3, false, false, false).seek(t));
-        Assert.assertEquals(2, (long) new SeekRow(
-                6, "num", 3, false, false, false).seek(t));
+    public void mono3() {
+        assertNaturallySorted(
+                new int[] {1, 1, 1}, 1,
+                new int[] {1, 2, 0},
+                new int[] {2, 0, 1},
+                new int[] {1, 2, 0},
+                new int[] {2, 0, 1});
     }
 
     @Test
-    public void descendingBackward() {
-        Table t = createSortedTable(false);
-        Assert.assertEquals(3, (long) new SeekRow(
-                0, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                1, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                2, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(2, (long) new SeekRow(
-                3, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                4, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                5, "num", 3, false, false, true).seek(t));
-        Assert.assertEquals(3, (long) new SeekRow(
-                6, "num", 3, false, false, true).seek(t));
+    public void start1() {
+        assertNaturallySorted(
+                new int[] {1, 2}, 1,
+                new int[] {0, 0},
+                new int[] {0, 0},
+                new int[] {1, 1},
+                new int[] {1, 1});
     }
 
-    private Table createSortedTable(boolean ascending) {
-        Table t = TableTools.newTable(intCol("num", 1, 1, 2, 3, 3, 4, 4)).sort("num");
-        if (ascending) {
-            return t.sort("num");
-        } else {
-            return t.sortDescending("num");
-        }
+    @Test
+    public void start2() {
+        assertNaturallySorted(
+                new int[] {1, 1, 2}, 1,
+                new int[] {1, 0, 0},
+                new int[] {1, 0, 1},
+                new int[] {1, 2, 1},
+                new int[] {2, 2, 1});
+    }
+
+    @Test
+    public void start3() {
+        assertNaturallySorted(
+                new int[] {1, 1, 1, 2}, 1,
+                new int[] {1, 2, 0, 0},
+                new int[] {2, 0, 1, 2},
+                new int[] {1, 2, 3, 1},
+                new int[] {3, 3, 1, 2});
+    }
+
+    @Test
+    public void middle1() {
+        assertNaturallySorted(
+                new int[] {1, 2, 3}, 2,
+                new int[] {1, 1, 1},
+                new int[] {1, 1, 1},
+                new int[] {1, 1, 1},
+                new int[] {1, 1, 1});
+    }
+
+    @Test
+    public void middle2() {
+        assertNaturallySorted(
+                new int[] {1, 2, 2, 3}, 2,
+                new int[] {1, 2, 1, 1},
+                new int[] {2, 2, 1, 2},
+                new int[] {1, 2, 1, 1},
+                new int[] {2, 2, 1, 2});
+    }
+
+    @Test
+    public void middle3() {
+        assertNaturallySorted(
+                new int[] {1, 2, 2, 2, 3}, 2,
+                new int[] {1, 2, 3, 1, 1},
+                new int[] {3, 3, 1, 2, 3},
+                new int[] {1, 2, 3, 1, 1},
+                new int[] {3, 3, 1, 2, 3});
+    }
+
+    @Test
+    public void end1() {
+        assertNaturallySorted(
+                new int[] {1, 2}, 2,
+                new int[] {1, 1},
+                new int[] {1, 1},
+                new int[] {0, 0},
+                new int[] {0, 0});
+    }
+
+    @Test
+    public void end2() {
+        assertNaturallySorted(
+                new int[] {1, 2, 2}, 2,
+                new int[] {1, 2, 1},
+                new int[] {2, 2, 1},
+                new int[] {1, 0, 0},
+                new int[] {1, 0, 1});
+    }
+
+    @Test
+    public void end3() {
+        assertNaturallySorted(
+                new int[] {1, 2, 2, 2}, 2,
+                new int[] {1, 2, 3, 1},
+                new int[] {3, 3, 1, 2},
+                new int[] {1, 2, 0, 0},
+                new int[] {2, 0, 1, 2});
+    }
+
+    @Test
+    public void notFound() {
+        assertNaturallySorted(
+                new int[] {2, 4, 6}, 1,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
+        assertNaturallySorted(
+                new int[] {2, 4, 6}, 3,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
+        assertNaturallySorted(
+                new int[] {2, 4, 6}, 5,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
+        assertNaturallySorted(
+                new int[] {2, 4, 6}, 7,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
+    }
+
+    @Test
+    public void unsorted() {
+        final Table t = newTable(intCol("num", 3, 1, 2, 1, 3, 2));
+        assertSeekPositionAllRows(t, 2,
+                new int[] {2, 2, 5, 5, 5, 2},
+                new int[] {5, 5, 5, 2, 2, 2});
     }
 }

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -108,7 +108,7 @@ public class SeekRowTest {
         if (ascending) {
             return t.sort("num");
         } else {
-            return t.sortDescending("n");
+            return t.sortDescending("num");
         }
     }
 }

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -23,7 +23,7 @@ public class SeekRowTest {
     /**
      * Helper to verify that a given value can not be found no matter which row is started from
      *
-     * @param t the table to search
+     * @param t               the table to search
      * @param impossibleValue a value that isn't present in the table
      */
     public static void assertNotFound(int impossibleValue, Table t) {
@@ -38,14 +38,14 @@ public class SeekRowTest {
      * Helper to run SeekRow and validate that the discovered row is what was expected. Validates the
      * {@code expectedPosition} before running, to ensure test data makes sense.
      *
-     * @param t the table to search
-     * @param seekValue the value to search for
-     * @param seekForward true to seek forward, false to seek backward
-     * @param currentPosition the position to start searching
+     * @param t                the table to search
+     * @param seekValue        the value to search for
+     * @param seekForward      true to seek forward, false to seek backward
+     * @param currentPosition  the position to start searching
      * @param expectedPosition the next expected position of the seek value
      */
     private static void assertSeekPosition(Table t, int seekValue, boolean seekForward, int currentPosition,
-            int expectedPosition) {
+                                           int expectedPosition) {
         if (expectedPosition != -1) {
             // Confirm that the expected position matches
             assertEquals(seekValue, t.flatten().getColumnSource("num").getInt(expectedPosition));
@@ -62,13 +62,13 @@ public class SeekRowTest {
      * Helper to seek from every row in a table, and assert that a valid value can be found in a valid position from
      * each.
      *
-     * @param t the table to search
-     * @param seekValue the value to search for
-     * @param forwardPositions expected positions when searching forward, indexed on starting row
+     * @param t                 the table to search
+     * @param seekValue         the value to search for
+     * @param forwardPositions  expected positions when searching forward, indexed on starting row
      * @param backwardPositions expected positions when searching backwards, indexed on starting row
      */
     private static void assertSeekPositionAllRows(Table t, int seekValue, int[] forwardPositions,
-            int[] backwardPositions) {
+                                                  int[] backwardPositions) {
         assertEquals(t.size(), forwardPositions.length);
         assertEquals(t.size(), backwardPositions.length);
         for (int i = 0; i < t.size(); i++) {
@@ -80,17 +80,17 @@ public class SeekRowTest {
 
     /**
      * Helper to run asserts for int rows that are already sorted at initialization
-     * 
-     * @param data the data, must be sorted in ascending order already
-     * @param seekValue the value to search for
-     * @param ascForwardPositions expected positions when searching forwards for ascending data
-     * @param ascBackwardPositions expected positions when searching backwards for ascending data
-     * @param descForwardPositions expected positions when searching forwards for descending data
+     *
+     * @param data                  the data, must be sorted in ascending order already
+     * @param seekValue             the value to search for
+     * @param ascForwardPositions   expected positions when searching forwards for ascending data
+     * @param ascBackwardPositions  expected positions when searching backwards for ascending data
+     * @param descForwardPositions  expected positions when searching forwards for descending data
      * @param descBackwardPositions expected positions when searching backwards for descending data
      */
     private static void assertNaturallySorted(int[] data, int seekValue,
-            int[] ascForwardPositions, int[] ascBackwardPositions,
-            int[] descForwardPositions, int[] descBackwardPositions) {
+                                              int[] ascForwardPositions, int[] ascBackwardPositions,
+                                              int[] descForwardPositions, int[] descBackwardPositions) {
         // ascending tables
         Table ascUnsorted = TableTools.newTable(intCol("num", data));
         Table ascSorted = ascUnsorted.sort("num");
@@ -152,161 +152,162 @@ public class SeekRowTest {
     @Test
     public void mono1() {
         assertNaturallySorted(
-                new int[] {1}, 1,
-                new int[] {0},
-                new int[] {0},
-                new int[] {0},
-                new int[] {0});
+                new int[]{1}, 1,
+                new int[]{0},
+                new int[]{0},
+                new int[]{0},
+                new int[]{0});
     }
 
     @Test
     public void mono2() {
         assertNaturallySorted(
-                new int[] {1, 1}, 1,
-                new int[] {1, 0},
-                new int[] {1, 0},
-                new int[] {1, 0},
-                new int[] {1, 0});
+                new int[]{1, 1}, 1,
+                new int[]{1, 0},
+                new int[]{1, 0},
+                new int[]{1, 0},
+                new int[]{1, 0});
     }
 
     @Test
     public void mono3() {
         assertNaturallySorted(
-                new int[] {1, 1, 1}, 1,
-                new int[] {1, 2, 0},
-                new int[] {2, 0, 1},
-                new int[] {1, 2, 0},
-                new int[] {2, 0, 1});
+                new int[]{1, 1, 1}, 1,
+                new int[]{1, 2, 0},
+                new int[]{2, 0, 1},
+                new int[]{1, 2, 0},
+                new int[]{2, 0, 1});
     }
 
     @Test
     public void start1() {
         assertNaturallySorted(
-                new int[] {1, 2}, 1,
-                new int[] {0, 0},
-                new int[] {0, 0},
-                new int[] {1, 1},
-                new int[] {1, 1});
+                new int[]{1, 2}, 1,
+                new int[]{0, 0},
+                new int[]{0, 0},
+                new int[]{1, 1},
+                new int[]{1, 1});
     }
 
     @Test
     public void start2() {
         assertNaturallySorted(
-                new int[] {1, 1, 2}, 1,
-                new int[] {1, 0, 0},
-                new int[] {1, 0, 1},
-                new int[] {1, 2, 1},
-                new int[] {2, 2, 1});
+                new int[]{1, 1, 2}, 1,
+                new int[]{1, 0, 0},
+                new int[]{1, 0, 1},
+                new int[]{1, 2, 1},
+                new int[]{2, 2, 1});
     }
 
     @Test
     public void start3() {
         assertNaturallySorted(
-                new int[] {1, 1, 1, 2}, 1,
-                new int[] {1, 2, 0, 0},
-                new int[] {2, 0, 1, 2},
-                new int[] {1, 2, 3, 1},
-                new int[] {3, 3, 1, 2});
+                new int[]{1, 1, 1, 2}, 1,
+                new int[]{1, 2, 0, 0},
+                new int[]{2, 0, 1, 2},
+                new int[]{1, 2, 3, 1},
+                new int[]{3, 3, 1, 2});
     }
 
     @Test
     public void middle1() {
         assertNaturallySorted(
-                new int[] {1, 2, 3}, 2,
-                new int[] {1, 1, 1},
-                new int[] {1, 1, 1},
-                new int[] {1, 1, 1},
-                new int[] {1, 1, 1});
+                new int[]{1, 2, 3}, 2,
+                new int[]{1, 1, 1},
+                new int[]{1, 1, 1},
+                new int[]{1, 1, 1},
+                new int[]{1, 1, 1});
     }
 
     @Test
     public void middle2() {
         assertNaturallySorted(
-                new int[] {1, 2, 2, 3}, 2,
-                new int[] {1, 2, 1, 1},
-                new int[] {2, 2, 1, 2},
-                new int[] {1, 2, 1, 1},
-                new int[] {2, 2, 1, 2});
+                new int[]{1, 2, 2, 3}, 2,
+                new int[]{1, 2, 1, 1},
+                new int[]{2, 2, 1, 2},
+                new int[]{1, 2, 1, 1},
+                new int[]{2, 2, 1, 2});
     }
 
     @Test
     public void middle3() {
         assertNaturallySorted(
-                new int[] {1, 2, 2, 2, 3}, 2,
-                new int[] {1, 2, 3, 1, 1},
-                new int[] {3, 3, 1, 2, 3},
-                new int[] {1, 2, 3, 1, 1},
-                new int[] {3, 3, 1, 2, 3});
+                new int[]{1, 2, 2, 2, 3}, 2,
+                new int[]{1, 2, 3, 1, 1},
+                new int[]{3, 3, 1, 2, 3},
+                new int[]{1, 2, 3, 1, 1},
+                new int[]{3, 3, 1, 2, 3});
     }
 
     @Test
     public void end1() {
         assertNaturallySorted(
-                new int[] {1, 2}, 2,
-                new int[] {1, 1},
-                new int[] {1, 1},
-                new int[] {0, 0},
-                new int[] {0, 0});
+                new int[]{1, 2}, 2,
+                new int[]{1, 1},
+                new int[]{1, 1},
+                new int[]{0, 0},
+                new int[]{0, 0});
     }
 
     @Test
     public void end2() {
         assertNaturallySorted(
-                new int[] {1, 2, 2}, 2,
-                new int[] {1, 2, 1},
-                new int[] {2, 2, 1},
-                new int[] {1, 0, 0},
-                new int[] {1, 0, 1});
+                new int[]{1, 2, 2}, 2,
+                new int[]{1, 2, 1},
+                new int[]{2, 2, 1},
+                new int[]{1, 0, 0},
+                new int[]{1, 0, 1});
     }
 
     @Test
     public void end3() {
         assertNaturallySorted(
-                new int[] {1, 2, 2, 2}, 2,
-                new int[] {1, 2, 3, 1},
-                new int[] {3, 3, 1, 2},
-                new int[] {1, 2, 0, 0},
-                new int[] {2, 0, 1, 2});
+                new int[]{1, 2, 2, 2}, 2,
+                new int[]{1, 2, 3, 1},
+                new int[]{3, 3, 1, 2},
+                new int[]{1, 2, 0, 0},
+                new int[]{2, 0, 1, 2});
     }
 
     @Test
     public void notFound() {
         assertNaturallySorted(
-                new int[] {2, 4, 6}, 1,
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1});
+                new int[]{2, 4, 6}, 1,
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1});
         assertNaturallySorted(
-                new int[] {2, 4, 6}, 3,
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1});
+                new int[]{2, 4, 6}, 3,
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1});
         assertNaturallySorted(
-                new int[] {2, 4, 6}, 5,
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1});
+                new int[]{2, 4, 6}, 5,
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1});
         assertNaturallySorted(
-                new int[] {2, 4, 6}, 7,
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1},
-                new int[] {-1, -1, -1});
+                new int[]{2, 4, 6}, 7,
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1},
+                new int[]{-1, -1, -1});
     }
 
     @Test
     public void unsorted() {
         final Table t = newTable(intCol("num", 3, 1, 1, 2, 3, 1, 1, 2));
         assertSeekPositionAllRows(t, 1,
-                new int[] {1, 2, 5, 5, 5, 6, 1, 1},
-                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
+                new int[]{1, 2, 5, 5, 5, 6, 1, 1},
+                new int[]{6, 6, 1, 2, 2, 2, 5, 6});
         assertSeekPositionAllRows(t, 2,
-                new int[] {3, 3, 3, 7, 7, 7, 7, 3},
-                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
+                new int[]{3, 3, 3, 7, 7, 7, 7, 3},
+                new int[]{6, 6, 1, 2, 2, 2, 5, 6});
         assertSeekPositionAllRows(t, 3,
-                new int[] {4, 4, 4, 4, 0, 0, 0, 0},
-                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
+                new int[]{4, 4, 4, 4, 0, 0, 0, 0},
+                new int[]{6, 6, 1, 2, 2, 2, 5, 6});
+    }
 }

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -1,0 +1,114 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.clientsupport.gotorow;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static io.deephaven.engine.util.TableTools.intCol;
+
+
+public class SeekRowTest {
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    @Test
+    public void singleRow() {
+        Table t = TableTools.newTable(intCol("num", 1)).sort("num");
+        Assert.assertEquals(0, (long) new SeekRow(
+                0, "num", 1, false, false, true).seek(t));
+        Assert.assertEquals(0, (long) new SeekRow(
+                0, "num", 1, false, false, false).seek(t));
+    }
+
+    @Test
+    public void ascendingForward() {
+        Table t = createSortedTable(true);
+        Assert.assertEquals(3, (long) new SeekRow(
+                0, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                1, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                2, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(4, (long) new SeekRow(
+                3, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                4, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                5, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                6, "num", 3, false, false, false).seek(t));
+    }
+
+    @Test
+    public void ascendingBackward() {
+        Table t = createSortedTable(true);
+        Assert.assertEquals(4, (long) new SeekRow(
+                0, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(4, (long) new SeekRow(
+                1, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(4, (long) new SeekRow(
+                2, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(4, (long) new SeekRow(
+                3, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                4, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(4, (long) new SeekRow(
+                5, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(4, (long) new SeekRow(
+                6, "num", 3, false, false, true).seek(t));
+    }
+
+    @Test
+    public void descendingForward() {
+        Table t = createSortedTable(false);
+        Assert.assertEquals(2, (long) new SeekRow(
+                0, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(2, (long) new SeekRow(
+                1, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                2, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(2, (long) new SeekRow(
+                3, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(2, (long) new SeekRow(
+                4, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(2, (long) new SeekRow(
+                5, "num", 3, false, false, false).seek(t));
+        Assert.assertEquals(2, (long) new SeekRow(
+                6, "num", 3, false, false, false).seek(t));
+    }
+
+    @Test
+    public void descendingBackward() {
+        Table t = createSortedTable(false);
+        Assert.assertEquals(3, (long) new SeekRow(
+                0, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                1, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                2, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(2, (long) new SeekRow(
+                3, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                4, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                5, "num", 3, false, false, true).seek(t));
+        Assert.assertEquals(3, (long) new SeekRow(
+                6, "num", 3, false, false, true).seek(t));
+    }
+
+    private Table createSortedTable(boolean ascending) {
+        Table t = TableTools.newTable(intCol("num", 1, 1, 2, 3, 3, 4, 4)).sort("num");
+        if (ascending) {
+            return t.sort("num");
+        } else {
+            return t.sortDescending("n");
+        }
+    }
+}

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -305,9 +305,9 @@ public class SeekRowTest {
                 new int[] {6, 6, 1, 2, 2, 2, 5, 6});
         assertSeekPositionAllRows(t, 2,
                 new int[] {3, 3, 3, 7, 7, 7, 7, 3},
-                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
+                new int[] {7, 7, 7, 7, 3, 3, 3, 3});
         assertSeekPositionAllRows(t, 3,
                 new int[] {4, 4, 4, 4, 0, 0, 0, 0},
-                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
+                new int[] {4, 0, 0, 0, 0, 4, 4, 4});
     }
 }

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -23,7 +23,7 @@ public class SeekRowTest {
     /**
      * Helper to verify that a given value can not be found no matter which row is started from
      *
-     * @param t               the table to search
+     * @param t the table to search
      * @param impossibleValue a value that isn't present in the table
      */
     public static void assertNotFound(int impossibleValue, Table t) {
@@ -38,14 +38,14 @@ public class SeekRowTest {
      * Helper to run SeekRow and validate that the discovered row is what was expected. Validates the
      * {@code expectedPosition} before running, to ensure test data makes sense.
      *
-     * @param t                the table to search
-     * @param seekValue        the value to search for
-     * @param seekForward      true to seek forward, false to seek backward
-     * @param currentPosition  the position to start searching
+     * @param t the table to search
+     * @param seekValue the value to search for
+     * @param seekForward true to seek forward, false to seek backward
+     * @param currentPosition the position to start searching
      * @param expectedPosition the next expected position of the seek value
      */
     private static void assertSeekPosition(Table t, int seekValue, boolean seekForward, int currentPosition,
-                                           int expectedPosition) {
+            int expectedPosition) {
         if (expectedPosition != -1) {
             // Confirm that the expected position matches
             assertEquals(seekValue, t.flatten().getColumnSource("num").getInt(expectedPosition));
@@ -62,13 +62,13 @@ public class SeekRowTest {
      * Helper to seek from every row in a table, and assert that a valid value can be found in a valid position from
      * each.
      *
-     * @param t                 the table to search
-     * @param seekValue         the value to search for
-     * @param forwardPositions  expected positions when searching forward, indexed on starting row
+     * @param t the table to search
+     * @param seekValue the value to search for
+     * @param forwardPositions expected positions when searching forward, indexed on starting row
      * @param backwardPositions expected positions when searching backwards, indexed on starting row
      */
     private static void assertSeekPositionAllRows(Table t, int seekValue, int[] forwardPositions,
-                                                  int[] backwardPositions) {
+            int[] backwardPositions) {
         assertEquals(t.size(), forwardPositions.length);
         assertEquals(t.size(), backwardPositions.length);
         for (int i = 0; i < t.size(); i++) {
@@ -81,16 +81,16 @@ public class SeekRowTest {
     /**
      * Helper to run asserts for int rows that are already sorted at initialization
      *
-     * @param data                  the data, must be sorted in ascending order already
-     * @param seekValue             the value to search for
-     * @param ascForwardPositions   expected positions when searching forwards for ascending data
-     * @param ascBackwardPositions  expected positions when searching backwards for ascending data
-     * @param descForwardPositions  expected positions when searching forwards for descending data
+     * @param data the data, must be sorted in ascending order already
+     * @param seekValue the value to search for
+     * @param ascForwardPositions expected positions when searching forwards for ascending data
+     * @param ascBackwardPositions expected positions when searching backwards for ascending data
+     * @param descForwardPositions expected positions when searching forwards for descending data
      * @param descBackwardPositions expected positions when searching backwards for descending data
      */
     private static void assertNaturallySorted(int[] data, int seekValue,
-                                              int[] ascForwardPositions, int[] ascBackwardPositions,
-                                              int[] descForwardPositions, int[] descBackwardPositions) {
+            int[] ascForwardPositions, int[] ascBackwardPositions,
+            int[] descForwardPositions, int[] descBackwardPositions) {
         // ascending tables
         Table ascUnsorted = TableTools.newTable(intCol("num", data));
         Table ascSorted = ascUnsorted.sort("num");
@@ -152,162 +152,162 @@ public class SeekRowTest {
     @Test
     public void mono1() {
         assertNaturallySorted(
-                new int[]{1}, 1,
-                new int[]{0},
-                new int[]{0},
-                new int[]{0},
-                new int[]{0});
+                new int[] {1}, 1,
+                new int[] {0},
+                new int[] {0},
+                new int[] {0},
+                new int[] {0});
     }
 
     @Test
     public void mono2() {
         assertNaturallySorted(
-                new int[]{1, 1}, 1,
-                new int[]{1, 0},
-                new int[]{1, 0},
-                new int[]{1, 0},
-                new int[]{1, 0});
+                new int[] {1, 1}, 1,
+                new int[] {1, 0},
+                new int[] {1, 0},
+                new int[] {1, 0},
+                new int[] {1, 0});
     }
 
     @Test
     public void mono3() {
         assertNaturallySorted(
-                new int[]{1, 1, 1}, 1,
-                new int[]{1, 2, 0},
-                new int[]{2, 0, 1},
-                new int[]{1, 2, 0},
-                new int[]{2, 0, 1});
+                new int[] {1, 1, 1}, 1,
+                new int[] {1, 2, 0},
+                new int[] {2, 0, 1},
+                new int[] {1, 2, 0},
+                new int[] {2, 0, 1});
     }
 
     @Test
     public void start1() {
         assertNaturallySorted(
-                new int[]{1, 2}, 1,
-                new int[]{0, 0},
-                new int[]{0, 0},
-                new int[]{1, 1},
-                new int[]{1, 1});
+                new int[] {1, 2}, 1,
+                new int[] {0, 0},
+                new int[] {0, 0},
+                new int[] {1, 1},
+                new int[] {1, 1});
     }
 
     @Test
     public void start2() {
         assertNaturallySorted(
-                new int[]{1, 1, 2}, 1,
-                new int[]{1, 0, 0},
-                new int[]{1, 0, 1},
-                new int[]{1, 2, 1},
-                new int[]{2, 2, 1});
+                new int[] {1, 1, 2}, 1,
+                new int[] {1, 0, 0},
+                new int[] {1, 0, 1},
+                new int[] {1, 2, 1},
+                new int[] {2, 2, 1});
     }
 
     @Test
     public void start3() {
         assertNaturallySorted(
-                new int[]{1, 1, 1, 2}, 1,
-                new int[]{1, 2, 0, 0},
-                new int[]{2, 0, 1, 2},
-                new int[]{1, 2, 3, 1},
-                new int[]{3, 3, 1, 2});
+                new int[] {1, 1, 1, 2}, 1,
+                new int[] {1, 2, 0, 0},
+                new int[] {2, 0, 1, 2},
+                new int[] {1, 2, 3, 1},
+                new int[] {3, 3, 1, 2});
     }
 
     @Test
     public void middle1() {
         assertNaturallySorted(
-                new int[]{1, 2, 3}, 2,
-                new int[]{1, 1, 1},
-                new int[]{1, 1, 1},
-                new int[]{1, 1, 1},
-                new int[]{1, 1, 1});
+                new int[] {1, 2, 3}, 2,
+                new int[] {1, 1, 1},
+                new int[] {1, 1, 1},
+                new int[] {1, 1, 1},
+                new int[] {1, 1, 1});
     }
 
     @Test
     public void middle2() {
         assertNaturallySorted(
-                new int[]{1, 2, 2, 3}, 2,
-                new int[]{1, 2, 1, 1},
-                new int[]{2, 2, 1, 2},
-                new int[]{1, 2, 1, 1},
-                new int[]{2, 2, 1, 2});
+                new int[] {1, 2, 2, 3}, 2,
+                new int[] {1, 2, 1, 1},
+                new int[] {2, 2, 1, 2},
+                new int[] {1, 2, 1, 1},
+                new int[] {2, 2, 1, 2});
     }
 
     @Test
     public void middle3() {
         assertNaturallySorted(
-                new int[]{1, 2, 2, 2, 3}, 2,
-                new int[]{1, 2, 3, 1, 1},
-                new int[]{3, 3, 1, 2, 3},
-                new int[]{1, 2, 3, 1, 1},
-                new int[]{3, 3, 1, 2, 3});
+                new int[] {1, 2, 2, 2, 3}, 2,
+                new int[] {1, 2, 3, 1, 1},
+                new int[] {3, 3, 1, 2, 3},
+                new int[] {1, 2, 3, 1, 1},
+                new int[] {3, 3, 1, 2, 3});
     }
 
     @Test
     public void end1() {
         assertNaturallySorted(
-                new int[]{1, 2}, 2,
-                new int[]{1, 1},
-                new int[]{1, 1},
-                new int[]{0, 0},
-                new int[]{0, 0});
+                new int[] {1, 2}, 2,
+                new int[] {1, 1},
+                new int[] {1, 1},
+                new int[] {0, 0},
+                new int[] {0, 0});
     }
 
     @Test
     public void end2() {
         assertNaturallySorted(
-                new int[]{1, 2, 2}, 2,
-                new int[]{1, 2, 1},
-                new int[]{2, 2, 1},
-                new int[]{1, 0, 0},
-                new int[]{1, 0, 1});
+                new int[] {1, 2, 2}, 2,
+                new int[] {1, 2, 1},
+                new int[] {2, 2, 1},
+                new int[] {1, 0, 0},
+                new int[] {1, 0, 1});
     }
 
     @Test
     public void end3() {
         assertNaturallySorted(
-                new int[]{1, 2, 2, 2}, 2,
-                new int[]{1, 2, 3, 1},
-                new int[]{3, 3, 1, 2},
-                new int[]{1, 2, 0, 0},
-                new int[]{2, 0, 1, 2});
+                new int[] {1, 2, 2, 2}, 2,
+                new int[] {1, 2, 3, 1},
+                new int[] {3, 3, 1, 2},
+                new int[] {1, 2, 0, 0},
+                new int[] {2, 0, 1, 2});
     }
 
     @Test
     public void notFound() {
         assertNaturallySorted(
-                new int[]{2, 4, 6}, 1,
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1});
+                new int[] {2, 4, 6}, 1,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
         assertNaturallySorted(
-                new int[]{2, 4, 6}, 3,
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1});
+                new int[] {2, 4, 6}, 3,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
         assertNaturallySorted(
-                new int[]{2, 4, 6}, 5,
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1});
+                new int[] {2, 4, 6}, 5,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
         assertNaturallySorted(
-                new int[]{2, 4, 6}, 7,
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1},
-                new int[]{-1, -1, -1});
+                new int[] {2, 4, 6}, 7,
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1},
+                new int[] {-1, -1, -1});
     }
 
     @Test
     public void unsorted() {
         final Table t = newTable(intCol("num", 3, 1, 1, 2, 3, 1, 1, 2));
         assertSeekPositionAllRows(t, 1,
-                new int[]{1, 2, 5, 5, 5, 6, 1, 1},
-                new int[]{6, 6, 1, 2, 2, 2, 5, 6});
+                new int[] {1, 2, 5, 5, 5, 6, 1, 1},
+                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
         assertSeekPositionAllRows(t, 2,
-                new int[]{3, 3, 3, 7, 7, 7, 7, 3},
-                new int[]{6, 6, 1, 2, 2, 2, 5, 6});
+                new int[] {3, 3, 3, 7, 7, 7, 7, 3},
+                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
         assertSeekPositionAllRows(t, 3,
-                new int[]{4, 4, 4, 4, 0, 0, 0, 0},
-                new int[]{6, 6, 1, 2, 2, 2, 5, 6});
+                new int[] {4, 4, 4, 4, 0, 0, 0, 0},
+                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
     }
 }

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -299,9 +299,14 @@ public class SeekRowTest {
 
     @Test
     public void unsorted() {
-        final Table t = newTable(intCol("num", 3, 1, 2, 1, 3, 2));
+        final Table t = newTable(intCol("num", 3, 1, 1, 2, 3, 1, 1, 2));
+        assertSeekPositionAllRows(t, 1,
+                new int[] {1, 2, 5, 5, 5, 6, 1, 1},
+                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
         assertSeekPositionAllRows(t, 2,
-                new int[] {2, 2, 5, 5, 5, 2},
-                new int[] {5, 5, 5, 2, 2, 2});
-    }
+                new int[] {3, 3, 3, 7, 7, 7, 7, 3},
+                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
+        assertSeekPositionAllRows(t, 3,
+                new int[] {4, 4, 4, 4, 0, 0, 0, 0},
+                new int[] {6, 6, 1, 2, 2, 2, 5, 6});
 }

--- a/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
+++ b/ClientSupport/src/test/java/io/deephaven/clientsupport/gotorow/SeekRowTest.java
@@ -102,7 +102,7 @@ public class SeekRowTest {
         }
         // descending tables
         Table descUnsorted = TableTools.newTable(intCol("num", data));
-        Table descSorted = descUnsorted.sort("num");
+        Table descSorted = descUnsorted.sortDescending("num");
 
         assertSeekPositionAllRows(ascUnsorted, seekValue, ascForwardPositions, ascBackwardPositions);
         assertSeekPositionAllRows(ascSorted, seekValue, ascForwardPositions, ascBackwardPositions);

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -459,13 +459,13 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                         final String columnName = request.getColumnName();
                         final Class<?> dataType = table.getDefinition().getColumn(columnName).getDataType();
                         final Object seekValue = getSeekValue(request.getSeekValue(), dataType);
-                        final Long result = table.apply(new SeekRow(
+                        final Long result = new SeekRow(
                                 request.getStartingRow(),
                                 columnName,
                                 seekValue,
                                 request.getInsensitive(),
                                 request.getContains(),
-                                request.getIsBackward()));
+                                request.getIsBackward()).seek(table);
                         SeekRowResponse.Builder rowResponse = SeekRowResponse.newBuilder();
                         safelyComplete(responseObserver, rowResponse.setResultRow(result).build());
                     });

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -459,7 +459,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                         final String columnName = request.getColumnName();
                         final Class<?> dataType = table.getDefinition().getColumn(columnName).getDataType();
                         final Object seekValue = getSeekValue(request.getSeekValue(), dataType);
-                        final Long result = new SeekRow(
+                        final long result = new SeekRow(
                                 request.getStartingRow(),
                                 columnName,
                                 seekValue,


### PR DESCRIPTION
- Change algorithm for sorted columns
  - Use `SortedColumnsAttribute.getOrderForColumn` instead of `guessSorted` to guarantee
  - Add a binary search algorithm to find first/last occurrence in a sorted list
  - Check next/prev row first, then loop around to end/start and get last/first occurrence
    - e.g. for `[1, 2, 2, 3]` and on the last `2`, the algorithm would check the next value (`3`) first, then search for first occurrence of `1, 2, 2`
- Change algorithm for unsorted columns to return `-1` when not found, instead of the closest value
- Replace `ConcurrentMethod` with snapshots