### PR TITLE
Create deephaven.time time-type aliases

### DIFF
--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -28,6 +28,13 @@ _JPeriod = jpy.get_type("java.time.Period")
 _NANOS_PER_SECOND = 1000000000
 _NANOS_PER_MICRO = 1000
 
+TimeZoneAlias = Union[TimeZone, str, datetime.tzinfo, datetime.datetime, pandas.Timestamp]
+LocalDateAlias = Union[LocalDate, str, datetime.date, datetime.datetime, numpy.datetime64, pandas.Timestamp]
+LocalTimeAlias = Union[LocalTime, int, str, datetime.time, datetime.datetime, numpy.datetime64, pandas.Timestamp]
+InstantAlias = Union[Instant, int, str, datetime.datetime, numpy.datetime64, pandas.Timestamp]
+ZonedDateTimeAlias = Union[ZonedDateTime, str, datetime.datetime, numpy.datetime64, pandas.Timestamp]
+DurationAlias = Union[Duration, int, str, datetime.timedelta, numpy.timedelta64, pandas.Timedelta]
+PeriodAlias = Union[Period, str, datetime.timedelta, numpy.timedelta64, pandas.Timedelta]
 
 # region Clock
 
@@ -220,15 +227,14 @@ def _tzinfo_to_j_time_zone(tzi: datetime.tzinfo) -> TimeZone:
     raise TypeError(f"Unsupported conversion: {str(type(tzi))} -> TimeZone\n\tDetails:\n\t{details}")
 
 
-def to_j_time_zone(tz: Union[None, TimeZone, str, datetime.tzinfo, datetime.datetime, pandas.Timestamp]) -> \
-        Optional[TimeZone]:
+def to_j_time_zone(tz: Optional[TimeZoneAlias]) -> Optional[TimeZone]:
     """
     Converts a time zone value to a Java TimeZone.
     Time zone values can be None, a Java TimeZone, a string, a datetime.tzinfo, a datetime.datetime,
     or a pandas.Timestamp.
 
     Args:
-        tz (Union[None, TimeZone, str, datetime.tzinfo, datetime.datetime, pandas.Timestamp]): A time zone value.
+        tz (Optional[TimeZoneAlias]): A time zone value.
             If None is provided, None is returned.
             If a string is provided, it is parsed as a time zone name.
 
@@ -263,8 +269,7 @@ def to_j_time_zone(tz: Union[None, TimeZone, str, datetime.tzinfo, datetime.date
         raise DHError(e) from e
 
 
-def to_j_local_date(dt: Union[None, LocalDate, str, datetime.date, datetime.datetime,
-                              numpy.datetime64, pandas.Timestamp]) -> Optional[LocalDate]:
+def to_j_local_date(dt: Optional[LocalDateAlias]) -> Optional[LocalDate]:
     """
     Converts a date time value to a Java LocalDate.
     Date time values can be None, a Java LocalDate, a string, a datetime.date, a datetime.datetime,
@@ -273,8 +278,7 @@ def to_j_local_date(dt: Union[None, LocalDate, str, datetime.date, datetime.date
     Date strings can be formatted according to the ISO 8601 date time format as 'YYYY-MM-DD'.
 
     Args:
-        dt (Union[None, LocalDate, str, datetime.date, datetime.datetime, numpy.datetime64, pandas.Timestamp]): 
-            A date time value. If None is provided, None is returned.
+        dt (Optional[LocalDateAlias]): A date time value. If None is provided, None is returned.
 
     Returns:
         LocalDate
@@ -302,8 +306,7 @@ def to_j_local_date(dt: Union[None, LocalDate, str, datetime.date, datetime.date
         raise DHError(e) from e
 
 
-def to_j_local_time(dt: Union[None, LocalTime, int, str, datetime.time, datetime.datetime,
-                              numpy.datetime64, pandas.Timestamp]) -> Optional[LocalTime]:
+def to_j_local_time(dt: Optional[LocalTimeAlias]) -> Optional[LocalTime]:
     """
     Converts a date time value to a Java LocalTime.
     Date time values can be None, a Java LocalTime, an int, a string, a datetime.time, a datetime.datetime,
@@ -314,8 +317,7 @@ def to_j_local_time(dt: Union[None, LocalTime, int, str, datetime.time, datetime
     Time strings can be formatted as 'hh:mm:ss[.nnnnnnnnn]'.
 
     Args:
-        dt (Union[None, LocalTime, int, str, datetime.time, datetime.datetime, numpy.datetime64, pandas.Timestamp]):
-            A date time value.  If None is provided, None is returned.
+        dt (Optional[LocalTimeAlias]): A date time value.  If None is provided, None is returned.
 
     Returns:
         LocalTime
@@ -348,8 +350,7 @@ def to_j_local_time(dt: Union[None, LocalTime, int, str, datetime.time, datetime
         raise DHError(e) from e
 
 
-def to_j_instant(dt: Union[None, Instant, int, str, datetime.datetime, numpy.datetime64, pandas.Timestamp]) -> \
-        Optional[Instant]:
+def to_j_instant(dt: Optional[InstantAlias]) -> Optional[Instant]:
     """
     Converts a date time value to a Java Instant.
     Date time values can be None, a Java Instant, an int, a string, a datetime.datetime,
@@ -363,8 +364,7 @@ def to_j_instant(dt: Union[None, Instant, int, str, datetime.datetime, numpy.dat
     from the Epoch.  Expected date ranges are used to infer the units.
 
     Args:
-        dt (Union[None, Instant, int, str, datetime.datetime, numpy.datetime64, pandas.Timestamp]): A date time value.
-            If None is provided, None is returned.
+        dt (Optional[InstantAlias]): A date time value. If None is provided, None is returned.
 
     Returns:
         Instant, TypeError
@@ -400,8 +400,7 @@ def to_j_instant(dt: Union[None, Instant, int, str, datetime.datetime, numpy.dat
         raise DHError(e) from e
 
 
-def to_j_zdt(dt: Union[None, ZonedDateTime, str, datetime.datetime, numpy.datetime64, pandas.Timestamp]) -> \
-        Optional[ZonedDateTime]:
+def to_j_zdt(dt: Optional[ZonedDateTimeAlias]) -> Optional[ZonedDateTime]:
     """
     Converts a date time value to a Java ZonedDateTime.
     Date time values can be None, a Java ZonedDateTime, a string, a datetime.datetime,
@@ -416,8 +415,7 @@ def to_j_zdt(dt: Union[None, ZonedDateTime, str, datetime.datetime, numpy.dateti
     Converting a numpy.datetime64 to a ZonedDateTime will use the Deephaven default time zone.
 
     Args:
-        dt (Union[None, ZonedDateTime, str, datetime.datetime, numpy.datetime64, pandas.Timestamp]):
-            A date time value.  If None is provided, None is returned.
+        dt (Optional[ZonedDateTimeAlias]): A date time value. If None is provided, None is returned.
 
     Returns:
         ZonedDateTime
@@ -452,8 +450,7 @@ def to_j_zdt(dt: Union[None, ZonedDateTime, str, datetime.datetime, numpy.dateti
         raise DHError(e) from e
 
 
-def to_j_duration(dt: Union[None, Duration, int, str, datetime.timedelta, numpy.timedelta64, pandas.Timedelta]) -> \
-        Optional[Duration]:
+def to_j_duration(dt: Optional[DurationAlias]) -> Optional[Duration]:
     """
     Converts a time duration value to a Java Duration,
     which is a unit of time in terms of clock time (24-hour days, hours, minutes, seconds, and nanoseconds).
@@ -477,8 +474,7 @@ def to_j_duration(dt: Union[None, Duration, int, str, datetime.timedelta, numpy.
         |    "-PT-6H+3M"  -- parses as "+6 hours and -3 minutes"
 
     Args:
-        dt (Union[None, Duration, int, str, datetime.timedelta, numpy.timedelta64, pandas.Timedelta]):
-            A time duration value.  If None is provided, None is returned.
+        dt (Optional[DurationAlias]): A time duration value. If None is provided, None is returned.
 
     Returns:
         Duration
@@ -512,8 +508,7 @@ def to_j_duration(dt: Union[None, Duration, int, str, datetime.timedelta, numpy.
         raise DHError(e) from e
 
 
-def to_j_period(dt: Union[None, Period, str, datetime.timedelta, numpy.timedelta64, pandas.Timedelta]) -> \
-        Optional[Period]:
+def to_j_period(dt: Optional[PeriodAlias]) -> Optional[Period]:
     """
     Converts a time duration value to a Java Period,
     which is a unit of time in terms of calendar time (days, weeks, months, years, etc.).
@@ -534,8 +529,7 @@ def to_j_period(dt: Union[None, Period, str, datetime.timedelta, numpy.timedelta
         |    "-P1Y2M"          -- -1 Year, -2 Months
 
     Args:
-        dt (Union[None, Period, str, datetime.timedelta, numpy.timedelta64, pandas.Timedelta]):
-            A Python period or period string.  If None is provided, None is returned.
+        dt (Optional[PeriodAlias]): A Python period or period string. If None is provided, None is returned.
 
     Returns:
         Period


### PR DESCRIPTION
This allows other library code to reference the proper time-types without having to worry about the minute details. This will also make the other library code easier to maintain if additional time-type conversions are added in the future.