### PR TITLE
Only support zoneinfo for python 3.9+

### DIFF
--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -186,7 +186,7 @@ def _tzinfo_to_j_time_zone(tzi: datetime.tzinfo) -> TimeZone:
 
     # Handle zoneinfo time zones
 
-    if sys.version_info >= (3, 8):
+    if sys.version_info >= (3, 9):
         import zoneinfo
         if isinstance(tzi, zoneinfo.ZoneInfo):
             return _JDateTimeUtils.parseTimeZone(tzi.key)

--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -5,7 +5,7 @@
 """ This module defines functions for handling Deephaven date/time data. """
 
 import datetime
-import zoneinfo
+import sys
 import pytz
 from typing import Union, Optional, Literal
 
@@ -186,8 +186,10 @@ def _tzinfo_to_j_time_zone(tzi: datetime.tzinfo) -> TimeZone:
 
     # Handle zoneinfo time zones
 
-    if isinstance(tzi, zoneinfo.ZoneInfo):
-        return _JDateTimeUtils.parseTimeZone(tzi.key)
+    if sys.version_info >= (3, 8):
+        import zoneinfo
+        if isinstance(tzi, zoneinfo.ZoneInfo):
+            return _JDateTimeUtils.parseTimeZone(tzi.key)
 
     # Handle constant UTC offset time zones (datetime.timezone)
 

--- a/py/server/tests/test_time.py
+++ b/py/server/tests/test_time.py
@@ -119,7 +119,7 @@ class TimeTestCase(BaseTestCase):
             to_j_time_zone(dt)
             self.fail("Expected DHError")
 
-        if sys.version_info >= (3, 8):
+        if sys.version_info >= (3, 9):
             import zoneinfo
             dttz = zoneinfo.ZoneInfo("America/New_York")
             dt = datetime.datetime(2022, 7, 7, 14, 21, 17, 123456, tzinfo=dttz)

--- a/py/server/tests/test_time.py
+++ b/py/server/tests/test_time.py
@@ -5,7 +5,7 @@
 import unittest
 from time import sleep
 import datetime
-import zoneinfo
+import sys
 import pandas as pd
 import numpy as np
 
@@ -119,10 +119,12 @@ class TimeTestCase(BaseTestCase):
             to_j_time_zone(dt)
             self.fail("Expected DHError")
 
-        dttz = zoneinfo.ZoneInfo("America/New_York")
-        dt = datetime.datetime(2022, 7, 7, 14, 21, 17, 123456, tzinfo=dttz)
-        self.assertEqual(to_j_time_zone(dttz), to_j_time_zone("America/New_York"))
-        self.assertEqual(to_j_time_zone(dt), to_j_time_zone("America/New_York"))
+        if sys.version_info >= (3, 8):
+            import zoneinfo
+            dttz = zoneinfo.ZoneInfo("America/New_York")
+            dt = datetime.datetime(2022, 7, 7, 14, 21, 17, 123456, tzinfo=dttz)
+            self.assertEqual(to_j_time_zone(dttz), to_j_time_zone("America/New_York"))
+            self.assertEqual(to_j_time_zone(dt), to_j_time_zone("America/New_York"))
 
         with self.assertRaises(TypeError):
             to_j_time_zone(False)


### PR DESCRIPTION
Resolves #5270 