### PR TITLE
Adds a quick CI job to verify python minimum version

### DIFF
--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -50,3 +50,18 @@ jobs:
           name: quick-ci-jvm-err
           path: '**/*_pid*.log'
           if-no-files-found: ignore
+
+  verify-python-min-version:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install vermin
+        run: pip install vermin==1.6.0
+
+      - name: Verify minimum version support
+        run: vermin -t=3.8 --no-tips --eval-annotations --violations py/server/deephaven py/client py/client-ticking py/embedded-server

--- a/py/server/deephaven/_udf.py
+++ b/py/server/deephaven/_udf.py
@@ -250,7 +250,7 @@ def _parse_signature(fn: Callable) -> _ParsedSignature:
     else:
         p_sig = _ParsedSignature(fn=fn)
         if sys.version_info.major == 3 and sys.version_info.minor >= 10:
-            sig = inspect.signature(fn, eval_str=True)
+            sig = inspect.signature(fn, eval_str=True) # novermin
         else:
             sig = inspect.signature(fn)
 

--- a/py/server/deephaven/dtypes.py
+++ b/py/server/deephaven/dtypes.py
@@ -443,7 +443,7 @@ def _np_ndarray_component_type(t: type) -> Optional[type]:
     # when np.ndarray is used, the 1st argument is the component type
     if not component_type and sys.version_info.major == 3 and sys.version_info.minor > 8:
         import types
-        if isinstance(t, types.GenericAlias) and (issubclass(t.__origin__, Sequence) or t.__origin__ == np.ndarray):
+        if isinstance(t, types.GenericAlias) and (issubclass(t.__origin__, Sequence) or t.__origin__ == np.ndarray): # novermin
             nargs = len(t.__args__)
             if nargs == 1:
                 component_type = t.__args__[0]


### PR DESCRIPTION
We've had a few recent issue/PRs dealing with python minimum version support: #5227, #5235, and #5271

Ultimately, we'd like a full matrix of testing support: #3724, #3725

In the more immediate term, there is a tool that I've verified is capable of catching these sorts of issues: https://github.com/netromdk/vermin. I've verified that it does catch #5227 and #5271, but does not catch #5235 (which seems like it is more of a runtime error).

This PR adds a quick CI job to verify a python minimum version of 3.8. The `# novermin` comment is necessary in a few locations where we've explicitly / manually worked around python minimum version support.