### PR TITLE
Bump server base images, jpy>=0.16.0

### DIFF
--- a/docker/registry/server-base/gradle.properties
+++ b/docker/registry/server-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:d4db20a0487d0eecc0e201d3e1aa77b746c5d1dd4fed4e6169c5f58fe4c43db5
+deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:c94df093802971767d073fca278dee703e014dfaeec83ce5bf14331a5c4119f2

--- a/docker/registry/slim-base/gradle.properties
+++ b/docker/registry/slim-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-slim-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:5d9eb6e5c3507d1d463720bb61c4ea62b98cf48a482c8c8f3faeaaf01b3c5f1f
+deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:2e8b338054b5a6112acecb913cd0a62b254fccdaba9910ffca0bd02c73cc73aa

--- a/docker/server-jetty/src/main/server-jetty/requirements.txt
+++ b/docker/server-jetty/src/main/server-jetty/requirements.txt
@@ -1,18 +1,19 @@
-adbc-driver-manager==0.9.0
-adbc-driver-postgresql==0.9.0
+adbc-driver-manager==0.10.0
+adbc-driver-postgresql==0.10.0
 connectorx==0.3.2; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
 java-utilities==0.2.0
 jedi==0.18.2
-jpy==0.15.0
+jpy==0.16.0
 llvmlite==0.42.0
-numba==0.59.0
-numpy==1.26.3
-pandas==2.2.0
+numba==0.59.1
+numpy==1.26.4
+pandas==2.2.1
 parso==0.8.3
 pyarrow==14.0.2
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 pytz==2024.1
 six==1.16.0
 turbodbc==4.8.0
-tzdata==2023.4
+typing_extensions==4.10.0
+tzdata==2024.1

--- a/docker/server/src/main/server-netty/requirements.txt
+++ b/docker/server/src/main/server-netty/requirements.txt
@@ -1,18 +1,19 @@
-adbc-driver-manager==0.9.0
-adbc-driver-postgresql==0.9.0
+adbc-driver-manager==0.10.0
+adbc-driver-postgresql==0.10.0
 connectorx==0.3.2; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
 java-utilities==0.2.0
 jedi==0.18.2
-jpy==0.15.0
+jpy==0.16.0
 llvmlite==0.42.0
-numba==0.59.0
-numpy==1.26.3
-pandas==2.2.0
+numba==0.59.1
+numpy==1.26.4
+pandas==2.2.1
 parso==0.8.3
 pyarrow==14.0.2
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 pytz==2024.1
 six==1.16.0
 turbodbc==4.8.0
-tzdata==2023.4
+typing_extensions==4.10.0
+tzdata==2024.1

--- a/py/embedded-server/setup.py
+++ b/py/embedded-server/setup.py
@@ -58,7 +58,7 @@ setup(
     keywords='Deephaven Development',
     python_requires='>=3.8',
     install_requires=[
-        'jpy>=0.14.0',
+        'jpy>=0.16.0',
         "java-utilities",
         f"deephaven-core[autocomplete]=={_version}",
     ]

--- a/py/jpy-ext/build.gradle
+++ b/py/jpy-ext/build.gradle
@@ -16,6 +16,6 @@ plugins {
 }
 
 dependencies {
-  api 'org.jpyconsortium:jpy:0.14.0'
+  api 'org.jpyconsortium:jpy:0.16.0'
   api project(':deephaven-jpy-config')
 }

--- a/py/server/setup.py
+++ b/py/server/setup.py
@@ -56,7 +56,7 @@ setup(
     keywords='Deephaven Development',
     python_requires='>=3.8',
     install_requires=[
-        'jpy>=0.15.0',
+        'jpy>=0.16.0',
         'deephaven-plugin>=0.6.0',
         'numpy',
         'pandas>=1.5.0',


### PR DESCRIPTION
It looks like embedded-server and our java dependency weren't updated on our bump to 0.15.0. This was to no ill-effect, as the java version didn't change, and embedded-server virtual environment likely picked up the newest dependency anyways.