### PR TITLE
Use AutoCloseable in some places where we previously used SafeCloseable, and standardize some SafeCloseable utilities

### DIFF
--- a/Util/src/main/java/io/deephaven/util/SafeCloseable.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseable.java
@@ -18,40 +18,43 @@ import java.util.stream.Stream;
  */
 public interface SafeCloseable extends AutoCloseable {
 
+    @Override
+    void close();
+
     /**
-     * {@link #close() Close} all non-{@code null} SafeCloseable arguments.
+     * {@link #close() Close} all non-{@code null} {@link AutoCloseable} arguments.
      *
-     * @param safeCloseables SafeCloseables to {@link #close() close}
+     * @param autoCloseables {@link AutoCloseable AutoCloseables} to {@link #close() close}
      */
-    static void closeAll(@NotNull final SafeCloseable... safeCloseables) {
-        closeAll(Arrays.asList(safeCloseables).iterator());
+    static void closeAll(@NotNull final AutoCloseable... autoCloseables) {
+        closeAll(Arrays.asList(autoCloseables).iterator());
     }
 
     /**
-     * {@link #close() Close} all non-{@code null} SafeCloseable elements. Terminates the {@code stream}.
+     * {@link #close() Close} all non-{@code null} {@link AutoCloseable} elements. Terminates the {@code stream}.
      *
-     * @param stream the stream of SafeCloseables to {@link #close() close}
-     * @param <SCT> the safe closable type
+     * @param stream the stream of {@link AutoCloseable AutoCloseables} to {@link #close() close}
+     * @param <ACT> the auto closable type
      */
-    static <SCT extends SafeCloseable> void closeAll(@NotNull final Stream<SCT> stream) {
+    static <ACT extends AutoCloseable> void closeAll(@NotNull final Stream<ACT> stream) {
         closeAll(stream.iterator());
     }
 
     /**
-     * {@link #close() Close} all non-{@code null} SafeCloseable elements. Consumes the {@code iterator}.
+     * {@link #close() Close} all non-{@code null} {@link AutoCloseable} elements. Consumes the {@code iterator}.
      *
-     * @param iterator the iterator of SafeCloseables to {@link #close() close}
-     * @param <SCT> the safe closable type
+     * @param iterator the iterator of {@link AutoCloseable AutoCloseables} to {@link #close() close}
+     * @param <ACT> the auto closable type
      */
-    static <SCT extends SafeCloseable> void closeAll(@NotNull final Iterator<SCT> iterator) {
+    static <ACT extends AutoCloseable> void closeAll(@NotNull final Iterator<ACT> iterator) {
         List<Exception> exceptions = null;
         while (iterator.hasNext()) {
-            final SafeCloseable safeCloseable = iterator.next();
-            if (safeCloseable == null) {
+            final AutoCloseable autoCloseable = iterator.next();
+            if (autoCloseable == null) {
                 continue;
             }
             try {
-                safeCloseable.close();
+                autoCloseable.close();
             } catch (Exception e) {
                 if (exceptions == null) {
                     exceptions = new ArrayList<>();
@@ -67,16 +70,17 @@ public interface SafeCloseable extends AutoCloseable {
     }
 
     /**
-     * {@link #close() Close} a single SafeCloseable argument if it is non-{@code null}.
+     * {@link #close() Close} a single {@link AutoCloseable} argument if it is non-{@code null}.
      *
-     * @param safeCloseable The SafeCloseable to {@link #close() close}
+     * @param autoCloseable The {@link AutoCloseable} to {@link #close() close}
      */
-    static void closeIfNonNull(@Nullable final SafeCloseable safeCloseable) {
-        if (safeCloseable != null) {
-            safeCloseable.close();
+    static void closeIfNonNull(@Nullable final AutoCloseable autoCloseable) {
+        if (autoCloseable != null) {
+            try {
+                autoCloseable.close();
+            } catch (Exception e) {
+                throw new UncheckedDeephavenException("Exception while closing resource", e);
+            }
         }
     }
-
-    @Override
-    void close();
 }

--- a/Util/src/main/java/io/deephaven/util/SafeCloseable.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseable.java
@@ -33,7 +33,7 @@ public interface SafeCloseable extends AutoCloseable {
     /**
      * {@link #close() Close} all non-{@code null} {@link AutoCloseable} elements. Terminates the {@code stream}.
      *
-     * @param stream the stream of {@link AutoCloseable AutoCloseables} to {@link #close() close}
+     * @param stream The stream of {@link AutoCloseable AutoCloseables} to {@link #close() close}
      * @param <ACT> the auto closable type
      */
     static <ACT extends AutoCloseable> void closeAll(@NotNull final Stream<ACT> stream) {
@@ -43,7 +43,7 @@ public interface SafeCloseable extends AutoCloseable {
     /**
      * {@link #close() Close} all non-{@code null} {@link AutoCloseable} elements. Consumes the {@code iterator}.
      *
-     * @param iterator the iterator of {@link AutoCloseable AutoCloseables} to {@link #close() close}
+     * @param iterator The iterator of {@link AutoCloseable AutoCloseables} to {@link #close() close}
      * @param <ACT> the auto closable type
      */
     static <ACT extends AutoCloseable> void closeAll(@NotNull final Iterator<ACT> iterator) {

--- a/Util/src/main/java/io/deephaven/util/SafeCloseableArray.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseableArray.java
@@ -16,11 +16,11 @@ import java.util.List;
  * then populate the array within the loop. If you fail before populating the array nothing is closed, if you fail
  * during or after populating the array the created values are closed.
  */
-public class SafeCloseableArray<SCT extends SafeCloseable> implements SafeCloseable {
+public class SafeCloseableArray<ACT extends AutoCloseable> implements SafeCloseable {
 
-    private final SCT[] array;
+    private final ACT[] array;
 
-    public SafeCloseableArray(SCT[] entries) {
+    public SafeCloseableArray(ACT[] entries) {
         array = entries;
     }
 
@@ -30,16 +30,16 @@ public class SafeCloseableArray<SCT extends SafeCloseable> implements SafeClosea
     }
 
     /**
-     * Close an array of {@link SafeCloseable} entries, ignoring {@code null} elements and assigning elements to
+     * Close an array of {@link AutoCloseable} entries, ignoring {@code null} elements and assigning elements to
      * {@code null} as they are cleared.
      * 
      * @param array The array to operate one
      */
-    public static <SCT extends SafeCloseable> void close(@NotNull final SCT[] array) {
+    public static <ACT extends AutoCloseable> void close(final ACT @NotNull [] array) {
         final int length = array.length;
         List<Exception> exceptions = null;
         for (int ii = 0; ii < length; ii++) {
-            try (final SafeCloseable ignored = array[ii]) {
+            try (final AutoCloseable ignored = array[ii]) {
                 array[ii] = null;
             } catch (Exception e) {
                 if (exceptions == null) {

--- a/Util/src/main/java/io/deephaven/util/SafeCloseableArray.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseableArray.java
@@ -10,11 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * {@link SafeCloseable} that will close non-null values inside of an array.
+ * {@link SafeCloseable} that will close non-null values inside an array.
  * <p>
  * The common use case is to create an array; use the SafeCloseableArray in an ignored try-with-resources variable, and
- * then populate the array within the loop. If you fail before populating the array nothing is closed, if you fail
- * during or after populating the array the created values are closed.
+ * then populate the array within the loop. If the operation fails before populating the array nothing is closed. If the
+ * operation fails during or after populating the array the populated values are closed.
  */
 public class SafeCloseableArray<ACT extends AutoCloseable> implements SafeCloseable {
 
@@ -32,7 +32,7 @@ public class SafeCloseableArray<ACT extends AutoCloseable> implements SafeClosea
     /**
      * Close an array of {@link AutoCloseable} entries, ignoring {@code null} elements and assigning elements to
      * {@code null} as they are cleared.
-     * 
+     *
      * @param array The array to operate one
      */
     public static <ACT extends AutoCloseable> void close(final ACT @NotNull [] array) {

--- a/Util/src/main/java/io/deephaven/util/SafeCloseableList.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseableList.java
@@ -63,7 +63,7 @@ public class SafeCloseableList implements SafeCloseable {
         }
     }
 
-    public static final Collector<SafeCloseable, SafeCloseableList, SafeCloseableList> COLLECTOR = new Collector<>() {
+    public static final Collector<AutoCloseable, SafeCloseableList, SafeCloseableList> COLLECTOR = new Collector<>() {
 
         @Override
         public Supplier<SafeCloseableList> supplier() {
@@ -71,7 +71,7 @@ public class SafeCloseableList implements SafeCloseable {
         }
 
         @Override
-        public BiConsumer<SafeCloseableList, SafeCloseable> accumulator() {
+        public BiConsumer<SafeCloseableList, AutoCloseable> accumulator() {
             return SafeCloseableList::add;
         }
 

--- a/Util/src/main/java/io/deephaven/util/SafeCloseablePair.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseablePair.java
@@ -5,7 +5,7 @@ package io.deephaven.util;
 
 import java.util.Objects;
 
-public class SafeCloseablePair<A extends SafeCloseable, B extends SafeCloseable> implements SafeCloseable {
+public class SafeCloseablePair<A extends AutoCloseable, B extends AutoCloseable> implements SafeCloseable {
     public final A first;
     public final B second;
 
@@ -32,12 +32,7 @@ public class SafeCloseablePair<A extends SafeCloseable, B extends SafeCloseable>
 
     @Override
     public void close() {
-        if (this.first != null) {
-            this.first.close();
-        }
-        if (this.second != null) {
-            this.second.close();
-        }
+        SafeCloseable.closeAll(first, second);
     }
 
     public static <AP extends SafeCloseable, BP extends SafeCloseable, A extends AP, B extends BP> SafeCloseablePair<AP, BP> downcast(

--- a/Util/src/main/java/io/deephaven/util/SafeCloseablePair.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseablePair.java
@@ -43,7 +43,7 @@ public class SafeCloseablePair<A extends AutoCloseable, B extends AutoCloseable>
     }
 
     public static <A extends SafeCloseable, B extends SafeCloseable> SafeCloseablePair<A, B> of(final A first,
-                                                                                                final B second) {
+            final B second) {
         return new SafeCloseablePair<>(first, second);
     }
 

--- a/Util/src/main/java/io/deephaven/util/SafeCloseablePair.java
+++ b/Util/src/main/java/io/deephaven/util/SafeCloseablePair.java
@@ -6,6 +6,7 @@ package io.deephaven.util;
 import java.util.Objects;
 
 public class SafeCloseablePair<A extends AutoCloseable, B extends AutoCloseable> implements SafeCloseable {
+
     public final A first;
     public final B second;
 
@@ -42,7 +43,7 @@ public class SafeCloseablePair<A extends AutoCloseable, B extends AutoCloseable>
     }
 
     public static <A extends SafeCloseable, B extends SafeCloseable> SafeCloseablePair<A, B> of(final A first,
-            final B second) {
+                                                                                                final B second) {
         return new SafeCloseablePair<>(first, second);
     }
 

--- a/engine/api/src/main/java/io/deephaven/engine/table/iterators/ColumnIterator.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/iterators/ColumnIterator.java
@@ -15,8 +15,7 @@ import io.deephaven.util.SafeCloseable;
 public interface ColumnIterator<DATA_TYPE> extends CloseableIterator<DATA_TYPE>, SafeCloseable {
 
     @Override
-    default void close() {
-    }
+    default void close() {}
 
     /**
      * @return The number of elements remaining in this ColumnIterator

--- a/engine/api/src/main/java/io/deephaven/engine/table/iterators/ColumnIterator.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/iterators/ColumnIterator.java
@@ -4,6 +4,7 @@
 package io.deephaven.engine.table.iterators;
 
 import io.deephaven.engine.primitive.iterator.CloseableIterator;
+import io.deephaven.util.SafeCloseable;
 
 /**
  * Iteration support for values supplied by a column.
@@ -11,7 +12,11 @@ import io.deephaven.engine.primitive.iterator.CloseableIterator;
  * @apiNote ColumnIterators must be explicitly {@link #close() closed} or used until exhausted in order to avoid
  *          resource leaks.
  */
-public interface ColumnIterator<DATA_TYPE> extends CloseableIterator<DATA_TYPE> {
+public interface ColumnIterator<DATA_TYPE> extends CloseableIterator<DATA_TYPE>, SafeCloseable {
+
+    @Override
+    default void close() {
+    }
 
     /**
      * @return The number of elements remaining in this ColumnIterator

--- a/engine/primitive/src/main/java/io/deephaven/engine/primitive/iterator/CloseableIterator.java
+++ b/engine/primitive/src/main/java/io/deephaven/engine/primitive/iterator/CloseableIterator.java
@@ -40,10 +40,6 @@ public interface CloseableIterator<TYPE> extends Iterator<TYPE>, AutoCloseable {
                 .onClose(this::close);
     }
 
-    /**
-     * @inheritDoc
-     * @apiNote Unlike {@link AutoCloseable}, CloseableIterators must not throw checked exceptions.
-     */
     @Override
     default void close() {}
 

--- a/engine/primitive/src/main/java/io/deephaven/engine/primitive/iterator/CloseableIterator.java
+++ b/engine/primitive/src/main/java/io/deephaven/engine/primitive/iterator/CloseableIterator.java
@@ -3,7 +3,6 @@
 //
 package io.deephaven.engine.primitive.iterator;
 
-import io.deephaven.util.SafeCloseable;
 import io.deephaven.util.SafeCloseableArray;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,14 +16,14 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * This interface extends {@link Iterator} and {@link SafeCloseable} in order to allow for iterators that acquire
+ * This interface extends {@link Iterator} and {@link AutoCloseable} in order to allow for iterators that acquire
  * resources that must be released. Such iterators must document this need, and appropriate measures (e.g. a
  * try-with-resources block) should be taken to ensure that they are {@link #close() closed}. Methods that return
  * streams over CloseableIterator instances should ensure that closing the resulting {@link Stream},
  * {@link java.util.stream.IntStream IntStream}, {@link java.util.stream.LongStream LongStream}, or
  * {@link java.util.stream.DoubleStream DoubleStream} will also close the iterator.
  */
-public interface CloseableIterator<TYPE> extends Iterator<TYPE>, SafeCloseable {
+public interface CloseableIterator<TYPE> extends Iterator<TYPE>, AutoCloseable {
 
     /**
      * Create a {@link Stream} over the remaining elements of this CloseableIterator. Closing the result will close this
@@ -41,6 +40,10 @@ public interface CloseableIterator<TYPE> extends Iterator<TYPE>, SafeCloseable {
                 .onClose(this::close);
     }
 
+    /**
+     * @inheritDoc
+     * @apiNote Unlike {@link AutoCloseable}, CloseableIterators must not throw checked exceptions.
+     */
     @Override
     default void close() {}
 


### PR DESCRIPTION
In some discussions with @devinrsmith, we realized we could make some of the `SafeCloseable` code better by allowing `AutoCloseable` usage in many existing patterns, at no loss of correctness or utility.