### PR TITLE
Implement DisplayWrapper#hashCode to fix SelectDistinct Behavior of Previewed Columns

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/DisplayWrapper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/DisplayWrapper.java
@@ -50,4 +50,9 @@ public class DisplayWrapper implements Serializable {
 
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        return displayString.hashCode();
+    }
 }


### PR DESCRIPTION
This is a behavior that makes #5280 more sane, but doesn't fix the "underlying" issue which is that we probably shouldn't support UI filters (quick or advanced) on previewed columns.