### PR TITLE
Bump to latest grpc version

### DIFF
--- a/buildSrc/src/main/groovy/Classpaths.groovy
+++ b/buildSrc/src/main/groovy/Classpaths.groovy
@@ -95,7 +95,7 @@ class Classpaths {
     static final String GRPC_GROUP = 'io.grpc'
     static final String GRPC_NAME = 'grpc-bom'
     // Only bump this in concert w/ BORINGSSL_VERSION
-    static final String GRPC_VERSION = '1.58.0'
+    static final String GRPC_VERSION = '1.62.2'
 
     // TODO(deephaven-core#1685): Create strategy around updating and maintaining protoc version
     static final String PROTOBUF_GROUP = 'com.google.protobuf'

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/ServletServerStream.java
@@ -223,7 +223,7 @@ final class ServletServerStream extends AbstractServerStream {
         final TrailerSupplier trailerSupplier = new TrailerSupplier();
 
         @Override
-        public void writeHeaders(Metadata headers) {
+        public void writeHeaders(Metadata headers, boolean flush) {
             writeHeadersToServletResponse(headers);
             try {
                 resp.setTrailerFields(trailerSupplier);
@@ -231,11 +231,13 @@ final class ServletServerStream extends AbstractServerStream {
                 logger.log(WARNING, String.format("[{%s}] Exception writing trailers", logId), e);
                 cancel(Status.fromThrowable(e));
             }
-            try {
-                writer.flush();
-            } catch (IllegalStateException | IOException e) {
-                logger.log(WARNING, String.format("[{%s}] Exception when flushBuffer", logId), e);
-                cancel(Status.fromThrowable(e));
+            if (flush) {
+                try {
+                    writer.flush();
+                } catch (IllegalStateException | IOException e) {
+                    logger.log(WARNING, String.format("[{%s}] Exception when flushBuffer", logId), e);
+                    cancel(Status.fromThrowable(e));
+                }
             }
         }
 

--- a/java-client/session/build.gradle
+++ b/java-client/session/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
   Classpaths.inheritJUnitClassic(project, 'testImplementation')
   testImplementation 'io.grpc:grpc-testing'
+  testImplementation 'io.grpc:grpc-inprocess'
 
   Classpaths.inheritAssertJ(project)
 


### PR DESCRIPTION
This is ostensibly for CVE-2023-44487.

Note: the netty-tcnative-boringssl-static version does not need to be updated for this.