### PR TITLE
Improve set inclusion kernel performance

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ByteSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ByteSetInclusionKernel.java
@@ -78,7 +78,7 @@ public class ByteSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asByteChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ByteSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ByteSetInclusionKernel.java
@@ -8,10 +8,9 @@
 package io.deephaven.engine.table.impl.select.setinclusion;
 
 import gnu.trove.iterator.TByteIterator;
-import io.deephaven.chunk.ByteChunk;
-import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.util.type.TypeUtils;
 import gnu.trove.set.TByteSet;
 import gnu.trove.set.hash.TByteHashSet;
@@ -24,24 +23,24 @@ public class ByteSetInclusionKernel implements SetInclusionKernel {
     private final TByteSet liveValues;
     private final boolean inclusion;
 
-    ByteSetInclusionKernel(Collection<Object> liveValues, boolean inclusion) {
+    ByteSetInclusionKernel(@NotNull final Collection<Object> liveValues, final boolean inclusion) {
         this.liveValues = new TByteHashSet(liveValues.size());
         liveValues.forEach(x -> this.liveValues.add(TypeUtils.unbox((Byte) x)));
         this.inclusion = inclusion;
     }
 
-    ByteSetInclusionKernel(boolean inclusion) {
+    ByteSetInclusionKernel(final boolean inclusion) {
         this.liveValues = new TByteHashSet();
         this.inclusion = inclusion;
     }
 
     @Override
-    public boolean add(Object key) {
+    public boolean add(@NotNull final Object key) {
         return liveValues.add(TypeUtils.unbox((Byte) key));
     }
 
     @Override
-    public boolean remove(Object key) {
+    public boolean remove(@NotNull final Object key) {
         return liveValues.remove(TypeUtils.unbox((Byte) key));
     }
 
@@ -75,22 +74,49 @@ public class ByteSetInclusionKernel implements SetInclusionKernel {
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches) {
-        matchValues(values.asByteChunk(), matches, inclusion);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        matchValues(values.asByteChunk(), keys, results, inclusion);
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches, boolean inclusionOverride) {
-        matchValues(values.asByteChunk(), matches, inclusionOverride);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results,
+            final boolean inclusionOverride) {
+        if (inclusionOverride) {
+            matchValues(values.asByteChunk(), keys, results);
+        } else {
+            matchValuesInvert(values.asByteChunk(), keys, results);
+        }
     }
 
     private void matchValues(
-            ByteChunk<Values> values,
-            WritableBooleanChunk<?> matches,
-            boolean inclusionToUse) {
+            @NotNull final ByteChunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
         for (int ii = 0; ii < values.size(); ++ii) {
-            matches.set(ii, liveValues.contains(values.get(ii)) == inclusionToUse);
+            final byte checkValue = values.get(ii);
+            if (liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
         }
-        matches.setSize(values.size());
+    }
+
+    private void matchValuesInvert(
+            @NotNull final ByteChunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
+        for (int ii = 0; ii < values.size(); ++ii) {
+            final byte checkValue = values.get(ii);
+            if (!liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
+        }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/CharSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/CharSetInclusionKernel.java
@@ -74,7 +74,7 @@ public class CharSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asCharChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/DoubleSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/DoubleSetInclusionKernel.java
@@ -78,7 +78,7 @@ public class DoubleSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asDoubleChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/FloatSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/FloatSetInclusionKernel.java
@@ -8,10 +8,9 @@
 package io.deephaven.engine.table.impl.select.setinclusion;
 
 import gnu.trove.iterator.TFloatIterator;
-import io.deephaven.chunk.FloatChunk;
-import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.util.type.TypeUtils;
 import gnu.trove.set.TFloatSet;
 import gnu.trove.set.hash.TFloatHashSet;
@@ -24,24 +23,24 @@ public class FloatSetInclusionKernel implements SetInclusionKernel {
     private final TFloatSet liveValues;
     private final boolean inclusion;
 
-    FloatSetInclusionKernel(Collection<Object> liveValues, boolean inclusion) {
+    FloatSetInclusionKernel(@NotNull final Collection<Object> liveValues, final boolean inclusion) {
         this.liveValues = new TFloatHashSet(liveValues.size());
         liveValues.forEach(x -> this.liveValues.add(TypeUtils.unbox((Float) x)));
         this.inclusion = inclusion;
     }
 
-    FloatSetInclusionKernel(boolean inclusion) {
+    FloatSetInclusionKernel(final boolean inclusion) {
         this.liveValues = new TFloatHashSet();
         this.inclusion = inclusion;
     }
 
     @Override
-    public boolean add(Object key) {
+    public boolean add(@NotNull final Object key) {
         return liveValues.add(TypeUtils.unbox((Float) key));
     }
 
     @Override
-    public boolean remove(Object key) {
+    public boolean remove(@NotNull final Object key) {
         return liveValues.remove(TypeUtils.unbox((Float) key));
     }
 
@@ -75,22 +74,49 @@ public class FloatSetInclusionKernel implements SetInclusionKernel {
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches) {
-        matchValues(values.asFloatChunk(), matches, inclusion);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        matchValues(values.asFloatChunk(), keys, results, inclusion);
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches, boolean inclusionOverride) {
-        matchValues(values.asFloatChunk(), matches, inclusionOverride);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results,
+            final boolean inclusionOverride) {
+        if (inclusionOverride) {
+            matchValues(values.asFloatChunk(), keys, results);
+        } else {
+            matchValuesInvert(values.asFloatChunk(), keys, results);
+        }
     }
 
     private void matchValues(
-            FloatChunk<Values> values,
-            WritableBooleanChunk<?> matches,
-            boolean inclusionToUse) {
+            @NotNull final FloatChunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
         for (int ii = 0; ii < values.size(); ++ii) {
-            matches.set(ii, liveValues.contains(values.get(ii)) == inclusionToUse);
+            final float checkValue = values.get(ii);
+            if (liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
         }
-        matches.setSize(values.size());
+    }
+
+    private void matchValuesInvert(
+            @NotNull final FloatChunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
+        for (int ii = 0; ii < values.size(); ++ii) {
+            final float checkValue = values.get(ii);
+            if (!liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
+        }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/FloatSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/FloatSetInclusionKernel.java
@@ -78,7 +78,7 @@ public class FloatSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asFloatChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/IntSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/IntSetInclusionKernel.java
@@ -78,7 +78,7 @@ public class IntSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asIntChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/LongSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/LongSetInclusionKernel.java
@@ -8,10 +8,9 @@
 package io.deephaven.engine.table.impl.select.setinclusion;
 
 import gnu.trove.iterator.TLongIterator;
-import io.deephaven.chunk.LongChunk;
-import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.util.type.TypeUtils;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
@@ -24,24 +23,24 @@ public class LongSetInclusionKernel implements SetInclusionKernel {
     private final TLongSet liveValues;
     private final boolean inclusion;
 
-    LongSetInclusionKernel(Collection<Object> liveValues, boolean inclusion) {
+    LongSetInclusionKernel(@NotNull final Collection<Object> liveValues, final boolean inclusion) {
         this.liveValues = new TLongHashSet(liveValues.size());
         liveValues.forEach(x -> this.liveValues.add(TypeUtils.unbox((Long) x)));
         this.inclusion = inclusion;
     }
 
-    LongSetInclusionKernel(boolean inclusion) {
+    LongSetInclusionKernel(final boolean inclusion) {
         this.liveValues = new TLongHashSet();
         this.inclusion = inclusion;
     }
 
     @Override
-    public boolean add(Object key) {
+    public boolean add(@NotNull final Object key) {
         return liveValues.add(TypeUtils.unbox((Long) key));
     }
 
     @Override
-    public boolean remove(Object key) {
+    public boolean remove(@NotNull final Object key) {
         return liveValues.remove(TypeUtils.unbox((Long) key));
     }
 
@@ -75,22 +74,49 @@ public class LongSetInclusionKernel implements SetInclusionKernel {
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches) {
-        matchValues(values.asLongChunk(), matches, inclusion);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        matchValues(values.asLongChunk(), keys, results, inclusion);
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches, boolean inclusionOverride) {
-        matchValues(values.asLongChunk(), matches, inclusionOverride);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results,
+            final boolean inclusionOverride) {
+        if (inclusionOverride) {
+            matchValues(values.asLongChunk(), keys, results);
+        } else {
+            matchValuesInvert(values.asLongChunk(), keys, results);
+        }
     }
 
     private void matchValues(
-            LongChunk<Values> values,
-            WritableBooleanChunk<?> matches,
-            boolean inclusionToUse) {
+            @NotNull final LongChunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
         for (int ii = 0; ii < values.size(); ++ii) {
-            matches.set(ii, liveValues.contains(values.get(ii)) == inclusionToUse);
+            final long checkValue = values.get(ii);
+            if (liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
         }
-        matches.setSize(values.size());
+    }
+
+    private void matchValuesInvert(
+            @NotNull final LongChunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
+        for (int ii = 0; ii < values.size(); ++ii) {
+            final long checkValue = values.get(ii);
+            if (!liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
+        }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/LongSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/LongSetInclusionKernel.java
@@ -78,7 +78,7 @@ public class LongSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asLongChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ObjectSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ObjectSetInclusionKernel.java
@@ -3,10 +3,10 @@
 //
 package io.deephaven.engine.table.impl.select.setinclusion;
 
-import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.ObjectChunk;
-import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -17,23 +17,23 @@ public class ObjectSetInclusionKernel implements SetInclusionKernel {
     private final Collection<Object> liveValues;
     private final boolean inclusion;
 
-    public ObjectSetInclusionKernel(Collection<Object> liveValues, boolean inclusion) {
+    public ObjectSetInclusionKernel(@NotNull final Collection<Object> liveValues, final boolean inclusion) {
         this.liveValues = new HashSet<>(liveValues);
         this.inclusion = inclusion;
     }
 
-    ObjectSetInclusionKernel(boolean inclusion) {
+    ObjectSetInclusionKernel(final boolean inclusion) {
         this.liveValues = new HashSet<>();
         this.inclusion = inclusion;
     }
 
     @Override
-    public boolean add(Object key) {
+    public boolean add(@NotNull final Object key) {
         return liveValues.add(key);
     }
 
     @Override
-    public boolean remove(Object key) {
+    public boolean remove(@NotNull final Object key) {
         return liveValues.remove(key);
     }
 
@@ -48,22 +48,49 @@ public class ObjectSetInclusionKernel implements SetInclusionKernel {
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches) {
-        matchValues(values.asObjectChunk(), matches, inclusion);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        matchValues(values.asObjectChunk(), keys, results, inclusion);
     }
 
     @Override
-    public void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches, boolean inclusionOverride) {
-        matchValues(values.asObjectChunk(), matches, inclusionOverride);
+    public void matchValues(
+            @NotNull final Chunk<Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results,
+            final boolean inclusionOverride) {
+        if (inclusionOverride) {
+            matchValues(values.asObjectChunk(), keys, results);
+        } else {
+            matchValuesInvert(values.asObjectChunk(), keys, results);
+        }
     }
 
     private void matchValues(
-            ObjectChunk<?, Values> values,
-            WritableBooleanChunk<?> matches,
-            boolean inclusionToUse) {
+            @NotNull final ObjectChunk<?, Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
         for (int ii = 0; ii < values.size(); ++ii) {
-            matches.set(ii, liveValues.contains(values.get(ii)) == inclusionToUse);
+            final Object checkValue = values.get(ii);
+            if (liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
         }
-        matches.setSize(values.size());
+    }
+
+    private void matchValuesInvert(
+            @NotNull final ObjectChunk<?, Values> values,
+            @NotNull final LongChunk<OrderedRowKeys> keys,
+            @NotNull WritableLongChunk<OrderedRowKeys> results) {
+        results.setSize(0);
+        for (int ii = 0; ii < values.size(); ++ii) {
+            final Object checkValue = values.get(ii);
+            if (!liveValues.contains(checkValue)) {
+                results.add(keys.get(ii));
+            }
+        }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ObjectSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ObjectSetInclusionKernel.java
@@ -52,7 +52,7 @@ public class ObjectSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asObjectChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/SetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/SetInclusionKernel.java
@@ -3,19 +3,22 @@
 //
 package io.deephaven.engine.table.impl.select.setinclusion;
 
-import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.ChunkType;
-import io.deephaven.chunk.WritableBooleanChunk;
+import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 
 import java.util.Collection;
 import java.util.Iterator;
 
 public interface SetInclusionKernel {
 
-    void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches);
+    void matchValues(Chunk<Values> values, LongChunk<OrderedRowKeys> keys, WritableLongChunk<OrderedRowKeys> results);
 
-    void matchValues(Chunk<Values> values, WritableBooleanChunk<?> matches, boolean inclusionOverride);
+    void matchValues(
+            Chunk<Values> values,
+            LongChunk<OrderedRowKeys> keys,
+            WritableLongChunk<OrderedRowKeys> results,
+            boolean inclusionOverride);
 
     boolean add(Object key);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ShortSetInclusionKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/setinclusion/ShortSetInclusionKernel.java
@@ -78,7 +78,7 @@ public class ShortSetInclusionKernel implements SetInclusionKernel {
             @NotNull final Chunk<Values> values,
             @NotNull final LongChunk<OrderedRowKeys> keys,
             @NotNull WritableLongChunk<OrderedRowKeys> results) {
-        matchValues(values.asShortChunk(), keys, results, inclusion);
+        matchValues(values, keys, results, inclusion);
     }
 
     @Override


### PR DESCRIPTION
Instead of setting a BooleanChunk to true, update the set inclusion kernels to fill a long chunk with the matching row keys.