### PR TITLE
Support numpy_nullable in to_pandas() by only checking Pandas version when 'pyarrow' is used

### DIFF
--- a/py/server/deephaven/pandas.py
+++ b/py/server/deephaven/pandas.py
@@ -114,7 +114,7 @@ def to_pandas(table: Table, cols: List[str] = None,
         DHError
     """
     try:
-        if dtype_backend is not None and not _is_dtype_backend_supported:
+        if dtype_backend == "pyarrow" and not _is_dtype_backend_supported:
             raise DHError(message=f"the dtype_backend ({dtype_backend}) option is only available for pandas 2.0.0 and "
                                   f"above. {pd.__version__} is being used.")
 


### PR DESCRIPTION
Fixes #5311 

Tested the change manually with Pandas 1.5.0.  Only the test cases where `dtype_backend='pyarrow'` is used failed.