### PR TITLE
Introduce TableUpdateImpl copy that takes an MCS

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AsOfJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AsOfJoinHelper.java
@@ -249,8 +249,6 @@ public class AsOfJoinHelper {
                 stampPair, columnsToAdd, order == SortingOrder.Descending, disallowExactMatch), leftTable, result) {
             @Override
             public void onUpdate(TableUpdate upstream) {
-                final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-
                 rowRedirection.removeAll(upstream.removed());
 
                 final boolean keysModified = upstream.modifiedColumnSet().containsAny(leftKeysOrStamps);
@@ -296,7 +294,8 @@ public class AsOfJoinHelper {
                     }
                 }
 
-                downstream.modifiedColumnSet = result.getModifiedColumnSetForUpdates();
+                final TableUpdateImpl downstream =
+                        TableUpdateImpl.copy(upstream, result.getModifiedColumnSetForUpdates());
                 leftTransformer.clearAndTransform(upstream.modifiedColumnSet(), downstream.modifiedColumnSet());
                 if (keysModified) {
                     downstream.modifiedColumnSet().setAll(allRightColumns);
@@ -1478,8 +1477,6 @@ public class AsOfJoinHelper {
                                     leftTable, result) {
                                 @Override
                                 public void onUpdate(TableUpdate upstream) {
-                                    final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-
                                     rowRedirection.removeAll(upstream.removed());
 
                                     final boolean stampModified = upstream.modified().isNonempty()
@@ -1504,7 +1501,8 @@ public class AsOfJoinHelper {
                                                 compactedRightStampKeys, rowRedirection);
                                     }
 
-                                    downstream.modifiedColumnSet = result.getModifiedColumnSetForUpdates();
+                                    final TableUpdateImpl downstream =
+                                            TableUpdateImpl.copy(upstream, result.getModifiedColumnSetForUpdates());
                                     leftTransformer.clearAndTransform(upstream.modifiedColumnSet(),
                                             downstream.modifiedColumnSet());
                                     if (stampModified) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -964,14 +964,9 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
         @Override
         public void onUpdate(final TableUpdate upstream) {
-            final TableUpdate downstream;
-            if (!canReuseModifiedColumnSet) {
-                final TableUpdateImpl upstreamCopy = TableUpdateImpl.copy(upstream);
-                upstreamCopy.modifiedColumnSet = ModifiedColumnSet.ALL;
-                downstream = upstreamCopy;
-            } else {
-                downstream = upstream.acquire();
-            }
+            final TableUpdate downstream = canReuseModifiedColumnSet
+                    ? upstream.acquire()
+                    : TableUpdateImpl.copy(upstream, ModifiedColumnSet.ALL);
             dependent.notifyListeners(downstream);
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/NaturalJoinHelper.java
@@ -354,8 +354,8 @@ class NaturalJoinHelper {
                             @Override
                             public void onUpdate(final TableUpdate upstream) {
                                 checkRightTableSizeZeroKeys(leftTable, rightTable, exactMatch);
-                                final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-                                downstream.modifiedColumnSet = result.getModifiedColumnSetForUpdates();
+                                final TableUpdateImpl downstream =
+                                        TableUpdateImpl.copy(upstream, result.getModifiedColumnSetForUpdates());
                                 leftTransformer.clearAndTransform(upstream.modifiedColumnSet(),
                                         downstream.modifiedColumnSet);
                                 result.notifyListeners(downstream);
@@ -476,14 +476,13 @@ class NaturalJoinHelper {
 
         @Override
         public void onUpdate(final TableUpdate upstream) {
-            final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
             rowRedirection.removeAll(upstream.removed());
 
             try (final RowSet prevRowSet = leftTable.getRowSet().copyPrev()) {
                 rowRedirection.applyShift(prevRowSet, upstream.shifted());
             }
 
-            downstream.modifiedColumnSet = result.getModifiedColumnSetForUpdates();
+            final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream, result.getModifiedColumnSetForUpdates());
             leftTransformer.clearAndTransform(upstream.modifiedColumnSet(), downstream.modifiedColumnSet);
 
             if (upstream.modifiedColumnSet().containsAny(leftKeyColumns)) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1821,8 +1821,8 @@ public class QueryTable extends BaseTable<QueryTable> {
 
         @Override
         public void onUpdate(final TableUpdate upstream) {
-            final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-            downstream.modifiedColumnSet = dependent.getModifiedColumnSetForUpdates();
+            final TableUpdateImpl downstream =
+                    TableUpdateImpl.copy(upstream, dependent.getModifiedColumnSetForUpdates());
             transformer.clearAndTransform(upstream.modifiedColumnSet(), downstream.modifiedColumnSet);
             dependent.notifyListeners(downstream);
         }
@@ -1896,19 +1896,19 @@ public class QueryTable extends BaseTable<QueryTable> {
                                         "dropColumns(" + Arrays.deepToString(columnNames) + ')', this, resultTable) {
                                     @Override
                                     public void onUpdate(final TableUpdate upstream) {
-                                        final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
+                                        final TableUpdateImpl downstream;
                                         final ModifiedColumnSet resultModifiedColumnSet =
                                                 resultTable.getModifiedColumnSetForUpdates();
                                         mcsTransformer.clearAndTransform(upstream.modifiedColumnSet(),
                                                 resultModifiedColumnSet);
                                         if (upstream.modified().isEmpty() || resultModifiedColumnSet.empty()) {
-                                            downstream.modifiedColumnSet = ModifiedColumnSet.EMPTY;
+                                            downstream = TableUpdateImpl.copy(upstream, ModifiedColumnSet.EMPTY);
                                             if (downstream.modified().isNonempty()) {
                                                 downstream.modified().close();
                                                 downstream.modified = RowSetFactory.empty();
                                             }
                                         } else {
-                                            downstream.modifiedColumnSet = resultModifiedColumnSet;
+                                            downstream = TableUpdateImpl.copy(upstream, resultModifiedColumnSet);
                                         }
                                         resultTable.notifyListeners(downstream);
                                     }
@@ -2039,13 +2039,14 @@ public class QueryTable extends BaseTable<QueryTable> {
                                     methodNuggetPrefix + pairsLogString + ')', this, resultTable) {
                                 @Override
                                 public void onUpdate(final TableUpdate upstream) {
-                                    final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
+                                    final TableUpdateImpl downstream;
                                     if (upstream.modified().isNonempty()) {
-                                        downstream.modifiedColumnSet = resultTable.getModifiedColumnSetForUpdates();
+                                        downstream = TableUpdateImpl.copy(upstream,
+                                                resultTable.getModifiedColumnSetForUpdates());
                                         mcsTransformer.clearAndTransform(upstream.modifiedColumnSet(),
                                                 downstream.modifiedColumnSet);
                                     } else {
-                                        downstream.modifiedColumnSet = ModifiedColumnSet.EMPTY;
+                                        downstream = TableUpdateImpl.copy(upstream, ModifiedColumnSet.EMPTY);
                                     }
                                     resultTable.notifyListeners(downstream);
                                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnOperation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftedColumnOperation.java
@@ -131,8 +131,7 @@ public class ShiftedColumnOperation {
             final BaseTable.ListenerImpl listener = new BaseTable.ListenerImpl("propagateUpdates", source, result) {
                 @Override
                 public void onUpdate(TableUpdate upstream) {
-                    final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-                    downstream.modifiedColumnSet = downstreamColumnSet;
+                    final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream, downstreamColumnSet);
                     mcsTransformer.clearAndTransform(
                             upstream.modifiedColumnSet(), downstream.modifiedColumnSet);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SparseSelect.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SparseSelect.java
@@ -189,8 +189,8 @@ public class SparseSelect {
 
                             @Override
                             public void onUpdate(TableUpdate upstream) {
-                                final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
-                                downstream.modifiedColumnSet = modifiedColumnSetForUpdates;
+                                final TableUpdateImpl downstream =
+                                        TableUpdateImpl.copy(upstream, modifiedColumnSetForUpdates);
                                 if (sparseObjectSources.length > 0) {
                                     try (final RowSet removedOnly = upstream.removed().minus(upstream.added())) {
                                         for (final ObjectSparseArraySource<?> objectSparseArraySource : sparseObjectSources) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateImpl.java
@@ -165,9 +165,19 @@ public class TableUpdateImpl implements TableUpdate {
             newMCS = new ModifiedColumnSet(oldMCS);
             newMCS.setAll(oldMCS);
         }
+        return copy(tableUpdate, newMCS);
+    }
+
+    /**
+     * Make a deep copy of a {@link TableUpdate} with the given {@code mcs}.
+     */
+    public static TableUpdateImpl copy(@NotNull final TableUpdate tableUpdate, @NotNull final ModifiedColumnSet mcs) {
         return new TableUpdateImpl(
-                tableUpdate.added().copy(), tableUpdate.removed().copy(), tableUpdate.modified().copy(),
-                tableUpdate.shifted(), newMCS);
+                tableUpdate.added().copy(),
+                tableUpdate.removed().copy(),
+                tableUpdate.modified().copy(),
+                tableUpdate.shifted(),
+                mcs);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
@@ -219,7 +219,7 @@ public class TableUpdateValidator implements QueryTable.Operation<QueryTable> {
                 return;
             }
 
-            final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
+            final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream); // TODO: can this be acquire?
             resultTable.notifyListeners(downstream);
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableUpdateValidator.java
@@ -10,7 +10,6 @@ import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.util.hashing.ChunkEquals;
 import io.deephaven.configuration.Configuration;
-import io.deephaven.datastructures.util.CollectionUtil;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetShiftData;
@@ -219,8 +218,7 @@ public class TableUpdateValidator implements QueryTable.Operation<QueryTable> {
                 return;
             }
 
-            final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream); // TODO: can this be acquire?
-            resultTable.notifyListeners(downstream);
+            resultTable.notifyListeners(upstream.acquire());
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/util/TickSuppressor.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/TickSuppressor.java
@@ -56,9 +56,8 @@ public class TickSuppressor {
             @Override
             public void onUpdate(TableUpdate upstream) {
                 final TableUpdateImpl downstream = new TableUpdateImpl();
-                // TODO: can we remove these copies?
-                downstream.added = upstream.added().copy().union(upstream.modified());
-                downstream.removed = upstream.removed().copy().union(upstream.getModifiedPreShift());
+                downstream.added = upstream.added().union(upstream.modified());
+                downstream.removed = upstream.removed().union(upstream.getModifiedPreShift());
                 downstream.modified = RowSetFactory.empty();
                 downstream.shifted = upstream.shifted();
                 downstream.modifiedColumnSet = ModifiedColumnSet.EMPTY;

--- a/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/WindowCheck.java
@@ -346,7 +346,8 @@ public class WindowCheck {
                 // now add the new timestamps
                 addRowSequence(upstream.added(), rowKeyToEntry != null);
 
-                final TableUpdateImpl downstream = TableUpdateImpl.copy(upstream);
+                final TableUpdateImpl downstream =
+                        TableUpdateImpl.copy(upstream, result.getModifiedColumnSetForUpdates());
 
                 try (final RowSet modifiedByTime = recomputeModified()) {
                     if (modifiedByTime.isNonempty()) {
@@ -355,7 +356,6 @@ public class WindowCheck {
                 }
 
                 // everything that was added, removed, or modified stays added removed or modified
-                downstream.modifiedColumnSet = result.getModifiedColumnSetForUpdates();
                 if (downstream.modified.isNonempty()) {
                     mcsTransformer.clearAndTransform(upstream.modifiedColumnSet(), downstream.modifiedColumnSet);
                     downstream.modifiedColumnSet.setAll(mcsResultWindowColumn);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/SelectOverheadLimiter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/SelectOverheadLimiter.java
@@ -141,8 +141,8 @@ public class SelectOverheadLimiter {
                     rowSet.remove(upstream.removed());
                     upstream.shifted().apply(rowSet);
                     rowSet.insert(upstream.added());
-                    final TableUpdateImpl copy = TableUpdateImpl.copy(upstream);
-                    copy.modifiedColumnSet = result.getModifiedColumnSetForUpdates();
+                    final TableUpdateImpl copy =
+                            TableUpdateImpl.copy(upstream, result.getModifiedColumnSetForUpdates());
                     flatTransformer.clearAndTransform(upstream.modifiedColumnSet(), copy.modifiedColumnSet());
                     result.notifyListeners(copy);
                     return;
@@ -157,8 +157,8 @@ public class SelectOverheadLimiter {
                 rowSet.insert(upstream.added());
 
                 if (overheadTracker.overhead() <= permittedOverhead) {
-                    final TableUpdateImpl copy = TableUpdateImpl.copy(upstream);
-                    copy.modifiedColumnSet = result.getModifiedColumnSetForUpdates();
+                    final TableUpdateImpl copy =
+                            TableUpdateImpl.copy(upstream, result.getModifiedColumnSetForUpdates());
                     inputTransformer.clearAndTransform(upstream.modifiedColumnSet(), copy.modifiedColumnSet());
                     result.notifyListeners(copy);
                     return;

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -264,7 +264,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
                 final BitSet subscribedColumns, final BitSet modifiedColumns) {
             this.step = step;
             this.deltaColumnOffset = deltaColumnOffset;
-            this.update = TableUpdateImpl.copy(update); // TODO: can this be acquire()
+            this.update = TableUpdateImpl.copy(update);
             this.recordedAdds = recordedAdds;
             this.recordedMods = recordedMods;
             this.subscribedColumns = subscribedColumns;

--- a/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
+++ b/server/src/main/java/io/deephaven/server/barrage/BarrageMessageProducer.java
@@ -264,7 +264,7 @@ public class BarrageMessageProducer<MessageView> extends LivenessArtifact
                 final BitSet subscribedColumns, final BitSet modifiedColumns) {
             this.step = step;
             this.deltaColumnOffset = deltaColumnOffset;
-            this.update = TableUpdateImpl.copy(update);
+            this.update = TableUpdateImpl.copy(update); // TODO: can this be acquire()
             this.recordedAdds = recordedAdds;
             this.recordedMods = recordedMods;
             this.subscribedColumns = subscribedColumns;


### PR DESCRIPTION
This allows allows the majority of copy callsites to be more efficient when they know they are going to overwrite the resulting modifiedColumnSet anyways.