### PR TITLE
Update ticking Python client readme

### DIFF
--- a/py/client-ticking/README.md
+++ b/py/client-ticking/README.md
@@ -7,8 +7,7 @@ wrapper around Deephaven's C++ library.
 
 ## Prerequisites
 
-`pydeephaven-ticking` requires a Linux operating system running on x86_64 architecture. It can be 
-installed via `pip` or built from source.
+`pydeephaven-ticking` requires a Linux operating system running on x86_64 architecture.
 
 ## Installation
 
@@ -36,7 +35,7 @@ First, install the Deephaven C++ client. Follow the instructions in `$DHROOT/cpp
 Note the restrictions on supported platforms mentioned there. The instructions will ask you to
 select a location for the installation of the C++ client library and its dependencies.  For the
 purpose of this document we assume that location is specified in the `${DHCPP}` environment
-variable.  On my computer `${DHCPP}` is `$HOME/dhcpp` (where `$HOME` points to your home directory).
+variable.
 
 ### Install pydeephaven
 

--- a/py/client-ticking/README.md
+++ b/py/client-ticking/README.md
@@ -7,7 +7,9 @@ wrapper around Deephaven's C++ library.
 
 ## Prerequisites
 
-`pydeephaven-ticking` requires a Linux operating system running on x86_64 architecture.
+The Deephaven C++ client (and ticking Python client) are tested regularly on Ubuntu 22.04 x86_64.
+Additionally, successful tests have been run on RHEL 8 and Fedora 38 (both on x86_64).
+Windows support is expected to be made available in the future.
 
 ## Installation
 
@@ -15,6 +17,7 @@ wrapper around Deephaven's C++ library.
 
 ## `pip`
 
+A Linux operating system on x86_64 architecture is required to install via `pip`.
 It's recommended to install this way in a Python virtual environment (venv).
 
 ```sh

--- a/py/client-ticking/README.md
+++ b/py/client-ticking/README.md
@@ -1,78 +1,96 @@
 # Deephaven Python Ticking Package
 
-The pydeephaven-ticking package helps you accesss Deephaven ticking data from Python. It extends
+The `pydeephaven-ticking` package enables access to ticking Deephaven data from Python. It extends
 the functionality of the pydeephaven package to add the ability to subscribe to tables and receive
-change notifications containing added, removed, and modified data. This package uses Cython to
-create a thin wrapper around the Deephaven native C++ library.
+change notifications containing added, removed, and modified data. It uses Cython to create a thin
+wrapper around Deephaven's C++ library.
 
 ## Prerequisites
 
-Before installing this library, you will need to install the Deephaven Core C++ library and the
-pydeephaven python package. All three packages (Deephaven Core C++, pydeephaven, Deephaven Core,
-and pydeephaven-ticking) are present in the Deephaven Core github repository. We assume you
-have checked out this repository at the location specified by `${DHROOT}`.
+`pydeephaven-ticking` requires a Linux operating system running on x86_64 architecture. It can be 
+installed via `pip` or built from source.
 
-### Installing Deephaven Core
+## Installation
 
-To install the Deephaven Core C++ library, follow the instructions in `$DHROOT/cpp-client/README.md`.
+`pydeephaven-ticking` can be installed with `pip` or by building from source.
+
+## `pip`
+
+It's recommended to install this way in a Python virtual environment (venv).
+
+```sh
+pip install pydeephaven-ticking
+```
+
+## Build from source
+
+If building from source, `pydeephaven-ticking` also requires a working installation of the C++
+client. All four packages (Deephaven Core, `pydeephaven`, `pydeephaven-ticking`, and the Deephaven 
+C++ client) are present in the [deephaven-core](https://github.com/deephaven/deephaven-core) 
+repository. It is assumed that you have the repository checked out at the location specified by 
+`${DHROOT}`.
+
+### Install the C++ client
+
+First, install the Deephaven C++ client. Follow the instructions in `$DHROOT/cpp-client/README.md`.
 Note the restrictions on supported platforms mentioned there. The instructions will ask you to
 select a location for the installation of the C++ client library and its dependencies.  For the
 purpose of this document we assume that location is specified in the `${DHCPP}` environment
-variable.  On my computer `${DHCPP}` is `$HOME/dhcpp` (where `$HOME` points to my home directory).
+variable.  On my computer `${DHCPP}` is `$HOME/dhcpp` (where `$HOME` points to your home directory).
 
-### Installing pydeephaven
+### Install pydeephaven
 
 To install pydeephaven, follow the instructions in `${DHROOT}/py/client/README.md`.
 
-These instructions will require you to create a python venv. After installing that package,
+These instructions will require you to create a Python venv. After installing that package,
 you will continue to use that venv here.
 
+### Build the ticking Python client
 
-## Building the Deephaven ticking library for Python
-
-### Install Cython in the venv
+#### Install Cython in the venv
 
 If you've exited your venv, re-activate it with something like:
-``` shell
+
+```sh
 source ~/py/cython/bin/activate
 ```
 
 Then run 
-``` shell
+
+```sh
 pip3 install cython
 ```
 
-### Build the shared library:
+#### Build the shared library:
 
-``` shell
+```sh
 cd ${DHROOT}/py/client-ticking
 ```
 
-``` shell
+```sh
 # Ensure the DHCPP environment variable is set per the instructions above
 rm -rf build dist  # Ensure we clean the remnants of any pre-existing build.
 DEEPHAVEN_VERSION=$(../../gradlew :printVersion -q) CFLAGS="-I${DHCPP}/include" LDFLAGS="-L${DHCPP}/lib" python3 setup.py build_ext -i
 ```
 
-### Install pydeephaven-ticking
+#### Install pydeephaven-ticking
 
 Build the wheel with
 
-``` shell
+```sh
 DEEPHAVEN_VERSION=$(../../gradlew :printVersion -q) python3 setup.py bdist_wheel
 ```
 
 Then install the package.
-Note the actual name of the `.whl` file may be different depending on system details.
+Note: the actual name of the `.whl` file may be different depending on system details.
 
-``` shell
+```sh
 pip3 install --force --no-deps dist/pydeephaven_ticking-<x.y.z>-cp310-cp310-linux_x86_64.whl
 ```
 
-The reason for the "--force" flag is to overwrite any previously-built version of the package that
-might already be there. The reason for the "--no-deps" flag is so that we are sure to refer to the
-`pydeephaven` package that you just built in the above steps, rather than pulling in a prebuilt
-one from the PyPI repository.
+The `--force` flag is required to overwrite any previously-built version of the package that might
+already be there. The `--no-deps` flag ensures that we are sure to refer to the `pydeephaven`
+package just built from the above steps, rather than one from PyPi.
 
 ## Testing the library
 
@@ -81,7 +99,7 @@ Run python from the venv while in this directory, and try this sample Python pro
 ``` python
 import pydeephaven as dh
 import time
-session = dh.Session() # assuming Deephaven Community Edition is running locally with the default configuration
+session = dh.Session() # assuming Deephaven Community Core is running locally with the default configuration
 table = session.time_table(period=1000000000).update(formulas=["Col1 = i"])
 listener_handle = dh.listen(table, lambda update : print(update.added()))
 listener_handle.start()


### PR DESCRIPTION
We now publish wheels for the ticking Python client. This updates the README to reflect that.

I'm tagging this with `NoReleaseNotesNeeded`, because I assume there is another PR that built the wheel that has that. I can change this if desired. This seems like the type of thing we want to mention in release notes.