### PR TITLE
Fix the intermittent failing GWT tests

### DIFF
--- a/web/client-api/src/test/java/io/deephaven/web/client/api/HierarchicalTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/HierarchicalTableTestGwt.java
@@ -52,7 +52,7 @@ public class HierarchicalTableTestGwt extends AbstractAsyncGwtTestCase {
                 .then(this::finish).catch_(this::report);
     }
 
-    public void ignore_testRefreshingTreeTable() {
+    public void testRefreshingTreeTable() {
         connect(tables)
                 .then(treeTable("ticking_tree"))
                 .then(treeTable -> {
@@ -75,10 +75,9 @@ public class HierarchicalTableTestGwt extends AbstractAsyncGwtTestCase {
                         // This call effectively asserts that there are 10 rows after expand, so we don't need
                         // to worry about an update from the underlying table racing the expand
                         return waitForEventWhere(treeTable, JsTreeTable.EVENT_UPDATED,
-                                (CustomEvent<JsTreeTable.TreeViewportData> d) -> d.detail.getTreeSize() == 1, 20004);
+                                (CustomEvent<JsTreeTable.TreeViewportData> d) -> d.detail.getTreeSize() == 10, 14004);
                     }).then(event -> {
                         treeTable.close();
-
                         assertTrue(treeTable.isClosed());
                         return null;
                     });

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/PartitionedTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/PartitionedTableTestGwt.java
@@ -135,7 +135,7 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
                 .then(this::finish).catch_(this::report);
     }
 
-    public void testTickingTransformedPartitionedTable() {
+    public void ignore_testTickingTransformedPartitionedTable() {
         connect(tickingTables)
                 .then(partitionedTable("partitioned_result"))
                 .then(partitionedTable -> {

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/PartitionedTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/PartitionedTableTestGwt.java
@@ -116,15 +116,12 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
 
                     return partitionedTable.getKeyTable().then(keyTable -> {
                         keyTable.setViewport(0, 99, keyTable.getColumns(), null);
-                        return keyTable.getViewportData().then(data -> {
-                            assertEquals(0d, keyTable.getSize());
-
-                            return waitForEventWhere(keyTable, JsTable.EVENT_UPDATED,
-                                    (CustomEvent<ViewportData> d) -> d.detail.getRows().length == 5, 20004);
-                        });
+                        return keyTable.getViewportData()
+                                .then(data -> waitForEventWhere(keyTable, JsTable.EVENT_UPDATED,
+                                        (CustomEvent<ViewportData> d) -> d.detail.getRows().length >= 5, 14004));
                     }).then(event -> partitionedTable.getTable("2")).then(constituentTable -> {
                         assertEquals(3, constituentTable.getColumns().length);
-                        assertEquals(2d, constituentTable.getSize());
+                        assertTrue(constituentTable.getSize() >= 2);
 
                         constituentTable.close();
                         partitionedTable.close();
@@ -135,7 +132,7 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
                 .then(this::finish).catch_(this::report);
     }
 
-    public void ignore_testTickingTransformedPartitionedTable() {
+    public void testTickingTransformedPartitionedTable() {
         connect(tickingTables)
                 .then(partitionedTable("partitioned_result"))
                 .then(partitionedTable -> {
@@ -151,21 +148,19 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
 
                     return partitionedTable.getKeyTable().then(keyTable -> {
                         keyTable.setViewport(0, 99, keyTable.getColumns(), null);
-                        return keyTable.getViewportData().then(data -> {
-                            assertEquals(0d, keyTable.getSize());
+                        return keyTable.getViewportData()
+                                .then(data -> waitForEventWhere(keyTable, JsTable.EVENT_UPDATED,
+                                        (CustomEvent<ViewportData> d) -> d.detail.getRows().length >= 5, 14004))
+                                .then(event -> partitionedTable.getTable("2")).then(constituentTable -> {
+                                    assertEquals(2, constituentTable.getColumns().length);
+                                    assertTrue(constituentTable.getSize() >= 1);
 
-                            return waitForEventWhere(keyTable, JsTable.EVENT_UPDATED,
-                                    (CustomEvent<ViewportData> d) -> d.detail.getRows().length == 5, 20004);
-                        }).then(event -> partitionedTable.getTable("2")).then(constituentTable -> {
-                            assertEquals(2, constituentTable.getColumns().length);
-                            assertEquals(2d, constituentTable.getSize());
+                                    keyTable.close();
+                                    constituentTable.close();
+                                    partitionedTable.close();
 
-                            keyTable.close();
-                            constituentTable.close();
-                            partitionedTable.close();
-
-                            return null;
-                        });
+                                    return null;
+                                });
                     });
                 })
                 .then(this::finish).catch_(this::report);


### PR DESCRIPTION
- Fix the check in HierarchicalTableTestGwt to check for a tree size of 10 after expansion, not 1
  - It was listening for an update with only 1 row, which would have been the size before expansion. It would only sometimes pass because of race
- Fix PartitionedTableTestGwt to have range checks
  - Because it's a ticking test and we can't control the exact timing, we can't be exact about how many rows will appear
- Fixes #5326 