### PR TITLE
Remove unnecessary (and duplicate) headers from do_exchange calls

### DIFF
--- a/py/client/pydeephaven/_arrow_flight_service.py
+++ b/py/client/pydeephaven/_arrow_flight_service.py
@@ -59,8 +59,7 @@ class ArrowFlightService:
         """
         try:
             desc = pa.flight.FlightDescriptor.for_command(b"dphn")
-            options = paflight.FlightCallOptions(headers=self.session.grpc_metadata)
-            writer, reader = self._flight_client.do_exchange(desc, options)
+            writer, reader = self._flight_client.do_exchange(desc)
             return writer, reader
 
         except Exception as e:


### PR DESCRIPTION
Fixes #5332