### PR TITLE
C++ Client: ensure all types are supported for static and ticking.

### DIFF
--- a/R/rdeephaven/src/client.cpp
+++ b/R/rdeephaven/src/client.cpp
@@ -709,7 +709,7 @@ public:
         std::unique_ptr<arrow::flight::FlightMetadataReader> fmr;
 
         auto ticket = internal_tbl_hdl_mngr.NewTicket();
-        auto fd = deephaven::client::utility::ConvertTicketToFlightDescriptor(ticket);
+        auto fd = deephaven::client::utility::ArrowUtil::ConvertTicketToFlightDescriptor(ticket);
 
         deephaven::client::utility::OkOrThrow(DEEPHAVEN_LOCATION_EXPR(wrapper.FlightClient()->DoPut(options, fd, schema, &fsw, &fmr)));
         while(true) {

--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -30,6 +30,8 @@ set(ALL_FILES
     include/private/deephaven/client/impl/update_by_operation_impl.h
     include/private/deephaven/client/impl/util.h
 
+    src/arrowutil/arrow_client_table.cc
+    include/private/deephaven/client/arrowutil/arrow_client_table.h
     include/private/deephaven/client/arrowutil/arrow_column_source.h
     include/private/deephaven/client/arrowutil/arrow_value_converter.h
     include/private/deephaven/client/arrowutil/arrow_visitors.h

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_client_table.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_client_table.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
  */
 #pragma once

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_client_table.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_client_table.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#pragma once
+#include <string>
+#include <cstdint>
+#include <arrow/array.h>
+#include <arrow/table.h>
+#include "deephaven/client/arrowutil/arrow_value_converter.h"
+#include "deephaven/dhcore/chunk/chunk_traits.h"
+#include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/column/column_source_utils.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
+#include "deephaven/dhcore/types.h"
+
+namespace deephaven::client::arrowutil {
+class ArrowClientTable final : public deephaven::dhcore::clienttable::ClientTable {
+  struct Private {};
+  using ClientTable = deephaven::dhcore::clienttable::ClientTable;
+  using SchemaType = deephaven::dhcore::clienttable::Schema;
+public:
+  static std::shared_ptr<ClientTable> Create(std::shared_ptr<arrow::Table> arrow_table);
+
+  ArrowClientTable(Private, std::shared_ptr<arrow::Table> arrow_table,
+      std::shared_ptr<SchemaType> schema, std::shared_ptr<RowSequence> row_sequence,
+      std::vector<std::shared_ptr<ColumnSource>> column_sources);
+  ArrowClientTable(ArrowClientTable &&other) noexcept;
+  ArrowClientTable &operator=(ArrowClientTable &&other) noexcept;
+  ~ArrowClientTable() final;
+
+  [[nodiscard]]
+  std::shared_ptr<RowSequence> GetRowSequence() const final {
+    return row_sequence_;
+  }
+
+  std::shared_ptr<ColumnSource> GetColumn(size_t column_index) const final;
+
+  [[nodiscard]]
+  size_t NumRows() const final {
+    return arrow_table_->num_rows();
+  }
+
+  [[nodiscard]]
+  size_t NumColumns() const final {
+    return arrow_table_->num_columns();
+  }
+
+  [[nodiscard]]
+  std::shared_ptr<SchemaType> Schema() const final {
+    return schema_;
+  }
+
+private:
+  std::shared_ptr<arrow::Table> arrow_table_;
+  std::shared_ptr<SchemaType> schema_;
+  std::shared_ptr<RowSequence> row_sequence_;
+  std::vector<std::shared_ptr<ColumnSource>> column_sources_;
+};
+}  // namespace deephaven::client::arrowutil

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_column_source.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_column_source.h
@@ -13,190 +13,214 @@
 
 namespace deephaven::client::arrowutil {
 namespace internal {
-template<typename ArrayType, typename ElementType>
-class NumericBackingStore {
-  using ColumnSourceImpls = deephaven::dhcore::column::ColumnSourceImpls;
+// Because this is a template function and we want to share code, we encode the
+// differences in behavior with this enum.
+// kNormal is used for the "simple" Deephaven primitive types (e.g. char, float, short), which have
+// special reserved values for nulls (e.g. DeephavenConstants.kNullChar), and copying can be
+// done with simple pointer and assignment operations.
+// kBooleanOrString uses Arrow iterators for copying (which yield std::optional<T>), and determines
+// null-ness by determining whether the optional has a value.
+// kTimestamp is its own special case, where nullness is determined by the underlying nanos
+// being equal to Deephaven's NULL_LONG.
+enum class ArrowProcessingStyle { kNormal, kBooleanOrString, kTimestamp };
 
-public:
-  explicit NumericBackingStore(const ArrayType *arrow_array) : array_(arrow_array) {}
-
-  void Get(size_t begin_index, size_t end_index, ElementType *dest, bool *optional_null_flags) const {
-    ColumnSourceImpls::AssertRangeValid(begin_index, end_index, array_->length());
-    for (auto i = begin_index; i != end_index; ++i) {
-      auto element = (*array_)[i];
-      ElementType value;
-      bool is_null;
-      if (element.has_value()) {
-        value = *element;
-          is_null = false;
-      } else {
-        value = deephaven::dhcore::DeephavenTraits<ElementType>::kNullValue;
-          is_null = true;
-      }
-      *dest++ = value;
-      if (optional_null_flags != nullptr) {
-        *optional_null_flags++ = is_null;
-      }
-    }
-  }
-
-private:
-  const ArrayType *array_ = nullptr;
-};
-
-template<typename ArrayType, typename ElementType>
-class GenericBackingStore {
-  using ColumnSourceImpls = deephaven::dhcore::column::ColumnSourceImpls;
+template<ArrowProcessingStyle Style, typename TColumnSourceBase, typename TArrowArray, typename TChunk>
+class GenericArrowColumnSource final : public TColumnSourceBase {
+  using BooleanChunk = deephaven::dhcore::chunk::BooleanChunk;
+  using Chunk = deephaven::dhcore::chunk::Chunk;
+  using ColumnSourceVisitor = deephaven::dhcore::column::ColumnSourceVisitor;
   using DateTime = deephaven::dhcore::DateTime;
-public:
-  explicit GenericBackingStore(const ArrayType *arrow_array) : array_(arrow_array) {}
+  using RowSequence = deephaven::dhcore::container::RowSequence;
+  using UInt64Chunk = deephaven::dhcore::chunk::UInt64Chunk;
 
-  void Get(size_t begin_index, size_t end_index, ElementType *dest, bool *optional_null_flags) const {
-    ColumnSourceImpls::AssertRangeValid(begin_index, end_index, array_->length());
-    for (auto i = begin_index; i != end_index; ++i) {
-      auto element = (*array_)[i];
-      bool is_null;
-      if (element.has_value()) {
-        ArrowValueConverter::Convert(*element, dest);
-        is_null = false;
-      } else {
-        // placeholder
-        *dest = ElementType();
-        is_null = true;
-      }
-      ++dest;
-      if (optional_null_flags != nullptr) {
-        *optional_null_flags++ = is_null;
-      }
+public:
+  static std::shared_ptr<GenericArrowColumnSource> OfArrowArray(std::shared_ptr<TArrowArray> array) {
+    std::vector<std::shared_ptr<TArrowArray>> arrays{std::move(array)};
+    return OfArrowArrayVec(std::move(arrays));
+  }
+
+  static std::shared_ptr<GenericArrowColumnSource> OfArrowArrayVec(
+      std::vector<std::shared_ptr<TArrowArray>> arrays) {
+    return std::make_shared<GenericArrowColumnSource>(std::move(arrays));
+  }
+
+  explicit GenericArrowColumnSource(std::vector<std::shared_ptr<TArrowArray>> arrays) :
+      arrays_(std::move(arrays)) {}
+
+  ~GenericArrowColumnSource() final = default;
+
+  void FillChunk(const RowSequence &rows, Chunk *dest_data,
+      BooleanChunk *optional_dest_null_flags) const final {
+    using deephaven::dhcore::DeephavenTraits;
+    using deephaven::dhcore::utility::VerboseCast;
+
+    if (rows.Empty()) {
+      return;
     }
+    if (arrays_.empty()) {
+      const auto *message = "Ran out of source data before processing whole RowSequence";
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
+
+    // This algorithm is a little tricky because the source data and RowSequence are both
+    // segmented, perhaps in different ways.
+    auto *typed_dest = VerboseCast<TChunk*>(DEEPHAVEN_LOCATION_EXPR(dest_data));
+    auto *destp = typed_dest->data();
+    auto outerp = arrays_.begin();
+    size_t src_segment_begin = 0;
+    size_t src_segment_end = (*outerp)->length();
+
+    auto *null_destp = optional_dest_null_flags != nullptr ? optional_dest_null_flags->data() : nullptr;
+
+    rows.ForEachInterval([&](uint64_t requested_segment_begin, uint64_t requested_segment_end) {
+      while (true) {
+        if (requested_segment_begin == requested_segment_end) {
+          return;
+        }
+        if (requested_segment_begin >= src_segment_end) {
+          // src_segment needs to catch up
+          ++outerp;
+          if (outerp == arrays_.end()) {
+            const auto *message = "Ran out of source data before processing whole RowSequence";
+            throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+          }
+          src_segment_begin = src_segment_end;
+          src_segment_end = src_segment_begin + (*outerp)->length();
+          continue;
+        }
+        if (requested_segment_begin < src_segment_begin) {
+          throw "can't happen";
+        }
+        auto min_end = std::min(requested_segment_end, src_segment_end);
+        // [relative_begin, relative_end) are the coordinates of the source data relative to the
+        // start of the current data segment being pointed to.
+        auto relative_begin = requested_segment_begin - src_segment_begin;
+        auto relative_end = min_end - src_segment_begin;
+        const auto &innerp = *outerp;
+
+        if constexpr (Style == ArrowProcessingStyle::kNormal) {
+          // Process these types using pointer operations and the Deephaven Null convention
+          const auto *src_beginp = innerp->raw_values() + relative_begin;
+          const auto *src_endp = innerp->raw_values() + relative_end;
+          std::copy(src_beginp, src_endp, destp);
+          destp += src_endp - src_beginp;
+
+          if (null_destp != nullptr) {
+            for (const auto *current = src_beginp; current != src_endp; ++current) {
+              *null_destp = *current == DeephavenTraits<typename TChunk::value_type>::kNullValue;
+              ++null_destp;
+            }
+          }
+        } else if constexpr (Style == ArrowProcessingStyle::kBooleanOrString) {
+          // Process booleans and strings by using the Arrow iterator which yields optionals;
+          // which also gives us access to the Arrow validity array.
+          const auto src_beginp = innerp->begin() + relative_begin;
+          const auto src_endp = innerp->begin() + relative_end;
+          for (auto ip = src_beginp; ip != src_endp; ++ip) {
+            const auto &optional_element = *ip;
+            if (optional_element.has_value()) {
+              *destp = *optional_element;
+            } else {
+              *destp = typename TChunk::value_type();
+            }
+            ++destp;
+
+            if (null_destp != nullptr) {
+              *null_destp = !optional_element.has_value();
+              ++null_destp;
+            }
+          }
+        } else if constexpr (Style == ArrowProcessingStyle::kTimestamp) {
+          // Process these types using pointer operations and the Deephaven Null convention
+          const auto *src_beginp = innerp->raw_values() + relative_begin;
+          const auto *src_endp = innerp->raw_values() + relative_end;
+
+          for (const auto *ip = src_beginp; ip != src_endp; ++ip) {
+            *destp = DateTime::FromNanos(*ip);
+            ++destp;
+
+            if (null_destp != nullptr) {
+              *null_destp = *ip == DeephavenTraits<int64_t>::kNullValue;
+              ++null_destp;
+            }
+          }
+        }
+        requested_segment_begin = min_end;
+      }
+    });
+  }
+
+  void FillChunkUnordered(const UInt64Chunk &rows, Chunk *dest_data,
+      BooleanChunk *optional_dest_null_flags) const final {
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR("Not implemented"));
+  }
+
+  void AcceptVisitor(ColumnSourceVisitor *visitor) const final {
+    visitor->Visit(*this);
   }
 
 private:
-  const ArrayType *array_ = nullptr;
+  std::vector<std::shared_ptr<TArrowArray>> arrays_;
 };
 }  // namespace internal
 
-template<typename ArrayType, typename ElementType>
-class NumericArrowColumnSource final : public deephaven::dhcore::column::NumericColumnSource<ElementType> {
-  struct Private {};
-  /**
-   * Alias.
-   */
-  using BooleanChunk = deephaven::dhcore::chunk::BooleanChunk;
-  /**
-   * Alias.
-   */
-  using Chunk = deephaven::dhcore::chunk::Chunk;
-  /**
-   * Alias.
-   */
-  using UInt64Chunk = deephaven::dhcore::chunk::UInt64Chunk;
-  /**
-   * Alias.
-   */
-  using ColumnSourceImpls = deephaven::dhcore::column::ColumnSourceImpls;
-  /**
-   * Alias.
-   */
-  using RowSequence = deephaven::dhcore::container::RowSequence;
-  /**
-   * Alias.
-   */
-  using ColumnSourceVisitor = deephaven::dhcore::column::ColumnSourceVisitor;
+using Int8ArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kNormal,
+    deephaven::dhcore::column::Int8ColumnSource,
+    arrow::Int8Array,
+    deephaven::dhcore::chunk::Int8Chunk>;
 
-public:
-  static std::shared_ptr<NumericArrowColumnSource> Create(std::shared_ptr<arrow::Array> storage,
-      const ArrayType *arrow_array) {
-    return std::make_shared<NumericArrowColumnSource>(Private(), std::move(storage), arrow_array);
-  }
+using Int16ArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kNormal,
+    deephaven::dhcore::column::Int16ColumnSource,
+    arrow::Int16Array,
+    deephaven::dhcore::chunk::Int16Chunk>;
 
-  explicit NumericArrowColumnSource(Private, std::shared_ptr<arrow::Array> storage, const ArrayType *arrow_array) :
-      storage_(std::move(storage)), backingStore_(arrow_array) {}
+using Int32ArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kNormal,
+    deephaven::dhcore::column::Int32ColumnSource,
+    arrow::Int32Array,
+    deephaven::dhcore::chunk::Int32Chunk>;
 
-  void FillChunk(const RowSequence &rows, Chunk *dest_data, BooleanChunk *optional_dest_null_flags) const final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<ElementType>::type_t chunkType_t;
-    ColumnSourceImpls::FillChunk<chunkType_t>(rows, dest_data, optional_dest_null_flags, backingStore_);
-  }
+using Int64ArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kNormal,
+    deephaven::dhcore::column::Int64ColumnSource,
+    arrow::Int64Array,
+    deephaven::dhcore::chunk::Int64Chunk>;
 
-  void FillChunkUnordered(const UInt64Chunk &rows, Chunk *dest_data, BooleanChunk *optional_dest_null_flags) const final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<ElementType>::type_t chunkType_t;
-    ColumnSourceImpls::FillChunkUnordered<chunkType_t>(rows, dest_data, optional_dest_null_flags,
-                                                       backingStore_);
-  }
+using FloatArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kNormal,
+    deephaven::dhcore::column::FloatColumnSource,
+    arrow::FloatArray,
+    deephaven::dhcore::chunk::FloatChunk>;
 
-  void AcceptVisitor(ColumnSourceVisitor *visitor) const final {
-    visitor->Visit(*this);
-  }
+using DoubleArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kNormal,
+    deephaven::dhcore::column::DoubleColumnSource,
+    arrow::DoubleArray,
+    deephaven::dhcore::chunk::DoubleChunk>;
 
-private:
-  std::shared_ptr<arrow::Array> storage_;
-  internal::NumericBackingStore<ArrayType, ElementType> backingStore_;
-};
+using CharArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kNormal,
+    deephaven::dhcore::column::CharColumnSource,
+    arrow::UInt16Array,
+    deephaven::dhcore::chunk::CharChunk>;
 
-template<typename ArrayType, typename ElementType>
-class GenericArrowColumnSource final : public deephaven::dhcore::column::GenericColumnSource<ElementType> {
-  struct Private {};
-  /**
-   * Alias.
-   */
-  using BooleanChunk = deephaven::dhcore::chunk::BooleanChunk;
-  /**
-   * Alias.
-   */
-  using Chunk = deephaven::dhcore::chunk::Chunk;
-  /**
-   * Alias.
-   */
-  using UInt64Chunk = deephaven::dhcore::chunk::UInt64Chunk;
-  /**
-   * Alias.
-   */
-  using RowSequence = deephaven::dhcore::container::RowSequence;
-  /**
-   * Alias.
-   */
-  using ColumnSourceImpls = deephaven::dhcore::column::ColumnSourceImpls;
-  /**
-   * Alias.
-   */
-  using ColumnSourceVisitor = deephaven::dhcore::column::ColumnSourceVisitor;
+using BooleanArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kBooleanOrString,
+    deephaven::dhcore::column::BooleanColumnSource,
+    arrow::BooleanArray,
+    deephaven::dhcore::chunk::BooleanChunk>;
 
-public:
-  static std::shared_ptr<GenericArrowColumnSource> Create(std::shared_ptr<arrow::Array> storage,
-      const ArrayType *arrow_array) {
-    return std::make_shared<GenericArrowColumnSource>(Private(), std::move(storage), arrow_array);
-  }
+using StringArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kBooleanOrString,
+    deephaven::dhcore::column::StringColumnSource,
+    arrow::StringArray,
+    deephaven::dhcore::chunk::StringChunk>;
 
-  explicit GenericArrowColumnSource(Private, std::shared_ptr<arrow::Array> storage, const ArrayType *arrow_array) :
-      storage_(std::move(storage)), backingStore_(arrow_array) {}
-
-  void FillChunk(const RowSequence &rows, Chunk *dest_data, BooleanChunk *optional_dest_null_flags) const final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<ElementType>::type_t chunkType_t;
-    ColumnSourceImpls::FillChunk<chunkType_t>(rows, dest_data, optional_dest_null_flags, backingStore_);
-  }
-  void FillChunkUnordered(const UInt64Chunk &rows, Chunk *dest_data, BooleanChunk *optional_dest_null_flags) const final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<ElementType>::type_t chunkType_t;
-    ColumnSourceImpls::FillChunkUnordered<chunkType_t>(rows, dest_data, optional_dest_null_flags,
-                                                       backingStore_);
-  }
-  void AcceptVisitor(ColumnSourceVisitor *visitor) const final {
-    visitor->Visit(*this);
-  }
-
-private:
-  std::shared_ptr<arrow::Array> storage_;
-  internal::GenericBackingStore<ArrayType, ElementType> backingStore_;
-};
-
-using ArrowCharColumnSource = NumericArrowColumnSource<arrow::UInt16Array, char16_t>;
-using ArrowInt8ColumnSource = NumericArrowColumnSource<arrow::Int8Array, int8_t>;
-using ArrowInt16ColumnSource = NumericArrowColumnSource<arrow::Int16Array, int16_t>;
-using ArrowInt32ColumnSource = NumericArrowColumnSource<arrow::Int32Array, int32_t>;
-using ArrowInt64ColumnSource = NumericArrowColumnSource<arrow::Int64Array, int64_t>;
-using ArrowFloatColumnSource = NumericArrowColumnSource<arrow::FloatArray, float>;
-using ArrowDoubleColumnSource = NumericArrowColumnSource<arrow::DoubleArray, double>;
-
-using ArrowBooleanColumnSource = GenericArrowColumnSource<arrow::BooleanArray, bool>;
-using ArrowStringColumnSource = GenericArrowColumnSource<arrow::StringArray, std::string>;
-using ArrowDateTimeColumnSource = GenericArrowColumnSource<arrow::TimestampArray, deephaven::dhcore::DateTime>;
+using DateTimeArrowColumnSource = internal::GenericArrowColumnSource<
+    internal::ArrowProcessingStyle::kTimestamp,
+    deephaven::dhcore::column::DateTimeColumnSource,
+    arrow::TimestampArray,
+    deephaven::dhcore::chunk::DateTimeChunk>;
 }  // namespace deephaven::client::arrowutil

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
@@ -7,6 +7,7 @@
 #include <string_view>
 #include "deephaven/client/client_options.h"
 #include "deephaven/client/utility/misc_types.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
 #include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/ticking/ticking.h"
 
@@ -29,6 +30,13 @@ class ClientImpl;
 class TableHandleImpl;
 class TableHandleManagerImpl;
 }  // namespace deephaven::client::impl
+
+/**
+ * Forward reference to arrow's Table
+ */
+namespace arrow {
+class Table;
+}  // namespace arrow
 
 /**
  * Forward reference to arrow's FlightStreamReader
@@ -866,6 +874,7 @@ inline AggregateCombo aggCombo(std::initializer_list<Aggregate> args) {
  * server resource is destructed, the resource will be released.
  */
 class TableHandle {
+  using ClientTable = deephaven::dhcore::clienttable::ClientTable;
   using SchemaType = deephaven::dhcore::clienttable::Schema;
   using TickingCallback = deephaven::dhcore::ticking::TickingCallback;
   using TickingUpdate = deephaven::dhcore::ticking::TickingUpdate;
@@ -1835,6 +1844,20 @@ public:
    */
   [[nodiscard]]
   std::shared_ptr<arrow::flight::FlightStreamReader> GetFlightStreamReader() const;
+
+  /**
+   * Read in the entire table as an Arrow table.
+   * @return the Arrow table
+   */
+  [[nodiscard]]
+  std::shared_ptr<arrow::Table> ToArrowTable() const;
+
+  /**
+   * Read in the entire table as a ClientTable.
+   * @return the ClientTable
+  */
+  [[nodiscard]]
+  std::shared_ptr<ClientTable> ToClientTable() const;
 
   /**
    * Subscribe to a ticking table.

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client_options.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <string>
-#include <utility>  // std::pair
+#include <utility>
 #include <vector>
 
 namespace deephaven::client {
@@ -100,7 +100,7 @@ public:
    * @param pem a PEM encoded private key.
    * @return *this, to be used for chaining
    */
-  ClientOptions &SetClientPrivateKey(std::string client_cert_chain);
+  ClientOptions &SetClientPrivateKey(std::string client_private_key);
   /**
    * Adds an int-valued option for the configuration of the underlying gRPC channels.
    * See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
@@ -10,10 +10,43 @@
 #include <arrow/type.h>
 #include <arrow/flight/types.h>
 
+#include "deephaven/dhcore/clienttable/client_table.h"
+#include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 
 namespace deephaven::client::utility {
-arrow::flight::FlightDescriptor ConvertTicketToFlightDescriptor(const std::string &ticket);
+class ArrowUtil {
+  using ElementTypeId = deephaven::dhcore::ElementTypeId;
+  using FlightDescriptor = arrow::flight::FlightDescriptor;
+  using Schema = deephaven::dhcore::clienttable::Schema;
+
+public:
+  /**
+   * This class should not be instantiated.
+   */
+  ArrowUtil() = delete;
+
+  static FlightDescriptor ConvertTicketToFlightDescriptor(const std::string &ticket);
+
+  /**
+   * Try to convert the Arrow DataType to an ElementTypeId.
+   * @param must_succeed Requires the conversion to succeed. If must_succeed is set, the method
+   *   will throw an exception rather than returning false.
+   * @return If the conversion succeeded, a populated optional. Otherwise (if the conversion failed)
+   *   and must_succeed is true, throws an exception. Otherwise (if the conversion failed
+   *   and must_succeed is false), returns an unset optional.
+   */
+  static std::optional<ElementTypeId::Enum> GetElementTypeId(const arrow::DataType &data_type,
+      bool must_succeed);
+
+  /**
+   * Convert an Arrow Schema into a Deephaven Schema
+   * @param schema The arrow Schema
+   * @return a Deephaven Schema
+   */
+  static std::shared_ptr<Schema> MakeDeephavenSchema(const arrow::Schema &schema);
+};
+
 
 /**
  * If status is OK, do nothing. Otherwise throw a runtime error with an informative message.

--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_client_table.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_client_table.cc
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/client/arrowutil/arrow_column_source.h"
+#include "deephaven/client/arrowutil/arrow_client_table.h"
+#include "deephaven/client/utility/arrow_util.h"
+#include "deephaven/dhcore/types.h"
+
+using deephaven::client::utility::ArrowUtil;
+using deephaven::client::utility::OkOrThrow;
+using deephaven::client::arrowutil::BooleanArrowColumnSource;
+using deephaven::client::arrowutil::CharArrowColumnSource;
+using deephaven::client::arrowutil::DateTimeArrowColumnSource;
+using deephaven::client::arrowutil::DoubleArrowColumnSource;
+using deephaven::client::arrowutil::FloatArrowColumnSource;
+using deephaven::client::arrowutil::Int8ArrowColumnSource;
+using deephaven::client::arrowutil::Int16ArrowColumnSource;
+using deephaven::client::arrowutil::Int32ArrowColumnSource;
+using deephaven::client::arrowutil::Int64ArrowColumnSource;
+using deephaven::client::arrowutil::StringArrowColumnSource;
+using deephaven::dhcore::chunk::BooleanChunk;
+using deephaven::dhcore::chunk::Chunk;
+using deephaven::dhcore::chunk::CharChunk;
+using deephaven::dhcore::chunk::DateTimeChunk;
+using deephaven::dhcore::chunk::FloatChunk;
+using deephaven::dhcore::chunk::DoubleChunk;
+using deephaven::dhcore::chunk::Int8Chunk;
+using deephaven::dhcore::chunk::Int16Chunk;
+using deephaven::dhcore::chunk::Int32Chunk;
+using deephaven::dhcore::chunk::Int64Chunk;
+using deephaven::dhcore::chunk::StringChunk;
+using deephaven::dhcore::chunk::UInt64Chunk;
+using deephaven::dhcore::clienttable::ClientTable;
+using deephaven::dhcore::column::BooleanColumnSource;
+using deephaven::dhcore::column::CharColumnSource;
+using deephaven::dhcore::column::ColumnSource;
+using deephaven::dhcore::column::DoubleColumnSource;
+using deephaven::dhcore::column::FloatColumnSource;
+using deephaven::dhcore::column::Int8ColumnSource;
+using deephaven::dhcore::column::Int16ColumnSource;
+using deephaven::dhcore::column::Int32ColumnSource;
+using deephaven::dhcore::column::Int64ColumnSource;
+using deephaven::dhcore::column::ColumnSourceVisitor;
+using deephaven::dhcore::column::StringColumnSource;
+using deephaven::dhcore::container::RowSequence;
+using deephaven::dhcore::DateTime;
+using deephaven::dhcore::DeephavenTraits;
+using deephaven::dhcore::utility::demangle;
+using deephaven::dhcore::utility::MakeReservedVector;
+using deephaven::dhcore::utility::VerboseCast;
+
+namespace deephaven::client::arrowutil {
+
+namespace {
+std::shared_ptr<ColumnSource> MakeColumnSource(const arrow::ChunkedArray &array);
+}  // namespace
+
+std::shared_ptr<ClientTable> ArrowClientTable::Create(std::shared_ptr<arrow::Table> arrow_table) {
+  auto schema = ArrowUtil::MakeDeephavenSchema(*arrow_table->schema());
+  auto row_sequence = RowSequence::CreateSequential(0, arrow_table->num_rows());
+
+  auto column_sources = MakeReservedVector<std::shared_ptr<ColumnSource>>(arrow_table->num_columns());
+  for (const auto &chunked_array : arrow_table->columns()) {
+    column_sources.push_back(MakeColumnSource(*chunked_array));
+  }
+
+  return std::make_shared<ArrowClientTable>(Private(), std::move(arrow_table),
+      std::move(schema), std::move(row_sequence), std::move(column_sources));
+}
+
+ArrowClientTable::ArrowClientTable(deephaven::client::arrowutil::ArrowClientTable::Private,
+    std::shared_ptr<arrow::Table> arrow_table, std::shared_ptr<SchemaType> schema,
+    std::shared_ptr<RowSequence> row_sequence,
+    std::vector<std::shared_ptr<ColumnSource>> column_sources) :
+    arrow_table_(std::move(arrow_table)), schema_(std::move(schema)),
+    row_sequence_(std::move(row_sequence)), column_sources_(std::move(column_sources)) {}
+ArrowClientTable::ArrowClientTable(ArrowClientTable &&other) noexcept = default;
+ArrowClientTable &ArrowClientTable::operator=(ArrowClientTable &&other) noexcept = default;
+ArrowClientTable::~ArrowClientTable() = default;
+
+std::shared_ptr<ColumnSource> ArrowClientTable::GetColumn(size_t column_index) const {
+  if (column_index >= column_sources_.size()) {
+    auto message = fmt::format("column_index ({}) >= num columns ({})", column_index,
+        column_sources_.size());
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+  }
+  return column_sources_[column_index];
+}
+
+namespace {
+template<typename TArrowArray>
+std::vector<std::shared_ptr<TArrowArray>> DowncastChunks(const arrow::ChunkedArray &chunked_array) {
+  auto downcasted = MakeReservedVector<std::shared_ptr<TArrowArray>>(chunked_array.num_chunks());
+  for (const auto &vec : chunked_array.chunks()) {
+    auto dest = std::dynamic_pointer_cast<TArrowArray>(vec);
+    if (dest == nullptr) {
+      const auto &deref_vec = *vec;
+      auto message = fmt::format("can't cast {} to {}",
+          demangle(typeid(deref_vec).name()),
+          demangle(typeid(TArrowArray).name()));
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
+    downcasted.push_back(std::move(dest));
+  }
+  return downcasted;
+}
+
+struct Visitor final : public arrow::TypeVisitor {
+  explicit Visitor(const arrow::ChunkedArray &chunked_array) : chunked_array_(chunked_array) {}
+
+  arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::UInt16Array>(chunked_array_);
+    result_ = CharArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int8Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int8Array>(chunked_array_);
+    result_ = Int8ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int16Array>(chunked_array_);
+    result_ = Int16ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int32Array>(chunked_array_);
+    result_ = Int32ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int64Array>(chunked_array_);
+    result_ = Int64ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::FloatType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::FloatArray>(chunked_array_);
+    result_ = FloatArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::DoubleArray>(chunked_array_);
+    result_ = DoubleArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::BooleanArray>(chunked_array_);
+    result_ = BooleanArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::StringType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::StringArray>(chunked_array_);
+    result_ = StringArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::TimestampType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::TimestampArray>(chunked_array_);
+    result_ = DateTimeArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  const arrow::ChunkedArray &chunked_array_;
+  std::shared_ptr<ColumnSource> result_;
+};
+
+std::shared_ptr<ColumnSource> MakeColumnSource(const arrow::ChunkedArray &chunked_array) {
+  Visitor visitor(chunked_array);
+  OkOrThrow(DEEPHAVEN_LOCATION_EXPR(chunked_array.type()->Accept(&visitor)));
+  return std::move(visitor.result_);
+}
+}  // namespace
+}  // namespace deephaven::client::arrowutil

--- a/cpp-client/deephaven/dhclient/src/client_options.cc
+++ b/cpp-client/deephaven/dhclient/src/client_options.cc
@@ -57,8 +57,8 @@ ClientOptions &ClientOptions::SetClientCertChain(std::string client_cert_chain) 
   return *this;
 }
 
-ClientOptions &ClientOptions::SetClientPrivateKey(std::string clientCertChain) {
-  clientPrivateKey_ = std::move(clientCertChain);
+ClientOptions &ClientOptions::SetClientPrivateKey(std::string client_private_key) {
+  clientPrivateKey_ = std::move(client_private_key);
   return *this;
 }
 

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
@@ -60,7 +60,7 @@ using deephaven::client::impl::MoveVectorData;
 using deephaven::client::server::Server;
 using deephaven::client::subscription::SubscriptionThread;
 using deephaven::client::subscription::SubscriptionHandle;
-using deephaven::client::utility::ConvertTicketToFlightDescriptor;
+using deephaven::client::utility::ArrowUtil;
 using deephaven::client::utility::Executor;
 using deephaven::client::utility::OkOrThrow;
 using deephaven::client::utility::OkOrThrow;
@@ -649,67 +649,6 @@ void TableHandleImpl::BindToVariable(std::string variable) {
   });
 }
 
-namespace {
-struct ArrowToElementTypeId final : public arrow::TypeVisitor {
-  arrow::Status Visit(const arrow::Int8Type &/*type*/) final {
-    typeId_ = ElementTypeId::kInt8;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
-    typeId_ = ElementTypeId::kInt16;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
-    typeId_ = ElementTypeId::kInt32;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
-    typeId_ = ElementTypeId::kInt64;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::FloatType &/*type*/) final {
-    typeId_ = ElementTypeId::kFloat;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
-    typeId_ = ElementTypeId::kDouble;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
-    typeId_ = ElementTypeId::kBool;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
-    typeId_ = ElementTypeId::kChar;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::StringType &/*type*/) final {
-    typeId_ = ElementTypeId::kString;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::TimestampType &/*type*/) final {
-    typeId_ = ElementTypeId::kTimestamp;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::ListType &/*type*/) final {
-    typeId_ = ElementTypeId::kList;
-    return arrow::Status::OK();
-  }
-
-  ElementTypeId::Enum typeId_ = ElementTypeId::kInt8;  // arbitrary initializer
-};
-}  // namespace
-
 std::shared_ptr<Schema> TableHandleImpl::Schema() {
   std::unique_lock guard(mutex_);
   if (schema_request_sent_) {
@@ -735,24 +674,14 @@ std::shared_ptr<Schema> TableHandleImpl::Schema() {
         }
     );
 
-    auto fd = ConvertTicketToFlightDescriptor(ticket_.ticket());
+    auto fd = ArrowUtil::ConvertTicketToFlightDescriptor(ticket_.ticket());
     auto gs_result = server->FlightClient()->GetSchema(options, fd);
     OkOrThrow(DEEPHAVEN_LOCATION_EXPR(gs_result));
 
     auto schema_result = (*gs_result)->GetSchema(nullptr);
-    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(schema_result));
-
-    const auto &fields = (*schema_result)->fields();
-    auto names = MakeReservedVector<std::string>(fields.size());
-    auto types = MakeReservedVector<ElementTypeId::Enum>(fields.size());
-    for (const auto &f: fields) {
-      ArrowToElementTypeId v;
-      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(f->type()->Accept(&v)));
-      names.push_back(f->name());
-      types.push_back(v.typeId_);
-    }
-    auto schema = Schema::Create(std::move(names), std::move(types));
-    schema_promise.set_value(std::move(schema));
+    auto arrow_schema = ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(schema_result));
+    auto deephaven_schema = ArrowUtil::MakeDeephavenSchema(*arrow_schema);
+    schema_promise.set_value(std::move(deephaven_schema));
   } catch (...) {
     schema_promise.set_exception(std::current_exception());
   }

--- a/cpp-client/deephaven/dhclient/src/subscription/subscribe_thread.cc
+++ b/cpp-client/deephaven/dhclient/src/subscription/subscribe_thread.cc
@@ -24,16 +24,16 @@ using deephaven::dhcore::ticking::TickingCallback;
 using deephaven::dhcore::utility::MakeReservedVector;
 using deephaven::dhcore::utility::separatedList;
 using deephaven::dhcore::utility::VerboseCast;
-using deephaven::client::arrowutil::ArrowBooleanColumnSource;
-using deephaven::client::arrowutil::ArrowCharColumnSource;
-using deephaven::client::arrowutil::ArrowDateTimeColumnSource;
-using deephaven::client::arrowutil::ArrowFloatColumnSource;
-using deephaven::client::arrowutil::ArrowDoubleColumnSource;
-using deephaven::client::arrowutil::ArrowInt8ColumnSource;
-using deephaven::client::arrowutil::ArrowInt16ColumnSource;
-using deephaven::client::arrowutil::ArrowInt32ColumnSource;
-using deephaven::client::arrowutil::ArrowInt64ColumnSource;
-using deephaven::client::arrowutil::ArrowStringColumnSource;
+using deephaven::client::arrowutil::BooleanArrowColumnSource;
+using deephaven::client::arrowutil::CharArrowColumnSource;
+using deephaven::client::arrowutil::DateTimeArrowColumnSource;
+using deephaven::client::arrowutil::DoubleArrowColumnSource;
+using deephaven::client::arrowutil::FloatArrowColumnSource;
+using deephaven::client::arrowutil::Int8ArrowColumnSource;
+using deephaven::client::arrowutil::Int16ArrowColumnSource;
+using deephaven::client::arrowutil::Int32ArrowColumnSource;
+using deephaven::client::arrowutil::Int64ArrowColumnSource;
+using deephaven::client::arrowutil::StringArrowColumnSource;
 using deephaven::client::utility::Executor;
 using deephaven::client::utility::OkOrThrow;
 using deephaven::client::server::Server;
@@ -256,60 +256,69 @@ OwningBuffer::OwningBuffer(std::vector<uint8_t> data) :
 OwningBuffer::~OwningBuffer() = default;
 
 struct ArrayToColumnSourceVisitor final : public arrow::ArrayVisitor {
-  explicit ArrayToColumnSourceVisitor(std::shared_ptr<arrow::Array> storage) : storage_(std::move(storage)) {}
+  explicit ArrayToColumnSourceVisitor(const std::shared_ptr<arrow::Array> &array) : array_(array) {}
 
-  arrow::Status Visit(const arrow::Int8Array &array) final {
-    result_ = ArrowInt8ColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::Int8Array &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::Int8Array>(array_);
+    result_ = Int8ArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::Int16Array &array) final {
-    result_ = ArrowInt16ColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::Int16Array &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::Int16Array>(array_);
+    result_ = Int16ArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::Int32Array &array) final {
-    result_ = ArrowInt32ColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::Int32Array &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::Int32Array>(array_);
+    result_ = Int32ArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::Int64Array &array) final {
-    result_ = ArrowInt64ColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::Int64Array &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::Int64Array>(array_);
+    result_ = Int64ArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::FloatArray &array) final {
-    result_ = ArrowFloatColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::FloatArray &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::FloatArray>(array_);
+    result_ = FloatArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::DoubleArray &array) final {
-    result_ = ArrowDoubleColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::DoubleArray &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::DoubleArray>(array_);
+    result_ = DoubleArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::BooleanArray &array) final {
-    result_ = ArrowBooleanColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::BooleanArray &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::BooleanArray>(array_);
+    result_ = BooleanArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::UInt16Array &array) final {
-    result_ = ArrowCharColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::UInt16Array &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::UInt16Array>(array_);
+    result_ = CharArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::StringArray &array) final {
-    result_ = ArrowStringColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::StringArray &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::StringArray>(array_);
+    result_ = StringArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::TimestampArray &array) final {
-    result_ = ArrowDateTimeColumnSource::Create(std::move(storage_), &array);
+  arrow::Status Visit(const arrow::TimestampArray &/*array*/) final {
+    auto typed_array = std::dynamic_pointer_cast<arrow::TimestampArray>(array_);
+    result_ = DateTimeArrowColumnSource::OfArrowArray(std::move(typed_array));
     return arrow::Status::OK();
   }
 
-  // We keep a shared_ptr to the arrow array in order to keep the underlying storage alive.
-  std::shared_ptr<arrow::Array> storage_;
+  const std::shared_ptr<arrow::Array> &array_;
   std::shared_ptr<ColumnSource> result_;
 };
 

--- a/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
@@ -6,7 +6,12 @@
 #include <ostream>
 #include <arrow/status.h>
 #include <arrow/flight/types.h>
+#include "deephaven/dhcore/clienttable/schema.h"
 #include "deephaven/dhcore/utility/utility.h"
+
+using deephaven::dhcore::clienttable::Schema;
+using deephaven::dhcore::ElementTypeId;
+using deephaven::dhcore::utility::MakeReservedVector;
 
 namespace deephaven::client::utility {
 void OkOrThrow(const deephaven::dhcore::utility::DebugInfo &debug_info,
@@ -19,7 +24,7 @@ void OkOrThrow(const deephaven::dhcore::utility::DebugInfo &debug_info,
   throw std::runtime_error(msg);
 }
 
-arrow::flight::FlightDescriptor ConvertTicketToFlightDescriptor(const std::string &ticket) {
+arrow::flight::FlightDescriptor ArrowUtil::ConvertTicketToFlightDescriptor(const std::string &ticket) {
   if (ticket.length() != 5 || ticket[0] != 'e') {
     const char *message = "Ticket is not in correct format for export";
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
@@ -28,4 +33,92 @@ arrow::flight::FlightDescriptor ConvertTicketToFlightDescriptor(const std::strin
   memcpy(&value, ticket.data() + 1, sizeof(uint32_t));
   return arrow::flight::FlightDescriptor::Path({"export", std::to_string(value)});
 };
+
+namespace {
+struct ArrowToElementTypeId final : public arrow::TypeVisitor {
+  arrow::Status Visit(const arrow::Int8Type &/*type*/) final {
+    type_id_ = ElementTypeId::kInt8;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
+    type_id_ = ElementTypeId::kInt16;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
+    type_id_ = ElementTypeId::kInt32;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
+    type_id_ = ElementTypeId::kInt64;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::FloatType &/*type*/) final {
+    type_id_ = ElementTypeId::kFloat;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
+    type_id_ = ElementTypeId::kDouble;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
+    type_id_ = ElementTypeId::kBool;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
+    type_id_ = ElementTypeId::kChar;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::StringType &/*type*/) final {
+    type_id_ = ElementTypeId::kString;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::TimestampType &/*type*/) final {
+    type_id_ = ElementTypeId::kTimestamp;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::ListType &/*type*/) final {
+    type_id_ = ElementTypeId::kList;
+    return arrow::Status::OK();
+  }
+
+  ElementTypeId::Enum type_id_ = ElementTypeId::kInt8;  // arbitrary initializer
+};
+}  // namespace
+
+std::optional<ElementTypeId::Enum> ArrowUtil::GetElementTypeId(const arrow::DataType &data_type,
+    bool must_succeed) {
+  ArrowToElementTypeId visitor;
+  auto result = data_type.Accept(&visitor);
+  if (result.ok()) {
+    return visitor.type_id_;
+  }
+  if (!must_succeed) {
+    return {};
+  }
+  auto message = fmt::format("Can't find Deephaven mapping for arrow data type {}",
+      data_type.ToString());
+  throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+}
+
+std::shared_ptr<Schema> ArrowUtil::MakeDeephavenSchema(const arrow::Schema &schema) {
+  const auto &fields = schema.fields();
+  auto names = MakeReservedVector<std::string>(fields.size());
+  auto types = MakeReservedVector<ElementTypeId::Enum>(fields.size());
+  for (const auto &f: fields) {
+    auto type_id = ArrowUtil::GetElementTypeId(*f->type(), true);
+    names.push_back(f->name());
+    types.push_back(*type_id);
+  }
+  return Schema::Create(std::move(names), std::move(types));
+}
 }  // namespace deephaven::client::utility

--- a/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
@@ -41,7 +41,7 @@ TableHandle TableMaker::MakeTable(const TableHandleManager &manager) {
 
   auto wrapper = manager.CreateFlightWrapper();
   auto ticket = manager.NewTicket();
-  auto flight_descriptor = ConvertTicketToFlightDescriptor(ticket);
+  auto flight_descriptor = ArrowUtil::ConvertTicketToFlightDescriptor(ticket);
 
   arrow::flight::FlightCallOptions options;
   wrapper.AddHeaders(&options);
@@ -65,15 +65,5 @@ TypeConverter::TypeConverter(std::shared_ptr<arrow::DataType> data_type,
     dataType_(std::move(data_type)), deephavenType_(std::move(deephaven_type)),
     column_(std::move(column)) {}
     TypeConverter::~TypeConverter() = default;
-
-const char * const TypeConverterTraits<char16_t>::kDeephavenTypeName = "char";
-const char * const TypeConverterTraits<bool>::kDeephavenTypeName = "java.lang.Boolean";
-const char * const TypeConverterTraits<int8_t>::kDeephavenTypeName = "byte";
-const char * const TypeConverterTraits<int16_t>::kDeephavenTypeName = "short";
-const char * const TypeConverterTraits<int32_t>::kDeephavenTypeName = "int";
-const char * const TypeConverterTraits<int64_t>::kDeephavenTypeName = "long";
-const char * const TypeConverterTraits<float>::kDeephavenTypeName = "float";
-const char * const TypeConverterTraits<double>::kDeephavenTypeName = "double";
-const char * const TypeConverterTraits<std::string>::kDeephavenTypeName = "java.lang.String";
 }  // namespace internal
 }  // namespace deephaven::client::utility

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/abstract_flex_vector.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/abstract_flex_vector.h
@@ -92,7 +92,7 @@ public:
 
   [[nodiscard]]
   std::shared_ptr<ColumnSource> MakeColumnSource() const final {
-    return deephaven::client::immerutil::NumericImmerColumnSource<T>::Create(vec_);
+    return NumericImmerColumnSource<T>::Create(vec_);
   }
 
 private:
@@ -138,11 +138,11 @@ public:
 
   [[nodiscard]]
   std::shared_ptr<ColumnSource> MakeColumnSource() const final {
-    return deephaven::client::immerutil::GenericImmerColumnSource<T>::Create(data_, nulls_);
+    return GenericImmerColumnSource<T>::Create(data_, nulls_);
   }
 
 private:
   immer::flex_vector<T> data_;
   immer::flex_vector<bool> nulls_;
 };
-}  // namespace deephaven::client::immerutil
+}  // namespace deephaven::dhcore::immerutil

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
@@ -10,7 +10,7 @@
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 
-namespace deephaven::client::immerutil {
+namespace deephaven::dhcore::immerutil {
 namespace internal {
 struct ImmerColumnSourceImpls {
   using BooleanChunk = deephaven::dhcore::chunk::BooleanChunk;
@@ -93,7 +93,7 @@ struct ImmerColumnSourceImpls {
         }
       };
 
-      auto copy_nulls_outer = [&src_data, src_null_flags, &copy_nulls_inner](uint64_t src_begin,
+      auto copy_nulls_outer = [&src_data, &copy_nulls_inner](uint64_t src_begin,
           uint64_t src_end) {
         auto src_beginp = src_data.begin() + src_begin;
         auto src_endp = src_data.begin() + src_end;
@@ -107,7 +107,7 @@ struct ImmerColumnSourceImpls {
         }
       };
 
-      auto copy_nulls_outer = [&src_data, src_null_flags, &copy_nulls_inner](uint64_t src_begin,
+      auto copy_nulls_outer = [src_null_flags, &copy_nulls_inner](uint64_t src_begin,
           uint64_t src_end) {
         auto nulls_begin = src_null_flags->begin() + src_begin;
         auto nulls_end = src_null_flags->begin() + src_end;

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -12,6 +12,8 @@
 
 namespace deephaven::dhcore {
 struct ElementTypeId {
+  ElementTypeId() = delete;
+
   // We don't use "enum class" here because we can't figure out how to get it to work right with Cython.
   // TODO(kosak): we are going to have to expand LIST to be a true nested type.
   enum Enum {

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
@@ -147,7 +147,7 @@ std::string FormatDebugString(const char *func, const char *file, size_t line,
   ::deephaven::dhcore::utility::FormatDebugString( \
     DEEPHAVEN_PRETTY_FUNCTION, __FILE__, __LINE__, MESSAGE)
 
-[[nodiscard]] std::string demangle(const char* name);
+[[nodiscard]] std::string demangle(const char *name);
 
 template<typename DESTP, typename SRCP>
 DESTP VerboseCast(const DebugInfo &debug_info, SRCP ptr) {

--- a/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
@@ -98,7 +98,8 @@ std::shared_ptr<RowSequence> ImmerTableState::AddKeys(const RowSequence &rows_to
 }
 
 void ImmerTableState::AddData(const std::vector<std::shared_ptr<ColumnSource>> &src,
-    const std::vector<size_t> &begins, const std::vector<size_t> &ends, const RowSequence &rows_to_add_index_space) {
+    const std::vector<size_t> &begins, const std::vector<size_t> &ends,
+    const RowSequence &rows_to_add_index_space) {
   auto ncols = src.size();
   auto nrows = rows_to_add_index_space.Size();
     AssertAllSame(src.size(), begins.size(), ends.size());
@@ -283,8 +284,8 @@ struct FlexVectorFromSourceMaker final : public ColumnSourceVisitor {
   std::unique_ptr<AbstractFlexVectorBase> result_;
 };
 
-std::unique_ptr<AbstractFlexVectorBase> MakeFlexVectorFromColumnSource(const ColumnSource &source, size_t begin,
-                                                                       size_t end) {
+std::unique_ptr<AbstractFlexVectorBase> MakeFlexVectorFromColumnSource(const ColumnSource &source,
+    size_t begin, size_t end) {
   FlexVectorFromSourceMaker v;
   source.AcceptVisitor(&v);
   v.result_->InPlaceAppendSource(source, begin, end);

--- a/cpp-client/deephaven/dhcore/src/utility/utility.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility.cc
@@ -145,7 +145,7 @@ TimePointToStr(
 }
 
 #ifdef __GNUG__
-std::string demangle(const char* name) {
+std::string demangle(const char *name) {
   int status = -1;
   char *res = abi::__cxa_demangle(name, nullptr, nullptr, &status);
   std::string result = status == 0 ? res : name;

--- a/cpp-client/deephaven/examples/create_table_with_arrow_flight/main.cc
+++ b/cpp-client/deephaven/examples/create_table_with_arrow_flight/main.cc
@@ -10,7 +10,7 @@
 using deephaven::client::Client;
 using deephaven::client::TableHandle;
 using deephaven::client::TableHandleManager;
-using deephaven::client::utility::ConvertTicketToFlightDescriptor;
+using deephaven::client::utility::ArrowUtil;
 using deephaven::client::utility::OkOrThrow;
 using deephaven::client::utility::TableMaker;
 using deephaven::client::utility::ValueOrThrow;
@@ -115,7 +115,7 @@ void Doit(const TableHandleManager &manager) {
   wrapper.AddHeaders(&options);
 
   // 11. Make a FlightDescriptor from the ticket
-  auto fd = deephaven::client::utility::ConvertTicketToFlightDescriptor(ticket);
+  auto fd = ArrowUtil::ConvertTicketToFlightDescriptor(ticket);
 
   // 12. Perform the doPut
   auto res = wrapper.FlightClient()->DoPut(options, fd, schema);

--- a/cpp-client/deephaven/examples/read_csv/main.cc
+++ b/cpp-client/deephaven/examples/read_csv/main.cc
@@ -16,7 +16,7 @@
 
 using deephaven::client::TableHandleManager;
 using deephaven::client::Client;
-using deephaven::client::utility::ConvertTicketToFlightDescriptor;
+using deephaven::client::utility::ArrowUtil;
 using deephaven::client::utility::OkOrThrow;
 using deephaven::client::utility::ValueOrThrow;
 
@@ -73,7 +73,7 @@ arrow::Status Doit(const TableHandleManager &manager, const std::string &csvfn) 
   arrow::flight::FlightCallOptions options;
   wrapper.AddHeaders(&options);
 
-  auto fd = ConvertTicketToFlightDescriptor(ticket);
+  auto fd = ArrowUtil::ConvertTicketToFlightDescriptor(ticket);
   auto res = wrapper.FlightClient()->DoPut(options, fd, arrow_table->schema());
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(res));
 

--- a/cpp-client/deephaven/tests/CMakeLists.txt
+++ b/cpp-client/deephaven/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(tests
     select_test.cc
     sort_test.cc
     string_filter_test.cc
+    table_test.cc
     test_util.cc
     test_util.h
     ticking_test.cc

--- a/cpp-client/deephaven/tests/table_test.cc
+++ b/cpp-client/deephaven/tests/table_test.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include <iostream>
+#include "tests/third_party/catch.hpp"
+#include "tests/test_util.h"
+#include "deephaven/client/client.h"
+#include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/container/row_sequence.h"
+#include "deephaven/dhcore/types.h"
+#include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
+
+using deephaven::client::Client;
+using deephaven::client::TableHandle;
+using deephaven::client::utility::TableMaker;
+using deephaven::dhcore::chunk::BooleanChunk;
+using deephaven::dhcore::chunk::Int32Chunk;
+using deephaven::dhcore::chunk::Int64Chunk;
+using deephaven::dhcore::container::RowSequence;
+using deephaven::dhcore::DateTime;
+using deephaven::dhcore::DeephavenConstants;
+using deephaven::dhcore::utility::MakeReservedVector;
+
+namespace deephaven::client::tests {
+TEST_CASE("Fetch the entire table (small)", "[client_table]") {
+  int64_t target = 10;
+  auto tm = TableMakerForTests::Create();
+  auto thm = tm.Client().GetManager();
+  auto th = thm.EmptyTable(target)
+      .Update({
+        "Chars = ii == 5 ? null : (char)('a' + ii)",
+        "Bytes = ii == 5 ? null : (byte)(ii)",
+        "Shorts = ii == 5 ? null : (short)(ii)",
+        "Ints = ii == 5 ? null : (int)(ii)",
+        "Longs = ii == 5 ? null : (long)(ii)",
+        "Floats = ii == 5 ? null : (float)(ii)",
+        "Doubles = ii == 5 ? null : (double)(ii)",
+        "Bools = ii == 5 ? null : ((ii % 2) == 0)",
+        "Strings = ii == 5 ? null : `hello ` + i",
+        "DateTimes = ii == 5 ? null : '2001-03-01T12:34:56Z' + ii"
+      });
+  std::cout << th.Stream(true) << '\n';
+
+  auto ct = th.ToClientTable();
+  auto schema = ct->Schema();
+
+  auto chars = MakeReservedVector<std::optional<char16_t>>(target);
+  auto int8s = MakeReservedVector<std::optional<int8_t>>(target);
+  auto int16s = MakeReservedVector<std::optional<int16_t>>(target);
+  auto int32s = MakeReservedVector<std::optional<int32_t>>(target);
+  auto int64s = MakeReservedVector<std::optional<int64_t>>(target);
+  auto floats = MakeReservedVector<std::optional<float>>(target);
+  auto doubles = MakeReservedVector<std::optional<double>>(target);
+  auto bools = MakeReservedVector<std::optional<bool>>(target);
+  auto strings = MakeReservedVector<std::optional<std::string>>(target);
+  auto date_times = MakeReservedVector<std::optional<DateTime>>(target);
+
+  auto date_time_start = DateTime::Parse("2001-03-01T12:34:56Z");
+
+  for (int64_t i = 0; i != target; ++i) {
+    chars.emplace_back('a' + i);
+    int8s.emplace_back(i);
+    int16s.emplace_back(i);
+    int32s.emplace_back(i);
+    int64s.emplace_back(i);
+    floats.emplace_back(i);
+    doubles.emplace_back(i);
+    bools.emplace_back((i % 2) == 0);
+    strings.emplace_back(fmt::format("hello {}", i));
+    date_times.emplace_back(DateTime::FromNanos(date_time_start.Nanos() + i));
+  }
+
+  auto t2 = target / 2;
+  // Set the middle element to the unset optional, which for the purposes of this test is
+  // our representation of null.
+  chars[t2] = {};
+  int8s[t2] = {};
+  int16s[t2] = {};
+  int32s[t2] = {};
+  int64s[t2] = {};
+  floats[t2] = {};
+  doubles[t2] = {};
+  bools[t2] = {};
+  strings[t2] = {};
+  date_times[t2] = {};
+
+  CompareColumn(*ct, "Chars", chars);
+  CompareColumn(*ct, "Bytes", int8s);
+  CompareColumn(*ct, "Shorts", int16s);
+  CompareColumn(*ct, "Ints", int32s);
+  CompareColumn(*ct, "Longs", int64s);
+  CompareColumn(*ct, "Floats", floats);
+  CompareColumn(*ct, "Doubles", doubles);
+  CompareColumn(*ct, "Bools", bools);
+  CompareColumn(*ct, "Strings", strings);
+  CompareColumn(*ct, "DateTimes", date_times);
+
+  tm.Client().Close();
+}
+}  // namespace deephaven::client::tests


### PR DESCRIPTION
There are a variety of changes here, but most importantly:

1. `TableHandle` now has both `ToArrowTable` and `ToClientTable` entry points. A `ClientTable` is a Deephaven-style representation of a local copy of a table, using Deephaven programming conventions (RowSequences, Chunks, etc.) rather than Arrow conventions.
2. Previously you could only get a `ClientTable` in ticking callbacks. Now the caller can get a `ClientTable` for static tables too, if they prefer that over Arrow tables. (This will be used for the C# client which would prefer not to have any Arrow dependencies, for now anyway)
3. Added tests to `table_test.cc` and `ticking_test.cc` that make sure that plumbing exists to support all types, for both the static and ticking cases.
4. Changed some global constants to static getter functions. (Building shared libraries on Windows is more friendly if there are no global variables)
5. Some small cleanups and reorgs. For example, there used to be two different Arrow ColumnSource implementations that did almost the same thing. Now there is only one.