### PR TITLE
Added fix for failing nightly job

### DIFF
--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -2123,7 +2123,7 @@ public final class ParquetTableReadWriteTest {
 
         // Read back fromDisk. Since the underlying file has changed, we expect this to fail.
         try {
-            fromDisk.select();
+            fromDisk.where("A % 2 == 0");
             TestCase.fail("Expected exception");
         } catch (RuntimeException ignored) {
             // expected


### PR DESCRIPTION
The nightly job was [failing](https://scans.gradle.com/s/wccv7agjdjzlc/tests/task/:extensions-parquet-table:testOutOfBand/details/io.deephaven.parquet.table.ParquetTableReadWriteTest/readChangedUnderlyingFileTests?expanded-stacktrace=WyIwIl0&top-execution=1) because of a change in the unit test that I made in the PR #5105.
This failure points to a potential issue in error reporting inside `select`, which will be handled separately as part of #5343.
For now, I have reverted my change back to a state so the nightlies can pass.