### PR TITLE
Added simple_date_format to python

### DIFF
--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -899,6 +899,7 @@ def simple_date_format(pattern: str) -> jpy.JType:
         DHError
     """
     try:
+        # Returning a Java object directly to avoid Python/Java boundary crossings in query strings
         return _JSimpleDateFormat(pattern)
     except Exception as e:
         raise DHError(e) from e

--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -884,6 +884,11 @@ def to_np_timedelta64(dt: Union[None, Duration, Period]) -> Optional[numpy.timed
 def simple_date_format(pattern: str) -> jpy.JType:
     """ Creates a Java SimpleDateFormat from a date-time format pattern.
 
+    This method is intended for use in Python code when a SimpleDateFormat is needed.
+    It should not be used directly in query strings.
+    The most common use case will use this function to construct a SimpleDateFormat
+    in Python and then use the result in query strings.
+
     Args:
         pattern (str): A date-time format pattern string.
 

--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -24,6 +24,7 @@ _JInstant = jpy.get_type("java.time.Instant")
 _JZonedDateTime = jpy.get_type("java.time.ZonedDateTime")
 _JDuration = jpy.get_type("java.time.Duration")
 _JPeriod = jpy.get_type("java.time.Period")
+_JSimpleDateFormat = jpy.get_type("java.text.SimpleDateFormat")
 
 _NANOS_PER_SECOND = 1000000000
 _NANOS_PER_MICRO = 1000
@@ -873,6 +874,27 @@ def to_np_timedelta64(dt: Union[None, Duration, Period]) -> Optional[numpy.timed
         raise e
     except TypeError as e:
         raise e
+    except Exception as e:
+        raise DHError(e) from e
+
+# endregion
+
+# region Utility
+
+def simple_date_format(pattern: str) -> jpy.JType:
+    """ Creates a Java SimpleDateFormat from a date-time format pattern.
+
+    Args:
+        pattern (str): A date-time format pattern string.
+
+    Returns:
+        JObject
+
+    Raises:
+        DHError
+    """
+    try:
+        return _JSimpleDateFormat(pattern)
     except Exception as e:
         raise DHError(e) from e
 

--- a/py/server/tests/test_time.py
+++ b/py/server/tests/test_time.py
@@ -633,6 +633,20 @@ class TimeTestCase(BaseTestCase):
 
     # endregion
 
+    # region: Utilities
+
+    def test_simple_date_format(self):
+        s = "12/10/2021 14:21:17 CST"
+        i = _JDateTimeUtils.parseInstant("2021-12-10T14:21:17 CT")
+        sdf = simple_date_format("MM/dd/yyyy HH:mm:ss z")
+        self.assertEqual(sdf.parse(s).toInstant(), i)
+
+        with self.assertRaises(DHError):
+            simple_date_format("junk")
+            self.fail("Expected DHError")
+
+    # endregion
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Using `SimpleDateFormat` required the use of `jpy`.  This is a common enough use case that it should have a helper method.