### PR TITLE
fix: Update copyright on sphinx generated docs

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -17,7 +17,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Deephaven'
-copyright = '2021, Deephaven Data Labs'
+copyright = '2024, Deephaven Data Labs'
 author = 'Deephaven Data Labs'
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
- Noticed they were incorrect on our docs: https://deephaven.io/core/client-api/python/
- Update copyright from 2021 to 2024 for sphinx generated docs
