### PR TITLE
Refactoring the ParquetTools read/write APIs

### DIFF
--- a/Base/src/main/java/io/deephaven/base/FileUtils.java
+++ b/Base/src/main/java/io/deephaven/base/FileUtils.java
@@ -30,7 +30,13 @@ public class FileUtils {
     };
     private final static String[] EMPTY_STRING_ARRAY = new String[0];
 
-    public static final Pattern DUPLICATE_SLASH_PATTERN = Pattern.compile("//+");
+    public static final char URI_SEPARATOR_CHAR = '/';
+
+    public static final String URI_SEPARATOR = "" + URI_SEPARATOR_CHAR;
+
+    public static final String REPEATED_URI_SEPARATOR = URI_SEPARATOR + URI_SEPARATOR;
+
+    public static final Pattern REPEATED_URI_SEPARATOR_PATTERN = Pattern.compile("//+");
 
     /**
      * Cleans the specified path. All files and subdirectories in the path will be deleted. (ie you'll be left with an
@@ -256,8 +262,6 @@ public class FileUtils {
         }
     }
 
-    public static final String URI_SEPARATOR = "/";
-
     /**
      * Take the file source path or URI string and convert it to a URI object. Any unnecessary path separators will be
      * removed. The URI object will always be {@link URI#isAbsolute() absolute}, i.e., will always have a scheme.
@@ -275,8 +279,8 @@ public class FileUtils {
             uri = new URI(source);
             // Replace two or more consecutive slashes in the path with a single slash
             final String path = uri.getPath();
-            if (path.contains("//")) {
-                final String canonicalizedPath = DUPLICATE_SLASH_PATTERN.matcher(path).replaceAll("/");
+            if (path.contains(REPEATED_URI_SEPARATOR)) {
+                final String canonicalizedPath = REPEATED_URI_SEPARATOR_PATTERN.matcher(path).replaceAll(URI_SEPARATOR);
                 uri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), canonicalizedPath,
                         uri.getQuery(), uri.getFragment());
             }
@@ -302,17 +306,17 @@ public class FileUtils {
      */
     public static URI convertToURI(final File file, final boolean isDirectory) {
         String absPath = file.getAbsolutePath();
-        if (File.separatorChar != '/') {
-            absPath = absPath.replace(File.separatorChar, '/');
+        if (File.separatorChar != URI_SEPARATOR_CHAR) {
+            absPath = absPath.replace(File.separatorChar, URI_SEPARATOR_CHAR);
         }
-        if (absPath.charAt(0) != '/') {
-            absPath = "/" + absPath;
+        if (absPath.charAt(0) != URI_SEPARATOR_CHAR) {
+            absPath = URI_SEPARATOR_CHAR + absPath;
         }
-        if (isDirectory && absPath.charAt(absPath.length() - 1) != '/') {
-            absPath = absPath + "/";
+        if (isDirectory && absPath.charAt(absPath.length() - 1) != URI_SEPARATOR_CHAR) {
+            absPath = absPath + URI_SEPARATOR_CHAR;
         }
-        if (absPath.startsWith("//")) {
-            absPath = "//" + absPath;
+        if (absPath.startsWith(REPEATED_URI_SEPARATOR)) {
+            absPath = REPEATED_URI_SEPARATOR + absPath;
         }
         try {
             return new URI("file", null, absPath, null);

--- a/Base/src/main/java/io/deephaven/base/FileUtils.java
+++ b/Base/src/main/java/io/deephaven/base/FileUtils.java
@@ -256,6 +256,8 @@ public class FileUtils {
         }
     }
 
+    public static final String URI_SEPARATOR = "/";
+
     /**
      * Take the file source path or URI string and convert it to a URI object. Any unnecessary path separators will be
      * removed. The URI object will always be {@link URI#isAbsolute() absolute}, i.e., will always have a scheme.

--- a/Base/src/main/java/io/deephaven/base/FileUtils.java
+++ b/Base/src/main/java/io/deephaven/base/FileUtils.java
@@ -258,7 +258,7 @@ public class FileUtils {
 
     /**
      * Take the file source path or URI string and convert it to a URI object. Any unnecessary path separators will be
-     * removed.
+     * removed. The URI object will always be {@link URI#isAbsolute() absolute}, i.e., will always have a scheme.
      *
      * @param source The file source path or URI
      * @param isDirectory Whether the source is a directory

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TableBackedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TableBackedDataIndex.java
@@ -52,17 +52,11 @@ public class TableBackedDataIndex extends AbstractDataIndex {
     public TableBackedDataIndex(
             @NotNull final QueryTable sourceTable,
             @NotNull final String... keyColumnNames) {
-        this(sourceTable, List.of(keyColumnNames));
-    }
-
-    public TableBackedDataIndex(
-            @NotNull final QueryTable sourceTable,
-            @NotNull final List<String> keyColumnNames) {
-        this.keyColumnNames = keyColumnNames;
+        this.keyColumnNames = List.of(keyColumnNames);
 
         // Create an in-order reverse lookup map for the key column names.
         keyColumnNamesByIndexedColumn = Collections.unmodifiableMap(
-                keyColumnNames.stream().collect(Collectors.toMap(
+                Arrays.stream(keyColumnNames).collect(Collectors.toMap(
                         sourceTable::getColumnSource, Function.identity(), Assert::neverInvoked, LinkedHashMap::new)));
 
         isRefreshing = sourceTable.isRefreshing();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TableBackedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TableBackedDataIndex.java
@@ -52,11 +52,17 @@ public class TableBackedDataIndex extends AbstractDataIndex {
     public TableBackedDataIndex(
             @NotNull final QueryTable sourceTable,
             @NotNull final String... keyColumnNames) {
-        this.keyColumnNames = List.of(keyColumnNames);
+        this(sourceTable, List.of(keyColumnNames));
+    }
+
+    public TableBackedDataIndex(
+            @NotNull final QueryTable sourceTable,
+            @NotNull final List<String> keyColumnNames) {
+        this.keyColumnNames = keyColumnNames;
 
         // Create an in-order reverse lookup map for the key column names.
         keyColumnNamesByIndexedColumn = Collections.unmodifiableMap(
-                Arrays.stream(keyColumnNames).collect(Collectors.toMap(
+                keyColumnNames.stream().collect(Collectors.toMap(
                         sourceTable::getColumnSource, Function.identity(), Assert::neverInvoked, LinkedHashMap::new)));
 
         isRefreshing = sourceTable.isRefreshing();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/indexer/DataIndexer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/indexer/DataIndexer.java
@@ -166,15 +166,7 @@ public class DataIndexer implements TrackingRowSet.Indexer {
      */
     @Nullable
     public static DataIndex getDataIndex(@NotNull final Table table, final String... keyColumnNames) {
-        if (keyColumnNames.length == 0) {
-            return null;
-        }
-        final Table tableToUse = table.coalesce();
-        final DataIndexer indexer = DataIndexer.existingOf(tableToUse.getRowSet());
-        if (indexer == null) {
-            return null;
-        }
-        return indexer.getDataIndex(getColumnSources(tableToUse, keyColumnNames));
+        return getDataIndex(table, Arrays.asList(keyColumnNames));
     }
 
     /**
@@ -271,13 +263,7 @@ public class DataIndexer implements TrackingRowSet.Indexer {
     public static DataIndex getOrCreateDataIndex(
             @NotNull final Table table,
             @NotNull final String... keyColumnNames) {
-        if (keyColumnNames.length == 0) {
-            throw new IllegalArgumentException("Cannot create a DataIndex without any key columns");
-        }
-        final QueryTable tableToUse = (QueryTable) table.coalesce();
-        final DataIndexer dataIndexer = DataIndexer.of(tableToUse.getRowSet());
-        return dataIndexer.rootCache.computeIfAbsent(dataIndexer.pathFor(getColumnSources(tableToUse, keyColumnNames)),
-                () -> new TableBackedDataIndex(tableToUse, keyColumnNames));
+        return getOrCreateDataIndex(table, Arrays.asList(keyColumnNames));
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/local/URIStreamKeyValuePartitionLayout.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/local/URIStreamKeyValuePartitionLayout.java
@@ -25,13 +25,13 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static io.deephaven.base.FileUtils.URI_SEPARATOR;
+
 /**
  * Extracts a key-value partitioned table layout from a stream of URIs.
  */
 public abstract class URIStreamKeyValuePartitionLayout<TLK extends TableLocationKey>
         extends KeyValuePartitionLayout<TLK, URI> {
-
-    private static final String URI_SEPARATOR = "/";
 
     protected final URI tableRootDirectory;
     private final Supplier<LocationTableBuilder> locationTableBuilderFactory;
@@ -96,7 +96,7 @@ public abstract class URIStreamKeyValuePartitionLayout<TLK extends TableLocation
             @NotNull final TIntObjectMap<ColumnNameInfo> partitionColInfo,
             final boolean registered) {
         final String relativePathString = relativePath.getPath();
-        // The following assumes that there is exactly one URI_SEPARATOR between each subdirectory in the path
+        // The following assumes that there is exactly one separator between each subdirectory in the path
         final String[] subDirs = relativePathString.split(URI_SEPARATOR);
         final int numPartitioningCol = subDirs.length - 1;
         if (registered) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestChunkedRegionedOperations.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestChunkedRegionedOperations.java
@@ -4,7 +4,6 @@
 package io.deephaven.engine.table.impl.sources.regioned;
 
 import io.deephaven.base.FileUtils;
-import io.deephaven.datastructures.util.CollectionUtil;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.*;
 import io.deephaven.stringset.ArrayStringSet;
@@ -226,36 +225,34 @@ public class TestChunkedRegionedOperations {
         final String tableName = "TestTable";
 
         final PartitionedTable partitionedInputData = inputData.partitionBy("PC");
-        final File[] partitionedInputDestinations;
+        final String[] partitionedInputDestinations;
         try (final Stream<String> partitionNames = partitionedInputData.table()
                 .<String>objectColumnIterator("PC").stream()) {
             partitionedInputDestinations = partitionNames.map(pcv -> new File(dataDirectory,
                     "IP" + File.separator + "P" + pcv + File.separator + tableName + File.separator
-                            + PARQUET_FILE_NAME))
-                    .toArray(File[]::new);
+                            + PARQUET_FILE_NAME)
+                    .getPath())
+                    .toArray(String[]::new);
         }
-        ParquetTools.writeParquetTables(
+        ParquetTools.writeTables(
                 partitionedInputData.constituents(),
-                partitionedDataDefinition.getWritable(),
-                parquetInstructions,
                 partitionedInputDestinations,
-                CollectionUtil.ZERO_LENGTH_STRING_ARRAY_ARRAY);
+                parquetInstructions.withTableDefinition(partitionedDataDefinition.getWritable()));
 
         final PartitionedTable partitionedInputMissingData = inputMissingData.view("PC", "II").partitionBy("PC");
-        final File[] partitionedInputMissingDestinations;
+        final String[] partitionedInputMissingDestinations;
         try (final Stream<String> partitionNames = partitionedInputMissingData.table()
                 .<String>objectColumnIterator("PC").stream()) {
             partitionedInputMissingDestinations = partitionNames.map(pcv -> new File(dataDirectory,
                     "IP" + File.separator + "P" + pcv + File.separator + tableName + File.separator
-                            + PARQUET_FILE_NAME))
-                    .toArray(File[]::new);
+                            + PARQUET_FILE_NAME)
+                    .getPath())
+                    .toArray(String[]::new);
         }
-        ParquetTools.writeParquetTables(
+        ParquetTools.writeTables(
                 partitionedInputMissingData.constituents(),
-                partitionedMissingDataDefinition.getWritable(),
-                parquetInstructions,
                 partitionedInputMissingDestinations,
-                CollectionUtil.ZERO_LENGTH_STRING_ARRAY_ARRAY);
+                parquetInstructions.withTableDefinition(partitionedMissingDataDefinition.getWritable()));
 
         expected = TableTools
                 .merge(

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetUtils.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetUtils.java
@@ -9,11 +9,17 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
+import static io.deephaven.base.FileUtils.URI_SEPARATOR;
+
 public final class ParquetUtils {
 
     public static final String METADATA_FILE_NAME = "_metadata";
     public static final String COMMON_METADATA_FILE_NAME = "_common_metadata";
     public static final String PARQUET_FILE_EXTENSION = ".parquet";
+    public static final String METADATA_FILE_URI_SUFFIX = URI_SEPARATOR + METADATA_FILE_NAME;
+    public static final String COMMON_METADATA_FILE_URI_SUFFIX = URI_SEPARATOR + COMMON_METADATA_FILE_NAME;
+    public static final String METADATA_FILE_SUFFIX = File.separator + METADATA_FILE_NAME;
+    public static final String COMMON_METADATA_FILE_SUFFIX = File.separator + COMMON_METADATA_FILE_NAME;
     private static final String MAGIC_STR = "PAR1";
     public static final byte[] MAGIC = MAGIC_STR.getBytes(StandardCharsets.US_ASCII);
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetUtils.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetUtils.java
@@ -9,17 +9,17 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
-import static io.deephaven.base.FileUtils.URI_SEPARATOR;
+import static io.deephaven.base.FileUtils.URI_SEPARATOR_CHAR;
 
 public final class ParquetUtils {
 
     public static final String METADATA_FILE_NAME = "_metadata";
     public static final String COMMON_METADATA_FILE_NAME = "_common_metadata";
     public static final String PARQUET_FILE_EXTENSION = ".parquet";
-    public static final String METADATA_FILE_URI_SUFFIX = URI_SEPARATOR + METADATA_FILE_NAME;
-    public static final String COMMON_METADATA_FILE_URI_SUFFIX = URI_SEPARATOR + COMMON_METADATA_FILE_NAME;
-    public static final String METADATA_FILE_SUFFIX = File.separator + METADATA_FILE_NAME;
-    public static final String COMMON_METADATA_FILE_SUFFIX = File.separator + COMMON_METADATA_FILE_NAME;
+    public static final String METADATA_FILE_URI_SUFFIX = URI_SEPARATOR_CHAR + METADATA_FILE_NAME;
+    public static final String COMMON_METADATA_FILE_URI_SUFFIX = URI_SEPARATOR_CHAR + COMMON_METADATA_FILE_NAME;
+    public static final String METADATA_FILE_SUFFIX = File.separatorChar + METADATA_FILE_NAME;
+    public static final String COMMON_METADATA_FILE_SUFFIX = File.separatorChar + COMMON_METADATA_FILE_NAME;
     private static final String MAGIC_STR = "PAR1";
     public static final byte[] MAGIC = MAGIC_STR.getBytes(StandardCharsets.US_ASCII);
 
@@ -39,6 +39,20 @@ public final class ParquetUtils {
      */
     public static String getPerFileMetadataKey(final String filePath) {
         return "deephaven_per_file_" + filePath.replace(File.separatorChar, '_');
+    }
+
+    /**
+     * This method verifies if the source points to a parquet file or a metadata file. Provided source can be a local
+     * file path or a URI. Also, it can point to a parquet file, metadata file or a directory.
+     */
+    public static boolean isParquetFile(@NotNull final String source) {
+        boolean ret = source.endsWith(PARQUET_FILE_EXTENSION)
+                || source.endsWith(METADATA_FILE_URI_SUFFIX)
+                || source.endsWith(COMMON_METADATA_FILE_URI_SUFFIX);
+        if (File.separatorChar != URI_SEPARATOR_CHAR) {
+            ret = ret || source.endsWith(METADATA_FILE_SUFFIX) || source.endsWith(COMMON_METADATA_FILE_SUFFIX);
+        }
+        return ret;
     }
 
     /**

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -213,19 +214,19 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
      */
     public abstract boolean generateMetadataFiles();
 
-    public abstract ParquetFileLayout getFileLayout();
+    public abstract Optional<ParquetFileLayout> getFileLayout();
 
-    public abstract TableDefinition getTableDefinition();
+    public abstract Optional<TableDefinition> getTableDefinition();
 
     /**
      * Creates a new {@link ParquetInstructions} object with the same properties as the current object and definition
      * set as the provided {@link TableDefinition}.
      */
-    ParquetInstructions withTableDefinition(final TableDefinition tableDefinition) {
+    final ParquetInstructions withTableDefinition(final TableDefinition tableDefinition) {
         return new ReadOnly(getColumnNameToInstructionsMap(), getParquetColumnNameToInstructionsMap(),
                 getCompressionCodecName(), getMaximumDictionaryKeys(), getMaximumDictionarySize(), isLegacyParquet(),
                 getTargetPageSize(), isRefreshing(), getSpecialInstructions(), generateMetadataFiles(),
-                baseNameForPartitionedParquetData(), getFileLayout(), tableDefinition);
+                baseNameForPartitionedParquetData(), getFileLayout(), Optional.of(tableDefinition));
     }
 
     /**
@@ -292,7 +293,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
 
         @Override
         @Nullable
-        public String getSpecialInstructions() {
+        public Object getSpecialInstructions() {
             return null;
         }
 
@@ -337,15 +338,13 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         @Override
-        @Nullable
-        public ParquetFileLayout getFileLayout() {
-            return null;
+        public Optional<ParquetFileLayout> getFileLayout() {
+            return Optional.empty();
         }
 
         @Override
-        @Nullable
-        public TableDefinition getTableDefinition() {
-            return null;
+        public Optional<TableDefinition> getTableDefinition() {
+            return Optional.empty();
         }
     };
 
@@ -417,8 +416,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         private final Object specialInstructions;
         private final boolean generateMetadataFiles;
         private final String baseNameForPartitionedParquetData;
-        private final ParquetFileLayout fileLayout;
-        private final TableDefinition tableDefinition;
+        private final Optional<ParquetFileLayout> fileLayout;
+        private final Optional<TableDefinition> tableDefinition;
 
         private ReadOnly(
                 final KeyedObjectHashMap<String, ColumnInstructions> columnNameToInstructions,
@@ -432,8 +431,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
                 final Object specialInstructions,
                 final boolean generateMetadataFiles,
                 final String baseNameForPartitionedParquetData,
-                final ParquetFileLayout fileLayout,
-                final TableDefinition tableDefinition) {
+                final Optional<ParquetFileLayout> fileLayout,
+                final Optional<TableDefinition> tableDefinition) {
             this.columnNameToInstructions = columnNameToInstructions;
             this.parquetColumnNameToInstructions = parquetColumnNameToColumnName;
             this.compressionCodecName = compressionCodecName;
@@ -546,7 +545,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         @Override
-        public @Nullable Object getSpecialInstructions() {
+        @Nullable
+        public Object getSpecialInstructions() {
             return specialInstructions;
         }
 
@@ -561,12 +561,12 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         @Override
-        public ParquetFileLayout getFileLayout() {
+        public Optional<ParquetFileLayout> getFileLayout() {
             return fileLayout;
         }
 
         @Override
-        public TableDefinition getTableDefinition() {
+        public Optional<TableDefinition> getTableDefinition() {
             return tableDefinition;
         }
 
@@ -623,8 +623,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         private Object specialInstructions;
         private boolean generateMetadataFiles = DEFAULT_GENERATE_METADATA_FILES;
         private String baseNameForPartitionedParquetData = DEFAULT_BASE_NAME_FOR_PARTITIONED_PARQUET_DATA;
-        private ParquetFileLayout fileLayout;
-        private TableDefinition tableDefinition;
+        private Optional<ParquetFileLayout> fileLayout;
+        private Optional<TableDefinition> tableDefinition;
 
         public Builder() {}
 
@@ -852,7 +852,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
          * computations to deduce the file layout from the source directory structure.
          */
         public Builder setFileLayout(final ParquetFileLayout fileLayout) {
-            this.fileLayout = fileLayout;
+            this.fileLayout = Optional.ofNullable(fileLayout);
             return this;
         }
 
@@ -868,7 +868,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
          * This definition can be used to skip some columns or add additional columns with {@code null} values.
          */
         public Builder setTableDefinition(final TableDefinition tableDefinition) {
-            this.tableDefinition = tableDefinition;
+            this.tableDefinition = Optional.ofNullable(tableDefinition);
             return this;
         }
 

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -153,6 +153,9 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
     static final String FILE_INDEX_TOKEN = "{i}";
     private static final String DEFAULT_BASE_NAME_FOR_PARTITIONED_PARQUET_DATA = UUID_TOKEN;
 
+    private static final Optional<ParquetFileLayout> DEFAULT_FILE_LAYOUT = Optional.empty();
+    private static final Optional<TableDefinition> DEFAULT_TABLE_DEFINITION = Optional.empty();
+
     public ParquetInstructions() {}
 
     public final String getColumnNameFromParquetColumnNameOrDefault(final String parquetColumnName) {
@@ -339,12 +342,12 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
 
         @Override
         public Optional<ParquetFileLayout> getFileLayout() {
-            return Optional.empty();
+            return DEFAULT_FILE_LAYOUT;
         }
 
         @Override
         public Optional<TableDefinition> getTableDefinition() {
-            return Optional.empty();
+            return DEFAULT_TABLE_DEFINITION;
         }
     };
 
@@ -623,8 +626,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         private Object specialInstructions;
         private boolean generateMetadataFiles = DEFAULT_GENERATE_METADATA_FILES;
         private String baseNameForPartitionedParquetData = DEFAULT_BASE_NAME_FOR_PARTITIONED_PARQUET_DATA;
-        private Optional<ParquetFileLayout> fileLayout;
-        private Optional<TableDefinition> tableDefinition;
+        private Optional<ParquetFileLayout> fileLayout = DEFAULT_FILE_LAYOUT;
+        private Optional<TableDefinition> tableDefinition = DEFAULT_TABLE_DEFINITION;
 
         public Builder() {}
 

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -215,17 +215,6 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
 
     public abstract ParquetFileLayout getFileLayout();
 
-    /**
-     * Creates a new {@link ParquetInstructions} object with the same properties as the current object and file layout
-     * set as the provided {@link ParquetFileLayout}.
-     */
-    ParquetInstructions withFileLayout(final ParquetFileLayout fileLayout) {
-        return new ReadOnly(getColumnNameToInstructionsMap(), getParquetColumnNameToInstructionsMap(),
-                getCompressionCodecName(), getMaximumDictionaryKeys(), getMaximumDictionarySize(), isLegacyParquet(),
-                getTargetPageSize(), isRefreshing(), getSpecialInstructions(), generateMetadataFiles(),
-                baseNameForPartitionedParquetData(), fileLayout, getTableDefinition());
-    }
-
     public abstract TableDefinition getTableDefinition();
 
     /**

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * This class provides instructions intended for read and write parquet operations (which take it as an optional
@@ -473,7 +473,10 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
             this.baseNameForPartitionedParquetData = baseNameForPartitionedParquetData;
             this.fileLayout = fileLayout;
             this.tableDefinition = tableDefinition;
-            this.indexColumns = indexColumns == null ? null : Collections.unmodifiableCollection(indexColumns);
+            this.indexColumns = indexColumns == null ? null
+                    : indexColumns.stream()
+                            .map(List::copyOf)
+                            .collect(Collectors.toUnmodifiableList());
         }
 
         private String getOrDefault(final String columnName, final String defaultValue,
@@ -935,7 +938,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
          */
         public Builder addIndexColumns(final String... indexColumns) {
             initIndexColumns();
-            this.indexColumns.add(Collections.unmodifiableList(Arrays.asList(indexColumns)));
+            this.indexColumns.add(List.of(indexColumns));
             return this;
         }
 
@@ -951,7 +954,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         public Builder addAllIndexColumns(final Iterable<List<String>> indexColumns) {
             initIndexColumns();
             for (final List<String> indexColumnList : indexColumns) {
-                this.indexColumns.add(Collections.unmodifiableList(indexColumnList));
+                this.indexColumns.add(List.copyOf(indexColumnList));
             }
             return this;
         }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -938,14 +938,19 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         /**
-         * Add a collection of index columns to persist. The write operation will store the index info as sidecar
-         * tables. This argument is used to narrow the set of indexes to write, or to be explicit about the expected set
-         * of indexes present on all sources. Indexes that are specified but missing will be computed on demand. To
-         * prevent the generation of index files, use an empty collection.
+         * Add a collection of index columns to persist. This operation would replace any existing index columns
+         * previously added to the builder. The provided collection should contain arrays of strings, where each array
+         * represents a group of columns to be indexed together.
+         * <p>
+         * The write operation will store the index info as sidecar tables. This argument is used to narrow the set of
+         * indexes to write, or to be explicit about the expected set of indexes present on all sources. Indexes that
+         * are specified but missing will be computed on demand. To prevent the generation of index files, use an empty
+         * collection.
          */
         public Builder setIndexColumns(final Iterable<String[]> indexColumns) {
             initIndexColumns();
             final Collection<String[]> indexColumnsCollection = this.indexColumns.get();
+            indexColumnsCollection.clear();
             indexColumns.forEach(indexColumnsCollection::add);
             return this;
         }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -5,6 +5,7 @@ package io.deephaven.parquet.table;
 
 import io.deephaven.base.verify.Require;
 import io.deephaven.configuration.Configuration;
+import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.ColumnToCodecMappings;
 import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
@@ -116,6 +117,24 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         return defaultTargetPageSize;
     }
 
+    public enum ParquetFileLayout {
+        // A single parquet file.
+        SINGLE_FILE,
+
+        // A single directory of parquet files.
+        FLAT_PARTITIONED,
+
+        // A key-value directory partitioning of parquet files.
+        KV_PARTITIONED,
+
+        // A directory containing a _metadata parquet file and an optional _common_metadata parquet file.
+        METADATA_PARTITIONED;
+    }
+
+    private static final ParquetFileLayout DEFAULT_FILE_LAYOUT = null;
+
+    private static final TableDefinition DEFAULT_TABLE_DEFINITION = null;
+
     private static final boolean DEFAULT_GENERATE_METADATA_FILES = false;
 
     static final String UUID_TOKEN = "{uuid}";
@@ -178,6 +197,9 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
      */
     public abstract boolean generateMetadataFiles();
 
+    public abstract ParquetFileLayout getFileLayout();
+
+    public abstract TableDefinition getTableDefinition();
 
     /**
      * @return the base name for partitioned parquet data. Check
@@ -270,6 +292,16 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         public String baseNameForPartitionedParquetData() {
             return DEFAULT_BASE_NAME_FOR_PARTITIONED_PARQUET_DATA;
         }
+
+        @Override
+        public ParquetFileLayout getFileLayout() {
+            return DEFAULT_FILE_LAYOUT;
+        }
+
+        @Override
+        public TableDefinition getTableDefinition() {
+            return DEFAULT_TABLE_DEFINITION;
+        }
     };
 
     private static class ColumnInstructions {
@@ -340,6 +372,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         private final Object specialInstructions;
         private final boolean generateMetadataFiles;
         private final String baseNameForPartitionedParquetData;
+        private final ParquetFileLayout fileLayout;
+        private final TableDefinition tableDefinition;
 
         private ReadOnly(
                 final KeyedObjectHashMap<String, ColumnInstructions> columnNameToInstructions,
@@ -352,7 +386,9 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
                 final boolean isRefreshing,
                 final Object specialInstructions,
                 final boolean generateMetadataFiles,
-                final String baseNameForPartitionedParquetData) {
+                final String baseNameForPartitionedParquetData,
+                final ParquetFileLayout fileLayout,
+                final TableDefinition tableDefinition) {
             this.columnNameToInstructions = columnNameToInstructions;
             this.parquetColumnNameToInstructions = parquetColumnNameToColumnName;
             this.compressionCodecName = compressionCodecName;
@@ -364,6 +400,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
             this.specialInstructions = specialInstructions;
             this.generateMetadataFiles = generateMetadataFiles;
             this.baseNameForPartitionedParquetData = baseNameForPartitionedParquetData;
+            this.fileLayout = fileLayout;
+            this.tableDefinition = tableDefinition;
         }
 
         private String getOrDefault(final String columnName, final String defaultValue,
@@ -467,6 +505,16 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
             return baseNameForPartitionedParquetData;
         }
 
+        @Override
+        public ParquetFileLayout getFileLayout() {
+            return fileLayout;
+        }
+
+        @Override
+        public TableDefinition getTableDefinition() {
+            return tableDefinition;
+        }
+
         KeyedObjectHashMap<String, ColumnInstructions> copyColumnNameToInstructions() {
             // noinspection unchecked
             return (columnNameToInstructions == null)
@@ -520,6 +568,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         private Object specialInstructions;
         private boolean generateMetadataFiles = DEFAULT_GENERATE_METADATA_FILES;
         private String baseNameForPartitionedParquetData = DEFAULT_BASE_NAME_FOR_PARTITIONED_PARQUET_DATA;
+        private ParquetFileLayout fileLayout = DEFAULT_FILE_LAYOUT;
+        private TableDefinition tableDefinition = DEFAULT_TABLE_DEFINITION;
 
         public Builder() {}
 
@@ -737,6 +787,31 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
             return this;
         }
 
+        /**
+         * Set the expected file layout when reading a parquet file or a directory. This info can be used to skip some
+         * computations to deduce the file layout from the source directory structure.
+         */
+        public Builder setFileLayout(final ParquetFileLayout fileLayout) {
+            this.fileLayout = fileLayout;
+            return this;
+        }
+
+        /**
+         * <ul>
+         * <li>When reading a parquet file, this corresponds to the table definition to use instead of the one implied
+         * by the parquet file being read. Providing a definition can help save additional computations to deduce the
+         * table definition from the parquet files as well as from the directory layouts when reading partitioned
+         * data.</li>
+         * <li>When writing a parquet file, this corresponds to the table definition to use instead of the one implied
+         * by the table being written</li>
+         * </ul>
+         * This definition can be used to skip some columns or add additional columns with {@code null} values.
+         */
+        public Builder setTableDefinition(final TableDefinition tableDefinition) {
+            this.tableDefinition = tableDefinition;
+            return this;
+        }
+
         public ParquetInstructions build() {
             final KeyedObjectHashMap<String, ColumnInstructions> columnNameToInstructionsOut = columnNameToInstructions;
             columnNameToInstructions = null;
@@ -745,7 +820,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
             parquetColumnNameToInstructions = null;
             return new ReadOnly(columnNameToInstructionsOut, parquetColumnNameToColumnNameOut, compressionCodecName,
                     maximumDictionaryKeys, maximumDictionarySize, isLegacyParquet, targetPageSize, isRefreshing,
-                    specialInstructions, generateMetadataFiles, baseNameForPartitionedParquetData);
+                    specialInstructions, generateMetadataFiles, baseNameForPartitionedParquetData, fileLayout,
+                    tableDefinition);
         }
     }
 

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -4,12 +4,25 @@
 package io.deephaven.parquet.table;
 
 import io.deephaven.UncheckedDeephavenException;
+import io.deephaven.api.util.NameValidator;
+import io.deephaven.base.ClassUtil;
+import io.deephaven.base.Pair;
+import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.stringset.StringSet;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.parquet.table.metadata.CodecInfo;
 import io.deephaven.parquet.table.metadata.ColumnTypeInfo;
 import io.deephaven.parquet.table.metadata.TableInfo;
 import io.deephaven.parquet.base.ParquetFileReader;
+import io.deephaven.util.SimpleTypeMap;
+import io.deephaven.vector.ByteVector;
+import io.deephaven.vector.CharVector;
+import io.deephaven.vector.DoubleVector;
+import io.deephaven.vector.FloatVector;
+import io.deephaven.vector.IntVector;
+import io.deephaven.vector.LongVector;
+import io.deephaven.vector.ObjectVector;
+import io.deephaven.vector.ShortVector;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import io.deephaven.util.codec.SimpleByteArrayCodec;
 import io.deephaven.util.codec.UTF8StringAsByteArrayCodec;
@@ -99,7 +112,7 @@ public class ParquetSchemaReader {
             @NotNull final ColumnDefinitionConsumer consumer,
             @NotNull final BiFunction<String, Set<String>, String> legalizeColumnNameFunc) throws IOException {
         final ParquetFileReader parquetFileReader =
-                ParquetTools.getParquetFileReaderChecked(new File(filePath), readInstructions);
+                ParquetFileReader.createChecked(new File(filePath), readInstructions.getSpecialInstructions());
         final ParquetMetadata parquetMetadata =
                 new ParquetMetadataConverter().fromParquetMetadata(parquetFileReader.fileMetaData);
         return readParquetSchema(parquetFileReader.getSchema(), parquetMetadata.getFileMetaData().getKeyValueMetaData(),
@@ -280,6 +293,92 @@ public class ParquetSchemaReader {
         return (instructionsBuilder.getValue() == null)
                 ? readInstructions
                 : instructionsBuilder.getValue().build();
+    }
+
+    /**
+     * Convert schema information from a {@link ParquetMetadata} into {@link ColumnDefinition ColumnDefinitions}.
+     *
+     * @param schema Parquet schema. DO NOT RELY ON {@link ParquetMetadataConverter} FOR THIS! USE
+     *        {@link ParquetFileReader}!
+     * @param keyValueMetadata Parquet key-value metadata map
+     * @param readInstructionsIn Input conversion {@link ParquetInstructions}
+     * @return A {@link Pair} with {@link ColumnDefinition ColumnDefinitions} and adjusted {@link ParquetInstructions}
+     */
+    public static Pair<List<ColumnDefinition<?>>, ParquetInstructions> convertSchema(
+            @NotNull final MessageType schema,
+            @NotNull final Map<String, String> keyValueMetadata,
+            @NotNull final ParquetInstructions readInstructionsIn) {
+        final ArrayList<ColumnDefinition<?>> cols = new ArrayList<>();
+        final ParquetSchemaReader.ColumnDefinitionConsumer colConsumer = makeSchemaReaderConsumer(cols);
+        return new Pair<>(cols, ParquetSchemaReader.readParquetSchema(
+                schema,
+                keyValueMetadata,
+                readInstructionsIn,
+                colConsumer,
+                (final String colName, final Set<String> takenNames) -> NameValidator.legalizeColumnName(colName,
+                        s -> s.replace(" ", "_"), takenNames)));
+    }
+
+    private static ParquetSchemaReader.ColumnDefinitionConsumer makeSchemaReaderConsumer(
+            final ArrayList<ColumnDefinition<?>> colsOut) {
+        return (final ParquetSchemaReader.ParquetMessageDefinition parquetColDef) -> {
+            Class<?> baseType;
+            if (parquetColDef.baseType == boolean.class) {
+                baseType = Boolean.class;
+            } else {
+                baseType = parquetColDef.baseType;
+            }
+            ColumnDefinition<?> colDef;
+            if (parquetColDef.codecType != null && !parquetColDef.codecType.isEmpty()) {
+                final Class<?> componentType =
+                        (parquetColDef.codecComponentType != null && !parquetColDef.codecComponentType.isEmpty())
+                                ? loadClass(parquetColDef.name, "codecComponentType", parquetColDef.codecComponentType)
+                                : null;
+                final Class<?> dataType = loadClass(parquetColDef.name, "codecType", parquetColDef.codecType);
+                colDef = ColumnDefinition.fromGenericType(parquetColDef.name, dataType, componentType);
+            } else if (parquetColDef.dhSpecialType != null) {
+                if (parquetColDef.dhSpecialType == ColumnTypeInfo.SpecialType.StringSet) {
+                    colDef = ColumnDefinition.fromGenericType(parquetColDef.name, StringSet.class, null);
+                } else if (parquetColDef.dhSpecialType == ColumnTypeInfo.SpecialType.Vector) {
+                    final Class<?> vectorType = VECTOR_TYPE_MAP.get(baseType);
+                    if (vectorType != null) {
+                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, vectorType, baseType);
+                    } else {
+                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, ObjectVector.class, baseType);
+                    }
+                } else {
+                    throw new UncheckedDeephavenException("Unhandled dbSpecialType=" + parquetColDef.dhSpecialType);
+                }
+            } else {
+                if (parquetColDef.isArray) {
+                    if (baseType == byte.class && parquetColDef.noLogicalType) {
+                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, byte[].class, byte.class);
+                    } else {
+                        // TODO: ParquetInstruction.loadAsVector
+                        final Class<?> componentType = baseType;
+                        // On Java 12, replace by: dataType = componentType.arrayType();
+                        final Class<?> dataType = java.lang.reflect.Array.newInstance(componentType, 0).getClass();
+                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, dataType, componentType);
+                    }
+                } else {
+                    colDef = ColumnDefinition.fromGenericType(parquetColDef.name, baseType, null);
+                }
+            }
+            colsOut.add(colDef);
+        };
+    }
+
+    private static final SimpleTypeMap<Class<?>> VECTOR_TYPE_MAP = SimpleTypeMap.create(
+            null, CharVector.class, ByteVector.class, ShortVector.class, IntVector.class, LongVector.class,
+            FloatVector.class, DoubleVector.class, ObjectVector.class);
+
+    private static Class<?> loadClass(final String colName, final String desc, final String className) {
+        try {
+            return ClassUtil.lookupClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new UncheckedDeephavenException(
+                    "Column " + colName + " with " + desc + "=" + className + " that can't be found in classloader");
+        }
     }
 
     private static LogicalTypeAnnotation.LogicalTypeAnnotationVisitor<Class<?>> getVisitor(

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTableWriter.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTableWriter.java
@@ -68,7 +68,7 @@ public class ParquetTableWriter {
         /**
          * Names of the indexing key columns
          */
-        final String[] indexColumnNames;
+        final List<String> indexColumnNames;
         /**
          * Parquet names of the indexing key columns
          */
@@ -85,7 +85,7 @@ public class ParquetTableWriter {
         final File destFile;
 
         IndexWritingInfo(
-                final String[] indexColumnNames,
+                final List<String> indexColumnNames,
                 final String[] parquetColumnNames,
                 final File destFileForMetadata,
                 final File destFile) {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
@@ -4,8 +4,6 @@
 package io.deephaven.parquet.table;
 
 import io.deephaven.UncheckedDeephavenException;
-import io.deephaven.api.util.NameValidator;
-import io.deephaven.base.ClassUtil;
 import io.deephaven.base.FileUtils;
 import io.deephaven.base.Pair;
 import io.deephaven.base.verify.Require;
@@ -24,11 +22,8 @@ import io.deephaven.engine.updategraph.UpdateSourceRegistrar;
 import io.deephaven.parquet.base.ParquetMetadataFileWriter;
 import io.deephaven.parquet.base.NullParquetMetadataFileWriter;
 import io.deephaven.util.SafeCloseable;
-import io.deephaven.util.channel.SeekableChannelsProvider;
-import io.deephaven.util.channel.SeekableChannelsProviderLoader;
 import io.deephaven.util.channel.SeekableChannelsProviderPlugin;
 import io.deephaven.vector.*;
-import io.deephaven.stringset.StringSet;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.PartitionAwareSourceTable;
 import io.deephaven.engine.table.impl.SimpleSourceTable;
@@ -49,14 +44,9 @@ import io.deephaven.parquet.table.layout.ParquetMetadataFileLayout;
 import io.deephaven.parquet.table.layout.ParquetSingleFileLayout;
 import io.deephaven.parquet.table.location.ParquetTableLocationFactory;
 import io.deephaven.parquet.table.location.ParquetTableLocationKey;
-import io.deephaven.parquet.table.metadata.ColumnTypeInfo;
 import io.deephaven.parquet.table.ParquetInstructions.ParquetFileLayout;
-import io.deephaven.util.SimpleTypeMap;
 import io.deephaven.util.annotations.VisibleForTesting;
-import io.deephaven.util.channel.CachedChannelProvider;
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
-import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -135,7 +125,7 @@ public class ParquetTools {
      * order) location found will be used to infer schema.
      *
      * @param source The path or URI of file or directory to examine
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return table
      * @see ParquetSingleFileLayout
      * @see ParquetMetadataFileLayout
@@ -212,7 +202,7 @@ public class ParquetTools {
      * {@link #readKeyValuePartitionedTable(File, ParquetInstructions)}.
      *
      * @param sourceFile The file or directory to examine
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return table
      * @see ParquetSingleFileLayout
      * @see ParquetMetadataFileLayout
@@ -569,8 +559,7 @@ public class ParquetTools {
      * @param sourceTable The table to partition and write
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      */
     public static void writeKeyValuePartitionedTable(@NotNull final Table sourceTable,
             @NotNull final String destinationDir,
@@ -588,8 +577,7 @@ public class ParquetTools {
      * @param sourceTable The table to partition and write
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
      *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
@@ -628,8 +616,7 @@ public class ParquetTools {
      * @param definition table definition to use (instead of the one implied by the table itself)
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @deprecated Use {@link #writeKeyValuePartitionedTable(Table, String, ParquetInstructions)} instead with
      *             {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
      */
@@ -653,8 +640,7 @@ public class ParquetTools {
      * @param definition table definition to use (instead of the one implied by the table itself)
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
      *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
@@ -683,8 +669,7 @@ public class ParquetTools {
      * @param partitionedTable The partitioned table to write
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      */
     public static void writeKeyValuePartitionedTable(@NotNull final PartitionedTable partitionedTable,
             @NotNull final String destinationDir,
@@ -701,8 +686,7 @@ public class ParquetTools {
      * @param partitionedTable The partitioned table to write
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
      *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
@@ -739,8 +723,7 @@ public class ParquetTools {
      * @param definition table definition to use (instead of the one implied by the table itself)
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @deprecated Use {@link #writeKeyValuePartitionedTable(PartitionedTable, String, ParquetInstructions)} instead
      *             with {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
      */
@@ -763,8 +746,7 @@ public class ParquetTools {
      * @param definition table definition to use (instead of the one implied by the table itself)
      * @param destinationDir The path to destination root directory to store partitioned data in nested format.
      *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
      *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
@@ -791,8 +773,7 @@ public class ParquetTools {
      * @param keyTableDefinition The definition for key columns
      * @param leafDefinition The definition for leaf parquet files to be written
      * @param destinationRoot The path to destination root directory to store partitioned data in nested format
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
      *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
@@ -973,8 +954,7 @@ public class ParquetTools {
      *
      * @param sources The tables to write
      * @param definition The common definition for all the tables to write
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @param destinations The destination paths. Any non-existing directories in the paths provided are created. If
      *        there is an error, any intermediate directories previously created are removed; note this makes this
      *        method unsafe for concurrent use.
@@ -1005,8 +985,7 @@ public class ParquetTools {
      * @param destinations The destination paths or URIs. Any non-existing directories in the paths provided are
      *        created. If there is an error, any intermediate directories previously created are removed; note this
      *        makes this method unsafe for concurrent use.
-     * @param writeInstructions Write instructions for customizations while writing, as well as provide
-     *        {@link TableDefinition}
+     * @param writeInstructions Write instructions for customizations while writing
      * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
      *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
@@ -1398,10 +1377,10 @@ public class ParquetTools {
      * {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
      *
      * @param tableLocationKey The {@link ParquetTableLocationKey location keys} to include
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return The table
      */
-    public static Table readTable(
+    private static Table readTable(
             @NotNull final ParquetTableLocationKey tableLocationKey,
             @NotNull final ParquetInstructions readInstructions) {
         if (readInstructions.isRefreshing()) {
@@ -1424,16 +1403,12 @@ public class ParquetTools {
      * Reads in a table from a single parquet file using the table definition provided through the
      * {@link ParquetInstructions}.
      *
-     * <p>
-     * Callers may prefer the simpler methods {@link #readTable(String, ParquetInstructions)} with layout provided as
-     * {@link ParquetFileLayout#SINGLE_FILE} using {@link ParquetInstructions.Builder#setFileLayout} and
-     * {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
-     *
      * @param tableLocationKey The {@link ParquetTableLocationKey location keys} to include
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return The table
      *
-     * @deprecated Use {@link #readTable(ParquetTableLocationKey, ParquetInstructions)} instead
+     * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
+     *             {@link ParquetFileLayout#SINGLE_FILE} using {@link ParquetInstructions.Builder#setFileLayout}.
      */
     @Deprecated
     public static Table readSingleFileTable(
@@ -1445,18 +1420,14 @@ public class ParquetTools {
     /**
      * Reads in a table from a single parquet file using the provided table definition.
      *
-     * <p>
-     * Callers may prefer the simpler methods {@link #readTable(String, ParquetInstructions)} with layout provided as
-     * {@link ParquetFileLayout#SINGLE_FILE} using {@link ParquetInstructions.Builder#setFileLayout} and
-     * {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
-     *
      * @param tableLocationKey The {@link ParquetTableLocationKey location keys} to include
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @param tableDefinition The table's {@link TableDefinition definition}
      * @return The table
      *
-     * @deprecated use {@link #readTable(ParquetTableLocationKey, ParquetInstructions)} instead with the table
-     *             definition provided through {@link ParquetInstructions.Builder#setTableDefinition}.
+     * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
+     *             {@link ParquetFileLayout#SINGLE_FILE} using {@link ParquetInstructions.Builder#setFileLayout} and
+     *             {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}
      */
     @Deprecated
     public static Table readSingleFileTable(
@@ -1476,7 +1447,7 @@ public class ParquetTools {
      * {@link ParquetInstructions.Builder#setFileLayout}.
      *
      * @param locationKeyFinder The source of {@link ParquetTableLocationKey location keys} to include
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return The table
      */
     public static Table readTable(
@@ -1535,7 +1506,7 @@ public class ParquetTools {
      * {@link ParquetInstructions.Builder#setFileLayout}.
      *
      * @param locationKeyFinder The source of {@link ParquetTableLocationKey location keys} to include
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return The table
      *
      * @deprecated use {@link #readTable(TableLocationKeyFinder, ParquetInstructions)} instead
@@ -1556,7 +1527,7 @@ public class ParquetTools {
      * {@link ParquetInstructions.Builder#setTableDefinition}.
      *
      * @param locationKeyFinder The source of {@link ParquetTableLocationKey location keys} to include
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @param tableDefinition The table's {@link TableDefinition definition}
      * @return The table
      *
@@ -1581,7 +1552,7 @@ public class ParquetTools {
      * {@link ParquetInstructions.Builder#setFileLayout}.
      *
      * @param locationKeyFinder The source of {@link ParquetTableLocationKey location keys} to include
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return The table
      * @deprecated use {@link #readTable(TableLocationKeyFinder, ParquetInstructions)}
      */
@@ -1600,7 +1571,7 @@ public class ParquetTools {
             throw new IllegalArgumentException(
                     "Unable to infer schema for a partitioned parquet table when there are no initial parquet files");
         }
-        final Pair<List<ColumnDefinition<?>>, ParquetInstructions> schemaInfo = convertSchema(
+        final Pair<List<ColumnDefinition<?>>, ParquetInstructions> schemaInfo = ParquetSchemaReader.convertSchema(
                 lastKey.getFileReader().getSchema(),
                 lastKey.getMetadata().getFileMetaData().getKeyValueMetaData(),
                 readInstructions);
@@ -1640,7 +1611,7 @@ public class ParquetTools {
      * Reads in a table using metadata files found in the supplied directory.
      *
      * @param directory the path for the root directory to search for .parquet files
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return The table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
      *             {@link ParquetFileLayout#METADATA_PARTITIONED} using
@@ -1657,7 +1628,7 @@ public class ParquetTools {
      * Reads in a table using metadata files found in the supplied directory.
      *
      * @param directory the path or URI for the root directory to search for .parquet files
-     * @param readInstructions Instructions for customizations while reading, as well as provide {@link TableDefinition}
+     * @param readInstructions Instructions for customizations while reading
      * @return The table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
      *             {@link ParquetFileLayout#METADATA_PARTITIONED} using
@@ -1711,8 +1682,7 @@ public class ParquetTools {
      * {@link #readKeyValuePartitionedTable(File, ParquetInstructions, TableDefinition)}.
      *
      * @param directory the root directory to search for .parquet files
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
      *             {@link ParquetFileLayout#KV_PARTITIONED} using {@link ParquetInstructions.Builder#setFileLayout}.
@@ -1732,8 +1702,7 @@ public class ParquetTools {
      * of read instructions using {@link ParquetInstructions.Builder#setTableDefinition}.
      *
      * @param directoryUri the URI for the root directory to search for .parquet files
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @return the table
      */
     private static Table readKeyValuePartitionedTable(
@@ -1757,8 +1726,7 @@ public class ParquetTools {
      * provided {@code tableDefinition}.
      *
      * @param directory the root directory to search for .parquet files
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @param tableDefinition the table definition
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
@@ -1783,8 +1751,7 @@ public class ParquetTools {
      * {@link #readFlatPartitionedTable(File, ParquetInstructions, TableDefinition)}.
      *
      * @param directory the directory to search for .parquet files
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
      *             {@link ParquetFileLayout#FLAT_PARTITIONED} using {@link ParquetInstructions.Builder#setFileLayout}.
@@ -1801,8 +1768,7 @@ public class ParquetTools {
      * definition from those files.
      *
      * @param sourceURI the path or URI for the directory to search for .parquet files
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @return the table
      * @see #readTable(TableLocationKeyFinder, ParquetInstructions)
      * @see ParquetFlatPartitionedLayout#ParquetFlatPartitionedLayout(URI, ParquetInstructions)
@@ -1819,8 +1785,7 @@ public class ParquetTools {
      * {@code tableDefinition}.
      *
      * @param directory the directory to search for .parquet files
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @param tableDefinition the table definition
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
@@ -1844,8 +1809,7 @@ public class ParquetTools {
      * {@link #readSingleFileTable(File, ParquetInstructions, TableDefinition)}.
      *
      * @param file the parquet file
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
      *             {@link ParquetFileLayout#SINGLE_FILE} using {@link ParquetInstructions.Builder#setFileLayout}.
@@ -1865,8 +1829,7 @@ public class ParquetTools {
      * {@link #readSingleFileTable(String, ParquetInstructions, TableDefinition)}.
      *
      * @param source the path or URI for the parquet file
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
      *             {@link ParquetFileLayout#SINGLE_FILE} using {@link ParquetInstructions.Builder#setFileLayout}.
@@ -1901,8 +1864,7 @@ public class ParquetTools {
      * Creates a single table via the parquet {@code file} using the provided {@code tableDefinition}.
      *
      * @param file the parquet file
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @param tableDefinition the table definition
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
@@ -1923,8 +1885,7 @@ public class ParquetTools {
      * provided can be a local file path or a URI to be resolved via the provided {@link SeekableChannelsProviderPlugin}
      *
      * @param source the path or URI for the parquet file
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
+     * @param readInstructions the instructions for customizations while reading
      * @param tableDefinition the table definition
      * @return the table
      * @deprecated Use {@link #readTable(String, ParquetInstructions)} instead with layout provided as
@@ -1940,132 +1901,6 @@ public class ParquetTools {
                 ensureTableDefinition(readInstructions, tableDefinition, true));
     }
 
-    private static final SimpleTypeMap<Class<?>> VECTOR_TYPE_MAP = SimpleTypeMap.create(
-            null, CharVector.class, ByteVector.class, ShortVector.class, IntVector.class, LongVector.class,
-            FloatVector.class, DoubleVector.class, ObjectVector.class);
-
-    private static Class<?> loadClass(final String colName, final String desc, final String className) {
-        try {
-            return ClassUtil.lookupClass(className);
-        } catch (ClassNotFoundException e) {
-            throw new UncheckedDeephavenException(
-                    "Column " + colName + " with " + desc + "=" + className + " that can't be found in classloader");
-        }
-    }
-
-    private static ParquetSchemaReader.ColumnDefinitionConsumer makeSchemaReaderConsumer(
-            final ArrayList<ColumnDefinition<?>> colsOut) {
-        return (final ParquetSchemaReader.ParquetMessageDefinition parquetColDef) -> {
-            Class<?> baseType;
-            if (parquetColDef.baseType == boolean.class) {
-                baseType = Boolean.class;
-            } else {
-                baseType = parquetColDef.baseType;
-            }
-            ColumnDefinition<?> colDef;
-            if (parquetColDef.codecType != null && !parquetColDef.codecType.isEmpty()) {
-                final Class<?> componentType =
-                        (parquetColDef.codecComponentType != null && !parquetColDef.codecComponentType.isEmpty())
-                                ? loadClass(parquetColDef.name, "codecComponentType", parquetColDef.codecComponentType)
-                                : null;
-                final Class<?> dataType = loadClass(parquetColDef.name, "codecType", parquetColDef.codecType);
-                colDef = ColumnDefinition.fromGenericType(parquetColDef.name, dataType, componentType);
-            } else if (parquetColDef.dhSpecialType != null) {
-                if (parquetColDef.dhSpecialType == ColumnTypeInfo.SpecialType.StringSet) {
-                    colDef = ColumnDefinition.fromGenericType(parquetColDef.name, StringSet.class, null);
-                } else if (parquetColDef.dhSpecialType == ColumnTypeInfo.SpecialType.Vector) {
-                    final Class<?> vectorType = VECTOR_TYPE_MAP.get(baseType);
-                    if (vectorType != null) {
-                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, vectorType, baseType);
-                    } else {
-                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, ObjectVector.class, baseType);
-                    }
-                } else {
-                    throw new UncheckedDeephavenException("Unhandled dbSpecialType=" + parquetColDef.dhSpecialType);
-                }
-            } else {
-                if (parquetColDef.isArray) {
-                    if (baseType == byte.class && parquetColDef.noLogicalType) {
-                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, byte[].class, byte.class);
-                    } else {
-                        // TODO: ParquetInstruction.loadAsVector
-                        final Class<?> componentType = baseType;
-                        // On Java 12, replace by: dataType = componentType.arrayType();
-                        final Class<?> dataType = java.lang.reflect.Array.newInstance(componentType, 0).getClass();
-                        colDef = ColumnDefinition.fromGenericType(parquetColDef.name, dataType, componentType);
-                    }
-                } else {
-                    colDef = ColumnDefinition.fromGenericType(parquetColDef.name, baseType, null);
-                }
-            }
-            colsOut.add(colDef);
-        };
-    }
-
-    /**
-     * Make a {@link ParquetFileReader} for the supplied {@link File}. Wraps {@link IOException} as
-     * {@link TableDataException}.
-     *
-     * @param parquetFile The parquet file or the parquet metadata file
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
-     * @return The new {@link ParquetFileReader}
-     */
-    public static ParquetFileReader getParquetFileReader(@NotNull final File parquetFile,
-            @NotNull final ParquetInstructions readInstructions) {
-        try {
-            return getParquetFileReaderChecked(parquetFile, readInstructions);
-        } catch (IOException e) {
-            throw new TableDataException("Failed to create Parquet file reader: " + parquetFile, e);
-        }
-    }
-
-    /**
-     * Make a {@link ParquetFileReader} for the supplied {@link URI}. Wraps {@link IOException} as
-     * {@link TableDataException}.
-     *
-     * @param parquetFileURI The URI for the parquet file or the parquet metadata file
-     * @param readInstructions the instructions for customizations while reading, as well as provide
-     *        {@link TableDefinition}
-     * @return The new {@link ParquetFileReader}
-     */
-    public static ParquetFileReader getParquetFileReader(@NotNull final URI parquetFileURI,
-            @NotNull final ParquetInstructions readInstructions) {
-        try {
-            return getParquetFileReaderChecked(parquetFileURI, readInstructions);
-        } catch (IOException e) {
-            throw new TableDataException("Failed to create Parquet file reader: " + parquetFileURI, e);
-        }
-    }
-
-    /**
-     * Make a {@link ParquetFileReader} for the supplied {@link File}.
-     *
-     * @param parquetFile The parquet file or the parquet metadata file
-     * @return The new {@link ParquetFileReader}
-     * @throws IOException if an IO exception occurs
-     */
-    public static ParquetFileReader getParquetFileReaderChecked(
-            @NotNull final File parquetFile,
-            @NotNull final ParquetInstructions readInstructions) throws IOException {
-        return getParquetFileReaderChecked(convertToURI(parquetFile, false), readInstructions);
-    }
-
-    /**
-     * Make a {@link ParquetFileReader} for the supplied {@link URI}.
-     *
-     * @param parquetFileURI The URI for the parquet file or the parquet metadata file
-     * @return The new {@link ParquetFileReader}
-     * @throws IOException if an IO exception occurs
-     */
-    public static ParquetFileReader getParquetFileReaderChecked(
-            @NotNull final URI parquetFileURI,
-            @NotNull final ParquetInstructions readInstructions) throws IOException {
-        final SeekableChannelsProvider provider = SeekableChannelsProviderLoader.getInstance().fromServiceLoader(
-                parquetFileURI, readInstructions.getSpecialInstructions());
-        return new ParquetFileReader(parquetFileURI, new CachedChannelProvider(provider, 1 << 7));
-    }
-
     @VisibleForTesting
     public static Table readParquetSchemaAndTable(
             @NotNull final File source,
@@ -2073,7 +1908,7 @@ public class ParquetTools {
             @Nullable final MutableObject<ParquetInstructions> mutableInstructionsOut) {
         final ParquetTableLocationKey tableLocationKey =
                 new ParquetTableLocationKey(source, 0, null, readInstructionsIn);
-        final Pair<List<ColumnDefinition<?>>, ParquetInstructions> schemaInfo = convertSchema(
+        final Pair<List<ColumnDefinition<?>>, ParquetInstructions> schemaInfo = ParquetSchemaReader.convertSchema(
                 tableLocationKey.getFileReader().getSchema(),
                 tableLocationKey.getMetadata().getFileMetaData().getKeyValueMetaData(),
                 readInstructionsIn);
@@ -2083,30 +1918,6 @@ public class ParquetTools {
             mutableInstructionsOut.setValue(instructionsOut);
         }
         return readTable(tableLocationKey, instructionsOut);
-    }
-
-    /**
-     * Convert schema information from a {@link ParquetMetadata} into {@link ColumnDefinition ColumnDefinitions}.
-     *
-     * @param schema Parquet schema. DO NOT RELY ON {@link ParquetMetadataConverter} FOR THIS! USE
-     *        {@link ParquetFileReader}!
-     * @param keyValueMetadata Parquet key-value metadata map
-     * @param readInstructionsIn Input conversion {@link ParquetInstructions}
-     * @return A {@link Pair} with {@link ColumnDefinition ColumnDefinitions} and adjusted {@link ParquetInstructions}
-     */
-    public static Pair<List<ColumnDefinition<?>>, ParquetInstructions> convertSchema(
-            @NotNull final MessageType schema,
-            @NotNull final Map<String, String> keyValueMetadata,
-            @NotNull final ParquetInstructions readInstructionsIn) {
-        final ArrayList<ColumnDefinition<?>> cols = new ArrayList<>();
-        final ParquetSchemaReader.ColumnDefinitionConsumer colConsumer = makeSchemaReaderConsumer(cols);
-        return new Pair<>(cols, ParquetSchemaReader.readParquetSchema(
-                schema,
-                keyValueMetadata,
-                readInstructionsIn,
-                colConsumer,
-                (final String colName, final Set<String> takenNames) -> NameValidator.legalizeColumnName(colName,
-                        s -> s.replace(" ", "_"), takenNames)));
     }
 
     public static final ParquetInstructions UNCOMPRESSED =

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
@@ -182,12 +182,6 @@ public class ParquetTools {
      * metadata file is supplied or discovered in the directory, the highest (by {@link ParquetTableLocationKey location
      * key} order) location found will be used to infer schema.
      *
-     * <p>
-     * Delegates to one of {@link #readSingleFileTable(File, ParquetInstructions)},
-     * {@link #readPartitionedTableWithMetadata(File, ParquetInstructions)},
-     * {@link #readFlatPartitionedTable(File, ParquetInstructions)}, or
-     * {@link #readKeyValuePartitionedTable(File, ParquetInstructions)}.
-     *
      * @param sourceFile The file or directory to examine
      * @return table
      * @see ParquetSingleFileLayout
@@ -402,7 +396,7 @@ public class ParquetTools {
      *         indexing column {@code "IndexingColName"}, the method will return
      *         {@code ".dh_metadata/indexes/IndexingColName/index_IndexingColName_table.parquet"} on unix systems.
      */
-    public static String getRelativeIndexFilePath(@NotNull final File tableDest, @NotNull final String[] columnNames) {
+    private static String getRelativeIndexFilePath(@NotNull final File tableDest, @NotNull final String[] columnNames) {
         final String columns = String.join(",", columnNames);
         return String.format(".dh_metadata%sindexes%s%s%sindex_%s_%s", File.separator, File.separator, columns,
                 File.separator, columns, tableDest.getName());
@@ -419,6 +413,7 @@ public class ParquetTools {
      *         grouping column {@code "GroupingColName"}, the method will return
      *         {@code "table_GroupingColName_grouping.parquet"}
      */
+    @VisibleForTesting
     public static String legacyGroupingFileName(@NotNull final File tableDest, @NotNull final String columnName) {
         final String prefix = minusParquetSuffix(tableDest.getName());
         return prefix + "_" + columnName + "_grouping.parquet";
@@ -803,8 +798,7 @@ public class ParquetTools {
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
      *        will be computed on demand.
      * @param sourceTable The optional source table, provided when user provides a merged source table to write, like in
-     *        {@link #writeKeyValuePartitionedTable(Table, String, ParquetInstructions)} and
-     *        {@link #writeKeyValuePartitionedTable(Table, TableDefinition, String, ParquetInstructions)}
+     *        {@link #writeKeyValuePartitionedTable(Table, String, ParquetInstructions)}
      */
     private static void writeKeyValuePartitionedTableImpl(@NotNull final PartitionedTable partitionedTable,
             @NotNull final TableDefinition keyTableDefinition,
@@ -1323,12 +1317,6 @@ public class ParquetTools {
      * parquet file, a metadata file, or a directory. If it's a directory, it additionally tries to guess the layout to
      * use. Unless a metadata file is supplied or discovered in the directory, the highest (by
      * {@link ParquetTableLocationKey location key} order) location found will be used to infer schema.
-     *
-     * <p>
-     * Delegates to one of {@link #readSingleFileTable(File, ParquetInstructions)},
-     * {@link #readPartitionedTableWithMetadata(File, ParquetInstructions)},
-     * {@link #readFlatPartitionedTable(File, ParquetInstructions)}, or
-     * {@link #readKeyValuePartitionedTable(File, ParquetInstructions)}.
      *
      * @param source The source URI with {@value ParquetFileReader#FILE_URI_SCHEME} scheme
      * @param instructions Instructions for reading
@@ -2147,7 +2135,7 @@ public class ParquetTools {
 
     /**
      * @deprecated Do not use this method, instead pass the above codecs as arguments to
-     *             {@link #writeTable(Table, File, ParquetInstructions)} method
+     *             {@link #writeTable(Table, String, ParquetInstructions)} method
      */
     @Deprecated
     public static void setDefaultCompressionCodecName(final String compressionCodecName) {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetTools.java
@@ -561,7 +561,8 @@ public class ParquetTools {
      *        Non-existing directories are created.
      * @param writeInstructions Write instructions for customizations while writing
      */
-    public static void writeKeyValuePartitionedTable(@NotNull final Table sourceTable,
+    public static void writeKeyValuePartitionedTable(
+            @NotNull final Table sourceTable,
             @NotNull final String destinationDir,
             @NotNull final ParquetInstructions writeInstructions) {
         writeKeyValuePartitionedTable(sourceTable, destinationDir, writeInstructions, indexedColumnNames(sourceTable));
@@ -583,7 +584,8 @@ public class ParquetTools {
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
      *        will be computed on demand.
      */
-    public static void writeKeyValuePartitionedTable(@NotNull final Table sourceTable,
+    public static void writeKeyValuePartitionedTable(
+            @NotNull final Table sourceTable,
             @NotNull final String destinationDir,
             @NotNull final ParquetInstructions writeInstructions,
             @Nullable final String[][] indexColumnArr) {
@@ -604,61 +606,6 @@ public class ParquetTools {
     }
 
     /**
-     * Write table to disk in parquet format with {@link TableDefinition#getPartitioningColumns() partitioning columns}
-     * written as "key=value" format in a nested directory structure. To generate these individual partitions, this
-     * method will call {@link Table#partitionBy(String...) partitionBy} on all the partitioning columns in the provided
-     * table definition. The generated parquet files will have names of the format provided by
-     * {@link ParquetInstructions#baseNameForPartitionedParquetData()}. Any indexing columns present on the source table
-     * will be written as sidecar tables. To write only a subset of the indexes or add additional indexes while writing,
-     * use {@link #writeKeyValuePartitionedTable(Table, TableDefinition, String, ParquetInstructions, String[][])}.
-     *
-     * @param sourceTable The table to partition and write
-     * @param definition table definition to use (instead of the one implied by the table itself)
-     * @param destinationDir The path to destination root directory to store partitioned data in nested format.
-     *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing
-     * @deprecated Use {@link #writeKeyValuePartitionedTable(Table, String, ParquetInstructions)} instead with
-     *             {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
-     */
-    @Deprecated
-    public static void writeKeyValuePartitionedTable(@NotNull final Table sourceTable,
-            @NotNull final TableDefinition definition,
-            @NotNull final String destinationDir,
-            @NotNull final ParquetInstructions writeInstructions) {
-        writeKeyValuePartitionedTable(sourceTable, destinationDir,
-                ensureTableDefinition(writeInstructions, definition, true));
-    }
-
-    /**
-     * Write table to disk in parquet format with {@link TableDefinition#getPartitioningColumns() partitioning columns}
-     * written as "key=value" format in a nested directory structure. To generate these individual partitions, this
-     * method will call {@link Table#partitionBy(String...) partitionBy} on all the partitioning columns in the provided
-     * table definition. The generated parquet files will have names of the format provided by
-     * {@link ParquetInstructions#baseNameForPartitionedParquetData()}.
-     *
-     * @param sourceTable The table to partition and write
-     * @param definition table definition to use (instead of the one implied by the table itself)
-     * @param destinationDir The path to destination root directory to store partitioned data in nested format.
-     *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing
-     * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
-     *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
-     *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
-     *        will be computed on demand.
-     * @deprecated Use {@link #writeKeyValuePartitionedTable(Table, String, ParquetInstructions, String[][])} instead
-     *             with {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
-     */
-    @Deprecated
-    public static void writeKeyValuePartitionedTable(@NotNull final Table sourceTable,
-            @NotNull final TableDefinition definition,
-            @NotNull final String destinationDir,
-            @NotNull final ParquetInstructions writeInstructions,
-            @Nullable final String[][] indexColumnArr) {
-        writeKeyValuePartitionedTable(sourceTable, destinationDir,
-                ensureTableDefinition(writeInstructions, definition, true), indexColumnArr);
-    }
-
-    /**
      * Write a partitioned table to disk in parquet format with all the {@link PartitionedTable#keyColumnNames() key
      * columns} as "key=value" format in a nested directory structure. To generate the partitioned table, users can call
      * {@link Table#partitionBy(String...) partitionBy} on the required columns. The generated parquet files will have
@@ -671,7 +618,8 @@ public class ParquetTools {
      *        Non-existing directories are created.
      * @param writeInstructions Write instructions for customizations while writing
      */
-    public static void writeKeyValuePartitionedTable(@NotNull final PartitionedTable partitionedTable,
+    public static void writeKeyValuePartitionedTable(
+            @NotNull final PartitionedTable partitionedTable,
             @NotNull final String destinationDir,
             @NotNull final ParquetInstructions writeInstructions) {
         writeKeyValuePartitionedTable(partitionedTable, destinationDir, writeInstructions, EMPTY_INDEXES);
@@ -692,7 +640,8 @@ public class ParquetTools {
      *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
      *        will be computed on demand.
      */
-    public static void writeKeyValuePartitionedTable(@NotNull final PartitionedTable partitionedTable,
+    public static void writeKeyValuePartitionedTable(
+            @NotNull final PartitionedTable partitionedTable,
             @NotNull final String destinationDir,
             @NotNull final ParquetInstructions writeInstructions,
             @Nullable final String[][] indexColumnArr) {
@@ -712,60 +661,6 @@ public class ParquetTools {
     }
 
     /**
-     * Write a partitioned table to disk in parquet format with all the {@link PartitionedTable#keyColumnNames() key
-     * columns} as "key=value" format in a nested directory structure. To generate the partitioned table, users can call
-     * {@link Table#partitionBy(String...) partitionBy} on the required columns. The generated parquet files will have
-     * names of the format provided by {@link ParquetInstructions#baseNameForPartitionedParquetData()}. This method does
-     * not write any indexes as sidecar tables to disk. To write indexes, use
-     * {@link #writeKeyValuePartitionedTable(PartitionedTable, TableDefinition, String, ParquetInstructions, String[][])}.
-     *
-     * @param partitionedTable The partitioned table to write
-     * @param definition table definition to use (instead of the one implied by the table itself)
-     * @param destinationDir The path to destination root directory to store partitioned data in nested format.
-     *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing
-     * @deprecated Use {@link #writeKeyValuePartitionedTable(PartitionedTable, String, ParquetInstructions)} instead
-     *             with {@link TableDefinition} provided through {@link ParquetInstructions.Builder#setTableDefinition}.
-     */
-    @Deprecated
-    public static void writeKeyValuePartitionedTable(@NotNull final PartitionedTable partitionedTable,
-            @NotNull final TableDefinition definition,
-            @NotNull final String destinationDir,
-            @NotNull final ParquetInstructions writeInstructions) {
-        writeKeyValuePartitionedTable(partitionedTable, destinationDir,
-                ensureTableDefinition(writeInstructions, definition, true));
-    }
-
-    /**
-     * Write a partitioned table to disk in parquet format with all the {@link PartitionedTable#keyColumnNames() key
-     * columns} as "key=value" format in a nested directory structure. To generate the partitioned table, users can call
-     * {@link Table#partitionBy(String...) partitionBy} on the required columns. The generated parquet files will have
-     * names of the format provided by {@link ParquetInstructions#baseNameForPartitionedParquetData()}.
-     *
-     * @param partitionedTable The partitioned table to write
-     * @param definition table definition to use (instead of the one implied by the table itself)
-     * @param destinationDir The path to destination root directory to store partitioned data in nested format.
-     *        Non-existing directories are created.
-     * @param writeInstructions Write instructions for customizations while writing
-     * @param indexColumnArr Arrays containing the column names for indexes to persist. The write operation will store
-     *        the index info as sidecar tables. This argument is used to narrow the set of indexes to write, or to be
-     *        explicit about the expected set of indexes present on all sources. Indexes that are specified but missing
-     *        will be computed on demand.
-     * @deprecated Use {@link #writeKeyValuePartitionedTable(PartitionedTable, String, ParquetInstructions, String[][])}
-     *             instead with {@link TableDefinition} provided through
-     *             {@link ParquetInstructions.Builder#setTableDefinition}.
-     */
-    @Deprecated
-    public static void writeKeyValuePartitionedTable(@NotNull final PartitionedTable partitionedTable,
-            @NotNull final TableDefinition definition,
-            @NotNull final String destinationDir,
-            @NotNull final ParquetInstructions writeInstructions,
-            @NotNull final String[][] indexColumnArr) {
-        writeKeyValuePartitionedTable(partitionedTable, destinationDir,
-                ensureTableDefinition(writeInstructions, definition, true), indexColumnArr);
-    }
-
-    /**
      * Write a partitioned table to disk in a key=value partitioning format with the already computed definition for the
      * key table and leaf table.
      *
@@ -781,7 +676,8 @@ public class ParquetTools {
      * @param sourceTable The optional source table, provided when user provides a merged source table to write, like in
      *        {@link #writeKeyValuePartitionedTable(Table, String, ParquetInstructions)}
      */
-    private static void writeKeyValuePartitionedTableImpl(@NotNull final PartitionedTable partitionedTable,
+    private static void writeKeyValuePartitionedTableImpl(
+            @NotNull final PartitionedTable partitionedTable,
             @NotNull final TableDefinition keyTableDefinition,
             @NotNull final TableDefinition leafDefinition,
             @NotNull final String destinationRoot,
@@ -882,7 +778,8 @@ public class ParquetTools {
      * Add data indexes to provided tables, if not present, and return a list of hard references to the indexes.
      */
     @Nullable
-    private static List<DataIndex> addIndexesToTables(@NotNull final Table[] tables,
+    private static List<DataIndex> addIndexesToTables(
+            @NotNull final Table[] tables,
             @Nullable final String[][] indexColumnArr) {
         if (indexColumnArr == null || indexColumnArr.length == 0) {
             return null;
@@ -900,7 +797,8 @@ public class ParquetTools {
      * Using the provided definition and key column names, create a sub table definition for the key columns that are
      * present in the definition.
      */
-    private static TableDefinition getKeyTableDefinition(@NotNull final Collection<String> keyColumnNames,
+    private static TableDefinition getKeyTableDefinition(
+            @NotNull final Collection<String> keyColumnNames,
             @NotNull final TableDefinition definition) {
         final Collection<ColumnDefinition<?>> keyColumnDefinitions = new ArrayList<>(keyColumnNames.size());
         for (final String keyColumnName : keyColumnNames) {
@@ -915,7 +813,8 @@ public class ParquetTools {
     /**
      * Using the provided definition and key column names, create a sub table definition for the non-key columns.
      */
-    private static TableDefinition getNonKeyTableDefinition(@NotNull final Collection<String> keyColumnNames,
+    private static TableDefinition getNonKeyTableDefinition(
+            @NotNull final Collection<String> keyColumnNames,
             @NotNull final TableDefinition definition) {
         final Collection<ColumnDefinition<?>> nonKeyColumnDefinition = definition.getColumns().stream()
                 .filter(columnDefinition -> !keyColumnNames.contains(columnDefinition.getName()))
@@ -1035,7 +934,8 @@ public class ParquetTools {
     /**
      * Refer to {@link #writeTables(Table[], String[], ParquetInstructions, String[][])} for more details.
      */
-    private static void writeTablesImpl(@NotNull final Table[] sources,
+    private static void writeTablesImpl(
+            @NotNull final Table[] sources,
             @NotNull final TableDefinition definition,
             @NotNull final ParquetInstructions writeInstructions,
             @NotNull final File[] destinations,
@@ -1564,7 +1464,8 @@ public class ParquetTools {
     }
 
     private static Pair<TableDefinition, ParquetInstructions> infer(
-            KnownLocationKeyFinder<ParquetTableLocationKey> inferenceKeys, ParquetInstructions readInstructions) {
+            KnownLocationKeyFinder<ParquetTableLocationKey> inferenceKeys,
+            ParquetInstructions readInstructions) {
         // TODO(deephaven-core#877): Support schema merge when discovering multiple parquet files
         final ParquetTableLocationKey lastKey = inferenceKeys.getLastKey().orElse(null);
         if (lastKey == null) {
@@ -1665,7 +1566,8 @@ public class ParquetTools {
                 ensureTableDefinition(layout.getInstructions(), layout.getTableDefinition(), true));
     }
 
-    private static void verifyFileLayout(@NotNull final ParquetInstructions readInstructions,
+    private static void verifyFileLayout(
+            @NotNull final ParquetInstructions readInstructions,
             @NotNull final ParquetFileLayout expectedLayout) {
         if (readInstructions.getFileLayout().isPresent() && readInstructions.getFileLayout().get() != expectedLayout) {
             throw new IllegalArgumentException("File layout provided in read instructions (=" +

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -257,8 +257,7 @@ public class ParquetTableLocation extends AbstractTableLocation {
                             getParquetKey().getURI(), Arrays.toString(columns)));
         }
         // Create a new index from the parquet table
-        final Table table = readDataIndexTable(getParquetKey().getURI(), indexFileMetaData,
-                readInstructions.withTableDefinitionAndLayout(null, ParquetInstructions.ParquetFileLayout.SINGLE_FILE));
+        final Table table = readDataIndexTable(getParquetKey().getURI(), indexFileMetaData, readInstructions);
         if (table == null) {
             return null;
         }
@@ -345,7 +344,9 @@ public class ParquetTableLocation extends AbstractTableLocation {
             @NotNull final URI parentFileURI,
             @NotNull final ParquetTableLocation.IndexFileMetadata indexFileMetaData,
             @NotNull final ParquetInstructions parquetInstructions) {
-        final Table indexTable = ParquetTools.readTable(indexFileMetaData.fileURI.toString(), parquetInstructions);
+        final Table indexTable = ParquetTools.readTable(indexFileMetaData.fileURI.toString(),
+                parquetInstructions.withTableDefinitionAndLayout(null,
+                        ParquetInstructions.ParquetFileLayout.SINGLE_FILE));
         if (indexFileMetaData.dataIndexInfo != null) {
             return indexTable;
         }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -257,7 +257,7 @@ public class ParquetTableLocation extends AbstractTableLocation {
                             getParquetKey().getURI(), Arrays.toString(columns)));
         }
         // Create a new index from the parquet table
-        final Table table = readDataIndexTable(getParquetKey().getURI(), indexFileMetaData, readInstructions);
+        final Table table = readDataIndexTable(getParquetKey().getURI(), indexFileMetaData, ParquetInstructions.EMPTY);
         if (table == null) {
             return null;
         }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -257,7 +257,8 @@ public class ParquetTableLocation extends AbstractTableLocation {
                             getParquetKey().getURI(), Arrays.toString(columns)));
         }
         // Create a new index from the parquet table
-        final Table table = readDataIndexTable(getParquetKey().getURI(), indexFileMetaData, ParquetInstructions.EMPTY);
+        final Table table = readDataIndexTable(getParquetKey().getURI(), indexFileMetaData,
+                readInstructions.withTableDefinitionAndLayout(null, ParquetInstructions.ParquetFileLayout.SINGLE_FILE));
         if (table == null) {
             return null;
         }
@@ -344,8 +345,7 @@ public class ParquetTableLocation extends AbstractTableLocation {
             @NotNull final URI parentFileURI,
             @NotNull final ParquetTableLocation.IndexFileMetadata indexFileMetaData,
             @NotNull final ParquetInstructions parquetInstructions) {
-        final Table indexTable =
-                ParquetTools.readSingleFileTable(indexFileMetaData.fileURI.toString(), parquetInstructions);
+        final Table indexTable = ParquetTools.readTable(indexFileMetaData.fileURI.toString(), parquetInstructions);
         if (indexFileMetaData.dataIndexInfo != null) {
             return indexTable;
         }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocationKey.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocationKey.java
@@ -5,7 +5,6 @@ package io.deephaven.parquet.table.location;
 
 import io.deephaven.engine.table.impl.locations.local.URITableLocationKey;
 import io.deephaven.parquet.table.ParquetInstructions;
-import io.deephaven.parquet.table.ParquetTools;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.TableLocationKey;
 import io.deephaven.parquet.base.ParquetFileReader;
@@ -102,7 +101,7 @@ public class ParquetTableLocationKey extends URITableLocationKey {
      * </ol>
      *
      * Callers wishing to handle these cases more explicit may call
-     * {@link ParquetTools#getParquetFileReaderChecked(URI, ParquetInstructions)}.
+     * {@link ParquetFileReader#createChecked(URI, Object)}.
      *
      * @return true if the file reader exists or was successfully created
      */
@@ -111,7 +110,7 @@ public class ParquetTableLocationKey extends URITableLocationKey {
             return true;
         }
         try {
-            fileReader = ParquetTools.getParquetFileReaderChecked(uri, readInstructions);
+            fileReader = ParquetFileReader.createChecked(uri, readInstructions.getSpecialInstructions());
         } catch (IOException e) {
             return false;
         }
@@ -128,7 +127,7 @@ public class ParquetTableLocationKey extends URITableLocationKey {
         if (fileReader != null) {
             return fileReader;
         }
-        return fileReader = ParquetTools.getParquetFileReader(uri, readInstructions);
+        return fileReader = ParquetFileReader.create(uri, readInstructions.getSpecialInstructions());
     }
 
     /**

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -605,7 +605,7 @@ public final class ParquetTableReadWriteTest {
         assertFalse(DataIndexer.hasDataIndex(fromDisk, "A", "B"));
 
         // Set multiple columns for indexing
-        final Collection<List<String>> indexColumns = Arrays.asList(Arrays.asList("A", "C"), List.of("C"));
+        final Collection<List<String>> indexColumns = List.of(List.of("A", "C"), List.of("C"));
         writeInstructions = ParquetInstructions.builder()
                 .addAllIndexColumns(indexColumns)
                 .build();

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -152,7 +152,7 @@ public final class ParquetTableReadWriteTest {
 
     private static Table getTableFlat(int size, boolean includeSerializable, boolean includeBigDecimal) {
         ExecutionContext.getContext().getQueryLibrary().importClass(SomeSillyTest.class);
-        ArrayList<String> columns =
+        final Collection<String> columns =
                 new ArrayList<>(Arrays.asList("someStringColumn = i % 10 == 0?null:(`` + (i % 101))",
                         "nonNullString = `` + (i % 60)",
                         "nonNullPolyString = `` + (i % 600)",
@@ -598,17 +598,16 @@ public final class ParquetTableReadWriteTest {
 
         // Clear all indexing columns
         writeInstructions = ParquetInstructions.builder()
-                .addIndexColumns("A")
-                .setIndexColumns(Collections.emptyList())
+                .addAllIndexColumns(Collections.emptyList())
                 .build();
         writeTable(source, destFile.getPath(), writeInstructions);
         fromDisk = readTable(destFile.getPath());
         assertFalse(DataIndexer.hasDataIndex(fromDisk, "A", "B"));
 
         // Set multiple columns for indexing
-        final Collection<String[]> indexColumns = Arrays.asList(new String[] {"A", "C"}, new String[] {"C"});
+        final Collection<List<String>> indexColumns = Arrays.asList(Arrays.asList("A", "C"), List.of("C"));
         writeInstructions = ParquetInstructions.builder()
-                .setIndexColumns(indexColumns)
+                .addAllIndexColumns(indexColumns)
                 .build();
         writeTable(source, destFile.getPath(), writeInstructions);
         fromDisk = readTable(destFile.getPath());
@@ -1153,7 +1152,7 @@ public final class ParquetTableReadWriteTest {
 
         // Next test passing additional indexing columns
         final String indexColumn = "NPC5";
-        final Collection<String[]> indexColumns = Collections.singleton(new String[] {indexColumn});
+        final Collection<List<String>> indexColumns = Collections.singleton(List.of(indexColumn));
         final ParquetInstructions withIndexColumns = writeInstructions.withIndexColumns(indexColumns);
         {
             writeKeyValuePartitionedTable(inputData, parentDir.getPath(), withIndexColumns);

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -549,13 +549,26 @@ public final class ParquetTableReadWriteTest {
 
         final File metadataFile = new File(rootFile, "_metadata");
         assertTrue(metadataFile.exists());
-        assertTrue(new File(rootFile, "_common_metadata").exists());
+        final File commonMetadataFile = new File(rootFile, "_common_metadata");
+        assertTrue(commonMetadataFile.exists());
 
         final Table fromDisk = readTable(destFile);
         assertTableEquals(table, fromDisk);
 
-        final Table fromDiskWithMetadata = readTable(metadataFile);
+        Table fromDiskWithMetadata = readTable(metadataFile);
         assertTableEquals(table, fromDiskWithMetadata);
+        Table fromDiskWithCommonMetadata = readTable(commonMetadataFile);
+        assertTableEquals(table, fromDiskWithCommonMetadata);
+
+        final ParquetInstructions readInstructions = ParquetInstructions.builder()
+                .setFileLayout(ParquetInstructions.ParquetFileLayout.METADATA_PARTITIONED)
+                .build();
+        fromDiskWithMetadata = readTable(metadataFile, readInstructions);
+        assertTableEquals(table, fromDiskWithMetadata);
+        fromDiskWithCommonMetadata = readTable(commonMetadataFile, readInstructions);
+        assertTableEquals(table, fromDiskWithCommonMetadata);
+
+
     }
 
     @Test

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -78,6 +78,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Collection;
@@ -1107,7 +1108,7 @@ public final class ParquetTableReadWriteTest {
 
         // Next test passing additional indexing columns
         final String indexColumn = "NPC5";
-        final String[][] indexColumns = new String[][] {{indexColumn}};
+        final Collection<String[]> indexColumns = Collections.singleton(new String[] {indexColumn});
         final ParquetInstructions withIndexColumns = writeInstructions.withIndexColumns(indexColumns);
         {
             writeKeyValuePartitionedTable(inputData, parentDir.getPath(), withIndexColumns);

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProvider.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProvider.java
@@ -38,7 +38,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static io.deephaven.base.FileUtils.DUPLICATE_SLASH_PATTERN;
+import static io.deephaven.base.FileUtils.REPEATED_URI_SEPARATOR;
+import static io.deephaven.base.FileUtils.REPEATED_URI_SEPARATOR_PATTERN;
+import static io.deephaven.base.FileUtils.URI_SEPARATOR;
 import static io.deephaven.extensions.s3.S3ChannelContext.handleS3Exception;
 import static io.deephaven.extensions.s3.S3SeekableChannelProviderPlugin.S3_URI_SCHEME;
 
@@ -208,8 +210,8 @@ final class S3SeekableChannelProvider implements SeekableChannelsProvider {
                         .filter(s3Object -> !s3Object.key().equals(directoryKey))
                         .map(s3Object -> {
                             String path = "/" + s3Object.key();
-                            if (path.contains("//")) {
-                                path = DUPLICATE_SLASH_PATTERN.matcher(path).replaceAll("/");
+                            if (path.contains(REPEATED_URI_SEPARATOR)) {
+                                path = REPEATED_URI_SEPARATOR_PATTERN.matcher(path).replaceAll(URI_SEPARATOR);
                             }
                             try {
                                 return new URI(S3_URI_SCHEME, directory.getUserInfo(), directory.getHost(),

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -14,6 +14,7 @@ import jpy
 from deephaven import DHError
 from deephaven.column import Column
 from deephaven.dtypes import DType
+from deephaven.jcompat import j_array_list
 from deephaven.table import Table, PartitionedTable
 from deephaven.experimental import s3
 
@@ -23,7 +24,6 @@ _JCompressionCodecName = jpy.get_type("org.apache.parquet.hadoop.metadata.Compre
 _JParquetInstructions = jpy.get_type("io.deephaven.parquet.table.ParquetInstructions")
 _JParquetFileLayout = jpy.get_type("io.deephaven.parquet.table.ParquetInstructions$ParquetFileLayout")
 _JTableDefinition = jpy.get_type("io.deephaven.engine.table.TableDefinition")
-_JArrayList = jpy.get_type('java.util.ArrayList')
 
 
 @dataclass
@@ -238,10 +238,7 @@ def _j_string_array(str_list: List[str]):
     return jpy.array("java.lang.String", str_list)
 
 def _j_list_of_array_of_string(str_seq_seq: Sequence[Sequence[str]]):
-    ret_list = _JArrayList(len(str_seq_seq))
-    for str_seq in str_seq_seq:
-        ret_list.add(jpy.array("java.lang.String", str_seq))
-    return ret_list
+    return j_array_list([jpy.array("java.lang.String", str_seq) for str_seq in str_seq_seq])
 
 def delete(path: str) -> None:
     """ Deletes a Parquet table on disk.

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -47,7 +47,12 @@ class ParquetFileLayout(Enum):
     """ A key-value directory partitioning of parquet files. """
 
     METADATA_PARTITIONED = 4
-    """ A directory containing a _metadata parquet file and an optional _common_metadata parquet file. """
+    """
+    Layout can be used to describe:
+        - A directory containing a METADATA_FILE_NAME parquet file and an optional COMMON_METADATA_FILE_NAME parquet file
+        - A single parquet METADATA_FILE_NAME file
+        - A single parquet COMMON_METADATA_FILE_NAME file
+    """
 
 
 def _build_parquet_instructions(

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -20,6 +20,7 @@ _JParquetTools = jpy.get_type("io.deephaven.parquet.table.ParquetTools")
 _JFile = jpy.get_type("java.io.File")
 _JCompressionCodecName = jpy.get_type("org.apache.parquet.hadoop.metadata.CompressionCodecName")
 _JParquetInstructions = jpy.get_type("io.deephaven.parquet.table.ParquetInstructions")
+_JParquetFileLayout = jpy.get_type("io.deephaven.parquet.table.ParquetInstructions$ParquetFileLayout")
 _JTableDefinition = jpy.get_type("io.deephaven.engine.table.TableDefinition")
 
 
@@ -31,6 +32,22 @@ class ColumnInstruction:
     codec_name: Optional[str] = None
     codec_args: Optional[str] = None
     use_dictionary: bool = False
+
+
+class ParquetFileLayout(Enum):
+    """ The parquet file layout. """
+
+    SINGLE_FILE = 1
+    """ A single parquet file. """
+
+    FLAT_PARTITIONED = 2
+    """ A single directory of parquet files. """
+
+    KV_PARTITIONED = 3
+    """ A key-value directory partitioning of parquet files. """
+
+    METADATA_PARTITIONED = 4
+    """ A directory containing a _metadata parquet file and an optional _common_metadata parquet file. """
 
 
 def _build_parquet_instructions(
@@ -45,6 +62,8 @@ def _build_parquet_instructions(
     force_build: bool = False,
     generate_metadata_files: Optional[bool] = None,
     base_name: Optional[str] = None,
+    file_layout: Optional[ParquetFileLayout] = None,
+    table_definition: Optional[Union[Dict[str, DType], List[Column]]] = None,
     special_instructions: Optional[s3.S3Instructions] = None,
 ):
     if not any(
@@ -59,6 +78,8 @@ def _build_parquet_instructions(
             is_refreshing,
             generate_metadata_files is not None,
             base_name is not None,
+            file_layout is not None,
+            table_definition is not None,
             special_instructions is not None
         ]
     ):
@@ -102,6 +123,12 @@ def _build_parquet_instructions(
     if base_name:
         builder.setBaseNameForPartitionedParquetData(base_name)
 
+    if file_layout is not None:
+        builder.setFileLayout(_j_file_layout(file_layout))
+
+    if table_definition is not None:
+        builder.setTableDefinition(_j_table_definition(table_definition))
+
     if special_instructions is not None:
         builder.setSpecialInstructions(special_instructions.j_object)
 
@@ -125,20 +152,18 @@ def _j_table_definition(table_definition: Union[Dict[str, DType], List[Column], 
         raise DHError(f"Unexpected table_definition type: {type(table_definition)}")
 
 
-class ParquetFileLayout(Enum):
-    """ The parquet file layout. """
-
-    SINGLE_FILE = 1
-    """ A single parquet file. """
-
-    FLAT_PARTITIONED = 2
-    """ A single directory of parquet files. """
-
-    KV_PARTITIONED = 3
-    """ A key-value directory partitioning of parquet files. """
-
-    METADATA_PARTITIONED = 4
-    """ A directory containing a _metadata parquet file and an optional _common_metadata parquet file. """
+def _j_file_layout(file_layout: Optional[ParquetFileLayout]) -> Optional[jpy.JType]:
+    if file_layout is None:
+        return None
+    elif file_layout == ParquetFileLayout.SINGLE_FILE:
+        return _JParquetFileLayout.SINGLE_FILE
+    elif file_layout == ParquetFileLayout.FLAT_PARTITIONED:
+        return _JParquetFileLayout.FLAT_PARTITIONED
+    elif file_layout == ParquetFileLayout.KV_PARTITIONED:
+        return _JParquetFileLayout.KV_PARTITIONED
+    elif file_layout == ParquetFileLayout.METADATA_PARTITIONED:
+        return _JParquetFileLayout.METADATA_PARTITIONED
+    raise DHError(f"Invalid parquet file_layout '{file_layout}'")
 
 
 def read(
@@ -183,45 +208,20 @@ def read(
             for_read=True,
             force_build=True,
             special_instructions=special_instructions,
+            file_layout=file_layout,
+            table_definition=table_definition,
         )
-        j_table_definition = _j_table_definition(table_definition)
-        if j_table_definition is not None:
-            if not file_layout:
-                raise DHError("Must provide file_layout when table_definition is set")
-            if file_layout == ParquetFileLayout.SINGLE_FILE:
-                j_table = _JParquetTools.readSingleFileTable(path, read_instructions, j_table_definition)
-            elif file_layout == ParquetFileLayout.FLAT_PARTITIONED:
-                j_table = _JParquetTools.readFlatPartitionedTable(path, read_instructions, j_table_definition)
-            elif file_layout == ParquetFileLayout.KV_PARTITIONED:
-                j_table = _JParquetTools.readKeyValuePartitionedTable(path, read_instructions, j_table_definition)
-            elif file_layout == ParquetFileLayout.METADATA_PARTITIONED:
-                raise DHError(f"file_layout={ParquetFileLayout.METADATA_PARTITIONED} with table_definition not currently supported")
-            else:
-                raise DHError(f"Invalid parquet file_layout '{file_layout}'")
-        else:
-            if not file_layout:
-                j_table = _JParquetTools.readTable(path, read_instructions)
-            elif file_layout == ParquetFileLayout.SINGLE_FILE:
-                j_table = _JParquetTools.readSingleFileTable(path, read_instructions)
-            elif file_layout == ParquetFileLayout.FLAT_PARTITIONED:
-                j_table = _JParquetTools.readFlatPartitionedTable(path, read_instructions)
-            elif file_layout == ParquetFileLayout.KV_PARTITIONED:
-                j_table = _JParquetTools.readKeyValuePartitionedTable(path, read_instructions)
-            elif file_layout == ParquetFileLayout.METADATA_PARTITIONED:
-                j_table = _JParquetTools.readPartitionedTableWithMetadata(_JFile(path), read_instructions)
-            else:
-                raise DHError(f"Invalid parquet file_layout '{file_layout}'")
-        return Table(j_table=j_table)
+        return Table(_JParquetTools.readTable(path, read_instructions))
     except Exception as e:
         raise DHError(e, "failed to read parquet data.") from e
 
 
-def _j_file_array(paths: List[str]):
-    return jpy.array("java.io.File", [_JFile(el) for el in paths])
+def _j_file_array(str_list: List[str]):
+    return jpy.array("java.io.File", [_JFile(el) for el in str_list])
 
 
-def _j_array_of_array_of_string(index_columns: Sequence[Sequence[str]]):
-    return jpy.array("[Ljava.lang.String;", [jpy.array("java.lang.String", index_cols) for index_cols in index_columns])
+def _j_array_of_array_of_string(str_seq_seq: Sequence[Sequence[str]]):
+    return jpy.array("[Ljava.lang.String;", [jpy.array("java.lang.String", str_seq) for str_seq in str_seq_seq])
 
 
 def delete(path: str) -> None:

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -46,7 +46,8 @@ class ParquetFileLayout(Enum):
     """ A single directory of parquet files. """
 
     KV_PARTITIONED = 3
-    """ A key-value directory partitioning of parquet files. """
+    """ A hierarchically partitioned directory layout of parquet files. Directory names are of the format "key=value" 
+     with keys derived from the partitioning columns. """
 
     METADATA_PARTITIONED = 4
     """
@@ -138,7 +139,7 @@ def _build_parquet_instructions(
         builder.setFileLayout(_j_file_layout(file_layout))
 
     if table_definition is not None and col_definitions is not None:
-        raise ValueError("Both table_definition and col_definitions cannot both be specified.")
+        raise ValueError("Both table_definition and col_definitions cannot be specified.")
 
     if table_definition is not None:
         builder.setTableDefinition(_j_table_definition(table_definition))
@@ -469,6 +470,7 @@ def batch_write(
     if col_definitions is not None:
         warn("col_definitions is deprecated and will be removed in a future release. Use table_definition "
              "instead.", DeprecationWarning, stacklevel=2)
+        #TODO(deephaven-core#5362): Remove col_definitions parameter
     elif table_definition is None:
         raise ValueError("Either table_definition or col_definitions must be specified.")
     try:

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -139,7 +139,7 @@ def _build_parquet_instructions(
         builder.setFileLayout(_j_file_layout(file_layout))
 
     if table_definition is not None and col_definitions is not None:
-        raise ValueError("Both table_definition and col_definitions cannot be specified.")
+        raise ValueError("table_definition and col_definitions cannot both be specified.")
 
     if table_definition is not None:
         builder.setTableDefinition(_j_table_definition(table_definition))

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -160,13 +160,13 @@ def _j_table_definition(table_definition: Union[Dict[str, DType], List[Column], 
 def _j_file_layout(file_layout: Optional[ParquetFileLayout]) -> Optional[jpy.JType]:
     if file_layout is None:
         return None
-    elif file_layout == ParquetFileLayout.SINGLE_FILE:
+    if file_layout == ParquetFileLayout.SINGLE_FILE:
         return _JParquetFileLayout.SINGLE_FILE
-    elif file_layout == ParquetFileLayout.FLAT_PARTITIONED:
+    if file_layout == ParquetFileLayout.FLAT_PARTITIONED:
         return _JParquetFileLayout.FLAT_PARTITIONED
-    elif file_layout == ParquetFileLayout.KV_PARTITIONED:
+    if file_layout == ParquetFileLayout.KV_PARTITIONED:
         return _JParquetFileLayout.KV_PARTITIONED
-    elif file_layout == ParquetFileLayout.METADATA_PARTITIONED:
+    if file_layout == ParquetFileLayout.METADATA_PARTITIONED:
         return _JParquetFileLayout.METADATA_PARTITIONED
     raise DHError(f"Invalid parquet file_layout '{file_layout}'")
 

--- a/py/server/deephaven/parquet.py
+++ b/py/server/deephaven/parquet.py
@@ -147,7 +147,7 @@ def _build_parquet_instructions(
         builder.setTableDefinition(_JTableDefinition.of([col.j_column_definition for col in col_definitions]))
 
     if index_columns:
-        builder.setIndexColumns(_j_list_of_array_of_string(index_columns))
+        builder.addAllIndexColumns(_j_list_of_list_of_string(index_columns))
 
     if special_instructions is not None:
         builder.setSpecialInstructions(special_instructions.j_object)
@@ -234,11 +234,11 @@ def read(
     except Exception as e:
         raise DHError(e, "failed to read parquet data.") from e
 
-def _j_string_array(str_list: List[str]):
-    return jpy.array("java.lang.String", str_list)
+def _j_string_array(str_seq: Sequence[str]):
+    return jpy.array("java.lang.String", str_seq)
 
-def _j_list_of_array_of_string(str_seq_seq: Sequence[Sequence[str]]):
-    return j_array_list([jpy.array("java.lang.String", str_seq) for str_seq in str_seq_seq])
+def _j_list_of_list_of_string(str_seq_seq: Sequence[Sequence[str]]):
+    return j_array_list([j_array_list(str_seq) for str_seq in str_seq_seq])
 
 def delete(path: str) -> None:
     """ Deletes a Parquet table on disk.

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -688,6 +688,17 @@ class ParquetTestCase(BaseTestCase):
         self.verify_index_files(".dh_metadata/indexes/x", expected_num_index_files=2)
         self.verify_index_files(".dh_metadata/indexes/y,z", expected_num_index_files=2)
 
+    def test_write_with_definition(self):
+        table = empty_table(3).update(
+            formulas=["a=i", "b=(double)(i/10.0)", "c=(double)(i*i)", "d=ii"]
+        )
+        write(table, "data_from_dh.parquet", table_definition={
+            "a": dtypes.int32,
+            "b": dtypes.double,
+            "c": dtypes.double
+        })
+        from_disk = read("data_from_dh.parquet")
+        self.assert_table_equals(from_disk, table.select(["a", "b", "c"]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -692,13 +692,22 @@ class ParquetTestCase(BaseTestCase):
         table = empty_table(3).update(
             formulas=["a=i", "b=(double)(i/10.0)", "c=(double)(i*i)", "d=ii"]
         )
-        write(table, "data_from_dh.parquet", table_definition={
+        table_definition = {
             "a": dtypes.int32,
             "b": dtypes.double,
-            "c": dtypes.double
-        })
+            "c": dtypes.double,
+        }
+        write(table, "data_from_dh.parquet", table_definition=table_definition)
         from_disk = read("data_from_dh.parquet")
         self.assert_table_equals(from_disk, table.select(["a", "b", "c"]))
+
+        col_definitions = from_disk.columns
+        write(table, "data_from_dh.parquet", col_definitions=col_definitions)
+        from_disk = read("data_from_dh.parquet")
+        self.assert_table_equals(from_disk, table.select(["a", "b", "c"]))
+
+        with self.assertRaises(Exception):
+            write(table, "data_from_dh.parquet", table_definition=table_definition, col_definitions=col_definitions)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -547,22 +547,14 @@ class ParquetTestCase(BaseTestCase):
             )
             self.assert_table_equals(actual, table)
 
-    def test_read_with_table_definition_no_type(self):
-        # no need to write actual file, shouldn't be reading it
-        fake_parquet = os.path.join(self.temp_dir.name, "fake.parquet")
-        with self.subTest(msg="read definition no type"):
-            with self.assertRaises(DHError) as cm:
-                read(
-                    fake_parquet,
-                    table_definition={
-                        "x": dtypes.int32,
-                        "y": dtypes.double,
-                        "z": dtypes.double,
-                    },
-                )
-            self.assertIn(
-                "Must provide file_layout when table_definition is set", str(cm.exception)
-            )
+    def test_read_with_table_definition_no_layout(self):
+        table = empty_table(3).update(
+            formulas=["x=i", "y=(double)(i/10.0)", "z=(double)(i*i)"]
+        )
+        single_parquet = os.path.join(self.temp_dir.name, "single.parquet")
+        write(table, single_parquet)
+        from_disk = read(single_parquet, table_definition={"x": dtypes.int32, "y": dtypes.double})
+        self.assert_table_equals(from_disk, table.select(["x", "y"]))
 
     def test_read_parquet_from_s3(self):
         """ Test that we can read parquet files from s3 """


### PR DESCRIPTION
Marked a number of parquet read/write APIs as `@deprecated`. These include methods that accept java `File` objects, and will be replaced by methods accepting `String` instead. 

Also, added a few new `ParquetInstruction` to replace some APIs: 
- Methods which accept a `TableDefinition`  have been deprecated and will be replaced by setting a new instruction for the definition. 
- Similarly, a new instruction for Parquet file layout has been added, which will replace APIs inside `ParquetTools` which had layout names in the method name (Ex. `readSingleFileTable` will be replaced by `readTable` with layout set as single file).
- Added a new instruction for providing index columns for writing. This will be the new default approach and older APIs have been deleted since those were not released yet.

Also, moved some public utility methods outside of ParquetTools, to prevent internal methods being exposed as APIs.

Initial work for this change was started as part of #5206, and has now been moved over to this PR.