### PR TITLE
fix: Listen to same key table as underlying table

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -33,6 +33,7 @@ import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Represents a set of Tables each corresponding to some key. The keys are available locally, but a call must be made to
@@ -75,18 +76,20 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
     @JsIgnore
     public Promise<JsPartitionedTable> refetch() {
         closeSubscriptions();
+
+        final AtomicReference<JsTable> rawKeyTable = new AtomicReference<>();
         return widget.refetch().then(w -> {
             descriptor = PartitionedTableDescriptor.deserializeBinary(w.getDataAsU8());
 
             return w.getExportedObjects()[0].fetch();
         }).then(result -> connection.newState((c, state, metadata) -> {
-            final JsTable rawKeyTable = (JsTable) result;
+            JsTable keyTable = (JsTable) result;
+            rawKeyTable.set(keyTable);
             DropColumnsRequest drop = new DropColumnsRequest();
             drop.setColumnNamesList(new String[] {descriptor.getConstituentColumnName()});
-            drop.setSourceId(rawKeyTable.state().getHandle().makeTableReference());
+            drop.setSourceId(keyTable.state().getHandle().makeTableReference());
             drop.setResultId(state.getHandle().makeTicket());
             connection.tableServiceClient().dropColumns(drop, metadata, c::apply);
-            rawKeyTable.close();
         }, "drop constituent column")
                 .refetch(this, connection.metadata())
                 .then(state -> Promise.resolve(new JsTable(connection, state)))).then(result -> {
@@ -131,6 +134,10 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
                         });
                     });
                     return subscribeToKeys();
+                }).finally_(() -> {
+                    if (rawKeyTable.get() != null) {
+                        rawKeyTable.get().close();
+                    }
                 });
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -56,6 +56,7 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
     private final JsWidget widget;
     private List<String> keyColumnTypes;
     private PartitionedTableDescriptor descriptor;
+    private JsTable rawKeyTable;
     private JsTable keys;
     private TableSubscription subscription;
 
@@ -74,58 +75,63 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
 
     @JsIgnore
     public Promise<JsPartitionedTable> refetch() {
-        if (keys != null) {
-            keys.close();
-        }
-        if (subscription != null) {
-            subscription.close();
-        }
+        closeSubscriptions();
         return widget.refetch().then(w -> {
             descriptor = PartitionedTableDescriptor.deserializeBinary(w.getDataAsU8());
 
             return w.getExportedObjects()[0].fetch();
-        }).then(result -> {
-            keys = (JsTable) result;
+        }).then(result -> connection.newState((c, state, metadata) -> {
+            rawKeyTable = (JsTable) result;
+            DropColumnsRequest drop = new DropColumnsRequest();
+            drop.setColumnNamesList(new String[] {descriptor.getConstituentColumnName()});
+            drop.setSourceId(rawKeyTable.state().getHandle().makeTableReference());
+            drop.setResultId(state.getHandle().makeTicket());
+            connection.tableServiceClient().dropColumns(drop, metadata, c::apply);
+        }, "drop constituent column")
+                .refetch(this, connection.metadata())
+                .then(state -> Promise.resolve(new JsTable(connection, state)))).then(result -> {
+                    keys = result;
 
-            keyColumnTypes = new ArrayList<>();
-            InitialTableDefinition tableDefinition = WebBarrageUtils.readTableDefinition(
-                    WebBarrageUtils.readSchemaMessage(descriptor.getConstituentDefinitionSchema_asU8()));
-            ColumnDefinition[] columnDefinitions = tableDefinition.getColumns();
-            Column[] columns = new Column[0];
-            for (int i = 0; i < columnDefinitions.length; i++) {
-                ColumnDefinition columnDefinition = columnDefinitions[i];
-                Column column = columnDefinition.makeJsColumn(columns.length, tableDefinition.getColumnsByName());
-                columns[columns.length] = column;
-            }
-            Column[] keyColumns = new Column[0];
-            JsArray<String> keyColumnNames = descriptor.getKeyColumnNamesList();
-            for (int i = 0; i < keyColumnNames.length; i++) {
-                String name = keyColumnNames.getAt(i);
-                Column keyColumn = keys.findColumn(name);
-                keyColumnTypes.add(keyColumn.getType());
-                keyColumns[keyColumns.length] = keyColumn;
-            }
-            this.columns = JsObject.freeze(columns);
-            this.keyColumns = JsObject.freeze(keyColumns);
+                    keyColumnTypes = new ArrayList<>();
+                    InitialTableDefinition tableDefinition = WebBarrageUtils.readTableDefinition(
+                            WebBarrageUtils.readSchemaMessage(descriptor.getConstituentDefinitionSchema_asU8()));
+                    ColumnDefinition[] columnDefinitions = tableDefinition.getColumns();
+                    Column[] columns = new Column[0];
+                    for (int i = 0; i < columnDefinitions.length; i++) {
+                        ColumnDefinition columnDefinition = columnDefinitions[i];
+                        Column column =
+                                columnDefinition.makeJsColumn(columns.length, tableDefinition.getColumnsByName());
+                        columns[columns.length] = column;
+                    }
+                    Column[] keyColumns = new Column[0];
+                    JsArray<String> keyColumnNames = descriptor.getKeyColumnNamesList();
+                    for (int i = 0; i < keyColumnNames.length; i++) {
+                        String name = keyColumnNames.getAt(i);
+                        Column keyColumn = keys.findColumn(name);
+                        keyColumnTypes.add(keyColumn.getType());
+                        keyColumns[keyColumns.length] = keyColumn;
+                    }
+                    this.columns = JsObject.freeze(columns);
+                    this.keyColumns = JsObject.freeze(keyColumns);
 
-            // TODO(deephaven-core#3604) in case of a new session, we should do a full refetch
-            keys.addEventListener(JsTable.EVENT_DISCONNECT, event -> fireEvent(EVENT_DISCONNECT));
-            keys.addEventListener(JsTable.EVENT_RECONNECT, event -> {
-                subscribeToKeys().then(ignore -> {
-                    unsuppressEvents();
-                    fireEvent(EVENT_RECONNECT);
-                    return null;
-                }, failure -> {
-                    CustomEventInit<Object> init = CustomEventInit.create();
-                    init.setDetail(failure);
-                    unsuppressEvents();
-                    fireEvent(EVENT_RECONNECTFAILED, init);
-                    suppressEvents();
-                    return null;
+                    // TODO(deephaven-core#3604) in case of a new session, we should do a full refetch
+                    keys.addEventListener(JsTable.EVENT_DISCONNECT, event -> fireEvent(EVENT_DISCONNECT));
+                    keys.addEventListener(JsTable.EVENT_RECONNECT, event -> {
+                        subscribeToKeys().then(ignore -> {
+                            unsuppressEvents();
+                            fireEvent(EVENT_RECONNECT);
+                            return null;
+                        }, failure -> {
+                            CustomEventInit<Object> init = CustomEventInit.create();
+                            init.setDetail(failure);
+                            unsuppressEvents();
+                            fireEvent(EVENT_RECONNECTFAILED, init);
+                            suppressEvents();
+                            return null;
+                        });
+                    });
+                    return subscribeToKeys();
                 });
-            });
-            return subscribeToKeys();
-        });
     }
 
     @Override
@@ -276,15 +282,20 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
      */
     @JsMethod
     public Promise<JsTable> getKeyTable() {
-        return connection.newState((c, state, metadata) -> {
-            DropColumnsRequest drop = new DropColumnsRequest();
-            drop.setColumnNamesList(new String[] {descriptor.getConstituentColumnName()});
-            drop.setSourceId(keys.state().getHandle().makeTableReference());
-            drop.setResultId(state.getHandle().makeTicket());
-            connection.tableServiceClient().dropColumns(drop, metadata, c::apply);
-        }, "drop constituent column")
-                .refetch(this, connection.metadata())
-                .then(state -> Promise.resolve(new JsTable(connection, state)));
+        return keys.copy();
+    }
+
+    /** Close any subscriptions to underlying tables or key tables */
+    private void closeSubscriptions() {
+        if (rawKeyTable != null) {
+            rawKeyTable.close();
+        }
+        if (keys != null) {
+            keys.close();
+        }
+        if (subscription != null) {
+            subscription.close();
+        }
     }
 
     /**
@@ -292,12 +303,7 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
      * will not affect tables in use.
      */
     public void close() {
-        if (keys != null) {
-            keys.close();
-        }
-        if (subscription != null) {
-            subscription.close();
-        }
+        closeSubscriptions();
 
         widget.close();
     }


### PR DESCRIPTION
- Was originally just listening to the raw keys table, whereas the test was listening to the table returned from `getKeyTable()` and there was a race where the latter would receive the `UPDATED` event before the former
- Instead, drop the columns right away, then just return a copy of the table when `.getKeyTable()` is called
- Previously was intermittent, example failure: https://github.com/deephaven/deephaven-core/actions/runs/8684185313/job/23811346964#step:9:12715