### PR TITLE
Fix inconsistencies in aggregations and query library functions.

### DIFF
--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1478,21 +1478,22 @@ public class Numeric {
      * @param values values.
      * @return sum of non-null values.
      */
-    public static ${pt.primitive} sum(${pt.vector} values) {
+    <#if pt.valueType.isFloat >
+    public static double sum(${pt.vector} values) {
         if (values == null) {
-            return ${pt.null};
+            return NULL_DOUBLE;
         }
 
-        ${pt.primitive} sum = 0;
+        double sum = 0;
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
             while ( vi.hasNext() ) {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
-    <#if pt.valueType.isFloat >
+
                 if (isNaN(c)) {
                     return ${pt.boxed}.NaN;
                 }
-    </#if>
+
                 if (!isNull(c)) {
                     sum += c;
                 }
@@ -1501,6 +1502,27 @@ public class Numeric {
 
         return sum;
     }
+    <#else>
+    public static long sum(${pt.vector} values) {
+        if (values == null) {
+            return NULL_LONG;
+        }
+
+        long sum = 0;
+
+        try ( final ${pt.vectorIterator} vi = values.iterator() ) {
+            while ( vi.hasNext() ) {
+                final ${pt.primitive} c = vi.${pt.iteratorNext}();
+
+                if (!isNull(c)) {
+                    sum += c;
+                }
+            }
+        }
+
+        return sum;
+    }
+    </#if>
 
     /**
      * Returns the sum.  Null values are excluded.
@@ -1508,13 +1530,23 @@ public class Numeric {
      * @param values values.
      * @return sum of non-null values.
      */
-    public static ${pt.primitive} sum(${pt.primitive}... values) {
+    <#if pt.valueType.isFloat >
+    public static double sum(${pt.primitive}... values) {
         if (values == null) {
-            return ${pt.null};
+            return NULL_DOUBLE;
         }
 
         return sum(new ${pt.vectorDirect}(values));
     }
+    <#else>
+    public static long sum(${pt.primitive}... values) {
+        if (values == null) {
+            return NULL_LONG;
+        }
+
+        return sum(new ${pt.vectorDirect}(values));
+    }
+    </#if>
 
     /**
      * Returns the product.  Null values are excluded.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1968,7 +1968,7 @@ public class Numeric {
             while (vi.hasNext()) {
                 final ${pt.primitive} v = vi.${pt.iteratorNext}();
 
-                if (isNaN(v)) {
+                if (isNaN(v) || isNaN(result[i - 1]) {
                     Arrays.fill(result, i, n, Double.NaN);
                     return result;
                 } else if (isNull(result[i - 1])) {
@@ -2553,6 +2553,10 @@ public class Numeric {
             while (vi.hasNext()) {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
                 final ${pt2.primitive} w = wi.${pt2.iteratorNext}();
+
+                if (isNaN(vsum)) {
+                    return Double.NaN;
+                }
 
                <#if pt.valueType.isFloat >
                 if (isNaN(c)) {

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1569,7 +1569,7 @@ public class Numeric {
             while ( vi.hasNext() ) {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
 
-                if (isNaN(c) || isNaN(prod)) {
+                if (isNaN(c)) {
                     return Double.NaN;
                 } else if (Double.isInfinite(c)) {
                     if (hasZero) {
@@ -1624,7 +1624,7 @@ public class Numeric {
             return NULL_LONG;
         }
 
-        return (${pt.primitive}) (prod);
+        return prod;
     }
     </#if>
 

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1968,7 +1968,7 @@ public class Numeric {
             while (vi.hasNext()) {
                 final ${pt.primitive} v = vi.${pt.iteratorNext}();
 
-                if (isNaN(v) || isNaN(result[i - 1]) {
+                if (isNaN(v) || isNaN(result[i - 1])) {
                     Arrays.fill(result, i, n, Double.NaN);
                     return result;
                 } else if (isNull(result[i - 1])) {

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1562,8 +1562,8 @@ public class Numeric {
 
         double prod = 1;
         int count = 0;
-        long zeroCount = 0;
-        long infCount = 0;
+        boolean hasZero = false;
+        boolean hasInf = false;
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
             while ( vi.hasNext() ) {
@@ -1572,15 +1572,15 @@ public class Numeric {
                 if (isNaN(c)) {
                     return Double.NaN;
                 } else if (Double.isInfinite(c)) {
-                    if (zeroCount > 0) {
+                    if (hasZero) {
                         return Double.NaN;
                     }
-                    infCount++;
+                    hasInf = true;
                 } else if (c == 0) {
-                    if (infCount > 0) {
+                    if (hasInf) {
                         return Double.NaN;
                     }
-                    zeroCount++;
+                    hasZero = true;
                 }
 
                 if (!isNull(c)) {
@@ -1594,7 +1594,7 @@ public class Numeric {
             return NULL_DOUBLE;
         }
 
-        return zeroCount > 0 ? 0 : prod;
+        return hasZero ? 0 : prod;
     }
     <#else>
     public static long product(${pt.vector} values) {
@@ -1846,8 +1846,11 @@ public class Numeric {
     
             while (vi.hasNext()) {
                 final ${pt.primitive} v = vi.${pt.iteratorNext}();
-    
-                if (isNull(result[i - 1])) {
+
+                if (isNaN(v)) {
+                    Arrays.fill(result, i, n, Double.NaN);
+                    return result;
+                } else if (isNull(result[i - 1])) {
                     result[i] = v;
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
@@ -1964,8 +1967,11 @@ public class Numeric {
     
             while (vi.hasNext()) {
                 final ${pt.primitive} v = vi.${pt.iteratorNext}();
-    
-                if (isNull(result[i - 1])) {
+
+                if (isNaN(v)) {
+                    Arrays.fill(result, i, n, Double.NaN);
+                    return result;
+                } else if (isNull(result[i - 1])) {
                     result[i] = v;
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
@@ -2519,7 +2525,7 @@ public class Numeric {
                 final ${pt2.primitive} w = wi.${pt2.iteratorNext}();
 
                 if (!isNull(c) && !isNull(w)) {
-                    vsum += c * w;
+                    vsum += c * (long) w;
                 }
             }
         }
@@ -2547,15 +2553,25 @@ public class Numeric {
             while (vi.hasNext()) {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
                 final ${pt2.primitive} w = wi.${pt2.iteratorNext}();
+
+               <#if pt.valueType.isFloat >
                 if (isNaN(c)) {
                     return Double.NaN;
                 }
+               </#if>
+
+               <#if pt2.valueType.isFloat >
                 if (isNaN(w)) {
                     return Double.NaN;
                 }
+               </#if>
 
                 if (!isNull(c) && !isNull(w)) {
-                    vsum += c * w;
+                   <#if pt.valueType.isFloat >
+                    vsum += (double) c * w;
+                   <#else>
+                    vsum += c * (double) w;
+                   </#if>>
                 }
             }
         }

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -2571,7 +2571,7 @@ public class Numeric {
                     vsum += (double) c * w;
                    <#else>
                     vsum += c * (double) w;
-                   </#if>>
+                   </#if>
                 }
             }
         }

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1786,9 +1786,15 @@ public class Numeric {
      * @param values values.
      * @return cumulative sum of non-null values.
      */
-    public static ${pt.primitive}[] cumsum(${pt.boxed}[] values) {
+    <#if pt.valueType.isFloat >
+    public static double[] cumsum(${pt.boxed}[] values) {
         return cumsum(unbox(values));
     }
+   <#else>
+    public static long[] cumsum(${pt.boxed}[] values) {
+        return cumsum(unbox(values));
+    }
+   </#if>
 
     /**
      * Returns the cumulative sum.  Null values are excluded.
@@ -1796,13 +1802,23 @@ public class Numeric {
      * @param values values.
      * @return cumulative sum of non-null values.
      */
-    public static ${pt.primitive}[] cumsum(${pt.primitive}... values) {
+    <#if pt.valueType.isFloat >
+    public static double[] cumsum(${pt.primitive}... values) {
         if (values == null) {
             return null;
         }
 
         return cumsum(new ${pt.vectorDirect}(values));
     }
+   <#else>
+    public static long[] cumsum(${pt.primitive}... values) {
+        if (values == null) {
+            return null;
+        }
+
+        return cumsum(new ${pt.vectorDirect}(values));
+    }
+   </#if>
 
     /**
      * Returns the cumulative sum.  Null values are excluded.
@@ -1810,20 +1826,22 @@ public class Numeric {
      * @param values values.
      * @return cumulative sum of non-null values.
      */
-    public static ${pt.primitive}[] cumsum(${pt.vector} values) {
+    <#if pt.valueType.isFloat >
+    public static double[] cumsum(${pt.vector} values) {
         if (values == null) {
             return null;
         }
 
         if (values.isEmpty()) {
-            return new ${pt.primitive}[0];
+            return new double[0];
         }
 
         final int n = values.intSize("cumsum");
-        ${pt.primitive}[] result = new ${pt.primitive}[n];
+        final double[] result = new double[n];
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
-            result[0] = vi.${pt.iteratorNext}();
+            final ${pt.primitive} v0 = vi.${pt.iteratorNext}();
+            result[0] = isNull(v0) ? NULL_DOUBLE : v0;
             int i = 1;
     
             while (vi.hasNext()) {
@@ -1834,7 +1852,7 @@ public class Numeric {
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
                 } else {
-                    result[i] = (${pt.primitive}) (result[i - 1] + v);
+                    result[i] = (double) (result[i - 1] + v);
                 }
     
                 i++;
@@ -1843,6 +1861,42 @@ public class Numeric {
 
         return result;
     }
+    <#else>
+    public static long[] cumsum(${pt.vector} values) {
+        if (values == null) {
+            return null;
+        }
+
+        if (values.isEmpty()) {
+            return new long[0];
+        }
+
+        final int n = values.intSize("cumsum");
+        final long[] result = new long[n];
+
+        try ( final ${pt.vectorIterator} vi = values.iterator() ) {
+            final ${pt.primitive} v0 = vi.${pt.iteratorNext}();
+            result[0] = isNull(v0) ? NULL_LONG : v0;
+            int i = 1;
+
+            while (vi.hasNext()) {
+                final ${pt.primitive} v = vi.${pt.iteratorNext}();
+
+                if (isNull(result[i - 1])) {
+                    result[i] = v;
+                } else if (isNull(v)) {
+                    result[i] = result[i - 1];
+                } else {
+                    result[i] = (long) (result[i - 1] + v);
+                }
+
+                i++;
+            }
+        }
+
+        return result;
+    }
+    </#if>
 
     /**
      * Returns the cumulative product.  Null values are excluded.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1240,9 +1240,9 @@ public class Numeric {
      * @param values values.
      * @return percentile, or null value in the Deephaven convention if values is null or empty.
      */
-    public static double percentile(double percentile, ${pt.primitive}... values) {
+    public static ${pt.primitive} percentile(double percentile, ${pt.primitive}... values) {
         if (values == null || values.length == 0) {
-            return NULL_DOUBLE;
+            return ${pt.null};
         }
 
         return percentile(percentile, new ${pt.vectorDirect}(values));
@@ -1255,9 +1255,9 @@ public class Numeric {
      * @param values values.
      * @return percentile, or null value in the Deephaven convention if values is null or empty.
      */
-    public static double percentile(double percentile, ${pt.vector} values) {
+    public static ${pt.primitive} percentile(double percentile, ${pt.vector} values) {
         if (values == null || values.isEmpty()) {
-            return NULL_DOUBLE;
+            return ${pt.null};
         }
 
         if (percentile < 0 || percentile > 1) {
@@ -1483,7 +1483,7 @@ public class Numeric {
             return ${pt.null};
         }
 
-        double sum = 0;
+        ${pt.primitive} sum = 0;
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
             while ( vi.hasNext() ) {
@@ -1499,7 +1499,7 @@ public class Numeric {
             }
         }
 
-        return (${pt.primitive}) (sum);
+        return sum;
     }
 
     /**

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -2421,13 +2421,23 @@ public class Numeric {
      * @param weights weights
      * @return weighted sum of non-null values.
      */
-    public static double wsum(${pt.primitive}[] values, ${pt2.primitive}[] weights) {
+   <#if pt.valueType.isInteger && pt2.valueType.isInteger >
+   public static long wsum(${pt.primitive}[] values, ${pt2.primitive}[] weights) {
+        if (values == null || weights == null) {
+            return NULL_LONG;
+        }
+
+        return wsum(new ${pt.vectorDirect}(values), new ${pt2.vector}Direct(weights));
+   }
+   <#else>
+   public static double wsum(${pt.primitive}[] values, ${pt2.primitive}[] weights) {
         if (values == null || weights == null) {
             return NULL_DOUBLE;
         }
 
         return wsum(new ${pt.vectorDirect}(values), new ${pt2.vector}Direct(weights));
     }
+    </#if>
 
     /**
      * Returns the weighted sum.  Null values are excluded.
@@ -2436,6 +2446,15 @@ public class Numeric {
      * @param weights weights
      * @return weighted sum of non-null values.
      */
+   <#if pt.valueType.isInteger && pt2.valueType.isInteger >
+    public static long wsum(${pt.primitive}[] values, ${pt2.vector} weights) {
+        if (values == null || weights == null) {
+            return NULL_LONG;
+        }
+
+        return wsum(new ${pt.vectorDirect}(values), weights);
+    }
+   <#else>
     public static double wsum(${pt.primitive}[] values, ${pt2.vector} weights) {
         if (values == null || weights == null) {
             return NULL_DOUBLE;
@@ -2443,6 +2462,7 @@ public class Numeric {
 
         return wsum(new ${pt.vectorDirect}(values), weights);
     }
+   </#if>
 
     /**
      * Returns the weighted sum.  Null values are excluded.
@@ -2451,6 +2471,15 @@ public class Numeric {
      * @param weights weights
      * @return weighted sum of non-null values.
      */
+   <#if pt.valueType.isInteger && pt2.valueType.isInteger >
+    public static long wsum(${pt.vector} values, ${pt2.primitive}[] weights) {
+        if (values == null || weights == null) {
+            return NULL_LONG;
+        }
+
+        return wsum(values, new ${pt2.vector}Direct(weights));
+    }
+    <#else>
     public static double wsum(${pt.vector} values, ${pt2.primitive}[] weights) {
         if (values == null || weights == null) {
             return NULL_DOUBLE;
@@ -2458,6 +2487,7 @@ public class Numeric {
 
         return wsum(values, new ${pt2.vector}Direct(weights));
     }
+    </#if>
 
     /**
      * Returns the weighted sum.  Null values are excluded.
@@ -2466,6 +2496,37 @@ public class Numeric {
      * @param weights weights
      * @return weighted sum of non-null values.
      */
+   <#if pt.valueType.isInteger && pt2.valueType.isInteger >
+    public static long wsum(${pt.vector} values, ${pt2.vector} weights) {
+        if (values == null || weights == null) {
+            return NULL_LONG;
+        }
+
+        final long n = values.size();
+
+        if (n != weights.size()) {
+            throw new IllegalArgumentException("Incompatible input sizes: " + values.size() + ", " + weights.size());
+        }
+
+        long vsum = 0;
+
+        try (
+            final ${pt.vectorIterator} vi = values.iterator();
+            final ${pt2.vectorIterator} wi = weights.iterator()
+        ) {
+            while (vi.hasNext()) {
+                final ${pt.primitive} c = vi.${pt.iteratorNext}();
+                final ${pt2.primitive} w = wi.${pt2.iteratorNext}();
+
+                if (!isNull(c) && !isNull(w)) {
+                    vsum += c * w;
+                }
+            }
+        }
+
+        return vsum;
+    }
+    <#else>
     public static double wsum(${pt.vector} values, ${pt2.vector} weights) {
         if (values == null || weights == null) {
             return NULL_DOUBLE;
@@ -2501,6 +2562,7 @@ public class Numeric {
 
         return vsum;
     }
+    </#if>
 
     /**
      * Returns the weighted average.  Null values are excluded.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1491,7 +1491,7 @@ public class Numeric {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
 
                 if (isNaN(c)) {
-                    return ${pt.boxed}.NaN;
+                    return Double.NaN;
                 }
 
                 if (!isNull(c)) {
@@ -1554,40 +1554,35 @@ public class Numeric {
      * @param values values.
      * @return product of non-null values.
      */
-    public static ${pt.primitive} product(${pt.vector} values) {
+    <#if pt.valueType.isFloat >
+    public static double product(${pt.vector} values) {
         if (values == null) {
-            return ${pt.null};
+            return NULL_DOUBLE;
         }
 
-        ${pt.primitive} prod = 1;
+        double prod = 1;
         int count = 0;
-    <#if pt.valueType.isFloat >
         long zeroCount = 0;
         long infCount = 0;
-    </#if>
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
             while ( vi.hasNext() ) {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
-    <#if pt.valueType.isFloat >
+
                 if (isNaN(c)) {
-                    return ${pt.boxed}.NaN;
+                    return Double.NaN;
                 } else if (Double.isInfinite(c)) {
                     if (zeroCount > 0) {
-                        return ${pt.boxed}.NaN;
+                        return Double.NaN;
                     }
                     infCount++;
                 } else if (c == 0) {
                     if (infCount > 0) {
-                        return ${pt.boxed}.NaN;
+                        return Double.NaN;
                     }
                     zeroCount++;
                 }
-    <#else>
-                if (c == 0) {
-                    return 0;
-                }
-    </#if>
+
                 if (!isNull(c)) {
                     count++;
                     prod *= c;
@@ -1596,15 +1591,42 @@ public class Numeric {
         }
 
         if (count == 0) {
-            return ${pt.null};
+            return NULL_DOUBLE;
         }
 
-    <#if pt.valueType.isFloat >
-        return zeroCount > 0 ? 0 : (${pt.primitive}) (prod);
-    <#else>
-        return (${pt.primitive}) (prod);
-    </#if>
+        return zeroCount > 0 ? 0 : prod;
     }
+    <#else>
+    public static long product(${pt.vector} values) {
+        if (values == null) {
+            return NULL_LONG;
+        }
+
+        long prod = 1;
+        int count = 0;
+
+        try ( final ${pt.vectorIterator} vi = values.iterator() ) {
+            while ( vi.hasNext() ) {
+                final ${pt.primitive} c = vi.${pt.iteratorNext}();
+
+                if (c == 0) {
+                    return 0;
+                }
+
+                if (!isNull(c)) {
+                    count++;
+                    prod *= c;
+                }
+            }
+        }
+
+        if (count == 0) {
+            return NULL_LONG;
+        }
+
+        return (${pt.primitive}) (prod);
+    }
+    </#if>
 
     /**
      * Returns the product.  Null values are excluded.
@@ -1612,13 +1634,23 @@ public class Numeric {
      * @param values values.
      * @return product of non-null values.
      */
-    public static ${pt.primitive} product(${pt.primitive}... values) {
+    <#if pt.valueType.isFloat >
+    public static double product(${pt.primitive}... values) {
         if (values == null) {
-            return ${pt.null};
+            return NULL_DOUBLE;
         }
 
         return product(new ${pt.vectorDirect}(values));
     }
+    <#else>
+    public static long product(${pt.primitive}... values) {
+        if (values == null) {
+            return NULL_LONG;
+        }
+
+        return product(new ${pt.vectorDirect}(values));
+    }
+    </#if>
 
     /**
      * Returns the cumulative minimum.  Null values are excluded.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1490,7 +1490,7 @@ public class Numeric {
             while ( vi.hasNext() ) {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
 
-                if (isNaN(c)) {
+                if (isNaN(c) || isNaN(sum)) {
                     return Double.NaN;
                 }
 
@@ -1569,7 +1569,7 @@ public class Numeric {
             while ( vi.hasNext() ) {
                 final ${pt.primitive} c = vi.${pt.iteratorNext}();
 
-                if (isNaN(c)) {
+                if (isNaN(c) || isNaN(prod)) {
                     return Double.NaN;
                 } else if (Double.isInfinite(c)) {
                     if (hasZero) {
@@ -1847,7 +1847,7 @@ public class Numeric {
             while (vi.hasNext()) {
                 final ${pt.primitive} v = vi.${pt.iteratorNext}();
 
-                if (isNaN(v)) {
+                if (isNaN(v) || isNaN(result[i - 1])) {
                     Arrays.fill(result, i, n, Double.NaN);
                     return result;
                 } else if (isNull(result[i - 1])) {
@@ -1855,7 +1855,7 @@ public class Numeric {
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
                 } else {
-                    result[i] = (double) (result[i - 1] + v);
+                    result[i] = result[i - 1] + v;
                 }
     
                 i++;
@@ -1890,7 +1890,7 @@ public class Numeric {
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
                 } else {
-                    result[i] = (long) (result[i - 1] + v);
+                    result[i] = result[i - 1] + v;
                 }
 
                 i++;
@@ -1976,7 +1976,7 @@ public class Numeric {
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
                 } else {
-                    result[i] = (double) (result[i - 1] * v);
+                    result[i] = result[i - 1] * v;
                 }
     
                 i++;
@@ -2011,7 +2011,7 @@ public class Numeric {
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
                 } else {
-                    result[i] = (long) (result[i - 1] * v);
+                    result[i] = result[i - 1] * v;
                 }
 
                 i++;

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1904,9 +1904,15 @@ public class Numeric {
      * @param values values.
      * @return cumulative product of non-null values.
      */
-    public static ${pt.primitive}[] cumprod(${pt.boxed}[] values) {
+    <#if pt.valueType.isFloat >
+    public static double[] cumprod(${pt.boxed}[] values) {
         return cumprod(unbox(values));
     }
+    <#else>
+    public static long[] cumprod(${pt.boxed}[] values) {
+        return cumprod(unbox(values));
+    }
+    </#if>
 
     /**
      * Returns the cumulative product.  Null values are excluded.
@@ -1914,13 +1920,23 @@ public class Numeric {
      * @param values values.
      * @return cumulative product of non-null values.
      */
-    public static ${pt.primitive}[] cumprod(${pt.primitive}... values) {
+    <#if pt.valueType.isFloat >
+    public static double[] cumprod(${pt.primitive}... values) {
         if (values == null) {
             return null;
         }
 
         return cumprod(new ${pt.vectorDirect}(values));
     }
+    <#else>
+    public static long[] cumprod(${pt.primitive}... values) {
+        if (values == null) {
+            return null;
+        }
+
+        return cumprod(new ${pt.vectorDirect}(values));
+    }
+    </#if>
 
     /**
      * Returns the cumulative product.  Null values are excluded.
@@ -1928,20 +1944,22 @@ public class Numeric {
      * @param values values.
      * @return cumulative product of non-null values.
      */
-    public static ${pt.primitive}[] cumprod(${pt.vector} values) {
+    <#if pt.valueType.isFloat >
+    public static double[] cumprod(${pt.vector} values) {
         if (values == null) {
             return null;
         }
 
         if (values.isEmpty()) {
-            return new ${pt.primitive}[0];
+            return new double[0];
         }
 
         final int n = values.intSize("cumprod");
-        ${pt.primitive}[] result = new ${pt.primitive}[n];
+        double[] result = new double[n];
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
-            result[0] = vi.${pt.iteratorNext}();
+            final ${pt.primitive} v0 = vi.${pt.iteratorNext}();
+            result[0] = isNull(v0) ? NULL_DOUBLE : v0;
             int i = 1;
     
             while (vi.hasNext()) {
@@ -1952,7 +1970,7 @@ public class Numeric {
                 } else if (isNull(v)) {
                     result[i] = result[i - 1];
                 } else {
-                    result[i] = (${pt.primitive}) (result[i - 1] * v);
+                    result[i] = (double) (result[i - 1] * v);
                 }
     
                 i++;
@@ -1961,6 +1979,42 @@ public class Numeric {
 
         return result;
     }
+    <#else>
+    public static long[] cumprod(${pt.vector} values) {
+        if (values == null) {
+            return null;
+        }
+
+        if (values.isEmpty()) {
+            return new long[0];
+        }
+
+        final int n = values.intSize("cumprod");
+        long[] result = new long[n];
+
+        try ( final ${pt.vectorIterator} vi = values.iterator() ) {
+            final ${pt.primitive} v0 = vi.${pt.iteratorNext}();
+            result[0] = isNull(v0) ? NULL_LONG : v0;
+            int i = 1;
+
+            while (vi.hasNext()) {
+                final ${pt.primitive} v = vi.${pt.iteratorNext}();
+
+                if (isNull(result[i - 1])) {
+                    result[i] = v;
+                } else if (isNull(v)) {
+                    result[i] = result[i - 1];
+                } else {
+                    result[i] = (long) (result[i - 1] * v);
+                }
+
+                i++;
+            }
+        }
+
+        return result;
+    }
+    </#if>
 
     /**
      * Returns the absolute value.

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -619,8 +619,10 @@ public class TestNumeric extends BaseArrayTestCase {
     public void test${pt.boxed}Product() {
         <#if pt.valueType.isFloat >
         final double nullResult = NULL_DOUBLE;
+        final double zeroValue = 0.0;
         <#else>
         final long nullResult = NULL_LONG;
+        final long zeroValue = 0;
         </#if>
 
         assertTrue(Math.abs(120 - product(new ${pt.primitive}[]{4, 5, 6})) == 0.0);
@@ -628,12 +630,14 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(nullResult, product(new ${pt.primitive}[]{${pt.null}}));
         assertTrue(Math.abs(75 - product(new ${pt.primitive}[]{5, ${pt.null}, 15})) == 0.0);
         assertEquals(nullResult, product((${pt.primitive}[]) null));
+        assertEquals(zeroValue, product(new ${pt.primitive}[]{4, 0, 5, 6}));
 
         assertTrue(Math.abs(120 - product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, 5, 6}))) == 0.0);
         assertEquals(nullResult, product(new ${pt.vectorDirect}()));
         assertEquals(nullResult, product(new ${pt.vectorDirect}(${pt.null})));
         assertTrue(Math.abs(75 - product(new ${pt.vectorDirect}(new ${pt.primitive}[]{5, ${pt.null}, 15}))) == 0.0);
         assertEquals(nullResult, product((${pt.vector}) null));
+        assertEquals(zeroValue, product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, 0, 5, 6})));
     }
 
 <#if pt.valueType.isFloat >
@@ -795,12 +799,14 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(new double[0], cumprod(new ${pt.primitive}[0]));
         assertEquals(new double[0], cumprod(new ${pt.boxed}[0]));
         assertEquals(null, cumprod((${pt.primitive}[]) null));
+        assertEquals(new double[]{1, Double.NaN, Double.NaN, Double.NaN, Double.NaN}, cumprod(new ${pt.primitive}[]{1, Float.NaN, 3, 4, 5}));
 
         assertEquals(new double[]{1, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, 4, 5})));
         assertEquals(new double[]{1, 2, 6, 6, 30}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5})));
         assertEquals(new double[]{NULL_DOUBLE, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5})));
         assertEquals(new double[0], cumprod(new ${pt.vectorDirect}()));
         assertEquals(null, cumprod((${pt.vector}) null));
+        assertEquals(new double[]{1, Double.NaN, Double.NaN, Double.NaN, Double.NaN}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, Float.NaN, 3, 4, 5})));
 
         // check that functions can be resolved with varargs
         assertEquals(new double[]{1, 2, 6, 24, 120}, cumprod((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
@@ -1103,6 +1109,14 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(1.0*4.0+2.0*5.0+3.0*6.0, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,${pt2.null}})));
         assertEquals(NULL_DOUBLE, wsum((${pt.vector}) null, new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6})));
         assertEquals(NULL_DOUBLE, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3}), (${pt2.vector}) null));
+
+        <#if pt.valueType.isFloat >
+        assertEquals(Double.NaN, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},Float.NaN}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,${pt2.null}})));
+        </#if>
+
+        <#if pt2.valueType.isFloat >
+        assertEquals(Double.NaN, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,Float.NaN,${pt2.null}})));
+        </#if>
 
         try {
             wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5}));

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -570,7 +570,12 @@ public class TestNumeric extends BaseArrayTestCase {
         assertTrue(Math.abs(0 - sum(new ${pt.vectorDirect}())) == 0.0);
         assertTrue(Math.abs(0 - sum(new ${pt.vectorDirect}(${pt.null}))) == 0.0);
         assertTrue(Math.abs(20 - sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{5, ${pt.null}, 15}))) == 0.0);
-        assertEquals(${pt.null}, sum((${pt.vector}) null));
+    <#if pt.valueType.isFloat >
+        assertEquals(NULL_DOUBLE, sum((${pt.vector}) null));
+    <#else>
+        assertEquals(NULL_LONG, sum((${pt.vector}) null));
+    </#if>
+
     }
 
     public void test${pt.boxed}Sum2() {
@@ -578,7 +583,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertTrue(Math.abs(0 - sum(new ${pt.primitive}[]{})) == 0.0);
         assertTrue(Math.abs(0 - sum(new ${pt.primitive}[]{${pt.null}})) == 0.0);
         assertTrue(Math.abs(20 - sum(new ${pt.primitive}[]{5, ${pt.null}, 15})) == 0.0);
-        assertEquals(${pt.null}, sum((${pt.primitive}[]) null));
+    <#if pt.valueType.isFloat >
+        assertEquals(NULL_DOUBLE, sum((${pt.primitive}[]) null));
+    <#else>
+        assertEquals(NULL_LONG, sum((${pt.primitive}[]) null));
+    </#if>
     }
 
 //    public void test${pt.boxed}SumObjectVector() {

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -572,6 +572,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertTrue(Math.abs(20 - sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{5, ${pt.null}, 15}))) == 0.0);
     <#if pt.valueType.isFloat >
         assertEquals(NULL_DOUBLE, sum((${pt.vector}) null));
+        assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, 6})));
+        assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY})));
+        assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6})));
+        assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY})));
+        assertEquals(Double.NaN, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY})));
     <#else>
         assertEquals(NULL_LONG, sum((${pt.vector}) null));
     </#if>
@@ -585,6 +590,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertTrue(Math.abs(20 - sum(new ${pt.primitive}[]{5, ${pt.null}, 15})) == 0.0);
     <#if pt.valueType.isFloat >
         assertEquals(NULL_DOUBLE, sum((${pt.primitive}[]) null));
+        assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, 6}));
+        assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY}));
+        assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6}));
+        assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+        assertEquals(Double.NaN, sum(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY}));
     <#else>
         assertEquals(NULL_LONG, sum((${pt.primitive}[]) null));
     </#if>
@@ -638,6 +648,21 @@ public class TestNumeric extends BaseArrayTestCase {
         assertTrue(Math.abs(75 - product(new ${pt.vectorDirect}(new ${pt.primitive}[]{5, ${pt.null}, 15}))) == 0.0);
         assertEquals(nullResult, product((${pt.vector}) null));
         assertEquals(zeroValue, product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, 0, 5, 6})));
+
+
+        <#if pt.valueType.isFloat >
+        assertEquals(Double.POSITIVE_INFINITY, product(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, 6}));
+        assertEquals(Double.POSITIVE_INFINITY, product(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY}));
+        assertEquals(Double.NEGATIVE_INFINITY, product(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6}));
+        assertEquals(Double.POSITIVE_INFINITY, product(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+        assertEquals(Double.NEGATIVE_INFINITY, product(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+
+        assertEquals(Double.POSITIVE_INFINITY, product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, 6})));
+        assertEquals(Double.POSITIVE_INFINITY, product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY})));
+        assertEquals(Double.NEGATIVE_INFINITY, product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6})));
+        assertEquals(Double.POSITIVE_INFINITY, product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY})));
+        assertEquals(Double.NEGATIVE_INFINITY, product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY})));
+        </#if>
     }
 
 <#if pt.valueType.isFloat >
@@ -770,6 +795,15 @@ public class TestNumeric extends BaseArrayTestCase {
 
         // check that functions can be resolved with varargs
         assertEquals(new double[]{1, 3, 6, 10, 15}, cumsum((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
+
+        assertEquals(new double[]{1, 3, 6, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, 5}));
+        assertEquals(new double[]{1, 3, 6, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, -5}));
+        assertEquals(new double[]{1, 3, 6, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY}));
+        assertEquals(new double[]{1, 3, 6, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, 5}));
+        assertEquals(new double[]{1, 3, 6, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, -5}));
+        assertEquals(new double[]{1, 3, 6, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+        assertEquals(new double[]{1, 3, 6, Double.POSITIVE_INFINITY, Double.NaN}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+        assertEquals(new double[]{1, 3, 6, Double.NEGATIVE_INFINITY, Double.NaN}, cumsum(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY}));
     }
 <#else>
     public void test${pt.boxed}CumSumArray() {
@@ -810,6 +844,15 @@ public class TestNumeric extends BaseArrayTestCase {
 
         // check that functions can be resolved with varargs
         assertEquals(new double[]{1, 2, 6, 24, 120}, cumprod((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
+
+        assertEquals(new double[]{1, 2, 6, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, 5}));
+        assertEquals(new double[]{1, 2, 6, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, -5}));
+        assertEquals(new double[]{1, 2, 6, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY}));
+        assertEquals(new double[]{1, 2, 6, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, 5}));
+        assertEquals(new double[]{1, 2, 6, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, -5}));
+        assertEquals(new double[]{1, 2, 6, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+        assertEquals(new double[]{1, 2, 6, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+        assertEquals(new double[]{1, 2, 6, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY}, cumprod(new ${pt.primitive}[]{1, 2, 3, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY}));
     }
 <#else>
     public void test${pt.boxed}CumProdArray() {
@@ -1112,10 +1155,16 @@ public class TestNumeric extends BaseArrayTestCase {
 
         <#if pt.valueType.isFloat >
         assertEquals(Double.NaN, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},Float.NaN}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,${pt2.null}})));
+        assertEquals(Double.POSITIVE_INFINITY, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},Float.POSITIVE_INFINITY}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,8})));
+        assertEquals(Double.NEGATIVE_INFINITY, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},Float.NEGATIVE_INFINITY}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,8})));
+        assertEquals(Double.NaN, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,Float.POSITIVE_INFINITY,Float.NEGATIVE_INFINITY}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,8})));
         </#if>
 
         <#if pt2.valueType.isFloat >
         assertEquals(Double.NaN, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,Float.NaN,${pt2.null}})));
+        assertEquals(Double.POSITIVE_INFINITY, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,4,5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,Float.POSITIVE_INFINITY,${pt2.null}})));
+        assertEquals(Double.NEGATIVE_INFINITY, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,4,5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,Float.NEGATIVE_INFINITY,${pt2.null}})));
+        assertEquals(Double.NaN, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,4,5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,Float.NEGATIVE_INFINITY,Float.POSITIVE_INFINITY})));
         </#if>
 
         try {

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -749,23 +749,43 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(new ${pt.primitive}[]{5, 5, 5, 5, 5}, cummax((${pt.primitive})5, (${pt.primitive})4, (${pt.primitive})3, (${pt.primitive})2, (${pt.primitive})1));
     }
 
+<#if pt.valueType.isFloat >
     public void test${pt.boxed}CumSumArray() {
-        assertEquals(new ${pt.primitive}[]{1, 3, 6, 10, 15}, cumsum(new ${pt.primitive}[]{1, 2, 3, 4, 5}));
-        assertEquals(new ${pt.primitive}[]{1, 3, 6, 6, 11}, cumsum(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5}));
-        assertEquals(new ${pt.primitive}[]{${pt.null}, 2, 5, 9, 14}, cumsum(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5}));
-        assertEquals(new ${pt.primitive}[0], cumsum(new ${pt.primitive}[0]));
-        assertEquals(new ${pt.primitive}[0], cumsum(new ${pt.boxed}[0]));
+        assertEquals(new double[]{1, 3, 6, 10, 15}, cumsum(new ${pt.primitive}[]{1, 2, 3, 4, 5}));
+        assertEquals(new double[]{1, 3, 6, 6, 11}, cumsum(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5}));
+        assertEquals(new double[]{NULL_DOUBLE, 2, 5, 9, 14}, cumsum(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5}));
+        assertEquals(new double[0], cumsum(new ${pt.primitive}[0]));
+        assertEquals(new double[0], cumsum(new ${pt.boxed}[0]));
         assertEquals(null, cumsum((${pt.primitive}[]) null));
 
-        assertEquals(new ${pt.primitive}[]{1, 3, 6, 10, 15}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, 4, 5})));
-        assertEquals(new ${pt.primitive}[]{1, 3, 6, 6, 11}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5})));
-        assertEquals(new ${pt.primitive}[]{${pt.null}, 2, 5, 9, 14}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5})));
-        assertEquals(new ${pt.primitive}[0], cumsum(new ${pt.vectorDirect}()));
+        assertEquals(new double[]{1, 3, 6, 10, 15}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, 4, 5})));
+        assertEquals(new double[]{1, 3, 6, 6, 11}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5})));
+        assertEquals(new double[]{NULL_DOUBLE, 2, 5, 9, 14}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5})));
+        assertEquals(new double[0], cumsum(new ${pt.vectorDirect}()));
         assertEquals(null, cumsum((${pt.vector}) null));
 
         // check that functions can be resolved with varargs
-        assertEquals(new ${pt.primitive}[]{1, 3, 6, 10, 15}, cumsum((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
+        assertEquals(new double[]{1, 3, 6, 10, 15}, cumsum((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
     }
+<#else>
+    public void test${pt.boxed}CumSumArray() {
+        assertEquals(new long[]{1, 3, 6, 10, 15}, cumsum(new ${pt.primitive}[]{1, 2, 3, 4, 5}));
+        assertEquals(new long[]{1, 3, 6, 6, 11}, cumsum(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5}));
+        assertEquals(new long[]{NULL_LONG, 2, 5, 9, 14}, cumsum(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5}));
+        assertEquals(new long[0], cumsum(new ${pt.primitive}[0]));
+        assertEquals(new long[0], cumsum(new ${pt.boxed}[0]));
+        assertEquals(null, cumsum((${pt.primitive}[]) null));
+
+        assertEquals(new long[]{1, 3, 6, 10, 15}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, 4, 5})));
+        assertEquals(new long[]{1, 3, 6, 6, 11}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5})));
+        assertEquals(new long[]{NULL_LONG, 2, 5, 9, 14}, cumsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5})));
+        assertEquals(new long[0], cumsum(new ${pt.vectorDirect}()));
+        assertEquals(null, cumsum((${pt.vector}) null));
+
+        // check that functions can be resolved with varargs
+        assertEquals(new long[]{1, 3, 6, 10, 15}, cumsum((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
+    }
+</#if>
 
     public void test${pt.boxed}CumProdArray() {
         assertEquals(new ${pt.primitive}[]{1, 2, 6, 24, 120}, cumprod(new ${pt.primitive}[]{1, 2, 3, 4, 5}));

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -975,15 +975,15 @@ public class TestNumeric extends BaseArrayTestCase {
     }
 
     public void test${pt.boxed}Percentile() {
-        assertEquals(2.0, percentile(0.00, new ${pt.primitive}[]{4,2,3}));
-        assertEquals(3.0, percentile(0.50, new ${pt.primitive}[]{4,2,3}));
-        assertEquals(NULL_DOUBLE, percentile(0.25, (${pt.primitive}[])null));
-        assertEquals(NULL_DOUBLE, percentile(0.25, new ${pt.primitive}[]{}));
+        assertEquals((${pt.primitive})2, percentile(0.00, new ${pt.primitive}[]{4,2,3}));
+        assertEquals((${pt.primitive})3, percentile(0.50, new ${pt.primitive}[]{4,2,3}));
+        assertEquals(${pt.null}, percentile(0.25, (${pt.primitive}[])null));
+        assertEquals(${pt.null}, percentile(0.25, new ${pt.primitive}[]{}));
 
-        assertEquals(2.0, percentile(0.00, new ${pt.vectorDirect}(new ${pt.primitive}[]{4,2,3})));
-        assertEquals(3.0, percentile(0.50, new ${pt.vectorDirect}(new ${pt.primitive}[]{4,2,3})));
-        assertEquals(NULL_DOUBLE, percentile(0.25, (${pt.vector}) null));
-        assertEquals(NULL_DOUBLE, percentile(0.50, new ${pt.vectorDirect}(new ${pt.primitive}[]{})));
+        assertEquals((${pt.primitive})2, percentile(0.00, new ${pt.vectorDirect}(new ${pt.primitive}[]{4,2,3})));
+        assertEquals((${pt.primitive})3, percentile(0.50, new ${pt.vectorDirect}(new ${pt.primitive}[]{4,2,3})));
+        assertEquals(${pt.null}, percentile(0.25, (${pt.vector}) null));
+        assertEquals(${pt.null}, percentile(0.50, new ${pt.vectorDirect}(new ${pt.primitive}[]{})));
 
         try {
             percentile(-1, new ${pt.primitive}[]{4,2,3});

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -787,23 +787,43 @@ public class TestNumeric extends BaseArrayTestCase {
     }
 </#if>
 
+<#if pt.valueType.isFloat >
     public void test${pt.boxed}CumProdArray() {
-        assertEquals(new ${pt.primitive}[]{1, 2, 6, 24, 120}, cumprod(new ${pt.primitive}[]{1, 2, 3, 4, 5}));
-        assertEquals(new ${pt.primitive}[]{1, 2, 6, 6, 30}, cumprod(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5}));
-        assertEquals(new ${pt.primitive}[]{${pt.null}, 2, 6, 24, 120}, cumprod(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5}));
-        assertEquals(new ${pt.primitive}[0], cumprod(new ${pt.primitive}[0]));
-        assertEquals(new ${pt.primitive}[0], cumprod(new ${pt.boxed}[0]));
+        assertEquals(new double[]{1, 2, 6, 24, 120}, cumprod(new ${pt.primitive}[]{1, 2, 3, 4, 5}));
+        assertEquals(new double[]{1, 2, 6, 6, 30}, cumprod(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5}));
+        assertEquals(new double[]{NULL_DOUBLE, 2, 6, 24, 120}, cumprod(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5}));
+        assertEquals(new double[0], cumprod(new ${pt.primitive}[0]));
+        assertEquals(new double[0], cumprod(new ${pt.boxed}[0]));
         assertEquals(null, cumprod((${pt.primitive}[]) null));
 
-        assertEquals(new ${pt.primitive}[]{1, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, 4, 5})));
-        assertEquals(new ${pt.primitive}[]{1, 2, 6, 6, 30}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5})));
-        assertEquals(new ${pt.primitive}[]{${pt.null}, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5})));
-        assertEquals(new ${pt.primitive}[0], cumprod(new ${pt.vectorDirect}()));
+        assertEquals(new double[]{1, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, 4, 5})));
+        assertEquals(new double[]{1, 2, 6, 6, 30}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5})));
+        assertEquals(new double[]{NULL_DOUBLE, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5})));
+        assertEquals(new double[0], cumprod(new ${pt.vectorDirect}()));
         assertEquals(null, cumprod((${pt.vector}) null));
 
         // check that functions can be resolved with varargs
-        assertEquals(new ${pt.primitive}[]{1, 2, 6, 24, 120}, cumprod((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
+        assertEquals(new double[]{1, 2, 6, 24, 120}, cumprod((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
     }
+<#else>
+    public void test${pt.boxed}CumProdArray() {
+        assertEquals(new long[]{1, 2, 6, 24, 120}, cumprod(new ${pt.primitive}[]{1, 2, 3, 4, 5}));
+        assertEquals(new long[]{1, 2, 6, 6, 30}, cumprod(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5}));
+        assertEquals(new long[]{NULL_LONG, 2, 6, 24, 120}, cumprod(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5}));
+        assertEquals(new long[0], cumprod(new ${pt.primitive}[0]));
+        assertEquals(new long[0], cumprod(new ${pt.boxed}[0]));
+        assertEquals(null, cumprod((${pt.primitive}[]) null));
+
+        assertEquals(new long[]{1, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, 4, 5})));
+        assertEquals(new long[]{1, 2, 6, 6, 30}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{1, 2, 3, ${pt.null}, 5})));
+        assertEquals(new long[]{NULL_LONG, 2, 6, 24, 120}, cumprod(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, 2, 3, 4, 5})));
+        assertEquals(new long[0], cumprod(new ${pt.vectorDirect}()));
+        assertEquals(null, cumprod((${pt.vector}) null));
+
+        // check that functions can be resolved with varargs
+        assertEquals(new long[]{1, 2, 6, 24, 120}, cumprod((${pt.primitive})1, (${pt.primitive})2, (${pt.primitive})3, (${pt.primitive})4, (${pt.primitive})5));
+    }
+</#if>
 
     public void test${pt.boxed}Abs() {
         ${pt.primitive} value = -5;

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -617,48 +617,58 @@ public class TestNumeric extends BaseArrayTestCase {
 //    }
 
     public void test${pt.boxed}Product() {
+        <#if pt.valueType.isFloat >
+        final double nullResult = NULL_DOUBLE;
+        <#else>
+        final long nullResult = NULL_LONG;
+        </#if>
+
         assertTrue(Math.abs(120 - product(new ${pt.primitive}[]{4, 5, 6})) == 0.0);
-        assertEquals(${pt.null}, product(new ${pt.primitive}[]{}));
-        assertEquals(${pt.null}, product(new ${pt.primitive}[]{${pt.null}}));
+        assertEquals(nullResult, product(new ${pt.primitive}[]{}));
+        assertEquals(nullResult, product(new ${pt.primitive}[]{${pt.null}}));
         assertTrue(Math.abs(75 - product(new ${pt.primitive}[]{5, ${pt.null}, 15})) == 0.0);
-        assertEquals(${pt.null}, product((${pt.primitive}[]) null));
+        assertEquals(nullResult, product((${pt.primitive}[]) null));
 
         assertTrue(Math.abs(120 - product(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, 5, 6}))) == 0.0);
-        assertEquals(${pt.null}, product(new ${pt.vectorDirect}()));
-        assertEquals(${pt.null}, product(new ${pt.vectorDirect}(${pt.null})));
+        assertEquals(nullResult, product(new ${pt.vectorDirect}()));
+        assertEquals(nullResult, product(new ${pt.vectorDirect}(${pt.null})));
         assertTrue(Math.abs(75 - product(new ${pt.vectorDirect}(new ${pt.primitive}[]{5, ${pt.null}, 15}))) == 0.0);
-        assertEquals(${pt.null}, product((${pt.vector}) null));
+        assertEquals(nullResult, product((${pt.vector}) null));
     }
 
 <#if pt.valueType.isFloat >
     public void test${pt.boxed}ProductOverflowAndNaN() {
+        <#if pt.primitive == "double" >
+
         final ${pt.primitive} LARGE_VALUE = Math.nextDown(${pt.boxed}.MAX_VALUE);
 
         final ${pt.primitive}[] overflow = new ${pt.primitive}[]{1, LARGE_VALUE, LARGE_VALUE};
-        final ${pt.primitive} overflowProduct = product(overflow);
-        assertTrue(${pt.boxed}.isInfinite(overflowProduct) && overflowProduct > 0);
+        final double overflowProduct = product(overflow);
+        assertTrue(Double.isInfinite(overflowProduct) && overflowProduct > 0);
 
         final ${pt.primitive}[] negOverflow = new ${pt.primitive}[]{1, LARGE_VALUE, -LARGE_VALUE};
-        final ${pt.primitive} negOverflowProduct = product(negOverflow);
-        assertTrue(${pt.boxed}.isInfinite(negOverflowProduct) && negOverflowProduct < 0);
+        final double negOverflowProduct = product(negOverflow);
+        assertTrue(Double.isInfinite(negOverflowProduct) && negOverflowProduct < 0);
 
         final ${pt.primitive}[] overflowWithZero = new ${pt.primitive}[]{1, LARGE_VALUE, LARGE_VALUE, 0};
         assertTrue(Math.abs(product(overflowWithZero)) == 0.0);
 
+        </#if>
+
         final ${pt.primitive}[] normalWithNaN = new ${pt.primitive}[]{1, 2, 3, ${pt.boxed}.NaN, 4, 5};
-        assertTrue(${pt.boxed}.isNaN(product(normalWithNaN)));
+        assertTrue(Double.isNaN(product(normalWithNaN)));
 
         final ${pt.primitive}[] posInfAndZero = new ${pt.primitive}[]{1, ${pt.boxed}.POSITIVE_INFINITY, 0};
-        assertTrue(${pt.boxed}.isNaN(product(posInfAndZero)));
+        assertTrue(Double.isNaN(product(posInfAndZero)));
 
         final ${pt.primitive}[] negInfAndZero = new ${pt.primitive}[]{1, ${pt.boxed}.NEGATIVE_INFINITY, 0};
-        assertTrue(${pt.boxed}.isNaN(product(negInfAndZero)));
+        assertTrue(Double.isNaN(product(negInfAndZero)));
 
         final ${pt.primitive}[] zeroAndPosInf = new ${pt.primitive}[]{1, 0, ${pt.boxed}.POSITIVE_INFINITY};
-        assertTrue(${pt.boxed}.isNaN(product(zeroAndPosInf)));
+        assertTrue(Double.isNaN(product(zeroAndPosInf)));
 
         final ${pt.primitive}[] zeroAndNegInf = new ${pt.primitive}[]{1, 0, ${pt.boxed}.NEGATIVE_INFINITY};
-        assertTrue(${pt.boxed}.isNaN(product(zeroAndNegInf)));
+        assertTrue(Double.isNaN(product(zeroAndNegInf)));
 
     }
 </#if>

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1064,6 +1064,30 @@ public class TestNumeric extends BaseArrayTestCase {
         <#list primitiveTypes as pt2>
         <#if pt2.valueType.isNumber >
 
+        <#if pt.valueType.isInteger && pt2.valueType.isInteger >
+        assertEquals(1*4+2*5+3*6, wsum(new ${pt.primitive}[]{1,2,3,${pt.null},5}, new ${pt2.primitive}[]{4,5,6,7,${pt2.null}}));
+        assertEquals(NULL_LONG, wsum((${pt.primitive}[])null, new ${pt2.primitive}[]{4,5,6}));
+        assertEquals(NULL_LONG, wsum(new ${pt.primitive}[]{1,2,3}, (${pt2.primitive}[])null));
+
+        assertEquals(1*4+2*5+3*6, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},5}), new ${pt2.primitive}[]{4,5,6,7,${pt2.null}}));
+        assertEquals(NULL_LONG, wsum((${pt.vector}) null, new ${pt2.primitive}[]{4,5,6}));
+        assertEquals(NULL_LONG, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3}), (${pt2.primitive}[])null));
+
+        assertEquals(1*4+2*5+3*6, wsum(new ${pt.primitive}[]{1,2,3,${pt.null},5}, new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,${pt2.null}})));
+        assertEquals(NULL_LONG, wsum((${pt.primitive}[])null, new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6})));
+        assertEquals(NULL_LONG, wsum(new ${pt.primitive}[]{1,2,3}, (${pt2.vector}) null));
+
+        assertEquals(1*4+2*5+3*6, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6,7,${pt2.null}})));
+        assertEquals(NULL_LONG, wsum((${pt.vector}) null, new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5,6})));
+        assertEquals(NULL_LONG, wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3}), (${pt2.vector}) null));
+
+        try {
+            wsum(new ${pt.vectorDirect}(new ${pt.primitive}[]{1,2,3,${pt.null},5}), new ${pt2.vectorDirect}(new ${pt2.primitive}[]{4,5}));
+            fail("Mismatched arguments");
+        } catch(IllegalArgumentException e){
+            // pass
+        }
+        <#else>
         assertEquals(1.0*4.0+2.0*5.0+3.0*6.0, wsum(new ${pt.primitive}[]{1,2,3,${pt.null},5}, new ${pt2.primitive}[]{4,5,6,7,${pt2.null}}));
         assertEquals(NULL_DOUBLE, wsum((${pt.primitive}[])null, new ${pt2.primitive}[]{4,5,6}));
         assertEquals(NULL_DOUBLE, wsum(new ${pt.primitive}[]{1,2,3}, (${pt2.primitive}[])null));
@@ -1086,6 +1110,7 @@ public class TestNumeric extends BaseArrayTestCase {
         } catch(IllegalArgumentException e){
             // pass
         }
+        </#if>
 
         </#if>
         </#list>

--- a/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
+++ b/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
@@ -1979,112 +1979,112 @@ public class GroovyStaticImports {
     public static  short[] cummin( io.deephaven.vector.ShortVector values ) {return Numeric.cummin( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(byte[]) */
-    public static  byte[] cumprod( byte... values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( byte... values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(double[]) */
     public static  double[] cumprod( double... values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(float[]) */
-    public static  float[] cumprod( float... values ) {return Numeric.cumprod( values );}
+    public static  double[] cumprod( float... values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(int[]) */
-    public static  int[] cumprod( int... values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( int... values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(long[]) */
     public static  long[] cumprod( long... values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(java.lang.Byte[]) */
-    public static  byte[] cumprod( java.lang.Byte[] values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( java.lang.Byte[] values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(java.lang.Double[]) */
     public static  double[] cumprod( java.lang.Double[] values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(java.lang.Float[]) */
-    public static  float[] cumprod( java.lang.Float[] values ) {return Numeric.cumprod( values );}
+    public static  double[] cumprod( java.lang.Float[] values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(java.lang.Integer[]) */
-    public static  int[] cumprod( java.lang.Integer[] values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( java.lang.Integer[] values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(java.lang.Long[]) */
     public static  long[] cumprod( java.lang.Long[] values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(java.lang.Short[]) */
-    public static  short[] cumprod( java.lang.Short[] values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( java.lang.Short[] values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(short[]) */
-    public static  short[] cumprod( short... values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( short... values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(io.deephaven.vector.ByteVector) */
-    public static  byte[] cumprod( io.deephaven.vector.ByteVector values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( io.deephaven.vector.ByteVector values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(io.deephaven.vector.DoubleVector) */
     public static  double[] cumprod( io.deephaven.vector.DoubleVector values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(io.deephaven.vector.FloatVector) */
-    public static  float[] cumprod( io.deephaven.vector.FloatVector values ) {return Numeric.cumprod( values );}
+    public static  double[] cumprod( io.deephaven.vector.FloatVector values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(io.deephaven.vector.IntVector) */
-    public static  int[] cumprod( io.deephaven.vector.IntVector values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( io.deephaven.vector.IntVector values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(io.deephaven.vector.LongVector) */
     public static  long[] cumprod( io.deephaven.vector.LongVector values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumprod(io.deephaven.vector.ShortVector) */
-    public static  short[] cumprod( io.deephaven.vector.ShortVector values ) {return Numeric.cumprod( values );}
+    public static  long[] cumprod( io.deephaven.vector.ShortVector values ) {return Numeric.cumprod( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(byte[]) */
-    public static  byte[] cumsum( byte... values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( byte... values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(double[]) */
     public static  double[] cumsum( double... values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(float[]) */
-    public static  float[] cumsum( float... values ) {return Numeric.cumsum( values );}
+    public static  double[] cumsum( float... values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(int[]) */
-    public static  int[] cumsum( int... values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( int... values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(long[]) */
     public static  long[] cumsum( long... values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(java.lang.Byte[]) */
-    public static  byte[] cumsum( java.lang.Byte[] values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( java.lang.Byte[] values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(java.lang.Double[]) */
     public static  double[] cumsum( java.lang.Double[] values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(java.lang.Float[]) */
-    public static  float[] cumsum( java.lang.Float[] values ) {return Numeric.cumsum( values );}
+    public static  double[] cumsum( java.lang.Float[] values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(java.lang.Integer[]) */
-    public static  int[] cumsum( java.lang.Integer[] values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( java.lang.Integer[] values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(java.lang.Long[]) */
     public static  long[] cumsum( java.lang.Long[] values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(java.lang.Short[]) */
-    public static  short[] cumsum( java.lang.Short[] values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( java.lang.Short[] values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(short[]) */
-    public static  short[] cumsum( short... values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( short... values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(io.deephaven.vector.ByteVector) */
-    public static  byte[] cumsum( io.deephaven.vector.ByteVector values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( io.deephaven.vector.ByteVector values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(io.deephaven.vector.DoubleVector) */
     public static  double[] cumsum( io.deephaven.vector.DoubleVector values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(io.deephaven.vector.FloatVector) */
-    public static  float[] cumsum( io.deephaven.vector.FloatVector values ) {return Numeric.cumsum( values );}
+    public static  double[] cumsum( io.deephaven.vector.FloatVector values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(io.deephaven.vector.IntVector) */
-    public static  int[] cumsum( io.deephaven.vector.IntVector values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( io.deephaven.vector.IntVector values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(io.deephaven.vector.LongVector) */
     public static  long[] cumsum( io.deephaven.vector.LongVector values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Numeric#cumsum(io.deephaven.vector.ShortVector) */
-    public static  short[] cumsum( io.deephaven.vector.ShortVector values ) {return Numeric.cumsum( values );}
+    public static  long[] cumsum( io.deephaven.vector.ShortVector values ) {return Numeric.cumsum( values );}
 
     /** @see io.deephaven.function.Basic#distinct(byte[]) */
     public static  byte[] distinct( byte... values ) {return Basic.distinct( values );}
@@ -3221,40 +3221,40 @@ public class GroovyStaticImports {
     public static  long parseUnsignedLong( java.lang.String s, int radix ) {return Parse.parseUnsignedLong( s, radix );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,byte[]) */
-    public static  double percentile( double percentile, byte... values ) {return Numeric.percentile( percentile, values );}
+    public static  byte percentile( double percentile, byte... values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,double[]) */
     public static  double percentile( double percentile, double... values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,float[]) */
-    public static  double percentile( double percentile, float... values ) {return Numeric.percentile( percentile, values );}
+    public static  float percentile( double percentile, float... values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,int[]) */
-    public static  double percentile( double percentile, int... values ) {return Numeric.percentile( percentile, values );}
+    public static  int percentile( double percentile, int... values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,long[]) */
-    public static  double percentile( double percentile, long... values ) {return Numeric.percentile( percentile, values );}
+    public static  long percentile( double percentile, long... values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,short[]) */
-    public static  double percentile( double percentile, short... values ) {return Numeric.percentile( percentile, values );}
+    public static  short percentile( double percentile, short... values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,io.deephaven.vector.ByteVector) */
-    public static  double percentile( double percentile, io.deephaven.vector.ByteVector values ) {return Numeric.percentile( percentile, values );}
+    public static  byte percentile( double percentile, io.deephaven.vector.ByteVector values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,io.deephaven.vector.DoubleVector) */
     public static  double percentile( double percentile, io.deephaven.vector.DoubleVector values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,io.deephaven.vector.FloatVector) */
-    public static  double percentile( double percentile, io.deephaven.vector.FloatVector values ) {return Numeric.percentile( percentile, values );}
+    public static  float percentile( double percentile, io.deephaven.vector.FloatVector values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,io.deephaven.vector.IntVector) */
-    public static  double percentile( double percentile, io.deephaven.vector.IntVector values ) {return Numeric.percentile( percentile, values );}
+    public static  int percentile( double percentile, io.deephaven.vector.IntVector values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,io.deephaven.vector.LongVector) */
-    public static  double percentile( double percentile, io.deephaven.vector.LongVector values ) {return Numeric.percentile( percentile, values );}
+    public static  long percentile( double percentile, io.deephaven.vector.LongVector values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#percentile(double,io.deephaven.vector.ShortVector) */
-    public static  double percentile( double percentile, io.deephaven.vector.ShortVector values ) {return Numeric.percentile( percentile, values );}
+    public static  short percentile( double percentile, io.deephaven.vector.ShortVector values ) {return Numeric.percentile( percentile, values );}
 
     /** @see io.deephaven.function.Numeric#pow(byte,byte) */
     public static  double pow( byte a, byte b ) {return Numeric.pow( a, b );}
@@ -3365,40 +3365,40 @@ public class GroovyStaticImports {
     public static  double pow( short a, short b ) {return Numeric.pow( a, b );}
 
     /** @see io.deephaven.function.Numeric#product(byte[]) */
-    public static  byte product( byte... values ) {return Numeric.product( values );}
+    public static  long product( byte... values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(double[]) */
     public static  double product( double... values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(float[]) */
-    public static  float product( float... values ) {return Numeric.product( values );}
+    public static  double product( float... values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(int[]) */
-    public static  int product( int... values ) {return Numeric.product( values );}
+    public static  long product( int... values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(long[]) */
     public static  long product( long... values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(short[]) */
-    public static  short product( short... values ) {return Numeric.product( values );}
+    public static  long product( short... values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(io.deephaven.vector.ByteVector) */
-    public static  byte product( io.deephaven.vector.ByteVector values ) {return Numeric.product( values );}
+    public static  long product( io.deephaven.vector.ByteVector values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(io.deephaven.vector.DoubleVector) */
     public static  double product( io.deephaven.vector.DoubleVector values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(io.deephaven.vector.FloatVector) */
-    public static  float product( io.deephaven.vector.FloatVector values ) {return Numeric.product( values );}
+    public static  double product( io.deephaven.vector.FloatVector values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(io.deephaven.vector.IntVector) */
-    public static  int product( io.deephaven.vector.IntVector values ) {return Numeric.product( values );}
+    public static  long product( io.deephaven.vector.IntVector values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(io.deephaven.vector.LongVector) */
     public static  long product( io.deephaven.vector.LongVector values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Numeric#product(io.deephaven.vector.ShortVector) */
-    public static  short product( io.deephaven.vector.ShortVector values ) {return Numeric.product( values );}
+    public static  long product( io.deephaven.vector.ShortVector values ) {return Numeric.product( values );}
 
     /** @see io.deephaven.function.Random#random() */
     public static  double random( ) {return Random.random( );}
@@ -4034,40 +4034,40 @@ public class GroovyStaticImports {
     public static  double ste( io.deephaven.vector.ShortVector values ) {return Numeric.ste( values );}
 
     /** @see io.deephaven.function.Numeric#sum(byte[]) */
-    public static  byte sum( byte... values ) {return Numeric.sum( values );}
+    public static  long sum( byte... values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(double[]) */
     public static  double sum( double... values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(float[]) */
-    public static  float sum( float... values ) {return Numeric.sum( values );}
+    public static  double sum( float... values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(int[]) */
-    public static  int sum( int... values ) {return Numeric.sum( values );}
+    public static  long sum( int... values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(long[]) */
     public static  long sum( long... values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(short[]) */
-    public static  short sum( short... values ) {return Numeric.sum( values );}
+    public static  long sum( short... values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(io.deephaven.vector.ByteVector) */
-    public static  byte sum( io.deephaven.vector.ByteVector values ) {return Numeric.sum( values );}
+    public static  long sum( io.deephaven.vector.ByteVector values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(io.deephaven.vector.DoubleVector) */
     public static  double sum( io.deephaven.vector.DoubleVector values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(io.deephaven.vector.FloatVector) */
-    public static  float sum( io.deephaven.vector.FloatVector values ) {return Numeric.sum( values );}
+    public static  double sum( io.deephaven.vector.FloatVector values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(io.deephaven.vector.IntVector) */
-    public static  int sum( io.deephaven.vector.IntVector values ) {return Numeric.sum( values );}
+    public static  long sum( io.deephaven.vector.IntVector values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(io.deephaven.vector.LongVector) */
     public static  long sum( io.deephaven.vector.LongVector values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#sum(io.deephaven.vector.ShortVector) */
-    public static  short sum( io.deephaven.vector.ShortVector values ) {return Numeric.sum( values );}
+    public static  long sum( io.deephaven.vector.ShortVector values ) {return Numeric.sum( values );}
 
     /** @see io.deephaven.function.Numeric#tan(byte) */
     public static  double tan( byte value ) {return Numeric.tan( value );}
@@ -5573,7 +5573,7 @@ public class GroovyStaticImports {
     public static  double wste( io.deephaven.vector.ShortVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wste( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],byte[]) */
-    public static  double wsum( byte[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],double[]) */
     public static  double wsum( byte[] values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5582,16 +5582,16 @@ public class GroovyStaticImports {
     public static  double wsum( byte[] values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],int[]) */
-    public static  double wsum( byte[] values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],long[]) */
-    public static  double wsum( byte[] values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],short[]) */
-    public static  double wsum( byte[] values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],io.deephaven.vector.ByteVector) */
-    public static  double wsum( byte[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],io.deephaven.vector.DoubleVector) */
     public static  double wsum( byte[] values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5600,13 +5600,13 @@ public class GroovyStaticImports {
     public static  double wsum( byte[] values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],io.deephaven.vector.IntVector) */
-    public static  double wsum( byte[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],io.deephaven.vector.LongVector) */
-    public static  double wsum( byte[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(byte[],io.deephaven.vector.ShortVector) */
-    public static  double wsum( byte[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( byte[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(double[],byte[]) */
     public static  double wsum( double[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
@@ -5681,7 +5681,7 @@ public class GroovyStaticImports {
     public static  double wsum( float[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],byte[]) */
-    public static  double wsum( int[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],double[]) */
     public static  double wsum( int[] values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5690,16 +5690,16 @@ public class GroovyStaticImports {
     public static  double wsum( int[] values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],int[]) */
-    public static  double wsum( int[] values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],long[]) */
-    public static  double wsum( int[] values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],short[]) */
-    public static  double wsum( int[] values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],io.deephaven.vector.ByteVector) */
-    public static  double wsum( int[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],io.deephaven.vector.DoubleVector) */
     public static  double wsum( int[] values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5708,16 +5708,16 @@ public class GroovyStaticImports {
     public static  double wsum( int[] values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],io.deephaven.vector.IntVector) */
-    public static  double wsum( int[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],io.deephaven.vector.LongVector) */
-    public static  double wsum( int[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(int[],io.deephaven.vector.ShortVector) */
-    public static  double wsum( int[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( int[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],byte[]) */
-    public static  double wsum( long[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],double[]) */
     public static  double wsum( long[] values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5726,16 +5726,16 @@ public class GroovyStaticImports {
     public static  double wsum( long[] values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],int[]) */
-    public static  double wsum( long[] values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],long[]) */
-    public static  double wsum( long[] values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],short[]) */
-    public static  double wsum( long[] values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],io.deephaven.vector.ByteVector) */
-    public static  double wsum( long[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],io.deephaven.vector.DoubleVector) */
     public static  double wsum( long[] values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5744,16 +5744,16 @@ public class GroovyStaticImports {
     public static  double wsum( long[] values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],io.deephaven.vector.IntVector) */
-    public static  double wsum( long[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],io.deephaven.vector.LongVector) */
-    public static  double wsum( long[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(long[],io.deephaven.vector.ShortVector) */
-    public static  double wsum( long[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( long[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],byte[]) */
-    public static  double wsum( short[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],double[]) */
     public static  double wsum( short[] values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5762,16 +5762,16 @@ public class GroovyStaticImports {
     public static  double wsum( short[] values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],int[]) */
-    public static  double wsum( short[] values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],long[]) */
-    public static  double wsum( short[] values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],short[]) */
-    public static  double wsum( short[] values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],io.deephaven.vector.ByteVector) */
-    public static  double wsum( short[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],io.deephaven.vector.DoubleVector) */
     public static  double wsum( short[] values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5780,16 +5780,16 @@ public class GroovyStaticImports {
     public static  double wsum( short[] values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],io.deephaven.vector.IntVector) */
-    public static  double wsum( short[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],io.deephaven.vector.LongVector) */
-    public static  double wsum( short[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(short[],io.deephaven.vector.ShortVector) */
-    public static  double wsum( short[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( short[] values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,byte[]) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,double[]) */
     public static  double wsum( io.deephaven.vector.ByteVector values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5798,16 +5798,16 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.ByteVector values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,int[]) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,long[]) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,short[]) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,io.deephaven.vector.ByteVector) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,io.deephaven.vector.DoubleVector) */
     public static  double wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5816,13 +5816,13 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,io.deephaven.vector.IntVector) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,io.deephaven.vector.LongVector) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ByteVector,io.deephaven.vector.ShortVector) */
-    public static  double wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ByteVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.DoubleVector,byte[]) */
     public static  double wsum( io.deephaven.vector.DoubleVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
@@ -5897,7 +5897,7 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.FloatVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,byte[]) */
-    public static  double wsum( io.deephaven.vector.IntVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,double[]) */
     public static  double wsum( io.deephaven.vector.IntVector values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5906,16 +5906,16 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.IntVector values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,int[]) */
-    public static  double wsum( io.deephaven.vector.IntVector values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,long[]) */
-    public static  double wsum( io.deephaven.vector.IntVector values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,short[]) */
-    public static  double wsum( io.deephaven.vector.IntVector values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,io.deephaven.vector.ByteVector) */
-    public static  double wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,io.deephaven.vector.DoubleVector) */
     public static  double wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5924,16 +5924,16 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,io.deephaven.vector.IntVector) */
-    public static  double wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,io.deephaven.vector.LongVector) */
-    public static  double wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.IntVector,io.deephaven.vector.ShortVector) */
-    public static  double wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.IntVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,byte[]) */
-    public static  double wsum( io.deephaven.vector.LongVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,double[]) */
     public static  double wsum( io.deephaven.vector.LongVector values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5942,16 +5942,16 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.LongVector values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,int[]) */
-    public static  double wsum( io.deephaven.vector.LongVector values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,long[]) */
-    public static  double wsum( io.deephaven.vector.LongVector values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,short[]) */
-    public static  double wsum( io.deephaven.vector.LongVector values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,io.deephaven.vector.ByteVector) */
-    public static  double wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,io.deephaven.vector.DoubleVector) */
     public static  double wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5960,16 +5960,16 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,io.deephaven.vector.IntVector) */
-    public static  double wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,io.deephaven.vector.LongVector) */
-    public static  double wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.LongVector,io.deephaven.vector.ShortVector) */
-    public static  double wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.LongVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,byte[]) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, byte[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,double[]) */
     public static  double wsum( io.deephaven.vector.ShortVector values, double[] weights ) {return Numeric.wsum( values, weights );}
@@ -5978,16 +5978,16 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.ShortVector values, float[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,int[]) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, int[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, int[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,long[]) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, long[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, long[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,short[]) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, short[] weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, short[] weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,io.deephaven.vector.ByteVector) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.ByteVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,io.deephaven.vector.DoubleVector) */
     public static  double wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.DoubleVector weights ) {return Numeric.wsum( values, weights );}
@@ -5996,13 +5996,13 @@ public class GroovyStaticImports {
     public static  double wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.FloatVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,io.deephaven.vector.IntVector) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.IntVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,io.deephaven.vector.LongVector) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.LongVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wsum(io.deephaven.vector.ShortVector,io.deephaven.vector.ShortVector) */
-    public static  double wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
+    public static  long wsum( io.deephaven.vector.ShortVector values, io.deephaven.vector.ShortVector weights ) {return Numeric.wsum( values, weights );}
 
     /** @see io.deephaven.function.Numeric#wtstat(byte[],byte[]) */
     public static  double wtstat( byte[] values, byte[] weights ) {return Numeric.wtstat( values, weights );}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumProd.java
@@ -318,7 +318,7 @@ public class TestCumProd extends BaseUpdateByTest {
         } else if (expected instanceof long[]) {
             assertArrayEquals(Numeric.cumprod((long[]) expected), (long[]) actual);
         } else if (expected instanceof float[]) {
-            assertArrayEquals(Numeric.cumprod((float[]) expected), (float[]) actual, .001f);
+            assertArrayEquals(Numeric.cumprod((float[]) expected), (double[]) actual, .001f);
         } else if (expected instanceof double[]) {
             assertArrayEquals(Numeric.cumprod((double[]) expected), (double[]) actual, .001d);
         } else {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumSum.java
@@ -358,7 +358,7 @@ public class TestCumSum extends BaseUpdateByTest {
         } else if (expected instanceof long[]) {
             assertArrayEquals(Numeric.cumsum((long[]) expected), (long[]) actual);
         } else if (expected instanceof float[]) {
-            assertArrayEquals(Numeric.cumsum((float[]) expected), (float[]) actual, .001f);
+            assertArrayEquals(Numeric.cumsum((float[]) expected), (double[]) actual, .001f);
         } else if (expected instanceof double[]) {
             assertArrayEquals(Numeric.cumsum((double[]) expected), (double[]) actual, .001d);
         } else if (expected instanceof Boolean[]) {


### PR DESCRIPTION
Aggregation operations in query library functions and built-in query aggregations are inconsistent.  This PR makes them consistent.  Query library functions were changed.

* `percentile` now returns the primitive type.
* `sum` returns a widened type of `double` for floating point inputs or `long` for integer inputs.
* `product` returns a widened type of `double` for floating point inputs or `long` for integer inputs.
* `cumsum` returns a widened type of `double[]` for floating point inputs or `long[]` for integer inputs.
* `cumprod` returns a widened type of `double[]` for floating point inputs or `long[]` for integer inputs.
* `wsum` returns a widened type of `long` for all integer inputs and `double` for inputs containing floating points.

Note:  Because the types have changed, the NULL return values have changed as well.
 
Resolves #4023