### PR TITLE
R client: fix warning caused by not checking return value of function

### DIFF
--- a/R/rdeephaven/src/client.cpp
+++ b/R/rdeephaven/src/client.cpp
@@ -545,7 +545,7 @@ public:
 
         std::shared_ptr<arrow::RecordBatchReader> record_batch_reader = arrow::RecordBatchReader::Make(empty_record_batches).ValueOrDie();
         ArrowArrayStream* stream_ptr = new ArrowArrayStream();
-        arrow::ExportRecordBatchReader(record_batch_reader, stream_ptr);
+        deephaven::client::utility::OkOrThrow(DEEPHAVEN_LOCATION_EXPR(arrow::ExportRecordBatchReader(record_batch_reader, stream_ptr)));
 
         // XPtr is needed here to ensure Rcpp can properly handle type casting, as it does not like raw pointers
         return Rcpp::XPtr<ArrowArrayStream>(stream_ptr, true);


### PR DESCRIPTION
The code is make a call and not checking the return value for an error.