### PR TITLE
S3 context should not call close on reset

### DIFF
--- a/Util/channel/src/main/java/io/deephaven/util/channel/BaseSeekableChannelContext.java
+++ b/Util/channel/src/main/java/io/deephaven/util/channel/BaseSeekableChannelContext.java
@@ -30,6 +30,7 @@ public class BaseSeekableChannelContext implements SeekableChannelContext {
     public void close() {
         if (resource != null) {
             resource.close();
+            resource = null;
         }
     }
 }

--- a/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DecompressorHolder.java
+++ b/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DecompressorHolder.java
@@ -53,6 +53,8 @@ class DecompressorHolder implements SafeCloseable {
     public void close() {
         if (decompressor != null) {
             CodecPool.returnDecompressor(decompressor);
+            codecName = null;
+            decompressor = null;
         }
     }
 }

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3ChannelContext.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3ChannelContext.java
@@ -158,9 +158,10 @@ final class S3ChannelContext extends BaseSeekableChannelContext implements Seeka
     }
 
     private void cancelOutstanding() {
-        for (final Request request : requests) {
-            if (request != null) {
-                request.release();
+        for (int i = 0; i < requests.length; i++) {
+            if (requests[i] != null) {
+                requests[i].release();
+                requests[i] = null;
             }
         }
     }

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3ChannelContext.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3ChannelContext.java
@@ -138,7 +138,7 @@ final class S3ChannelContext extends BaseSeekableChannelContext implements Seeka
 
     private void reset() {
         // Cancel all outstanding requests
-        close();
+        cancelOutstanding();
         // Reset the internal state
         uri = null;
         size = UNINITIALIZED_SIZE;
@@ -154,10 +154,13 @@ final class S3ChannelContext extends BaseSeekableChannelContext implements Seeka
         if (log.isDebugEnabled()) {
             log.debug().append("Closing context: ").append(ctxStr()).endl();
         }
-        for (int i = 0; i < requests.length; i++) {
-            if (requests[i] != null) {
-                requests[i].release();
-                requests[i] = null;
+        cancelOutstanding();
+    }
+
+    private void cancelOutstanding() {
+        for (final Request request : requests) {
+            if (request != null) {
+                request.release();
             }
         }
     }


### PR DESCRIPTION
@devinrsmith noticed a failure after the new PR #5351 where reading a partitioned parquet file was leading to failures.
As pointed out by @rcaudy, the issue was being caused by the S3 context calling `close()` during `reset()`.
Note that `reset()` is called when pulling a different URI with the same context. So calling `close()` during `reset()` was leading to the decompressor being closed and therefore failures on reading from the new URI. This PR fixes the issue.