### PR TITLE
Optimize UDF return value conversion

### DIFF
--- a/py/server/deephaven/_udf.py
+++ b/py/server/deephaven/_udf.py
@@ -153,18 +153,18 @@ class _ParsedReturnAnnotation:
                 null_value = _PRIMITIVE_DTYPE_NULL_MAP.get(dtypes.from_np_dtype(np.dtype(t)))
                 self.ret_converter = partial(lambda nv, x: nv if x is None else int(x), null_value)
             else:
-                self.ret_converter = int
+                self.ret_converter = int if self.orig_type != int else None
         elif t in _NUMPY_FLOATING_TYPE_CODES:
             if self.none_allowed:
                 null_value = _PRIMITIVE_DTYPE_NULL_MAP.get(dtypes.from_np_dtype(np.dtype(t)))
                 self.ret_converter = partial(lambda nv, x: nv if x is None else float(x), null_value)
             else:
-                self.ret_converter = float
+                self.ret_converter = float if self.orig_type != float else None
         elif t == '?':
             if self.none_allowed:
                 self.ret_converter = lambda x: bool(x) if x is not None else None
             else:
-                self.ret_converter = bool
+                self.ret_converter = bool if self.orig_type != bool else None
         elif t == 'M':
             from deephaven.time import to_j_instant
             self.ret_converter = to_j_instant

--- a/py/server/deephaven/_udf.py
+++ b/py/server/deephaven/_udf.py
@@ -118,9 +118,9 @@ class _ParsedParam:
                 f"instead.")
 
     def _setup_datetime_arg_converter(self, effective_type):
-        if effective_type == datetime:
+        if effective_type is datetime:
             self.arg_converter = to_datetime
-        elif effective_type == pd.Timestamp:
+        elif effective_type is pd.Timestamp:
             if "N" in self.encoded_types:
                 self.arg_converter = to_pd_timestamp
             else:
@@ -153,18 +153,18 @@ class _ParsedReturnAnnotation:
                 null_value = _PRIMITIVE_DTYPE_NULL_MAP.get(dtypes.from_np_dtype(np.dtype(t)))
                 self.ret_converter = partial(lambda nv, x: nv if x is None else int(x), null_value)
             else:
-                self.ret_converter = int if self.orig_type != int else None
+                self.ret_converter = int if self.orig_type is not int else None
         elif t in _NUMPY_FLOATING_TYPE_CODES:
             if self.none_allowed:
                 null_value = _PRIMITIVE_DTYPE_NULL_MAP.get(dtypes.from_np_dtype(np.dtype(t)))
                 self.ret_converter = partial(lambda nv, x: nv if x is None else float(x), null_value)
             else:
-                self.ret_converter = float if self.orig_type != float else None
+                self.ret_converter = float if self.orig_type is not float else None
         elif t == '?':
             if self.none_allowed:
                 self.ret_converter = lambda x: bool(x) if x is not None else None
             else:
-                self.ret_converter = bool if self.orig_type != bool else None
+                self.ret_converter = bool if self.orig_type is not bool else None
         elif t == 'M':
             from deephaven.time import to_j_instant
             self.ret_converter = to_j_instant
@@ -221,7 +221,7 @@ def _encode_param_type(t: type) -> str:
     if t is type(None):
         return "N"
 
-    if t == typing.Any or t == object or t == jpy.JType:
+    if t is typing.Any or t is object or t is jpy.JType:
         return "O"
 
     # find the component type if it is numpy ndarray
@@ -247,7 +247,7 @@ def _np_dtype_char(t: Union[type, str]) -> str:
 
     try:
         np_dtype = np.dtype(t)
-        if np_dtype.char == "O" and t != object: # np.dtype() returns np.dtype('O') for unrecognized types
+        if np_dtype.char == "O" and t is not object: # np.dtype() returns np.dtype('O') for unrecognized types
             return "X"
         return np_dtype.char
     except TypeError:
@@ -260,7 +260,7 @@ def _component_np_dtype_char(t: type) -> Optional[str]:
     component_type = _py_sequence_component_type(t)
 
     if not component_type:
-        if t == bytes or t == bytearray:
+        if t is bytes or t is bytearray:
             return "b"
 
     if not component_type:
@@ -300,7 +300,7 @@ def _np_ndarray_component_type(t: type) -> Optional[type]:
     # component type
     component_type = None
     if (3, 9) > sys.version_info >= (3, 8):
-        if isinstance(t, np._typing._generic_alias._GenericAlias) and t.__origin__ == np.ndarray:
+        if isinstance(t, np._typing._generic_alias._GenericAlias) and t.__origin__ is np.ndarray:
             component_type = t.__args__[1].__args__[0]
     # Py3.9+, np.ndarray as a generic alias is only supported in Python 3.9+, also npt.NDArray is still available but a
     # specific alias (e.g. npt.NDArray[np.int64]) now is an instance of typing.GenericAlias.
@@ -309,7 +309,7 @@ def _np_ndarray_component_type(t: type) -> Optional[type]:
     # when np.ndarray is used, the 1st argument is the component type
     if not component_type and sys.version_info >= (3, 9):
         import types
-        if isinstance(t, types.GenericAlias) and t.__origin__ == np.ndarray:  # novermin
+        if isinstance(t, types.GenericAlias) and t.__origin__ is np.ndarray:  # novermin
             nargs = len(t.__args__)
             if nargs == 1:
                 component_type = t.__args__[0]
@@ -328,7 +328,7 @@ def _is_union_type(t: type) -> bool:
         if isinstance(t, types.UnionType):  # novermin
             return True
 
-    return isinstance(t, _GenericAlias) and t.__origin__ == Union
+    return isinstance(t, _GenericAlias) and t.__origin__ is Union
 
 
 def _parse_param(name: str, annotation: Union[type, dtypes.DType]) -> _ParsedParam:
@@ -382,10 +382,10 @@ def _parse_return_annotation(annotation: Any) -> _ParsedReturnAnnotation:
     pra.orig_type = t
     if _is_union_type(annotation) and len(annotation.__args__) == 2:
         # if the annotation is a Union of two types, we'll use the non-None type
-        if annotation.__args__[1] == type(None):  # noqa: E721
+        if annotation.__args__[1] is type(None):  # noqa: E721
             pra.none_allowed = True
             t = annotation.__args__[0]
-        elif annotation.__args__[0] == type(None):  # noqa: E721
+        elif annotation.__args__[0] is type(None):  # noqa: E721
             pra.none_allowed = True
             t = annotation.__args__[1]
 

--- a/py/server/deephaven/_udf.py
+++ b/py/server/deephaven/_udf.py
@@ -164,11 +164,11 @@ class _ParsedReturnAnnotation:
             if self.none_allowed:
                 self.ret_converter = lambda x: bool(x) if x is not None else None
             else:
-                # Note this is not ideal because in the case of return type is bool, we should rely on JPY's conversion.
-                # The extra conversion however is least surprising for the users, and we should revisit
-                # when https://github.com/deephaven/deephaven-core/issues/5397 and/or
+                # Note this is not ideal because in the case where actual return is np.bool_ but type hint is bool,
+                # we raise a mystic error (PyObject can't be cast to Boolean). We need to revisit this when
+                # https://github.com/deephaven/deephaven-core/issues/5397 and/or
                 # https://github.com/deephaven/deephaven-core/issues/4068 is resolved.
-                self.ret_converter = bool
+                self.ret_converter = None if self.orig_type is bool else bool
         elif t == 'M':
             from deephaven.time import to_j_instant
             self.ret_converter = to_j_instant

--- a/py/server/deephaven/_udf.py
+++ b/py/server/deephaven/_udf.py
@@ -164,7 +164,11 @@ class _ParsedReturnAnnotation:
             if self.none_allowed:
                 self.ret_converter = lambda x: bool(x) if x is not None else None
             else:
-                self.ret_converter = bool if self.orig_type is not bool else None
+                # Note this is not ideal because in the case of return type is bool, we should rely on JPY's conversion.
+                # The extra conversion however is least surprising for the users, and we should revisit
+                # when https://github.com/deephaven/deephaven-core/issues/5397 and/or
+                # https://github.com/deephaven/deephaven-core/issues/4068 is resolved.
+                self.ret_converter = bool
         elif t == 'M':
             from deephaven.time import to_j_instant
             self.ret_converter = to_j_instant

--- a/py/server/tests/test_udf_array_args.py
+++ b/py/server/tests/test_udf_array_args.py
@@ -45,7 +45,7 @@ def test_udf(x {th}, y {th}) -> bool:
                         tbl = empty_table(100).update([x_formula, y_formula]).group_by("X")
 
                         func_str = f"""
-def test_udf(x {th}, y {th}) -> bool:
+def test_udf(x {th}, y {th}) -> np.bool_:
     j_array_type = _J_TYPE_J_ARRAY_TYPE_MAP[{j_dtype!r}].j_type
     return (isinstance(x, int) and isinstance(y, j_array_type) and np.any(np.array(y) == {null_name}))
                             """
@@ -80,7 +80,7 @@ def test_udf(x {th}, y {th}) -> bool:
                     tbl = empty_table(100).update([x_formula, y_formula]).group_by("X")
 
                     func_str = f"""
-def test_udf(x, y: np.ndarray[{np_dtype}]) -> bool:
+def test_udf(x, y: np.ndarray[{np_dtype}]) -> np.bool_:
     return (isinstance(x, int) and isinstance(y, np.ndarray) and y.dtype.type == {np_dtype} and np.nanmean(
     y) == np.mean( y))
                             """
@@ -95,7 +95,7 @@ def test_udf(x, y: np.ndarray[{np_dtype}]) -> bool:
                     tbl = empty_table(100).update([x_formula, y_formula]).group_by("X")
 
                     func_str = f"""
-def test_udf(x, y: np.ndarray[{_J_TYPE_NP_DTYPE_MAP[j_dtype]}]) -> bool:
+def test_udf(x, y: np.ndarray[{_J_TYPE_NP_DTYPE_MAP[j_dtype]}]) -> np.bool_:
     return (isinstance(x, int) and isinstance(y, np.ndarray) and y.dtype.type == 
     {_J_TYPE_NP_DTYPE_MAP[j_dtype]} and np.nanmean(y) == np.mean( y))
                             """
@@ -257,7 +257,7 @@ def test_udf(x, y: np.ndarray[{_J_TYPE_NP_DTYPE_MAP[j_dtype]}]) -> bool:
 
 
         with self.subTest("boolean"):
-            def test_udf(p1: np.ndarray[np.bool_], p2=None, tp: bool = True) -> bool:
+            def test_udf(p1: np.ndarray[np.bool_], p2=None, tp: bool = True) -> np.bool_:
                 z = dh_null_to_nan(p1, type_promotion=tp)
                 return z.dtype.type == np.float64 and np.any(np.isnan(z))
 

--- a/py/server/tests/test_udf_return.py
+++ b/py/server/tests/test_udf_return.py
@@ -184,8 +184,9 @@ foo = Foo()
             def fn4(col: int) -> bool:
                 return np.bool_(col)
 
-            t = empty_table(2).update("X = i").update(f"Y= fn4(X + 1)")
-            self.assertEqual(t.columns[1].data_type, dtypes.bool_)
+            with self.assertRaises(DHError) as cm:
+                 t = empty_table(2).update("X = i").update(f"Y= fn4(X + 1)")
+            self.assertIn("class org.jpy.PyObject cannot be cast to class java.lang.Boolean", str(cm.exception))
 
     def test_vectorization_off_on_return_type(self):
         def f1(x) -> List[str]:
@@ -319,6 +320,7 @@ def fn(col) -> Optional[{np_dtype}]:
             return [to_j_instant("2021-01-01T00:00:00Z")]
         t = empty_table(10).update(["X1 = udf()"])
         self.assertEqual(t.columns[0].data_type, dtypes.instant_array)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/server/tests/test_udf_return.py
+++ b/py/server/tests/test_udf_return.py
@@ -180,6 +180,15 @@ foo = Foo()
             t = empty_table(1).update("X = i").update(f"Y= fn3(X + 1)")
             self.assertEqual(t.columns[1].data_type, dtypes.JObject)
 
+        with self.subTest("wrong typehint bool vs. np.bool_"):
+            def fn4(col: int) -> bool:
+                return np.bool_(col)
+
+            with self.assertRaises(DHError) as cm:
+                t = empty_table(2).update("X = i").update(f"Y= fn4(X + 1)")
+            self.assertIn("class org.jpy.PyObject cannot be cast to class java.lang.Boolean", str(cm.exception))
+
+
     def test_vectorization_off_on_return_type(self):
         def f1(x) -> List[str]:
             return ["a"]

--- a/py/server/tests/test_udf_return.py
+++ b/py/server/tests/test_udf_return.py
@@ -184,10 +184,8 @@ foo = Foo()
             def fn4(col: int) -> bool:
                 return np.bool_(col)
 
-            with self.assertRaises(DHError) as cm:
-                t = empty_table(2).update("X = i").update(f"Y= fn4(X + 1)")
-            self.assertIn("class org.jpy.PyObject cannot be cast to class java.lang.Boolean", str(cm.exception))
-
+            t = empty_table(2).update("X = i").update(f"Y= fn4(X + 1)")
+            self.assertEqual(t.columns[1].data_type, dtypes.bool_)
 
     def test_vectorization_off_on_return_type(self):
         def f1(x) -> List[str]:

--- a/py/server/tests/test_udf_scalar_args.py
+++ b/py/server/tests/test_udf_scalar_args.py
@@ -218,7 +218,7 @@ def test_udf(col: Optional[{py_type}]) -> bool: # Optional enables auto DH null 
             self.assertEqual(5, t2.to_string(cols="Z").count("true"))
 
         with self.subTest("boolean"):
-            def test_udf(p1: np.bool_, p2=None) -> bool:
+            def test_udf(p1: np.bool_, p2=None) -> np.bool_:
                 return p1 == True
 
             t = empty_table(10).update(["X = i % 3", "Y = i % 2 == 0? true : false"])  # no null
@@ -247,7 +247,7 @@ def test_udf(col: Optional[{py_type}]) -> bool: # Optional enables auto DH null 
             self.assertEqual(5, t1.to_string(cols="Z").count("false"))
 
         with self.subTest("np.datetime64"):
-            def test_udf(p1: np.datetime64, p2=None) -> bool:  # numpy supports NaT, NaT for null
+            def test_udf(p1: np.datetime64, p2=None) -> np.bool_:  # numpy supports NaT, NaT for null
                 return p1.dtype.type == np.datetime64 and np.isnat(p1)
 
             t = empty_table(10).update(["X = i % 3", "Y = i % 2 == 0? now() : null"])
@@ -423,14 +423,14 @@ def test_udf(x: {np_type}) -> bool:
         t = new_table([int_col(c, [0, 1, 2, 3, 4, 5, 6]) for c in cols])
 
         with self.subTest("valid varargs typehint"):
-            def test_udf(p1: np.int32, *args: np.int64) -> int:
+            def test_udf(p1: np.int32, *args: np.int64) -> np.int64:
                 return sum(args)
 
             result = t.update(f"X = test_udf({','.join(cols)})")
             self.assertEqual(result.columns[4].data_type, dtypes.int64)
 
         with self.subTest("invalid varargs typehint"):
-            def test_udf(p1: np.int32, *args: np.int16) -> int:
+            def test_udf(p1: np.int32, *args: np.int16) -> np.int64:
                 return sum(args)
 
             with self.assertRaises(DHError) as cm:
@@ -507,7 +507,7 @@ def test_udf(x: {np_type}) -> bool:
             self.assertEqual(10, t.to_string().count("true"))
 
         with self.subTest("f5"):
-            def f5(col1, col2: np.ndarray[np.int32]) -> bool:
+            def f5(col1, col2: np.ndarray[np.int32]) -> np.bool_:
                 return np.nanmean(col2) == np.mean(col2)
 
             t = empty_table(10).update(["X = i % 3", "Y = i"]).group_by("X")
@@ -517,7 +517,7 @@ def test_udf(x: {np_type}) -> bool:
             self.assertRegex(str(cm.exception), "f5: Expected .* got null")
 
         with self.subTest("f51"):
-            def f51(col1, col2: Optional[np.ndarray[np.int32]]) -> bool:
+            def f51(col1, col2: Optional[np.ndarray[np.int32]]) -> np.bool_:
                 return np.nanmean(col2) == np.mean(col2)
 
             t = empty_table(10).update(["X = i % 3", "Y = i"]).group_by("X")

--- a/py/server/tests/test_vectorization.py
+++ b/py/server/tests/test_vectorization.py
@@ -307,7 +307,7 @@ def test_udf(col1, col2: np.ndarray[{_J_TYPE_NP_DTYPE_MAP[j_dtype]}]) -> np.ndar
 
     def test_1d_str_bool_datetime_array(self):
         with self.subTest("str"):
-            def f1(p1: np.ndarray[str]) -> bool:
+            def f1(p1: np.ndarray[str]) -> np.bool_:
                 return (p1 == 'None').any()
 
             t = empty_table(10).update(["X = i % 3", "Y = i % 2 == 0? `deephaven`: null"]).group_by("X").update("Y = Y.toArray()")
@@ -318,7 +318,7 @@ def test_udf(col1, col2: np.ndarray[{_J_TYPE_NP_DTYPE_MAP[j_dtype]}]) -> np.ndar
             _udf.vectorized_count = 0
 
         with self.subTest("datetime"):
-            def f2(p1: np.ndarray[np.datetime64]) -> bool:
+            def f2(p1: np.ndarray[np.datetime64]) -> np.bool_:
                 return np.isnat(p1).any()
 
             t = empty_table(10).update(["X = i % 3", "Y = i % 2 == 0? now() : null"]).group_by("X").update("Y = Y.toArray()")


### PR DESCRIPTION
When the return type is one of the Python built-in types, rely solely on JPY's conversion.