### PR TITLE
C++ client: process the envp argument to main instead of calling getenv()

### DIFF
--- a/cpp-client/deephaven/tests/include/private/deephaven/tests/test_util.h
+++ b/cpp-client/deephaven/tests/include/private/deephaven/tests/test_util.h
@@ -37,14 +37,14 @@ public:
   static void Init(char **envp);
 
   /**
-   * Look up 'key' in the environment_ map. Returns a set optional if found, otherwise
-   * returns an unset optional.
+   * Look up 'key' in the environment_ map. Returns the associated value if found;
+   * otherwise returns the value contained in 'defaultValue'.
    *
    * @param key The key
-   * @return If found, an optional set to a string_view of the value. If not found,
-   *   an unset optional.
+   * @param default_value The value to return if the key is not found.
+   * @return The associated value if found, otherwise the value contained in 'defaultValue'.
    */
-  static std::optional<std::string_view> GetEnv(std::string_view key);
+  static std::string_view GetEnv(std::string_view key, std::string_view default_value);
 
   // This is a pointer, so we don't have to worry about global construction/destruction.
   // At global teardown time we will just leak memory.

--- a/cpp-client/deephaven/tests/include/private/deephaven/tests/test_util.h
+++ b/cpp-client/deephaven/tests/include/private/deephaven/tests/test_util.h
@@ -24,6 +24,35 @@
 #include "deephaven/dhcore/utility/utility.h"
 
 namespace deephaven::client::tests {
+/**
+ * Stores a static global map of environment variable key/value pairs.
+ * Initialized from the 'envp' variable passed in to main.
+ */
+class GlobalEnvironmentForTests {
+public:
+  /**
+   * Initialize the environment_ map from the envp array passed into main().
+   * @param envp The envp parameter that was passed by the OS into 'main'.
+   */
+  static void Init(char **envp);
+
+  /**
+   * Look up 'key' in the environment_ map. Returns a set optional if found, otherwise
+   * returns an unset optional.
+   *
+   * @param key The key
+   * @return If found, an optional set to a string_view of the value. If not found,
+   *   an unset optional.
+   */
+  static std::optional<std::string_view> GetEnv(std::string_view key);
+
+  // This is a pointer, so we don't have to worry about global construction/destruction.
+  // At global teardown time we will just leak memory.
+  // Also, std::less<> gets us the transparent comparator, so we can do lookups
+  // directly with string_view.
+  static std::map<std::string, std::string, std::less<>> *environment_;
+};
+
 class ColumnNamesForTests {
 public:
   ColumnNamesForTests();

--- a/cpp-client/deephaven/tests/src/main.cc
+++ b/cpp-client/deephaven/tests/src/main.cc
@@ -1,5 +1,14 @@
 /*
  * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
  */
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include "deephaven/third_party/catch.hpp"
+#include "deephaven/tests/test_util.h"
+
+using deephaven::client::tests::GlobalEnvironmentForTests;
+
+int main(int argc, char *argv[], char **envp) {
+  // Process envp so we don't have to call getenv(), which Windows complains about.
+  GlobalEnvironmentForTests::Init(envp);
+  return Catch::Session().run(argc, argv);
+}

--- a/cpp-client/deephaven/tests/src/test_util.cc
+++ b/cpp-client/deephaven/tests/src/test_util.cc
@@ -37,13 +37,14 @@ void GlobalEnvironmentForTests::Init(char **envp) {
   }
 }
 
-std::optional<std::string_view> GlobalEnvironmentForTests::GetEnv(std::string_view key) {
+std::string_view GlobalEnvironmentForTests::GetEnv(std::string_view key,
+    std::string_view default_value) {
   if (environment_ == nullptr) {
-    return {};
+    return default_value;
   }
   auto ip = environment_->find(key);
   if (ip == environment_->end()) {
-    return {};
+    return default_value;
   }
   return ip->second;
 }
@@ -149,15 +150,9 @@ TableMakerForTests TableMakerForTests::Create() {
 }
 
 Client TableMakerForTests::CreateClient(const ClientOptions &options) {
-  auto host = GlobalEnvironmentForTests::GetEnv("DH_HOST");
-  auto port = GlobalEnvironmentForTests::GetEnv("DH_PORT");
-  if (!host.has_value()) {
-    host = "localhost";
-  }
-  if (!port.has_value()) {
-    port = "10000";
-  }
-  auto connection_string = fmt::format("{}:{}", *host, *port);
+  auto host = GlobalEnvironmentForTests::GetEnv("DH_HOST", "localhost");
+  auto port = GlobalEnvironmentForTests::GetEnv("DH_PORT", "10000");
+  auto connection_string = fmt::format("{}:{}", host, port);
   fmt::print(std::cerr, "Connecting to {}\n", connection_string);
   auto client = Client::Connect(connection_string, options);
   return client;


### PR DESCRIPTION
This helps us avoid a warning from Windows about the unsafety of getenv().