### PR TITLE
C++ Client: Make it work on Windows

### DIFF
--- a/cpp-client/.gitignore
+++ b/cpp-client/.gitignore
@@ -2,3 +2,4 @@
 cmake-build-debug
 cmake-build-release
 cmake-build-relwithdebinfo
+vcpkg_installed/

--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -8,8 +8,11 @@ We have used the instructions in the past to build
 for older Ubuntu versions (20.04) and for some Fedora versions, but we don't regularly test
 on them anymore so we do not guarantee they are current for those platforms.
 
-Instructions for Linux are below. Instructions for Windows are at the end of
-the document.
+================================================================================
+Instructions for Linux are below. Instructions for Windows are in the section
+that follows.
+
+# Building the C++ client on Ubuntu 22.04
 
 1. Start with an Ubuntu 22.04 install
 

--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -1,10 +1,15 @@
-# Building the C++ client from a base Ubuntu 20.04 or 22.04 image
+# Building the C++ client on Ubuntu 20.04 / 22.04 and Windows 10 / 11.
 
-These instructions show how to install and run the Deephaven C++ client, its dependencies,
-and its unit tests. We have tested these instructions in Ubuntu 22.04 with the default
-C++ compiler and tool suite (cmake etc).  We have used the instructions in the past to build
+These instructions show how to install and run the Deephaven C++ client, its
+dependencies, its unit tests on Linux and Windows. We have tested these instructions in Ubuntu 22.04 with the default
+C++ compiler and tool suite (cmake etc). We have also tested these instructions
+on Windows 10 and 11 with Visual Studio Community Edition.
+We have used the instructions in the past to build
 for older Ubuntu versions (20.04) and for some Fedora versions, but we don't regularly test
-on them anymore so we do notguarantee they are current for those platforms.
+on them anymore so we do not guarantee they are current for those platforms.
+
+Instructions for Linux are below. Instructions for Windows are at the end of
+the document.
 
 1. Start with an Ubuntu 22.04 install
 
@@ -197,3 +202,84 @@ Notes
       run the `build-cpp-protos.sh` script.
       This should generate up-to-date versions of the C++ stubs
       according to the proto sources on the same clone.
+
+# Building the C++ client on Windows 10 / Windows 11
+
+1. Get Deephaven running by following the instructions here:
+
+   https://deephaven.io/core/docs/how-to-guides/launch-build/
+
+2. Install Visual Studio 2022 Community Edition (or Professional, or Enterprise)
+   from here:
+
+   https://visualstudio.microsoft.com/downloads/
+
+   When the installer runs, select the workload "Desktop development with C++"
+
+3. Use your preferred version of git, or install Git from here:
+
+   https://git-scm.com/download/win
+
+4. We will do the actual build process inside a Visual Studio developer
+   command prompt. Run the developer command prompt by navigating here:
+
+   Start -> V -> Visual Studio 2022 -> Developer Command Prompt for VS 2022
+
+5. Make a 'dhsrc' directory that will hold the two repositories: the vcpkg
+   package manager and Deephaven Core. Then make a 'dhinstall' directory that
+   will hold the libraries and executables that are the result of this
+   build process.
+   ```
+   mkdir %HOMEDRIVE%%HOMEPATH%\dhsrc
+   mkdir %HOMEDRIVE%%HOMEPATH%\dhinstall
+   ```
+
+6. Use git to clone the two repositories mentioned above.
+   If you are using Git for Windows, you can run the "Git Bash Shell"
+   and type these commands into it:
+   ```
+   cd $HOME/dhsrc
+   git clone https://github.com/microsoft/vcpkg.git
+   git clone https://github.com/deephaven/deephaven-core.git
+   ```
+
+7. Come back to the Visual Studio developer command prompt and do the
+   one-time installation steps for vcpkg. Do not forget to set VCPKG_ROOT,
+   as our build scripts rely on it being set correctly.
+   ```
+   cd /d %HOMEDRIVE%%HOMEPATH%\dhsrc\vcpkg
+   .\bootstrap-vcpkg.bat
+   set VCPKG_ROOT=%HOMEDRIVE%%HOMEPATH%\dhsrc\vcpkg
+   ```
+
+8. Change to the Deephaven core directory and build/install the dependent
+   packages. On my computer this process took about 20 minutes.
+   ```
+   cd /d %HOMEDRIVE%%HOMEPATH%\dhsrc\deephaven-core\cpp-client\deephaven
+   %VCPKG_ROOT%\vcpkg.exe install --triplet x64-windows
+    ```
+
+9. Now configure the build for Deephaven Core:
+   ``` 
+   cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=%HOMEDRIVE%%HOMEPATH%/dhinstall -DX_VCPKG_APPLOCAL_DEPS_INSTALL=ON
+   ```
+   
+10. Finally, build and install Deephaven Core:
+    ```
+    cmake --build build --target install
+    ```
+
+11. Run the tests.
+    First, make sure Deephaven is running. If your Deephaven instance
+    is running somewhere other than the default location of localhost:10000,
+    then set these environment variables appropriately:
+    ```
+    set DH_HOST=...
+    set DH_PORT=...
+    ```
+
+    then run the tests executable:
+    ```
+    cd /d %HOMEDRIVE%%HOMEPATH%\dhinstall\bin
+    .\dhclient_tests.exe
+    ```

--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -8,7 +8,6 @@ We have used the instructions in the past to build
 for older Ubuntu versions (20.04) and for some Fedora versions, but we don't regularly test
 on them anymore so we do not guarantee they are current for those platforms.
 
-================================================================================
 Instructions for Linux are below. Instructions for Windows are in the section
 that follows.
 

--- a/cpp-client/deephaven/CMakeLists.txt
+++ b/cpp-client/deephaven/CMakeLists.txt
@@ -39,7 +39,7 @@ if(NOT DHCORE_ONLY)
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 
-    install(TARGETS dhclient dhcore dhclient_tests
+    install(TARGETS dhclient dhcore dhcore_static dhclient_tests
         EXPORT deephavenConfig
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cpp-client/deephaven/CMakeLists.txt
+++ b/cpp-client/deephaven/CMakeLists.txt
@@ -13,8 +13,6 @@ set(CMAKE_CXX_STANDARD 17)
 # for CMAKE_INSTALL_{dir}
 include(GNUInstallDirs)
 
-add_compile_options(-Wall -Werror -Wno-deprecated-declarations)
-
 # To enable address sanitizer, add `-DSANITIZE_ADDRESS=ON` to
 # the list of options you pass for running cmake.
 option(SANITIZE_ADDRESS "Enable address sanitizer" "OFF")
@@ -41,7 +39,7 @@ if(NOT DHCORE_ONLY)
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 
-    install(TARGETS dhclient dhcore_static dhcore dhclient_tests
+    install(TARGETS dhclient dhcore dhclient_tests
         EXPORT deephavenConfig
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cpp-client/deephaven/CMakePresets.json
+++ b/cpp-client/deephaven/CMakePresets.json
@@ -1,0 +1,62 @@
+﻿{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "windows-base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "installDir": "${sourceDir}/out/install/${presetName}",
+             "cacheVariables": {
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe",
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "x64-debug",
+            "displayName": "x64 Debug",
+            "inherits": "windows-base",
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "x64-release",
+            "displayName": "x64 Release",
+            "inherits": "x64-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "x86-debug",
+            "displayName": "x86 Debug",
+            "inherits": "windows-base",
+            "architecture": {
+                "value": "x86",
+                "strategy": "external"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "x86-release",
+            "displayName": "x86 Release",
+            "inherits": "x86-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ]
+}

--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_CXX_STANDARD 17)
 # for CMAKE_INSTALL_{dir}
 include(GNUInstallDirs)
 
-find_package(Arrow REQUIRED)
-find_package(ArrowFlight REQUIRED HINTS ${Arrow_DIR})
+find_package(Arrow CONFIG REQUIRED)
+find_package(ArrowFlight CONFIG REQUIRED)
 find_package(Immer REQUIRED)
 find_package(Protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
@@ -22,7 +22,6 @@ set(ALL_FILES
     src/impl/table_handle_impl.cc
     src/impl/table_handle_manager_impl.cc
     src/impl/update_by_operation_impl.cc
-
     include/private/deephaven/client/impl/aggregate_impl.h
     include/private/deephaven/client/impl/client_impl.h
     include/private/deephaven/client/impl/table_handle_impl.h
@@ -40,7 +39,6 @@ set(ALL_FILES
     src/client.cc
     src/flight.cc
     src/update_by.cc
-
     include/public/deephaven/client/client.h
     include/public/deephaven/client/client_options.h
     include/public/deephaven/client/flight.h
@@ -99,26 +97,35 @@ set(ALL_FILES
     proto/deephaven/proto/ticket.pb.h
 )
 
-add_library(dhclient ${ALL_FILES})
-# In order to make a shared library suitable for Cython.
-set_property(TARGET dhclient PROPERTY POSITION_INDEPENDENT_CODE ON)
+add_library(dhclient SHARED ${ALL_FILES})
 
 # This is so deephaven::client works both when using the installed CMake config
 # and when using this project as a CMake subdirectory of your own project.
 add_library(deephaven::client ALIAS dhclient)
-target_compile_options(dhclient PRIVATE -Wall -Werror -Wno-deprecated-declarations)
+
+set_property(TARGET dhclient PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if (LINUX)
+    target_compile_options(dhclient PRIVATE -Wall -Werror -Wno-deprecated-declarations)
+endif()
+
+if (WIN32)
+    set_property(TARGET dhclient PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    # /Wall is a bit too chatty so we stick with /W3
+    # /bigobj needed because ticking/immer_table_state.cc compiles to something too large apparently
+    target_compile_options(dhclient PRIVATE /W3 /bigobj)
+endif()
 
 target_include_directories(dhclient PRIVATE include/private)
 target_include_directories(dhclient PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>)
-
 # Protos and flatbuf are doing their own thing.
 target_include_directories(dhclient PRIVATE "./proto")
 target_include_directories(dhclient PRIVATE "./flatbuf")
 
-target_link_libraries(dhclient PUBLIC dhcore)
+target_link_libraries(dhclient PUBLIC deephaven::dhcore)
 
-target_link_libraries(dhclient PUBLIC arrow_flight_static)
-target_link_libraries(dhclient PUBLIC arrow_static)
+target_link_libraries(dhclient PUBLIC ArrowFlight::arrow_flight_shared)
+target_link_libraries(dhclient PUBLIC Arrow::arrow_shared)
 target_link_libraries(dhclient PUBLIC immer)
 target_link_libraries(dhclient PUBLIC protobuf::libprotobuf)
 target_link_libraries(dhclient PUBLIC gRPC::grpc++)

--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 
 find_package(Arrow CONFIG REQUIRED)
-find_package(ArrowFlight CONFIG REQUIRED)
+find_package(ArrowFlight CONFIG REQUIRED HINTS ${Arrow_DIR})
 find_package(Immer REQUIRED)
 find_package(Protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -106,29 +106,36 @@ set(ALL_FILES
 #
 
 add_library(dhcore SHARED ${ALL_FILES})
+add_library(dhcore_static STATIC ${ALL_FILES})
 
 # This is so deephaven::dhcore works both when using the installed CMake config
 # and when using this project as a CMake subdirectory of your own project.
 add_library(deephaven::dhcore ALIAS dhcore)
 
 set_property(TARGET dhcore PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-if (LINUX)
-    target_compile_options(dhcore PRIVATE -Wall -Werror -Wno-deprecated-declarations)
-endif()
-
 if (WIN32)
   set_property(TARGET dhcore PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
-  # /Wall is a bit too chatty so we stick with /W3
-  # /bigobj needed because ticking/immer_table_state.cc compiles to something too large apparently
-  target_compile_options(dhcore PRIVATE /W3 /bigobj)
-  target_compile_definitions(dhcore PRIVATE _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 endif()
 
-target_include_directories(dhcore PRIVATE include/private)
-target_include_directories(dhcore PRIVATE third_party/date/include)
-target_include_directories(dhcore PRIVATE third_party/flatbuffers/include)
-target_include_directories(dhcore PRIVATE third_party/roaring/include)
-target_include_directories(dhcore PRIVATE flatbuf)
-target_include_directories(dhcore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>)
-target_link_libraries(dhcore PUBLIC immer)
+foreach (whichlib dhcore dhcore_static)
+  if (LINUX)
+    target_compile_options(${whichlib} PRIVATE -Wall -Werror -Wno-deprecated-declarations)
+  endif()
+
+  if (WIN32)
+    # /Wall is a bit too chatty so we stick with /W3
+    # /bigobj needed because ticking/immer_table_state.cc compiles to something too large apparently
+    target_compile_options(${whichlib} PRIVATE /W3 /bigobj)
+
+    target_compile_definitions(${whichlib} PRIVATE _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
+  endif()
+
+  target_include_directories(${whichlib} PRIVATE include/private)
+  target_include_directories(${whichlib} PRIVATE third_party/date/include)
+  target_include_directories(${whichlib} PRIVATE third_party/flatbuffers/include)
+  target_include_directories(${whichlib} PRIVATE third_party/roaring/include)
+  target_include_directories(${whichlib} PRIVATE flatbuf)
+  target_include_directories(${whichlib} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>)
+
+  target_link_libraries(${whichlib} PUBLIC immer)
+endforeach()

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -112,12 +112,13 @@ add_library(dhcore_static STATIC ${ALL_FILES})
 # and when using this project as a CMake subdirectory of your own project.
 add_library(deephaven::dhcore ALIAS dhcore)
 
-set_property(TARGET dhcore PROPERTY POSITION_INDEPENDENT_CODE ON)
 if (WIN32)
   set_property(TARGET dhcore PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
 foreach (whichlib dhcore dhcore_static)
+  set_property(TARGET ${whichlib} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
   if (LINUX)
     target_compile_options(${whichlib} PRIVATE -Wall -Werror -Wno-deprecated-declarations)
   endif()

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -98,23 +98,6 @@ set(ALL_FILES
     third_party/date/include/date/date.h
 )
 
-add_library(dhcore_objlib OBJECT ${ALL_FILES})
-# In order to make a shared library suitable for Cython.
-set_property(TARGET dhcore_objlib PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-target_compile_options(dhcore_objlib PRIVATE -Wall -Werror -Wno-deprecated-declarations)
-
-target_include_directories(dhcore_objlib PRIVATE include/private)
-target_include_directories(dhcore_objlib PRIVATE third_party/flatbuffers/include)
-target_include_directories(dhcore_objlib PRIVATE third_party/date/include)
-target_include_directories(dhcore_objlib PRIVATE third_party/roaring/include)
-target_include_directories(dhcore_objlib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>)
-
-# The flatbuf include directory is in its own part of the tree.
-target_include_directories(dhcore_objlib PRIVATE "./flatbuf")
-
-target_link_libraries(dhcore_objlib PUBLIC immer)
-
 #
 # shared and static libraries built from the same object files
 # https://stackoverflow.com/questions/2152077/is-it-possible-to-get-cmake-to-build-both-a-static-and-shared-library-at-the-sam
@@ -122,27 +105,30 @@ target_link_libraries(dhcore_objlib PUBLIC immer)
 # https://stackoverflow.com/questions/38832528/transitive-target-include-directories-on-object-libraries
 #
 
-get_property(object_link_libs TARGET dhcore_objlib PROPERTY LINK_LIBRARIES)
-
-add_library(dhcore SHARED $<TARGET_OBJECTS:dhcore_objlib>)
-# TODO: How to avoid repetition here for target_include_directories?
-target_include_directories(dhcore PRIVATE include/private)
-target_include_directories(dhcore PRIVATE third_party/date/include)
-target_include_directories(dhcore PRIVATE third_party/flatbuffers/include)
-target_include_directories(dhcore PRIVATE third_party/roaring/include)
-target_include_directories(dhcore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>)
-target_link_libraries(dhcore PUBLIC ${object_link_libs})
-
-add_library(dhcore_static STATIC $<TARGET_OBJECTS:dhcore_objlib>)
-# TODO: How to avoid repetition here for target_include_directories?
-target_include_directories(dhcore_static PRIVATE include/private)
-target_include_directories(dhcore_static PRIVATE third_party/date/include)
-target_include_directories(dhcore_static PRIVATE third_party/flatbuffers/include)
-target_include_directories(dhcore_static PRIVATE third_party/roaring/include)
-target_include_directories(dhcore_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>)
-target_link_libraries(dhcore_static PUBLIC ${object_link_libs})
+add_library(dhcore SHARED ${ALL_FILES})
 
 # This is so deephaven::dhcore works both when using the installed CMake config
 # and when using this project as a CMake subdirectory of your own project.
 add_library(deephaven::dhcore ALIAS dhcore)
-add_library(deephaven::dhcore_static ALIAS dhcore_static)
+
+set_property(TARGET dhcore PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if (LINUX)
+    target_compile_options(dhcore PRIVATE -Wall -Werror -Wno-deprecated-declarations)
+endif()
+
+if (WIN32)
+  set_property(TARGET dhcore PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  # /Wall is a bit too chatty so we stick with /W3
+  # /bigobj needed because ticking/immer_table_state.cc compiles to something too large apparently
+  target_compile_options(dhcore PRIVATE /W3 /bigobj)
+  target_compile_definitions(dhcore PRIVATE _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
+endif()
+
+target_include_directories(dhcore PRIVATE include/private)
+target_include_directories(dhcore PRIVATE third_party/date/include)
+target_include_directories(dhcore PRIVATE third_party/flatbuffers/include)
+target_include_directories(dhcore PRIVATE third_party/roaring/include)
+target_include_directories(dhcore PRIVATE flatbuf)
+target_include_directories(dhcore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>)
+target_link_libraries(dhcore PUBLIC immer)

--- a/cpp-client/deephaven/tests/CMakeLists.txt
+++ b/cpp-client/deephaven/tests/CMakeLists.txt
@@ -37,7 +37,14 @@ add_executable(dhclient_tests
         include/private/deephaven/third_party/catch.hpp
 )
 
-target_compile_options(dhclient_tests PRIVATE -Wall -Werror)
+if (LINUX)
+    target_compile_options(dhclient_tests PRIVATE -Wall -Werror -Wno-deprecated-declarations)
+endif()
+
+if (WIN32)
+    target_compile_options(dhclient_tests PRIVATE /W3)
+endif()
+
 target_include_directories(dhclient_tests PRIVATE include/private)
 
 target_link_libraries(dhclient_tests deephaven::client)

--- a/cpp-client/deephaven/vcpkg-configuration.json
+++ b/cpp-client/deephaven/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "0dc005fb66801c8a8266e81bd2cedb4d5501f30e",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/cpp-client/deephaven/vcpkg.json
+++ b/cpp-client/deephaven/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": [
+    "immer",
+    "grpc",
+    {
+      "name": "arrow",
+      "features": [
+        "flight"
+      ]
+    }
+  ],
+
+  "overrides": [
+    { "name": "arrow", "version": "13.0.0#1" },
+    { "name": "protobuf", "version": "3.21.2" }
+  ]
+}


### PR DESCRIPTION
Note I have dropped `dhcore_static` for the sake of making this work easier. We can bring it back as a separate PR if it is needed.

At the moment I don't remember why we wanted/needed `dhcore_static`.
