### PR TITLE
Expose table downsample on JS API

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -1517,7 +1517,18 @@ public class JsTable extends HasLifecycle implements HasTableBinding, JoinableTa
         }
     }
 
-    public Promise<JsTable> downsample(LongWrapper[] zoomRange, int pixelCount, String xCol, String[] yCols) {
+    /**
+     * Get a downsampled version of the table. Currently only supports downsampling with an Instant or long `xCol`.
+     *
+     * @param zoomRange The visible range as `[start, end]` or null to always use all data.
+     * @param pixelCount The width of the visible area in pixels.
+     * @param xCol The name of the X column to downsample. Must be an Instant or long.
+     * @param yCols The names of the Y columns to downsample.
+     * @return A promise that resolves to the downsampled table.
+     */
+    @JsMethod
+    public Promise<JsTable> downsample(@JsNullable LongWrapper[] zoomRange, int pixelCount, String xCol,
+            String[] yCols) {
         JsLog.info("downsample", zoomRange, pixelCount, xCol, yCols);
         final String fetchSummary = "downsample(" + Arrays.toString(zoomRange) + ", " + pixelCount + ", " + xCol + ", "
                 + Arrays.toString(yCols) + ")";

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -1526,8 +1526,7 @@ public class JsTable extends HasLifecycle implements HasTableBinding, JoinableTa
      * @param yCols The names of the Y columns to downsample.
      * @return A promise that resolves to the downsampled table.
      */
-    @JsMethod
-    public Promise<JsTable> downsample(@JsNullable LongWrapper[] zoomRange, int pixelCount, String xCol,
+    public Promise<JsTable> downsample(LongWrapper[] zoomRange, int pixelCount, String xCol,
             String[] yCols) {
         JsLog.info("downsample", zoomRange, pixelCount, xCol, yCols);
         final String fetchSummary = "downsample(" + Arrays.toString(zoomRange) + ", " + pixelCount + ", " + xCol + ", "

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/Downsample.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/Downsample.java
@@ -16,8 +16,8 @@ import jsinterop.annotations.JsType;
 @JsType(namespace = "dh.plot")
 public class Downsample {
     /**
-     * Downsamples a table so that the data can be used for a time-series line plot.
-     * The downsampled table should have the same visual fidelity as the original table, but with fewer rows.
+     * Downsamples a table so that the data can be used for a time-series line plot. The downsampled table should have
+     * the same visual fidelity as the original table, but with fewer rows.
      *
      * @param table The table to downsample.
      * @param xCol The name of the X column to downsample. Must be an Instant or long.

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/Downsample.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/Downsample.java
@@ -5,6 +5,7 @@ package io.deephaven.web.client.api.widget.plot;
 
 import elemental2.promise.Promise;
 import io.deephaven.web.client.api.*;
+import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsNullable;
 import jsinterop.annotations.JsOptional;
 import jsinterop.annotations.JsType;
@@ -15,8 +16,8 @@ import jsinterop.annotations.JsType;
 @JsType(namespace = "dh.plot")
 public class Downsample {
     /**
-     * Downsamples a table so that the data can be used for a line plot. The downsampled table should have the same
-     * visual fidelity as the original table, but with fewer rows.
+     * Downsamples a table so that the data can be used for a time-series line plot.
+     * The downsampled table should have the same visual fidelity as the original table, but with fewer rows.
      *
      * @param table The table to downsample.
      * @param xCol The name of the X column to downsample. Must be an Instant or long.
@@ -26,10 +27,11 @@ public class Downsample {
      * 
      * @return A promise that resolves to the downsampled table.
      */
-    public static Promise<JsTable> linearDownsample(JsTable table, String xCol, String[] yCols, int width,
+    public static Promise<JsTable> runChartDownsample(JsTable table, String xCol, String[] yCols, int width,
             @JsOptional @JsNullable LongWrapper[] xRange) {
         return table.downsample(xRange, width, xCol, yCols);
     }
 
+    @JsIgnore
     private Downsample() {}
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/Downsample.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/Downsample.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.web.client.api.widget.plot;
+
+import elemental2.promise.Promise;
+import io.deephaven.web.client.api.*;
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOptional;
+import jsinterop.annotations.JsType;
+
+/**
+ * Helper class for plot downsampling methods.
+ */
+@JsType(namespace = "dh.plot")
+public class Downsample {
+    /**
+     * Downsamples a table so that the data can be used for a line plot. The downsampled table should have the same
+     * visual fidelity as the original table, but with fewer rows.
+     *
+     * @param table The table to downsample.
+     * @param xCol The name of the X column to downsample. Must be an Instant or long.
+     * @param yCols The names of the Y columns to downsample.
+     * @param width The width of the visible area in pixels.
+     * @param xRange The visible range as `[start, end]` or null to always use all data.
+     * 
+     * @return A promise that resolves to the downsampled table.
+     */
+    public static Promise<JsTable> linearDownsample(JsTable table, String xCol, String[] yCols, int width,
+            @JsOptional @JsNullable LongWrapper[] xRange) {
+        return table.downsample(xRange, width, xCol, yCols);
+    }
+
+    private Downsample() {}
+}


### PR DESCRIPTION
Needed for https://github.com/deephaven/deephaven-plugins/issues/41 as the plotly-express plugin does not create `JsFigure`s, but listens to tables and passes the events through `ChartData` to maintain the data array