### PR TITLE
fix: Could not re-open application created variables

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsVariableDefinition.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/console/JsVariableDefinition.java
@@ -29,7 +29,8 @@ public class JsVariableDefinition {
 
     public JsVariableDefinition(String type, String title, String id, String description) {
         // base64('s/' + str) starts with 'cy8' or 'cy9'
-        if (!id.startsWith("cy")) {
+        // base64('a/' + str) starts with 'YS8' or 'YS9'
+        if (!id.startsWith("cy") && !id.startsWith("YS")) {
             throw new IllegalArgumentException("Cannot create a VariableDefinition from a non-scope ticket");
         }
         this.type = type;


### PR DESCRIPTION
- Passing in a VariableDescriptor with a valid ID was not creating a proper VariableDefinition
- It's checking "s/" specifically, whereas application variable is prefixed with "a/"
- Tested by following the steps in the description.
