### PR TITLE
Move Script Cache Clearing to Dagger

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
@@ -814,13 +814,13 @@ public class QueryCompilerImpl implements QueryCompiler, LogOutputAppendable {
         final String tempDirAsString;
         try {
             rootPathAsString = getClassDestination().getAbsolutePath();
-            final Path tempPath =
-                    Files.createTempDirectory(Paths.get(rootPathAsString), "temporaryCompilationDirectory");
-            tempDirAsString = tempPath.toFile().getAbsolutePath();
-
             for (final CompilationRequestAttempt request : requests) {
                 request.ensureDirectories(rootPathAsString);
             }
+
+            final Path tempPath =
+                    Files.createTempDirectory(Paths.get(rootPathAsString), "temporaryCompilationDirectory");
+            tempDirAsString = tempPath.toFile().getAbsolutePath();
         } catch (IOException ioe) {
             Exception err = new UncheckedIOException(ioe);
             for (final CompilationRequestAttempt request : requests) {

--- a/server/src/main/java/io/deephaven/server/console/ConsoleModule.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleModule.java
@@ -12,6 +12,7 @@ import io.deephaven.lang.completion.CustomCompletion;
 import io.deephaven.server.session.TicketResolver;
 import io.grpc.BindableService;
 
+import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.Set;
 
@@ -24,6 +25,12 @@ public interface ConsoleModule {
     @Binds
     @IntoSet
     TicketResolver bindConsoleTicketResolver(ScopeTicketResolver resolver);
+
+    @Provides
+    @Singleton
+    static ScriptSessionCacheInit bindScriptSessionCacheInit() {
+        return new ScriptSessionCacheInit();
+    }
 
     @Provides
     @ElementsIntoSet

--- a/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
@@ -10,6 +10,7 @@ import dagger.multibindings.StringKey;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
+import io.deephaven.engine.util.AbstractScriptSession;
 import io.deephaven.engine.util.NoLanguageDeephavenSession;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.server.console.groovy.InitScriptsModule;
@@ -29,6 +30,8 @@ public class NoConsoleSessionModule {
     NoLanguageDeephavenSession bindNoLanguageSession(
             @Named(PeriodicUpdateGraph.DEFAULT_UPDATE_GRAPH_NAME) final UpdateGraph updateGraph,
             final OperationInitializer operationInitializer) {
+        // create the script cache (or clear previous sessions)
+        AbstractScriptSession.createScriptCache();
         return new NoLanguageDeephavenSession(updateGraph, operationInitializer);
     }
 }

--- a/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
@@ -10,7 +10,6 @@ import dagger.multibindings.StringKey;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
-import io.deephaven.engine.util.AbstractScriptSession;
 import io.deephaven.engine.util.NoLanguageDeephavenSession;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.server.console.groovy.InitScriptsModule;
@@ -29,9 +28,8 @@ public class NoConsoleSessionModule {
     @Provides
     NoLanguageDeephavenSession bindNoLanguageSession(
             @Named(PeriodicUpdateGraph.DEFAULT_UPDATE_GRAPH_NAME) final UpdateGraph updateGraph,
-            final OperationInitializer operationInitializer) {
-        // create the script cache (or clear previous sessions)
-        AbstractScriptSession.createScriptCache();
+            final OperationInitializer operationInitializer,
+            final ScriptSessionCacheInit ignored) {
         return new NoLanguageDeephavenSession(updateGraph, operationInitializer);
     }
 }

--- a/server/src/main/java/io/deephaven/server/console/ScriptSessionCacheInit.java
+++ b/server/src/main/java/io/deephaven/server/console/ScriptSessionCacheInit.java
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.console;
+
+import io.deephaven.engine.util.AbstractScriptSession;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class ScriptSessionCacheInit {
+
+    @Inject
+    public ScriptSessionCacheInit() {
+        // create the script cache (or clear previous sessions)
+        AbstractScriptSession.createScriptCache();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
@@ -10,6 +10,7 @@ import dagger.multibindings.StringKey;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
+import io.deephaven.engine.util.AbstractScriptSession;
 import io.deephaven.engine.util.GroovyDeephavenSession;
 import io.deephaven.engine.util.GroovyDeephavenSession.RunScripts;
 import io.deephaven.engine.util.ScriptSession;
@@ -36,6 +37,8 @@ public class GroovyConsoleSessionModule {
             final ScriptSession.Listener listener,
             final RunScripts runScripts) {
         try {
+            // create the script cache (or clear previous sessions)
+            AbstractScriptSession.createScriptCache();
             return GroovyDeephavenSession.of(updateGraph, operationInitializer, lookup, listener, runScripts);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);

--- a/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/groovy/GroovyConsoleSessionModule.java
@@ -10,11 +10,11 @@ import dagger.multibindings.StringKey;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
-import io.deephaven.engine.util.AbstractScriptSession;
 import io.deephaven.engine.util.GroovyDeephavenSession;
 import io.deephaven.engine.util.GroovyDeephavenSession.RunScripts;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.plugin.type.ObjectTypeLookup;
+import io.deephaven.server.console.ScriptSessionCacheInit;
 
 import javax.inject.Named;
 import java.io.IOException;
@@ -35,10 +35,9 @@ public class GroovyConsoleSessionModule {
             final OperationInitializer operationInitializer,
             final ObjectTypeLookup lookup,
             final ScriptSession.Listener listener,
-            final RunScripts runScripts) {
+            final RunScripts runScripts,
+            final ScriptSessionCacheInit ignored) {
         try {
-            // create the script cache (or clear previous sessions)
-            AbstractScriptSession.createScriptCache();
             return GroovyDeephavenSession.of(updateGraph, operationInitializer, lookup, listener, runScripts);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);

--- a/server/src/main/java/io/deephaven/server/console/python/PythonConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonConsoleSessionModule.java
@@ -10,6 +10,7 @@ import dagger.multibindings.StringKey;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
+import io.deephaven.engine.util.AbstractScriptSession;
 import io.deephaven.engine.util.PythonEvaluatorJpy;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.integrations.python.PythonDeephavenSession;
@@ -38,6 +39,8 @@ public class PythonConsoleSessionModule {
             final ScriptSession.Listener listener,
             final PythonEvaluatorJpy pythonEvaluator) {
         try {
+            // create the script cache (or clear previous sessions)
+            AbstractScriptSession.createScriptCache();
             return new PythonDeephavenSession(
                     updateGraph, operationInitializer, threadInitializationFactory, lookup, listener,
                     true, pythonEvaluator);

--- a/server/src/main/java/io/deephaven/server/console/python/PythonConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonConsoleSessionModule.java
@@ -10,11 +10,11 @@ import dagger.multibindings.StringKey;
 import io.deephaven.engine.updategraph.OperationInitializer;
 import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
-import io.deephaven.engine.util.AbstractScriptSession;
 import io.deephaven.engine.util.PythonEvaluatorJpy;
 import io.deephaven.engine.util.ScriptSession;
 import io.deephaven.integrations.python.PythonDeephavenSession;
 import io.deephaven.plugin.type.ObjectTypeLookup;
+import io.deephaven.server.console.ScriptSessionCacheInit;
 import io.deephaven.util.thread.ThreadInitializationFactory;
 
 import javax.inject.Named;
@@ -37,10 +37,9 @@ public class PythonConsoleSessionModule {
             final OperationInitializer operationInitializer,
             final ObjectTypeLookup lookup,
             final ScriptSession.Listener listener,
-            final PythonEvaluatorJpy pythonEvaluator) {
+            final PythonEvaluatorJpy pythonEvaluator,
+            final ScriptSessionCacheInit ignored) {
         try {
-            // create the script cache (or clear previous sessions)
-            AbstractScriptSession.createScriptCache();
             return new PythonDeephavenSession(
                     updateGraph, operationInitializer, threadInitializationFactory, lookup, listener,
                     true, pythonEvaluator);

--- a/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
+++ b/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
@@ -177,9 +177,6 @@ public class DeephavenApiServer {
         log.info().append("Configuring logging...").endl();
         logInit.run();
 
-        log.info().append("Creating/Clearing Script Cache...").endl();
-        AbstractScriptSession.createScriptCache();
-
         for (BusinessCalendar calendar : calendars.get()) {
             Calendars.addCalendar(calendar);
         }


### PR DESCRIPTION
The QueryCompiler change somehow now requires that the directory is cleared before the sub-directory is created. The simplest solution I could find defers the parent directory clearing to just prior to the session construction.