### PR TITLE
Collect all pydeephaven-ticking wheels into single directory

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -73,8 +73,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingRequired: true
 
       - name: Upload Artifacts
-        # DO NOT MERGE
-        #if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
+        if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         uses: actions/upload-artifact@v4
         with:
           name: artifacts

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -73,7 +73,8 @@ jobs:
           ORG_GRADLE_PROJECT_signingRequired: true
 
       - name: Upload Artifacts
-        if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
+        # DO NOT MERGE
+        #if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         uses: actions/upload-artifact@v4
         with:
           name: artifacts

--- a/py/client-ticking/build.gradle
+++ b/py/client-ticking/build.gradle
@@ -166,7 +166,14 @@ def testPyClientTicking = project.tasks.register('testPyClientTicking') {
     }
 }
 
-assemble.dependsOn cpythonBuilds.values()
+def syncWheels = tasks.register('syncWheels', Sync) {
+    cpythonBuilds.values().each { cpythonBuild ->
+        from cpythonBuild.get().outputs
+    }
+    into layout.buildDirectory.dir('wheel')
+}
+
+assemble.dependsOn syncWheels
 
 check.dependsOn testPyClientTicking
 


### PR DESCRIPTION
This matches the expectations and conventions established by publish-ci.yml.

Fixes #5425