### PR TITLE
Make Numeric.sum return null when there are no inputs or all null inputs

### DIFF
--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -1488,6 +1488,7 @@ public class Numeric {
         }
 
         double sum = 0;
+        long nullCount = 0;
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
             while ( vi.hasNext() ) {
@@ -1499,8 +1500,14 @@ public class Numeric {
 
                 if (!isNull(c)) {
                     sum += c;
+                } else {
+                    nullCount++;
                 }
             }
+        }
+
+        if (nullCount == values.size()) {
+            return NULL_DOUBLE;
         }
 
         return sum;
@@ -1512,6 +1519,7 @@ public class Numeric {
         }
 
         long sum = 0;
+        long nullCount = 0;
 
         try ( final ${pt.vectorIterator} vi = values.iterator() ) {
             while ( vi.hasNext() ) {
@@ -1519,8 +1527,14 @@ public class Numeric {
 
                 if (!isNull(c)) {
                     sum += c;
+                } else {
+                    nullCount++;
                 }
             }
+        }
+
+        if (nullCount == values.size()) {
+            return NULL_LONG;
         }
 
         return sum;

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -577,6 +577,7 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6})));
         assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY})));
         assertEquals(Double.NaN, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY})));
+        assertEquals(Double.NaN, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NaN, 6})));
     <#else>
         assertEquals(NULL_LONG, sum((${pt.vector}) null));
         assertEquals(NULL_LONG, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{})));
@@ -596,6 +597,7 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6}));
         assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY}));
         assertEquals(Double.NaN, sum(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY}));
+        assertEquals(Double.NaN, sum(new ${pt.primitive}[]{4, Float.NaN, 6}));
     <#else>
         assertEquals(NULL_LONG, sum((${pt.primitive}[]) null));
         assertEquals(NULL_LONG, sum(new ${pt.primitive}[]{}));

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -567,11 +567,11 @@ public class TestNumeric extends BaseArrayTestCase {
 
     public void test${pt.boxed}Sum1() {
         assertTrue(Math.abs(15 - sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, 5, 6}))) == 0.0);
-        assertTrue(Math.abs(0 - sum(new ${pt.vectorDirect}())) == 0.0);
-        assertTrue(Math.abs(0 - sum(new ${pt.vectorDirect}(${pt.null}))) == 0.0);
         assertTrue(Math.abs(20 - sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{5, ${pt.null}, 15}))) == 0.0);
     <#if pt.valueType.isFloat >
         assertEquals(NULL_DOUBLE, sum((${pt.vector}) null));
+        assertEquals(NULL_DOUBLE, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{})));
+        assertEquals(NULL_DOUBLE, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, ${pt.null}})));
         assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, 6})));
         assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY})));
         assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6})));
@@ -579,17 +579,18 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(Double.NaN, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY})));
     <#else>
         assertEquals(NULL_LONG, sum((${pt.vector}) null));
+        assertEquals(NULL_LONG, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{})));
+        assertEquals(NULL_LONG, sum(new ${pt.vectorDirect}(new ${pt.primitive}[]{${pt.null}, ${pt.null}})));
     </#if>
-
     }
 
     public void test${pt.boxed}Sum2() {
         assertTrue(Math.abs(15 - sum(new ${pt.primitive}[]{4, 5, 6})) == 0.0);
-        assertTrue(Math.abs(0 - sum(new ${pt.primitive}[]{})) == 0.0);
-        assertTrue(Math.abs(0 - sum(new ${pt.primitive}[]{${pt.null}})) == 0.0);
         assertTrue(Math.abs(20 - sum(new ${pt.primitive}[]{5, ${pt.null}, 15})) == 0.0);
     <#if pt.valueType.isFloat >
         assertEquals(NULL_DOUBLE, sum((${pt.primitive}[]) null));
+        assertEquals(NULL_DOUBLE, sum(new ${pt.primitive}[]{}));
+        assertEquals(NULL_DOUBLE, sum(new ${pt.primitive}[]{${pt.null}, ${pt.null}}));
         assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, 6}));
         assertEquals(Double.POSITIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY}));
         assertEquals(Double.NEGATIVE_INFINITY, sum(new ${pt.primitive}[]{4, Float.NEGATIVE_INFINITY, 6}));
@@ -597,6 +598,8 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(Double.NaN, sum(new ${pt.primitive}[]{4, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY}));
     <#else>
         assertEquals(NULL_LONG, sum((${pt.primitive}[]) null));
+        assertEquals(NULL_LONG, sum(new ${pt.primitive}[]{}));
+        assertEquals(NULL_LONG, sum(new ${pt.primitive}[]{${pt.null}, ${pt.null}}));
     </#if>
     }
 


### PR DESCRIPTION
Make Numeric.sum return null when there are no inputs or all null inputs.  This makes the method consistent with the aggregations.