### PR TITLE
Fix Local Smoke Tests by Allowing ScriptSessionCacheInit's mkdir to Race in Parallel Tests

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/GroovyDeephavenSession.java
@@ -187,7 +187,7 @@ public class GroovyDeephavenSession extends AbstractScriptSession<GroovySnapshot
             addDefaultImports(loadedGroovyScriptImports);
         }
 
-        final File classCacheDirectory = AbstractScriptSession.newClassCacheLocation();
+        final File classCacheDirectory = AbstractScriptSession.newClassCacheLocation().toFile();
 
         // Specify a classloader to read from the classpath, with script imports
         CompilerConfiguration scriptConfig = new CompilerConfiguration();

--- a/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
@@ -28,7 +28,8 @@ public class NoConsoleSessionModule {
     @Provides
     NoLanguageDeephavenSession bindNoLanguageSession(
             @Named(PeriodicUpdateGraph.DEFAULT_UPDATE_GRAPH_NAME) final UpdateGraph updateGraph,
-            final OperationInitializer operationInitializer) {
+            final OperationInitializer operationInitializer,
+            final ScriptSessionCacheInit ignored) {
         return new NoLanguageDeephavenSession(updateGraph, operationInitializer);
     }
 }

--- a/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/NoConsoleSessionModule.java
@@ -28,8 +28,7 @@ public class NoConsoleSessionModule {
     @Provides
     NoLanguageDeephavenSession bindNoLanguageSession(
             @Named(PeriodicUpdateGraph.DEFAULT_UPDATE_GRAPH_NAME) final UpdateGraph updateGraph,
-            final OperationInitializer operationInitializer,
-            final ScriptSessionCacheInit ignored) {
+            final OperationInitializer operationInitializer) {
         return new NoLanguageDeephavenSession(updateGraph, operationInitializer);
     }
 }

--- a/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
+++ b/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
@@ -7,7 +7,6 @@ import dagger.BindsInstance;
 import dagger.Component;
 import io.deephaven.client.ClientDefaultsModule;
 import io.deephaven.engine.context.ExecutionContext;
-import io.deephaven.engine.context.TestExecutionContext;
 import io.deephaven.engine.liveness.LivenessScope;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph;
@@ -41,7 +40,6 @@ import javax.inject.Singleton;
 import java.io.PrintStream;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Manages a single instance of {@link DeephavenApiServer}.
@@ -145,7 +143,9 @@ public abstract class DeephavenApiServerTestBase {
 
     @After
     public void tearDown() throws Exception {
-        scopeCloseable.close();
+        if (scopeCloseable != null) {
+            scopeCloseable.close();
+        }
 
         try {
             server.teardownForUnitTests();

--- a/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
+++ b/server/src/test/java/io/deephaven/server/runner/DeephavenApiServerTestBase.java
@@ -145,6 +145,7 @@ public abstract class DeephavenApiServerTestBase {
     public void tearDown() throws Exception {
         if (scopeCloseable != null) {
             scopeCloseable.close();
+            scopeCloseable = null;
         }
 
         try {

--- a/server/src/test/java/io/deephaven/server/table/ops/GrpcTableOperationTestBase.java
+++ b/server/src/test/java/io/deephaven/server/table/ops/GrpcTableOperationTestBase.java
@@ -38,12 +38,16 @@ public abstract class GrpcTableOperationTestBase<Request extends Message>
 
     @Override
     public void tearDown() throws Exception {
-        for (ExportObject<?> export : exports) {
-            export.cancel();
+        if (exports != null) {
+            for (ExportObject<?> export : exports) {
+                export.cancel();
+            }
+            exports = null;
         }
-        exports = null;
-        executionContext.close();
-        executionContext = null;
+        if (executionContext != null) {
+            executionContext.close();
+            executionContext = null;
+        }
         super.tearDown();
     }
 


### PR DESCRIPTION
Turns out that `NoConsoleSessionModule` is used in the testing context and if we simply do not require the `ScriptSessionCacheInit` then it no longer fails. I've left a few null checks in tearDown that fix cascading failures when setUp throws an exception in a super class.