### PR TITLE
Provide Gradle toolchain resolver implementation

### DIFF
--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,1 +1,4 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention'
+}
 rootProject.name = 'buildSrc'

--- a/server/src/main/java/io/deephaven/server/runner/SafetyChecks.java
+++ b/server/src/main/java/io/deephaven/server/runner/SafetyChecks.java
@@ -92,7 +92,9 @@ public final class SafetyChecks {
             }
             if (isVulnerableVersion() && !hasWorkaround()) {
                 throw exception(JDK_8287432.class, String.format(
-                        "The current JDK is vulnerable to the bug https://bugs.openjdk.org/browse/JDK-8287432. We recommend updating to 11.0.17+, 17.0.5+, or 21+. If that is not possible, you can apply a workaround '%s'.",
+                        "The current JDK %s (located at %s) is vulnerable to the bug https://bugs.openjdk.org/browse/JDK-8287432. We recommend updating to 11.0.17+, 17.0.5+, or 21+. If that is not possible, you can apply a workaround '%s'.",
+                        Runtime.version(),
+                        System.getProperty("java.home"),
                         String.join(" ", workaroundJvmArguments())));
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.gradle.enterprise' version '3.13.1'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 
 gradle.ext.buildStartTime = new Date()


### PR DESCRIPTION
It seems Gradle 8.2 changed how autoprovisioning toolkits works, but without any warning/error, just missing behavior and a [one line mention in the release notes](https://docs.gradle.org/8.2/userguide/upgrading_version_7.html#using_automatic_toolchain_downloading_without_having_a_repository_configured). Adding the foojay resolver plugin to our settings files makes it possible to again download JDKs automatically as needed.

Also adds debugging detail to the newly added SafetyChecks.