### PR TITLE
Document deephaven gradle properties

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: burrunan/gradle-cache-action@v1
         with:
           job-id: gradle-run
-          arguments: --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
+          arguments: --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -Pdeephaven.testRuntimeVersion=${{ matrix.test-jvm-version }}
           gradle-version: wrapper
 
       - name: Upload Test Results

--- a/GRADLE.md
+++ b/GRADLE.md
@@ -1,0 +1,88 @@
+# Gradle
+
+The Deephaven Community Core project is built using [Gradle](https://docs.gradle.org/8.7/userguide/userguide.html).
+A full rundown of the ins-and-outs of Gradle and the Deephaven configuration of Gradle is out-of-scope of this document, but the following may be helpful context:
+
+* [Configuring the build environment](https://docs.gradle.org/8.7/userguide/build_environment.html)
+* [Toolchains for JVM projects](https://docs.gradle.org/8.7/userguide/toolchains.html)
+* [io.deephaven.java-toolchain-conventions.gradle](buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle)
+
+## Toolchains
+
+This project uses toolchains to configure how different Gradle tasks are run.
+This means that the JDK used for the Gradle daemon may not be the same JDK used for the Gradle client (where tasks are executed).
+By default, Gradle is configured to download the necessary toolchains if it is unable to find a suitable one locally.
+To disable this behavior, you can set the gradle property `org.gradle.java.installations.auto-download=false`.
+
+For example, our [CI unit tests properties](.github/scripts/gradle-properties.sh) turns off auto-download and auto-detect,
+and explicitly sets the Java install paths:
+
+```properties
+org.gradle.java.installations.auto-download=false
+org.gradle.java.installations.auto-detect=false
+org.gradle.java.installations.paths=${JAVA_INSTALL_PATHS}
+```
+
+The command `./gradlew -q javaToolchains` may be useful to debug and diagnose toolchain related issues.
+
+### Runtime Toolchain
+
+The runtime toolchains are used to invoke "normal" java executable tasks; that is, tasks of `org.gradle.api.tasks.JavaExec`.
+The most visible task is the `server-jetty-app:run` task, but other tasks like code generation use the runtime toolchain
+as well.
+
+* `deephaven.runtimeVersion`: the runtime Java version to use, by default is 11
+* `deephaven.runtimeVendor`: the runtime Java vendor to use
+
+For example, the following would ensure that the server is run with JDK 21 from a JVM vendor name that contains "azul":
+
+`./gradlew server-jetty-app:run -Pdeephaven.runtimeVersion=21 -Pdeephaven.runtimeVendor=azul`
+
+### Test Runtime Toolchain
+
+The test runtime toolchains are used to invoke "test" java tasks; that is, tasks of `org.gradle.api.tasks.testing.Test`.
+
+* `deephaven.testRuntimeVersion`: the test runtime Java version to use, by default is 11
+* `deephaven.testRuntimeVendor`: the test runtime Java vendor to use
+
+The [nightly checks](.github/workflows/nightly-check-ci.yml) takes advantage of this to test multiple Java version for
+unit testing.
+
+For example, the following will run the test tasks with JDK 21 from a JVM vendor name that contains "amazon":
+
+`./gradlew test -Pdeephaven.testRuntimeVersion=21 -Pdeephaven.runtimeVendor=amazon`
+
+### Compiler Toolchain
+
+The compiler toolchains are used to invoke "compile" java tasks; that is, tasks of `org.gradle.api.tasks.compile.JavaCompile`.
+
+* `deephaven.compilerVersion`: the compile Java version to use, by default is 11
+* `deephaven.compilerVendor`: the compile Java vendor to use
+
+Note: these gradle properties control both compiling of the main source sets and test source sets.
+
+### Language Levels
+
+A language level is the Java language level the source is written for. This dictates the minimum version required to run
+the specific project. Depending on context, some subprojects have a different language level than other subprojects. For
+example, `server-jetty-app` has a language level of 11 - it must be run with Java 11 or greater;
+`java-client-session` has a language level of 8 - it must be run with Java 8 or greater.
+
+* `deephaven.languageLevel`: the language level for the main source set
+* `deephaven.testLanguageLevel`: the language level for the test source set
+
+The language levels are mostly internal properties of the individual subprojects.
+
+### Application options
+
+* `deephaven.javaOpts`: the "generally applicable and recommended JVM options" for the application. Currently, defaults
+to `-XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication`.
+
+This property is mainly meant to serve as the defaults for `org.gradle.api.plugins.JavaApplication` tasks, which in
+turn serves as the defaults for users running the application (it also applies to `org.gradle.api.tasks.JavaExec`
+and `org.gradle.api.tasks.testing.Test` tasks). Overly specific options do not belong here. For example, heap settings
+(`-Xmx4g`) or system properties (`-Dkey=value`) should not be set here.
+
+For example, the following will create an application tar that uses Generational ZGC by default:
+
+`./gradlew server-jetty-app:distTar -Pdeephaven.javaOpts="-XX:+UseZGC -XX:+ZGenerational"`

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ docker run hello-world
 ```
 
 > **_NOTE:_** Internally, the Java build process will use [Gradle Auto Provisioning](https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning)
-to download and use the appropriate Java version for building and testing.
+to download and use the appropriate Java version for building and testing. See [GRADLE.md](GRADLE.md) for more information on Deephaven's Gradle setup.
 
 > **_NOTE:_** On Windows, all commands must be run inside a WSL 2 terminal.
 

--- a/Util/immutables/gradle.properties
+++ b/Util/immutables/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_LOCAL
-languageLevel=8
+deephaven.languageLevel=8

--- a/buildSrc/src/main/groovy/io.deephaven.java-open-nio.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-open-nio.gradle
@@ -2,8 +2,8 @@ plugins {
   id 'java'
 }
 
-def runtimeVersion = Integer.parseInt((String)project.findProperty('runtimeVersion') ?: '11')
-def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRuntimeVersion') ?: '11')
+def runtimeVersion = Integer.parseInt((String)project.findProperty('deephaven.runtimeVersion') ?: '11')
+def testRuntimeVersion = Integer.parseInt((String)project.findProperty('deephaven.testRuntimeVersion') ?: '11')
 
 //    Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field long java.nio.Buffer.address accessible: module java.base does not "opens java.nio" to unnamed module @5a42bbf4
 //     at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)

--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -4,31 +4,33 @@ plugins {
   id 'java'
 }
 
-def compilerVersion = Integer.parseInt((String)project.findProperty('compilerVersion') ?: '11')
-def compilerVendor = project.hasProperty('compilerVendor') ?  JvmVendorSpec.matching((String)project.property('compilerVendor')): null
+// Update GRADLE.md if these details change
 
-def languageLevel = Integer.parseInt((String)project.findProperty('languageLevel') ?: '11')
-def runtimeVersion = Integer.parseInt((String)project.findProperty('runtimeVersion') ?: '11')
-def runtimeVendor = project.hasProperty('runtimeVendor') ?  JvmVendorSpec.matching((String)project.property('runtimeVendor')): null
+def compilerVersion = Integer.parseInt((String)project.findProperty('deephaven.compilerVersion') ?: '11')
+def compilerVendor = project.hasProperty('deephaven.compilerVendor') ?  JvmVendorSpec.matching((String)project.property('deephaven.compilerVendor')): null
 
-def testLanguageLevel = Integer.parseInt((String)project.findProperty('testLanguageLevel') ?: '11')
-def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRuntimeVersion') ?: '11')
-def testRuntimeVendor = project.hasProperty('testRuntimeVendor') ?  JvmVendorSpec.matching((String)project.property('testRuntimeVendor')): null
+def languageLevel = Integer.parseInt((String)project.findProperty('deephaven.languageLevel') ?: '11')
+def runtimeVersion = Integer.parseInt((String)project.findProperty('deephaven.runtimeVersion') ?: '11')
+def runtimeVendor = project.hasProperty('deephaven.runtimeVendor') ?  JvmVendorSpec.matching((String)project.property('deephaven.runtimeVendor')): null
+
+def testLanguageLevel = Integer.parseInt((String)project.findProperty('deephaven.testLanguageLevel') ?: '11')
+def testRuntimeVersion = Integer.parseInt((String)project.findProperty('deephaven.testRuntimeVersion') ?: '11')
+def testRuntimeVendor = project.hasProperty('deephaven.testRuntimeVendor') ?  JvmVendorSpec.matching((String)project.property('deephaven.testRuntimeVendor')): null
 
 if (languageLevel > compilerVersion) {
-  throw new IllegalArgumentException("languageLevel must be less than or equal to compileVersion")
+  throw new IllegalArgumentException("deephaven.languageLevel must be less than or equal to deephaven.compileVersion")
 }
 if (languageLevel < 8) {
-  throw new IllegalArgumentException("languageLevel must be greater than or equal to 8")
+  throw new IllegalArgumentException("deephaven.languageLevel must be greater than or equal to 8")
 }
 if (testLanguageLevel < 8) {
-  throw new IllegalArgumentException("testLanguageLevel must be greater than or equal to 8")
+  throw new IllegalArgumentException("deephaven.testLanguageLevel must be greater than or equal to 8")
 }
 if (runtimeVersion < languageLevel) {
-  throw new IllegalArgumentException("runtimeVersion must be greater than or equal to languageLevel")
+  throw new IllegalArgumentException("deephaven.runtimeVersion must be greater than or equal to deephaven.languageLevel")
 }
 if (testRuntimeVersion < testLanguageLevel) {
-  throw new IllegalArgumentException("testRuntimeVersion must be greater than or equal to testLanguageLevel")
+  throw new IllegalArgumentException("deephaven.testRuntimeVersion must be greater than or equal to deephaven.testLanguageLevel")
 }
 
 java {

--- a/engine/query-constants/gradle.properties
+++ b/engine/query-constants/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionSha256Sum=194717442575a6f96e1c1befa2c30e9a4fc90f701d7aee33eb879b79e7ff05c0
+# Update GRADLE.md info and links when updating this
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 networkTimeout=10000
 validateDistributionUrl=true

--- a/java-client/flight-dagger/gradle.properties
+++ b/java-client/flight-dagger/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/java-client/flight/gradle.properties
+++ b/java-client/flight/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/java-client/session-dagger/gradle.properties
+++ b/java-client/session-dagger/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
 
-languageLevel=8
+deephaven.languageLevel=8

--- a/java-client/session/gradle.properties
+++ b/java-client/session/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/java-client/uri/gradle.properties
+++ b/java-client/uri/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/proto/proto-backplane-grpc-flight/gradle.properties
+++ b/proto/proto-backplane-grpc-flight/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/proto/proto-backplane-grpc/gradle.properties
+++ b/proto/proto-backplane-grpc/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/py/jpy-config/gradle.properties
+++ b/py/jpy-config/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/py/jpy-ext/gradle.properties
+++ b/py/jpy-ext/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/qst/gradle.properties
+++ b/qst/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/qst/type/gradle.properties
+++ b/qst/type/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/sql/gradle.properties
+++ b/sql/gradle.properties
@@ -2,4 +2,4 @@ io.deephaven.project.ProjectType=JAVA_PUBLIC
 
 # Note: it would take a little bit of work, but we _could_ make this project Java 8 compatible. This would benefit
 # external java-client users who need Java 8 compatibility.
-# languageLevel=8
+# deephaven.languageLevel=8

--- a/ssl/config/gradle.properties
+++ b/ssl/config/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/ssl/kickstart/gradle.properties
+++ b/ssl/kickstart/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8

--- a/table-api/gradle.properties
+++ b/table-api/gradle.properties
@@ -1,2 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8
+deephaven.languageLevel=8


### PR DESCRIPTION
This also updates deephaven-specific gradle properties to have a "deephaven." prefix to ensure users don't mistake the properties for generic gradle properties.

https://github.com/deephaven/deephaven-docs-community/issues/205