### PR TITLE
Don't close long-lived RowSets in Downsampler BucketState

### DIFF
--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/BucketState.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/BucketState.java
@@ -316,8 +316,9 @@ public class BucketState {
                     } catch (final RuntimeException e) {
                         final String msg =
                                 "Bad data! indexInChunk=" + indexInChunk + ", col=" + columnIndex + ", usePrev="
-                                        + usePrev + ", offset=" + offset + ", indexInChunk=" + keyChunk.get(indexInChunk);
-                        log.error().append(msg).append("rowSet=").append(rowSet).endl();
+                                        + usePrev + ", offset=" + offset + ", indexInChunk="
+                                        + keyChunk.get(indexInChunk);
+                        log.error().append(msg).append(", rowSet=").append(rowSet).endl();
                         throw new IllegalStateException(msg, e);
                     }
                 }

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/BucketState.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/BucketState.java
@@ -9,6 +9,8 @@ import io.deephaven.engine.rowset.*;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.rowset.impl.RowSetUtils;
 import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
+import io.deephaven.internal.log.LoggerFactory;
+import io.deephaven.io.logger.Logger;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.LongChunk;
@@ -26,6 +28,8 @@ import java.util.stream.IntStream;
  * its own offset in those arrays.
  */
 public class BucketState {
+    private static final Logger log = LoggerFactory.getLogger(BucketState.class);
+
     private final WritableRowSet rowSet = RowSetFactory.empty();
 
     private RowSet cachedRowSet;
@@ -310,22 +314,15 @@ public class BucketState {
                         values[columnIndex].validate(offset, keyChunk.get(indexInChunk), valueChunks[columnIndex],
                                 indexInChunk, trackNulls ? nulls[columnIndex] : null);
                     } catch (final RuntimeException e) {
-                        System.out.println(rowSet);
                         final String msg =
                                 "Bad data! indexInChunk=" + indexInChunk + ", col=" + columnIndex + ", usePrev="
-                                        + usePrev + ", offset=" + offset + ", rowSet=" + keyChunk.get(indexInChunk);
+                                        + usePrev + ", offset=" + offset + ", indexInChunk=" + keyChunk.get(indexInChunk);
+                        log.error().append(msg).append("rowSet=").append(rowSet).endl();
                         throw new IllegalStateException(msg, e);
                     }
                 }
             }
         }
         Assert.eqTrue(makeRowSet().subsetOf(rowSet), "makeRowSet().subsetOf(rowSet)");
-    }
-
-    public void close() {
-        if (cachedRowSet != null) {
-            cachedRowSet.close();
-        }
-        rowSet.close();
     }
 }

--- a/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/RunChartDownsample.java
+++ b/ClientSupport/src/main/java/io/deephaven/clientsupport/plotdownsampling/RunChartDownsample.java
@@ -318,12 +318,6 @@ public class RunChartDownsample implements Function<Table, Table> {
         }
 
         @Override
-        protected void destroy() {
-            super.destroy();
-            states.values().forEach(BucketState::close);
-        }
-
-        @Override
         public void onUpdate(final TableUpdate upstream) {
             try (final DownsampleChunkContext context =
                     new DownsampleChunkContext(xColumnSource, valueColumnSources, CHUNK_SIZE)) {
@@ -684,7 +678,6 @@ public class RunChartDownsample implements Function<Table, Table> {
                     // if it has no keys at all, remove it so we quit checking it
                     iterator.remove();
                     releasePosition(bucket.getOffset());
-                    bucket.close();
                 } else {
                     bucket.rescanIfNeeded(context);
                 }


### PR DESCRIPTION
Fixes a bug in downsampling where a table may cause an error if freed while processing an update.

Fixes #5476