### PR TITLE
Free performance data when ExportObject is released

### DIFF
--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -1141,6 +1141,7 @@ public class SessionState {
             if (!(caughtException instanceof StatusRuntimeException)) {
                 caughtException = null;
             }
+            queryPerformanceRecorder = null;
         }
 
         /**


### PR DESCRIPTION
Cuts leaked memory from released objects by around 50%.

Partial #5479