### PR TITLE
Barrage Ingestion: Support TimeUnit Conversion on Instant and ZonedDateTime Columns

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -380,10 +380,9 @@ public class BarrageUtil {
                 final ArrowType.Timestamp timestampType = (ArrowType.Timestamp) arrowType;
                 final String tz = timestampType.getTimezone();
                 final TimeUnit timestampUnit = timestampType.getUnit();
-                if (tz == null || "UTC".equals(tz)) {
-                    if (maybeConvertForTimeUnit(timestampUnit, result, columnOffset)) {
-                        return Instant.class;
-                    }
+                boolean conversionSuccess = maybeConvertForTimeUnit(timestampUnit, result, columnOffset);
+                if ((tz == null || "UTC".equals(tz)) && conversionSuccess) {
+                    return Instant.class;
                 }
                 if (explicitType != null) {
                     return explicitType;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -311,26 +311,32 @@ public class BarrageUtil {
         metadata.put(ATTR_DH_PREFIX + key, value);
     }
 
-    private static boolean maybeConvertForTimeUnit(final TimeUnit unit, final ConvertedArrowSchema result,
-            final int i) {
+    private static boolean maybeConvertForTimeUnit(
+            final TimeUnit unit,
+            final ConvertedArrowSchema result,
+            final int columnOffset) {
         switch (unit) {
             case NANOSECOND:
                 return true;
             case MICROSECOND:
-                setConversionFactor(result, i, 1000);
+                setConversionFactor(result, columnOffset, 1000);
                 return true;
             case MILLISECOND:
-                setConversionFactor(result, i, 1000 * 1000);
+                setConversionFactor(result, columnOffset, 1000 * 1000);
                 return true;
             case SECOND:
-                setConversionFactor(result, i, 1000 * 1000 * 1000);
+                setConversionFactor(result, columnOffset, 1000 * 1000 * 1000);
                 return true;
             default:
                 return false;
         }
     }
 
-    private static Class<?> getDefaultType(final ArrowType arrowType, final ConvertedArrowSchema result, final int i) {
+    private static Class<?> getDefaultType(
+            final ArrowType arrowType,
+            final ConvertedArrowSchema result,
+            final int columnOffset,
+            final Class<?> explicitType) {
         final String exMsg = "Schema did not include `" + ATTR_DH_PREFIX + ATTR_TYPE_TAG + "` metadata for field ";
         switch (arrowType.getTypeID()) {
             case Int:
@@ -365,7 +371,7 @@ public class BarrageUtil {
             case Duration:
                 final ArrowType.Duration durationType = (ArrowType.Duration) arrowType;
                 final TimeUnit durationUnit = durationType.getUnit();
-                if (maybeConvertForTimeUnit(durationUnit, result, i)) {
+                if (maybeConvertForTimeUnit(durationUnit, result, columnOffset)) {
                     return long.class;
                 }
                 throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
@@ -375,9 +381,12 @@ public class BarrageUtil {
                 final String tz = timestampType.getTimezone();
                 final TimeUnit timestampUnit = timestampType.getUnit();
                 if (tz == null || "UTC".equals(tz)) {
-                    if (maybeConvertForTimeUnit(timestampUnit, result, i)) {
+                    if (maybeConvertForTimeUnit(timestampUnit, result, columnOffset)) {
                         return Instant.class;
                     }
+                }
+                if (explicitType != null) {
+                    return explicitType;
                 }
                 throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
                         " of timestampType(Timezone=" + tz +
@@ -397,6 +406,9 @@ public class BarrageUtil {
             case Utf8:
                 return java.lang.String.class;
             default:
+                if (explicitType != null) {
+                    return explicitType;
+                }
                 throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, exMsg +
                         " of type " + arrowType.getTypeID().toString());
         }
@@ -431,12 +443,15 @@ public class BarrageUtil {
         }
     }
 
-    private static void setConversionFactor(final ConvertedArrowSchema result, final int i, final int factor) {
+    private static void setConversionFactor(
+            final ConvertedArrowSchema result,
+            final int columnOffset,
+            final int factor) {
         if (result.conversionFactors == null) {
             result.conversionFactors = new int[result.nCols];
             Arrays.fill(result.conversionFactors, 1);
         }
-        result.conversionFactors[i] = factor;
+        result.conversionFactors[columnOffset] = factor;
     }
 
     public static TableDefinition convertTableDefinition(final ExportedTableCreationResponse response) {
@@ -514,13 +529,14 @@ public class BarrageUtil {
                 }
             });
 
+            // this has side effects such as setting the conversion factor; must call even if dest type is well known
+            Class<?> defaultType = getDefaultType(getArrowType.apply(i), result, i, type.getValue());
+
             if (type.getValue() == null) {
-                Class<?> defaultType = getDefaultType(getArrowType.apply(i), result, i);
                 type.setValue(defaultType);
             } else if (type.getValue() == boolean.class || type.getValue() == Boolean.class) {
                 // check existing barrage clients that might be sending int8 instead of bool
                 // TODO (deephaven-core#3403) widen this check for better assurances
-                Class<?> defaultType = getDefaultType(getArrowType.apply(i), result, i);
                 Assert.eq(Boolean.class, "deephaven column type", defaultType, "arrow inferred type");
                 // force to boxed boolean to allow nullability in the column sources
                 type.setValue(Boolean.class);

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -260,12 +260,13 @@ public class ArrowFlightUtil {
             }
             localResultTable.dropReference();
 
-            // let's finally export the table to our listener
-            localExportBuilder.submit(() -> {
-                GrpcUtil.safelyComplete(observer);
-                session.removeOnCloseCallback(this);
-                return localResultTable;
-            });
+            // let's finally export the table to our destination export
+            localExportBuilder
+                    .onSuccess(() -> GrpcUtil.safelyComplete(observer))
+                    .submit(() -> {
+                        session.removeOnCloseCallback(this);
+                        return localResultTable;
+                    });
         }
 
         @Override


### PR DESCRIPTION
Fixes #5470. 

Also fixes:
-  deephaven null handling on conversion factor affected columns
- always look up conversion factor even if deephaven:type is provided

Adds three similar sets of tests for Duration (provided to users as a long), Instant, and ZonedDateTime columns to ensure that all four different conversion factors can be uploaded via doPut.

Nightlies: https://github.com/nbauernfeind/deephaven-core/actions/runs/9083540412/