### PR TITLE
Add a C++ client concurrent test/example

### DIFF
--- a/cpp-client/deephaven/dhclient/src/server/server.cc
+++ b/cpp-client/deephaven/dhclient/src/server/server.cc
@@ -10,7 +10,6 @@
 #include <grpc/support/log.h>
 #include <arrow/flight/client_auth.h>
 #include <arrow/flight/client.h>
-#include <arrow/flight/client_middleware.h>
 #include <arrow/flight/types.h>
 #include <arrow/array.h>
 #include <arrow/array/array_primitive.h>
@@ -20,46 +19,12 @@
 #include "deephaven/third_party/fmt/format.h"
 
 using arrow::flight::FlightClient;
-using deephaven::client::impl::MoveVectorData;
-using deephaven::dhcore::utility::Bit_cast;
 using deephaven::dhcore::utility::GetWhat;
-using io::deephaven::proto::backplane::grpc::AddTableRequest;
-using io::deephaven::proto::backplane::grpc::AddTableResponse;
-using io::deephaven::proto::backplane::grpc::AjRajTablesRequest;
-using io::deephaven::proto::backplane::grpc::AuthenticationConstantsRequest;
 using io::deephaven::proto::backplane::grpc::ConfigurationConstantsRequest;
 using io::deephaven::proto::backplane::grpc::ConfigurationConstantsResponse;
-using io::deephaven::proto::backplane::grpc::ConfigService;
-using io::deephaven::proto::backplane::grpc::CreateInputTableRequest;
-using io::deephaven::proto::backplane::grpc::CrossJoinTablesRequest;
-using io::deephaven::proto::backplane::grpc::DeleteTableRequest;
-using io::deephaven::proto::backplane::grpc::DeleteTableResponse;
-using io::deephaven::proto::backplane::grpc::DropColumnsRequest;
-using io::deephaven::proto::backplane::grpc::EmptyTableRequest;
-using io::deephaven::proto::backplane::grpc::ExactJoinTablesRequest;
-using io::deephaven::proto::backplane::grpc::ExportedTableCreationResponse;
-using io::deephaven::proto::backplane::grpc::FetchTableRequest;
-using io::deephaven::proto::backplane::grpc::HandshakeRequest;
-using io::deephaven::proto::backplane::grpc::HeadOrTailRequest;
-using io::deephaven::proto::backplane::grpc::HeadOrTailByRequest;
-using io::deephaven::proto::backplane::grpc::LeftJoinTablesRequest;
-using io::deephaven::proto::backplane::grpc::MergeTablesRequest;
-using io::deephaven::proto::backplane::grpc::NaturalJoinTablesRequest;
 using io::deephaven::proto::backplane::grpc::ReleaseRequest;
 using io::deephaven::proto::backplane::grpc::ReleaseResponse;
-using io::deephaven::proto::backplane::grpc::SelectDistinctRequest;
-using io::deephaven::proto::backplane::grpc::SelectOrUpdateRequest;
-using io::deephaven::proto::backplane::grpc::SortTableRequest;
 using io::deephaven::proto::backplane::grpc::Ticket;
-using io::deephaven::proto::backplane::grpc::TimeTableRequest;
-using io::deephaven::proto::backplane::grpc::WhereInRequest;
-using io::deephaven::proto::backplane::grpc::UpdateByRequest;
-using io::deephaven::proto::backplane::grpc::UnstructuredFilterTableRequest;
-using io::deephaven::proto::backplane::grpc::UngroupRequest;
-using io::deephaven::proto::backplane::script::grpc::BindTableToVariableRequest;
-using io::deephaven::proto::backplane::script::grpc::ExecuteCommandRequest;
-using io::deephaven::proto::backplane::script::grpc::ExecuteCommandResponse;
-using io::deephaven::proto::backplane::script::grpc::StartConsoleRequest;
 
 using UpdateByOperation = io::deephaven::proto::backplane::grpc::UpdateByRequest::UpdateByOperation;
 

--- a/cpp-client/deephaven/dhclient/src/server/server.cc
+++ b/cpp-client/deephaven/dhclient/src/server/server.cc
@@ -409,7 +409,7 @@ bool Server::KeepaliveHelper() {
       }
     }
     // Set a default nextHandshakeTime_. This will likely be overwritten by SendRpc, if it succeeds.
-    nextHandshakeTime_ = now + kHandshakeResendInterval;
+    nextHandshakeTime_ = now + std::chrono::seconds(3);
   }
 
   // Send a 'GetConfigurationConstants' as a handshake. On the way out, we note our local time.

--- a/cpp-client/deephaven/dhclient/src/server/server.cc
+++ b/cpp-client/deephaven/dhclient/src/server/server.cc
@@ -374,7 +374,7 @@ bool Server::KeepaliveHelper() {
       }
     }
     // Set a default nextHandshakeTime_. This will likely be overwritten by SendRpc, if it succeeds.
-    nextHandshakeTime_ = now + std::chrono::seconds(3);
+    nextHandshakeTime_ = now + kHandshakeResendInterval;
   }
 
   // Send a 'GetConfigurationConstants' as a handshake. On the way out, we note our local time.

--- a/cpp-client/deephaven/examples/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(table_cleanup)
+add_subdirectory(concurrent_client)
 add_subdirectory(create_table_with_arrow_flight)
 add_subdirectory(create_table_with_table_maker)
 add_subdirectory(demos)

--- a/cpp-client/deephaven/examples/concurrent_client/CMakeLists.txt
+++ b/cpp-client/deephaven/examples/concurrent_client/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(hello_world)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(concurrent_session main.cc)
+
+target_link_libraries(concurrent_session deephaven::client)

--- a/cpp-client/deephaven/examples/concurrent_client/main.cc
+++ b/cpp-client/deephaven/examples/concurrent_client/main.cc
@@ -8,6 +8,8 @@
 #include <cstdlib>
 #include <thread>
 #include "deephaven/client/client.h"
+#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/ostream.h"
 
 using deephaven::client::Client;
 using deephaven::client::TableHandleManager;
@@ -32,9 +34,9 @@ void ThreadFun(std::shared_ptr<Client> clientp, const std::size_t ti) {
 }
 
 void Run(std::shared_ptr<Client> clientp, const std::size_t nthreads) {
-  std::thread threads[nthreads];
+  std::vector<std::thread> threads(nthreads);
   for (std::size_t i = 0; i < nthreads; ++i) {
-    threads[i] = std::move(std::thread(&ThreadFun, clientp, i));
+    threads.emplace_back(&ThreadFun, clientp, i);
   }
   
   for (std::size_t i = 0; i < nthreads; ++i) {
@@ -60,10 +62,8 @@ std::size_t get_size_arg(
     }
     return val;
   } catch (const std::invalid_argument &e) {
-    std::cerr << argv[0] << ": can't convert " << description << " argument #" << c << " '"
-              << argv[c] << "' to a positive intenger ["
-              << e.what() << "], aborting."
-              << '\n';
+    fmt::println(std::cerr, "{}: can't convert {} argument #{} '{}' to a positive intenger [{}], aborting.",
+                 argv[0], description, c, argv[c], e.what());
     std::exit(1);
   }
 }

--- a/cpp-client/deephaven/examples/concurrent_client/main.cc
+++ b/cpp-client/deephaven/examples/concurrent_client/main.cc
@@ -34,7 +34,7 @@ void ThreadFun(std::shared_ptr<Client> clientp, const std::size_t ti) {
 }
 
 void Run(std::shared_ptr<Client> clientp, const std::size_t nthreads) {
-  std::vector<std::thread> threads(nthreads);
+  std::vector<std::thread> threads;
   for (std::size_t i = 0; i < nthreads; ++i) {
     threads.emplace_back(&ThreadFun, clientp, i);
   }

--- a/cpp-client/deephaven/examples/concurrent_client/main.cc
+++ b/cpp-client/deephaven/examples/concurrent_client/main.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include <exception>
+#include <iostream>
+#include <iomanip>
+#include <cstdlib>
+#include <thread>
+#include "deephaven/client/client.h"
+
+using deephaven::client::Client;
+using deephaven::client::TableHandleManager;
+
+void Usage(const char *const argv0, const int exit_status) {
+  std::cerr << "Usage: " << argv0 << "[numthreads [host:port]]" << '\n';
+  std::exit(exit_status);
+}
+
+void ThreadFun(Client *const client, const std::size_t ti) {
+    auto manager = client->GetManager();
+    using namespace std::chrono_literals;
+    std::cout << "THREAD START " << ti << std::endl << std::flush;
+    const std::string t1_name = std::string("import deephaven; t1_") + std::to_string(ti);
+    while (true) {
+        manager.RunScript(
+                t1_name + "= deephaven.time_table(\"PT1S\")");
+        std::this_thread::sleep_for(2000ms);
+        auto t1 = manager.FetchTable(std::string("t1_") + std::to_string(ti));
+    }
+    std::cout << "THREAD END " << ti << std::endl << std::flush;
+}
+
+void Run(Client *const client, const std::size_t nthreads) {
+  std::thread threads[nthreads];
+  for (std::size_t i = 0; i < nthreads; ++i) {
+    threads[i] = std::move(std::thread(&ThreadFun, client, i));
+  }
+  
+  for (std::size_t i = 0; i < nthreads; ++i) {
+    threads[i].join();
+  }
+}
+
+int main(int argc, char *argv[]) {
+  const char *server = "localhost:10000";
+  std::size_t nthreads = 200;
+  int c = 1;
+  if (argc > 1 && std::strcmp("-h", argv[1]) == 0) {
+    Usage(argv[0], 0);
+  }
+  if (argc > c) {
+    ++c;
+    try {
+      nthreads = static_cast<std::size_t>(std::stoi(argv[c]));
+      if (nthreads <= 0) {
+        throw std::invalid_argument("<= 0");
+      }
+    } catch (const std::invalid_argument &e) {
+      std::cerr << "argv[0]: can't convert number of threads argument #" << c << " '"
+                << argv[c] << "' to a positive intenger ["
+                << e.what() << "], aborting."
+                << '\n';
+      std::exit(1);
+    }
+  }
+  if (argc > c) {
+    server = argv[c];
+  }
+  ++c;
+  if (argc > c) {
+    Usage(argv[0], 1);
+  }
+  try {
+    auto client = Client::Connect(server);
+    Run(&client, nthreads);
+  } catch (const std::exception &e) {
+    std::cerr << "Caught exception: " << e.what() << '\n';
+  }
+  return 0;
+}


### PR DESCRIPTION
While debugging some issues in the python pydeephaven client (non-ticking) in a multi threading context, it was useful to compare the behavior with a similar C++ test.   I'd like to keep this code around since it may be useful again in the future.