### PR TITLE
Bugfix in URI conversion when working with directories

### DIFF
--- a/Base/src/main/java/io/deephaven/base/FileUtils.java
+++ b/Base/src/main/java/io/deephaven/base/FileUtils.java
@@ -39,6 +39,8 @@ public class FileUtils {
 
     public static final Pattern REPEATED_URI_SEPARATOR_PATTERN = Pattern.compile("//+");
 
+    public static final String FILE_URI_SCHEME = "file";
+
     /**
      * Cleans the specified path. All files and subdirectories in the path will be deleted. (ie you'll be left with an
      * empty directory).
@@ -286,6 +288,9 @@ public class FileUtils {
                 // Convert to a "file" URI
                 return convertToURI(new File(source), isDirectory);
             }
+            if (uri.getScheme().equals(FILE_URI_SCHEME)) {
+                return convertToURI(new File(uri), isDirectory);
+            }
             String path = uri.getPath();
             final boolean endsWithSlash = path.charAt(path.length() - 1) == URI_SEPARATOR_CHAR;
             if (!isDirectory && endsWithSlash) {
@@ -330,7 +335,7 @@ public class FileUtils {
             absPath = absPath + URI_SEPARATOR_CHAR;
         }
         try {
-            return new URI("file", null, absPath, null);
+            return new URI(FILE_URI_SCHEME, null, absPath, null);
         } catch (final URISyntaxException e) {
             throw new IllegalStateException("Failed to convert file to URI: " + file, e);
         }

--- a/Base/src/main/java/io/deephaven/base/FileUtils.java
+++ b/Base/src/main/java/io/deephaven/base/FileUtils.java
@@ -287,9 +287,12 @@ public class FileUtils {
                 return convertToURI(new File(source), isDirectory);
             }
             String path = uri.getPath();
+            final boolean endsWithSlash = path.charAt(path.length() - 1) == URI_SEPARATOR_CHAR;
+            if (!isDirectory && endsWithSlash) {
+                throw new IllegalArgumentException("Non-directory URI should not end with a slash: " + uri);
+            }
             boolean isUpdated = false;
-            // Directory URIs should end with a slash
-            if (isDirectory && path.charAt(path.length() - 1) != URI_SEPARATOR_CHAR) {
+            if (isDirectory && !endsWithSlash) {
                 path = path + URI_SEPARATOR_CHAR;
                 isUpdated = true;
             }

--- a/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
+++ b/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
@@ -17,7 +17,7 @@ public class FileUtilsTest extends TestCase {
         final File currentDir = new File("").getAbsoluteFile();
         fileUriTestHelper(currentDir.toString(), true, currentDir.toURI().toString());
 
-        final File someFile = new File(currentDir, "tempFile.txt");
+        final File someFile = new File(currentDir, "tempFile");
         fileUriTestHelper(someFile.getPath(), false, someFile.toURI().toString());
 
         // Check if trailing slash gets added for a directory
@@ -25,10 +25,13 @@ public class FileUtilsTest extends TestCase {
         fileUriTestHelper(currentDir.getPath() + "/path/to/directory", true, expectedURI);
 
         // Check if multiple slashes get normalized
-        fileUriTestHelper(currentDir.getPath() + "////path///to////directory", true, expectedURI);
+        fileUriTestHelper(currentDir.getPath() + "////path///to////directory////", true, expectedURI);
 
         // Check if multiple slashes in the beginning get normalized
         fileUriTestHelper("////" + currentDir.getPath() + "/path/to/directory", true, expectedURI);
+
+        // Check for bad inputs
+        fileUriTestHelper(someFile.getPath() + "/", false, someFile.toURI().toString());
     }
 
     private static void fileUriTestHelper(final String filePath, final boolean isDirectory,
@@ -39,16 +42,22 @@ public class FileUtilsTest extends TestCase {
     }
 
     public void testConvertToS3URI() throws URISyntaxException {
-        assertEquals("s3://bucket/key", FileUtils.convertToURI("s3://bucket/key", false).toString());
+        Assert.assertEquals("s3://bucket/key", FileUtils.convertToURI("s3://bucket/key", false).toString());
 
         // Check if trailing slash gets added for a directory
-        assertEquals("s3://bucket/key/".toString(), FileUtils.convertToURI("s3://bucket/key", true).toString());
+        Assert.assertEquals("s3://bucket/key/".toString(), FileUtils.convertToURI("s3://bucket/key", true).toString());
 
         // Check if multiple slashes get normalized
-        assertEquals("s3://bucket/key/", FileUtils.convertToURI("s3://bucket///key///", true).toString());
+        Assert.assertEquals("s3://bucket/key/", FileUtils.convertToURI("s3://bucket///key///", true).toString());
 
         try {
             FileUtils.convertToURI("", false);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        }
+
+        try {
+            FileUtils.convertToURI("s3://bucket/key/", false);
             Assert.fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException expected) {
         }

--- a/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
+++ b/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
@@ -33,12 +33,6 @@ public class FileUtilsTest extends TestCase {
 
         // Check if multiple slashes in the beginning get normalized
         fileUriTestHelper("////" + someDir.getPath() + "/path/to/directory", true, expectedURI);
-
-        try {
-            fileUriTestHelper("", false, "file:/");
-            Assert.fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException expected) {
-        }
     }
 
     private static void fileUriTestHelper(final String filePath, final boolean isDirectory,
@@ -58,7 +52,7 @@ public class FileUtilsTest extends TestCase {
         assertEquals("s3:/bucket/key/", FileUtils.convertToURI("s3:////bucket///key///", true).toString());
 
         try {
-            fileUriTestHelper("", false, "s3:/");
+            FileUtils.convertToURI("", false);
             Assert.fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException expected) {
         }

--- a/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
+++ b/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
@@ -21,17 +21,20 @@ public class FileUtilsTest extends TestCase {
         fileUriTestHelper(someFile.getPath(), false, someFile.toURI().toString());
 
         // Check if trailing slash gets added for a directory
-        final String expectedURI = "file:" + currentDir.getPath() + "/path/to/directory/";
-        fileUriTestHelper(currentDir.getPath() + "/path/to/directory", true, expectedURI);
+        final String expectedDirURI = "file:" + currentDir.getPath() + "/path/to/directory/";
+        fileUriTestHelper(currentDir.getPath() + "/path/to/directory", true, expectedDirURI);
 
         // Check if multiple slashes get normalized
-        fileUriTestHelper(currentDir.getPath() + "////path///to////directory////", true, expectedURI);
+        fileUriTestHelper(currentDir.getPath() + "////path///to////directory////", true, expectedDirURI);
 
         // Check if multiple slashes in the beginning get normalized
-        fileUriTestHelper("////" + currentDir.getPath() + "/path/to/directory", true, expectedURI);
+        fileUriTestHelper("////" + currentDir.getPath() + "/path/to/directory", true, expectedDirURI);
 
-        // Check for bad inputs
-        fileUriTestHelper(someFile.getPath() + "/", false, someFile.toURI().toString());
+        // Check for bad inputs for files with trailing slashes
+        final String expectedFileURI = someFile.toURI().toString();
+        fileUriTestHelper(someFile.getPath() + "/", false, expectedFileURI);
+        Assert.assertEquals(expectedFileURI,
+                FileUtils.convertToURI("file:" + someFile.getPath() + "/", false).toString());
     }
 
     private static void fileUriTestHelper(final String filePath, final boolean isDirectory,

--- a/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
+++ b/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.base;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.rules.TemporaryFolder;
+
+public class FileUtilsTest extends TestCase {
+
+    public void testConvertToFileURI() throws IOException {
+        final TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+
+        final File someDir = folder.newFolder();
+        fileUriTestHelper(someDir.getPath(), true, someDir.toURI().toString());
+
+        final File someFile = folder.newFile();
+        fileUriTestHelper(someFile.getPath(), false, someFile.toURI().toString());
+
+        // Check if trailing slash gets added for a directory
+        final String expectedURI = "file:" + someDir.getPath() + "/path/to/directory/";
+        fileUriTestHelper(someDir.getPath() + "/path/to/directory", true, expectedURI);
+
+        // Check if multiple slashes get normalized
+        fileUriTestHelper(someDir.getPath() + "////path///to////directory", true, expectedURI);
+
+        // Check if multiple slashes in the beginning get normalized
+        fileUriTestHelper("////" + someDir.getPath() + "/path/to/directory", true, expectedURI);
+
+        try {
+            fileUriTestHelper("", false, "file:/");
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    private static void fileUriTestHelper(final String filePath, final boolean isDirectory,
+            final String expctedURIString) {
+        Assert.assertEquals(expctedURIString, FileUtils.convertToURI(filePath, isDirectory).toString());
+        Assert.assertEquals(expctedURIString, FileUtils.convertToURI(new File(filePath), isDirectory).toString());
+        Assert.assertEquals(expctedURIString, FileUtils.convertToURI(Path.of(filePath), isDirectory).toString());
+    }
+
+    public void testConvertToS3URI() throws URISyntaxException {
+        assertEquals("s3:/bucket/key", FileUtils.convertToURI("s3:/bucket/key", false).toString());
+
+        // Check if trailing slash gets added for a directory
+        assertEquals("s3:/bucket/key/".toString(), FileUtils.convertToURI("s3:/bucket/key", true).toString());
+
+        // Check if multiple slashes get normalized
+        assertEquals("s3:/bucket/key/", FileUtils.convertToURI("s3:////bucket///key///", true).toString());
+
+        try {
+            fileUriTestHelper("", false, "s3:/");
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+}

--- a/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
+++ b/Base/src/test/java/io/deephaven/base/FileUtilsTest.java
@@ -10,46 +10,42 @@ import java.nio.file.Path;
 
 import junit.framework.TestCase;
 import org.junit.Assert;
-import org.junit.rules.TemporaryFolder;
 
 public class FileUtilsTest extends TestCase {
 
     public void testConvertToFileURI() throws IOException {
-        final TemporaryFolder folder = new TemporaryFolder();
-        folder.create();
+        final File currentDir = new File("").getAbsoluteFile();
+        fileUriTestHelper(currentDir.toString(), true, currentDir.toURI().toString());
 
-        final File someDir = folder.newFolder();
-        fileUriTestHelper(someDir.getPath(), true, someDir.toURI().toString());
-
-        final File someFile = folder.newFile();
+        final File someFile = new File(currentDir, "tempFile.txt");
         fileUriTestHelper(someFile.getPath(), false, someFile.toURI().toString());
 
         // Check if trailing slash gets added for a directory
-        final String expectedURI = "file:" + someDir.getPath() + "/path/to/directory/";
-        fileUriTestHelper(someDir.getPath() + "/path/to/directory", true, expectedURI);
+        final String expectedURI = "file:" + currentDir.getPath() + "/path/to/directory/";
+        fileUriTestHelper(currentDir.getPath() + "/path/to/directory", true, expectedURI);
 
         // Check if multiple slashes get normalized
-        fileUriTestHelper(someDir.getPath() + "////path///to////directory", true, expectedURI);
+        fileUriTestHelper(currentDir.getPath() + "////path///to////directory", true, expectedURI);
 
         // Check if multiple slashes in the beginning get normalized
-        fileUriTestHelper("////" + someDir.getPath() + "/path/to/directory", true, expectedURI);
+        fileUriTestHelper("////" + currentDir.getPath() + "/path/to/directory", true, expectedURI);
     }
 
     private static void fileUriTestHelper(final String filePath, final boolean isDirectory,
-            final String expctedURIString) {
-        Assert.assertEquals(expctedURIString, FileUtils.convertToURI(filePath, isDirectory).toString());
-        Assert.assertEquals(expctedURIString, FileUtils.convertToURI(new File(filePath), isDirectory).toString());
-        Assert.assertEquals(expctedURIString, FileUtils.convertToURI(Path.of(filePath), isDirectory).toString());
+            final String expectedURIString) {
+        Assert.assertEquals(expectedURIString, FileUtils.convertToURI(filePath, isDirectory).toString());
+        Assert.assertEquals(expectedURIString, FileUtils.convertToURI(new File(filePath), isDirectory).toString());
+        Assert.assertEquals(expectedURIString, FileUtils.convertToURI(Path.of(filePath), isDirectory).toString());
     }
 
     public void testConvertToS3URI() throws URISyntaxException {
-        assertEquals("s3:/bucket/key", FileUtils.convertToURI("s3:/bucket/key", false).toString());
+        assertEquals("s3://bucket/key", FileUtils.convertToURI("s3://bucket/key", false).toString());
 
         // Check if trailing slash gets added for a directory
-        assertEquals("s3:/bucket/key/".toString(), FileUtils.convertToURI("s3:/bucket/key", true).toString());
+        assertEquals("s3://bucket/key/".toString(), FileUtils.convertToURI("s3://bucket/key", true).toString());
 
         // Check if multiple slashes get normalized
-        assertEquals("s3:/bucket/key/", FileUtils.convertToURI("s3:////bucket///key///", true).toString());
+        assertEquals("s3://bucket/key/", FileUtils.convertToURI("s3://bucket///key///", true).toString());
 
         try {
             FileUtils.convertToURI("", false);

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileWriter.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileWriter.java
@@ -18,7 +18,6 @@ import org.apache.parquet.internal.hadoop.metadata.IndexReference;
 import org.apache.parquet.schema.MessageType;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/extensions/trackedfile/src/main/java/io/deephaven/extensions/trackedfile/TrackedSeekableChannelsProvider.java
+++ b/extensions/trackedfile/src/main/java/io/deephaven/extensions/trackedfile/TrackedSeekableChannelsProvider.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.stream.Stream;
 
-import static io.deephaven.extensions.trackedfile.TrackedSeekableChannelsProviderPlugin.FILE_URI_SCHEME;
+import static io.deephaven.base.FileUtils.FILE_URI_SCHEME;
 
 /**
  * {@link SeekableChannelsProvider} implementation that is constrained by a Deephaven {@link TrackedFileHandleFactory}.

--- a/extensions/trackedfile/src/main/java/io/deephaven/extensions/trackedfile/TrackedSeekableChannelsProviderPlugin.java
+++ b/extensions/trackedfile/src/main/java/io/deephaven/extensions/trackedfile/TrackedSeekableChannelsProviderPlugin.java
@@ -12,13 +12,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 
+import static io.deephaven.base.FileUtils.FILE_URI_SCHEME;
+
 /**
  * {@link SeekableChannelsProviderPlugin} implementation used for reading files from local disk.
  */
 @AutoService(SeekableChannelsProviderPlugin.class)
 public final class TrackedSeekableChannelsProviderPlugin implements SeekableChannelsProviderPlugin {
-
-    static final String FILE_URI_SCHEME = "file";
 
     @Override
     public boolean isCompatible(@NotNull final URI uri, @Nullable final Object object) {


### PR DESCRIPTION
This PR fixes a bug in the conversion code for String -> URI when working with directories.
This bug could lead to failure in reading flat partitioned parquet files from S3 using a URI which doesn't end with a `\` character.