### PR TITLE
Fixed the parquet uint32 reading failure

### DIFF
--- a/Base/src/main/java/io/deephaven/base/FileUtils.java
+++ b/Base/src/main/java/io/deephaven/base/FileUtils.java
@@ -16,19 +16,9 @@ import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 public class FileUtils {
-    private final static FileFilter DIRECTORY_FILE_FILTER = new FileFilter() {
-        @Override
-        public boolean accept(File pathname) {
-            return pathname.isDirectory();
-        }
-    };
+    private final static FileFilter DIRECTORY_FILE_FILTER = File::isDirectory;
     private final static File[] EMPTY_DIRECTORY_ARRAY = new File[0];
-    private final static FilenameFilter DIRECTORY_FILENAME_FILTER = new FilenameFilter() {
-        @Override
-        public boolean accept(File dir, String name) {
-            return new File(dir, name).isDirectory();
-        }
-    };
+    private final static FilenameFilter DIRECTORY_FILENAME_FILTER = (dir, name) -> new File(dir, name).isDirectory();
     private final static String[] EMPTY_STRING_ARRAY = new String[0];
 
     public static final char URI_SEPARATOR_CHAR = '/';

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
@@ -468,7 +468,6 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
 
         @Override
         public Optional<ToPage<ATTR, ?>> visit(final LogicalTypeAnnotation.IntLogicalTypeAnnotation intLogicalType) {
-
             if (intLogicalType.isSigned()) {
                 switch (intLogicalType.getBitWidth()) {
                     case 8:
@@ -486,10 +485,9 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
                     case 16:
                         return Optional.of(ToCharPageFromInt.create(componentType));
                     case 32:
-                        return Optional.of(ToLongPage.create(componentType));
+                        return Optional.of(ToLongPageFromUnsignedInt.create(componentType));
                 }
             }
-
             return Optional.empty();
         }
 

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
@@ -7,13 +7,15 @@ import io.deephaven.chunk.ChunkType;
 import io.deephaven.chunk.attributes.Any;
 import org.jetbrains.annotations.NotNull;
 
+import static io.deephaven.util.QueryConstants.NULL_INT;
 import static io.deephaven.util.QueryConstants.NULL_INT_BOXED;
+import static io.deephaven.util.QueryConstants.NULL_LONG;
 
 public class ToLongPageFromUnsignedInt<ATTR extends Any> implements ToPage<ATTR, long[]> {
 
     private static final ToLongPageFromUnsignedInt INSTANCE = new ToLongPageFromUnsignedInt<>();
 
-    public static <ATTR extends Any> ToLongPageFromUnsignedInt<ATTR> create(Class<?> nativeType) {
+    public static <ATTR extends Any> ToLongPageFromUnsignedInt<ATTR> create(final Class<?> nativeType) {
         if (nativeType == null || long.class.equals(nativeType)) {
             // noinspection unchecked
             return INSTANCE;
@@ -42,11 +44,11 @@ public class ToLongPageFromUnsignedInt<ATTR extends Any> implements ToPage<ATTR,
     }
 
     @Override
-    public final long[] convertResult(Object result) {
-        int[] from = (int[]) result;
-        long[] to = new long[from.length];
+    public final long[] convertResult(final Object result) {
+        final int[] from = (int[]) result;
+        final long[] to = new long[from.length];
         for (int i = 0; i < from.length; ++i) {
-            to[i] = Integer.toUnsignedLong(from[i]);
+            to[i] = from[i] == NULL_INT ? NULL_LONG : Integer.toUnsignedLong(from[i]);
         }
         return to;
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
@@ -25,8 +25,8 @@ public class ToLongPageFromUnsignedInt<ATTR extends Any> implements ToPage<ATTR,
 
     @Override
     @NotNull
-    public final Class<Integer> getNativeType() {
-        return int.class;
+    public final Class<Long> getNativeType() {
+        return long.class;
     }
 
     @Override

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
@@ -48,7 +48,8 @@ public class ToLongPageFromUnsignedInt<ATTR extends Any> implements ToPage<ATTR,
         final int[] from = (int[]) result;
         final long[] to = new long[from.length];
         for (int i = 0; i < from.length; ++i) {
-            to[i] = from[i] == NULL_INT ? NULL_LONG : Integer.toUnsignedLong(from[i]);
+            final int fromValue = from[i];
+            to[i] = fromValue == NULL_INT ? NULL_LONG : Integer.toUnsignedLong(fromValue);
         }
         return to;
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/pagestore/topage/ToLongPageFromUnsignedInt.java
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.parquet.table.pagestore.topage;
+
+import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.attributes.Any;
+import org.jetbrains.annotations.NotNull;
+
+import static io.deephaven.util.QueryConstants.NULL_INT_BOXED;
+
+public class ToLongPageFromUnsignedInt<ATTR extends Any> implements ToPage<ATTR, long[]> {
+
+    private static final ToLongPageFromUnsignedInt INSTANCE = new ToLongPageFromUnsignedInt<>();
+
+    public static <ATTR extends Any> ToLongPageFromUnsignedInt<ATTR> create(Class<?> nativeType) {
+        if (nativeType == null || long.class.equals(nativeType)) {
+            // noinspection unchecked
+            return INSTANCE;
+        }
+        throw new IllegalArgumentException("The native type for a Long column is " + nativeType.getCanonicalName());
+    }
+
+    private ToLongPageFromUnsignedInt() {}
+
+    @Override
+    @NotNull
+    public final Class<Integer> getNativeType() {
+        return int.class;
+    }
+
+    @Override
+    @NotNull
+    public final ChunkType getChunkType() {
+        return ChunkType.Long;
+    }
+
+    @Override
+    @NotNull
+    public final Object nullValue() {
+        return NULL_INT_BOXED;
+    }
+
+    @Override
+    public final long[] convertResult(Object result) {
+        int[] from = (int[]) result;
+        long[] to = new long[from.length];
+        for (int i = 0; i < from.length; ++i) {
+            to[i] = Integer.toUnsignedLong(from[i]);
+        }
+        return to;
+    }
+}

--- a/extensions/parquet/table/src/test/resources/ReferenceUintParquetData.parquet
+++ b/extensions/parquet/table/src/test/resources/ReferenceUintParquetData.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e878356376bbb29acfe8ee13f3e8daae97087042f26a57c6a342fbe9a9aaf8e7
+size 1151

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -8,12 +8,13 @@ import tempfile
 import unittest
 import fnmatch
 
+import numpy as np
 import pandas
 import pyarrow.parquet
 
 from deephaven import DHError, empty_table, dtypes, new_table
 from deephaven import arrow as dharrow
-from deephaven.column import InputColumn, Column, ColumnType, string_col, int_col
+from deephaven.column import InputColumn, Column, ColumnType, string_col, int_col, char_col, long_col
 from deephaven.pandas import to_pandas, to_table
 from deephaven.parquet import (write, batch_write, read, delete, ColumnInstruction, ParquetFileLayout,
                                write_partitioned)
@@ -708,6 +709,29 @@ class ParquetTestCase(BaseTestCase):
 
         with self.assertRaises(Exception):
             write(table, "data_from_dh.parquet", table_definition=table_definition, col_definitions=col_definitions)
+
+    def test_unsigned_ints(self):
+        df = pandas.DataFrame.from_records(
+            data=[(-1, -1, -1), (2, 2, 2), (0, 0, 0)],
+            columns=['uint8Col', 'uint16Col',  'uint32Col']
+        )
+        df['uint8Col'] = df['uint8Col'].astype(np.uint8)
+        df['uint16Col'] = df['uint16Col'].astype(np.uint16)
+        df['uint32Col'] = df['uint32Col'].astype(np.uint32)
+
+        pyarrow.parquet.write_table(pyarrow.Table.from_pandas(df), 'data_from_pyarrow.parquet')
+        schema_from_disk = pyarrow.parquet.read_metadata("data_from_pyarrow.parquet").schema.to_arrow_schema()
+        self.assertTrue(schema_from_disk.field('uint8Col').type.equals(pyarrow.uint8()))
+        self.assertTrue(schema_from_disk.field('uint16Col').type.equals(pyarrow.uint16()))
+        self.assertTrue(schema_from_disk.field('uint32Col').type.equals(pyarrow.uint32()))
+
+        table_from_disk = read("data_from_pyarrow.parquet")
+        expected = new_table([
+            char_col("uint8Col", [255, 2, 0]),
+            char_col("uint16Col", [65535, 2, 0]),
+            long_col("uint32Col", [4294967295, 2, 0]),
+        ])
+        self.assert_table_equals(table_from_disk, expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Our parquet reading code crashes when reading a parquet column of type `Int(bitWidth=32, isSigned=false)`.
The idea is to read the unit32 values as a long column, but there was a bug which led to a failure. This PR fixes the issue.