### PR TITLE
5414 reconnect subscriptions

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1399,7 +1399,7 @@ public class WorkerConnection {
                         }
                     }
                 }
-            } else {
+            } else if (state.isRunning()) {
                 List<TableSubscriptionRequest> vps = new ArrayList<>();
                 state.forActiveSubscriptions((table, subscription) -> {
                     assert table.isActive(state) : "Inactive table has a viewport still attached";


### PR DESCRIPTION
DHC reconnects are able to restore server streams to an existing session, but most of the JS API was written to assume that a lost connection requires rebuilding objects on the server by replaying operations. This fix handles cases where a table failed and then a network error occurred, causing the table to be stuck unable to reconnect, since the table has failed.

Two bugs prevented this from working, both cases where after some operation couldn't be scheduled, a microtask would immediately try again, leading effectively to an infinite loop in the browser. Table subscriptions are fixed by first checking if the table is running, so can be subscribed, and table refetch is fixed by using null for its fetcher, and during refetch if the fetcher is null either fail right away with the existing fail message, or succeed right away. 

This fix currently makes it possible for a failed table on a reconnected worker to not signal that it is still failed - this will be addressed in a follow-up.

Fixes #5414