### PR TITLE
Small ring chunk source cleanup

### DIFF
--- a/engine/chunk/src/main/java/io/deephaven/chunk/Chunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/Chunk.java
@@ -17,7 +17,7 @@ public interface Chunk<ATTR extends Any> {
     /**
      * The threshold at which we should use System.arrayCopy rather than our own copy
      */
-    int SYSTEM_ARRAYCOPY_THRESHOLD = 0;
+    int SYSTEM_ARRAYCOPY_THRESHOLD = 16;
     /**
      * The threshold at which we should use Array.fill rather than our own fill
      */

--- a/engine/chunk/src/main/java/io/deephaven/chunk/Chunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/Chunk.java
@@ -17,7 +17,7 @@ public interface Chunk<ATTR extends Any> {
     /**
      * The threshold at which we should use System.arrayCopy rather than our own copy
      */
-    int SYSTEM_ARRAYCOPY_THRESHOLD = 16;
+    int SYSTEM_ARRAYCOPY_THRESHOLD = 0;
     /**
      * The threshold at which we should use Array.fill rather than our own fill
      */

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/AbstractRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/AbstractRingChunkSource.java
@@ -72,7 +72,7 @@ abstract class AbstractRingChunkSource<T, ARRAY, SELF extends AbstractRingChunkS
             throw new IllegalArgumentException("Capacity must be positive");
         }
         this.capacity = capacity;
-        //noinspection unchecked
+        // noinspection unchecked
         ring = type.isArray()
                 // Must fake it with nested arrays to match the expectations that we can accept an empty Object array in
                 // lieu of the real type (ie, new Object[0]).

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/AbstractRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/AbstractRingChunkSource.java
@@ -72,8 +72,14 @@ abstract class AbstractRingChunkSource<T, ARRAY, SELF extends AbstractRingChunkS
             throw new IllegalArgumentException("Capacity must be positive");
         }
         this.capacity = capacity;
-        // noinspection unchecked
-        ring = (ARRAY) Array.newInstance(type, capacity);
+        //noinspection unchecked
+        ring = type.isArray()
+                // Must fake it with nested arrays to match the expectations that we can accept an empty Object array in
+                // lieu of the real type (ie, new Object[0]).
+                // io.deephaven.util.type.ArrayTypeUtils.EMPTY_OBJECT_ARRAY / ObjectChunk.
+                // See https://github.com/deephaven/deephaven-core/issues/5498
+                ? (ARRAY) new Object[capacity]
+                : (ARRAY) Array.newInstance(type, capacity);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/AbstractRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/AbstractRingChunkSource.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.Closeable;
 import java.lang.reflect.Array;
+import java.util.Objects;
 import java.util.function.LongConsumer;
 
 import static io.deephaven.engine.table.impl.AbstractColumnSource.USE_RANGES_AVERAGE_RUN_LENGTH;
@@ -67,19 +68,12 @@ abstract class AbstractRingChunkSource<T, ARRAY, SELF extends AbstractRingChunkS
     protected final int capacity;
     long nextRingIx;
 
-    public AbstractRingChunkSource(@NotNull Class<T> type, int capacity) {
+    public AbstractRingChunkSource(ARRAY ring) {
+        this.ring = Objects.requireNonNull(ring);
+        this.capacity = Array.getLength(ring);
         if (capacity <= 0) {
             throw new IllegalArgumentException("Capacity must be positive");
         }
-        this.capacity = capacity;
-        // noinspection unchecked
-        ring = type.isArray()
-                // Must fake it with nested arrays to match the expectations that we can accept an empty Object array in
-                // lieu of the real type (ie, new Object[0]).
-                // io.deephaven.util.type.ArrayTypeUtils.EMPTY_OBJECT_ARRAY / ObjectChunk.
-                // See https://github.com/deephaven/deephaven-core/issues/5498
-                ? (ARRAY) new Object[capacity]
-                : (ARRAY) Array.newInstance(type, capacity);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ByteRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ByteRingChunkSource.java
@@ -25,7 +25,7 @@ final class ByteRingChunkSource extends AbstractRingChunkSource<Byte, byte[], By
     }
 
     public ByteRingChunkSource(int capacity) {
-        super(byte.class, capacity);
+        super(new byte[capacity]);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/CharacterRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/CharacterRingChunkSource.java
@@ -21,7 +21,7 @@ final class CharacterRingChunkSource extends AbstractRingChunkSource<Character, 
     }
 
     public CharacterRingChunkSource(int capacity) {
-        super(char.class, capacity);
+        super(new char[capacity]);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/DoubleRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/DoubleRingChunkSource.java
@@ -25,7 +25,7 @@ final class DoubleRingChunkSource extends AbstractRingChunkSource<Double, double
     }
 
     public DoubleRingChunkSource(int capacity) {
-        super(double.class, capacity);
+        super(new double[capacity]);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/FloatRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/FloatRingChunkSource.java
@@ -25,7 +25,7 @@ final class FloatRingChunkSource extends AbstractRingChunkSource<Float, float[],
     }
 
     public FloatRingChunkSource(int capacity) {
-        super(float.class, capacity);
+        super(new float[capacity]);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/IntegerRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/IntegerRingChunkSource.java
@@ -25,7 +25,7 @@ final class IntegerRingChunkSource extends AbstractRingChunkSource<Integer, int[
     }
 
     public IntegerRingChunkSource(int capacity) {
-        super(int.class, capacity);
+        super(new int[capacity]);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/LongRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/LongRingChunkSource.java
@@ -25,7 +25,7 @@ final class LongRingChunkSource extends AbstractRingChunkSource<Long, long[], Lo
     }
 
     public LongRingChunkSource(int capacity) {
-        super(long.class, capacity);
+        super(new long[capacity]);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ObjectRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ObjectRingChunkSource.java
@@ -10,22 +10,33 @@ import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.rowset.RowSet;
 import org.jetbrains.annotations.NotNull;
 
+import java.lang.reflect.Array;
 import java.util.Objects;
 
 // Note: this is not being auto-generated ATM
-final class ObjectRingChunkSource<T> extends AbstractRingChunkSource<T, Object[], ObjectRingChunkSource<T>> {
+final class ObjectRingChunkSource<T> extends AbstractRingChunkSource<T, T[], ObjectRingChunkSource<T>> {
     public static <T> RingColumnSource<T> columnSource(Class<T> type, int capacity) {
+        if (type.isPrimitive()) {
+            throw new IllegalArgumentException();
+        }
         return new RingColumnSource<>(type, new ObjectRingChunkSource<>(type, capacity),
                 new ObjectRingChunkSource<>(type, capacity));
     }
 
     public static <T> RingColumnSource<T> columnSource(Class<T> type, Class<?> componentType, int capacity) {
+        if (type.isPrimitive()) {
+            throw new IllegalArgumentException();
+        }
         return new RingColumnSource<>(type, componentType, new ObjectRingChunkSource<>(type, capacity),
                 new ObjectRingChunkSource<>(type, capacity));
     }
 
-    public ObjectRingChunkSource(Class<T> type, int capacity) {
-        super(type, capacity);
+    private ObjectRingChunkSource(Class<T> type, int capacity) {
+        // In the general case, we can't know that Array.newInstance(Class<T>, ...) will result in T[]; for example,
+        // type=int.class (T=Integer) => int[] (not Integer[]). That said, we know that type is generic, and thus we
+        // know resulting array type is T[].
+        //noinspection unchecked
+        super((T[]) Array.newInstance(type, capacity));
     }
 
     @Override
@@ -42,8 +53,7 @@ final class ObjectRingChunkSource<T> extends AbstractRingChunkSource<T, Object[]
             throw new IllegalArgumentException(
                     String.format("Invalid key %d. available=[%d, %d]", key, firstKey(), lastKey()));
         }
-        // noinspection unchecked
-        return (T) ring[keyToRingIndex(key)];
+        return ring[keyToRingIndex(key)];
     }
 
     @Override
@@ -60,14 +70,12 @@ final class ObjectRingChunkSource<T> extends AbstractRingChunkSource<T, Object[]
 
         @Override
         protected void copyFromRing(int srcRingIx, int destOffset) {
-            // noinspection unchecked
-            dest.set(destOffset, (T) ring[srcRingIx]);
+            dest.set(destOffset, ring[srcRingIx]);
         }
 
         @Override
         protected void copyFromRing(int srcRingIx, int destOffset, int size) {
-            // noinspection unchecked
-            dest.copyFromTypedArray((T[]) ring, srcRingIx, destOffset, size);
+            dest.copyFromTypedArray(ring, srcRingIx, destOffset, size);
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ObjectRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ObjectRingChunkSource.java
@@ -35,7 +35,7 @@ final class ObjectRingChunkSource<T> extends AbstractRingChunkSource<T, T[], Obj
         // In the general case, we can't know that Array.newInstance(Class<T>, ...) will result in T[]; for example,
         // type=int.class (T=Integer) => int[] (not Integer[]). That said, we know that type is generic, and thus we
         // know resulting array type is T[].
-        //noinspection unchecked
+        // noinspection unchecked
         super((T[]) Array.newInstance(type, capacity));
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ShortRingChunkSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ring/ShortRingChunkSource.java
@@ -25,7 +25,7 @@ final class ShortRingChunkSource extends AbstractRingChunkSource<Short, short[],
     }
 
     public ShortRingChunkSource(int capacity) {
-        super(short.class, capacity);
+        super(new short[capacity]);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ColumnHolder.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ColumnHolder.java
@@ -15,6 +15,7 @@ import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.ShortChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSequenceFactory;
 import io.deephaven.engine.table.ChunkSink;
 import io.deephaven.engine.table.WritableColumnSource;
@@ -291,8 +292,10 @@ public class ColumnHolder<T> {
 
         final WritableColumnSource<?> cs = ArrayBackedColumnSource.getMemoryColumnSource(
                 chunkData.size(), dataType, componentType);
-        try (final ChunkSink.FillFromContext ffc = cs.makeFillFromContext(chunkData.size())) {
-            cs.fillFromChunk(ffc, chunkData, RowSequenceFactory.forRange(0, chunkData.size() - 1));
+        try (
+                final ChunkSink.FillFromContext ffc = cs.makeFillFromContext(chunkData.size());
+                final RowSequence rs = RowSequenceFactory.forRange(0, chunkData.size() - 1)) {
+            cs.fillFromChunk(ffc, chunkData, rs);
         }
         return cs;
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/ring/RingTableToolsTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/ring/RingTableToolsTest.java
@@ -72,16 +72,14 @@ public class RingTableToolsTest {
     }
 
     @Test
-    public void doubleArrayAndEmptyObjectArray() {
-        final Object[] genericArray = {
+    public void doubleArrayChunk() {
+        final Object[] objectArray = {
                 null,
-                // this is the important piece; it's the only one that can't be assigned to a double[]
-                ObjectChunk.makeArray(0),
                 new double[] {},
                 new double[] {42.42, 43.43}
         };
         final Table table = TableTools.newTable(TstUtils.columnHolderForChunk(
-                "DoubleArray", double[].class, double.class, ObjectChunk.chunkWrap(genericArray)));
+                "DoubleArray", double[].class, double.class, ObjectChunk.chunkWrap(objectArray)));
         final Table ring = RingTableTools.of(table, 32, true);
         checkEquals(table, ring);
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/ring/RingTableToolsTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/ring/RingTableToolsTest.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.engine.table.impl.sources.ring;
 
+import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
@@ -68,6 +69,21 @@ public class RingTableToolsTest {
         coprime(1, 93);
         coprime(5, 71);
         coprime(14, 25);
+    }
+
+    @Test
+    public void doubleArrayAndEmptyObjectArray() {
+        final Object[] genericArray = {
+                null,
+                // this is the important piece; it's the only one that can't be assigned to a double[]
+                ObjectChunk.makeArray(0),
+                new double[]{},
+                new double[]{42.42, 43.43}
+        };
+        final Table table = TableTools.newTable(TstUtils.columnHolderForChunk(
+                "DoubleArray", double[].class, double.class, ObjectChunk.chunkWrap(genericArray)));
+        final Table ring = RingTableTools.of(table, 32, true);
+        checkEquals(table, ring);
     }
 
     private static void coprime(int a, int b) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/ring/RingTableToolsTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/ring/RingTableToolsTest.java
@@ -77,8 +77,8 @@ public class RingTableToolsTest {
                 null,
                 // this is the important piece; it's the only one that can't be assigned to a double[]
                 ObjectChunk.makeArray(0),
-                new double[]{},
-                new double[]{42.42, 43.43}
+                new double[] {},
+                new double[] {42.42, 43.43}
         };
         final Table table = TableTools.newTable(TstUtils.columnHolderForChunk(
                 "DoubleArray", double[].class, double.class, ObjectChunk.chunkWrap(genericArray)));


### PR DESCRIPTION
This was originally explored as a fix for #5498; ultimately, it was an upstream data issue that was solved in #5503. Along the way though, it was noted that ring chunk sources were 1) using reflection in places they didn't need to, and 2) using specifically typed arrays for generic types as opposed to other object chunks which use `Object[]` at the top layer. In the latest iteration of this, the construction reflection was removed (there is a new getLength check); but I'm apt to keep the more specifically typed arrays unless we know they are causing other issues. At a minimum, the specifically typed arrays helped us notice and fix #5503. 