### PR TITLE
ci: Workflow to check PR for conventional commit format

### DIFF
--- a/.github/workflows/conventional-pr-check.yml
+++ b/.github/workflows/conventional-pr-check.yml
@@ -1,0 +1,39 @@
+name: 'Conventional PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  pr-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Pull Request titles must follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
- PRs will need to adhere to the conventional commit specification: https://www.conventionalcommits.org/en/v1.0.0/
- If they do not, a comment will be added to the PR with details about the spec
- Goal is to automate prettier release notes (e.g. separate Features from Fixes, highlight Breaking Changes). Could potentially be used for automated version bumping as well (which we do in deephaven-plugins, automatically bumping the correct version based on if there are breaking changes (major), features (minor), or fixes only (patch) in the release.
- Follow up:
  - Add this check to branch protection
  - Use the commit history to automatically generate the changelog. In the deephaven-plugins repo, we use cocogitto, which also automatically bumps the version
  - Recommend to use PR_BODY and PR_TITLE for the default squash_merge_commit_mesage and squash_merge_commit_title

I also noticed that with GitHub's automated release notes, you can actually [configure it to use the labels to categorize PRs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes). That could be useful if there's hesitation to using conventional commits. One advantage of conventional commits is that you can easily handle automatic version bumping (we use cocogitto), which I don't think GitHub can do.