### PR TITLE
Add a new init parameter to the embedded server to allow the user to only override the Deephaven recommended JVM args

### DIFF
--- a/py/embedded-server/README.md
+++ b/py/embedded-server/README.md
@@ -5,8 +5,7 @@ directly as part of startup.
 
 ## Dev environment setup
 Java 11 and Docker are required to build this project, as most of the repository is needed to properly build it.
-Note that jpy or deephaven-jpy (built for your OS and archetecture) and the deephaven server apiwheel is also
-required. 
+Note that jpy and the deephaven server api wheel is also required. 
 
 ## Build
 From the root directory of this repository
@@ -27,5 +26,5 @@ server = Server()
 server.start()
 
 from deephaven import time_table
-ticking_table = time_table('00:00:01').update_view(formulas=["Col1 = i % 2"])
+ticking_table = time_table('PT1s').update_view(formulas=["Col1 = i % 2"])
 ```

--- a/py/embedded-server/README_PyPi.md
+++ b/py/embedded-server/README_PyPi.md
@@ -8,7 +8,7 @@ Deephaven Community Core is a real-time, time-series, column-oriented analytics 
 
 Java 11+ is required for this module, and the `JAVA_HOME` environment variable must be set appropriately.
 
-This module also requires Python version 3.7 or newer.
+This module also requires Python version 3.8 or newer.
 
 ## Setup
 

--- a/py/embedded-server/deephaven_server/cli.py
+++ b/py/embedded-server/deephaven_server/cli.py
@@ -22,7 +22,8 @@ def cli():
 @click.option("--port", default=None, type=int, help="The port to bind to.")
 @click.option("--jvm-args", default=None, help="The JVM arguments to use.")
 @click.option("--extra-classpath", default=None, help="The extra classpath to use.")
-def server(host, port, jvm_args, extra_classpath):
+@click.option("--sig-handled-by", type=click.Choice(["python", "java"]), default="python", help="The signal handling to be done by Python or Java.")
+def server(host, port, jvm_args, extra_classpath, sig_handled_by):
     """
     Start the Deephaven server.
     """
@@ -36,7 +37,7 @@ def server(host, port, jvm_args, extra_classpath):
         extra_classpath = ""
     extra_classpath = extra_classpath.split()
 
-    s = Server(host=host, port=port, jvm_args=jvm_args, extra_classpath=extra_classpath)
+    s = Server(host=host, port=port, jvm_args=jvm_args, extra_classpath=extra_classpath, sig_handled_by=sig_handled_by)
     s.start()
 
     target_url_or_default = s.server_config.target_url_or_default

--- a/py/embedded-server/deephaven_server/cli.py
+++ b/py/embedded-server/deephaven_server/cli.py
@@ -22,22 +22,18 @@ def cli():
 @click.option("--port", default=None, type=int, help="The port to bind to.")
 @click.option("--jvm-args", default=None, help="The JVM arguments to use.")
 @click.option("--extra-classpath", default=None, help="The extra classpath to use.")
-@click.option("--sig-handled-by", type=click.Choice(["python", "java"]), default="python", help="The signal handling to be done by Python or Java.")
-def server(host, port, jvm_args, extra_classpath, sig_handled_by):
+@click.option("--default-jvm_args", default=None, help="The advanced JVM arguments to use in place of the default ones that Deephaven recommends.")
+def server(host, port, jvm_args, extra_classpath, default_jvm_args):
     """
     Start the Deephaven server.
     """
     click.echo("Starting Deephaven server...")
 
-    if jvm_args is None:
-        jvm_args = ""
-    jvm_args = jvm_args.split()
+    jvm_args = jvm_args.split() if jvm_args else None
+    default_jvm_args = default_jvm_args.split() if default_jvm_args else None
+    extra_classpath = extra_classpath.split() if extra_classpath else None
 
-    if extra_classpath is None:
-        extra_classpath = ""
-    extra_classpath = extra_classpath.split()
-
-    s = Server(host=host, port=port, jvm_args=jvm_args, extra_classpath=extra_classpath, sig_handled_by=sig_handled_by)
+    s = Server(host=host, port=port, jvm_args=jvm_args, extra_classpath=extra_classpath, default_jvm_args=default_jvm_args)
     s.start()
 
     target_url_or_default = s.server_config.target_url_or_default

--- a/py/embedded-server/deephaven_server/cli.py
+++ b/py/embedded-server/deephaven_server/cli.py
@@ -22,7 +22,7 @@ def cli():
 @click.option("--port", default=None, type=int, help="The port to bind to.")
 @click.option("--jvm-args", default=None, help="The JVM arguments to use.")
 @click.option("--extra-classpath", default=None, help="The extra classpath to use.")
-@click.option("--default-jvm_args", default=None, help="The advanced JVM arguments to use in place of the default ones that Deephaven recommends.")
+@click.option("--default-jvm-args", default=None, help="The advanced JVM arguments to use in place of the default ones that Deephaven recommends.")
 def server(host, port, jvm_args, extra_classpath, default_jvm_args):
     """
     Start the Deephaven server.

--- a/py/embedded-server/deephaven_server/server.py
+++ b/py/embedded-server/deephaven_server/server.py
@@ -120,7 +120,7 @@ class Server:
         port: Optional[int] = None,
         jvm_args: Optional[List[str]] = None,
         extra_classpath: Optional[List[str]] = None,
-        sig_handled_by: Literal["python", "java"] = "python",
+        default_jvm_args: Optional[List[str]] = None,
     ):
         """
         Creates a Deephaven embedded server. Only one instance can be created at this time.
@@ -128,12 +128,12 @@ class Server:
         Args:
             host (Optional[str]): The host to bind the server to, defaults to None, meaning local host.
             port (Optional[int]): The port to bind the server to, defaults to None, meaning 10000.
-            jvm_args (Optional[List[str]]): The JVM arguments to use. Defaults to None. Deephaven has a set of default
-                JVM arguments. When provided, the user's JVM arguments will be merged with the default JVM arguments. If
-                there are conflicting options, the user's JVM arguments will override the default JVM arguments.
-                TODO provide a list of default JVM arguments?
+            jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, the
+                authentication handler to use, and other related JVM options. Defaults to None.
             extra_classpath (Optional[List[str]]): The extra classpath to use.
-            sig_handled_by (Literal["python", "java"]): The signal handling to be done by Python or Java, defaults to "Python".
+            default_jvm_args (Optional[List[str]]): The advanced JVM arguments to use instead of the default ones that
+                Deephaven recommends, such as a specific garbage collector and related tuning parameters, or whether to
+                let Python or Java to handle signals. Defaults to None.
         """
         # TODO deephaven-core#2453 consider providing @dataclass for arguments
 
@@ -145,15 +145,8 @@ class Server:
         if extra_classpath is None:
             extra_classpath = []
 
-        if sig_handled_by == "python":
-            # Disable the JVM's signal handling for interactive python consoles - if python will
-            # not be handling signals like ctrl-c (for KeyboardInterrupt), this should be safe to
-            # remove for a small performance gain.
-            jvm_args = jvm_args or []
-            jvm_args.append("-Xrs")
-
         # given the jvm args, ensure that the jvm has started
-        start_jvm(jvm_args=jvm_args, extra_classpath=extra_classpath)
+        start_jvm(jvm_args=jvm_args, default_jvm_args=default_jvm_args, extra_classpath=extra_classpath)
 
         # it is now safe to import jpy
         import jpy

--- a/py/embedded-server/deephaven_server/server.py
+++ b/py/embedded-server/deephaven_server/server.py
@@ -133,7 +133,7 @@ class Server:
             extra_classpath (Optional[List[str]]): The extra classpath to use.
             default_jvm_args (Optional[List[str]]): The advanced JVM arguments to use instead of the default ones that
                 Deephaven recommends, such as a specific garbage collector and related tuning parameters, or whether to
-                let Python or Java to handle signals. Defaults to None.
+                let Python or Java handle signals. Defaults to None, the Deephaven defaults.
         """
         # TODO deephaven-core#2453 consider providing @dataclass for arguments
 

--- a/py/embedded-server/deephaven_server/server.py
+++ b/py/embedded-server/deephaven_server/server.py
@@ -131,8 +131,8 @@ class Server:
             port (Optional[int]): The port to bind the server to, defaults to None. When None, if a user defined
                 configuration file is present and 'http.port' is specified in it, use that port, otherwise, use the
                 default 10000. Refer to the Deephaven documentation for more information on the configuration file.
-            jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, the
-                authentication handler to use, and other related JVM options. Defaults to None.
+            jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, and other
+                related JVM options. Defaults to None.
             extra_classpath (Optional[List[str]]): The extra classpath to use.
             default_jvm_args (Optional[List[str]]): The advanced JVM arguments to use instead of the default ones that
                 Deephaven recommends, such as a specific garbage collector and related tuning parameters, or whether to

--- a/py/embedded-server/deephaven_server/server.py
+++ b/py/embedded-server/deephaven_server/server.py
@@ -125,9 +125,11 @@ class Server:
         Creates a Deephaven embedded server. Only one instance can be created at this time.
 
         Args:
-            host (Optional[str]): The host to bind the server to, defaults to None, meaning local host.
+            host (Optional[str]): The host to bind the server to, defaults to None. When None, if a user defined
+                configuration file is present and 'http.host' is specified in it, use its value, otherwise, use the
+                default 'localhost'. Refer to the Deephaven documentation for more information on the configuration file.
             port (Optional[int]): The port to bind the server to, defaults to None. When None, if a user defined
-                configuration file is present and a port number is specified in it, use that port, otherwise, use the
+                configuration file is present and 'http.port' is specified in it, use that port, otherwise, use the
                 default 10000. Refer to the Deephaven documentation for more information on the configuration file.
             jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, the
                 authentication handler to use, and other related JVM options. Defaults to None.

--- a/py/embedded-server/deephaven_server/server.py
+++ b/py/embedded-server/deephaven_server/server.py
@@ -32,7 +32,6 @@ class ServerConfig:
         """
         return self.j_server_config.targetUrlOrDefault()
 
-
 class AuthenticationHandler:
     """
     Represents an authentication handler for a Deephaven server.
@@ -127,7 +126,9 @@ class Server:
 
         Args:
             host (Optional[str]): The host to bind the server to, defaults to None, meaning local host.
-            port (Optional[int]): The port to bind the server to, defaults to None, meaning 10000.
+            port (Optional[int]): The port to bind the server to, defaults to None. When None, if a user defined
+                configuration file is present and a port number is specified in it, use that port, otherwise, use the
+                default 10000. Refer to the Deephaven documentation for more information on the configuration file.
             jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, the
                 authentication handler to use, and other related JVM options. Defaults to None.
             extra_classpath (Optional[List[str]]): The extra classpath to use.

--- a/py/embedded-server/deephaven_server/server.py
+++ b/py/embedded-server/deephaven_server/server.py
@@ -3,7 +3,7 @@
 #
 """ This module supports embedding a Deephaven server in Python."""
 
-from typing import Dict, List, Optional, Literal
+from typing import List, Optional
 import sys
 
 from .start_jvm import start_jvm

--- a/py/embedded-server/deephaven_server/start_jvm.py
+++ b/py/embedded-server/deephaven_server/start_jvm.py
@@ -51,29 +51,31 @@ def _merge_with_default_jvm_args(jvm_args: Optional[List[str]] = None) -> List[s
 
     # Remove any conflicting options
     for jvm_arg in jvm_args:
-        # -XX boolean options
-        if jvm_arg.startswith("-XX:+") or jvm_arg.startswith("-XX:-"):
-            opt = jvm_arg[5:]
-            result_args = [arg for arg in result_args if not arg.endswith(opt)]
-            # result_args.append(jvm_arg)
-        # -XX numeric/string options
-        elif jvm_arg.startswith("-XX:"):
-            opt, val, *_ = jvm_arg[4:].split('=', 1)
-            result_args = [arg for arg in result_args if arg.startswith("-XX:") and opt != arg[4:].split('=', 1)[0]]
-            # result_args.append(jvm_arg)
-        # -X options
-        elif jvm_arg.startswith("-X"):
-            opt, val = jvm_arg[2:].split(':', 1)
-            result_args = [arg for arg in result_args if not arg.startswith("-X") or opt != arg[2:].split(':', 1)[0]]
-        # JVM system properties
-        elif jvm_arg.startswith("-D"):
-            opt, val = jvm_arg[2:].split('=', 1)
-            result_args = [arg for arg in result_args if not arg.startswith("-D") or opt != arg[2:].split('=', 1)[0]]
-        # JPMS - Java Platform Module System options
-        elif jvm_arg.startswith("--add-opens=") or jvm_arg.startswith("--add-exports="):
-            ...
+        try:
+            # -XX boolean options
+            if jvm_arg.startswith("-XX:+") or jvm_arg.startswith("-XX:-"):
+                opt = jvm_arg[5:]
+                result_args = [arg for arg in result_args if not arg.endswith(opt)]
+            # -XX numeric/string options
+            elif jvm_arg.startswith("-XX:"):
+                opt, val, *_ = jvm_arg[4:].split('=', 1)
+                result_args = [arg for arg in result_args if arg.startswith("-XX:") and opt != arg[4:].split('=', 1)[0]]
+            # -X options
+            elif jvm_arg.startswith("-X"):
+                opt = jvm_arg[2:].split(':', 1)[0]
+                result_args = [arg for arg in result_args if not arg.startswith("-X") or opt != arg[2:].split(':', 1)[0]]
+            # JVM system properties
+            elif jvm_arg.startswith("-D"):
+                opt, val = jvm_arg[2:].split('=', 1)
+                result_args = [arg for arg in result_args if not arg.startswith("-D") or opt != arg[2:].split('=', 1)[0]]
+            # JPMS - Java Platform Module System options
+            elif jvm_arg.startswith("--add-opens=") or jvm_arg.startswith("--add-exports="):
+                ...
+        except ValueError:
+            # Ignore any errors in parsing the JVM args to avoid unnecessary surprises in case a new JVM option format is added in the future
+            pass
 
-    # Append the user-provided JVM args
+    # Append the user-provided JVM args to make sure they override the defaults
     result_args.extend(jvm_args)
     return result_args
 

--- a/py/embedded-server/deephaven_server/start_jvm.py
+++ b/py/embedded-server/deephaven_server/start_jvm.py
@@ -6,6 +6,7 @@ import glob
 import itertools
 import os
 import pathlib
+import types
 from typing import Optional, List, Dict
 
 from deephaven_internal import jvm
@@ -55,10 +56,25 @@ def start_jvm(
         java_home: Optional[str] = None,
         extra_classpath: Optional[List[str]] = None,
         prop_file: str = None,
-        config = None,
+        config: Optional[types.ModuleType] = None,
 ) -> None:
     """ This function uses the default DH property file to embed the Deephaven server and starts a Deephaven Python
-    Script session. """
+    Script session.
+
+    Args:
+        jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, the
+            authentication handler to use, and other related JVM options. Defaults to None.
+        default_jvm_args (Optional[List[str]]): The advanced JVM arguments to use instead of the default ones that
+            Deephaven recommends, such as a specific garbage collector and related tuning parameters, or whether to
+            let Python or Java handle signals. Defaults to None, the Deephaven defaults as defined in DEFAULT_JVM_ARGS.
+        jvm_properties (Optional[Dict[str, str]]): The JVM properties to use. Defaults to None, meaning to use the
+            predefined DEFAULT_JVM_PROPERTIES .
+        java_home (Optional[str]): The JAVA_HOME path to use. Defaults to None, meaning using the JAVA_HOME environment
+            variable.
+        extra_classpath (Optional[List[str]]): The extra classpath to use.
+        prop_file (str): The property file to use. Defaults to None.
+        config (Optional[types.ModuleType]): The JPY configuration module to use. Defaults to None.
+    """
     default_jvm_args = default_jvm_args or DEFAULT_JVM_ARGS
     jvm_args = default_jvm_args + jvm_args if jvm_args else default_jvm_args
 

--- a/py/embedded-server/deephaven_server/start_jvm.py
+++ b/py/embedded-server/deephaven_server/start_jvm.py
@@ -62,8 +62,8 @@ def start_jvm(
     Script session.
 
     Args:
-        jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, the
-            authentication handler to use, and other related JVM options. Defaults to None.
+        jvm_args (Optional[List[str]]): The common, user specific JVM arguments, such as JVM heap size, and other
+            related JVM options. Defaults to None.
         default_jvm_args (Optional[List[str]]): The advanced JVM arguments to use instead of the default ones that
             Deephaven recommends, such as a specific garbage collector and related tuning parameters, or whether to
             let Python or Java handle signals. Defaults to None, the Deephaven defaults as defined in DEFAULT_JVM_ARGS.
@@ -72,8 +72,9 @@ def start_jvm(
         java_home (Optional[str]): The JAVA_HOME path to use. Defaults to None, meaning using the JAVA_HOME environment
             variable.
         extra_classpath (Optional[List[str]]): The extra classpath to use.
-        prop_file (str): The property file to use. Defaults to None.
-        config (Optional[types.ModuleType]): The JPY configuration module to use. Defaults to None.
+        prop_file (str): The property file to use. Defaults to None, meaning not loading any JVM properties from a file.
+        config (Optional[types.ModuleType]): The JPY configuration module to use. Defaults to None, meaning not providing
+            a JPY configuration module for the jpyutil module to load and config the JVM.
     """
     default_jvm_args = default_jvm_args or DEFAULT_JVM_ARGS
     jvm_args = default_jvm_args + jvm_args if jvm_args else default_jvm_args

--- a/py/embedded-server/setup.py
+++ b/py/embedded-server/setup.py
@@ -11,11 +11,13 @@ import pathlib
 from pkg_resources import parse_version
 from setuptools import find_namespace_packages, setup
 
+
 def _get_readme() -> str:
     # The directory containing this file
-    HERE = pathlib.Path(__file__).parent
+    here = pathlib.Path(__file__).parent
     # The text of the README file
-    return (HERE / "README_PyPi.md").read_text(encoding="utf-8")
+    return (here / "README_PyPi.md").read_text(encoding="utf-8")
+
 
 def _normalize_version(java_version) -> str:
     partitions = java_version.partition("-")
@@ -24,8 +26,10 @@ def _normalize_version(java_version) -> str:
     python_version = f"{regular_version}+{local_segment}" if local_segment else regular_version
     return str(parse_version(python_version))
 
+
 def _compute_version():
     return _normalize_version(os.environ['DEEPHAVEN_VERSION'])
+
 
 _version = _compute_version()
 


### PR DESCRIPTION
Fixes #5521 