### PR TITLE
fix: Allow LayoutHints to be accessible from Python, TreeTables

### DIFF
--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -251,6 +251,66 @@ class RollupTable(JObjectWrapper):
         except Exception as e:
             raise DHError(e, "with_filters operation on RollupTable failed.") from e
 
+    def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
+                     freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None,
+                     column_groups: List[dict] = None, search_display_mode: SearchDisplayMode = None) -> Table:
+        """ Sets layout hints on the Table
+
+        Args:
+            front (Union[str, List[str]]): the columns to show at the front.
+            back (Union[str, List[str]]): the columns to show at the back.
+            freeze (Union[str, List[str]]): the columns to freeze to the front.
+                These will not be affected by horizontal scrolling.
+            hide (Union[str, List[str]]): the columns to hide.
+            column_groups (List[Dict]): A list of dicts specifying which columns should be grouped in the UI.
+                The dicts can specify the following:
+
+                * name (str): The group name
+                * children (List[str]): The column names in the group
+                * color (Optional[str]): The hex color string or Deephaven color name
+            search_display_mode (SearchDisplayMode): set the search bar to explicitly be accessible or inaccessible,
+                or use the system default. :attr:`SearchDisplayMode.SHOW` will show the search bar,
+                :attr:`SearchDisplayMode.HIDE` will hide the search bar, and :attr:`SearchDisplayMode.DEFAULT` will
+                use the default value configured by the user and system settings.
+
+        Returns:
+            a new table with the layout hints set
+
+        Raises:
+            DHError
+        """
+        try:
+            _j_layout_hint_builder = _JLayoutHintBuilder.get()
+
+            if front is not None:
+                _j_layout_hint_builder.atFront(to_sequence(front))
+
+            if back is not None:
+                _j_layout_hint_builder.atBack(to_sequence(back))
+
+            if freeze is not None:
+                _j_layout_hint_builder.freeze(to_sequence(freeze))
+
+            if hide is not None:
+                _j_layout_hint_builder.hide(to_sequence(hide))
+
+            if column_groups is not None:
+                for group in column_groups:
+                    _j_layout_hint_builder.columnGroup(group.get("name"), j_array_list(group.get("children")),
+                                                       group.get("color", ""))
+
+            if search_display_mode is not None:
+                _j_layout_hint_builder.setSearchBarAccess(search_display_mode.value)
+
+        except Exception as e:
+            raise DHError(e, "failed to create layout hints") from e
+
+        try:
+            return RollupTable(j_rollup_table=self.j_rollup_table.setLayoutHints(_j_layout_hint_builder.build()),
+                               include_constituents=self.include_constituents, aggs=self.aggs, by=self.by)
+        except Exception as e:
+            raise DHError(e, "failed to set layout hints on table") from e
+
 
 class TreeNodeOperationsRecorder(JObjectWrapper, _FormatOperationsRecorder,
                                  _SortOperationsRecorder, _FilterOperationsRecorder):

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -254,7 +254,7 @@ class RollupTable(JObjectWrapper):
     def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
                      freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None,
                      column_groups: List[dict] = None, search_display_mode: SearchDisplayMode = None) -> Table:
-        """ Sets layout hints on the Table
+        """ Sets layout hints on the RollupTable
 
         Args:
             front (Union[str, List[str]]): the columns to show at the front.
@@ -274,7 +274,7 @@ class RollupTable(JObjectWrapper):
                 use the default value configured by the user and system settings.
 
         Returns:
-            a new table with the layout hints set
+            a new rollup table with the layout hints set
 
         Raises:
             DHError
@@ -309,7 +309,7 @@ class RollupTable(JObjectWrapper):
             return RollupTable(j_rollup_table=self.j_rollup_table.setLayoutHints(_j_layout_hint_builder.build()),
                                include_constituents=self.include_constituents, aggs=self.aggs, by=self.by)
         except Exception as e:
-            raise DHError(e, "failed to set layout hints on table") from e
+            raise DHError(e, "failed to set layout hints on rollup table") from e
 
 
 class TreeNodeOperationsRecorder(JObjectWrapper, _FormatOperationsRecorder,
@@ -403,6 +403,65 @@ class TreeTable(JObjectWrapper):
         except Exception as e:
             raise DHError(e, "with_filters operation on TreeTable failed.") from e
 
+    def layout_hints(self, front: Union[str, List[str]] = None, back: Union[str, List[str]] = None,
+                     freeze: Union[str, List[str]] = None, hide: Union[str, List[str]] = None,
+                     column_groups: List[dict] = None, search_display_mode: SearchDisplayMode = None) -> Table:
+        """ Sets layout hints on the TreeTable
+
+        Args:
+            front (Union[str, List[str]]): the columns to show at the front.
+            back (Union[str, List[str]]): the columns to show at the back.
+            freeze (Union[str, List[str]]): the columns to freeze to the front.
+                These will not be affected by horizontal scrolling.
+            hide (Union[str, List[str]]): the columns to hide.
+            column_groups (List[Dict]): A list of dicts specifying which columns should be grouped in the UI.
+                The dicts can specify the following:
+
+                * name (str): The group name
+                * children (List[str]): The column names in the group
+                * color (Optional[str]): The hex color string or Deephaven color name
+            search_display_mode (SearchDisplayMode): set the search bar to explicitly be accessible or inaccessible,
+                or use the system default. :attr:`SearchDisplayMode.SHOW` will show the search bar,
+                :attr:`SearchDisplayMode.HIDE` will hide the search bar, and :attr:`SearchDisplayMode.DEFAULT` will
+                use the default value configured by the user and system settings.
+
+        Returns:
+            a new tree table with the layout hints set
+
+        Raises:
+            DHError
+        """
+        try:
+            _j_layout_hint_builder = _JLayoutHintBuilder.get()
+
+            if front is not None:
+                _j_layout_hint_builder.atFront(to_sequence(front))
+
+            if back is not None:
+                _j_layout_hint_builder.atBack(to_sequence(back))
+
+            if freeze is not None:
+                _j_layout_hint_builder.freeze(to_sequence(freeze))
+
+            if hide is not None:
+                _j_layout_hint_builder.hide(to_sequence(hide))
+
+            if column_groups is not None:
+                for group in column_groups:
+                    _j_layout_hint_builder.columnGroup(group.get("name"), j_array_list(group.get("children")),
+                                                       group.get("color", ""))
+
+            if search_display_mode is not None:
+                _j_layout_hint_builder.setSearchBarAccess(search_display_mode.value)
+
+        except Exception as e:
+            raise DHError(e, "failed to create layout hints") from e
+
+        try:
+            return TreeTable(j_tree_table=self.j_tree_table.setLayoutHints(_j_layout_hint_builder.build()),
+                             id_col=self.id_col, parent_col=self.parent_col)
+        except Exception as e:
+            raise DHError(e, "failed to set layout hints on tree table") from e
 
 def _j_py_script_session() -> _JPythonScriptSession:
     j_execution_context = _JExecutionContext.getContext()

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -359,6 +359,7 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
     private Column rowExpandedCol;
     private final Column actionCol;
     private final JsArray<Column> groupedColumns;
+    private JsLayoutHints layoutHints;
 
     // The source JsTable behind the original HierarchicalTable, lazily built at this time
     private final JsLazy<Promise<JsTable>> sourceTable;
@@ -1080,6 +1081,25 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
     @JsNullable
     public String getDescription() {
         return tableDefinition.getAttributes().getDescription();
+    }
+
+    @JsProperty
+    @JsNullable
+    public JsLayoutHints getLayoutHints() {
+        if (layoutHints == null) {
+            createLayoutHints();
+        }
+        return layoutHints;
+    }
+
+    private void createLayoutHints() {
+        String hintsString = tableDefinition.getAttributes().getLayoutHints();
+        JsLayoutHints jsHints = new JsLayoutHints();
+        if (hintsString == null) {
+            layoutHints = null;
+        } else {
+            layoutHints = jsHints.parse(hintsString);
+        }
     }
 
     /**


### PR DESCRIPTION
- Related to Enterprise ticket DH-17076, which has been identified as a Blocker by support
- Groovy had setLayoutHints exposed on TreeTables, but was not exposed through JsTreeTable and was also not accessible through Python
- Added layoutHints to JsTreeTable, and exposed layout_hints through Python (they were already accessible through Groovy)
- Will have a follow up UI change as well to read the layout hints correctly from a JsTreeTable
- Fixes #5554 

Tested with the following snippet:
```python
# For RollupTable
from deephaven import empty_table, agg
source = empty_table(100).update(["K1 = ii", "K2=K1%10", "Y=randomDouble(0, 10)", "Z=randomDouble(0, 10)"])
result_norollup = source.layout_hints(column_groups=[{"name": "MyCols", "children": ["Y", "Z"]}])
result_rollup = source.rollup([agg.avg(["Y", "Z"])], "K2", False).layout_hints(column_groups=[{"name": "MyCols", "children": ["Y", "Z"]}])

# For TreeTable
from deephaven.constants import NULL_INT
from deephaven import empty_table

source2 = empty_table(100).update_view(
    ["ID = i", "Parent = i == 0 ? NULL_INT : (int)(i / 4)", "X=Math.sin(i)", "Y=Math.cos(i)"]
)

result2_tree = source2.tree(id_col="ID", parent_col="Parent").layout_hints(column_groups=[{"name": "Trig", "children": ["X", "Y"]}])
```