### PR TITLE
fix: PyPi README should indicate we require 3.8 or newer

### DIFF
--- a/py/embedded-server/README_PyPi.md
+++ b/py/embedded-server/README_PyPi.md
@@ -8,7 +8,7 @@ Deephaven Community Core is a real-time, time-series, column-oriented analytics 
 
 Java 11+ is required for this module, and the `JAVA_HOME` environment variable must be set appropriately.
 
-This module also requires Python version 3.7 or newer.
+This module also requires Python version 3.8 or newer.
 
 ## Setup
 


### PR DESCRIPTION
- We were showing 3.7 or newer, which is incorrect. We require 3.8 or newer.
