### PR TITLE
fix: Expose layoutHints in JS API for TreeTable

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -359,6 +359,7 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
     private Column rowExpandedCol;
     private final Column actionCol;
     private final JsArray<Column> groupedColumns;
+    private JsLayoutHints layoutHints;
 
     // The source JsTable behind the original HierarchicalTable, lazily built at this time
     private final JsLazy<Promise<JsTable>> sourceTable;
@@ -1080,6 +1081,25 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
     @JsNullable
     public String getDescription() {
         return tableDefinition.getAttributes().getDescription();
+    }
+
+    @JsProperty
+    @JsNullable
+    public JsLayoutHints getLayoutHints() {
+        if (layoutHints == null) {
+            createLayoutHints();
+        }
+        return layoutHints;
+    }
+
+    private void createLayoutHints() {
+        String hintsString = tableDefinition.getAttributes().getLayoutHints();
+        JsLayoutHints jsHints = new JsLayoutHints();
+        if (hintsString == null) {
+            layoutHints = null;
+        } else {
+            layoutHints = jsHints.parse(hintsString);
+        }
     }
 
     /**


### PR DESCRIPTION
- You could set layout hints in Groovy, but they were not accessible through the JS API
- Required for DH-17076
- Needs UI change https://github.com/deephaven/web-client-ui/pull/2041
- Refactored from #5543 , only the JS API part