### PR TITLE
Fix names of type annotations not matching between definition and use.

### DIFF
--- a/py/client/pydeephaven/session.py
+++ b/py/client/pydeephaven/session.py
@@ -252,7 +252,7 @@ class Session:
                 self._auth_header_value = v if isinstance(v, bytes) else v.encode('ascii')
                 break
 
-    def wrap_rpc(self, stub_call: NotBidiRpc, *args, **kwargs) -> Any:
+    def wrap_rpc(self, stub_call: _NotBidiRpc, *args, **kwargs) -> Any:
         if 'metadata' in kwargs:
             raise DHError('Internal error: "metadata" in kwargs not supported in wrap_rpc.')
         kwargs["metadata"] = self.grpc_metadata
@@ -263,7 +263,7 @@ class Session:
         # Now block until we get the result (or an exception)
         return future.result()
 
-    def wrap_bidi_rpc(self, stub_call: BidiRpc, *args, **kwargs) -> Any:
+    def wrap_bidi_rpc(self, stub_call: _BidiRpc, *args, **kwargs) -> Any:
         if 'metadata' in kwargs:
             raise DHError('Internal error: "metadata" in kwargs not supported in wrap_bidi_rpc.')
         kwargs["metadata"] = self.grpc_metadata


### PR DESCRIPTION
Somehow the github test runs miss this, but if you try to run tests locally with `./gradlew :py-client:testPyClient`, you get failures due to the type annotation name mismatch:

```
[...]
> Task :py-client:testPyClientRun FAILED
Created container with ID '490146f474607a404c8d35e0d4641b3fa8dc8e03bbbc1bdbb69779780cb5bcb7'.
Container exited with code 1

Running tests...
----------------------------------------------------------------------
  test_console (unittest.loader._FailedTest) ... ERROR (0.001s)
  test_multi_session (unittest.loader._FailedTest) ... ERROR (0.000s)
  test_plugin_client (unittest.loader._FailedTest) ... ERROR (0.000s)
  test_query (unittest.loader._FailedTest) ... ERROR (0.000s)
  test_session (unittest.loader._FailedTest) ... ERROR (0.000s)
  test_table (unittest.loader._FailedTest) ... ERROR (0.000s)
  test_updateby (unittest.loader._FailedTest) ... ERROR (0.000s)
  testbase (unittest.loader._FailedTest) ... ERROR (0.000s)

======================================================================
ERROR [0.001s]: test_console (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_console
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/local/lib/python3.10/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/project/tests/test_console.py", line 9, in <module>
    from pydeephaven import DHError
  File "/project/pydeephaven/__init__.py", line 28, in <module>
    from .session import Session
  File "/project/pydeephaven/session.py", line 87, in <module>
    class Session:
  File "/project/pydeephaven/session.py", line 225, in Session
    def wrap_rpc(self, stub_call: NotBidiRpc, *args, **kwargs) -> Any:
NameError: name 'NotBidiRpc' is not defined
[...]
```