### PR TITLE
BaseArrayBackedInputTable user safety fixes

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedInputTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedInputTable.java
@@ -306,18 +306,23 @@ abstract class BaseArrayBackedInputTable extends UpdatableTable {
             if (updateGraph.currentThreadProcessesUpdates()) {
                 throw new UnsupportedOperationException("Attempted to make a blocking input table edit from a listener "
                         + "or notification. This is unsupported, because it will block the update graph from making "
-                        + "progress.");
+                        + "progress and hang indefinitely.");
+            }
+            if (updateGraph.sharedLock().isHeldByCurrentThread()) {
+                throw new UnsupportedOperationException("Attempted to make a blocking input table edit while holding "
+                        + "the update graph's shared lock. This is unsupported, because it will block the update graph "
+                        + "from making progress and hang indefinitely.");
             }
         }
 
         private void checkAsyncEditSafety(@NotNull final Table changeData) {
             if (changeData.isRefreshing()
-                    && updateGraph.currentThreadProcessesUpdates()
-                    && !changeData.satisfied(updateGraph.clock().currentStep())) {
+                    && changeData.getUpdateGraph().currentThreadProcessesUpdates()
+                    && !changeData.satisfied(changeData.getUpdateGraph().clock().currentStep())) {
                 throw new UnsupportedOperationException("Attempted to make an asynchronous input table edit from a "
-                        + "listener or notification before the change data table is satisfied on the current cycle. "
-                        + "This is unsupported, because it may block the update graph from making progress or produce "
-                        + "inconsistent results.");
+                        + "listener or notification before the table of data to add or delete is satisfied on the "
+                        + "current cycle. This is unsupported, because it may block the update graph from making "
+                        + "progress or produce inconsistent results.");
             }
         }
 


### PR DESCRIPTION
Add test to prevent doing a blocking input table edit from a thread that holds the update graph's shared lock.

Correct test for async edits to use the right update graph.

Fixes #5585 