### PR TITLE
Make `region` optional for S3 instructions

### DIFF
--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3AsyncClientFactory.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3AsyncClientFactory.java
@@ -55,8 +55,8 @@ class S3AsyncClientFactory {
                         // .addMetricPublisher(LoggingMetricPublisher.create(Level.INFO, Format.PRETTY))
                         .scheduledExecutorService(ensureScheduledExecutor())
                         .build())
-                .region(Region.of(instructions.regionName()))
                 .credentialsProvider(instructions.awsV2CredentialsProvider());
+        instructions.regionName().ifPresent(regionName -> builder.region(Region.of(regionName)));
         instructions.endpointOverride().ifPresent(builder::endpointOverride);
         final S3AsyncClient ret = builder.build();
         if (log.isDebugEnabled()) {

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3AsyncClientFactory.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3AsyncClientFactory.java
@@ -56,7 +56,7 @@ class S3AsyncClientFactory {
                         .scheduledExecutorService(ensureScheduledExecutor())
                         .build())
                 .credentialsProvider(instructions.awsV2CredentialsProvider());
-        instructions.regionName().ifPresent(regionName -> builder.region(Region.of(regionName)));
+        instructions.regionName().map(Region::of).ifPresent(builder::region);
         instructions.endpointOverride().ifPresent(builder::endpointOverride);
         final S3AsyncClient ret = builder.build();
         if (log.isDebugEnabled()) {

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3Instructions.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3Instructions.java
@@ -32,14 +32,19 @@ public abstract class S3Instructions implements LogOutputAppendable {
     private final static Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(2);
     private final static Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(2);
 
+    static final S3Instructions DEFAULT_S3_INSTRUCTIONS = builder().build();
+
     public static Builder builder() {
         return ImmutableS3Instructions.builder();
     }
 
     /**
-     * The region name to use when reading or writing to S3.
+     * The region name to use when reading or writing to S3. If not provided, the region name is picked by the AWS SDK
+     * from 'aws.region' system property, "AWS_REGION" environment variable, the {user.home}/.aws/credentials or
+     * {user.home}/.aws/config files, or from EC2 metadata service, if running in EC2. Please check
+     * {@link software.amazon.awssdk.awscore.client.builder.AwsClientBuilder#region} for more details.
      */
-    public abstract String regionName();
+    public abstract Optional<String> regionName();
 
     /**
      * The maximum number of concurrent requests to make to S3, defaults to {@value #DEFAULT_MAX_CONCURRENT_REQUESTS}.

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3Instructions.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3Instructions.java
@@ -32,7 +32,7 @@ public abstract class S3Instructions implements LogOutputAppendable {
     private final static Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(2);
     private final static Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(2);
 
-    static final S3Instructions DEFAULT_S3_INSTRUCTIONS = builder().build();
+    static final S3Instructions DEFAULT = builder().build();
 
     public static Builder builder() {
         return ImmutableS3Instructions.builder();
@@ -41,8 +41,7 @@ public abstract class S3Instructions implements LogOutputAppendable {
     /**
      * The region name to use when reading or writing to S3. If not provided, the region name is picked by the AWS SDK
      * from 'aws.region' system property, "AWS_REGION" environment variable, the {user.home}/.aws/credentials or
-     * {user.home}/.aws/config files, or from EC2 metadata service, if running in EC2. Please check
-     * {@link software.amazon.awssdk.awscore.client.builder.AwsClientBuilder#region} for more details.
+     * {user.home}/.aws/config files, or from EC2 metadata service, if running in EC2.
      */
     public abstract Optional<String> regionName();
 

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProviderPlugin.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProviderPlugin.java
@@ -29,8 +29,11 @@ public final class S3SeekableChannelProviderPlugin implements SeekableChannelsPr
         if (!isCompatible(uri, config)) {
             throw new IllegalArgumentException("Arguments not compatible, provided uri " + uri);
         }
-        if (!(config instanceof S3Instructions)) {
+        if (config != null && !(config instanceof S3Instructions)) {
             throw new IllegalArgumentException("Must provide S3Instructions to read files from S3");
+        }
+        if (config == null) {
+            return new S3SeekableChannelProvider(S3Instructions.DEFAULT_S3_INSTRUCTIONS);
         }
         return new S3SeekableChannelProvider((S3Instructions) config);
     }

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProviderPlugin.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProviderPlugin.java
@@ -30,10 +30,11 @@ public final class S3SeekableChannelProviderPlugin implements SeekableChannelsPr
             throw new IllegalArgumentException("Arguments not compatible, provided uri " + uri);
         }
         if (config != null && !(config instanceof S3Instructions)) {
-            throw new IllegalArgumentException("Must provide S3Instructions to read files from S3");
+            throw new IllegalArgumentException("Only S3Instructions are valid when reading files from S3, provided " +
+                    "config instance of class " + config.getClass().getName());
         }
         if (config == null) {
-            return new S3SeekableChannelProvider(S3Instructions.DEFAULT_S3_INSTRUCTIONS);
+            return new S3SeekableChannelProvider(S3Instructions.DEFAULT);
         }
         return new S3SeekableChannelProvider((S3Instructions) config);
     }

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProviderPlugin.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProviderPlugin.java
@@ -33,9 +33,6 @@ public final class S3SeekableChannelProviderPlugin implements SeekableChannelsPr
             throw new IllegalArgumentException("Only S3Instructions are valid when reading files from S3, provided " +
                     "config instance of class " + config.getClass().getName());
         }
-        if (config == null) {
-            return new S3SeekableChannelProvider(S3Instructions.DEFAULT);
-        }
-        return new S3SeekableChannelProvider((S3Instructions) config);
+        return new S3SeekableChannelProvider(config == null ? S3Instructions.DEFAULT : (S3Instructions) config);
     }
 }

--- a/extensions/s3/src/test/java/io/deephaven/extensions/s3/S3InstructionsTest.java
+++ b/extensions/s3/src/test/java/io/deephaven/extensions/s3/S3InstructionsTest.java
@@ -6,6 +6,7 @@ package io.deephaven.extensions.s3;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -13,8 +14,8 @@ public class S3InstructionsTest {
 
     @Test
     void defaults() {
-        final S3Instructions instructions = S3Instructions.builder().regionName("some-region").build();
-        assertThat(instructions.regionName()).isEqualTo("some-region");
+        final S3Instructions instructions = S3Instructions.builder().build();
+        assertThat(instructions.regionName().isEmpty()).isTrue();
         assertThat(instructions.maxConcurrentRequests()).isEqualTo(256);
         assertThat(instructions.readAheadCount()).isEqualTo(32);
         assertThat(instructions.fragmentSize()).isEqualTo(65536);
@@ -26,12 +27,13 @@ public class S3InstructionsTest {
     }
 
     @Test
-    void missingRegion() {
-        try {
-            S3Instructions.builder().build();
-        } catch (IllegalStateException e) {
-            assertThat(e).hasMessageContaining("regionName");
-        }
+    void testSetRegion() {
+        final Optional<String> region = S3Instructions.builder()
+                .regionName("some-region")
+                .build()
+                .regionName();
+        assertThat(region.isPresent()).isTrue();
+        assertThat(region.get()).isEqualTo("some-region");
     }
 
     @Test

--- a/py/server/deephaven/experimental/s3.py
+++ b/py/server/deephaven/experimental/s3.py
@@ -34,7 +34,7 @@ class S3Instructions(JObjectWrapper):
     j_object_type = _JS3Instructions or type(None)
 
     def __init__(self,
-                 region_name: str,
+                 region_name: Optional[str] = None,
                  max_concurrent_requests: Optional[int] = None,
                  read_ahead_count: Optional[int] = None,
                  fragment_size: Optional[int] = None,
@@ -52,7 +52,10 @@ class S3Instructions(JObjectWrapper):
         Initializes the instructions.
 
         Args:
-            region_name (str): the region name for reading parquet files, mandatory parameter.
+            region_name (str): the region name for reading parquet files. If not provided, the default region will be
+            picked by the AWS SDK from 'aws.region' system property, "AWS_REGION" environment variable, the
+            {user.home}/.aws/credentials or {user.home}/.aws/config files, or from EC2 metadata service, if running in
+            EC2.
             max_concurrent_requests (int): the maximum number of concurrent requests for reading files, default is 256.
             read_ahead_count (int): the number of fragments to send asynchronous read requests for while reading the current
                 fragment. Defaults to 32, which means fetch the next 32 fragments in advance when reading the current fragment.
@@ -87,7 +90,9 @@ class S3Instructions(JObjectWrapper):
 
         try:
             builder = self.j_object_type.builder()
-            builder.regionName(region_name)
+
+            if region_name is not None:
+                builder.regionName(region_name)
 
             if max_concurrent_requests is not None:
                 builder.maxConcurrentRequests(max_concurrent_requests)

--- a/py/server/tests/test_parquet.py
+++ b/py/server/tests/test_parquet.py
@@ -570,9 +570,7 @@ class ParquetTestCase(BaseTestCase):
 
         # Fails since we have a negative read_ahead_count
         with self.assertRaises(DHError):
-            s3.S3Instructions(region_name="us-east-1",
-                              read_ahead_count=-1,
-                              )
+            s3.S3Instructions(read_ahead_count=-1)
 
         # Fails since we provide the key without the secret key
         with self.assertRaises(DHError):
@@ -580,9 +578,8 @@ class ParquetTestCase(BaseTestCase):
                               access_key_id="Some key without secret",
                               )
 
-        s3_instructions = s3.S3Instructions(region_name="us-east-1",
-                                            read_ahead_count=1,
-                                            )
+        s3_instructions = s3.S3Instructions()
+
         # Fails because we don't have the right credentials
         with self.assertRaises(Exception):
             read("s3://dh-s3-parquet-test1/multiColFile.parquet", special_instructions=s3_instructions).select()


### PR DESCRIPTION
Before this change, `region` was a mandatory parameter for reading parquet files from S3.
After this change, if `region` is not provided, it will be picked up by the AWS sdk using the following provider chain:

```
1. Check the 'aws.region' system property for the region.
2. Check the 'AWS_REGION' environment variable for the region.
3. Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the region.
4. If running in EC2, check the EC2 metadata service for the region.

Throw exception if not found in any of the locations above
```
Reference:   https://sdk.amazonaws.com/java/api/2.0.0-preview-11/software/amazon/awssdk/awscore/client/builder/AwsClientBuilder.html

Also, since `region` was the only mandatory parameter in S3 instructions, after this change, reading from S3 will be allowed without passing any S3 instructions. For example, code like the following python example will work, as long as the region, access key and secret key are set properly using properties or config files:

```
from deephaven import parquet

test = parquet.read("s3://bucket-name/file-name.parquet")   # Note no s3 instructions
```



