### PR TITLE
Improvements to buffered reading for parquet

### DIFF
--- a/Util/channel/src/main/java/io/deephaven/util/channel/CachedChannelProvider.java
+++ b/Util/channel/src/main/java/io/deephaven/util/channel/CachedChannelProvider.java
@@ -107,6 +107,11 @@ public class CachedChannelProvider implements SeekableChannelsProvider {
     }
 
     @Override
+    public InputStream getInputStream(SeekableByteChannel channel, int sizeLimit) throws IOException {
+        return wrappedProvider.getInputStream(channel, sizeLimit);
+    }
+
+    @Override
     public SeekableByteChannel getWriteChannel(@NotNull final Path path, final boolean append) throws IOException {
         final String pathKey = path.toAbsolutePath().toString();
         final ChannelType channelType = append ? ChannelType.WriteAppend : ChannelType.Write;

--- a/Util/channel/src/main/java/io/deephaven/util/channel/CachedChannelProvider.java
+++ b/Util/channel/src/main/java/io/deephaven/util/channel/CachedChannelProvider.java
@@ -102,13 +102,8 @@ public class CachedChannelProvider implements SeekableChannelsProvider {
     }
 
     @Override
-    public InputStream getInputStream(SeekableByteChannel channel) throws IOException {
-        return wrappedProvider.getInputStream(channel);
-    }
-
-    @Override
-    public InputStream getInputStream(SeekableByteChannel channel, int sizeLimit) throws IOException {
-        return wrappedProvider.getInputStream(channel, sizeLimit);
+    public InputStream getInputStream(final SeekableByteChannel channel, final int sizeHint) throws IOException {
+        return wrappedProvider.getInputStream(channel, sizeHint);
     }
 
     @Override
@@ -120,7 +115,7 @@ public class CachedChannelProvider implements SeekableChannelsProvider {
         return result == null
                 ? new CachedChannel(wrappedProvider.getWriteChannel(path, append), channelType, pathKey)
                 : result.position(append ? result.size() : 0); // The seek isn't really necessary for append; will be at
-                                                               // end no matter what.
+        // end no matter what.
     }
 
     @Override

--- a/Util/channel/src/main/java/io/deephaven/util/channel/LocalFSChannelProvider.java
+++ b/Util/channel/src/main/java/io/deephaven/util/channel/LocalFSChannelProvider.java
@@ -19,6 +19,8 @@ import java.nio.file.StandardOpenOption;
 import java.util.stream.Stream;
 
 public class LocalFSChannelProvider implements SeekableChannelsProvider {
+    private static final int MAX_READ_BUFFER_SIZE = 1 << 16; // 64 KiB
+
     @Override
     public SeekableChannelContext makeContext() {
         // No additional context required for local FS
@@ -40,9 +42,10 @@ public class LocalFSChannelProvider implements SeekableChannelsProvider {
     }
 
     @Override
-    public InputStream getInputStream(SeekableByteChannel channel) {
+    public InputStream getInputStream(final SeekableByteChannel channel, final int sizeHint) {
         // FileChannel is not buffered, need to buffer
-        return new BufferedInputStream(Channels.newInputStreamNoClose(channel));
+        final int bufferSize = Math.min(sizeHint, MAX_READ_BUFFER_SIZE);
+        return new BufferedInputStream(Channels.newInputStreamNoClose(channel), bufferSize);
     }
 
     @Override

--- a/Util/channel/src/main/java/io/deephaven/util/channel/SeekableChannelsProvider.java
+++ b/Util/channel/src/main/java/io/deephaven/util/channel/SeekableChannelsProvider.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.util.channel;
 
+import com.google.common.io.ByteStreams;
 import io.deephaven.util.SafeCloseable;
 import org.jetbrains.annotations.NotNull;
 
@@ -80,6 +81,14 @@ public interface SeekableChannelsProvider extends SafeCloseable {
      * @throws IOException if an IO exception occurs
      */
     InputStream getInputStream(SeekableByteChannel channel) throws IOException;
+
+    /**
+     * Creates an {@link InputStream} from the current position of {@code channel} from which at most {@code sizeLimit}
+     * bytes can be read. More details in {@link #getInputStream(SeekableByteChannel)}.
+     */
+    default InputStream getInputStream(SeekableByteChannel channel, int sizeLimit) throws IOException {
+        return ByteStreams.limit(getInputStream(channel), sizeLimit);
+    }
 
     default SeekableByteChannel getWriteChannel(@NotNull final String path, final boolean append) throws IOException {
         return getWriteChannel(Paths.get(path), append);

--- a/Util/channel/src/main/java/io/deephaven/util/channel/SeekableChannelsProvider.java
+++ b/Util/channel/src/main/java/io/deephaven/util/channel/SeekableChannelsProvider.java
@@ -29,6 +29,7 @@ public interface SeekableChannelsProvider extends SafeCloseable {
      *
      * @param provider the provider
      * @param ch the seekable channel
+     * @param sizeHint the number of bytes the caller expects to read from the input stream
      * @return the position-safe input stream
      * @throws IOException if an IO exception occurs
      * @see ChannelPositionInputStream#of(SeekableByteChannel, InputStream)
@@ -77,6 +78,7 @@ public interface SeekableChannelsProvider extends SafeCloseable {
      * {@link #channelPositionInputStream(SeekableChannelsProvider, SeekableByteChannel, int)}.
      *
      * @param channel the channel
+     * @param sizeHint the number of bytes the caller expects to read from the input stream
      * @return the input stream
      * @throws IOException if an IO exception occurs
      */

--- a/Util/channel/src/test/java/io/deephaven/util/channel/CachedChannelProviderTest.java
+++ b/Util/channel/src/test/java/io/deephaven/util/channel/CachedChannelProviderTest.java
@@ -214,7 +214,7 @@ public class CachedChannelProviderTest {
         }
 
         @Override
-        public InputStream getInputStream(SeekableByteChannel channel) {
+        public InputStream getInputStream(SeekableByteChannel channel, int sizeHint) {
             // TestMockChannel is always empty, so no need to buffer
             return Channels.newInputStreamNoClose(channel);
         }

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnChunkReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnChunkReaderImpl.java
@@ -191,15 +191,7 @@ final class ColumnChunkReaderImpl implements ColumnChunkReader {
         } else {
             return NULL_DICTIONARY;
         }
-        // Use the context object provided by the caller, or create (and close) a new one
-        try (
-                final ContextHolder holder = SeekableChannelContext.ensureContext(channelsProvider, channelContext);
-                final SeekableByteChannel ch =
-                        channelsProvider.getReadChannel(holder.get(), getURI()).position(dictionaryPageOffset)) {
-            return readDictionary(ch, holder.get());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return readDictionary(dictionaryPageOffset, channelContext);
     }
 
     @Override
@@ -218,31 +210,37 @@ final class ColumnChunkReaderImpl implements ColumnChunkReader {
     }
 
     @NotNull
-    private Dictionary readDictionary(SeekableByteChannel ch, SeekableChannelContext channelContext)
-            throws IOException {
-        // explicitly not closing this, caller is responsible
-        final PageHeader pageHeader = readPageHeader(ch);
-        if (pageHeader.getType() != PageType.DICTIONARY_PAGE) {
-            // In case our fallback in getDictionary was too optimistic...
-            return NULL_DICTIONARY;
-        }
-        final DictionaryPageHeader dictHeader = pageHeader.getDictionary_page_header();
-        final int compressedPageSize = pageHeader.getCompressed_page_size();
-        final BytesInput payload;
-        try (final InputStream in = (compressedPageSize == 0) ? null
-                : SeekableChannelsProvider.channelPositionInputStream(channelsProvider, ch, compressedPageSize)) {
-            if (compressedPageSize == 0) {
-                // Sometimes the size is explicitly empty, just use an empty payload
-                payload = BytesInput.empty();
-            } else {
-                payload = decompressor.decompress(in, compressedPageSize, pageHeader.getUncompressed_page_size(),
-                        channelContext);
+    private Dictionary readDictionary(long dictionaryPageOffset, SeekableChannelContext channelContext) {
+        // Use the context object provided by the caller, or create (and close) a new one
+        try (
+                final ContextHolder holder = SeekableChannelContext.ensureContext(channelsProvider, channelContext);
+                final SeekableByteChannel ch =
+                        channelsProvider.getReadChannel(holder.get(), getURI()).position(dictionaryPageOffset)) {
+            final PageHeader pageHeader = readPageHeader(ch);
+            if (pageHeader.getType() != PageType.DICTIONARY_PAGE) {
+                // In case our fallback in getDictionary was too optimistic...
+                return NULL_DICTIONARY;
             }
-            final Encoding encoding = Encoding.valueOf(dictHeader.getEncoding().name());
-            final DictionaryPage dictionaryPage = new DictionaryPage(payload, dictHeader.getNum_values(), encoding);
-            // We are safe to not copy the payload because the Dictionary doesn't hold a reference to dictionaryPage or
-            // payload and thus doesn't hold a reference to the input stream.
-            return encoding.initDictionary(path, dictionaryPage);
+            final DictionaryPageHeader dictHeader = pageHeader.getDictionary_page_header();
+            final int compressedPageSize = pageHeader.getCompressed_page_size();
+            final BytesInput payload;
+            try (final InputStream in = (compressedPageSize == 0) ? null
+                    : channelsProvider.getInputStream(ch, compressedPageSize)) {
+                if (compressedPageSize == 0) {
+                    // Sometimes the size is explicitly empty, just use an empty payload
+                    payload = BytesInput.empty();
+                } else {
+                    payload = decompressor.decompress(in, compressedPageSize, pageHeader.getUncompressed_page_size(),
+                            holder.get());
+                }
+                final Encoding encoding = Encoding.valueOf(dictHeader.getEncoding().name());
+                final DictionaryPage dictionaryPage = new DictionaryPage(payload, dictHeader.getNum_values(), encoding);
+                // We are safe to not copy the payload because the Dictionary doesn't hold a reference to dictionaryPage
+                // or payload and thus doesn't hold a reference to the input stream.
+                return encoding.initDictionary(path, dictionaryPage);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -318,6 +316,9 @@ final class ColumnChunkReaderImpl implements ColumnChunkReader {
         }
     }
 
+    /**
+     * Read the page header from the given channel and increment the channel position by the number of bytes read.
+     */
     private PageHeader readPageHeader(final SeekableByteChannel ch) throws IOException {
         // We expect page headers to be smaller than 128 bytes
         try (final InputStream in = SeekableChannelsProvider.channelPositionInputStream(channelsProvider, ch, 128)) {

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
@@ -206,7 +206,7 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
             @NotNull final SeekableChannelContext channelContext) throws IOException {
         switch (pageHeader.type) {
             case DATA_PAGE:
-                try (final InputStream in = channelsProvider.getInputStream(ch)) {
+                try (final InputStream in = channelsProvider.getInputStream(ch, pageHeader.getCompressed_page_size())) {
                     return readRowCountFromPageV1(readV1Unsafe(in, channelContext));
                 }
             case DATA_PAGE_V2:
@@ -225,12 +225,12 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
             @NotNull final SeekableChannelContext channelContext) throws IOException {
         switch (pageHeader.type) {
             case DATA_PAGE:
-                try (final InputStream in = channelsProvider.getInputStream(ch)) {
+                try (final InputStream in = channelsProvider.getInputStream(ch, pageHeader.getCompressed_page_size())) {
                     return readKeysFromPageV1(readV1Unsafe(in, channelContext), keyDest, nullPlaceholder,
                             channelContext);
                 }
             case DATA_PAGE_V2:
-                try (final InputStream in = channelsProvider.getInputStream(ch)) {
+                try (final InputStream in = channelsProvider.getInputStream(ch, pageHeader.getCompressed_page_size())) {
                     return readKeysFromPageV2(readV2Unsafe(in, channelContext), keyDest, nullPlaceholder,
                             channelContext);
                 }
@@ -246,11 +246,11 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
             @NotNull final SeekableChannelContext channelContext) throws IOException {
         switch (pageHeader.type) {
             case DATA_PAGE:
-                try (final InputStream in = channelsProvider.getInputStream(ch)) {
+                try (final InputStream in = channelsProvider.getInputStream(ch, pageHeader.getCompressed_page_size())) {
                     return readPageV1(readV1Unsafe(in, channelContext), nullValue, channelContext);
                 }
             case DATA_PAGE_V2:
-                try (final InputStream in = channelsProvider.getInputStream(ch)) {
+                try (final InputStream in = channelsProvider.getInputStream(ch, pageHeader.getCompressed_page_size())) {
                     return readPageV2(readV2Unsafe(in, channelContext), nullValue, channelContext);
                 }
             default:

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/OffsetIndexReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/OffsetIndexReaderImpl.java
@@ -55,7 +55,8 @@ final class OffsetIndexReaderImpl implements OffsetIndexReader {
                         SeekableChannelContext.ensureContext(channelsProvider, channelContext);
                 final SeekableByteChannel readChannel = channelsProvider.getReadChannel(holder.get(), columnChunkURI);
                 final InputStream in =
-                        channelsProvider.getInputStream(readChannel.position(columnChunk.getOffset_index_offset()))) {
+                        channelsProvider.getInputStream(readChannel.position(columnChunk.getOffset_index_offset()),
+                                columnChunk.getOffset_index_length())) {
             return (offsetIndex = ParquetMetadataConverter.fromParquetOffsetIndex(Util.readOffsetIndex(in)));
         } catch (final IOException e) {
             throw new UncheckedIOException(e);

--- a/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCompressorAdapterFactory.java
+++ b/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCompressorAdapterFactory.java
@@ -154,8 +154,8 @@ public class DeephavenCompressorAdapterFactory {
             try {
                 // Note that we don't close the decompressed stream because doing so may return the decompressor to the
                 // pool
-                final InputStream buffered = ByteStreams.limit(IOUtils.buffer(inputStream), compressedSize);
-                final CompressionInputStream decompressed = compressionCodec.createInputStream(buffered, decompressor);
+                final CompressionInputStream decompressed =
+                        compressionCodec.createInputStream(inputStream, decompressor);
                 return BytesInput.copy(BytesInput.from(decompressed, uncompressedSize));
             } finally {
                 if (decompressor != null) {

--- a/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCompressorAdapterFactory.java
+++ b/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DeephavenCompressorAdapterFactory.java
@@ -154,8 +154,8 @@ public class DeephavenCompressorAdapterFactory {
             try {
                 // Note that we don't close the decompressed stream because doing so may return the decompressor to the
                 // pool
-                final CompressionInputStream decompressed =
-                        compressionCodec.createInputStream(inputStream, decompressor);
+                final InputStream buffered = ByteStreams.limit(IOUtils.buffer(inputStream), compressedSize);
+                final CompressionInputStream decompressed = compressionCodec.createInputStream(buffered, decompressor);
                 return BytesInput.copy(BytesInput.from(decompressed, uncompressedSize));
             } finally {
                 if (decompressor != null) {

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -521,14 +521,10 @@ public final class ParquetTableReadWriteTest {
 
         final Table fromDisk = checkSingleTable(table, dest).select();
 
-        try {
-            // The following file is tagged as LZ4 compressed based on its metadata, but is actually compressed with
-            // LZ4_RAW. We should be able to read it anyway with no exceptions.
-            String path = TestParquetTools.class.getResource("/sample_lz4_compressed.parquet").getFile();
-            readTable(path, EMPTY.withLayout(ParquetInstructions.ParquetFileLayout.SINGLE_FILE)).select();
-        } catch (RuntimeException e) {
-            TestCase.fail("Failed to read parquet file sample_lz4_compressed.parquet");
-        }
+        // The following file is tagged as LZ4 compressed based on its metadata, but is actually compressed with
+        // LZ4_RAW. We should be able to read it anyway with no exceptions.
+        String path = TestParquetTools.class.getResource("/sample_lz4_compressed.parquet").getFile();
+        readTable(path, EMPTY.withLayout(ParquetInstructions.ParquetFileLayout.SINGLE_FILE)).select();
         final File randomDest = new File(rootFile, "random.parquet");
         writeTable(fromDisk, randomDest.getPath(), ParquetTools.LZ4_RAW);
 

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -1652,7 +1652,7 @@ public final class ParquetTableReadWriteTest {
 
     /**
      * Reference data is generated using the following code:
-     * 
+     *
      * <pre>
      *      num_rows = 100000
      *      dh_table = empty_table(num_rows).update(formulas=[

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProvider.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/S3SeekableChannelProvider.java
@@ -89,7 +89,7 @@ final class S3SeekableChannelProvider implements SeekableChannelsProvider {
     }
 
     @Override
-    public InputStream getInputStream(final SeekableByteChannel channel) {
+    public InputStream getInputStream(final SeekableByteChannel channel, final int sizeHint) {
         // S3SeekableByteChannel is internally buffered, no need to re-buffer
         return Channels.newInputStreamNoClose(channel);
     }

--- a/extensions/trackedfile/src/main/java/io/deephaven/extensions/trackedfile/TrackedSeekableChannelsProvider.java
+++ b/extensions/trackedfile/src/main/java/io/deephaven/extensions/trackedfile/TrackedSeekableChannelsProvider.java
@@ -3,7 +3,6 @@
 //
 package io.deephaven.extensions.trackedfile;
 
-import com.google.common.io.ByteStreams;
 import io.deephaven.base.FileUtils;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.util.file.FileHandle;
@@ -35,7 +34,7 @@ import static io.deephaven.base.FileUtils.FILE_URI_SCHEME;
  */
 final class TrackedSeekableChannelsProvider implements SeekableChannelsProvider {
 
-    private static int MAX_READ_BUFFER_SIZE = 1 << 16; // 64 KiB
+    private static final int MAX_READ_BUFFER_SIZE = 1 << 16; // 64 KiB
 
     private final TrackedFileHandleFactory fileHandleFactory;
 
@@ -62,17 +61,10 @@ final class TrackedSeekableChannelsProvider implements SeekableChannelsProvider 
     }
 
     @Override
-    public InputStream getInputStream(SeekableByteChannel channel) {
-        // TrackedSeekableByteChannel is not buffered, need to buffer
-        return new BufferedInputStream(Channels.newInputStreamNoClose(channel));
-    }
-
-    @Override
-    public InputStream getInputStream(SeekableByteChannel channel, int sizeLimit) {
-        // The following stream will read from the channel in chunks of bufferSize bytes, up to sizeLimit bytes.
-        final int bufferSize = Math.min(sizeLimit, MAX_READ_BUFFER_SIZE);
-        return new BufferedInputStream(ByteStreams.limit(Channels.newInputStreamNoClose(channel), sizeLimit),
-                bufferSize);
+    public InputStream getInputStream(SeekableByteChannel channel, int sizeHint) {
+        // The following stream will read from the channel in chunks of bufferSize bytes
+        final int bufferSize = Math.min(sizeHint, MAX_READ_BUFFER_SIZE);
+        return new BufferedInputStream(Channels.newInputStreamNoClose(channel), bufferSize);
     }
 
     @Override


### PR DESCRIPTION
Currently, while reading bytes from parquet files, we read in chunks of 8K bytes. 
So for cases, where we need fewer bytes (like reading page headers), this leads to extra bytes read.
And for cases where we need to read bulk of data (like reading actual data bytes), this can lead to repeated reads in 8k chunks, till we get the required  number of bytes.

This PR adds a size hint to the stream creation method, so that we can accurately created an internal buffered input stream based on how much data the user actually want to read from the stream.

This PR leads to minor parquet read performance improvements.