### PR TITLE
fix: JS InputTable test failure and race

### DIFF
--- a/web/client-api/src/test/java/io/deephaven/web/client/api/InputTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/InputTableTestGwt.java
@@ -16,7 +16,7 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
             .script("result3", "input_table(init_table=source, key_cols=[\"C\"])")
             .script("result4", "input_table(init_table=source, key_cols=[\"E\" , \"F\" ])");
 
-    public void testInputTable() {
+    public void testNoKeyCols() {
         connect(tables)
                 .then(table("result1"))
                 .then(JsTable::inputTable)
@@ -26,7 +26,8 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                     return null;
                 })
                 .then(this::finish).catch_(this::report);
-
+    }
+    public void testFirstColsAreKeyCols() {
         connect(tables)
                 .then(table("result2"))
                 .then(JsTable::inputTable)
@@ -40,7 +41,8 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                     return null;
                 })
                 .then(this::finish).catch_(this::report);
-
+    }
+    public void testOneKeyCol() {
         connect(tables)
                 .then(table("result3"))
                 .then(JsTable::inputTable)
@@ -53,7 +55,8 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                     return null;
                 })
                 .then(this::finish).catch_(this::report);
-
+    }
+    public void testLaterColsAreKeyCols() {
         connect(tables)
                 .then(table("result4"))
                 .then(JsTable::inputTable)

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/InputTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/InputTableTestGwt.java
@@ -34,7 +34,7 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                     JsArray<Column> keyColumns = Js.uncheckedCast(inputTable.getKeyColumns());
                     assertEquals(2,
                             keyColumns.filter((col, idx) -> col.getName() == "A" || col.getName() == "B").length);
-                    JsArray<Column> valueColumns = Js.uncheckedCast(inputTable.getValues());
+                    JsArray<Column> valueColumns = Js.uncheckedCast(inputTable.getValueColumns());
                     assertEquals(4, valueColumns.filter((col, idx) -> col.getName() == "C" || col.getName() == "D"
                             || col.getName() == "E" || col.getName() == "F").length);
                     return null;
@@ -47,7 +47,7 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                 .then(inputTable -> {
                     JsArray<Column> keyColumns = Js.uncheckedCast(inputTable.getKeyColumns());
                     assertEquals(1, keyColumns.filter((col, idx) -> col.getName() == "C").length);
-                    JsArray<Column> valueColumns = Js.uncheckedCast(inputTable.getValues());
+                    JsArray<Column> valueColumns = Js.uncheckedCast(inputTable.getValueColumns());
                     assertEquals(5, valueColumns.filter((col, idx) -> col.getName() == "A" || col.getName() == "B"
                             || col.getName() == "D" || col.getName() == "E" || col.getName() == "F").length);
                     return null;
@@ -61,7 +61,7 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                     JsArray<Column> keyColumns = Js.uncheckedCast(inputTable.getKeyColumns());
                     assertEquals(2,
                             keyColumns.filter((col, idx) -> col.getName() == "E" || col.getName() == "F").length);
-                    JsArray<Column> valueColumns = Js.uncheckedCast(inputTable.getValues());
+                    JsArray<Column> valueColumns = Js.uncheckedCast(inputTable.getValueColumns());
                     assertEquals(4, valueColumns.filter((col, idx) -> col.getName() == "A" || col.getName() == "B"
                             || col.getName() == "C" || col.getName() == "D").length);
                     return null;

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/InputTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/InputTableTestGwt.java
@@ -27,6 +27,7 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                 })
                 .then(this::finish).catch_(this::report);
     }
+
     public void testFirstColsAreKeyCols() {
         connect(tables)
                 .then(table("result2"))
@@ -42,6 +43,7 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                 })
                 .then(this::finish).catch_(this::report);
     }
+
     public void testOneKeyCol() {
         connect(tables)
                 .then(table("result3"))
@@ -56,6 +58,7 @@ public class InputTableTestGwt extends AbstractAsyncGwtTestCase {
                 })
                 .then(this::finish).catch_(this::report);
     }
+
     public void testLaterColsAreKeyCols() {
         connect(tables)
                 .then(table("result4"))


### PR DESCRIPTION
This test was slightly racy, able to fail other unrelated tests in some situations.

Follow-up to #5600