### PR TITLE
fix: signal.pause is not available on Windows

### DIFF
--- a/py/embedded-server/deephaven_server/cli.py
+++ b/py/embedded-server/deephaven_server/cli.py
@@ -53,14 +53,10 @@ def server(host, port, jvm_args, extra_classpath, default_jvm_args):
     )
     click.echo("Press Control-C to exit")
 
-    def signal_handler(sig, frame):
+    try:
+        while True:
+            input()
+    except KeyboardInterrupt:
+        # signal_handler should already be called
         click.echo("Exiting Deephaven...")
         sys.exit(0)
-
-    signal.signal(signal.SIGINT, signal_handler)
-    try:
-        signal.pause()
-    except AttributeError:
-        # signal.pause() is not available on Windows
-        while True:
-            input('')

--- a/py/embedded-server/deephaven_server/cli.py
+++ b/py/embedded-server/deephaven_server/cli.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
 #
 import click
+import os
 import signal
 import sys
 import webbrowser
@@ -58,4 +59,8 @@ def server(host, port, jvm_args, extra_classpath, default_jvm_args):
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)
-    signal.pause()
+    try:
+        signal.pause()
+    except AttributeError:
+        # signal.pause() is not available on Windows
+        os.system("pause")

--- a/py/embedded-server/deephaven_server/cli.py
+++ b/py/embedded-server/deephaven_server/cli.py
@@ -63,4 +63,5 @@ def server(host, port, jvm_args, extra_classpath, default_jvm_args):
         signal.pause()
     except AttributeError:
         # signal.pause() is not available on Windows
-        os.system("pause")
+        while True:
+            input('')

--- a/py/embedded-server/deephaven_server/cli.py
+++ b/py/embedded-server/deephaven_server/cli.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
 #
 import click
-import os
 import signal
 import sys
 import webbrowser

--- a/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
+++ b/py/embedded-server/java-runtime/src/main/java/io/deephaven/python/server/EmbeddedServer.java
@@ -99,6 +99,7 @@ public class EmbeddedServer {
      *
      * @deprecated use {@link #EmbeddedServer(String, Integer)} instead. dict is not used.
      */
+    @Deprecated
     public EmbeddedServer(String host, Integer port, PyObject dict) throws IOException {
         this(host, port);
     }


### PR DESCRIPTION
- Use os.system("pause") instead on Windows
- Need to test on Windows
- Fixes #5525 
