### PR TITLE
fix: Update web version to 0.78.2

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,10 +2,10 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.68.0
-ARG GRID_VERSION=0.68.0
-ARG CHART_VERSION=0.68.0
-ARG WIDGET_VERSION=0.68.0
+ARG WEB_VERSION=0.78.2
+ARG GRID_VERSION=0.78.0
+ARG CHART_VERSION=0.78.0
+ARG WIDGET_VERSION=0.78.2
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
- Includes the ObjectFetchManager which is needed for deephaven.ui 0.15