### PR TITLE
Remove latest symlink for docs-ci-v2

### DIFF
--- a/.github/workflows/docs-ci-v2.yml
+++ b/.github/workflows/docs-ci-v2.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           mkdir -p tmp-deephaven-core-v2/symlinks
           cd tmp-deephaven-core-v2/symlinks
-          ln -s ../${{ github.ref_name }} latest
           ln -s ../main next
           
       - name: Deploy Symlinks


### PR DESCRIPTION
Note: docs-ci-v2 is no longer present in main, but is applicable for 0.33.x releases.

Workaround for #5591