### PR TITLE
Change py-embedded-server from WARN to INFO logging

### DIFF
--- a/py/embedded-server/java-runtime/src/main/resources/logback-minimal.xml
+++ b/py/embedded-server/java-runtime/src/main/resources/logback-minimal.xml
@@ -15,7 +15,7 @@
   <!--<logger name="io.netty" level="INFO"/>-->
   <!--<logger name="io.deephaven" level="INFO"/>-->
 
-  <root level="warn">
+  <root level="info">
     <appender-ref ref="LOGBUFFER" />
   </root>
 </configuration>


### PR DESCRIPTION
The python embedded Deephaven server does not currently show the end-user any INFO logging. It was stated that the default was WARN so that the end-user doesn't get command line spam, but that is already covered in the setup - the slf4j / logback logging does _not_ hit the terminal regardless. This is only applicable for logging that hits the web UI via LogBufferAppender / ConsoleService.SubscribeToLogs.

Note: this should merge after #5642 is fixed.