### PR TITLE
fix: Only update the redir index on the first column

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/SubscriptionTableData.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/SubscriptionTableData.java
@@ -68,6 +68,7 @@ public class SubscriptionTableData {
 
         long includedRowCount = snapshot.getIncludedRows().size();
         RangeSet destination = freeRows(includedRowCount);
+        boolean indexUpdated = false;
 
         for (int index = 0; index < dataColumns.length; index++) {
             ColumnData dataColumn = dataColumns[index];
@@ -89,10 +90,14 @@ public class SubscriptionTableData {
             while (indexIter.hasNext()) {
                 assert destIter.hasNext();
                 long dest = destIter.nextLong();
-                redirectedIndexes.put(indexIter.nextLong(), dest);
+                long nextIndex = indexIter.nextLong();
+                if (indexUpdated) {
+                    redirectedIndexes.put(nextIndex, dest);
+                }
                 arrayCopy.copyTo(localCopy, dest, dataColumn.getData(), j++);
             }
             assert !destIter.hasNext();
+            indexUpdated = true;
         }
 
         return notifyUpdates(index, RangeSet.empty(), RangeSet.empty());

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/SubscriptionTableData.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/SubscriptionTableData.java
@@ -91,7 +91,7 @@ public class SubscriptionTableData {
                 assert destIter.hasNext();
                 long dest = destIter.nextLong();
                 long nextIndex = indexIter.nextLong();
-                if (indexUpdated) {
+                if (!indexUpdated) {
                     redirectedIndexes.put(nextIndex, dest);
                 }
                 arrayCopy.copyTo(localCopy, dest, dataColumn.getData(), j++);


### PR DESCRIPTION
JS API full table subscriptions currently spend more time than they should updating redirection indexes for large snapshots. This patch is a small step to reduce the work done when receiving these large payloads.

Fixes #5658