### PR TITLE
fix: Modify key table viewport to only include key columns

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsPartitionedTable.java
@@ -90,7 +90,7 @@ public class JsPartitionedTable extends HasLifecycle implements ServerObject {
                 keyTable.close();
                 c.apply(fail, success);
             });
-        }, "get keys table")
+        }, "view only keys columns")
                 .refetch(this, connection.metadata())
                 .then(state -> Promise.resolve(new JsTable(connection, state)))).then(result -> {
                     keys = result;


### PR DESCRIPTION
- Partial fix for https://github.com/deephaven/web-client-ui/issues/2066 (Partitioned Table now loads, but you still cannot select different partitions correctly. Will be resolved in another web-client-ui PR).