### PR TITLE
Instant Column gRPC Filters: Fix Range Quick Filters and use MatchFilter over ConditionFilter

### DIFF
--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
@@ -25,7 +25,6 @@ import io.deephaven.proto.backplane.grpc.MatchType;
 import io.deephaven.proto.backplane.grpc.NotCondition;
 import io.deephaven.proto.backplane.grpc.Reference;
 import io.deephaven.proto.backplane.grpc.Value;
-import io.deephaven.time.DateTimeUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;

--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
@@ -139,7 +139,7 @@ public class FilterFactory implements FilterVisitor<WhereFilter> {
                 valueString = Long.toString(value.getLongValue());
                 break;
             case NANO_TIME_VALUE:
-                valueString = Long.toString(value.getNanoTimeValue());
+                valueString = String.format("'%d'", value.getNanoTimeValue());
                 break;
             case VALUE_NOT_SET:
             default:

--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
@@ -184,8 +184,7 @@ public class FilterFactory implements FilterVisitor<WhereFilter> {
             Literal literal = d.getLiteral();
             // all other literals get created from a toString except DateTime
             if (literal.getValueCase() == Literal.ValueCase.NANO_TIME_VALUE) {
-                values[i] = "'" + DateTimeUtils.formatDateTime(
-                        DateTimeUtils.epochNanosToInstant(literal.getNanoTimeValue()), DateTimeUtils.timeZone()) + "'";
+                values[i] = String.format("'%d'", literal.getNanoTimeValue());
             } else {
                 values[i] = FilterPrinter.printNoEscape(literal);
             }

--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterPrinter.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterPrinter.java
@@ -278,7 +278,7 @@ public class FilterPrinter implements FilterVisitor<Void> {
                 sb.append(literal.getLongValue());
                 break;
             case NANO_TIME_VALUE:
-                sb.append("DateTimeUtils.epochNanosToInstant(").append(literal.getNanoTimeValue()).append(")");
+                sb.append("'").append(literal.getNanoTimeValue()).append("'");
                 break;
             case VALUE_NOT_SET:
             default:


### PR DESCRIPTION
Fixes the error hit when quick filtering through the web-ui:
```
Internal Error '1c813e17-8191-4f29-8680-4fc9991b6a2a' java.lang.IllegalArgumentException: Failed to convert literal value <1719427193000000000> for column "Timestamp" of type java.time.Instant
	at io.deephaven.engine.table.impl.select.MatchFilter$ColumnTypeConvertor.convertValue(MatchFilter.java:382)
	at io.deephaven.engine.table.impl.select.RangeFilter.init(RangeFilter.java:185)
	at io.deephaven.engine.table.impl.QueryTable.initializeAndPrioritizeFilters(QueryTable.java:1175)
	at io.deephaven.engine.table.impl.QueryTable.lambda$whereInternal$29(QueryTable.java:1225)
	at io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder.withNugget(QueryPerformanceRecorder.java:369)
	at io.deephaven.engine.table.impl.QueryTable.whereInternal(QueryTable.java:1223)
	at io.deephaven.engine.table.impl.QueryTable.where(QueryTable.java:1162)
	at io.deephaven.engine.table.impl.QueryTable.where(QueryTable.java:100)
	at io.deephaven.server.table.ops.FilterTableGrpcImpl.create(FilterTableGrpcImpl.java:57)
	at io.deephaven.server.table.ops.FilterTableGrpcImpl.create(FilterTableGrpcImpl.java:30)
	at io.deephaven.server.table.ops.TableServiceGrpcImpl$BatchExportBuilder.doExport(TableServiceGrpcImpl.java:757)
	at io.deephaven.server.session.SessionState$ExportObject.doExport(SessionState.java:995)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at io.deephaven.server.runner.scheduler.SchedulerModule$ThreadFactory.lambda$newThread$0(SchedulerModule.java:100)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.lang.IllegalArgumentException: Instant literal not enclosed in single-quotes ("1719427193000000000")
	at io.deephaven.engine.table.impl.select.MatchFilter$ColumnTypeConvertorFactory$13.convertStringLiteral(MatchFilter.java:720)
	at io.deephaven.engine.table.impl.select.MatchFilter$ColumnTypeConvertor.convertValue(MatchFilter.java:380)
	... 18 more
```