### PR TITLE
C++ Client: End of Barrage stream should throw; reformat exception messages

### DIFF
--- a/cpp-client/deephaven/dhcore/src/utility/utility.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility.cc
@@ -104,7 +104,7 @@ void TrueOrThrowHelper(const DebugInfo &debug_info) {
 
 std::string FormatDebugString(const char *func, const char *file, size_t line,
     const std::string &message) {
-  return fmt::format("{}@{}:{}: {}", func, file, line, message);
+  return fmt::format("{}: {}@{}:{}", message, func, file, line);
 }
 
 std::string GetWhat(std::exception_ptr eptr) {


### PR DESCRIPTION
There are two changes in this PR.
1. At the end of a Barrage stream, throw exception rather than segfault.
2. Reformat exception messages to put the message first (before pathname and line number) rather than after.

Rationale:
1. Under normal Deephaven operation, Barrage streams don't really end (unless cancelled by the user). But I noticed that sometimes if you kill the server, the client will receive an "end of stream" indication that it is not expecting. This situation is indicated by a null in the `data` field. When we get this null, throw an exception.
2. Putting the exception message first rather than last makes it more readable to the user (especially my Excel users who would like to see the cause at the beginning of their cell rather than a long pathname).
