### PR TITLE
Add javadoc and sources jar for shadow publishing

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
@@ -25,7 +25,9 @@ PublishingTools.setupPublications(project) { publication ->
   // the pom late enough to pick up gradle's own artifactId wiring from our archivesBaseName changes.
   // Also un-sets the classifier for the shadow jar, since we want this to be the default artifact
 //  project.shadow.component(publication)
-  publication.artifact(source: project.tasks.named("shadowJar"), classifier: '')
+  publication.artifact(source: project.tasks.named('shadowJar'), classifier: '')
+  publication.artifact(source: project.tasks.named('sourcesJar'))
+  publication.artifact(source: project.tasks.named('javadocJar'))
   publication.pom {
     withXml {
       def root = asNode()


### PR DESCRIPTION
This (hopefully) fixes the maven central javadoc and sources jar requirement.