### PR TITLE
C++ client: clean up some tests

### DIFF
--- a/cpp-client/deephaven/tests/src/add_drop_test.cc
+++ b/cpp-client/deephaven/tests/src/add_drop_test.cc
@@ -6,7 +6,7 @@
 
 namespace deephaven::client::tests {
 
-TEST_CASE("Drop all columns", "[adddrop]") {
+TEST_CASE("Drop some columns", "[adddrop]") {
   auto tm = TableMakerForTests::Create();
   auto table = tm.Table();
   auto t = table.Update("II = ii").Where("Ticker == `AAPL`");

--- a/cpp-client/deephaven/tests/src/attributes_test.cc
+++ b/cpp-client/deephaven/tests/src/attributes_test.cc
@@ -28,6 +28,6 @@ TEST_CASE("TableHandle Created By DoPut", "[attributes]") {
   CHECK(table.IsStatic());
   // The columns all have the same size, so look at the source data for any one of them and get its size
   auto expected_size = static_cast<int64_t>(tm.ColumnData().ImportDate().size());
-  CHECK(table.NumRows() == expected_size);
+  CHECK(expected_size == table.NumRows());
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/join_test.cc
+++ b/cpp-client/deephaven/tests/src/join_test.cc
@@ -135,8 +135,6 @@ TEST_CASE("Aj", "[join]") {
 
 TEST_CASE("Raj", "[join]") {
   auto tm = TableMakerForTests::Create();
-  auto q = arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
-
   TableHandle trades;
   {
     std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL", "IBM", "IBM"};
@@ -206,15 +204,6 @@ TEST_CASE("Raj", "[join]") {
     std::vector<std::optional<int32_t>> bid_size_data = {10, {}, {}, 5, 13};
     std::vector<std::optional<double>> ask_data = {2.5, {}, {}, 105, 110};
     std::vector<std::optional<int32_t>> ask_size_data = {83, {}, {}, 47, 15};
-    TableMaker table_maker;
-    table_maker.AddColumn("Ticker", ticker_data);
-    table_maker.AddColumn("Timestamp", timestamp_data);
-    table_maker.AddColumn("Price", price_data);
-    table_maker.AddColumn("Size", size_data);
-    table_maker.AddColumn("Bid", bid_data);
-    table_maker.AddColumn("BidSize", bid_size_data);
-    table_maker.AddColumn("Ask", ask_data);
-    table_maker.AddColumn("AskSize", ask_size_data);
 
     CompareTable(
         result,

--- a/cpp-client/deephaven/tests/src/sort_test.cc
+++ b/cpp-client/deephaven/tests/src/sort_test.cc
@@ -54,12 +54,6 @@ TEST_CASE("Sort temp Table", "[sort]") {
 
   auto sorted = temp_table.Sort(SortPair::Descending("IntValue3"), SortPair::Ascending("IntValue2"));
 
-  std::vector<std::string> import_date_data = {"2017-11-01", "2017-11-01", "2017-11-01"};
-  std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL"};
-  std::vector<double> open_data = {22.1, 26.8, 31.5};
-  std::vector<double> close_data = {23.5, 24.2, 26.7};
-  std::vector<int64_t> vol_data = {100000, 250000, 19000};
-
   std::vector<int32_t> sid0{8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7};
   std::vector<int32_t> sid1{4, 4, 5, 5, 6, 6, 7, 7, 0, 0, 1, 1, 2, 2, 3, 3};
   std::vector<int32_t> sid2{2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1};

--- a/cpp-client/deephaven/tests/src/update_by_test.cc
+++ b/cpp-client/deephaven/tests/src/update_by_test.cc
@@ -154,7 +154,6 @@ TEST_CASE("UpdateBy: Multiple Ops", "[update_by]") {
 
 namespace {
 std::vector<TableHandle> MakeTables(const Client &client) {
-  std::vector<TableHandle> result;
   auto tm = client.GetManager();
   auto static_table = MakeRandomTable(client).Update("Timestamp=now()");
   auto ticking_table = tm.TimeTable(std::chrono::seconds(1))


### PR DESCRIPTION
This PR is just doing some mild cleanup:
1. Remove dead code
2. In `validation_test` remove a call to a helper method. Formerly we had the test entry point calling `TestSelects` which called `TestSelectsHelper`.  Now we have the test entry point doing some work, then calling `TestSelectsHelper`.
3. Likewise for `TestWheres` and `TestWheresHelper`.
4. In `validation_test` we now use the printing routines provided by the `fmt` library (which know how to print a vector) rather than explicitly making our own comma separated list
