### PR TITLE
chore: Add dependabot commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci(github-actions)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "ci(github-actions)"
+      prefix: "chore(github-actions)"


### PR DESCRIPTION
This is to ensure the commit message from dependabot aligns with the conventional commit requirements established in https://github.com/deephaven/deephaven-core/pull/5528