### PR TITLE
chore: Upgrade jedi to 0.19.1

### DIFF
--- a/docker/registry/server-base/gradle.properties
+++ b/docker/registry/server-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:ccb2934e6e24c1c81a83daa81b68ddcf796cba74b2ccbd6b3aa9a34df214c6e1
+deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:6e10203f44b175dcaabb9eb3c6ba743371193c578f85ae30919e9caed3846359

--- a/docker/registry/slim-base/gradle.properties
+++ b/docker/registry/slim-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-slim-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:ca9b55d2e075dc12e220b8cb13fdd9cd4cb7fc8f68dfdaba99fc240f5a916266
+deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:8011b73d42aebf3d240c25e2b0a12c21dbc0049fa8444924fe9f9dbeb1ca9ddfs

--- a/docker/registry/slim-base/gradle.properties
+++ b/docker/registry/slim-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-slim-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:8011b73d42aebf3d240c25e2b0a12c21dbc0049fa8444924fe9f9dbeb1ca9ddfs
+deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:8011b73d42aebf3d240c25e2b0a12c21dbc0049fa8444924fe9f9dbeb1ca9ddf

--- a/docker/server-jetty/src/main/server-jetty/requirements.txt
+++ b/docker/server-jetty/src/main/server-jetty/requirements.txt
@@ -4,7 +4,7 @@ connectorx==0.3.3; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
 importlib_resources==6.4.0
 java-utilities==0.3.0
-jedi==0.18.2
+jedi==0.19.1
 jpy==0.17.0
 llvmlite==0.43.0
 numba==0.60.0

--- a/docker/server/src/main/server-netty/requirements.txt
+++ b/docker/server/src/main/server-netty/requirements.txt
@@ -4,7 +4,7 @@ connectorx==0.3.3; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
 importlib_resources==6.4.0
 java-utilities==0.3.0
-jedi==0.18.2
+jedi==0.19.1
 jpy==0.17.0
 llvmlite==0.43.0
 numba==0.60.0

--- a/py/server/setup.py
+++ b/py/server/setup.py
@@ -68,7 +68,7 @@ setup(
         'numba; python_version < "3.13"',
     ],
     extras_require={
-        "autocomplete": ["jedi==0.18.2"],
+        "autocomplete": ["jedi==0.19.1"],
     },
     entry_points={
         'deephaven.plugin': ['registration_cls = deephaven.pandasplugin:PandasPluginRegistration']


### PR DESCRIPTION
Adds support for Python 3.11 and 3.12.

Also, the 0.19.0 changelog notes a massive performance improvement for `Interpreter` mode which we use by default. It felt a bit snappier to me while using it locally.

Also adds a new flag to avoid unsafe execution if we want to enable that. Not sure what the default is based on the changelog.

https://jedi.readthedocs.io/en/latest/docs/changelog.html