### PR TITLE
feat(cppclient): provide entry points for C API

### DIFF
--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -44,6 +44,13 @@ set(ALL_FILES
     include/public/deephaven/client/flight.h
     include/public/deephaven/client/update_by.h
 
+    src/interop/client_interop.cc
+    src/interop/client_options_interop.cc
+    src/interop/update_by_interop.cc
+    include/public/deephaven/client/interop/client_interop.h
+    include/public/deephaven/client/interop/client_options_interop.h
+    include/public/deephaven/client/interop/update_by_interop.h
+
     src/subscription/subscribe_thread.cc
 
     include/private/deephaven/client/subscription/subscribe_thread.h

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/interop/client_interop.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/interop/client_interop.h
@@ -1,0 +1,678 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include <cstdint>
+#include "deephaven/client/client.h"
+#include "deephaven/client/client_options.h"
+#include "deephaven/client/utility/table_maker.h"
+#include "deephaven/dhcore/interop/interop_util.h"
+
+
+namespace deephaven::client::interop {
+/**
+ * A thin wrapper about std::shared_ptr<ArrowTable>. Not really necessary but
+ * makes it easier for humans to map to the corresponding class on the C# side.
+ */
+struct ArrowTableSpWrapper {
+public:
+  explicit ArrowTableSpWrapper(std::shared_ptr<arrow::Table> table) : table_(std::move(table)) {}
+  std::shared_ptr<arrow::Table> table_;
+};
+
+/**
+ * This class exists so we don't get confused about what we are passing
+ * back and forth to .NET. Basically, like any other object, we need to
+ * heap-allocate this object and pass an opaque pointer back and forth
+ * to .NET. The fact that this object's only member is a shared pointer
+ * is irrelevant in terms of what we need to do.
+ */
+struct ClientTableSpWrapper {
+  using ClientTable = deephaven::dhcore::clienttable::ClientTable;
+public:
+  explicit ClientTableSpWrapper(std::shared_ptr<ClientTable> table) : table_(std::move(table)) {}
+  std::shared_ptr<ClientTable> table_;
+};
+}  // namespace deephaven::client::interop {
+
+extern "C" {
+void deephaven_client_TableHandleManager_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> self);
+
+void deephaven_client_TableHandleManager_EmptyTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> self,
+    int64_t size,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandleManager_FetchTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> self,
+    const char *table_name,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandleManager_TimeTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> period,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TimePointSpecifier> start_time,
+    deephaven::dhcore::interop::InteropBool blink_table,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandleManager_InputTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> initial_table,
+    const char **key_columns, int32_t num_key_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandleManager_RunScript(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> self,
+    const char *code,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_Client_Connect(const char *target,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> options,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Client> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_Client_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Client> self);
+
+void deephaven_client_Client_Close(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Client> self,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_Client_GetManager(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Client> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_GetAttributes(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    int32_t *num_columns, int64_t *num_rows,
+    deephaven::dhcore::interop::InteropBool *is_static,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_GetSchema(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    int32_t num_columns,
+    deephaven::dhcore::interop::StringHandle *columns, int32_t *column_types,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self);
+
+void deephaven_client_TableHandle_GetManager(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Where(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char *condition,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Ungroup(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::InteropBool null_fill,
+    const char **group_by_columns, int32_t num_group_by_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Sort(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **columns,
+    const deephaven::dhcore::interop::InteropBool *ascendings,
+    const deephaven::dhcore::interop::InteropBool *abss,
+    int32_t num_sort_pairs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Select(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_SelectDistinct(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_View(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_DropColumns(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Update(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_LazyUpdate(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_LastBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Head(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    int64_t num_rows,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Tail(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    int64_t num_rows,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Merge(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char *key_column,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *sources,
+    int32_t num_sources,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_CrossJoin(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_NaturalJoin(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_LeftOuterJoin(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_ExactJoin(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Aj(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Raj(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_UpdateBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *ops,
+    int32_t num_ops,
+    const char **by, int32_t num_by,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_WhereIn(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> filter_table,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_AddTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> table_to_add,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_RemoveTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> table_to_remove,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_By(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::AggregateCombo> aggregate_combo,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_MinBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_MaxBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_SumBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_AbsSumBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_VarBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_StdBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_AvgBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_LastBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_FirstBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_MedianBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_PercentileBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    double percentile, deephaven::dhcore::interop::InteropBool avg_median,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_CountBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char *weightColumn,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_WavgBy(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char *weightColumn,
+    const char **column_specs, int32_t num_column_specs,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_BindToVariable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    const char *variable,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_ToClientTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> *client_table,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_ToString(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::InteropBool want_headers,
+    deephaven::dhcore::interop::StringHandle *result_handle,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_ToArrowTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ArrowTableSpWrapper> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+using NativeOnUpdate = void(
+    deephaven::dhcore::interop::NativePtr<deephaven::dhcore::ticking::TickingUpdate> ticking_update);
+using NativeOnFailure = void(deephaven::dhcore::interop::StringHandle,
+    deephaven::dhcore::interop::StringPoolHandle);
+
+void deephaven_client_TableHandle_Subscribe(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<NativeOnUpdate> native_on_update,
+    deephaven::dhcore::interop::NativePtr<NativeOnFailure> native_on_failure,
+    deephaven::dhcore::interop::NativePtr<std::shared_ptr<deephaven::client::subscription::SubscriptionHandle>> *native_subscription_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TableHandle_Unsubscribe(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> self,
+    deephaven::dhcore::interop::NativePtr<std::shared_ptr<deephaven::client::subscription::SubscriptionHandle>> native_subscription_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_SubscriptionHandle_dtor(
+    deephaven::dhcore::interop::NativePtr<std::shared_ptr<deephaven::client::subscription::SubscriptionHandle>> self);
+
+void deephaven_client_ArrowTable_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ArrowTableSpWrapper> self);
+
+void deephaven_client_ArrowTable_GetDimensions(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ArrowTableSpWrapper> self,
+    int32_t *num_columns, int64_t *num_rows,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_ArrowTable_GetSchema(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ArrowTableSpWrapper> self,
+    int32_t num_columns,
+    deephaven::dhcore::interop::StringHandle *column_handles, int32_t *column_types,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_ClientTable_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self);
+
+void deephaven_client_ClientTable_GetDimensions(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t *num_columns, int64_t *num_rows,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_ClientTable_Schema(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t num_columns,
+    deephaven::dhcore::interop::StringHandle *column_handles,
+    int32_t *column_types,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_ClientTable_ToString(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    deephaven::dhcore::interop::InteropBool want_headers,
+    deephaven::dhcore::interop::InteropBool want_row_numbers,
+    deephaven::dhcore::interop::StringHandle *text_handle,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_ClientTableHelper_GetInt8Column(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, int8_t *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetInt16Column(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, int16_t *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetInt32Column(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, int32_t *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetInt64Column(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, int64_t *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetFloatColumn(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, float *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetDoubleColumn(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, double *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags,
+    int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetCharAsInt16Column(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, int16_t *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags,
+    int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetBooleanAsInteropBoolColumn(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, int8_t *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetStringColumn(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, deephaven::dhcore::interop::StringHandle *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientTableHelper_GetDateTimeAsInt64Column(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> self,
+    int32_t column_index, int64_t *data,
+    deephaven::dhcore::interop::InteropBool *optional_dest_null_flags, int64_t num_rows,
+    deephaven::dhcore::interop::StringPoolHandle *string_pool_handle,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_TickingUpdate_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::dhcore::ticking::TickingUpdate> self);
+
+void deephaven_client_TickingUpdate_Current(
+    deephaven::dhcore::interop::NativePtr<deephaven::dhcore::ticking::TickingUpdate> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::interop::ClientTableSpWrapper> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_AggregateCombo_Create(
+    const deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *aggregate_ptrs,
+    int32_t num_aggregates,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::AggregateCombo> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_AggregateCombo_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::AggregateCombo> self);
+
+void deephaven_client_Aggregate_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> self);
+void deephaven_client_Aggregate_AbsSum(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Group(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Avg(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Count(
+    const char *column,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_First(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Last(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Max(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Med(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Min(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Pct(
+    double percentile, deephaven::dhcore::interop::InteropBool avg_median,
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Std(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Sum(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_Var(
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_Aggregate_WAvg(const char *weight,
+    const char **columns, int32_t num_columns,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::Aggregate> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+
+void deephaven_client_utility_DurationSpecifier_ctor_nanos(
+    int64_t nanos,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_utility_DurationSpecifier_ctor_durationstr(
+    const char *duration_str,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_utility_DurationSpecifier_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> result);
+
+void deephaven_client_utility_TimePointSpecifier_ctor_nanos(
+    int64_t nanos,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TimePointSpecifier> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_utility_TimePointSpecifier_ctor_timepointstr(
+    const char *time_point_str,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TimePointSpecifier> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_utility_TimePointSpecifier_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TimePointSpecifier> result);
+
+void deephaven_dhclient_utility_TableMaker_ctor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self);
+void deephaven_dhclient_utility_TableMaker_MakeTable(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandleManager> manager,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::TableHandle> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__CharAsInt16(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const int16_t *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int8(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const int8_t *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int16(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const int16_t *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int32(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const int32_t *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int64(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const int64_t *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__Float(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const float *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__Double(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const double *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__BoolAsInteropBool(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const int8_t *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__String(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const char **data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_dhclient_utility_TableMaker_AddColumn__DateTimeAsInt64(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::TableMaker> self,
+    const char *name,
+    const int64_t *data,
+    int32_t length,
+    const deephaven::dhcore::interop::InteropBool *optional_nulls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+}  // extern "C"

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/interop/client_options_interop.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/interop/client_options_interop.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include <cstdint>
+#include "deephaven/client/client_options.h"
+#include "deephaven/dhcore/interop/interop_util.h"
+
+extern "C" {
+void deephaven_client_ClientOptions_ctor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self);
+void deephaven_client_ClientOptions_SetDefaultAuthentication(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_SetBasicAuthentication(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *username, const char *password,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_SetCustomAuthentication(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *authentication_key, const char *authentication_value,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_SetSessionType(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *session_type,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_SetUseTls(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    deephaven::dhcore::interop::InteropBool use_tls,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_SetTlsRootCerts(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *tls_root_certs,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_SetClientCertChain(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *client_cert_chain,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_SetClientPrivateKey(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *client_private_key,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_AddIntOption(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *opt, int32_t val,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_AddStringOption(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *opt, const char *val,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_ClientOptions_AddExtraHeader(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::ClientOptions> self,
+    const char *header_name, const char *header_value,
+    deephaven::dhcore::interop::ErrorStatus *status);
+}  // extern "C"

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/interop/update_by_interop.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/interop/update_by_interop.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include <cstdint>
+#include "deephaven/client/client.h"
+#include "deephaven/client/client_options.h"
+#include "deephaven/client/update_by.h"
+#include "deephaven/client/utility/table_maker.h"
+#include "deephaven/dhcore/interop/interop_util.h"
+
+
+extern "C" {
+void deephaven_client_UpdateByOperation_dtor(
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> self);
+void deephaven_client_update_by_cumSum(
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_cumProd(
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_cumMin(
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_cumMax(
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_forwardFill(
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_delta(
+    const char **cols, int32_t num_cols,
+    deephaven::client::update_by::DeltaControl delta_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emaTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emaTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emsTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emsTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emminTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emminTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emmaxTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emmaxTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emstdTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_emstdTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const deephaven::client::update_by::OperationControl *op_control,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingSumTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingSumTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingGroupTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingGroupTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingAvgTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingAvgTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingMinTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingMinTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingMaxTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingMaxTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingProdTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingProdTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingCountTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingCountTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingStdTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingStdTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingWavgTick(const char *weight_col,
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+void deephaven_client_update_by_rollingWavgTime(const char *timestamp_col,
+    const char *weight_col,
+    const char **cols, int32_t num_cols,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> rev_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> fwd_time,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::UpdateByOperation> *result,
+    deephaven::dhcore::interop::ErrorStatus *status);
+}  // extern "C"

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
@@ -30,6 +30,11 @@ public:
   [[nodiscard]]
   static TypeConverter CreateNew(const std::vector<T> &values);
 
+  template<typename T, typename GetValue, typename IsNull>
+  [[nodiscard]]
+  static TypeConverter CreateNew(const GetValue &get_value, const IsNull &is_null,
+      size_t size);
+
   TypeConverter(std::shared_ptr<arrow::DataType> data_type, std::string deephaven_type,
       std::shared_ptr<arrow::Array> column);
   ~TypeConverter();
@@ -107,6 +112,13 @@ public:
   template<typename T>
   void AddColumn(std::string name, const std::vector<T> &values);
 
+  template<typename T>
+  void AddColumn(std::string name, const std::vector<std::optional<T>> &values);
+
+  template<typename T, typename GetValue, typename IsNull>
+  void AddColumn(std::string name, const GetValue &get_value, const IsNull &is_null,
+      size_t size);
+
   /**
    * Make the table. Call this after all your calls to AddColumn().
    * @param manager The TableHandleManager
@@ -129,7 +141,7 @@ struct TypeConverterTraits {
   // The below assert fires when this class is instantiated; i.e. when none of the specializations
   // match. It needs to be written this way (with "is_same<T,T>") because for technical reasons it
   // needso be dependent on T, even if degenerately so.
-  static_assert(!std::is_same<T, T>::value, "TableMaker doesn't know how to work with this type");
+  static_assert(!std::is_same_v<T, T>, "TableMaker doesn't know how to work with this type");
 };
 
 // Implementation note: GetDeephavenTypeName() is better as a function rather than a constant,
@@ -137,8 +149,15 @@ struct TypeConverterTraits {
 
 template<>
 struct TypeConverterTraits<char16_t> {
-  using arrowType_t = arrow::UInt16Type;
-  using arrowBuilder_t = arrow::UInt16Builder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::UInt16Type>();
+  }
+  static arrow::UInt16Builder GetBuilder() {
+    return arrow::UInt16Builder();
+  }
+  static char16_t Reinterpret(char16_t o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "char";
   }
@@ -146,8 +165,15 @@ struct TypeConverterTraits<char16_t> {
 
 template<>
 struct TypeConverterTraits<bool> {
-  using arrowType_t = arrow::BooleanType;
-  using arrowBuilder_t = arrow::BooleanBuilder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::BooleanType>();
+  }
+  static arrow::BooleanBuilder GetBuilder() {
+    return arrow::BooleanBuilder();
+  }
+  static bool Reinterpret(bool o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "java.lang.Boolean";
   }
@@ -155,8 +181,15 @@ struct TypeConverterTraits<bool> {
 
 template<>
 struct TypeConverterTraits<int8_t> {
-  using arrowType_t = arrow::Int8Type;
-  using arrowBuilder_t = arrow::Int8Builder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::Int8Type>();
+  }
+  static arrow::Int8Builder GetBuilder() {
+    return arrow::Int8Builder();
+  }
+  static int8_t Reinterpret(int8_t o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "byte";
   }
@@ -164,8 +197,15 @@ struct TypeConverterTraits<int8_t> {
 
 template<>
 struct TypeConverterTraits<int16_t> {
-  using arrowType_t = arrow::Int16Type;
-  using arrowBuilder_t = arrow::Int16Builder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::Int16Type>();
+  }
+  static arrow::Int16Builder GetBuilder() {
+    return arrow::Int16Builder();
+  }
+  static int16_t Reinterpret(int16_t o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "short";
   }
@@ -173,8 +213,15 @@ struct TypeConverterTraits<int16_t> {
 
 template<>
 struct TypeConverterTraits<int32_t> {
-  using arrowType_t = arrow::Int32Type;
-  using arrowBuilder_t = arrow::Int32Builder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::Int32Type>();
+  }
+  static arrow::Int32Builder GetBuilder() {
+    return arrow::Int32Builder();
+  }
+  static int32_t Reinterpret(int32_t o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "int";
   }
@@ -182,8 +229,15 @@ struct TypeConverterTraits<int32_t> {
 
 template<>
 struct TypeConverterTraits<int64_t> {
-  using arrowType_t = arrow::Int64Type;
-  using arrowBuilder_t = arrow::Int64Builder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::Int64Type>();
+  }
+  static arrow::Int64Builder GetBuilder() {
+    return arrow::Int64Builder();
+  }
+  static int64_t Reinterpret(int64_t o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "long";
   }
@@ -191,8 +245,15 @@ struct TypeConverterTraits<int64_t> {
 
 template<>
 struct TypeConverterTraits<float> {
-  using arrowType_t = arrow::FloatType;
-  using arrowBuilder_t = arrow::FloatBuilder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::FloatType>();
+  }
+  static arrow::FloatBuilder GetBuilder() {
+    return arrow::FloatBuilder();
+  }
+  static float Reinterpret(float o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "float";
   }
@@ -200,8 +261,15 @@ struct TypeConverterTraits<float> {
 
 template<>
 struct TypeConverterTraits<double> {
-  using arrowType_t = arrow::DoubleType;
-  using arrowBuilder_t = arrow::DoubleBuilder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::DoubleType>();
+  }
+  static arrow::DoubleBuilder GetBuilder() {
+    return arrow::DoubleBuilder();
+  }
+  static double Reinterpret(double o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "double";
   }
@@ -209,18 +277,48 @@ struct TypeConverterTraits<double> {
 
 template<>
 struct TypeConverterTraits<std::string> {
-  using arrowType_t = arrow::StringType;
-  using arrowBuilder_t = arrow::StringBuilder;
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return std::make_shared<arrow::StringType>();
+  }
+  static arrow::StringBuilder GetBuilder() {
+    return arrow::StringBuilder();
+  }
+  static const std::string &Reinterpret(const std::string &o) {
+    return o;
+  }
   static std::string_view GetDeephavenTypeName() {
     return "java.lang.String";
+  }
+};
+
+template<>
+struct TypeConverterTraits<deephaven::dhcore::DateTime> {
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
+  }
+  static arrow::TimestampBuilder GetBuilder() {
+    return arrow::TimestampBuilder(GetDataType(), arrow::default_memory_pool());
+  }
+  static int64_t Reinterpret(const deephaven::dhcore::DateTime &dt) {
+    return dt.Nanos();
+  }
+  static std::string_view GetDeephavenTypeName() {
+    return "java.time.ZonedDateTime";
   }
 };
 
 template<typename T>
 struct TypeConverterTraits<std::optional<T>> {
   using inner_t = TypeConverterTraits<T>;
-  using arrowType_t = typename inner_t::arrowType_t;
-  using arrowBuilder_t = typename inner_t::arrowBuilder_t;
+  static auto GetDataType() {
+    return inner_t::GetDataType();
+  }
+  static auto GetBuilder() {
+    return inner_t::GetBuilder();
+  }
+  static auto Reinterpret(const T &o) {
+    return inner_t::Reinterpret(o);
+  }
   static std::string_view GetDeephavenTypeName() {
     return TypeConverterTraits<T>::GetDeephavenTypeName();
   }
@@ -232,14 +330,14 @@ TypeConverter TypeConverter::CreateNew(const std::vector<T> &values) {
 
   typedef TypeConverterTraits<T> traits_t;
 
-  auto data_type = std::make_shared<typename traits_t::arrowType_t>();
+  auto data_type = traits_t::GetDataType();
+  auto builder = traits_t::GetBuilder();
 
-  typename traits_t::arrowBuilder_t builder;
   for (const auto &value : values) {
     bool valid;
     const auto *contained_value = TryGetContainedValue(&value, &valid);
     if (valid) {
-      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.Append(*contained_value)));
+      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.Append(traits_t::Reinterpret(*contained_value))));
     } else {
       OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.AppendNull()));
     }
@@ -254,20 +352,20 @@ TypeConverter TypeConverter::CreateNew(const std::vector<T> &values) {
       std::move(array));
 }
 
-template<>
-inline TypeConverter TypeConverter::CreateNew(const std::vector<deephaven::dhcore::DateTime> &values) {
+template<typename T, typename GetValue, typename IsNull>
+TypeConverter TypeConverter::CreateNew(const GetValue &get_value, const IsNull &is_null,
+    size_t size) {
   using deephaven::client::utility::OkOrThrow;
 
-  // TODO(kosak): put somewhere
-  constexpr const char *kDeephavenTypeName = "java.time.ZonedDateTime";
+  typedef TypeConverterTraits<T> traits_t;
 
-  auto data_type = arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
-  arrow::TimestampBuilder builder(data_type, arrow::default_memory_pool());
-  for (const auto &value : values) {
-    bool valid;
-    const auto *contained_value = TryGetContainedValue(&value, &valid);
-    if (valid) {
-      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.Append(contained_value->Nanos())));
+  auto data_type = traits_t::GetDataType();
+  auto builder = traits_t::GetBuilder();
+
+  for (size_t i = 0; i != size; ++i) {
+    if (!is_null(i)) {
+       OkOrThrow(DEEPHAVEN_LOCATION_EXPR(
+           builder.Append(traits_t::Reinterpret(get_value(i)))));
     } else {
       OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.AppendNull()));
     }
@@ -275,16 +373,35 @@ inline TypeConverter TypeConverter::CreateNew(const std::vector<deephaven::dhcor
   auto builder_res = builder.Finish();
   if (!builder_res.ok()) {
     auto message = fmt::format("Error building array of type {}: {}",
-        kDeephavenTypeName, builder_res.status().ToString());
+        traits_t::GetDeephavenTypeName(), builder_res.status().ToString());
   }
   auto array = builder_res.ValueUnsafe();
-  return TypeConverter(std::move(data_type), kDeephavenTypeName, std::move(array));
+  return TypeConverter(std::move(data_type), std::string(traits_t::GetDeephavenTypeName()),
+      std::move(array));
 }
 }  // namespace internal
 
 template<typename T>
 void TableMaker::AddColumn(std::string name, const std::vector<T> &values) {
-  auto info = internal::TypeConverter::CreateNew(values);
+  // Specifying the return type here in this way (rather than const T &)
+  // allows us to deal with std::vector<bool>, which is very special, and would
+  // otherwise cause a compiler error, because of the way it is specialized.
+  auto get_value = [&](size_t index) -> typename std::vector<T>::const_reference { return values[index]; };
+  auto is_null = [](size_t /*index*/) { return false; };
+  return AddColumn<T>(std::move(name), get_value, is_null, values.size());
+}
+
+template<typename T>
+void TableMaker::AddColumn(std::string name, const std::vector<std::optional<T>> &values) {
+  auto get_value = [&](size_t index) -> const T& { return *values[index]; };
+  auto is_null = [&](size_t index) { return !values[index].has_value(); };
+  return AddColumn<T>(std::move(name), get_value, is_null, values.size());
+}
+
+template<typename T, typename GetValue, typename IsNull>
+void TableMaker::AddColumn(std::string name, const GetValue &get_value, const IsNull &is_null,
+    size_t size) {
+  auto info = internal::TypeConverter::CreateNew<T>(get_value, is_null, size);
   FinishAddColumn(std::move(name), std::move(info));
 }
 }  // namespace deephaven::client::utility

--- a/cpp-client/deephaven/dhclient/src/interop/client_interop.cc
+++ b/cpp-client/deephaven/dhclient/src/interop/client_interop.cc
@@ -1,0 +1,1370 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/client/interop/client_interop.h"
+
+#include <codecvt>
+#include <locale>
+#include <arrow/table.h>
+#include "deephaven/client/client.h"
+#include "deephaven/client/client_options.h"
+#include "deephaven/client/subscription/subscription_handle.h"
+#include "deephaven/client/update_by.h"
+#include "deephaven/client/utility/arrow_util.h"
+#include "deephaven/client/utility/table_maker.h"
+#include "deephaven/dhcore/interop/interop_util.h"
+#include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/format.h"
+
+using deephaven::client::Aggregate;
+using deephaven::client::AggregateCombo;
+using deephaven::client::Client;
+using deephaven::client::ClientOptions;
+using deephaven::client::SortDirection;
+using deephaven::client::SortPair;
+using deephaven::client::TableHandle;
+using deephaven::client::TableHandleManager;
+using deephaven::client::UpdateByOperation;
+using deephaven::client::subscription::SubscriptionHandle;
+using deephaven::client::interop::ArrowTableSpWrapper;
+using deephaven::client::utility::ArrowUtil;
+using deephaven::client::interop::ClientTableSpWrapper;
+using deephaven::client::utility::DurationSpecifier;
+using deephaven::client::utility::TableMaker;
+using deephaven::client::utility::TimePointSpecifier;
+using deephaven::dhcore::DateTime;
+using deephaven::dhcore::chunk::BooleanChunk;
+using deephaven::dhcore::chunk::CharChunk;
+using deephaven::dhcore::chunk::Chunk;
+using deephaven::dhcore::chunk::DateTimeChunk;
+using deephaven::dhcore::chunk::DoubleChunk;
+using deephaven::dhcore::chunk::FloatChunk;
+using deephaven::dhcore::chunk::Int8Chunk;
+using deephaven::dhcore::chunk::Int16Chunk;
+using deephaven::dhcore::chunk::Int32Chunk;
+using deephaven::dhcore::chunk::Int64Chunk;
+using deephaven::dhcore::chunk::StringChunk;
+using deephaven::dhcore::interop::ErrorStatus;
+using deephaven::dhcore::interop::InteropBool;
+using deephaven::dhcore::interop::NativePtr;
+using deephaven::dhcore::interop::StringHandle;
+using deephaven::dhcore::interop::StringPoolBuilder;
+using deephaven::dhcore::interop::StringPoolHandle;
+using deephaven::dhcore::ticking::TickingCallback;
+using deephaven::dhcore::ticking::TickingUpdate;
+using deephaven::dhcore::utility::GetWhat;
+using deephaven::dhcore::utility::MakeReservedVector;
+
+namespace {
+void GetColumnHelper(ClientTableSpWrapper *self,
+    int32_t column_index,
+    Chunk *data_chunk, InteropBool *optional_dest_null_flags, int64_t num_rows) {
+  auto cs = self->table_->GetColumn(column_index);
+  std::unique_ptr<bool[]> null_data;
+  BooleanChunk null_chunk;
+  BooleanChunk *null_chunkp = nullptr;
+  if (optional_dest_null_flags != nullptr) {
+    null_data.reset(new bool[num_rows]);
+    null_chunk = BooleanChunk::CreateView(null_data.get(), num_rows);
+    null_chunkp = &null_chunk;
+  }
+
+  auto rows = self->table_->GetRowSequence();
+  cs->FillChunk(*rows, data_chunk, null_chunkp);
+
+  if (optional_dest_null_flags != nullptr) {
+    for (int64_t i = 0; i != num_rows; ++i) {
+      optional_dest_null_flags[i] = InteropBool(null_data[i]);
+    }
+  }
+}
+
+void JoinHelper(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status,
+    TableHandle (TableHandle::*invoker)(const TableHandle &, std::vector<std::string>,
+        std::vector<std::string>) const) {
+  status->Run([=]() {
+    std::vector<std::string> cols_to_match(columns_to_match,
+        columns_to_match + num_columns_to_match);
+    std::vector<std::string> cols_to_add(columns_to_add,
+        columns_to_add + num_columns_to_add);
+    auto table = (self->*invoker)(*right_side, std::move(cols_to_match), std::move(cols_to_add));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void ByHelper(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status,
+    TableHandle (TableHandle::*invoker)(std::vector<std::string>) const) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = (self->*invoker)(std::move(cols));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+}  // namespace
+
+extern "C" {
+// There is no TableHandleManager_ctor entry point because we don't need callers to invoke
+// the TableHandleManager ctor directly.
+void deephaven_client_TableHandleManager_dtor(NativePtr<TableHandleManager> self) {
+  delete self.Get();
+}
+
+void deephaven_client_TableHandleManager_EmptyTable(
+    NativePtr<TableHandleManager> self,
+    int64_t size,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto table = self->EmptyTable(size);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandleManager_FetchTable(
+    NativePtr<TableHandleManager> self,
+    const char *table_name,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto table = self->FetchTable(table_name);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandleManager_TimeTable(
+    NativePtr<TableHandleManager> self,
+    NativePtr<DurationSpecifier> period,
+    NativePtr<TimePointSpecifier> start_time,
+    InteropBool blink_table,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto table = self->TimeTable(*period, *start_time, (bool)blink_table);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandleManager_InputTable(
+    NativePtr<TableHandleManager> self,
+    NativePtr<TableHandle> initial_table,
+    const char **key_columns, int32_t num_key_columns,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> kcs(key_columns, key_columns + num_key_columns);
+    auto table = self->InputTable(*initial_table, std::move(kcs));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandleManager_RunScript(
+    NativePtr<TableHandleManager> self,
+    const char *code,
+    ErrorStatus *status) {
+  status->Run([self, code]() {
+    self->RunScript(code);
+  });
+}
+
+void deephaven_client_Client_Connect(const char *target,
+    NativePtr<ClientOptions> options,
+    NativePtr<Client> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto res = Client::Connect(target, *options);
+    result->Reset(new Client(std::move(res)));
+  });
+}
+
+// There is no Client_ctor entry point because we don't need callers to invoke
+// the Client ctor directly.
+void deephaven_client_Client_dtor(NativePtr<Client> self) {
+  delete self;
+}
+
+
+void deephaven_client_Client_Close(NativePtr<Client> self,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->Close();
+  });
+}
+
+void deephaven_client_Client_GetManager(NativePtr<Client> self,
+    NativePtr<TableHandleManager> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto res = self->GetManager();
+    result->Reset(new TableHandleManager(std::move(res)));
+  });
+}
+
+void deephaven_client_TableHandle_GetAttributes(
+    NativePtr<TableHandle> self,
+    int32_t *num_columns, int64_t *num_rows, InteropBool *is_static,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    *num_columns = self->Schema()->NumCols();
+    *num_rows = self->NumRows();
+    *is_static = (InteropBool)self->IsStatic();
+  });
+}
+
+void deephaven_client_TableHandle_GetSchema(
+    NativePtr<TableHandle> self,
+    int32_t num_columns, StringHandle *column_handles, int32_t *column_types,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    const auto &schema = self->Schema();
+
+    if (num_columns != schema->NumCols()) {
+      auto message = fmt::format("Expected {} columns, but schema has {}",
+          num_columns, schema->NumCols());
+      throw std::runtime_error(message);
+    }
+
+    StringPoolBuilder builder;
+    for (int32_t i = 0; i != num_columns; ++i) {
+      column_handles[i] = builder.Add(schema->Names()[i]);
+      column_types[i] = static_cast<int32_t>(schema->Types()[i]);
+    }
+    *string_pool_handle = builder.Build();
+  });
+}
+
+// There is no TableHandle_ctor entry point because we don't need callers to invoke
+// the TableHandle ctor directly.
+void deephaven_client_TableHandle_dtor(NativePtr<TableHandle> self) {
+  delete self.Get();
+}
+
+void deephaven_client_TableHandle_GetManager(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandleManager> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto manager = self->GetManager();
+    result->Reset(new TableHandleManager(std::move(manager)));
+  });
+}
+
+void deephaven_client_TableHandle_Where(
+    NativePtr<TableHandle> self,
+    const char *condition,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto table = self->Where(condition);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_Ungroup(
+    NativePtr<TableHandle> self,
+    InteropBool null_fill,
+    const char **group_by_columns, int32_t num_group_by_columns,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(group_by_columns, group_by_columns + num_group_by_columns);
+    auto table = self->Ungroup((bool)null_fill, std::move(cols));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_Sort(
+    NativePtr<TableHandle> self,
+    const char **columns,
+    const InteropBool *ascendings,
+    const InteropBool *abss,
+    int32_t num_sort_pairs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto sort_pairs = MakeReservedVector<SortPair>(num_sort_pairs);
+    for (int32_t i = 0; i != num_sort_pairs; ++i) {
+      sort_pairs.emplace_back(
+          columns[i],
+          ascendings[i] ? SortDirection::kAscending : SortDirection::kDescending,
+          (bool)abss[i]);
+    }
+    auto table = self->Sort(std::move(sort_pairs));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+
+}
+
+void deephaven_client_TableHandle_Select(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->Select(cols);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_SelectDistinct(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->SelectDistinct(cols);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_View(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->View(cols);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_DropColumns(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->DropColumns(cols);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_Update(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->Update(cols);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_LazyUpdate(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->LazyUpdate(cols);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_MinBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::MinBy);
+}
+
+void deephaven_client_TableHandle_SumBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::SumBy);
+}
+
+void deephaven_client_TableHandle_AbsSumBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::AbsSumBy);
+}
+
+void deephaven_client_TableHandle_VarBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::VarBy);
+}
+
+void deephaven_client_TableHandle_StdBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::StdBy);
+}
+
+void deephaven_client_TableHandle_AvgBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::AvgBy);
+}
+
+void deephaven_client_TableHandle_LastBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::LastBy);
+}
+
+void deephaven_client_TableHandle_FirstBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::FirstBy);
+}
+
+void deephaven_client_TableHandle_MedianBy(
+    NativePtr<TableHandle> self,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  ByHelper(self, column_specs, num_column_specs, result, status, &TableHandle::MedianBy);
+}
+
+void deephaven_client_TableHandle_PercentileBy(
+    NativePtr<TableHandle> self,
+    double percentile, deephaven::dhcore::interop::InteropBool avg_median,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->PercentileBy(percentile, (bool)avg_median, std::move(cols));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_CountBy(
+    NativePtr<TableHandle> self,
+    const char *weight_column,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->CountBy(weight_column, std::move(cols));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_WavgBy(
+    NativePtr<TableHandle> self,
+    const char *weight_column,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->WAvgBy(weight_column, std::move(cols));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_WhereIn(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> filter_table,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->WhereIn(*filter_table, cols);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_CrossJoin(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  JoinHelper(self, right_side,
+      columns_to_match, num_columns_to_match,
+      columns_to_add, num_columns_to_add,
+      result, status,
+      &TableHandle::CrossJoin);
+}
+
+void deephaven_client_TableHandle_NaturalJoin(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  JoinHelper(self, right_side,
+      columns_to_match, num_columns_to_match,
+      columns_to_add, num_columns_to_add,
+      result, status,
+      &TableHandle::NaturalJoin);
+}
+
+void deephaven_client_TableHandle_LeftOuterJoin(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  JoinHelper(self, right_side,
+      columns_to_match, num_columns_to_match,
+      columns_to_add, num_columns_to_add,
+      result, status,
+      &TableHandle::LeftOuterJoin);
+}
+
+void deephaven_client_TableHandle_ExactJoin(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  JoinHelper(self, right_side,
+      columns_to_match, num_columns_to_match,
+      columns_to_add, num_columns_to_add,
+      result, status,
+      &TableHandle::ExactJoin);
+}
+
+void deephaven_client_TableHandle_Aj(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  JoinHelper(self, right_side,
+      columns_to_match, num_columns_to_match,
+      columns_to_add, num_columns_to_add,
+      result, status,
+      &TableHandle::Aj);
+}
+
+void deephaven_client_TableHandle_Raj(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> right_side,
+    const char **columns_to_match, int32_t num_columns_to_match,
+    const char **columns_to_add, int32_t num_columns_to_add,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  JoinHelper(self, right_side,
+      columns_to_match, num_columns_to_match,
+      columns_to_add, num_columns_to_add,
+      result, status,
+      &TableHandle::Raj);
+}
+
+void deephaven_client_TableHandle_UpdateBy(
+    NativePtr<TableHandle> self,
+    const NativePtr<UpdateByOperation> *ops, int32_t num_ops,
+    const char **by, int32_t num_by,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto ops_vec = MakeReservedVector<UpdateByOperation>(num_ops);
+    for (int32_t i = 0; i != num_ops; ++i) {
+      ops_vec.emplace_back(*ops[i].Get());
+    }
+    std::vector<std::string> by_vec(by, by + num_by);
+    auto res = self->UpdateBy(std::move(ops_vec), std::move(by_vec));
+    result->Reset(new TableHandle(std::move(res)));
+  });
+}
+
+void deephaven_client_TableHandle_AddTable(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> table_to_add,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->AddTable(*table_to_add);
+  });
+}
+
+void deephaven_client_TableHandle_RemoveTable(
+    NativePtr<TableHandle> self,
+    NativePtr<TableHandle> table_to_remove,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->RemoveTable(*table_to_remove);
+  });
+}
+
+void deephaven_client_TableHandle_By(
+    NativePtr<TableHandle> self,
+    NativePtr<AggregateCombo> aggregate_combo,
+    const char **column_specs, int32_t num_column_specs,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> cols(column_specs, column_specs + num_column_specs);
+    auto table = self->By(*aggregate_combo, std::move(cols));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_Head(
+    NativePtr<TableHandle> self,
+    int64_t num_rows,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto table = self->Head(num_rows);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_Tail(
+    NativePtr<TableHandle> self,
+    int64_t num_rows,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto table = self->Tail(num_rows);
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_Merge(NativePtr<TableHandle> self,
+    const char *key_column,
+    NativePtr<TableHandle> *sources, int32_t num_sources,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    // We need to make copies of the passed-in TableHandles because we're not
+    // allowed to modify or move them.
+    auto sources_copy = MakeReservedVector<TableHandle>(num_sources);
+    for (int32_t i = 0; i != num_sources; ++i) {
+      sources_copy.push_back(*sources[i]);
+    }
+    auto table = self->Merge(key_column, std::move(sources_copy));
+    result->Reset(new TableHandle(std::move(table)));
+  });
+}
+
+void deephaven_client_TableHandle_BindToVariable(
+    NativePtr<TableHandle> self,
+    const char *variable,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->BindToVariable(variable);
+  });
+}
+
+void deephaven_client_TableHandle_ToString(
+    NativePtr<TableHandle> self,
+    InteropBool want_headers,
+    StringHandle *result_handle,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    StringPoolBuilder builder;
+    *result_handle = builder.Add(self->ToString((bool)want_headers));
+    *string_pool_handle = builder.Build();
+  });
+}
+
+void deephaven_client_TableHandle_ToArrowTable(
+    NativePtr<TableHandle> self,
+    NativePtr<ArrowTableSpWrapper> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto at = self->ToArrowTable();
+    result->Reset(new ArrowTableSpWrapper(std::move(at)));
+  });
+}
+
+class WrappedTickingCallback final : public TickingCallback {
+public:
+  WrappedTickingCallback(NativeOnUpdate *on_update, NativeOnFailure *on_failure) :
+     on_update_(on_update), on_failure_(on_failure) {}
+
+  void OnTick(TickingUpdate update) final {
+    NativePtr<TickingUpdate> nptr(new TickingUpdate(std::move(update)));
+    (*on_update_)(nptr);
+  }
+
+  void OnFailure(std::exception_ptr eptr) final {
+    StringPoolBuilder builder;
+    auto string_handle = builder.Add(GetWhat(eptr));
+    auto pool_handle = builder.Build();
+    (*on_failure_)(string_handle, pool_handle);
+  }
+
+private:
+  NativeOnUpdate *on_update_ = nullptr;
+  NativeOnFailure *on_failure_ = nullptr;
+};
+
+void deephaven_client_TableHandle_Subscribe(
+    NativePtr<TableHandle> self,
+    NativePtr<NativeOnUpdate> native_on_update,
+    NativePtr<NativeOnFailure> native_on_failure,
+    NativePtr<std::shared_ptr<SubscriptionHandle>> *native_subscription_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto wtc = std::make_shared<WrappedTickingCallback>(native_on_update, native_on_failure);
+    auto handle = self->Subscribe(std::move(wtc));
+    native_subscription_handle->Reset(new std::shared_ptr<SubscriptionHandle>(std::move(handle)));
+  });
+}
+
+void deephaven_client_TableHandle_Unsubscribe(
+    NativePtr<deephaven::client::TableHandle> self,
+    NativePtr<std::shared_ptr<deephaven::client::subscription::SubscriptionHandle>> native_subscription_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->Unsubscribe(*native_subscription_handle);
+  });
+}
+
+void deephaven_client_SubscriptionHandle_dtor(
+    deephaven::dhcore::interop::NativePtr<std::shared_ptr<deephaven::client::subscription::SubscriptionHandle>> self) {
+  delete self.Get();
+}
+
+void deephaven_client_TableHandle_ToClientTable(
+    NativePtr<TableHandle> self,
+    NativePtr<ClientTableSpWrapper> *client_table,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto ct = self->ToClientTable();
+    client_table->Reset(new ClientTableSpWrapper(std::move(ct)));
+  });
+}
+
+void deephaven_client_ArrowTable_dtor(
+    NativePtr<ArrowTableSpWrapper> self) {
+  delete self.Get();
+}
+
+void deephaven_client_ArrowTable_GetDimensions(
+    NativePtr<ArrowTableSpWrapper> self,
+    int32_t *num_columns, int64_t *num_rows,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    *num_columns = self->table_->num_columns();
+    *num_rows = self->table_->num_rows();
+  });
+}
+
+void deephaven_client_ArrowTable_GetSchema(
+    NativePtr<ArrowTableSpWrapper> self,
+  int32_t num_columns, StringHandle *column_handles, int32_t *column_types,
+  StringPoolHandle *string_pool_handle, ErrorStatus *status) {
+  status->Run([=]() {
+    const auto &schema = self->table_->schema();
+    if (schema->num_fields() != num_columns) {
+      auto message = fmt::format("Expected schema->num_fields ({}) == num_columns ({})",
+          schema->num_fields(), num_columns);
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
+
+    StringPoolBuilder builder;
+    for (int32_t i = 0; i != num_columns; ++i) {
+      const auto &field = schema->fields()[i];
+      column_handles[i] = builder.Add(field->name());
+      auto element_type_id = *ArrowUtil::GetElementTypeId(*field->type(), true);
+      column_types[i] = static_cast<int32_t>(element_type_id);
+    }
+    *string_pool_handle = builder.Build();
+  });
+}
+
+void deephaven_client_TickingUpdate_dtor(NativePtr<TickingUpdate> self) {
+  delete self.Get();
+}
+
+void deephaven_client_TickingUpdate_Current(NativePtr<TickingUpdate> self,
+    NativePtr<ClientTableSpWrapper> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    result->Reset(new ClientTableSpWrapper(self->Current()));
+  });
+}
+
+void deephaven_client_ClientTable_GetDimensions(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t *num_columns, int64_t *num_rows,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    *num_columns = static_cast<int32_t>(self->table_->NumColumns());
+    *num_rows = static_cast<int64_t>(self->table_->NumRows());
+  });
+}
+
+void deephaven_client_ClientTable_Schema(NativePtr<ClientTableSpWrapper> self,
+    int32_t num_columns, StringHandle *column_handles, int32_t *column_types,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    const auto &schema = self->table_->Schema();
+    if (schema->NumCols() != num_columns) {
+      auto message = fmt::format("Expected schema->num_fields ({}) == num_columns ({})",
+          schema->NumCols(), num_columns);
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
+
+    StringPoolBuilder builder;
+    for (int32_t i = 0; i != num_columns; ++i) {
+      column_handles[i] = builder.Add(schema->Names()[i]);
+      column_types[i] = static_cast<int32_t>(schema->Types()[i]);
+    }
+    *string_pool_handle = builder.Build();
+  });
+}
+
+void deephaven_client_ClientTable_ToString(
+    NativePtr<ClientTableSpWrapper> self,
+    InteropBool want_headers,
+    InteropBool want_row_numbers,
+    StringHandle *text_handle,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    StringPoolBuilder builder;
+    auto text = self->table_->ToString((bool)want_headers, (bool)want_row_numbers);
+    *text_handle = builder.Add(text);
+    *string_pool_handle = builder.Build();
+  });
+}
+
+void deephaven_client_ClientTable_dtor(NativePtr<ClientTableSpWrapper> self) {
+  delete self.Get();
+}
+
+void deephaven_client_ClientTableHelper_GetInt8Column(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index,
+    int8_t *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto data_chunk = Int8Chunk::CreateView(data, num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetInt16Column(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index,
+    int16_t *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto data_chunk = Int16Chunk::CreateView(data, num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetInt32Column(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index,
+    int32_t *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto data_chunk = Int32Chunk::CreateView(data, num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetInt64Column(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index,
+    int64_t *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto data_chunk = Int64Chunk::CreateView(data, num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetFloatColumn(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index, float *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto data_chunk = FloatChunk::CreateView(data, num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetDoubleColumn(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index, double *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto data_chunk = DoubleChunk::CreateView(data, num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetCharAsInt16Column(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index, int16_t *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto data_chunk = CharChunk::Create(num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    // For char, boolean, DateTime, and String we have to do a little data conversion.
+    for (int64_t i = 0; i != num_rows; ++i) {
+      data[i] = static_cast<int16_t>(data_chunk.data()[i]);
+    }
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetBooleanAsInteropBoolColumn(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index, int8_t *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    // For char, boolean, DateTime, and String we have to do a little data conversion.
+    auto data_chunk = BooleanChunk::Create(num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    for (int64_t i = 0; i != num_rows; ++i) {
+      data[i] = data_chunk.data()[i] ? 1 : 0;
+    }
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetStringColumn(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index, StringHandle *data, InteropBool *optional_dest_null_flags,
+    int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    // For char, boolean, DateTime, and String we have to do a little data conversion.
+    auto data_chunk = StringChunk::Create(num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    StringPoolBuilder builder;
+    for (int64_t i = 0; i != num_rows; ++i) {
+      data[i] = builder.Add(data_chunk.data()[i]);
+    }
+    *string_pool_handle = builder.Build();
+  });
+}
+
+void deephaven_client_ClientTableHelper_GetDateTimeAsInt64Column(
+    NativePtr<ClientTableSpWrapper> self,
+    int32_t column_index, int64_t *data, InteropBool *optional_dest_null_flags, int64_t num_rows,
+    StringPoolHandle *string_pool_handle,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    // For char, boolean, DateTime, and String we have to do a little data conversion.
+    auto data_chunk = DateTimeChunk::Create(num_rows);
+    GetColumnHelper(self, column_index, &data_chunk, optional_dest_null_flags, num_rows);
+    for (int64_t i = 0; i != num_rows; ++i) {
+      data[i] = data_chunk.data()[i].Nanos();
+    }
+    // return default StringPoolHandle because this type doesn't need a string pool
+    *string_pool_handle = StringPoolHandle();
+  });
+}
+
+void deephaven_client_AggregateCombo_Create(
+    const NativePtr<Aggregate> *aggregate_ptrs,
+    int32_t num_aggregates,
+    NativePtr<AggregateCombo> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto agg_copies = MakeReservedVector<Aggregate>(num_aggregates);
+    for (int32_t i = 0; i != num_aggregates; ++i) {
+      agg_copies.push_back(*aggregate_ptrs[i]);
+    }
+    auto ac = AggregateCombo::Create(std::move(agg_copies));
+    result->Reset(new AggregateCombo(std::move(ac)));
+  });
+}
+
+void deephaven_client_AggregateCombo_dtor(NativePtr<AggregateCombo> self) {
+  delete self.Get();
+}
+
+void deephaven_client_Aggregate_dtor(NativePtr<Aggregate> self) {
+  delete self.Get();
+}
+
+void deephaven_client_Aggregate_AbsSum(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::AbsSum(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Group(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Group(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Avg(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Avg(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Count(
+    const char *column,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    result->Reset(new Aggregate(Aggregate::Count(column)));
+  });
+}
+
+void deephaven_client_Aggregate_First(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::First(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Last(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Last(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Max(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Max(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Med(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Med(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Min(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Min(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Pct(
+    double percentile, InteropBool avg_median,
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Pct(percentile, (bool)avg_median, std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Std(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Std(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Sum(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Sum(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_Var(
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::Var(std::move(cols))));
+  });
+}
+
+void deephaven_client_Aggregate_WAvg(const char *weight,
+    const char **columns, int32_t num_columns,
+    NativePtr<Aggregate> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    auto cols = std::vector<std::string>(columns, columns + num_columns);
+    result->Reset(new Aggregate(Aggregate::WAvg(std::string(weight), std::move(cols))));
+  });
+}
+
+void deephaven_client_utility_DurationSpecifier_ctor_nanos(int64_t nanos,
+    NativePtr<DurationSpecifier> *result,
+    ErrorStatus *status) {
+  status->Run([=] {
+    result->Reset(new DurationSpecifier(nanos));
+  });
+}
+
+void deephaven_client_utility_DurationSpecifier_ctor_durationstr(
+    const char *duration_str,
+    NativePtr<DurationSpecifier> *result,
+    ErrorStatus *status) {
+  status->Run([=] {
+    result->Reset(new DurationSpecifier(duration_str));
+  });
+}
+
+void deephaven_client_utility_DurationSpecifier_dtor(NativePtr<DurationSpecifier> self) {
+  delete self.Get();
+}
+
+void deephaven_client_utility_TimePointSpecifier_ctor_nanos(
+    int64_t nanos,
+    NativePtr<TimePointSpecifier> *result,
+    ErrorStatus *status) {
+  status->Run([=] {
+    result->Reset(new TimePointSpecifier(nanos));
+  });
+}
+
+void deephaven_client_utility_TimePointSpecifier_ctor_timepointstr(
+    const char *time_point_str,
+    NativePtr<TimePointSpecifier> *result,
+    ErrorStatus *status) {
+  status->Run([=] {
+    result->Reset(new TimePointSpecifier(time_point_str));
+  });
+}
+
+void deephaven_client_utility_TimePointSpecifier_dtor(NativePtr<TimePointSpecifier> self) {
+  delete self.Get();
+}
+
+void deephaven_dhclient_utility_TableMaker_ctor(
+    NativePtr<TableMaker> *result,
+    ErrorStatus *status) {
+  status->Run([=] {
+    result->Reset(new TableMaker());
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_dtor(NativePtr<TableMaker> self) {
+  delete self.Get();
+}
+
+void deephaven_dhclient_utility_TableMaker_MakeTable(
+    NativePtr<TableMaker> self,
+    NativePtr<TableHandleManager> manager,
+    NativePtr<TableHandle> *result,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto th = self->MakeTable(*manager);
+    result->Reset(new TableHandle(std::move(th)));
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__CharAsInt16(
+    NativePtr<TableMaker> self,
+    const char *name, const int16_t *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) -> int16_t { return static_cast<int16_t>(data[index]); };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<char16_t>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int8(
+    NativePtr<TableMaker> self,
+    const char *name, const int8_t *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return data[index]; };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<int8_t>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int16(
+    NativePtr<TableMaker> self,
+    const char *name, const int16_t *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return data[index]; };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<int16_t>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int32(
+    NativePtr<TableMaker> self,
+    const char *name, const int32_t *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return data[index]; };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<int32_t>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__Int64(
+    NativePtr<TableMaker> self,
+    const char *name, const int64_t *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return data[index]; };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<int64_t>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__Float(
+    NativePtr<TableMaker> self,
+    const char *name, const float *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return data[index]; };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<float>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__Double(
+    NativePtr<TableMaker> self,
+    const char *name, const double *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return data[index]; };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<double>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__BoolAsInteropBool(
+    NativePtr<TableMaker> self,
+    const char *name, const int8_t *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return data[index] != 0; };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<bool>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__DateTimeAsInt64(
+    NativePtr<TableMaker> self,
+    const char *name, const int64_t *data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) { return DateTime::FromNanos(data[index]); };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<DateTime>(name, get_value, is_null, length);
+  });
+}
+
+void deephaven_dhclient_utility_TableMaker_AddColumn__String(
+    NativePtr<TableMaker> self,
+    const char *name, const char **data, int32_t length,
+    const InteropBool *optional_nulls,
+    ErrorStatus *status) {
+  status->Run([=] {
+    auto get_value = [=](size_t index) -> std::string {
+      if (data[index] == nullptr) {
+        return "";
+      }
+      return data[index];
+    };
+    auto is_null = [=](size_t index) { return optional_nulls != nullptr && (bool)optional_nulls[index]; };
+    self->AddColumn<std::string>(name, get_value, is_null, length);
+  });
+}
+}  // extern "C"

--- a/cpp-client/deephaven/dhclient/src/interop/client_options_interop.cc
+++ b/cpp-client/deephaven/dhclient/src/interop/client_options_interop.cc
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/client/interop/client_options_interop.h"
+
+#include "deephaven/client/client.h"
+#include "deephaven/client/client_options.h"
+#include "deephaven/dhcore/interop/interop_util.h"
+
+using deephaven::dhcore::interop::ErrorStatus;
+using deephaven::dhcore::interop::InteropBool;
+using deephaven::dhcore::interop::NativePtr;
+
+using deephaven::client::ClientOptions;
+
+extern "C" {
+void deephaven_client_ClientOptions_ctor(NativePtr<ClientOptions> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    result->Reset(new ClientOptions());
+  });
+}
+
+void deephaven_client_ClientOptions_dtor(NativePtr<ClientOptions> self) {
+  delete self;
+}
+
+void deephaven_client_ClientOptions_SetDefaultAuthentication(NativePtr<ClientOptions> self,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetDefaultAuthentication();
+  });
+}
+
+void deephaven_client_ClientOptions_SetBasicAuthentication(NativePtr<ClientOptions> self,
+    const char *username, const char *password,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetBasicAuthentication(username, password);
+  });
+}
+
+void deephaven_client_ClientOptions_SetCustomAuthentication(NativePtr<ClientOptions> self,
+    const char *authentication_key, const char *authentication_value,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetCustomAuthentication(authentication_key, authentication_value);
+  });
+}
+
+void deephaven_client_ClientOptions_SetSessionType(NativePtr<ClientOptions> self,
+    const char *session_type,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetSessionType(session_type);
+  });
+}
+
+void deephaven_client_ClientOptions_SetUseTls(NativePtr<ClientOptions> self,
+    InteropBool use_tls,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetUseTls((bool)use_tls);
+  });
+
+}
+
+void deephaven_client_ClientOptions_SetTlsRootCerts(NativePtr<ClientOptions> self,
+    const char *tls_root_certs,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetTlsRootCerts(tls_root_certs);
+  });
+}
+
+void deephaven_client_ClientOptions_SetClientCertChain(NativePtr<ClientOptions> self,
+    const char *client_cert_chain,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetClientCertChain(client_cert_chain);
+  });
+
+}
+
+void deephaven_client_ClientOptions_SetClientPrivateKey(NativePtr<ClientOptions> self,
+    const char *client_private_key,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->SetClientPrivateKey(client_private_key);
+  });
+
+}
+
+void deephaven_client_ClientOptions_AddIntOption(NativePtr<ClientOptions> self,
+    const char *opt, int32_t val,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->AddIntOption(opt, val);
+  });
+
+}
+
+void deephaven_client_ClientOptions_AddStringOption(NativePtr<ClientOptions> self,
+    const char *opt, const char *val,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->AddStringOption(opt, val);
+  });
+}
+
+void deephaven_client_ClientOptions_AddExtraHeader(NativePtr<ClientOptions> self,
+    const char *header_name, const char *header_value,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    self->AddExtraHeader(header_name, header_value);
+  });
+}
+}  // extern "C"

--- a/cpp-client/deephaven/dhclient/src/interop/update_by_interop.cc
+++ b/cpp-client/deephaven/dhclient/src/interop/update_by_interop.cc
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/client/interop/update_by_interop.h"
+
+#include "deephaven/client/client.h"
+#include "deephaven/client/client_options.h"
+#include "deephaven/client/update_by.h"
+#include "deephaven/dhcore/interop/interop_util.h"
+
+using deephaven::dhcore::interop::ErrorStatus;
+using deephaven::dhcore::interop::InteropBool;
+using deephaven::dhcore::interop::NativePtr;
+
+using deephaven::client::ClientOptions;
+using deephaven::client::UpdateByOperation;
+using deephaven::client::update_by::DeltaControl;
+using deephaven::client::update_by::OperationControl;
+using deephaven::client::utility::DurationSpecifier;
+
+namespace {
+void WithColsHelper(const char **cols, int32_t num_cols,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status,
+    UpdateByOperation (*fp)(std::vector<std::string>)) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = (*fp)(std::move(columns));
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+
+void WithTicksHelper(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status,
+    UpdateByOperation (*fp)(double, std::vector<std::string>, const OperationControl &)) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = (*fp)(decay_ticks, std::move(columns), *op_control);
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+
+void WithTimeHelper(const char *timestamp_col,
+    NativePtr<DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status,
+    UpdateByOperation (*fp)(std::string, DurationSpecifier, std::vector<std::string>, const OperationControl &)) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = (*fp)(timestamp_col, *decay_time, std::move(columns), *op_control);
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+
+void WithRollingTicksHelper(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status,
+    UpdateByOperation (*fp)(std::vector<std::string>, int32_t, int32_t)) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = (*fp)(std::move(columns), rev_ticks, fwd_ticks);
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+
+void WithRollingTimeHelper(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status,
+    UpdateByOperation (*fp)(std::string, std::vector<std::string>, DurationSpecifier, DurationSpecifier)) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = (*fp)(timestamp_col, std::move(columns), *rev_time, *fwd_time);
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+
+void WithRollingWavgTicksHelper(const char *weight_col,
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status,
+    UpdateByOperation (*fp)(std::string, std::vector<std::string>, int32_t, int32_t)) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = (*fp)(weight_col, std::move(columns), rev_ticks, fwd_ticks);
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+
+void WithRollingWavgTimeHelper(const char *timestamp_col, const char *weight_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status,
+    UpdateByOperation (*fp)(std::string, std::string, std::vector<std::string>, DurationSpecifier, DurationSpecifier)) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = (*fp)(timestamp_col, weight_col, std::move(columns), *rev_time, *fwd_time);
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+}  // namespace
+
+extern "C" {
+void deephaven_client_UpdateByOperation_dtor(
+    NativePtr<UpdateByOperation> self) {
+  delete self.Get();
+}
+
+void deephaven_client_update_by_cumSum(
+    const char **cols, int32_t num_cols,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithColsHelper(cols, num_cols, result, status, &deephaven::client::update_by::cumSum);
+}
+
+void deephaven_client_update_by_cumProd(
+    const char **cols, int32_t num_cols,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithColsHelper(cols, num_cols, result, status, &deephaven::client::update_by::cumProd);
+}
+
+void deephaven_client_update_by_cumMin(
+    const char **cols, int32_t num_cols,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithColsHelper(cols, num_cols, result, status, &deephaven::client::update_by::cumMin);
+}
+
+void deephaven_client_update_by_cumMax(
+    const char **cols, int32_t num_cols,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithColsHelper(cols, num_cols, result, status, &deephaven::client::update_by::cumMax);
+}
+
+void deephaven_client_update_by_forwardFill(
+    const char **cols, int32_t num_cols,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithColsHelper(cols, num_cols, result, status, &deephaven::client::update_by::forwardFill);
+}
+
+void deephaven_client_update_by_delta(
+    const char **cols, int32_t num_cols,
+    deephaven::client::update_by::DeltaControl delta_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  status->Run([=]() {
+    std::vector<std::string> columns(cols, cols + num_cols);
+    auto ubo = deephaven::client::update_by::delta(std::move(columns), delta_control);
+    result->Reset(new UpdateByOperation(std::move(ubo)));
+  });
+}
+
+void deephaven_client_update_by_emaTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTicksHelper(decay_ticks, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emaTick);
+}
+
+void deephaven_client_update_by_emaTime(const char *timestamp_col,
+    NativePtr<DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTimeHelper(timestamp_col, decay_time, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emaTime);
+}
+
+void deephaven_client_update_by_emsTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTicksHelper(decay_ticks, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emsTick);
+}
+
+void deephaven_client_update_by_emsTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTimeHelper(timestamp_col, decay_time, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emsTime);
+}
+
+void deephaven_client_update_by_emminTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTicksHelper(decay_ticks, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emminTick);
+}
+
+void deephaven_client_update_by_emminTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTimeHelper(timestamp_col, decay_time, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emminTime);
+}
+
+void deephaven_client_update_by_emmaxTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTicksHelper(decay_ticks, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emmaxTick);
+}
+
+void deephaven_client_update_by_emmaxTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTimeHelper(timestamp_col, decay_time, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emmaxTime);
+}
+
+void deephaven_client_update_by_emstdTick(double decay_ticks,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTicksHelper(decay_ticks, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emstdTick);
+}
+
+void deephaven_client_update_by_emstdTime(const char *timestamp_col,
+    deephaven::dhcore::interop::NativePtr<deephaven::client::utility::DurationSpecifier> decay_time,
+    const char **cols, int32_t num_cols,
+    const OperationControl *op_control,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithTimeHelper(timestamp_col, decay_time, cols, num_cols, op_control, result, status,
+      &deephaven::client::update_by::emstdTime);
+}
+
+void deephaven_client_update_by_rollingSumTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingSumTick);
+}
+
+void deephaven_client_update_by_rollingSumTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingSumTime);
+}
+
+void deephaven_client_update_by_rollingGroupTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingGroupTick);
+}
+
+void deephaven_client_update_by_rollingGroupTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingGroupTime);
+}
+
+void deephaven_client_update_by_rollingAvgTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingAvgTick);
+}
+
+void deephaven_client_update_by_rollingAvgTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingAvgTime);
+}
+
+void deephaven_client_update_by_rollingMinTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingMinTick);
+}
+
+void deephaven_client_update_by_rollingMinTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingMinTime);
+}
+
+void deephaven_client_update_by_rollingMaxTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingMaxTick);
+}
+
+void deephaven_client_update_by_rollingMaxTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingMaxTime);
+}
+
+void deephaven_client_update_by_rollingProdTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingProdTick);
+}
+
+void deephaven_client_update_by_rollingProdTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingProdTime);
+}
+
+void deephaven_client_update_by_rollingCountTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingCountTick);
+}
+
+void deephaven_client_update_by_rollingCountTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingCountTime);
+}
+
+void deephaven_client_update_by_rollingStdTick(
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTicksHelper(cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingStdTick);
+}
+
+void deephaven_client_update_by_rollingStdTime(const char *timestamp_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingTimeHelper(timestamp_col, cols, num_cols, rev_time, fwd_time, result, status,
+      &deephaven::client::update_by::rollingStdTime);
+}
+
+void deephaven_client_update_by_rollingWavgTick(const char *weight_col,
+    const char **cols, int32_t num_cols,
+    int32_t rev_ticks, int32_t fwd_ticks,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingWavgTicksHelper(weight_col, cols, num_cols, rev_ticks, fwd_ticks, result, status,
+      &deephaven::client::update_by::rollingWavgTick);
+}
+
+void deephaven_client_update_by_rollingWavgTime(const char *timestamp_col,
+    const char *weight_col,
+    const char **cols, int32_t num_cols,
+    NativePtr<DurationSpecifier> rev_time,
+    NativePtr<DurationSpecifier> fwd_time,
+    NativePtr<UpdateByOperation> *result,
+    ErrorStatus *status) {
+  WithRollingWavgTimeHelper(timestamp_col, weight_col, cols, num_cols, rev_time, fwd_time,
+      result, status,
+      &deephaven::client::update_by::rollingWavgTime);
+}
+}  // extern "C"


### PR DESCRIPTION
This PR provides the entry points for the "C API" to the Deephaven C++ library.

Notes for the reviewer: `client_options_interop.[cc,h]` is probably the easiest to understand so I would recommend starting there. Then `client_interop.[cc,h]`

In many cases this is just writing "glue code" mechanically just by looking at the signatures of the methods in the C++ classes.

In a few cases we have made exceptions for simplicity.

For example `TableHandle::Sort` takes a vector of `SortPair`. For the C API, we *could* take an array of SortPair objects. But I decided it was simpler to decompose the SortPair object into its three components: `column_name_`, `direction_`, and `abs_`. So, for the Sort() C API we just pass in three arrays: of column names, of directions, and of abs, plus their length. Then the C API doesn't need to define a "SortPair" object at all.

There is also a bunch of template-heavy code involving changes to `TableMaker`. The C# code relies on this heavily (to make temporary tables for use in tests). You may not need to drill into this code, because it is complicated.

Currently the C++ test code, such as in `select_test.cc`, uses a call to the templated `CompareTables` method to compare actual tables to expected tables. In a future PR I will modify all this code to use `TableMaker` instead. At that time it will probably be more obvious how `TableMaker` is used.
