### PR TITLE
fix(cppclient): Remove extension from dhclient and dhcore for cross-platform compatibility

### DIFF
--- a/csharp/client/DeephavenClient/Interop/InteropSupport.cs
+++ b/csharp/client/DeephavenClient/Interop/InteropSupport.cs
@@ -6,8 +6,8 @@ using System.Text.Unicode;
 namespace Deephaven.DeephavenClient.Interop;
 
 internal class LibraryPaths {
-  internal const string Dhcore = "dhcore.dll";
-  internal const string Dhclient = "dhclient.dll";
+  internal const string Dhcore = "dhcore";
+  internal const string Dhclient = "dhclient";
 }
 
 /// <summary>


### PR DESCRIPTION
Windows expects a ".dll" suffix, and Linux expects ".so", but the machinery behind LibraryImport seems to know to do the right thing.
