### PR TITLE
ci: add gradle to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,15 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(github-actions)"
+    labels:
+      - "NoDocumentationNeeded"
+      - "NoReleaseNotesNeeded"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(gradle)"
+    labels:
+      - "NoDocumentationNeeded"
+      - "NoReleaseNotesNeeded"


### PR DESCRIPTION
This also adds "NoDocumentationNeeded" and "NoReleaseNotesNeeded" to the dependabot PRs.

See [dependabot gradle](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#gradle)

See [dependabot labels](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels)