### PR TITLE
fix(cppclient): Update versions and change build type

### DIFF
--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -263,7 +263,7 @@ Notes
 
 9. Now configure the build for Deephaven Core:
    ``` 
-   cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=%HOMEDRIVE%%HOMEPATH%/dhinstall -DX_VCPKG_APPLOCAL_DEPS_INSTALL=ON
+   cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=%HOMEDRIVE%%HOMEPATH%/dhinstall -DX_VCPKG_APPLOCAL_DEPS_INSTALL=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
    ```
    
 10. Finally, build and install Deephaven Core:

--- a/cpp-client/deephaven/vcpkg-configuration.json
+++ b/cpp-client/deephaven/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "0dc005fb66801c8a8266e81bd2cedb4d5501f30e",
+    "baseline": "2444315f12ac0151ebcb8b28ba7cb132927f285d",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/cpp-client/deephaven/vcpkg.json
+++ b/cpp-client/deephaven/vcpkg.json
@@ -12,6 +12,6 @@
 
   "overrides": [
     { "name": "arrow", "version": "13.0.0#1" },
-    { "name": "protobuf", "version": "3.21.2" }
+    { "name": "protobuf", "version": "4.25.1" }
   ]
 }


### PR DESCRIPTION
For Windows build:
* Update protobuf to 4.25.1
* Update vcpkg itself to current SHA
* Change README.md so that user builds with type `RelWithDebInfo`
