### PR TITLE
build: Make it easier to manually run GWT tests from the IDE

### DIFF
--- a/web/client-api/client-api.gradle
+++ b/web/client-api/client-api.gradle
@@ -70,6 +70,7 @@ artifacts {
 }
 
 def gwtUnitTest = tasks.register('gwtUnitTest', Test) { t ->
+    t.group = 'verification'
     t.systemProperties = [
             'gwt.args': ['-sourceLevel auto',
                          '-runStyle HtmlUnit',
@@ -138,6 +139,7 @@ def stopSelenium = project.tasks.register('stopSelenium', DockerRemoveContainer)
 }
 
 def gwtIntegrationTest = tasks.register('gwtIntegrationTest', Test) { t ->
+    t.group = 'verification'
     t.dependsOn(deephavenDocker.portTask, seleniumHealthy)
     t.finalizedBy(deephavenDocker.endTask, stopSelenium)
     t.doFirst {
@@ -161,6 +163,7 @@ def gwtIntegrationTest = tasks.register('gwtIntegrationTest', Test) { t ->
 }
 
 tasks.register('manualGwtTest', Test) {t ->
+    t.group = 'verification'
     t.description = '''Test wiring to run either unit or integration tests with a manual browser and an already-running server.
 This makes it easier to run a tests repeatedly, either one at a time or as a class/suite, without
 paying to start/stop selenium and deephaven each time. The port will remain constant at 8888 each

--- a/web/client-api/client-api.gradle
+++ b/web/client-api/client-api.gradle
@@ -71,7 +71,8 @@ artifacts {
 
 def gwtUnitTest = tasks.register('gwtUnitTest', Test) { t ->
     t.systemProperties = [
-            'gwt.args': ['-runStyle HtmlUnit',
+            'gwt.args': ['-sourceLevel auto',
+                         '-runStyle HtmlUnit',
                          '-ea',
                          '-style PRETTY',
                          "-war ${layout.buildDirectory.dir('unitTest-war').get().asFile.absolutePath}"
@@ -139,9 +140,10 @@ def stopSelenium = project.tasks.register('stopSelenium', DockerRemoveContainer)
 def gwtIntegrationTest = tasks.register('gwtIntegrationTest', Test) { t ->
     t.dependsOn(deephavenDocker.portTask, seleniumHealthy)
     t.finalizedBy(deephavenDocker.endTask, stopSelenium)
-    doFirst {
+    t.doFirst {
         def webdriverUrl = "http://localhost:${seleniumPort}/"
-        t.systemProperty('gwt.args', ["-runStyle io.deephaven.web.junit.RunStyleRemoteWebDriver:${webdriverUrl}?firefox",
+        t.systemProperty('gwt.args', ['-sourceLevel auto',
+                                      "-runStyle io.deephaven.web.junit.RunStyleRemoteWebDriver:${webdriverUrl}?firefox",
                                       '-ea',
                                       '-style PRETTY',
                                       "-setProperty dh.server=http://${deephavenDocker.containerName.get()}:10000",
@@ -149,12 +151,42 @@ def gwtIntegrationTest = tasks.register('gwtIntegrationTest', Test) { t ->
         ].join(' '))
         t.classpath += tasks.getByName('gwtCompile').src
     }
-    t.finalizedBy(deephavenDocker.endTask)
     t.systemProperties = [
             'gwt.persistentunitcachedir':layout.buildDirectory.dir('integrationTest-unitCache').get().asFile.absolutePath,
             'webdriver.test.host':'host.docker.internal',
     ]
     t.include '**/ClientIntegrationTestSuite.class'
+    t.useJUnit()
+    t.scanForTestClasses = false
+}
+
+tasks.register('manualGwtTest', Test) {t ->
+    t.description = '''Test wiring to run either unit or integration tests with a manual browser and an already-running server.
+This makes it easier to run a tests repeatedly, either one at a time or as a class/suite, without
+paying to start/stop selenium and deephaven each time. The port will remain constant at 8888 each
+run to let breakpoints continue to work across repeated runs.
+
+To use this, first start a server on port 10000 with anonymous access enabled. Then, either select
+a test in IntelliJ to run using the manualGwtTest task, or invoke from the command line with info
+logging enabled and a specific test selected, e.g.:
+./gradlew :web-client-api:manualGwtTest --info --tests io.deephaven.web.client.api.NullValueTestGwt
+
+When the URL appears to run in your browser, click on it, or refresh an existing browser window.'''
+    t.doFirst {
+        t.systemProperty 'gwt.args', ['-port 8888',
+                                      '-sourceLevel auto',
+                                      '-runStyle Manual:1',
+                                      '-ea',
+                                      '-style PRETTY',
+                                      '-setProperty dh.server=http://localhost:10000',
+                                      '-setProperty compiler.useSourceMaps=true',
+                                      "-war ${layout.buildDirectory.dir('manualTest-war').get().asFile.absolutePath}"
+        ].join(' ')
+        t.classpath += tasks.getByName('gwtCompile').src
+    }
+    t.systemProperties = [
+            'gwt.persistentunitcachedir':layout.buildDirectory.dir('integrationTest-unitCache').get().asFile.absolutePath,
+    ]
     t.useJUnit()
     t.scanForTestClasses = false
 }

--- a/web/client-api/client-api.gradle
+++ b/web/client-api/client-api.gradle
@@ -171,7 +171,7 @@ a test in IntelliJ to run using the manualGwtTest task, or invoke from the comma
 logging enabled and a specific test selected, e.g.:
 ./gradlew :web-client-api:manualGwtTest --info --tests io.deephaven.web.client.api.NullValueTestGwt
 
-When the URL appears to run in your browser, click on it, or refresh an existing browser window.'''
+Click the URL that is printed out to run the test in your browser, or refresh an existing browser window.'''
     t.doFirst {
         t.systemProperty 'gwt.args', ['-port 8888',
                                       '-sourceLevel auto',


### PR DESCRIPTION
Summary from the task description:

> Test wiring to run either unit or integration tests with a manual browser and an already-running server. This makes it easier to run a tests repeatedly, either one at a time or as a class/suite, without paying to start/stop selenium and deephaven each time. The port will remain constant at 8888 each run to let breakpoints continue to work across repeated runs.
> 
> To use this, first start a server on port 10000 with anonymous access enabled. Then, either select a test in IntelliJ to run using the manualGwtTest task, or invoke from the command line with info logging enabled and a specific test selected, e.g.:
>
> ./gradlew :web-client-api:manualGwtTest --info --tests io.deephaven.web.client.api.NullValueTestGwt
>
> Click the URL that is printed out to run the test in your browser, or refresh an existing browser window.