### PR TITLE
refactor!: Remove tracking of "culprit" from Require methods

### DIFF
--- a/Base/src/main/java/io/deephaven/base/stats/Composite.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Composite.java
@@ -25,13 +25,13 @@ public class Composite extends Value {
 
     // ----------------------------------------------------------------
     private static Value[] checkValues(Value[] values) {
-        Require.neqNull(values, "values", 1);
-        Require.gtZero(values.length, "values.length", 1);
-        Require.neqNull(values[0], "values[0]", 1);
+        Require.neqNull(values, "values");
+        Require.gtZero(values.length, "values.length");
+        Require.neqNull(values[0], "values[0]");
         char typeTag = values[0].getTypeTag();
         for (int nIndex = 1; nIndex < values.length; nIndex++) {
-            Require.neqNull(values[nIndex], "values[nIndex]", 1);
-            Require.eq(values[nIndex].getTypeTag(), "values[nIndex].getTypeTag()", typeTag, "typeTag", 1);
+            Require.neqNull(values[nIndex], "values[nIndex]");
+            Require.eq(values[nIndex].getTypeTag(), "values[nIndex].getTypeTag()", typeTag, "typeTag");
         }
         return values;
     }

--- a/Base/src/main/java/io/deephaven/base/verify/Require.java
+++ b/Base/src/main/java/io/deephaven/base/verify/Require.java
@@ -89,8 +89,7 @@ public final class Require {
     // ----------------------------------------------------------------
     private static void fail(String conditionText, int numCallsBelowRequirer) {
         final RequirementFailure requirementFailure = new RequirementFailure(
-                ExceptionMessageUtil.failureMessage("Requirement", "required", conditionText, null),
-                numCallsBelowRequirer + 1);
+                ExceptionMessageUtil.failureMessage("Requirement", "required", conditionText, null));
         if (onFailureCallback != null) {
             try {
                 onFailureCallback.accept(requirementFailure);
@@ -103,8 +102,7 @@ public final class Require {
     // ----------------------------------------------------------------
     private static void fail(String conditionText, String detailMessage, int numCallsBelowRequirer) {
         final RequirementFailure requirementFailure = new RequirementFailure(
-                ExceptionMessageUtil.failureMessage("Requirement", "required", conditionText, detailMessage),
-                numCallsBelowRequirer + 1);
+                ExceptionMessageUtil.failureMessage("Requirement", "required", conditionText, detailMessage));
         if (onFailureCallback != null) {
             try {
                 onFailureCallback.accept(requirementFailure);

--- a/Base/src/main/java/io/deephaven/base/verify/Require.java
+++ b/Base/src/main/java/io/deephaven/base/verify/Require.java
@@ -16,42 +16,41 @@ import java.util.function.Consumer;
  * <p>
  * Methods:
  * <ul>
- * <li>void requirement(boolean condition, String conditionText[, String detailMessage][, int numCallsBelowRequirer])
- * <li>void requirement(boolean condition, String conditionText, value0, String name0, value1, String name1, ... [, int
- * numCallsBelowRequirer])
+ * <li>void requirement(boolean condition, String conditionText[, String detailMessage])
+ * <li>void requirement(boolean condition, String conditionText, value0, String name0, value1, String name1, ... )
  * </ul>
  * <ul>
- * <li>void statementNeverExecuted([int numCallsBelowRequirer])
- * <li>void statementNeverExecuted(String statementDescription[, int numCallsBelowRequirer])
- * <li>void exceptionNeverCaught(Exception caughtException[, int numCallsBelowRequirer])
- * <li>void exceptionNeverCaught(String tryStatementDescription, Exception caughtException[, int numCallsBelowRequirer])
- * <li>void valueNeverOccurs(value, String name[, int numCallsBelowRequirer])
- * <li>void valuesNeverOccur(value0, name0, value1, name1, ... [, int numCallsBelowRequirer])
+ * <li>void statementNeverExecuted()
+ * <li>void statementNeverExecuted(String statementDescription)
+ * <li>void exceptionNeverCaught(Exception caughtException)
+ * <li>void exceptionNeverCaught(String tryStatementDescription, Exception caughtException)
+ * <li>void valueNeverOccurs(value, String name)
+ * <li>void valuesNeverOccur(value0, name0, value1, name1, ... )
  * </ul>
  * <ul>
- * <li>void holdsLock/notHoldsLock(Object, String name[, int numCallsBelowRequirer])
+ * <li>void holdsLock/notHoldsLock(Object, String name)
  * </ul>
  * <ul>
- * <li>void instanceOf/notInstanceOf(Object, String name, Class type[, int numCallsBelowRequirer])
+ * <li>void instanceOf/notInstanceOf(Object, String name, Class type)
  * </ul>
  * <ul>
  * <li>void eq/neq(boolean/char/byte/short/int/long/float/double, String name0,
- * boolean/char/byte/short/int/long/float/double[, String name1][, int numCallsBelowRequirer])
+ * boolean/char/byte/short/int/long/float/double[, String name1])
  * <li>void lt/leq/gt/geq(char/byte/short/int/long/float/double, String name0, char/byte/short/int/long/float/double[,
- * String name1][, int numCallsBelowRequirer])
+ * String name1])
  * </ul>
  * <ul>
- * <li>void eqFalse/neqFalse/eqTrue/neqTrue(boolean, String name[, int numCallsBelowRequirer])
- * <li>void eqZero/neqZero(char/byte/short/int/long/float/double, String name[, int numCallsBelowRequirer])
- * <li>void ltZero/leqZero/gtZero/geqZero(byte/short/int/long/float/double, String name[, int numCallsBelowRequirer])
+ * <li>void eqFalse/neqFalse/eqTrue/neqTrue(boolean, String name)
+ * <li>void eqZero/neqZero(char/byte/short/int/long/float/double, String name)
+ * <li>void ltZero/leqZero/gtZero/geqZero(byte/short/int/long/float/double, String name)
  * </ul>
  * <ul>
- * <li>void eq/neq(Object, name0, Object[, name1][, int numCallsBelowRequirer])
- * <li>void eqNull/neqNull(Object, String name[, int numCallsBelowRequirer])
+ * <li>void eq/neq(Object, name0, Object[, name1])
+ * <li>void eqNull/neqNull(Object, String name)
  * </ul>
  * <ul>
- * <li>void equals(Object, String name0, Object, String name1[, int numCallsBelowRequirer])
- * <li>void nonempty(String, String name[, int numCallsBelowRequirer])
+ * <li>void equals(Object, String name0, Object, String name1)
+ * <li>void nonempty(String, String name)
  * </ul>
  * <p>
  * Naming Rationale:
@@ -87,7 +86,7 @@ public final class Require {
     // Handle failed requirements
 
     // ----------------------------------------------------------------
-    private static void fail(String conditionText, int numCallsBelowRequirer) {
+    private static void fail(String conditionText) {
         final RequirementFailure requirementFailure = new RequirementFailure(
                 ExceptionMessageUtil.failureMessage("Requirement", "required", conditionText, null));
         if (onFailureCallback != null) {
@@ -100,7 +99,7 @@ public final class Require {
     }
 
     // ----------------------------------------------------------------
-    private static void fail(String conditionText, String detailMessage, int numCallsBelowRequirer) {
+    private static void fail(String conditionText, String detailMessage) {
         final RequirementFailure requirementFailure = new RequirementFailure(
                 ExceptionMessageUtil.failureMessage("Requirement", "required", conditionText, detailMessage));
         if (onFailureCallback != null) {
@@ -116,430 +115,247 @@ public final class Require {
     // requirement
 
     // ----------------------------------------------------------------
-    /**
-     * require (condition, conditionText)
-     */
-    public static void requirement(boolean condition, String conditionText, int numCallsBelowRequirer) {
-        if (!(condition)) {
-            fail(conditionText, numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void requirement(boolean condition, String conditionText) {
-        requirement(condition, conditionText, 1);
+        if (!(condition)) {
+            fail(conditionText);
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (condition, conditionText, detailMessage)
-     */
-    public static void requirement(boolean condition, String conditionText, String detailMessage,
-            int numCallsBelowRequirer) {
-        if (!(condition)) {
-            fail(conditionText, detailMessage, numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void requirement(boolean condition, String conditionText, String detailMessage) {
-        requirement(condition, conditionText, detailMessage, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (condition, Object o0, String name0, ... )
-     */
-    public static void requirement(boolean condition, String conditionText, Object o0, String name0,
-            int numCallsBelowRequirer) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0), numCallsBelowRequirer + 1);
+            fail(conditionText, detailMessage);
         }
     }
 
-    public static void requirement(boolean condition, String conditionText, Object o0, String name0) {
-        requirement(condition, conditionText, o0, name0, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void requirement(boolean condition, String conditionText, Object o0, String name0, Object o1,
-            String name1, int numCallsBelowRequirer) {
+    public static void requirement(boolean condition, String conditionText, Object o0, String name0) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1), numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0));
         }
     }
 
     public static void requirement(boolean condition, String conditionText, Object o0, String name0, Object o1,
             String name1) {
-        requirement(condition, conditionText, o0, name0, o1, name1, 1);
-    }
-
-    public static void requirement(boolean condition, String conditionText, Object o0, String name0, Object o1,
-            String name1, Object o2, String name2, int numCallsBelowRequirer) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1, o2, name2),
-                    numCallsBelowRequirer + 1);
-        }
-    }
-
-    public static void requirement(boolean condition, String conditionText, long o0, String name0, long o1,
-            String name1, long o2, String name2, int numCallsBelowRequirer) {
-        if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1, o2, name2),
-                    numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1));
         }
     }
 
     public static void requirement(boolean condition, String conditionText, Object o0, String name0, Object o1,
             String name1, Object o2, String name2) {
-        requirement(condition, conditionText, o0, name0, o1, name1, o2, name2, 1);
+        if (!(condition)) {
+            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1, o2, name2));
+        }
     }
 
     public static void requirement(boolean condition, String conditionText, long o0, String name0, long o1,
             String name1, long o2, String name2) {
-        requirement(condition, conditionText, o0, name0, o1, name1, o2, name2, 1);
-    }
-
-    public static void requirement(boolean condition, String conditionText, Object o0, String name0, Object o1,
-            String name1, Object o2, String name2, Object o3, String name3, int numCallsBelowRequirer) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1, o2, name2, o3, name3),
-                    numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1, o2, name2));
         }
     }
 
     public static void requirement(boolean condition, String conditionText, Object o0, String name0, Object o1,
             String name1, Object o2, String name2, Object o3, String name3) {
-        requirement(condition, conditionText, o0, name0, o1, name1, o2, name2, o3, name3, 1);
+        if (!(condition)) {
+            fail(conditionText, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1, o2, name2, o3, name3));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (condition, boolean b0, String name0, ... )
-     */
-    public static void requirement(boolean condition, String conditionText, boolean b0, String name0,
-            int numCallsBelowRequirer) {
-        if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void requirement(boolean condition, String conditionText, boolean b0, String name0) {
-        requirement(condition, conditionText, b0, name0, 1);
-    }
-
-    public static void requirement(boolean condition, String conditionText, boolean b0, String name0, boolean b1,
-            String name1, int numCallsBelowRequirer) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1), numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0));
         }
     }
 
     public static void requirement(boolean condition, String conditionText, boolean b0, String name0, boolean b1,
             String name1) {
-        requirement(condition, conditionText, b0, name0, b1, name1, 1);
+        if (!(condition)) {
+            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
+        }
     }
 
     public static void requirement(boolean condition, String conditionText, boolean b0, String name0, double d1,
-            String name1, int numCallsBelowRequirer) {
+            String name1) {
         if (!(condition)) {
             fail(conditionText, ExceptionMessageUtil.concat(ExceptionMessageUtil.valueAndName(b0, name0),
-                    ExceptionMessageUtil.valueAndName(d1, name1)), numCallsBelowRequirer + 1);
-        }
-    }
-
-    public static void requirement(boolean condition, String conditionText, boolean b0, String name0, double d1,
-            String name1) {
-        requirement(condition, conditionText, b0, name0, d1, name1, 1);
-    }
-
-    public static void requirement(boolean condition, String conditionText, boolean b0, String name0, boolean b1,
-            String name1, boolean b2, String name2, int numCallsBelowRequirer) {
-        if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1, b2, name2),
-                    numCallsBelowRequirer + 1);
+                    ExceptionMessageUtil.valueAndName(d1, name1)));
         }
     }
 
     public static void requirement(boolean condition, String conditionText, boolean b0, String name0, boolean b1,
             String name1, boolean b2, String name2) {
-        requirement(condition, conditionText, b0, name0, b1, name1, b2, name2, 1);
-    }
-
-    public static void requirement(boolean condition, String conditionText, boolean b0, String name0, boolean b1,
-            String name1, boolean b2, String name2, boolean b3, String name3, int numCallsBelowRequirer) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1, b2, name2, b3, name3),
-                    numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1, b2, name2));
         }
     }
 
     public static void requirement(boolean condition, String conditionText, boolean b0, String name0, boolean b1,
             String name1, boolean b2, String name2, boolean b3, String name3) {
-        requirement(condition, conditionText, b0, name0, b1, name1, b2, name2, b3, name3, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (condition, int i0, String name0, ... )
-     */
-    public static void requirement(boolean condition, String conditionText, int i0, String name0,
-            int numCallsBelowRequirer) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(i0, name0), numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1, b2, name2, b3, name3));
         }
     }
 
-    public static void requirement(boolean condition, String conditionText, int i0, String name0) {
-        requirement(condition, conditionText, i0, name0, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void requirement(boolean condition, String conditionText, int i0, String name0, int i1, String name1,
-            int numCallsBelowRequirer) {
+    public static void requirement(boolean condition, String conditionText, int i0, String name0) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1), numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(i0, name0));
         }
     }
 
     public static void requirement(boolean condition, String conditionText, int i0, String name0, int i1,
             String name1) {
-        requirement(condition, conditionText, i0, name0, i1, name1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (condition, long l0, String name0, ... )
-     */
-    public static void requirement(boolean condition, String conditionText, long l0, String name0,
-            int numCallsBelowRequirer) {
         if (!(condition)) {
-            fail(conditionText, ExceptionMessageUtil.valueAndName(l0, name0), numCallsBelowRequirer + 1);
+            fail(conditionText, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1));
         }
     }
 
+    // ----------------------------------------------------------------
+
     public static void requirement(boolean condition, String conditionText, long l0, String name0) {
-        requirement(condition, conditionText, l0, name0, 1);
+        if (!(condition)) {
+            fail(conditionText, ExceptionMessageUtil.valueAndName(l0, name0));
+        }
     }
 
     // ################################################################
     // statementNeverExecuted
 
     // ----------------------------------------------------------------
-    /**
-     * require (this statement is never executed)
-     */
-    public static RequirementFailure statementNeverExecuted(int numCallsBelowRequirer) {
-        fail("statement is never executed", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure statementNeverExecuted() {
-        return statementNeverExecuted(1);
+        fail("statement is never executed");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (statementDescription is never executed)
-     */
-    public static RequirementFailure statementNeverExecuted(String statementDescription, int numCallsBelowRequirer) {
-        fail(statementDescription + " is never executed", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure statementNeverExecuted(String statementDescription) {
-        return statementNeverExecuted(statementDescription, 1);
+        fail(statementDescription + " is never executed");
+        return null;
     }
 
     // ################################################################
     // exceptionNeverCaught
 
     // ----------------------------------------------------------------
-    /**
-     * require (this exception is never caught, Exception e)
-     */
-    public static RequirementFailure exceptionNeverCaught(Exception e, int numCallsBelowRequirer) {
+
+    public static RequirementFailure exceptionNeverCaught(Exception e) {
         try {
             fail(e.getClass().getName() + " is never caught",
-                    e.getClass().getName() + "(" + e.getMessage() + ") caught", numCallsBelowRequirer + 1);
+                    e.getClass().getName() + "(" + e.getMessage() + ") caught");
         } catch (RequirementFailure requirementFailure) {
             requirementFailure.initCause(e);
             throw requirementFailure;
         }
         return null;
-    }
-
-    public static RequirementFailure exceptionNeverCaught(Exception e) {
-        return exceptionNeverCaught(e, 1);
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (tryStatementDescription succeeds, Exception e)
-     */
-    public static RequirementFailure exceptionNeverCaught(String tryStatementDescription, Exception e,
-            int numCallsBelowRequirer) {
+
+    public static RequirementFailure exceptionNeverCaught(String tryStatementDescription, Exception e) {
         try {
-            fail(tryStatementDescription + " succeeds", e.getClass().getName() + "(" + e.getMessage() + ") caught",
-                    numCallsBelowRequirer + 1);
+            fail(tryStatementDescription + " succeeds", e.getClass().getName() + "(" + e.getMessage() + ") caught");
         } catch (RequirementFailure requirementFailure) {
             requirementFailure.initCause(e);
             throw requirementFailure;
         }
         return null;
-    }
-
-    public static RequirementFailure exceptionNeverCaught(String tryStatementDescription, Exception e) {
-        return exceptionNeverCaught(tryStatementDescription, e, 1);
     }
 
     // ################################################################
     // valueNeverOccurs
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, Object o, name)
-     */
-    public static RequirementFailure valueNeverOccurs(Object o, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(o, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(Object o, String name) {
-        return valueNeverOccurs(o, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(o, name) + " never occurs");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, boolean b, name)
-     */
-    public static RequirementFailure valueNeverOccurs(boolean b, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(b, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(boolean b, String name) {
-        return valueNeverOccurs(b, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(b, name) + " never occurs");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, char c, name)
-     */
-    public static RequirementFailure valueNeverOccurs(char c, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(c, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(char c, String name) {
-        return valueNeverOccurs(c, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(c, name) + " never occurs");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, byte b, name)
-     */
-    public static RequirementFailure valueNeverOccurs(byte b, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(b, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(byte b, String name) {
-        return valueNeverOccurs(b, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(b, name) + " never occurs");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, short s, name)
-     */
-    public static RequirementFailure valueNeverOccurs(short s, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(s, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(short s, String name) {
-        return valueNeverOccurs(s, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(s, name) + " never occurs");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, int i, name)
-     */
-    public static RequirementFailure valueNeverOccurs(int i, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(i, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(int i, String name) {
-        return valueNeverOccurs(i, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(i, name) + " never occurs");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, long l, name)
-     */
-    public static RequirementFailure valueNeverOccurs(long l, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(l, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(long l, String name) {
-        return valueNeverOccurs(l, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(l, name) + " never occurs");
+        return null;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, float f, name)
-     */
-    public static RequirementFailure valueNeverOccurs(float f, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(f, name) + " never occurs", numCallsBelowRequirer + 1);
-        return null;
-    }
 
     public static RequirementFailure valueNeverOccurs(float f, String name) {
-        return valueNeverOccurs(f, name, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (this value never occurs, double d, name)
-     */
-    public static RequirementFailure valueNeverOccurs(double d, String name, int numCallsBelowRequirer) {
-        fail(ExceptionMessageUtil.valueAndName(d, name) + " never occurs", numCallsBelowRequirer + 1);
+        fail(ExceptionMessageUtil.valueAndName(f, name) + " never occurs");
         return null;
     }
 
+    // ----------------------------------------------------------------
+
     public static RequirementFailure valueNeverOccurs(double d, String name) {
-        return valueNeverOccurs(d, name, 1);
+        fail(ExceptionMessageUtil.valueAndName(d, name) + " never occurs");
+        return null;
     }
 
     // ################################################################
     // holdsLock, notHoldsLock
 
     // ----------------------------------------------------------------
-    /**
-     * require (o != null &amp;&amp; (current thread holds o's lock))
-     */
-    public static void holdsLock(Object o, String name, int numCallsBelowRequirer) {
-        neqNull(o, "o");
-        if (!Thread.holdsLock(o)) {
-            fail("\"" + Thread.currentThread().getName() + "\".holdsLock(" + name + ")", numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void holdsLock(Object o, String name) {
-        holdsLock(o, name, 1);
+        neqNull(o, "o");
+        if (!Thread.holdsLock(o)) {
+            fail("\"" + Thread.currentThread().getName() + "\".holdsLock(" + name + ")");
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (o != null &amp;&amp; !(current thread holds o's lock))
-     */
-    public static void notHoldsLock(Object o, String name, int numCallsBelowRequirer) {
-        neqNull(o, "o");
-        if (Thread.holdsLock(o)) {
-            fail("!\"" + Thread.currentThread().getName() + "\".holdsLock(" + name + ")", numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void notHoldsLock(Object o, String name) {
-        notHoldsLock(o, name, 1);
+        neqNull(o, "o");
+        if (Thread.holdsLock(o)) {
+            fail("!\"" + Thread.currentThread().getName() + "\".holdsLock(" + name + ")");
+        }
     }
 
 
@@ -547,1216 +363,714 @@ public final class Require {
     // instanceOf, notInstanceOf
 
     // ----------------------------------------------------------------
-    /**
-     * require (o instanceof type)
-     */
-    public static <T> void instanceOf(Object o, String name, Class<T> type, int numCallsBelowRequirer) {
-        if (!type.isInstance(o)) {
-            fail(name + " instanceof " + type, null == o ? ExceptionMessageUtil.valueAndName(o, name)
-                    : name + " instanceof " + o.getClass() + " (" + ExceptionMessageUtil.valueAndName(o, name) + ")",
-                    numCallsBelowRequirer + 1);
-        }
-    }
 
     public static <T> void instanceOf(Object o, String name, Class<T> type) {
-        instanceOf(o, name, type, 1);
+        if (!type.isInstance(o)) {
+            fail(name + " instanceof " + type, null == o ? ExceptionMessageUtil.valueAndName(o, name)
+                    : name + " instanceof " + o.getClass() + " (" + ExceptionMessageUtil.valueAndName(o, name) + ")");
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require !(o instanceof type)
-     */
-    public static <T> void notInstanceOf(Object o, String name, Class<T> type, int numCallsBelowRequirer) {
-        if (type.isInstance(o)) {
-            fail("!(" + name + " instanceof " + type + ")",
-                    name + " instanceof " + o.getClass() + " (" + ExceptionMessageUtil.valueAndName(o, name) + ")",
-                    numCallsBelowRequirer + 1);
-        }
-    }
 
     public static <T> void notInstanceOf(Object o, String name, Class<T> type) {
-        notInstanceOf(o, name, type, 1);
+        if (type.isInstance(o)) {
+            fail("!(" + name + " instanceof " + type + ")",
+                    name + " instanceof " + o.getClass() + " (" + ExceptionMessageUtil.valueAndName(o, name) + ")");
+        }
     }
 
     // ################################################################
     // eq (primitiveValue == primitiveValue)
 
     // ----------------------------------------------------------------
-    /**
-     * require (b0 == b1)
-     */
-    public static void eq(boolean b0, String name0, boolean b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 == b1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eq(boolean b0, String name0, boolean b1, String name1) {
-        eq(b0, name0, b1, name1, 1);
-    }
-
-    public static void eq(boolean b0, String name0, boolean b1, int numCallsBelowRequirer) {
         if (!(b0 == b1)) {
-            fail(name0 + " == " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
     }
 
     public static void eq(boolean b0, String name0, boolean b1) {
-        eq(b0, name0, b1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (c0 == c1)
-     */
-    public static void eq(char c0, String name0, char c1, String name1, int numCallsBelowRequirer) {
-        if (!(c0 == c1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(b0 == b1)) {
+            fail(name0 + " == " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
         }
     }
 
-    public static void eq(char c0, String name0, char c1, String name1) {
-        eq(c0, name0, c1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void eq(char c0, String name0, char c1, int numCallsBelowRequirer) {
+    public static void eq(char c0, String name0, char c1, String name1) {
         if (!(c0 == c1)) {
-            fail(name0 + " == " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1));
         }
     }
 
     public static void eq(char c0, String name0, char c1) {
-        eq(c0, name0, c1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (b0 == b1)
-     */
-    public static void eq(byte b0, String name0, byte b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 == b1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(c0 == c1)) {
+            fail(name0 + " == " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0));
         }
     }
 
-    public static void eq(byte b0, String name0, byte b1, String name1) {
-        eq(b0, name0, b1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void eq(byte b0, String name0, byte b1, int numCallsBelowRequirer) {
+    public static void eq(byte b0, String name0, byte b1, String name1) {
         if (!(b0 == b1)) {
-            fail(name0 + " == " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
     }
 
     public static void eq(byte b0, String name0, byte b1) {
-        eq(b0, name0, b1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (s0 == s1)
-     */
-    public static void eq(short s0, String name0, short s1, String name1, int numCallsBelowRequirer) {
-        if (!(s0 == s1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(b0 == b1)) {
+            fail(name0 + " == " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
         }
     }
 
-    public static void eq(short s0, String name0, short s1, String name1) {
-        eq(s0, name0, s1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void eq(short s0, String name0, short s1, int numCallsBelowRequirer) {
+    public static void eq(short s0, String name0, short s1, String name1) {
         if (!(s0 == s1)) {
-            fail(name0 + " == " + s1, ExceptionMessageUtil.valueAndName(s0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1));
         }
     }
 
     public static void eq(short s0, String name0, short s1) {
-        eq(s0, name0, s1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (i0 == i1)
-     */
-    public static void eq(int i0, String name0, int i1, String name1, int numCallsBelowRequirer) {
-        if (!(i0 == i1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(s0 == s1)) {
+            fail(name0 + " == " + s1, ExceptionMessageUtil.valueAndName(s0, name0));
         }
     }
 
-    public static void eq(int i0, String name0, int i1, String name1) {
-        eq(i0, name0, i1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void eq(int i0, String name0, int i1, int numCallsBelowRequirer) {
+    public static void eq(int i0, String name0, int i1, String name1) {
         if (!(i0 == i1)) {
-            fail(name0 + " == " + i1, ExceptionMessageUtil.valueAndName(i0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1));
         }
     }
 
     public static void eq(int i0, String name0, int i1) {
-        eq(i0, name0, i1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (l0 == l1)
-     */
-    public static void eq(long l0, String name0, long l1, String name1, int numCallsBelowRequirer) {
-        if (!(l0 == l1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(i0 == i1)) {
+            fail(name0 + " == " + i1, ExceptionMessageUtil.valueAndName(i0, name0));
         }
     }
 
-    public static void eq(long l0, String name0, long l1, String name1) {
-        eq(l0, name0, l1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void eq(long l0, String name0, long l1, int numCallsBelowRequirer) {
+    public static void eq(long l0, String name0, long l1, String name1) {
         if (!(l0 == l1)) {
-            fail(name0 + " == " + l1, ExceptionMessageUtil.valueAndName(l0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1));
         }
     }
 
     public static void eq(long l0, String name0, long l1) {
-        eq(l0, name0, l1, 1);
+        if (!(l0 == l1)) {
+            fail(name0 + " == " + l1, ExceptionMessageUtil.valueAndName(l0, name0));
+        }
     }
 
     // ----------------------------------------------------------------
     /**
      * require (f0 == f1)
      */
-    public static void eq(float f0, String name0, float f1, String name1, int numCallsBelowRequirer) {
-        if (!(f0 == f1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-    }
-
     public static void eq(float f0, String name0, float f1, String name1) {
-        eq(f0, name0, f1, name1, 1);
-    }
-
-    public static void eq(float f0, String name0, float f1, int numCallsBelowRequirer) {
         if (!(f0 == f1)) {
-            fail(name0 + " == " + f1, ExceptionMessageUtil.valueAndName(f0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1));
         }
     }
 
     public static void eq(float f0, String name0, float f1) {
-        eq(f0, name0, f1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (d0 == d1)
-     */
-    public static void eq(double d0, String name0, double d1, String name1, int numCallsBelowRequirer) {
-        if (!(d0 == d1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(f0 == f1)) {
+            fail(name0 + " == " + f1, ExceptionMessageUtil.valueAndName(f0, name0));
         }
     }
 
-    public static void eq(double d0, String name0, double d1, String name1) {
-        eq(d0, name0, d1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void eq(double d0, String name0, double d1, int numCallsBelowRequirer) {
+    public static void eq(double d0, String name0, double d1, String name1) {
         if (!(d0 == d1)) {
-            fail(name0 + " == " + d1, ExceptionMessageUtil.valueAndName(d0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1));
         }
     }
 
     public static void eq(double d0, String name0, double d1) {
-        eq(d0, name0, d1, 1);
+        if (!(d0 == d1)) {
+            fail(name0 + " == " + d1, ExceptionMessageUtil.valueAndName(d0, name0));
+        }
     }
 
     // ################################################################
     // neq (primitiveValue != primitiveValue)
 
     // ----------------------------------------------------------------
-    /**
-     * require (b0 != b1)
-     */
-    public static void neq(boolean b0, String name0, boolean b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 != b1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void neq(boolean b0, String name0, boolean b1, String name1) {
-        neq(b0, name0, b1, name1, 1);
-    }
-
-    public static void neq(boolean b0, String name0, boolean b1, int numCallsBelowRequirer) {
         if (!(b0 != b1)) {
-            fail(name0 + " != " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
     }
 
     public static void neq(boolean b0, String name0, boolean b1) {
-        neq(b0, name0, b1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (c0 != c1)
-     */
-    public static void neq(char c0, String name0, char c1, String name1, int numCallsBelowRequirer) {
-        if (!(c0 != c1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(b0 != b1)) {
+            fail(name0 + " != " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
         }
     }
 
-    public static void neq(char c0, String name0, char c1, String name1) {
-        neq(c0, name0, c1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void neq(char c0, String name0, char c1, int numCallsBelowRequirer) {
+    public static void neq(char c0, String name0, char c1, String name1) {
         if (!(c0 != c1)) {
-            fail(name0 + " != " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1));
         }
     }
 
     public static void neq(char c0, String name0, char c1) {
-        neq(c0, name0, c1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (b0 != b1)
-     */
-    public static void neq(byte b0, String name0, byte b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 != b1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(c0 != c1)) {
+            fail(name0 + " != " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0));
         }
     }
 
-    public static void neq(byte b0, String name0, byte b1, String name1) {
-        neq(b0, name0, b1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void neq(byte b0, String name0, byte b1, int numCallsBelowRequirer) {
+    public static void neq(byte b0, String name0, byte b1, String name1) {
         if (!(b0 != b1)) {
-            fail(name0 + " != " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
     }
 
     public static void neq(byte b0, String name0, byte b1) {
-        neq(b0, name0, b1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (s0 != s1)
-     */
-    public static void neq(short s0, String name0, short s1, String name1, int numCallsBelowRequirer) {
-        if (!(s0 != s1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(b0 != b1)) {
+            fail(name0 + " != " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
         }
     }
 
-    public static void neq(short s0, String name0, short s1, String name1) {
-        neq(s0, name0, s1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void neq(short s0, String name0, short s1, int numCallsBelowRequirer) {
+    public static void neq(short s0, String name0, short s1, String name1) {
         if (!(s0 != s1)) {
-            fail(name0 + " != " + s1, ExceptionMessageUtil.valueAndName(s0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1));
         }
     }
 
     public static void neq(short s0, String name0, short s1) {
-        neq(s0, name0, s1, 1);
+        if (!(s0 != s1)) {
+            fail(name0 + " != " + s1, ExceptionMessageUtil.valueAndName(s0, name0));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (i0 != i1)
-     */
-    public static int neq(int i0, String name0, int i1, String name1, int numCallsBelowRequirer) {
+
+    public static int neq(int i0, String name0, int i1, String name1) {
         if (!(i0 != i1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1));
         }
         return i0;
     }
 
-    public static int neq(int i0, String name0, int i1, String name1) {
-        return neq(i0, name0, i1, name1, 1);
-    }
-
-    public static void neq(int i0, String name0, int i1, int numCallsBelowRequirer) {
-        if (!(i0 != i1)) {
-            fail(name0 + " != " + i1, ExceptionMessageUtil.valueAndName(i0, name0), numCallsBelowRequirer + 1);
-        }
-    }
-
     public static void neq(int i0, String name0, int i1) {
-        neq(i0, name0, i1, 1);
+        if (!(i0 != i1)) {
+            fail(name0 + " != " + i1, ExceptionMessageUtil.valueAndName(i0, name0));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (l0 != l1)
-     */
-    public static void neq(long l0, String name0, long l1, String name1, int numCallsBelowRequirer) {
-        if (!(l0 != l1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void neq(long l0, String name0, long l1, String name1) {
-        neq(l0, name0, l1, name1, 1);
-    }
-
-    public static void neq(long l0, String name0, long l1, int numCallsBelowRequirer) {
         if (!(l0 != l1)) {
-            fail(name0 + " != " + l1, ExceptionMessageUtil.valueAndName(l0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1));
         }
     }
 
     public static void neq(long l0, String name0, long l1) {
-        neq(l0, name0, l1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (f0 != f1)
-     */
-    public static void neq(float f0, String name0, float f1, String name1, int numCallsBelowRequirer) {
-        if (!(f0 != f1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(l0 != l1)) {
+            fail(name0 + " != " + l1, ExceptionMessageUtil.valueAndName(l0, name0));
         }
     }
 
-    public static void neq(float f0, String name0, float f1, String name1) {
-        neq(f0, name0, f1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void neq(float f0, String name0, float f1, int numCallsBelowRequirer) {
+    public static void neq(float f0, String name0, float f1, String name1) {
         if (!(f0 != f1)) {
-            fail(name0 + " != " + f1, ExceptionMessageUtil.valueAndName(f0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1));
         }
     }
 
     public static void neq(float f0, String name0, float f1) {
-        neq(f0, name0, f1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (d0 != d1)
-     */
-    public static void neq(double d0, String name0, double d1, String name1, int numCallsBelowRequirer) {
-        if (!(d0 != d1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(f0 != f1)) {
+            fail(name0 + " != " + f1, ExceptionMessageUtil.valueAndName(f0, name0));
         }
     }
 
-    public static void neq(double d0, String name0, double d1, String name1) {
-        neq(d0, name0, d1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void neq(double d0, String name0, double d1, int numCallsBelowRequirer) {
+    public static void neq(double d0, String name0, double d1, String name1) {
         if (!(d0 != d1)) {
-            fail(name0 + " != " + d1, ExceptionMessageUtil.valueAndName(d0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1));
         }
     }
 
     public static void neq(double d0, String name0, double d1) {
-        neq(d0, name0, d1, 1);
+        if (!(d0 != d1)) {
+            fail(name0 + " != " + d1, ExceptionMessageUtil.valueAndName(d0, name0));
+        }
     }
 
     // ################################################################
     // lt (primitiveValue < primitiveValue)
 
     // ----------------------------------------------------------------
-    /**
-     * require (c0 &lt; c1)
-     */
-    public static char lt(char c0, String name0, char c1, String name1, int numCallsBelowRequirer) {
-        if (!(c0 < c1)) {
-            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return c0;
-    }
 
     public static char lt(char c0, String name0, char c1, String name1) {
-        return lt(c0, name0, c1, name1, 1);
-    }
-
-    public static char lt(char c0, String name0, char c1, int numCallsBelowRequirer) {
         if (!(c0 < c1)) {
-            fail(name0 + " < " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1));
         }
         return c0;
     }
 
     public static char lt(char c0, String name0, char c1) {
-        return lt(c0, name0, c1, 1);
+        if (!(c0 < c1)) {
+            fail(name0 + " < " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0));
+        }
+        return c0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (b0 &lt; b1)
-     */
-    public static byte lt(byte b0, String name0, byte b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 < b1)) {
-            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return b0;
-    }
 
     public static byte lt(byte b0, String name0, byte b1, String name1) {
-        return lt(b0, name0, b1, name1, 1);
-    }
-
-    public static byte lt(byte b0, String name0, byte b1, int numCallsBelowRequirer) {
         if (!(b0 < b1)) {
-            fail(name0 + " < " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
         return b0;
     }
 
     public static byte lt(byte b0, String name0, byte b1) {
-        return lt(b0, name0, b1, 1);
+        if (!(b0 < b1)) {
+            fail(name0 + " < " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
+        }
+        return b0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (s0 &lt; s1)
-     */
-    public static short lt(short s0, String name0, short s1, String name1, int numCallsBelowRequirer) {
-        if (!(s0 < s1)) {
-            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return s0;
-    }
 
     public static short lt(short s0, String name0, short s1, String name1) {
-        return lt(s0, name0, s1, name1, 1);
-    }
-
-    public static short lt(short s0, String name0, short s1, int numCallsBelowRequirer) {
         if (!(s0 < s1)) {
-            fail(name0 + " < " + s1, ExceptionMessageUtil.valueAndName(s0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1));
         }
         return s0;
     }
 
     public static short lt(short s0, String name0, short s1) {
-        return lt(s0, name0, s1, 1);
+        if (!(s0 < s1)) {
+            fail(name0 + " < " + s1, ExceptionMessageUtil.valueAndName(s0, name0));
+        }
+        return s0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (i0 &lt; i1)
-     */
-    public static int lt(int i0, String name0, int i1, String name1, int numCallsBelowRequirer) {
-        if (!(i0 < i1)) {
-            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return i0;
-    }
 
     public static int lt(int i0, String name0, int i1, String name1) {
-        return lt(i0, name0, i1, name1, 1);
-    }
-
-    public static int lt(int i0, String name0, int i1, int numCallsBelowRequirer) {
         if (!(i0 < i1)) {
-            fail(name0 + " < " + i1, ExceptionMessageUtil.valueAndName(i0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1));
         }
         return i0;
     }
 
     public static int lt(int i0, String name0, int i1) {
-        return lt(i0, name0, i1, 1);
+        if (!(i0 < i1)) {
+            fail(name0 + " < " + i1, ExceptionMessageUtil.valueAndName(i0, name0));
+        }
+        return i0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (l0 &lt; l1)
-     */
-    public static long lt(long l0, String name0, long l1, String name1, int numCallsBelowRequirer) {
-        if (!(l0 < l1)) {
-            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return l0;
-    }
 
     public static long lt(long l0, String name0, long l1, String name1) {
-        return lt(l0, name0, l1, name1, 1);
-    }
-
-    public static long lt(long l0, String name0, long l1, int numCallsBelowRequirer) {
         if (!(l0 < l1)) {
-            fail(name0 + " < " + l1, ExceptionMessageUtil.valueAndName(l0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1));
         }
         return l0;
     }
 
     public static long lt(long l0, String name0, long l1) {
-        return lt(l0, name0, l1, 1);
+        if (!(l0 < l1)) {
+            fail(name0 + " < " + l1, ExceptionMessageUtil.valueAndName(l0, name0));
+        }
+        return l0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (f0 &lt; f1)
-     */
-    public static float lt(float f0, String name0, float f1, String name1, int numCallsBelowRequirer) {
-        if (!(f0 < f1)) {
-            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return f0;
-    }
 
     public static float lt(float f0, String name0, float f1, String name1) {
-        return lt(f0, name0, f1, name1, 1);
-    }
-
-    public static float lt(float f0, String name0, float f1, int numCallsBelowRequirer) {
         if (!(f0 < f1)) {
-            fail(name0 + " < " + f1, ExceptionMessageUtil.valueAndName(f0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1));
         }
         return f0;
     }
 
     public static float lt(float f0, String name0, float f1) {
-        return lt(f0, name0, f1, 1);
+        if (!(f0 < f1)) {
+            fail(name0 + " < " + f1, ExceptionMessageUtil.valueAndName(f0, name0));
+        }
+        return f0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (d0 &lt; d1)
-     */
-    public static double lt(double d0, String name0, double d1, String name1, int numCallsBelowRequirer) {
-        if (!(d0 < d1)) {
-            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return d0;
-    }
 
     public static double lt(double d0, String name0, double d1, String name1) {
-        return lt(d0, name0, d1, name1, 1);
-    }
-
-    public static double lt(double d0, String name0, double d1, int numCallsBelowRequirer) {
         if (!(d0 < d1)) {
-            fail(name0 + " < " + d1, ExceptionMessageUtil.valueAndName(d0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " < " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1));
         }
         return d0;
     }
 
     public static double lt(double d0, String name0, double d1) {
-        return lt(d0, name0, d1, 1);
+        if (!(d0 < d1)) {
+            fail(name0 + " < " + d1, ExceptionMessageUtil.valueAndName(d0, name0));
+        }
+        return d0;
     }
 
     // ################################################################
     // leq (primitiveValue <= primitiveValue)
 
     // ----------------------------------------------------------------
-    /**
-     * require (c0 &lt;= c1)
-     */
-    public static char leq(char c0, String name0, char c1, String name1, int numCallsBelowRequirer) {
-        if (!(c0 <= c1)) {
-            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return c0;
-    }
 
     public static char leq(char c0, String name0, char c1, String name1) {
-        return leq(c0, name0, c1, name1, 1);
-    }
-
-    public static char leq(char c0, String name0, char c1, int numCallsBelowRequirer) {
         if (!(c0 <= c1)) {
-            fail(name0 + " <= " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1));
         }
         return c0;
     }
 
     public static char leq(char c0, String name0, char c1) {
-        return leq(c0, name0, c1, 1);
+        if (!(c0 <= c1)) {
+            fail(name0 + " <= " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0));
+        }
+        return c0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (b0 &lt;= b1)
-     */
-    public static byte leq(byte b0, String name0, byte b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 <= b1)) {
-            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return b0;
-    }
 
     public static byte leq(byte b0, String name0, byte b1, String name1) {
-        return leq(b0, name0, b1, name1, 1);
-    }
-
-    public static byte leq(byte b0, String name0, byte b1, int numCallsBelowRequirer) {
         if (!(b0 <= b1)) {
-            fail(name0 + " <= " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
         return b0;
     }
 
     public static byte leq(byte b0, String name0, byte b1) {
-        return leq(b0, name0, b1, 1);
+        if (!(b0 <= b1)) {
+            fail(name0 + " <= " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
+        }
+        return b0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (s0 &lt;= s1)
-     */
-    public static short leq(short s0, String name0, short s1, String name1, int numCallsBelowRequirer) {
-        if (!(s0 <= s1)) {
-            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return s0;
-    }
 
     public static short leq(short s0, String name0, short s1, String name1) {
-        return leq(s0, name0, s1, name1, 1);
-    }
-
-    public static short leq(short s0, String name0, short s1, int numCallsBelowRequirer) {
         if (!(s0 <= s1)) {
-            fail(name0 + " <= " + s1, ExceptionMessageUtil.valueAndName(s0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1));
         }
         return s0;
     }
 
     public static short leq(short s0, String name0, short s1) {
-        return leq(s0, name0, s1, 1);
+        if (!(s0 <= s1)) {
+            fail(name0 + " <= " + s1, ExceptionMessageUtil.valueAndName(s0, name0));
+        }
+        return s0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (i0 &lt;= i1)
-     */
-    public static int leq(int i0, String name0, int i1, String name1, int numCallsBelowRequirer) {
-        if (!(i0 <= i1)) {
-            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return i0;
-    }
 
     public static int leq(int i0, String name0, int i1, String name1) {
-        return leq(i0, name0, i1, name1, 1);
-    }
-
-    public static int leq(int i0, String name0, int i1, int numCallsBelowRequirer) {
         if (!(i0 <= i1)) {
-            fail(name0 + " <= " + i1, ExceptionMessageUtil.valueAndName(i0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1));
         }
         return i0;
     }
 
     public static int leq(int i0, String name0, int i1) {
-        return leq(i0, name0, i1, 1);
+        if (!(i0 <= i1)) {
+            fail(name0 + " <= " + i1, ExceptionMessageUtil.valueAndName(i0, name0));
+        }
+        return i0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (l0 &lt;= l1)
-     */
-    public static long leq(long l0, String name0, long l1, String name1, int numCallsBelowRequirer) {
-        if (!(l0 <= l1)) {
-            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return l0;
-    }
 
     public static long leq(long l0, String name0, long l1, String name1) {
-        return leq(l0, name0, l1, name1, 1);
-    }
-
-    public static long leq(long l0, String name0, long l1, int numCallsBelowRequirer) {
         if (!(l0 <= l1)) {
-            fail(name0 + " <= " + l1, ExceptionMessageUtil.valueAndName(l0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1));
         }
         return l0;
     }
 
     public static long leq(long l0, String name0, long l1) {
-        return leq(l0, name0, l1, 1);
+        if (!(l0 <= l1)) {
+            fail(name0 + " <= " + l1, ExceptionMessageUtil.valueAndName(l0, name0));
+        }
+        return l0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (f0 &lt;= f1)
-     */
-    public static float leq(float f0, String name0, float f1, String name1, int numCallsBelowRequirer) {
-        if (!(f0 <= f1)) {
-            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return f0;
-    }
 
     public static float leq(float f0, String name0, float f1, String name1) {
-        return leq(f0, name0, f1, name1, 1);
-    }
-
-    public static float leq(float f0, String name0, float f1, int numCallsBelowRequirer) {
         if (!(f0 <= f1)) {
-            fail(name0 + " <= " + f1, ExceptionMessageUtil.valueAndName(f0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1));
         }
         return f0;
     }
 
     public static float leq(float f0, String name0, float f1) {
-        return leq(f0, name0, f1, 1);
+        if (!(f0 <= f1)) {
+            fail(name0 + " <= " + f1, ExceptionMessageUtil.valueAndName(f0, name0));
+        }
+        return f0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (d0 &lt;= d1)
-     */
-    public static double leq(double d0, String name0, double d1, String name1, int numCallsBelowRequirer) {
-        if (!(d0 <= d1)) {
-            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return d0;
-    }
 
     public static double leq(double d0, String name0, double d1, String name1) {
-        return leq(d0, name0, d1, name1, 1);
-    }
-
-    public static double leq(double d0, String name0, double d1, int numCallsBelowRequirer) {
         if (!(d0 <= d1)) {
-            fail(name0 + " <= " + d1, ExceptionMessageUtil.valueAndName(d0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " <= " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1));
         }
         return d0;
     }
 
     public static double leq(double d0, String name0, double d1) {
-        return leq(d0, name0, d1, 1);
+        if (!(d0 <= d1)) {
+            fail(name0 + " <= " + d1, ExceptionMessageUtil.valueAndName(d0, name0));
+        }
+        return d0;
     }
 
     // ################################################################
     // gt (primitiveValue > primitiveValue)
 
     // ----------------------------------------------------------------
-    /**
-     * require (c0 &gt; c1)
-     */
-    public static char gt(char c0, String name0, char c1, String name1, int numCallsBelowRequirer) {
-        if (!(c0 > c1)) {
-            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return c0;
-    }
 
     public static char gt(char c0, String name0, char c1, String name1) {
-        return gt(c0, name0, c1, name1, 1);
-    }
-
-    public static char gt(char c0, String name0, char c1, int numCallsBelowRequirer) {
         if (!(c0 > c1)) {
-            fail(name0 + " > " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1));
         }
         return c0;
     }
 
     public static char gt(char c0, String name0, char c1) {
-        return gt(c0, name0, c1, 1);
+        if (!(c0 > c1)) {
+            fail(name0 + " > " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0));
+        }
+        return c0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (b0 &gt; b1)
-     */
-    public static byte gt(byte b0, String name0, byte b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 > b1)) {
-            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return b0;
-    }
 
     public static byte gt(byte b0, String name0, byte b1, String name1) {
-        return gt(b0, name0, b1, name1, 1);
-    }
-
-    public static byte gt(byte b0, String name0, byte b1, int numCallsBelowRequirer) {
         if (!(b0 > b1)) {
-            fail(name0 + " > " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
         return b0;
     }
 
     public static byte gt(byte b0, String name0, byte b1) {
-        return gt(b0, name0, b1, 1);
+        if (!(b0 > b1)) {
+            fail(name0 + " > " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
+        }
+        return b0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (s0 &gt; s1)
-     */
-    public static short gt(short s0, String name0, short s1, String name1, int numCallsBelowRequirer) {
-        if (!(s0 > s1)) {
-            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return s0;
-    }
 
     public static short gt(short s0, String name0, short s1, String name1) {
-        return gt(s0, name0, s1, name1, 1);
-    }
-
-    public static short gt(short s0, String name0, short s1, int numCallsBelowRequirer) {
         if (!(s0 > s1)) {
-            fail(name0 + " > " + s1, ExceptionMessageUtil.valueAndName(s0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1));
         }
         return s0;
     }
 
     public static short gt(short s0, String name0, short s1) {
-        return gt(s0, name0, s1, 1);
+        if (!(s0 > s1)) {
+            fail(name0 + " > " + s1, ExceptionMessageUtil.valueAndName(s0, name0));
+        }
+        return s0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (i0 &gt; i1)
-     */
-    public static int gt(int i0, String name0, int i1, String name1, int numCallsBelowRequirer) {
-        if (!(i0 > i1)) {
-            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return i0;
-    }
 
     public static int gt(int i0, String name0, int i1, String name1) {
-        return gt(i0, name0, i1, name1, 1);
-    }
-
-    public static int gt(int i0, String name0, int i1, int numCallsBelowRequirer) {
         if (!(i0 > i1)) {
-            fail(name0 + " > " + i1, ExceptionMessageUtil.valueAndName(i0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1));
         }
         return i0;
     }
 
     public static int gt(int i0, String name0, int i1) {
-        return gt(i0, name0, i1, 1);
+        if (!(i0 > i1)) {
+            fail(name0 + " > " + i1, ExceptionMessageUtil.valueAndName(i0, name0));
+        }
+        return i0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (l0 &gt; l1)
-     */
-    public static long gt(long l0, String name0, long l1, String name1, int numCallsBelowRequirer) {
-        if (!(l0 > l1)) {
-            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return l0;
-    }
 
     public static long gt(long l0, String name0, long l1, String name1) {
-        return gt(l0, name0, l1, name1, 1);
-    }
-
-    public static long gt(long l0, String name0, long l1, int numCallsBelowRequirer) {
         if (!(l0 > l1)) {
-            fail(name0 + " > " + l1, ExceptionMessageUtil.valueAndName(l0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1));
         }
         return l0;
     }
 
     public static long gt(long l0, String name0, long l1) {
-        return gt(l0, name0, l1, 1);
+        if (!(l0 > l1)) {
+            fail(name0 + " > " + l1, ExceptionMessageUtil.valueAndName(l0, name0));
+        }
+        return l0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (f0 &gt; f1)
-     */
-    public static float gt(float f0, String name0, float f1, String name1, int numCallsBelowRequirer) {
-        if (!(f0 > f1)) {
-            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return f0;
-    }
 
     public static float gt(float f0, String name0, float f1, String name1) {
-        return gt(f0, name0, f1, name1, 1);
-    }
-
-    public static float gt(float f0, String name0, float f1, int numCallsBelowRequirer) {
         if (!(f0 > f1)) {
-            fail(name0 + " > " + f1, ExceptionMessageUtil.valueAndName(f0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1));
         }
         return f0;
     }
 
     public static float gt(float f0, String name0, float f1) {
-        return gt(f0, name0, f1, 1);
+        if (!(f0 > f1)) {
+            fail(name0 + " > " + f1, ExceptionMessageUtil.valueAndName(f0, name0));
+        }
+        return f0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (d0 &gt; d1)
-     */
-    public static double gt(double d0, String name0, double d1, String name1, int numCallsBelowRequirer) {
-        if (!(d0 > d1)) {
-            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return d0;
-    }
 
     public static double gt(double d0, String name0, double d1, String name1) {
-        return gt(d0, name0, d1, name1, 1);
-    }
-
-    public static double gt(double d0, String name0, double d1, int numCallsBelowRequirer) {
         if (!(d0 > d1)) {
-            fail(name0 + " > " + d1, ExceptionMessageUtil.valueAndName(d0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " > " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1));
         }
         return d0;
     }
 
     public static double gt(double d0, String name0, double d1) {
-        return gt(d0, name0, d1, 1);
+        if (!(d0 > d1)) {
+            fail(name0 + " > " + d1, ExceptionMessageUtil.valueAndName(d0, name0));
+        }
+        return d0;
     }
 
     // ################################################################
     // geq (primitiveValue >= primitiveValue)
 
     // ----------------------------------------------------------------
-    /**
-     * require (c0 &gt;= c1)
-     */
-    public static char geq(char c0, String name0, char c1, String name1, int numCallsBelowRequirer) {
-        if (!(c0 >= c1)) {
-            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return c0;
-    }
 
     public static char geq(char c0, String name0, char c1, String name1) {
-        return geq(c0, name0, c1, name1, 1);
-    }
-
-    public static char geq(char c0, String name0, char c1, int numCallsBelowRequirer) {
         if (!(c0 >= c1)) {
-            fail(name0 + " >= " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(c0, name0, c1, name1));
         }
         return c0;
     }
 
     public static char geq(char c0, String name0, char c1) {
-        return geq(c0, name0, c1, 1);
+        if (!(c0 >= c1)) {
+            fail(name0 + " >= " + ExceptionMessageUtil.valueString(c1), ExceptionMessageUtil.valueAndName(c0, name0));
+        }
+        return c0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (b0 &gt;= b1)
-     */
-    public static byte geq(byte b0, String name0, byte b1, String name1, int numCallsBelowRequirer) {
-        if (!(b0 >= b1)) {
-            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return b0;
-    }
 
     public static byte geq(byte b0, String name0, byte b1, String name1) {
-        return geq(b0, name0, b1, name1, 1);
-    }
-
-    public static byte geq(byte b0, String name0, byte b1, int numCallsBelowRequirer) {
         if (!(b0 >= b1)) {
-            fail(name0 + " >= " + b1, ExceptionMessageUtil.valueAndName(b0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(b0, name0, b1, name1));
         }
         return b0;
     }
 
     public static byte geq(byte b0, String name0, byte b1) {
-        return geq(b0, name0, b1, 1);
+        if (!(b0 >= b1)) {
+            fail(name0 + " >= " + b1, ExceptionMessageUtil.valueAndName(b0, name0));
+        }
+        return b0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (s0 &gt;= s1)
-     */
-    public static short geq(short s0, String name0, short s1, String name1, int numCallsBelowRequirer) {
-        if (!(s0 >= s1)) {
-            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return s0;
-    }
 
     public static short geq(short s0, String name0, short s1, String name1) {
-        return geq(s0, name0, s1, name1, 1);
-    }
-
-    public static short geq(short s0, String name0, short s1, int numCallsBelowRequirer) {
         if (!(s0 >= s1)) {
-            fail(name0 + " >= " + s1, ExceptionMessageUtil.valueAndName(s0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(s0, name0, s1, name1));
         }
         return s0;
     }
 
     public static short geq(short s0, String name0, short s1) {
-        return geq(s0, name0, s1, 1);
+        if (!(s0 >= s1)) {
+            fail(name0 + " >= " + s1, ExceptionMessageUtil.valueAndName(s0, name0));
+        }
+        return s0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (i0 &gt;= i1)
-     */
-    public static int geq(int i0, String name0, int i1, String name1, int numCallsBelowRequirer) {
-        if (!(i0 >= i1)) {
-            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return i0;
-    }
 
     public static int geq(int i0, String name0, int i1, String name1) {
-        return geq(i0, name0, i1, name1, 1);
-    }
-
-    public static int geq(int i0, String name0, int i1, int numCallsBelowRequirer) {
         if (!(i0 >= i1)) {
-            fail(name0 + " >= " + i1, ExceptionMessageUtil.valueAndName(i0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(i0, name0, i1, name1));
         }
         return i0;
     }
 
     public static int geq(int i0, String name0, int i1) {
-        return geq(i0, name0, i1, 1);
+        if (!(i0 >= i1)) {
+            fail(name0 + " >= " + i1, ExceptionMessageUtil.valueAndName(i0, name0));
+        }
+        return i0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (l0 &gt;= l1)
-     */
-    public static long geq(long l0, String name0, long l1, String name1, int numCallsBelowRequirer) {
-        if (!(l0 >= l1)) {
-            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return l0;
-    }
 
     public static long geq(long l0, String name0, long l1, String name1) {
-        return geq(l0, name0, l1, name1, 1);
-    }
-
-    public static long geq(long l0, String name0, long l1, int numCallsBelowRequirer) {
         if (!(l0 >= l1)) {
-            fail(name0 + " >= " + l1, ExceptionMessageUtil.valueAndName(l0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(l0, name0, l1, name1));
         }
         return l0;
     }
 
     public static long geq(long l0, String name0, long l1) {
-        return geq(l0, name0, l1, 1);
+        if (!(l0 >= l1)) {
+            fail(name0 + " >= " + l1, ExceptionMessageUtil.valueAndName(l0, name0));
+        }
+        return l0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (f0 &gt;= f1)
-     */
-    public static float geq(float f0, String name0, float f1, String name1, int numCallsBelowRequirer) {
-        if (!(f0 >= f1)) {
-            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return f0;
-    }
 
     public static float geq(float f0, String name0, float f1, String name1) {
-        return geq(f0, name0, f1, name1, 1);
-    }
-
-    public static float geq(float f0, String name0, float f1, int numCallsBelowRequirer) {
         if (!(f0 >= f1)) {
-            fail(name0 + " >= " + f1, ExceptionMessageUtil.valueAndName(f0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(f0, name0, f1, name1));
         }
         return f0;
     }
 
     public static float geq(float f0, String name0, float f1) {
-        return geq(f0, name0, f1, 1);
+        if (!(f0 >= f1)) {
+            fail(name0 + " >= " + f1, ExceptionMessageUtil.valueAndName(f0, name0));
+        }
+        return f0;
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (d0 &gt;= d1)
-     */
-    public static double geq(double d0, String name0, double d1, String name1, int numCallsBelowRequirer) {
-        if (!(d0 >= d1)) {
-            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-        return d0;
-    }
 
     public static double geq(double d0, String name0, double d1, String name1) {
-        return geq(d0, name0, d1, name1, 1);
-    }
-
-    public static double geq(double d0, String name0, double d1, int numCallsBelowRequirer) {
         if (!(d0 >= d1)) {
-            fail(name0 + " >= " + d1, ExceptionMessageUtil.valueAndName(d0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + " >= " + name1, ExceptionMessageUtil.valueAndName(d0, name0, d1, name1));
         }
         return d0;
     }
 
     public static double geq(double d0, String name0, double d1) {
-        return geq(d0, name0, d1, 1);
+        if (!(d0 >= d1)) {
+            fail(name0 + " >= " + d1, ExceptionMessageUtil.valueAndName(d0, name0));
+        }
+        return d0;
     }
 
     // ################################################################
@@ -1764,640 +1078,387 @@ public final class Require {
 
     // ----------------------------------------------------------------
 
-    /**
-     * require (b == false)
-     */
-    public static void eqFalse(boolean b, String name, int numCallsBelowRequirer) {
-        if (!(false == b)) {
-            fail(name + " == false", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
-        }
-    }
-
     public static void eqFalse(boolean b, String name) {
-        eqFalse(b, name, 1);
+        if (!(false == b)) {
+            fail(name + " == false", ExceptionMessageUtil.valueAndName(b, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (b != false)
-     */
-    public static void neqFalse(boolean b, String name, int numCallsBelowRequirer) {
-        if (!(false != b)) {
-            fail(name + " != false", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void neqFalse(boolean b, String name) {
-        neqFalse(b, name, 1);
+        if (!(false != b)) {
+            fail(name + " != false", ExceptionMessageUtil.valueAndName(b, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (b == true)
-     */
-    public static void eqTrue(boolean b, String name, int numCallsBelowRequirer) {
-        if (!(true == b)) {
-            fail(name + " == true", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqTrue(boolean b, String name) {
-        eqTrue(b, name, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (b != true)
-     */
-    public static void neqTrue(boolean b, String name, int numCallsBelowRequirer) {
-        if (!(true != b)) {
-            fail(name + " != true", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
+        if (!(true == b)) {
+            fail(name + " == true", ExceptionMessageUtil.valueAndName(b, name));
         }
     }
 
+    // ----------------------------------------------------------------
+
     public static void neqTrue(boolean b, String name) {
-        neqTrue(b, name, 1);
+        if (!(true != b)) {
+            fail(name + " != true", ExceptionMessageUtil.valueAndName(b, name));
+        }
     }
 
     // ################################################################
     // eqZero (primitiveValue == 0)
 
     // ----------------------------------------------------------------
-    /**
-     * require (c == 0)
-     */
-    public static void eqZero(char c, String name, int numCallsBelowRequirer) {
-        if (!(0 == c)) {
-            fail(name + " == 0", ExceptionMessageUtil.valueAndName(c, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqZero(char c, String name) {
-        eqZero(c, name, 1);
+        if (!(0 == c)) {
+            fail(name + " == 0", ExceptionMessageUtil.valueAndName(c, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (b == 0)
-     */
-    public static void eqZero(byte b, String name, int numCallsBelowRequirer) {
-        if (!(0 == b)) {
-            fail(name + " == 0", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqZero(byte b, String name) {
-        eqZero(b, name, 1);
+        if (!(0 == b)) {
+            fail(name + " == 0", ExceptionMessageUtil.valueAndName(b, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (s == 0)
-     */
-    public static void eqZero(short s, String name, int numCallsBelowRequirer) {
-        if (!(0 == s)) {
-            fail(name + " == 0", ExceptionMessageUtil.valueAndName(s, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqZero(short s, String name) {
-        eqZero(s, name, 1);
+        if (!(0 == s)) {
+            fail(name + " == 0", ExceptionMessageUtil.valueAndName(s, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (i == 0)
-     */
-    public static void eqZero(int i, String name, int numCallsBelowRequirer) {
-        if (!(0 == i)) {
-            fail(name + " == 0", ExceptionMessageUtil.valueAndName(i, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqZero(int i, String name) {
-        eqZero(i, name, 1);
+        if (!(0 == i)) {
+            fail(name + " == 0", ExceptionMessageUtil.valueAndName(i, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (l == 0)
-     */
-    public static void eqZero(long l, String name, int numCallsBelowRequirer) {
-        if (!(0 == l)) {
-            fail(name + " == 0", ExceptionMessageUtil.valueAndName(l, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqZero(long l, String name) {
-        eqZero(l, name, 1);
+        if (!(0 == l)) {
+            fail(name + " == 0", ExceptionMessageUtil.valueAndName(l, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (f == 0)
-     */
-    public static void eqZero(float f, String name, int numCallsBelowRequirer) {
-        if (!(0 == f)) {
-            fail(name + " == 0", ExceptionMessageUtil.valueAndName(f, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqZero(float f, String name) {
-        eqZero(f, name, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (d == 0)
-     */
-    public static void eqZero(double d, String name, int numCallsBelowRequirer) {
-        if (!(0 == d)) {
-            fail(name + " == 0", ExceptionMessageUtil.valueAndName(d, name), numCallsBelowRequirer + 1);
+        if (!(0 == f)) {
+            fail(name + " == 0", ExceptionMessageUtil.valueAndName(f, name));
         }
     }
 
+    // ----------------------------------------------------------------
+
     public static void eqZero(double d, String name) {
-        eqZero(d, name, 1);
+        if (!(0 == d)) {
+            fail(name + " == 0", ExceptionMessageUtil.valueAndName(d, name));
+        }
     }
 
     // ################################################################
     // neqZero (primitiveValue != 0)
 
     // ----------------------------------------------------------------
-    /**
-     * require (c != 0)
-     */
-    public static char neqZero(char c, String name, int numCallsBelowRequirer) {
+
+    public static char neqZero(char c, String name) {
         if (!(0 != c)) {
-            fail(name + " != 0", ExceptionMessageUtil.valueAndName(c, name), numCallsBelowRequirer + 1);
+            fail(name + " != 0", ExceptionMessageUtil.valueAndName(c, name));
         }
         return c;
     }
 
-    public static char neqZero(char c, String name) {
-        return neqZero(c, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (b != 0)
-     */
-    public static byte neqZero(byte b, String name, int numCallsBelowRequirer) {
+
+    public static byte neqZero(byte b, String name) {
         if (!(0 != b)) {
-            fail(name + " != 0", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
+            fail(name + " != 0", ExceptionMessageUtil.valueAndName(b, name));
         }
         return b;
     }
 
-    public static byte neqZero(byte b, String name) {
-        return neqZero(b, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (s != 0)
-     */
-    public static short neqZero(short s, String name, int numCallsBelowRequirer) {
+
+    public static short neqZero(short s, String name) {
         if (!(0 != s)) {
-            fail(name + " != 0", ExceptionMessageUtil.valueAndName(s, name), numCallsBelowRequirer + 1);
+            fail(name + " != 0", ExceptionMessageUtil.valueAndName(s, name));
         }
         return s;
     }
 
-    public static short neqZero(short s, String name) {
-        return neqZero(s, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (i != 0)
-     */
-    public static int neqZero(int i, String name, int numCallsBelowRequirer) {
+
+    public static int neqZero(int i, String name) {
         if (!(0 != i)) {
-            fail(name + " != 0", ExceptionMessageUtil.valueAndName(i, name), numCallsBelowRequirer + 1);
+            fail(name + " != 0", ExceptionMessageUtil.valueAndName(i, name));
         }
         return i;
     }
 
-    public static int neqZero(int i, String name) {
-        return neqZero(i, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (l != 0)
-     */
-    public static long neqZero(long l, String name, int numCallsBelowRequirer) {
+
+    public static long neqZero(long l, String name) {
         if (!(0 != l)) {
-            fail(name + " != 0", ExceptionMessageUtil.valueAndName(l, name), numCallsBelowRequirer + 1);
+            fail(name + " != 0", ExceptionMessageUtil.valueAndName(l, name));
         }
         return l;
     }
 
-    public static long neqZero(long l, String name) {
-        return neqZero(l, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (f != 0)
-     */
-    public static float neqZero(float f, String name, int numCallsBelowRequirer) {
+
+    public static float neqZero(float f, String name) {
         if (!(0 != f)) {
-            fail(name + " != 0", ExceptionMessageUtil.valueAndName(f, name), numCallsBelowRequirer + 1);
+            fail(name + " != 0", ExceptionMessageUtil.valueAndName(f, name));
         }
         return f;
     }
 
-    public static float neqZero(float f, String name) {
-        return neqZero(f, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (d != 0)
-     */
-    public static double neqZero(double d, String name, int numCallsBelowRequirer) {
-        if (!(0 != d)) {
-            fail(name + " != 0", ExceptionMessageUtil.valueAndName(d, name), numCallsBelowRequirer + 1);
-        }
-        return d;
-    }
 
     public static double neqZero(double d, String name) {
-        return neqZero(d, name, 1);
+        if (!(0 != d)) {
+            fail(name + " != 0", ExceptionMessageUtil.valueAndName(d, name));
+        }
+        return d;
     }
 
     // ################################################################
     // ltZero (primitiveValue < 0)
 
     // ----------------------------------------------------------------
-    /**
-     * require (b &lt; 0)
-     */
-    public static byte ltZero(byte b, String name, int numCallsBelowRequirer) {
+
+    public static byte ltZero(byte b, String name) {
         if (!(b < 0)) {
-            fail(name + " < 0", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
+            fail(name + " < 0", ExceptionMessageUtil.valueAndName(b, name));
         }
         return b;
     }
 
-    public static byte ltZero(byte b, String name) {
-        return ltZero(b, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (s &lt; 0)
-     */
-    public static short ltZero(short s, String name, int numCallsBelowRequirer) {
+
+    public static short ltZero(short s, String name) {
         if (!(s < 0)) {
-            fail(name + " < 0", ExceptionMessageUtil.valueAndName(s, name), numCallsBelowRequirer + 1);
+            fail(name + " < 0", ExceptionMessageUtil.valueAndName(s, name));
         }
         return s;
     }
 
-    public static short ltZero(short s, String name) {
-        return ltZero(s, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (i &lt; 0)
-     */
-    public static int ltZero(int i, String name, int numCallsBelowRequirer) {
+
+    public static int ltZero(int i, String name) {
         if (!(i < 0)) {
-            fail(name + " < 0", ExceptionMessageUtil.valueAndName(i, name), numCallsBelowRequirer + 1);
+            fail(name + " < 0", ExceptionMessageUtil.valueAndName(i, name));
         }
         return i;
     }
 
-    public static int ltZero(int i, String name) {
-        return ltZero(i, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (l &lt; 0)
-     */
-    public static long ltZero(long l, String name, int numCallsBelowRequirer) {
+
+    public static long ltZero(long l, String name) {
         if (!(l < 0)) {
-            fail(name + " < 0", ExceptionMessageUtil.valueAndName(l, name), numCallsBelowRequirer + 1);
+            fail(name + " < 0", ExceptionMessageUtil.valueAndName(l, name));
         }
         return l;
     }
 
-    public static long ltZero(long l, String name) {
-        return ltZero(l, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (f &lt; 0)
-     */
-    public static float ltZero(float f, String name, int numCallsBelowRequirer) {
+
+    public static float ltZero(float f, String name) {
         if (!(f < 0)) {
-            fail(name + " < 0", ExceptionMessageUtil.valueAndName(f, name), numCallsBelowRequirer + 1);
+            fail(name + " < 0", ExceptionMessageUtil.valueAndName(f, name));
         }
         return f;
     }
 
-    public static float ltZero(float f, String name) {
-        return ltZero(f, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (d &lt; 0)
-     */
-    public static double ltZero(double d, String name, int numCallsBelowRequirer) {
-        if (!(d < 0)) {
-            fail(name + " < 0", ExceptionMessageUtil.valueAndName(d, name), numCallsBelowRequirer + 1);
-        }
-        return d;
-    }
 
     public static double ltZero(double d, String name) {
-        return ltZero(d, name, 1);
+        if (!(d < 0)) {
+            fail(name + " < 0", ExceptionMessageUtil.valueAndName(d, name));
+        }
+        return d;
     }
 
     // ################################################################
     // leqZero (primitiveValue <= 0)
 
     // ----------------------------------------------------------------
-    /**
-     * require (b &lt;= 0)
-     */
-    public static byte leqZero(byte b, String name, int numCallsBelowRequirer) {
+
+    public static byte leqZero(byte b, String name) {
         if (!(b <= 0)) {
-            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
+            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(b, name));
         }
         return b;
     }
 
-    public static byte leqZero(byte b, String name) {
-        return leqZero(b, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (s &lt;= 0)
-     */
-    public static short leqZero(short s, String name, int numCallsBelowRequirer) {
+
+    public static short leqZero(short s, String name) {
         if (!(s <= 0)) {
-            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(s, name), numCallsBelowRequirer + 1);
+            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(s, name));
         }
         return s;
     }
 
-    public static short leqZero(short s, String name) {
-        return leqZero(s, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (i &lt;= 0)
-     */
-    public static int leqZero(int i, String name, int numCallsBelowRequirer) {
+
+    public static int leqZero(int i, String name) {
         if (!(i <= 0)) {
-            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(i, name), numCallsBelowRequirer + 1);
+            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(i, name));
         }
         return i;
     }
 
-    public static int leqZero(int i, String name) {
-        return leqZero(i, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (l &lt;= 0)
-     */
-    public static long leqZero(long l, String name, int numCallsBelowRequirer) {
+
+    public static long leqZero(long l, String name) {
         if (!(l <= 0)) {
-            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(l, name), numCallsBelowRequirer + 1);
+            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(l, name));
         }
         return l;
     }
 
-    public static long leqZero(long l, String name) {
-        return leqZero(l, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (f &lt;= 0)
-     */
-    public static float leqZero(float f, String name, int numCallsBelowRequirer) {
+
+    public static float leqZero(float f, String name) {
         if (!(f <= 0)) {
-            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(f, name), numCallsBelowRequirer + 1);
+            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(f, name));
         }
         return f;
     }
 
-    public static float leqZero(float f, String name) {
-        return leqZero(f, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (d &lt;= 0)
-     */
-    public static double leqZero(double d, String name, int numCallsBelowRequirer) {
-        if (!(d <= 0)) {
-            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(d, name), numCallsBelowRequirer + 1);
-        }
-        return d;
-    }
 
     public static double leqZero(double d, String name) {
-        return leqZero(d, name, 1);
+        if (!(d <= 0)) {
+            fail(name + " <= 0", ExceptionMessageUtil.valueAndName(d, name));
+        }
+        return d;
     }
 
     // ################################################################
     // gtZero (primitiveValue > 0)
 
     // ----------------------------------------------------------------
-    /**
-     * require (b &gt; 0)
-     */
-    public static byte gtZero(byte b, String name, int numCallsBelowRequirer) {
+
+    public static byte gtZero(byte b, String name) {
         if (!(b > 0)) {
-            fail(name + " > 0", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
+            fail(name + " > 0", ExceptionMessageUtil.valueAndName(b, name));
         }
         return b;
     }
 
-    public static byte gtZero(byte b, String name) {
-        return gtZero(b, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (s &gt; 0)
-     */
-    public static short gtZero(short s, String name, int numCallsBelowRequirer) {
+
+    public static short gtZero(short s, String name) {
         if (!(s > 0)) {
-            fail(name + " > 0", ExceptionMessageUtil.valueAndName(s, name), numCallsBelowRequirer + 1);
+            fail(name + " > 0", ExceptionMessageUtil.valueAndName(s, name));
         }
         return s;
     }
 
-    public static short gtZero(short s, String name) {
-        return gtZero(s, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (i &gt; 0)
-     */
-    public static int gtZero(int i, String name, int numCallsBelowRequirer) {
+
+    public static int gtZero(int i, String name) {
         if (!(i > 0)) {
-            fail(name + " > 0", ExceptionMessageUtil.valueAndName(i, name), numCallsBelowRequirer + 1);
+            fail(name + " > 0", ExceptionMessageUtil.valueAndName(i, name));
         }
         return i;
     }
 
-    public static int gtZero(int i, String name) {
-        return gtZero(i, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (l &gt; 0)
-     */
-    public static long gtZero(long l, String name, int numCallsBelowRequirer) {
+
+    public static long gtZero(long l, String name) {
         if (!(l > 0)) {
-            fail(name + " > 0", ExceptionMessageUtil.valueAndName(l, name), numCallsBelowRequirer + 1);
+            fail(name + " > 0", ExceptionMessageUtil.valueAndName(l, name));
         }
         return l;
     }
 
-    public static long gtZero(long l, String name) {
-        return gtZero(l, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (f &gt; 0)
-     */
-    public static float gtZero(float f, String name, int numCallsBelowRequirer) {
+
+    public static float gtZero(float f, String name) {
         if (!(f > 0)) {
-            fail(name + " > 0", ExceptionMessageUtil.valueAndName(f, name), numCallsBelowRequirer + 1);
+            fail(name + " > 0", ExceptionMessageUtil.valueAndName(f, name));
         }
         return f;
     }
 
-    public static float gtZero(float f, String name) {
-        return gtZero(f, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (d > 0)
-     */
-    public static double gtZero(double d, String name, int numCallsBelowRequirer) {
-        if (!(d > 0)) {
-            fail(name + " > 0", ExceptionMessageUtil.valueAndName(d, name), numCallsBelowRequirer + 1);
-        }
-        return d;
-    }
 
     public static double gtZero(double d, String name) {
-        return gtZero(d, name, 1);
+        if (!(d > 0)) {
+            fail(name + " > 0", ExceptionMessageUtil.valueAndName(d, name));
+        }
+        return d;
     }
 
     // ################################################################
     // geqZero (primitiveValue >= 0)
 
     // ----------------------------------------------------------------
-    /**
-     * require (b &gt;= 0)
-     */
-    public static byte geqZero(byte b, String name, int numCallsBelowRequirer) {
+
+    public static byte geqZero(byte b, String name) {
         if (!(b >= 0)) {
-            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(b, name), numCallsBelowRequirer + 1);
+            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(b, name));
         }
         return b;
     }
 
-    public static byte geqZero(byte b, String name) {
-        return geqZero(b, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (s &gt;= 0)
-     */
-    public static short geqZero(short s, String name, int numCallsBelowRequirer) {
+
+    public static short geqZero(short s, String name) {
         if (!(s >= 0)) {
-            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(s, name), numCallsBelowRequirer + 1);
+            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(s, name));
         }
         return s;
     }
 
-    public static short geqZero(short s, String name) {
-        return geqZero(s, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (i &gt;= 0)
-     */
-    public static int geqZero(int i, String name, int numCallsBelowRequirer) {
+
+    public static int geqZero(int i, String name) {
         if (!(i >= 0)) {
-            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(i, name), numCallsBelowRequirer + 1);
+            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(i, name));
         }
         return i;
     }
 
-    public static int geqZero(int i, String name) {
-        return geqZero(i, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (l &gt;= 0)
-     */
-    public static long geqZero(long l, String name, int numCallsBelowRequirer) {
+
+    public static long geqZero(long l, String name) {
         if (!(l >= 0)) {
-            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(l, name), numCallsBelowRequirer + 1);
+            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(l, name));
         }
         return l;
     }
 
-    public static long geqZero(long l, String name) {
-        return geqZero(l, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (f &gt;= 0)
-     */
-    public static float geqZero(float f, String name, int numCallsBelowRequirer) {
+
+    public static float geqZero(float f, String name) {
         if (!(f >= 0)) {
-            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(f, name), numCallsBelowRequirer + 1);
+            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(f, name));
         }
         return f;
     }
 
-    public static float geqZero(float f, String name) {
-        return geqZero(f, name, 1);
-    }
-
     // ----------------------------------------------------------------
-    /**
-     * require (d &gt;= 0)
-     */
-    public static double geqZero(double d, String name, int numCallsBelowRequirer) {
-        if (!(d >= 0)) {
-            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(d, name), numCallsBelowRequirer + 1);
-        }
-        return d;
-    }
 
     public static double geqZero(double d, String name) {
-        return geqZero(d, name, 1);
+        if (!(d >= 0)) {
+            fail(name + " >= 0", ExceptionMessageUtil.valueAndName(d, name));
+        }
+        return d;
     }
 
     // ################################################################
@@ -2405,55 +1466,30 @@ public final class Require {
 
     // ----------------------------------------------------------------
 
-    /**
-     * require (o0 == o1)
-     */
-    public static void eq(Object o0, String name0, Object o1, String name1, int numCallsBelowRequirer) {
-        if (!(o0 == o1)) {
-            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-    }
-
     public static void eq(Object o0, String name0, Object o1, String name1) {
-        eq(o0, name0, o1, name1, 1);
-    }
-
-    public static void eq(Object o0, String name0, Object o1, int numCallsBelowRequirer) {
         if (!(o0 == o1)) {
-            fail(name0 + " == " + ExceptionMessageUtil.valueString(o1), ExceptionMessageUtil.valueAndName(o0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " == " + name1, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1));
         }
     }
 
     public static void eq(Object o0, String name0, Object o1) {
-        eq(o0, name0, o1, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (o0 != o1)
-     */
-    public static void neq(Object o0, String name0, Object o1, String name1, int numCallsBelowRequirer) {
-        if (!(o0 != o1)) {
-            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1),
-                    numCallsBelowRequirer + 1);
+        if (!(o0 == o1)) {
+            fail(name0 + " == " + ExceptionMessageUtil.valueString(o1), ExceptionMessageUtil.valueAndName(o0, name0));
         }
     }
 
-    public static void neq(Object o0, String name0, Object o1, String name1) {
-        neq(o0, name0, o1, name1, 1);
-    }
+    // ----------------------------------------------------------------
 
-    public static void neq(Object o0, String name0, Object o1, int numCallsBelowRequirer) {
+    public static void neq(Object o0, String name0, Object o1, String name1) {
         if (!(o0 != o1)) {
-            fail(name0 + " != " + ExceptionMessageUtil.valueString(o1), ExceptionMessageUtil.valueAndName(o0, name0),
-                    numCallsBelowRequirer + 1);
+            fail(name0 + " != " + name1, ExceptionMessageUtil.valueAndName(o0, name0, o1, name1));
         }
     }
 
     public static void neq(Object o0, String name0, Object o1) {
-        neq(o0, name0, o1, 1);
+        if (!(o0 != o1)) {
+            fail(name0 + " != " + ExceptionMessageUtil.valueString(o1), ExceptionMessageUtil.valueAndName(o0, name0));
+        }
     }
 
 
@@ -2461,98 +1497,54 @@ public final class Require {
     // eqNull, neqNull (Object ==/!= null)
 
     // ----------------------------------------------------------------
-    /**
-     * require (o == null)
-     */
-    public static void eqNull(Object o, String name, int numCallsBelowRequirer) {
-        if (!(null == o)) {
-            fail(name + " == null", ExceptionMessageUtil.valueAndName(o, name), numCallsBelowRequirer + 1);
-        }
-    }
 
     public static void eqNull(Object o, String name) {
-        eqNull(o, name, 1);
+        if (!(null == o)) {
+            fail(name + " == null", ExceptionMessageUtil.valueAndName(o, name));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (o != null)
-     */
-    @NotNull
-    public static <T> T neqNull(T o, String name, int numCallsBelowRequirer) {
-        if (!(null != o)) {
-            fail(name + " != null", ExceptionMessageUtil.valueAndName(o, name), numCallsBelowRequirer + 1);
-        }
-        return o;
-    }
 
     @NotNull
     public static <T> T neqNull(T o, String name) {
-        return neqNull(o, name, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (o != NaN)
-     */
-    public static double neqNaN(double o, String name, int numCallsBelowRequirer) {
-        if (Double.isNaN(o)) {
-            fail(name + " != NaN", ExceptionMessageUtil.valueAndName(o, name), numCallsBelowRequirer + 1);
+        if (!(null != o)) {
+            fail(name + " != null", ExceptionMessageUtil.valueAndName(o, name));
         }
         return o;
     }
+
+    // ----------------------------------------------------------------
 
     public static double neqNaN(double o, String name) {
-        return neqNaN(o, name, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * require (o != +/-Inf)
-     */
-    public static double neqInf(double o, String name, int numCallsBelowRequirer) {
-        if (Double.isInfinite(o)) {
-            fail(name + " != +/-Inf", ExceptionMessageUtil.valueAndName(o, name), numCallsBelowRequirer + 1);
+        if (Double.isNaN(o)) {
+            fail(name + " != NaN", ExceptionMessageUtil.valueAndName(o, name));
         }
         return o;
     }
 
+    // ----------------------------------------------------------------
+
     public static double neqInf(double o, String name) {
-        return neqInf(o, name, 1);
+        if (Double.isInfinite(o)) {
+            fail(name + " != +/-Inf", ExceptionMessageUtil.valueAndName(o, name));
+        }
+        return o;
     }
 
     // ################################################################
     // equals (Object.equals(Object))
 
     // ----------------------------------------------------------------
-    /**
-     * require (o0 != null &amp;&amp; o1 != null &amp;&amp; o0.equals(o1))
-     */
-    public static void equals(Object o0, String name0, Object o1, String name1, int numCallsBelowRequirer) {
-        neqNull(o0, name0, numCallsBelowRequirer + 1);
-        neqNull(o1, name1, numCallsBelowRequirer + 1);
-        if (!(o0.equals(o1))) {
-            fail(name0 + ".equals(" + name1 + ")", ExceptionMessageUtil.valueAndName(o0, name0, o1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-    }
 
     /**
      * require (o0 != null &amp;&amp; o1 != null &amp;&amp; o0.equals(o1))
      */
     public static void equals(Object o0, String name0, Object o1, String name1) {
-        equals(o0, name0, o1, name1, 1);
-    }
-
-    /**
-     * require (o0 != null &amp;&amp; o1 != null &amp;&amp; o0.equals(o1))
-     */
-    public static void equals(Object o0, String name0, Object o1, int numCallsBelowRequirer) {
-        neqNull(o0, name0, numCallsBelowRequirer + 1);
-        neqNull(o1, "o1", numCallsBelowRequirer + 1);
+        neqNull(o0, name0);
+        neqNull(o1, name1);
         if (!(o0.equals(o1))) {
-            fail(name0 + ".equals(" + ExceptionMessageUtil.valueString(o1) + ")",
-                    ExceptionMessageUtil.valueAndName(o0, name0), numCallsBelowRequirer + 1);
+            fail(name0 + ".equals(" + name1 + ")", ExceptionMessageUtil.valueAndName(o0, name0, o1, name1));
         }
     }
 
@@ -2560,38 +1552,24 @@ public final class Require {
      * require (o0 != null &amp;&amp; o1 != null &amp;&amp; o0.equals(o1))
      */
     public static void equals(Object o0, String name0, Object o1) {
-        equals(o0, name0, o1, 1);
+        neqNull(o0, name0);
+        neqNull(o1, "o1");
+        if (!(o0.equals(o1))) {
+            fail(name0 + ".equals(" + ExceptionMessageUtil.valueString(o1) + ")",
+                    ExceptionMessageUtil.valueAndName(o0, name0));
+        }
     }
 
     // ----------------------------------------------------------------
-    /**
-     * require (o0 != null &amp;&amp; o1 != null &amp;&amp; !o0.equals(o1))
-     */
-    public static void notEquals(Object o0, String name0, Object o1, String name1, int numCallsBelowRequirer) {
-        neqNull(o0, name0, numCallsBelowRequirer + 1);
-        neqNull(o1, name1, numCallsBelowRequirer + 1);
-        if (o0.equals(o1)) {
-            fail("!" + name0 + ".equals(" + name1 + ")", ExceptionMessageUtil.valueAndName(o0, name0, o1, name1),
-                    numCallsBelowRequirer + 1);
-        }
-    }
 
     /**
      * require (o0 != null &amp;&amp; o1 != null &amp;&amp; !o0.equals(o1))
      */
     public static void notEquals(Object o0, String name0, Object o1, String name1) {
-        notEquals(o0, name0, o1, name1, 1);
-    }
-
-    /**
-     * require (o0 != null &amp;&amp; o1 != null &amp;&amp; !o0.equals(o1))
-     */
-    public static void notEquals(Object o0, String name0, Object o1, int numCallsBelowRequirer) {
-        neqNull(o0, name0, numCallsBelowRequirer + 1);
-        neqNull(o1, "o1", numCallsBelowRequirer + 1);
+        neqNull(o0, name0);
+        neqNull(o1, name1);
         if (o0.equals(o1)) {
-            fail("!" + name0 + ".equals(" + ExceptionMessageUtil.valueString(o1) + ")",
-                    ExceptionMessageUtil.valueAndName(o0, name0), numCallsBelowRequirer + 1);
+            fail("!" + name0 + ".equals(" + name1 + ")", ExceptionMessageUtil.valueAndName(o0, name0, o1, name1));
         }
     }
 
@@ -2599,226 +1577,158 @@ public final class Require {
      * require (o0 != null &amp;&amp; o1 != null &amp;&amp; !o0.equals(o1))
      */
     public static void notEquals(Object o0, String name0, Object o1) {
-        notEquals(o0, name0, o1, 1);
+        neqNull(o0, name0);
+        neqNull(o1, "o1");
+        if (o0.equals(o1)) {
+            fail("!" + name0 + ".equals(" + ExceptionMessageUtil.valueString(o1) + ")",
+                    ExceptionMessageUtil.valueAndName(o0, name0));
+        }
     }
 
     // ################################################################
     // nonempty (String.equals(nonempty))
 
     // ----------------------------------------------------------------
-    /**
-     * require (s != null &amp;&amp; s.length() &gt; 0)
-     */
-    public static String nonempty(String s, String name, int numCallsBelowRequirer) {
-        neqNull(s, name, numCallsBelowRequirer + 1);
+
+    public static String nonempty(String s, String name) {
+        neqNull(s, name);
         if (!(s.length() > 0)) {
-            fail(name + ".length() > 0", ExceptionMessageUtil.valueAndName(s, name), numCallsBelowRequirer + 1);
+            fail(name + ".length() > 0", ExceptionMessageUtil.valueAndName(s, name));
         }
         return s;
     }
 
-    public static String nonempty(String s, String name) {
-        return nonempty(s, name, 1);
-    }
-
     // ################################################################
 
     // ----------------------------------------------------------------
-    /** require (collection != null &amp;&amp; collection.contains(element)) */
+
     public static <C extends Collection<T>, T> C contains(C collection, String collectionName, T element,
-            String elementName, int numCallsBelowRequirer) {
-        neqNull(collection, collectionName, numCallsBelowRequirer + 1);
+            String elementName) {
+        neqNull(collection, collectionName);
         if (!(collection.contains(element))) {
             fail(collectionName + ".contains(" + elementName + ")",
-                    ExceptionMessageUtil.valueAndName(element, elementName), numCallsBelowRequirer + 1);
+                    ExceptionMessageUtil.valueAndName(element, elementName));
         }
         return collection;
     }
 
-    public static <C extends Collection<T>, T> C contains(C collection, String collectionName, T element,
-            String elementName) {
-        return contains(collection, collectionName, element, elementName, 1);
-    }
-
     // ----------------------------------------------------------------
-    /** require (collection != null &amp;&amp; !collection.contains(element)) */
+
     public static <C extends Collection<T>, T> C notContains(C collection, String collectionName, T element,
-            String elementName, int numCallsBelowRequirer) {
-        neqNull(collection, collectionName, numCallsBelowRequirer + 1);
+            String elementName) {
+        neqNull(collection, collectionName);
         if (collection.contains(element)) {
             fail("!" + collectionName + ".contains(" + elementName + ")",
-                    ExceptionMessageUtil.valueAndName(element, elementName), numCallsBelowRequirer + 1);
+                    ExceptionMessageUtil.valueAndName(element, elementName));
         }
         return collection;
-    }
-
-    public static <C extends Collection<T>, T> C notContains(C collection, String collectionName, T element,
-            String elementName) {
-        return notContains(collection, collectionName, element, elementName, 1);
     }
 
     // ----------------------------------------------------------------
-    /** require (collection != null &amp;&amp; !collection.stream().anyMatch(Objects::isNull) */
-    public static <C extends Collection<T>, T> C notContainsNull(C collection, String collectionName,
-            int numCallsBelowRequirer) {
-        neqNull(collection, collectionName, numCallsBelowRequirer + 1);
-        if (collection.stream().anyMatch(Objects::isNull)) {
-            fail(collectionName + " does not contain null", numCallsBelowRequirer + 1);
-        }
-        return collection;
-    }
 
     public static <C extends Collection<T>, T> C notContainsNull(C collection, String collectionName) {
-        return notContainsNull(collection, collectionName, 1);
+        neqNull(collection, collectionName);
+        if (collection.stream().anyMatch(Objects::isNull)) {
+            fail(collectionName + " does not contain null");
+        }
+        return collection;
     }
 
     // ----------------------------------------------------------------
-    /** require (map != null &amp;&amp; map.containsKey(key)) */
-    public static <M extends Map<K, V>, K, V> M containsKey(M map, String mapName, K key, String keyName,
-            int numCallsBelowRequirer) {
-        neqNull(map, mapName, numCallsBelowRequirer + 1);
-        if (!(map.containsKey(key))) {
-            fail(mapName + ".containsKey(" + keyName + ")", ExceptionMessageUtil.valueAndName(key, keyName),
-                    numCallsBelowRequirer + 1);
-        }
-        return map;
-    }
 
     public static <M extends Map<K, V>, K, V> M containsKey(M map, String mapName, K key, String keyName) {
-        return containsKey(map, mapName, key, keyName, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /** require (map != null &amp;&amp; !map.containsKey(element)) */
-    public static <M extends Map<K, V>, K, V> M notContainsKey(M map, String mapName, K key, String keyName,
-            int numCallsBelowRequirer) {
-        neqNull(map, mapName, numCallsBelowRequirer + 1);
-        if (map.containsKey(key)) {
-            fail("!" + mapName + ".containsKey(" + keyName + ")", ExceptionMessageUtil.valueAndName(key, keyName),
-                    numCallsBelowRequirer + 1);
+        neqNull(map, mapName);
+        if (!(map.containsKey(key))) {
+            fail(mapName + ".containsKey(" + keyName + ")", ExceptionMessageUtil.valueAndName(key, keyName));
         }
         return map;
     }
 
+    // ----------------------------------------------------------------
+
     public static <M extends Map<K, V>, K, V> M notContainsKey(M map, String mapName, K key, String keyName) {
-        return notContainsKey(map, mapName, key, keyName, 1);
+        neqNull(map, mapName);
+        if (map.containsKey(key)) {
+            fail("!" + mapName + ".containsKey(" + keyName + ")", ExceptionMessageUtil.valueAndName(key, keyName));
+        }
+        return map;
     }
 
     // ----------------------------------------------------------------
-    /** require (offset &gt;= 0 &amp;&amp; offset &lt; length) */
-    public static int inRange(int offset, String offsetName, int length, String lengthName, int numCallsBelowRequirer) {
-        if (!(offset >= 0)) {
-            fail(offsetName + " >= 0", ExceptionMessageUtil.valueAndName(offset, offsetName),
-                    numCallsBelowRequirer + 1);
-        } else if (!(offset < length)) {
-            fail(offsetName + " < " + lengthName,
-                    ExceptionMessageUtil.valueAndName(offset, offsetName, length, lengthName),
-                    numCallsBelowRequirer + 1);
-        }
-        return offset;
-    }
 
     /** require (offset &gt;= 0 &amp;&amp; offset &lt; length) */
     public static int inRange(int offset, String offsetName, int length, String lengthName) {
-        return inRange(offset, offsetName, length, lengthName, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /** require (offset &gt;= start &amp;&amp; offset &lt; end) */
-    public static int inRange(int offset, String offsetName, int start, String startName, int end, String endName,
-            int numCallsBelowRequirer) {
-        if (!(offset >= start)) {
-            fail(offsetName + " >= " + startName,
-                    ExceptionMessageUtil.valueAndName(offset, offsetName, start, startName), numCallsBelowRequirer + 1);
-        } else if (!(offset < end)) {
-            fail(offsetName + " < " + endName, ExceptionMessageUtil.valueAndName(offset, offsetName, end, endName),
-                    numCallsBelowRequirer + 1);
+        if (!(offset >= 0)) {
+            fail(offsetName + " >= 0", ExceptionMessageUtil.valueAndName(offset, offsetName));
+        } else if (!(offset < length)) {
+            fail(offsetName + " < " + lengthName,
+                    ExceptionMessageUtil.valueAndName(offset, offsetName, length, lengthName));
         }
         return offset;
     }
+
+    // ----------------------------------------------------------------
 
     /** require (offset &gt;= start &amp;&amp; offset &lt; end) */
     public static int inRange(int offset, String offsetName, int start, String startName, int end, String endName) {
-        return inRange(offset, offsetName, start, startName, end, endName, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /** require (offset &gt;= 0 &amp;&amp; offset &lt; length) */
-    public static long inRange(long offset, String offsetName, long length, String lengthName,
-            int numCallsBelowRequirer) {
-        if (!(offset >= 0L)) {
-            fail(offsetName + " >= 0L", ExceptionMessageUtil.valueAndName(offset, offsetName),
-                    numCallsBelowRequirer + 1);
-        } else if (!(offset < length)) {
-            fail(offsetName + " < " + lengthName,
-                    ExceptionMessageUtil.valueAndName(offset, offsetName, length, lengthName),
-                    numCallsBelowRequirer + 1);
+        if (!(offset >= start)) {
+            fail(offsetName + " >= " + startName,
+                    ExceptionMessageUtil.valueAndName(offset, offsetName, start, startName));
+        } else if (!(offset < end)) {
+            fail(offsetName + " < " + endName, ExceptionMessageUtil.valueAndName(offset, offsetName, end, endName));
         }
         return offset;
     }
+
+    // ----------------------------------------------------------------
 
     /** require (offset &gt;= 0 &amp;&amp; offset &lt; length) */
     public static long inRange(long offset, String offsetName, long length, String lengthName) {
-        return inRange(offset, offsetName, length, lengthName, 1);
-    }
-
-    // ----------------------------------------------------------------
-    /** require (offset &gt;= start &amp;&amp; offset &lt; end) */
-    public static long inRange(long offset, String offsetName, long start, String startName, long end, String endName,
-            int numCallsBelowRequirer) {
-        if (!(offset >= start)) {
-            fail(offsetName + " >= " + startName,
-                    ExceptionMessageUtil.valueAndName(offset, offsetName, start, startName), numCallsBelowRequirer + 1);
-        } else if (!(offset < end)) {
-            fail(offsetName + " < " + endName, ExceptionMessageUtil.valueAndName(offset, offsetName, end, endName),
-                    numCallsBelowRequirer + 1);
+        if (!(offset >= 0L)) {
+            fail(offsetName + " >= 0L", ExceptionMessageUtil.valueAndName(offset, offsetName));
+        } else if (!(offset < length)) {
+            fail(offsetName + " < " + lengthName,
+                    ExceptionMessageUtil.valueAndName(offset, offsetName, length, lengthName));
         }
         return offset;
     }
 
+    // ----------------------------------------------------------------
+
     /** require (offset &gt;= start &amp;&amp; offset &lt; end) */
     public static long inRange(long offset, String offsetName, long start, String startName, long end, String endName) {
-        return inRange(offset, offsetName, start, startName, end, endName, 1);
+        if (!(offset >= start)) {
+            fail(offsetName + " >= " + startName,
+                    ExceptionMessageUtil.valueAndName(offset, offsetName, start, startName));
+        } else if (!(offset < end)) {
+            fail(offsetName + " < " + endName, ExceptionMessageUtil.valueAndName(offset, offsetName, end, endName));
+        }
+        return offset;
     }
 
     // ################################################################
 
     /** require d != {Infinity, -Infinity, NaN}. */
-    public static double normalized(double d, String name, int numCallsBelowRequirer) {
+    public static double normalized(double d, String name) {
         if (!(!Double.isNaN(d) && !Double.isInfinite(d))) {
-            fail(name + " is normalized (not infinity or NaN)", ExceptionMessageUtil.valueAndName(d, name),
-                    numCallsBelowRequirer + 1);
+            fail(name + " is normalized (not infinity or NaN)", ExceptionMessageUtil.valueAndName(d, name));
         }
         return d;
     }
 
-    /** require d != {Infinity, -Infinity, NaN}. */
-    public static double normalized(double d, String name) {
-        return normalized(d, name, 1);
-    }
-
-    public static <T> T[] nonEmpty(final T[] a, final String name, final int numCallsBelowRequirer) {
-        neqNull(a, name, numCallsBelowRequirer + 1);
-        if (!(a.length > 0)) {
-            fail(name + ".length > 0", ExceptionMessageUtil.valueAndName(a, name), numCallsBelowRequirer + 1);
-        }
-        return a;
-    }
-
     public static <T> T[] nonEmpty(final T[] a, final String name) {
-        return nonEmpty(a, name, 1);
-    }
-
-    public static int[] lengthEqual(final int[] a, final String name, final int length,
-            final int numCallsBelowRequirer) {
-        if (!(a.length == length)) {
-            fail(name + ".length == " + length, ExceptionMessageUtil.valueAndName(a, name), numCallsBelowRequirer + 1);
+        neqNull(a, name);
+        if (!(a.length > 0)) {
+            fail(name + ".length > 0", ExceptionMessageUtil.valueAndName(a, name));
         }
         return a;
     }
 
     public static int[] lengthEqual(final int[] a, final String name, final int length) {
-        return lengthEqual(a, name, length, 1);
+        if (!(a.length == length)) {
+            fail(name + ".length == " + length, ExceptionMessageUtil.valueAndName(a, name));
+        }
+        return a;
     }
 
     public static <T> T[] elementsNeqNull(final T[] elements, final String name) {
@@ -2874,7 +1784,7 @@ public final class Require {
     public static void isSquare(double[][] m, String name) {
         for (int i = 0; i < m.length; i++) {
             if (m[i].length != m.length) {
-                fail("Matrix is not square: " + name, "matrix is not square: " + name, 1);
+                fail("Matrix is not square: " + name, "matrix is not square: " + name);
             }
         }
     }
@@ -2889,7 +1799,7 @@ public final class Require {
         }
         if (trialValue < minRange || maxRange < trialValue) {
             fail(name + " = " + trialValue + " is expected to be in the range of [" + minRange + "," + maxRange
-                    + "] but was not", 1);
+                    + "] but was not");
         }
         return trialValue;
     }
@@ -2904,7 +1814,7 @@ public final class Require {
         }
         if (trialValue < minRange || maxRange < trialValue) {
             fail(name + " = " + trialValue + " is expected to be in the range of [" + minRange + "," + maxRange
-                    + "] but was not", 1);
+                    + "] but was not");
         }
         return trialValue;
     }

--- a/Base/src/main/java/io/deephaven/base/verify/RequirementFailure.java
+++ b/Base/src/main/java/io/deephaven/base/verify/RequirementFailure.java
@@ -3,122 +3,17 @@
 //
 package io.deephaven.base.verify;
 
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 // ----------------------------------------------------------------
 /**
  * {@link RuntimeException} to be thrown on requirement failures.
  */
 public class RequirementFailure extends RuntimeException {
 
-    /**
-     * The number of stack frames that should be removed from the stack to find the method whose requirements did not
-     * hold.
-     */
-    private int m_nCallsBelowRequirer;
-
-    // ----------------------------------------------------------------
-    public RequirementFailure(String message, int nCallsBelowRequirer) {
+    public RequirementFailure(String message) {
         super(message);
-        m_nCallsBelowRequirer = nCallsBelowRequirer;
     }
 
-    // ----------------------------------------------------------------
-    public RequirementFailure(String message, Exception caughtException, int nCallsBelowRequirer) {
+    public RequirementFailure(String message, Exception caughtException) {
         super(message, caughtException);
-        m_nCallsBelowRequirer = nCallsBelowRequirer;
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * Gets the number of stack frames that should be removed from the stack to find the caller which failed to meet
-     * requirements.
-     */
-    public int getNumCallsBelowRequirer() {
-        return m_nCallsBelowRequirer;
-    }
-
-    // ----------------------------------------------------------------
-    @Override
-    public void printStackTrace() {
-        printStackTrace(System.err);
-    }
-
-    // ----------------------------------------------------------------
-    @Override
-    public void printStackTrace(PrintStream s) {
-        s.print(getFixedStackTrace());
-    }
-
-    // ----------------------------------------------------------------
-    @Override
-    public void printStackTrace(PrintWriter s) {
-        s.print(getFixedStackTrace());
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * Gets a stack trace with a line added identifying the offending stack frame.
-     */
-    private StringBuffer getFixedStackTrace() {
-        StringBuffer sb = getOriginalStackTrace();
-
-        String sStackTrace = sb.toString();
-        int nInsertPoint = sStackTrace.indexOf("\n\tat ");
-        for (int nCount = m_nCallsBelowRequirer; nCount >= 0; nCount--) {
-            nInsertPoint = sStackTrace.indexOf("\n\tat ", nInsertPoint + 1);
-        }
-        if (-1 != nInsertPoint) {
-            sb.insert(nInsertPoint, "\n    (culprit:)");
-        }
-        return sb;
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * Gets the unmodified stack trace, instead of the one with the culprit identified.
-     */
-    public StringBuffer getOriginalStackTrace() {
-        StringWriter stringWriter = new StringWriter();
-        PrintWriter printWriter = new PrintWriter(stringWriter);
-        super.printStackTrace(printWriter);
-        printWriter.close();
-        return stringWriter.getBuffer();
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * If this stack frame caused the exception, adjust the culprit to be the caller. Used when a delegating method
-     * can't verify all requirements itself but shouldn't receive the blame.
-     */
-    public RequirementFailure adjustForDelegatingMethod() {
-        if (isThisStackFrameCulprit(1)) {
-            m_nCallsBelowRequirer++;
-        }
-        return this;
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * If this stack frame caused the exception, adjust the culprit to be the caller. Used when a delegating method
-     * can't verify all requirements itself but shouldn't receive the blame.
-     */
-    public RequirementFailure adjustForDelegatingMethodAndSyntheticAccessor() {
-        if (isThisStackFrameCulprit(0)) {
-            m_nCallsBelowRequirer += 2;
-        }
-        return this;
-    }
-
-    // ----------------------------------------------------------------
-    /**
-     * Returns true if this stack frame is blamed for causing the exception.
-     */
-    public boolean isThisStackFrameCulprit(int nFramesBelowTargetFrame) {
-        StackTraceElement[] stackTrace = new Throwable().getStackTrace();
-        StackTraceElement[] failureStackTrace = getStackTrace();
-        return failureStackTrace.length - m_nCallsBelowRequirer == stackTrace.length - nFramesBelowTargetFrame;
     }
 }

--- a/Base/src/test/java/io/deephaven/base/TestLowGarbageArrayIntegerMap.java
+++ b/Base/src/test/java/io/deephaven/base/TestLowGarbageArrayIntegerMap.java
@@ -60,7 +60,6 @@ public class TestLowGarbageArrayIntegerMap extends TestCase {
             integerToStringMap.put(-1, "negative one");
             fail("expected bad index to fail");
         } catch (RequirementFailure requirementFailure) {
-            assertTrue(requirementFailure.isThisStackFrameCulprit(-1));
         }
 
         try {

--- a/Base/src/test/java/io/deephaven/base/TestLowGarbageArrayIntegerMap.java
+++ b/Base/src/test/java/io/deephaven/base/TestLowGarbageArrayIntegerMap.java
@@ -59,7 +59,7 @@ public class TestLowGarbageArrayIntegerMap extends TestCase {
         try {
             integerToStringMap.put(-1, "negative one");
             fail("expected bad index to fail");
-        } catch (RequirementFailure requirementFailure) {
+        } catch (RequirementFailure expected) {
         }
 
         try {

--- a/Base/src/test/java/io/deephaven/base/pool/TestThreadSafeLenientFixedSizePool.java
+++ b/Base/src/test/java/io/deephaven/base/pool/TestThreadSafeLenientFixedSizePool.java
@@ -142,8 +142,8 @@ public class TestThreadSafeLenientFixedSizePool extends TestCase {
         // too small
         try {
             new ThreadSafeLenientFixedSizePool<Object>(6, m_mockObjectFactory, m_mockClearingProcedure);
-        } catch (RequirementFailure requirementFailure) {
-            assertTrue(requirementFailure.isThisStackFrameCulprit(0));
+            fail("expected to throw");
+        } catch (RequirementFailure expected) {
         }
 
         // minimum size
@@ -156,15 +156,15 @@ public class TestThreadSafeLenientFixedSizePool extends TestCase {
         // no factory
         try {
             ThreadSafeLenientFixedSizePool.FACTORY.create(OBJECTS.length, null, m_mockClearingProcedure);
-        } catch (RequirementFailure requirementFailure) {
-            assertTrue(requirementFailure.isThisStackFrameCulprit(0));
+            fail("expected to throw");
+        } catch (RequirementFailure expected) {
         }
 
         // too small
         try {
             ThreadSafeLenientFixedSizePool.FACTORY.create(6, m_mockObjectFactory, m_mockClearingProcedure);
-        } catch (RequirementFailure requirementFailure) {
-            assertTrue(requirementFailure.isThisStackFrameCulprit(0));
+            fail("expected to throw");
+        } catch (RequirementFailure expected) {
         }
 
         // minimum size

--- a/DataStructures/src/main/java/io/deephaven/datastructures/util/CollectionUtil.java
+++ b/DataStructures/src/main/java/io/deephaven/datastructures/util/CollectionUtil.java
@@ -30,29 +30,17 @@ public class CollectionUtil {
 
     // ----------------------------------------------------------------
     public static <K, V> Map<K, V> unmodifiableMapFromArray(Class<K> typeK, Class<V> typeV, Object... data) {
-        try {
-            return Collections.unmodifiableMap(mapFromArray(typeK, typeV, data));
-        } catch (RequirementFailure e) {
-            throw e.adjustForDelegatingMethod();
-        }
+        return Collections.unmodifiableMap(mapFromArray(typeK, typeV, data));
     }
 
     // ----------------------------------------------------------------
     public static <K, V> Map<K, V> unmodifiableInvertMap(Map<V, K> sourceMap) {
-        try {
-            return Collections.unmodifiableMap(invertMap(sourceMap));
-        } catch (RequirementFailure e) {
-            throw e.adjustForDelegatingMethod();
-        }
+        return Collections.unmodifiableMap(invertMap(sourceMap));
     }
 
     // ----------------------------------------------------------------
     public static <E> Set<E> unmodifiableSetFromArray(E... data) {
-        try {
-            return Collections.unmodifiableSet(setFromArray(data));
-        } catch (RequirementFailure e) {
-            throw e.adjustForDelegatingMethod();
-        }
+        return Collections.unmodifiableSet(setFromArray(data));
     }
 
     // ----------------------------------------------------------------

--- a/Util/src/main/java/io/deephaven/util/Utils.java
+++ b/Util/src/main/java/io/deephaven/util/Utils.java
@@ -375,17 +375,10 @@ public class Utils {
     /**
      * require (o instanceof type)
      */
-    public static <T> T castTo(Object o, String name, Class<T> type, int numCallsBelowRequirer) {
-        io.deephaven.base.verify.Require.instanceOf(o, name, type, numCallsBelowRequirer);
+    public static <T> T castTo(Object o, String name, Class<T> type) {
+        io.deephaven.base.verify.Require.instanceOf(o, name, type);
         // noinspection unchecked
         return (T) o;
-    }
-
-    /**
-     * require (o instanceof type)
-     */
-    public static <T> T castTo(Object o, String name, Class<T> type) {
-        return castTo(o, name, type, 1);
     }
 
     /**

--- a/Util/src/test/java/io/deephaven/util/pool/TestThreadSafeLenientFixedSizePool.java
+++ b/Util/src/test/java/io/deephaven/util/pool/TestThreadSafeLenientFixedSizePool.java
@@ -147,8 +147,8 @@ public class TestThreadSafeLenientFixedSizePool extends TestCase {
         try {
             new io.deephaven.base.pool.ThreadSafeLenientFixedSizePool<Object>(6, m_mockObjectFactory,
                     m_mockClearingProcedure);
-        } catch (RequirementFailure requirementFailure) {
-            assertTrue(requirementFailure.isThisStackFrameCulprit(0));
+            fail("expected to throw");
+        } catch (RequirementFailure expected) {
         }
 
         // minimum size
@@ -162,16 +162,16 @@ public class TestThreadSafeLenientFixedSizePool extends TestCase {
         try {
             io.deephaven.base.pool.ThreadSafeLenientFixedSizePool.FACTORY.create(OBJECTS.length, null,
                     m_mockClearingProcedure);
-        } catch (RequirementFailure requirementFailure) {
-            assertTrue(requirementFailure.isThisStackFrameCulprit(0));
+            fail("expected to throw");
+        } catch (RequirementFailure expected) {
         }
 
         // too small
         try {
             io.deephaven.base.pool.ThreadSafeLenientFixedSizePool.FACTORY.create(6, m_mockObjectFactory,
                     m_mockClearingProcedure);
-        } catch (RequirementFailure requirementFailure) {
-            assertTrue(requirementFailure.isThisStackFrameCulprit(0));
+            fail("expected to throw");
+        } catch (RequirementFailure expected) {
         }
 
         // minimum size


### PR DESCRIPTION
The string `culprit` as a marker for pointing to an issue in a stack trace has never appeared in a DHC issue, nor in DHC slack, and the last DHE slack message to use it in a mildly helpful way was more than two years ago.

This patch removes the functionality from `RequirementFailure`, and also removes any overload of a method in `Require` that would allow callers to customize the depth within the stack that should be marked.

Partial #188