### PR TITLE
chore: Bump calcite to 1.37.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ avro = "1.11.3"
 awssdk = "2.24.5"
 # See dependency matrix for particular gRPC versions at https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
 boringssl = "2.0.61.Final"
-calcite = "1.36.0"
+calcite = "1.37.0"
 classgraph = "4.8.165"
 commons-compress = "1.26.0"
 commons-io = "2.11.0"

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -9,13 +9,6 @@ description = 'The Deephaven SQL parser'
 dependencies {
     api project(':qst')
     implementation libs.calcite.core
-    constraints {
-        // This constraint can be removed once calcite-core has next release and we can
-        // pick up the fixed dependency transitively.
-        implementation('com.jayway.jsonpath:json-path:2.9.0') {
-            because 'json-path Out-of-bounds Write vulnerability, CVE-2023-51074'
-        }
-    }
 
     compileOnly project(':util-immutables')
     annotationProcessor libs.immutables.value

--- a/sql/src/main/java/io/deephaven/sql/RexVisitorBase.java
+++ b/sql/src/main/java/io/deephaven/sql/RexVisitorBase.java
@@ -8,6 +8,8 @@ import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexDynamicParam;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLambda;
+import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
@@ -76,6 +78,16 @@ class RexVisitorBase<T> implements RexVisitor<T> {
 
     @Override
     public T visitPatternFieldRef(RexPatternFieldRef fieldRef) {
+        throw unsupported(fieldRef);
+    }
+
+    @Override
+    public T visitLambda(RexLambda fieldRef) {
+        throw unsupported(fieldRef);
+    }
+
+    @Override
+    public T visitLambdaRef(RexLambdaRef fieldRef) {
         throw unsupported(fieldRef);
     }
 


### PR DESCRIPTION
Calcite introduced lambda expression support. Until such time as we need it, we'll won't adapt lambdas.

https://github.com/apache/calcite/pull/3502

https://calcite.apache.org/news/2024/05/06/release-1.37.0/

https://calcite.apache.org/docs/history.html#v1-37-0