### PR TITLE
feat: Add props for controlling WebGL settings

### DIFF
--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -63,6 +63,7 @@ authentication.client.configuration.list=AuthHandlers
 
 # List of configuration properties to provide to authenticated clients, so they can interact with the server.
 client.configuration.list=java.version,deephaven.version,barrage.version,http.session.durationMs,file.separator,web.storage.layout.directory,web.storage.notebook.directory,web.webgl,web.webgl.editable
+
 # Version list to add to the configuration property list. Each `=`-delimited pair denotes a short name for a versioned
 # jar, and a class that is found in that jar. Any such keys will be made available to the client.configuration.list
 # as <key>.version.

--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -53,12 +53,16 @@ authentication.anonymous.warn=true
 web.storage.layout.directory=/layouts
 web.storage.notebook.directory=/notebooks
 
+# Enable WebGL support in the web interface, or forcibly disable it and prevent users from enabling it.
+web.webgl=true
+web.webgl.editable=true
+
 # List of configuration properties to provide to unauthenticated clients, so that they can decide how best to prove their
 # identity to the server.
 authentication.client.configuration.list=AuthHandlers
 
 # List of configuration properties to provide to authenticated clients, so they can interact with the server.
-client.configuration.list=java.version,deephaven.version,barrage.version,http.session.durationMs,file.separator,web.storage.layout.directory,web.storage.notebook.directory
+client.configuration.list=java.version,deephaven.version,barrage.version,http.session.durationMs,file.separator,web.storage.layout.directory,web.storage.notebook.directory,web.webgl,web.webgl.editable
 # Version list to add to the configuration property list. Each `=`-delimited pair denotes a short name for a versioned
 # jar, and a class that is found in that jar. Any such keys will be made available to the client.configuration.list
 # as <key>.version.


### PR DESCRIPTION
- Web UI now has controls for enabling/disabling WebGL: https://github.com/deephaven/web-client-ui/pull/2143
- These can be controlled by config values on the server
- Add the default values to dh-defaults.prop
  - If they're unset, UI defaults to `true` for both values (same value as the dh-defaults.prop)