### PR TITLE
test: Update JS API PartitionedTable test to stop using getKeyTable()

### DIFF
--- a/web/client-api/src/test/java/io/deephaven/web/client/api/PartitionedTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/PartitionedTableTestGwt.java
@@ -42,8 +42,7 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
                     assertEquals("MyKey", columns[0].getName());
                     assertEquals("x", columns[1].getName());
 
-                    return partitionedTable.getKeyTable().then(keyTable -> {
-                        System.out.println("KeyTable size: " + keyTable.getSize());
+                    return partitionedTable.getBaseTable().then(keyTable -> {
                         assertEquals(5d, keyTable.getSize());
 
                         return partitionedTable.getTable("2");
@@ -70,7 +69,7 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
                     assertEquals(1, columns.length);
                     assertEquals("x", columns[0].getName());
 
-                    return partitionedTable.getKeyTable().then(keyTable -> {
+                    return partitionedTable.getBaseTable().then(keyTable -> {
                         assertEquals(5d, keyTable.getSize());
 
                         return partitionedTable.getTable("2");
@@ -114,19 +113,17 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
                     assertEquals("MyKey", columns[1].getName());
                     assertEquals("x", columns[2].getName());
 
-                    return partitionedTable.getKeyTable().then(keyTable -> {
-                        keyTable.setViewport(0, 99, keyTable.getColumns(), null);
-                        return waitForEventWhere(keyTable, JsTable.EVENT_UPDATED,
-                                (CustomEvent<ViewportData> d) -> d.detail.getRows().length >= 5, 14004);
-                    }).then(event -> partitionedTable.getTable("2")).then(constituentTable -> {
-                        assertEquals(3, constituentTable.getColumns().length);
-                        assertTrue(constituentTable.getSize() >= 2);
+                    return waitForEventWhere(partitionedTable, JsPartitionedTable.EVENT_KEYADDED,
+                            (CustomEvent<JsArray<Object>> e) -> e.detail.getAt(0).equals("2"), 14004)
+                            .then(event -> partitionedTable.getTable("2")).then(constituentTable -> {
+                                assertEquals(3, constituentTable.getColumns().length);
+                                assertTrue(constituentTable.getSize() >= 2);
 
-                        constituentTable.close();
-                        partitionedTable.close();
+                                constituentTable.close();
+                                partitionedTable.close();
 
-                        return null;
-                    });
+                                return null;
+                            });
                 })
                 .then(this::finish).catch_(this::report);
     }
@@ -145,21 +142,17 @@ public class PartitionedTableTestGwt extends AbstractAsyncGwtTestCase {
                     assertEquals("Timestamp", columns[0].getName());
                     assertEquals("x", columns[1].getName());
 
-                    return partitionedTable.getKeyTable().then(keyTable -> {
-                        keyTable.setViewport(0, 99, keyTable.getColumns(), null);
-                        return waitForEventWhere(keyTable, JsTable.EVENT_UPDATED,
-                                (CustomEvent<ViewportData> d) -> d.detail.getRows().length >= 5, 14004)
-                                .then(event -> partitionedTable.getTable("2")).then(constituentTable -> {
-                                    assertEquals(2, constituentTable.getColumns().length);
-                                    assertTrue(constituentTable.getSize() >= 1);
+                    return waitForEventWhere(partitionedTable, JsPartitionedTable.EVENT_KEYADDED,
+                            (CustomEvent<JsArray<Object>> e) -> e.detail.getAt(0).equals("2"), 14005)
+                            .then(event -> partitionedTable.getTable("2")).then(constituentTable -> {
+                                assertEquals(2, constituentTable.getColumns().length);
+                                assertTrue(constituentTable.getSize() >= 1);
 
-                                    keyTable.close();
-                                    constituentTable.close();
-                                    partitionedTable.close();
+                                constituentTable.close();
+                                partitionedTable.close();
 
-                                    return null;
-                                });
-                    });
+                                return null;
+                            });
                 })
                 .then(this::finish).catch_(this::report);
     }


### PR DESCRIPTION
This method is deprecated and should not be used. The test now has simple usage of getBaseTable(), and also tests the EVENT_KEY_ADDED which will never race with the presence of the constituent table.

Follow-up: #5645