### PR TITLE
refactor!: Rearrange TypeUtils and ArrayTypeUtils so they can be shared with JS API

### DIFF
--- a/Plot/src/main/java/io/deephaven/plot/util/ArgumentValidations.java
+++ b/Plot/src/main/java/io/deephaven/plot/util/ArgumentValidations.java
@@ -4,7 +4,6 @@
 package io.deephaven.plot.util;
 
 import io.deephaven.base.verify.Require;
-import io.deephaven.base.verify.RequirementFailure;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.plot.datasets.data.IndexableNumericData;
@@ -13,6 +12,7 @@ import io.deephaven.plot.filters.SelectableDataSet;
 import io.deephaven.plot.util.tables.TableHandle;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.util.type.NumericTypeUtils;
 import io.deephaven.util.type.TypeUtils;
 import org.apache.commons.lang3.ClassUtils;
 
@@ -362,24 +362,24 @@ public class ArgumentValidations {
     }
 
     /**
-     * Whether the class is {@link TypeUtils#isNumeric(Class)} or {@link #isTime(Class, PlotInfo)}
+     * Whether the class is {@link NumericTypeUtils#isNumeric(Class)} or {@link #isTime(Class, PlotInfo)}
      *
      * @param c class
      * @return true if {@code c} is a numeric or time class, false otherwise
      */
     public static boolean isNumericOrTime(final Class c) {
-        return TypeUtils.isNumeric(c) || isTime(c, null);
+        return NumericTypeUtils.isNumeric(c) || isTime(c, null);
     }
 
     /**
-     * Whether the class is {@link TypeUtils#isNumeric(Class)} or {@link #isTime(Class, PlotInfo)}
+     * Whether the class is {@link NumericTypeUtils#isNumeric(Class)} or {@link #isTime(Class, PlotInfo)}
      *
      * @param c class
      * @param plotInfo source of the exception
      * @return true if {@code c} is a numeric or time class, false otherwise
      */
     public static boolean isNumericOrTime(final Class c, final PlotInfo plotInfo) {
-        return TypeUtils.isNumeric(c) || isTime(c, plotInfo);
+        return NumericTypeUtils.isNumeric(c) || isTime(c, plotInfo);
     }
 
     /**
@@ -432,7 +432,7 @@ public class ArgumentValidations {
     }
 
     /**
-     * Whether the column's data type {@link TypeUtils#isBoxedNumeric(Class)}.
+     * Whether the column's data type {@link NumericTypeUtils#isBoxedNumeric(Class)}.
      *
      * @param t table
      * @param column column
@@ -441,11 +441,11 @@ public class ArgumentValidations {
      */
     public static boolean isBoxedNumeric(final Table t, final String column, final PlotInfo plotInfo) {
         assertNotNull(t, "t", plotInfo);
-        return TypeUtils.isBoxedNumeric(getColumnType(t, column, plotInfo));
+        return NumericTypeUtils.isBoxedNumeric(getColumnType(t, column, plotInfo));
     }
 
     /**
-     * Whether the column's data type {@link TypeUtils#isNumeric(Class)}.
+     * Whether the column's data type {@link NumericTypeUtils#isNumeric(Class)}.
      *
      * @param t table
      * @param column column
@@ -454,11 +454,11 @@ public class ArgumentValidations {
      */
     public static boolean isNumeric(final Table t, final String column, final PlotInfo plotInfo) {
         assertNotNull(t, "t", plotInfo);
-        return TypeUtils.isNumeric(getColumnType(t, column, plotInfo));
+        return NumericTypeUtils.isNumeric(getColumnType(t, column, plotInfo));
     }
 
     /**
-     * Whether the column's data type {@link TypeUtils#isNumeric(Class)}.
+     * Whether the column's data type {@link NumericTypeUtils#isNumeric(Class)}.
      *
      * @param t table
      * @param column column
@@ -467,11 +467,11 @@ public class ArgumentValidations {
      */
     public static boolean isNumeric(final TableDefinition t, final String column, final PlotInfo plotInfo) {
         assertNotNull(t, "t", plotInfo);
-        return TypeUtils.isNumeric(getColumnType(t, column, plotInfo));
+        return NumericTypeUtils.isNumeric(getColumnType(t, column, plotInfo));
     }
 
     /**
-     * Whether the column's data type {@link TypeUtils#isNumeric(Class)}.
+     * Whether the column's data type {@link NumericTypeUtils#isNumeric(Class)}.
      *
      * @param sds selectable dataset
      * @param column column
@@ -480,7 +480,7 @@ public class ArgumentValidations {
      */
     public static boolean isNumeric(final SelectableDataSet sds, final String column, final PlotInfo plotInfo) {
         assertNotNull(sds, "t", plotInfo);
-        return TypeUtils.isNumeric(getColumnType(sds, column, plotInfo));
+        return NumericTypeUtils.isNumeric(getColumnType(sds, column, plotInfo));
     }
 
     /**
@@ -616,7 +616,7 @@ public class ArgumentValidations {
 
     /**
      * Requires the column's data type to be an instance of {@link Number} as defined in
-     * {@link TypeUtils#isBoxedNumeric(Class)}
+     * {@link NumericTypeUtils#isBoxedNumeric(Class)}
      *
      * @throws RuntimeException if the column's data type isn't an instance of {@link Number}
      * @param t table
@@ -631,7 +631,7 @@ public class ArgumentValidations {
 
     /**
      * Requires the column's data type to be an instance of {@link Number} as defined in
-     * {@link TypeUtils#isBoxedNumeric(Class)}
+     * {@link NumericTypeUtils#isBoxedNumeric(Class)}
      *
      * @throws RuntimeException if the column's data type isn't an instance of {@link Number}
      * @param t table
@@ -649,7 +649,7 @@ public class ArgumentValidations {
 
 
     /**
-     * Requires the column's data type to be a numeric instance as defined in {@link TypeUtils#isNumeric(Class)}
+     * Requires the column's data type to be a numeric instance as defined in {@link NumericTypeUtils#isNumeric(Class)}
      *
      * @throws PlotRuntimeException if the column's data type isn't a numeric instance
      * @param t table
@@ -663,7 +663,7 @@ public class ArgumentValidations {
 
 
     /**
-     * Requires the column's data type to be a numeric instance as defined in {@link TypeUtils#isNumeric(Class)}
+     * Requires the column's data type to be a numeric instance as defined in {@link NumericTypeUtils#isNumeric(Class)}
      *
      * @throws PlotRuntimeException if the column's data type isn't a numeric instance
      * @param t table
@@ -677,7 +677,7 @@ public class ArgumentValidations {
 
 
     /**
-     * Requires the column's data type to be a numeric instance as defined in {@link TypeUtils#isNumeric(Class)}
+     * Requires the column's data type to be a numeric instance as defined in {@link NumericTypeUtils#isNumeric(Class)}
      *
      * @throws PlotRuntimeException if the column's data type isn't a numeric instance
      * @param t table
@@ -695,7 +695,7 @@ public class ArgumentValidations {
 
 
     /**
-     * Requires the column's data type to be a numeric instance as defined in {@link TypeUtils#isNumeric(Class)}
+     * Requires the column's data type to be a numeric instance as defined in {@link NumericTypeUtils#isNumeric(Class)}
      *
      * @throws PlotRuntimeException if the column's data type isn't a numeric instance
      * @param t table
@@ -713,7 +713,7 @@ public class ArgumentValidations {
 
 
     /**
-     * Requires the column's data type to be a numeric instance as defined in {@link TypeUtils#isNumeric(Class)}
+     * Requires the column's data type to be a numeric instance as defined in {@link NumericTypeUtils#isNumeric(Class)}
      *
      * @throws PlotRuntimeException if the column's data type isn't a numeric instance
      * @param sds selectable dataset

--- a/Plot/src/main/java/io/deephaven/plot/util/ArgumentValidations.java
+++ b/Plot/src/main/java/io/deephaven/plot/util/ArgumentValidations.java
@@ -419,7 +419,7 @@ public class ArgumentValidations {
     }
 
     /**
-     * Whether the column's data type {@link TypeUtils#isPrimitiveNumeric(Class)}.
+     * Whether the column's data type {@link NumericTypeUtils#isPrimitiveNumeric(Class)}.
      *
      * @param t table
      * @param column column
@@ -428,7 +428,7 @@ public class ArgumentValidations {
      */
     public static boolean isPrimitiveNumeric(final Table t, final String column, final PlotInfo plotInfo) {
         assertNotNull(t, "t", plotInfo);
-        return TypeUtils.isPrimitiveNumeric(getColumnType(t, column, plotInfo));
+        return NumericTypeUtils.isPrimitiveNumeric(getColumnType(t, column, plotInfo));
     }
 
     /**
@@ -583,7 +583,7 @@ public class ArgumentValidations {
 
     /**
      * Requires the column's data type to be a numeric primitive as defined in
-     * {@link TypeUtils#isPrimitiveNumeric(Class)}
+     * {@link NumericTypeUtils#isPrimitiveNumeric(Class)}
      *
      * @throws RuntimeException if the column's data type isn't a numeric primitive
      * @param t table
@@ -598,7 +598,7 @@ public class ArgumentValidations {
 
     /**
      * Requires the column's data type to be a numeric primitive as defined in
-     * {@link TypeUtils#isPrimitiveNumeric(Class)}
+     * {@link NumericTypeUtils#isPrimitiveNumeric(Class)}
      *
      * @throws RuntimeException if the column's data type isn't a numeric primitive
      * @param t table

--- a/Util/src/main/java/io/deephaven/util/type/ArrayTypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/ArrayTypeUtils.java
@@ -5,11 +5,7 @@ package io.deephaven.util.type;
 
 import io.deephaven.base.verify.Require;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Set;
 
 import static io.deephaven.util.QueryConstants.*;
 
@@ -31,52 +27,25 @@ public class ArrayTypeUtils {
     public static final String[][] EMPTY_STRING_ARRAY_ARRAY = new String[0][];
     public static final Boolean[] EMPTY_BOOLEANBOXED_ARRAY = new Boolean[0];
 
-    public static ArrayAccessor getArrayAccessor(Object array) {
-        final Class<?> c = array.getClass();
-        if (c.equals(Boolean[].class)) {
+    public static ArrayAccessor<?> getArrayAccessor(Object array) {
+        if (array instanceof Boolean[]) {
             return new BooleanArrayAccessor((Boolean[]) array);
-        } else if (c.equals(byte[].class)) {
+        } else if (array instanceof byte[]) {
             return new ByteArrayAccessor((byte[]) array);
-        } else if (c.equals(char[].class)) {
+        } else if (array instanceof char[]) {
             return new CharArrayAccessor((char[]) array);
-        } else if (c.equals(double[].class)) {
+        } else if (array instanceof double[]) {
             return new DoubleArrayAccessor((double[]) array);
-        } else if (c.equals(float[].class)) {
+        } else if (array instanceof float[]) {
             return new FloatArrayAccessor((float[]) array);
-        } else if (c.equals(int[].class)) {
+        } else if (array instanceof int[]) {
             return new IntArrayAccessor((int[]) array);
-        } else if (c.equals(long[].class)) {
+        } else if (array instanceof long[]) {
             return new LongArrayAccessor((long[]) array);
-        } else if (c.equals(short[].class)) {
+        } else if (array instanceof short[]) {
             return new ShortArrayAccessor((short[]) array);
         } else {
-            return new ObjectArrayAccessor((Object[]) array);
-        }
-    }
-
-    public static ArrayAccessor createArrayAccessor(Object element, int size) {
-        if (element == null) {
-            return new ObjectArrayAccessor(new Object[size]);
-        }
-        final Class<?> c = element.getClass();
-        if (c.equals(boolean.class) || c.equals(Boolean.class)) {
-            return new BooleanArrayAccessor(booleanNullArray(size));
-        } else if (c.equals(byte.class) || c.equals(Byte.class)) {
-            return new ByteArrayAccessor(byteNullArray(size));
-        } else if (c.equals(char.class) || c.equals(Character.class)) {
-            return new CharArrayAccessor(charNullArray(size));
-        } else if (c.equals(double.class) || c.equals(Double.class)) {
-            return new DoubleArrayAccessor(doubleNullArray(size));
-        } else if (c.equals(float.class) || c.equals(Float.class)) {
-            return new FloatArrayAccessor(floatNullArray(size));
-        } else if (c.equals(int.class) || c.equals(Integer.class)) {
-            return new IntArrayAccessor(intNullArray(size));
-        } else if (c.equals(long.class) || c.equals(Long.class)) {
-            return new LongArrayAccessor(longNullArray(size));
-        } else if (c.equals(short.class) || c.equals(Short.class)) {
-            return new ShortArrayAccessor(shortNullArray(size));
-        } else {
-            return new ObjectArrayAccessor((Object[]) Array.newInstance(c, size));
+            return new ObjectArrayAccessor<>((Object[]) array);
         }
     }
 
@@ -126,99 +95,6 @@ public class ArrayTypeUtils {
         short[] result = new short[size];
         Arrays.fill(result, NULL_SHORT);
         return result;
-    }
-
-    public static Object toArray(Collection<?> objects, Class elementType) {
-        if (elementType == boolean.class) {
-            elementType = Boolean.class;
-        }
-        Object result = Array.newInstance(elementType, objects.size());
-        ArrayAccessor accessor = getArrayAccessor(result);
-        int i = 0;
-        for (Object object : objects) {
-            accessor.set(i++, object);
-        }
-        return result;
-    }
-
-    public static Object boxedToPrimitive(Set<?> objects, Class type) {
-        Iterator<?> it = objects.iterator();
-        if (objects.isEmpty()) {
-            Class primitiveType = io.deephaven.util.type.TypeUtils.getUnboxedType(type);
-            if (primitiveType == null) {
-                return Array.newInstance(type, 0);
-            } else {
-                return Array.newInstance(primitiveType, 0);
-            }
-        }
-        Object current = it.next();
-        ArrayAccessor resultAccessor = createArrayAccessor(current, objects.size());
-        int i = 0;
-        resultAccessor.set(i++, current);
-        while (it.hasNext()) {
-            current = it.next();
-            resultAccessor.set(i++, current);
-        }
-        return resultAccessor.getArray();
-    }
-
-    public static ArrayAccessor getArrayAccessorFromArray(Object arrayPrototype, int size) {
-        final Class<?> c = arrayPrototype.getClass();
-        if (c.equals(boolean[].class)) {
-            return new BooleanArrayAccessor(booleanNullArray(size));
-        } else if (c.equals(byte[].class)) {
-            return new ByteArrayAccessor(byteNullArray(size));
-        } else if (c.equals(char[].class)) {
-            return new CharArrayAccessor(charNullArray(size));
-        } else if (c.equals(double[].class)) {
-            return new DoubleArrayAccessor(doubleNullArray(size));
-        } else if (c.equals(float[].class)) {
-            return new FloatArrayAccessor(floatNullArray(size));
-        } else if (c.equals(int[].class)) {
-            return new IntArrayAccessor(intNullArray(size));
-        } else if (c.equals(long[].class)) {
-            return new LongArrayAccessor(longNullArray(size));
-        } else if (c.equals(short[].class)) {
-            return new ShortArrayAccessor(shortNullArray(size));
-        } else {
-            return new ObjectArrayAccessor((Object[]) Array.newInstance(c.getComponentType(), size));
-        }
-    }
-
-    public static Object toArray(Collection<?> objects) {
-        if (objects.size() == 0) {
-            return toArray(objects, Object.class);
-        }
-        Object prototype = objects.iterator().next();
-        if (prototype == null) {
-            return toArray(objects, Object.class);
-        }
-        Class ubType = TypeUtils.getUnboxedType(prototype.getClass());
-
-        return toArray(objects, (ubType == null ? prototype.getClass() : ubType));
-    }
-
-    public static ArrayAccessor getAccessorForElementType(Class componentType, int size) {
-        if (componentType.equals(boolean.class) || componentType.equals(Boolean.class)) {
-            return new BooleanArrayAccessor(booleanNullArray(size));
-        } else if (componentType.equals(byte.class) || componentType.equals(Byte.class)) {
-            return new ByteArrayAccessor(byteNullArray(size));
-        } else if (componentType.equals(char.class) || componentType.equals(Character.class)) {
-            return new CharArrayAccessor(charNullArray(size));
-        } else if (componentType.equals(double.class) || componentType.equals(Double.class)) {
-            return new DoubleArrayAccessor(doubleNullArray(size));
-        } else if (componentType.equals(float.class) || componentType.equals(Float.class)) {
-            return new FloatArrayAccessor(floatNullArray(size));
-        } else if (componentType.equals(int.class) || componentType.equals(Integer.class)) {
-            return new IntArrayAccessor(intNullArray(size));
-        } else if (componentType.equals(long.class) || componentType.equals(Long.class)) {
-            return new LongArrayAccessor(longNullArray(size));
-        } else if (componentType.equals(short.class) || componentType.equals(Short.class)) {
-            return new ShortArrayAccessor(shortNullArray(size));
-        } else {
-            return new ObjectArrayAccessor((Object[]) Array.newInstance(componentType, size));
-        }
-
     }
 
     public static Character[] getBoxedArray(char[] referenceData) {
@@ -426,22 +302,21 @@ public class ArrayTypeUtils {
             return null;
         }
 
-        final Class<?> c = value.getClass();
-        if (c.equals(boolean[].class)) {
+        if (value instanceof boolean[]) {
             return getBoxedArray((boolean[]) value);
-        } else if (c.equals(byte[].class)) {
+        } else if (value instanceof byte[]) {
             return getBoxedArray((byte[]) value);
-        } else if (c.equals(char[].class)) {
+        } else if (value instanceof char[]) {
             return getBoxedArray((char[]) value);
-        } else if (c.equals(double[].class)) {
+        } else if (value instanceof double[]) {
             return getBoxedArray((double[]) value);
-        } else if (c.equals(float[].class)) {
+        } else if (value instanceof float[]) {
             return getBoxedArray((float[]) value);
-        } else if (c.equals(int[].class)) {
+        } else if (value instanceof int[]) {
             return getBoxedArray((int[]) value);
-        } else if (c.equals(long[].class)) {
+        } else if (value instanceof long[]) {
             return getBoxedArray((long[]) value);
-        } else if (c.equals(short[].class)) {
+        } else if (value instanceof short[]) {
             return getBoxedArray((short[]) value);
         } else {
             return (Object[]) value;
@@ -449,47 +324,42 @@ public class ArrayTypeUtils {
     }
 
     public static boolean equals(Object actualValue, Object expectedValue) {
-        final Class<?> ct = actualValue.getClass().getComponentType();
-        if (Object.class.isAssignableFrom(ct)) {
-            return Arrays.equals((Object[]) actualValue, (Object[]) expectedValue);
-        } else if (byte.class.isAssignableFrom(ct)) {
+        if (actualValue instanceof byte[] && expectedValue instanceof byte[]) {
             return Arrays.equals((byte[]) actualValue, (byte[]) expectedValue);
-        } else if (char.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof char[] && expectedValue instanceof char[]) {
             return Arrays.equals((char[]) actualValue, (char[]) expectedValue);
-        } else if (double.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof double[] && expectedValue instanceof double[]) {
             return Arrays.equals((double[]) actualValue, (double[]) expectedValue);
-        } else if (float.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof float[] && expectedValue instanceof float[]) {
             return Arrays.equals((float[]) actualValue, (float[]) expectedValue);
-        } else if (int.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof int[] && expectedValue instanceof int[]) {
             return Arrays.equals((int[]) actualValue, (int[]) expectedValue);
-        } else if (long.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof long[] && expectedValue instanceof long[]) {
             return Arrays.equals((long[]) actualValue, (long[]) expectedValue);
-        } else if (short.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof short[] && expectedValue instanceof short[]) {
             return Arrays.equals((short[]) actualValue, (short[]) expectedValue);
+        } else {
+            return Arrays.equals((Object[]) actualValue, (Object[]) expectedValue);
         }
-        return false;
     }
 
     public static String toString(Object actualValue) {
-        final Class<?> ct = actualValue.getClass().getComponentType();
-        if (Object.class.isAssignableFrom(ct)) {
-            return Arrays.toString((Object[]) actualValue);
-        } else if (byte.class.isAssignableFrom(ct)) {
+        if (actualValue instanceof byte[]) {
             return Arrays.toString((byte[]) actualValue);
-        } else if (char.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof char[]) {
             return Arrays.toString((char[]) actualValue);
-        } else if (double.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof double[]) {
             return Arrays.toString((double[]) actualValue);
-        } else if (float.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof float[]) {
             return Arrays.toString((float[]) actualValue);
-        } else if (int.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof int[]) {
             return Arrays.toString((int[]) actualValue);
-        } else if (long.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof long[]) {
             return Arrays.toString((long[]) actualValue);
-        } else if (short.class.isAssignableFrom(ct)) {
+        } else if (actualValue instanceof short[]) {
             return Arrays.toString((short[]) actualValue);
         }
-        return null;
+        return Arrays.toString((Object[]) actualValue);
     }
 
     public static String toString(boolean[] a, int offset, int length) {
@@ -674,10 +544,10 @@ public class ArrayTypeUtils {
 
     public static class ObjectArrayAccessor<T> implements ArrayAccessor<T> {
 
-        private T array[];
+        private final T[] array;
 
 
-        public ObjectArrayAccessor(T array[]) {
+        public ObjectArrayAccessor(T[] array) {
             this.array = array;
         }
 
@@ -717,9 +587,9 @@ public class ArrayTypeUtils {
 
     public static class BooleanArrayAccessor implements ArrayAccessor<Boolean> {
 
-        private Boolean array[];
+        private final Boolean[] array;
 
-        public BooleanArrayAccessor(Boolean array[]) {
+        public BooleanArrayAccessor(Boolean[] array) {
             this.array = array;
         }
 
@@ -761,9 +631,9 @@ public class ArrayTypeUtils {
 
     public static class ByteArrayAccessor implements ArrayAccessor<Byte> {
 
-        private byte array[];
+        private final byte[] array;
 
-        public ByteArrayAccessor(byte array[]) {
+        public ByteArrayAccessor(byte[] array) {
             this.array = array;
         }
 
@@ -804,9 +674,9 @@ public class ArrayTypeUtils {
     }
     public static class CharArrayAccessor implements ArrayAccessor<Character> {
 
-        private char array[];
+        private final char[] array;
 
-        public CharArrayAccessor(char array[]) {
+        public CharArrayAccessor(char[] array) {
             this.array = array;
         }
 
@@ -847,9 +717,9 @@ public class ArrayTypeUtils {
     }
     public static class DoubleArrayAccessor implements ArrayAccessor<Double> {
 
-        private double array[];
+        private final double[] array;
 
-        public DoubleArrayAccessor(double array[]) {
+        public DoubleArrayAccessor(double[] array) {
             this.array = array;
         }
 
@@ -890,9 +760,9 @@ public class ArrayTypeUtils {
     }
     public static class FloatArrayAccessor implements ArrayAccessor<Float> {
 
-        private float array[];
+        private final float[] array;
 
-        public FloatArrayAccessor(float array[]) {
+        public FloatArrayAccessor(float[] array) {
             this.array = array;
         }
 
@@ -933,9 +803,9 @@ public class ArrayTypeUtils {
     }
     public static class IntArrayAccessor implements ArrayAccessor<Integer> {
 
-        private int array[];
+        private final int[] array;
 
-        public IntArrayAccessor(int array[]) {
+        public IntArrayAccessor(int[] array) {
             this.array = array;
         }
 
@@ -981,9 +851,9 @@ public class ArrayTypeUtils {
     }
     public static class LongArrayAccessor implements ArrayAccessor<Long> {
 
-        private long array[];
+        private final long[] array;
 
-        public LongArrayAccessor(long array[]) {
+        public LongArrayAccessor(long[] array) {
             this.array = array;
         }
 
@@ -1025,9 +895,9 @@ public class ArrayTypeUtils {
     }
     public static class ShortArrayAccessor implements ArrayAccessor<Short> {
 
-        private short array[];
+        private final short[] array;
 
-        public ShortArrayAccessor(short array[]) {
+        public ShortArrayAccessor(short[] array) {
             this.array = array;
         }
 

--- a/Util/src/main/java/io/deephaven/util/type/NumericTypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/NumericTypeUtils.java
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.util.type;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class NumericTypeUtils {
+    private NumericTypeUtils() {}
+
+    /**
+     * Whether the class is an instance of {@link Number}.
+     *
+     * @param c class
+     * @return true if Number.class is assignable from {@code c}, false otherwise
+     */
+    public static boolean isBoxedNumeric(@NotNull final Class<?> c) {
+        return Number.class.isAssignableFrom(c);
+    }
+
+    /**
+     * Whether the class is {@link TypeUtils#isPrimitiveNumeric(Class)} or {@link #isBoxedNumeric(Class)}
+     *
+     * @param c class
+     * @return true if {@code c} is numeric, false otherwise
+     */
+    public static boolean isNumeric(@NotNull final Class<?> c) {
+        return TypeUtils.isPrimitiveNumeric(c) || isBoxedNumeric(c);
+    }
+
+    /**
+     * Whether the class is a {@link BigInteger} or {@link BigDecimal}
+     *
+     * @param type the class
+     * @return true if the type is BigInteger or BigDecimal, false otherwise
+     */
+    public static boolean isBigNumeric(Class<?> type) {
+        return BigInteger.class.isAssignableFrom(type) || BigDecimal.class.isAssignableFrom(type);
+    }
+}

--- a/Util/src/main/java/io/deephaven/util/type/NumericTypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/NumericTypeUtils.java
@@ -22,13 +22,13 @@ public class NumericTypeUtils {
     }
 
     /**
-     * Whether the class is {@link TypeUtils#isPrimitiveNumeric(Class)} or {@link #isBoxedNumeric(Class)}
+     * Whether the class is {@link NumericTypeUtils#isPrimitiveNumeric(Class)} or {@link #isBoxedNumeric(Class)}
      *
      * @param c class
      * @return true if {@code c} is numeric, false otherwise
      */
     public static boolean isNumeric(@NotNull final Class<?> c) {
-        return TypeUtils.isPrimitiveNumeric(c) || isBoxedNumeric(c);
+        return isPrimitiveNumeric(c) || isBoxedNumeric(c);
     }
 
     /**
@@ -39,5 +39,16 @@ public class NumericTypeUtils {
      */
     public static boolean isBigNumeric(Class<?> type) {
         return BigInteger.class.isAssignableFrom(type) || BigDecimal.class.isAssignableFrom(type);
+    }
+
+    /**
+     * Whether the class is equal to one of the six numeric primitives: float, double, int, long, short, or byte.
+     *
+     * @param c class
+     * @return true if {@code c} is a numeric primitive, false otherwise
+     */
+    public static boolean isPrimitiveNumeric(@NotNull final Class<?> c) {
+        return c == double.class || c == float.class
+                || c == int.class || c == long.class || c == short.class || c == byte.class;
     }
 }

--- a/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
@@ -7,8 +7,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -55,6 +53,10 @@ public class TypeUtils {
                 .unmodifiableMap(PRIMITIVE_TYPES.stream().collect(Collectors.toMap(Class::getName, type -> type)));
     }
 
+    /**
+     * Deprecated with no replacement.
+     */
+    @Deprecated
     @Retention(RetentionPolicy.RUNTIME)
     public @interface IsDateTime {
         boolean value() default true;
@@ -381,16 +383,6 @@ public class TypeUtils {
     }
 
     /**
-     * Whether the class is an instance of {@link Number}.
-     *
-     * @param c class
-     * @return true if Number.class is assignable from {@code c}, false otherwise
-     */
-    public static boolean isBoxedNumeric(@NotNull final Class<?> c) {
-        return Number.class.isAssignableFrom(c);
-    }
-
-    /**
      * Whether the class is equal to char.class.
      *
      * @param c class
@@ -491,16 +483,6 @@ public class TypeUtils {
     }
 
     /**
-     * Whether the class is {@link #isPrimitiveNumeric(Class)} or {@link #isBoxedNumeric(Class)}
-     *
-     * @param c class
-     * @return true if {@code c} is numeric, false otherwise
-     */
-    public static boolean isNumeric(@NotNull final Class<?> c) {
-        return isPrimitiveNumeric(c) || isBoxedNumeric(c);
-    }
-
-    /**
      * Whether the class equals char.class or Character.class is assignable from it.
      *
      * @param c class
@@ -511,15 +493,13 @@ public class TypeUtils {
     }
 
     /**
-     * Whether the class is an {@link Instant}, a {@link ZonedDateTime}, or annotated as {@link IsDateTime}.
+     * Whether the class is an {@link Instant} or a {@link ZonedDateTime}.
      *
      * @param type The class.
-     * @return true if the type is a DateTime, {@link java.time.ZonedDateTime} or {@link Instant}.
+     * @return true if the type is a DateTime: {@link java.time.ZonedDateTime} or {@link Instant}.
      */
     public static boolean isDateTime(Class<?> type) {
-        return Instant.class.isAssignableFrom(type)
-                || ZonedDateTime.class.isAssignableFrom(type)
-                || (type.getAnnotation(IsDateTime.class) != null && type.getAnnotation(IsDateTime.class).value());
+        return Instant.class == type || ZonedDateTime.class == type;
     }
 
     /**
@@ -530,16 +510,6 @@ public class TypeUtils {
      */
     public static boolean isString(Class<?> type) {
         return String.class == type;
-    }
-
-    /**
-     * Whether the class is a {@link BigInteger} or {@link BigDecimal}
-     *
-     * @param type the class
-     * @return true if the type is BigInteger or BigDecimal, false otherwise
-     */
-    public static boolean isBigNumeric(Class<?> type) {
-        return BigInteger.class.isAssignableFrom(type) || BigDecimal.class.isAssignableFrom(type);
     }
 
     /**

--- a/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
@@ -7,8 +7,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -479,16 +477,6 @@ public class TypeUtils {
      */
     public static boolean isCharacter(@NotNull final Class<?> c) {
         return isPrimitiveChar(c) || isBoxedChar(c);
-    }
-
-    /**
-     * Whether the class is an {@link Instant} or a {@link ZonedDateTime}.
-     *
-     * @param type The class.
-     * @return true if the type is a DateTime: {@link java.time.ZonedDateTime} or {@link Instant}.
-     */
-    public static boolean isDateTime(Class<?> type) {
-        return Instant.class == type || ZonedDateTime.class == type;
     }
 
     /**

--- a/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
@@ -5,7 +5,6 @@ package io.deephaven.util.type;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.io.*;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.math.BigDecimal;
@@ -14,8 +13,6 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import java.lang.reflect.*;
 
 import static io.deephaven.util.QueryConstants.*;
 
@@ -555,232 +552,6 @@ public class TypeUtils {
         return type.equals(double.class) || type.equals(float.class) || isBoxedDouble(type) || isBoxedFloat(type);
     }
 
-    /**
-     * Converts an Object to a String for writing to a workspace. This is meant to be used in conjunction with
-     * {@code TypeUtils.fromString}. Strings, Numbers, and primitives will all convert using {@code Obect.toString}.
-     * Serializable objects will be encoded in base64. All others will return null.
-     *
-     * @param o the object to convert
-     * @return a String representation of the object, null if it cannot be converted
-     * @throws IOException if an IO error occurs during conversion
-     */
-    public static String objectToString(Object o) throws IOException {
-        if (o == null) {
-            return null;
-        }
-
-        final Class<?> type = o.getClass();
-        // isNumeric gets BigInteger and BigDecimal in addition to everything gotten by isConvertibleToPrimitive
-        if (type == String.class || isConvertibleToPrimitive(type) || isNumeric(type)) {
-            return o.toString();
-        } else if (o instanceof Serializable) {
-            return encode64Serializable((Serializable) o);
-        }
-
-        throw new RuntimeException(
-                "Failed to convert object of type " + type.getCanonicalName() + ".  Type not supported");
-    }
-
-    /**
-     * Creates an Object from a String. This is meant to be used in conjunction with {@code TypeUtils.objectToString}
-     * Strings, Numbers, and primitives will all parse using their boxed type parsing methods. Serializable types will
-     * be decoded from base64. Returns null if the String fails to parse.
-     *
-     * @param string the String to parse
-     * @param typeString the Canonical Name of the class type
-     * @return an object parsed from the String
-     * @throws RuntimeException if the string fails to parse
-     * @throws IOException if an IO error occurs during conversion
-     */
-    public static Optional<Object> fromString(String string, String typeString) throws IOException {
-        final Class<?> type;
-        try {
-            type = Class.forName(typeString);
-            return Optional.ofNullable(fromString(string, type));
-        } catch (ClassNotFoundException e) {
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * Creates an Object from a String. This is meant to be used in conjunction with {@code TypeUtils.objectToString}
-     * Strings, Numbers, and primitives will all parse using their boxed type parsing methods. Serializable types will
-     * be decoded from base64. Returns null if the String fails to parse.
-     *
-     * @param string the String to parse
-     * @param type the type of the object
-     * @return an object parsed from the String
-     * @throws RuntimeException if the string fails to parse
-     * @throws IOException if an IO error occurs during conversion
-     */
-    public static Object fromString(String string, Class<?> type) throws IOException {
-        final Class<?> boxedType = getBoxedType(type);
-        try {
-            if (boxedType == String.class) {
-                return string;
-            } else if (boxedType == Boolean.class) {
-                return Boolean.parseBoolean(string);
-            } else if (boxedType == Integer.class) {
-                return Integer.parseInt(string);
-            } else if (boxedType == Double.class) {
-                return Double.parseDouble(string);
-            } else if (boxedType == Short.class) {
-                return Short.parseShort(string);
-            } else if (boxedType == Long.class) {
-                return Long.parseLong(string);
-            } else if (boxedType == Float.class) {
-                return Float.parseFloat(string);
-            } else if (boxedType == BigInteger.class) {
-                return new BigInteger(string);
-            } else if (boxedType == BigDecimal.class) {
-                return new BigDecimal(string);
-            } else if (boxedType == Byte.class) {
-                return Byte.parseByte(string);
-            } else if (boxedType == Character.class) {
-                return string.charAt(0);
-            } else if (Serializable.class.isAssignableFrom(boxedType)) {
-                return decode64Serializable(string);
-            }
-        } catch (IOException ioe) {
-            throw ioe;
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to parse " + string + "into type " + type.getCanonicalName(), e);
-        }
-
-        throw new RuntimeException(
-                "Failed to parse " + string + "into type " + type.getCanonicalName() + ".  Type not supported");
-    }
-
-    /**
-     * Encodes a Serializable Object into base64 String.
-     *
-     * @param serializable the object to encode
-     * @return the base64 encoded string
-     * @throws IOException if the string cannot be encoded
-     */
-    public static String encode64Serializable(Serializable serializable) throws IOException {
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                ObjectOutputStream os = new ObjectOutputStream(bos)) {
-            os.writeObject(serializable);
-            return Base64.getEncoder().encodeToString(bos.toByteArray());
-        }
-    }
-
-    /**
-     * Decodes a Serializable Object from a base64 encoded String.
-     *
-     * @param string the base64 encoded String
-     * @return the encoded Object
-     * @throws IOException if the string cannot be decoded
-     * @throws ClassNotFoundException if the Object type is unknown
-     */
-    public static Object decode64Serializable(String string) throws IOException, ClassNotFoundException {
-        try (ObjectInputStream is =
-                new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(string)))) {
-            return is.readObject();
-        }
-    }
-
-    /**
-     * Determine the Class from the Type.
-     */
-    public static Class<?> getErasedType(Type paramType) {
-        if (paramType instanceof Class) {
-            return (Class<?>) paramType;
-        } else if (paramType instanceof ParameterizedType) {
-            return (Class<?>) // We are asking the parameterized type for it's raw type, which is always Class
-            ((ParameterizedType) paramType).getRawType();
-        } else if (paramType instanceof WildcardType) {
-            final Type[] upper = ((WildcardType) paramType).getUpperBounds();
-            return getErasedType(upper[0]);
-        } else if (paramType instanceof java.lang.reflect.TypeVariable) {
-            final Type[] bounds = ((TypeVariable<?>) paramType).getBounds();
-            if (bounds.length > 1) {
-                Class<?>[] erasedBounds = new Class[bounds.length];
-                Class<?> weakest = null;
-                for (int i = 0; i < erasedBounds.length; i++) {
-                    erasedBounds[i] = getErasedType(bounds[i]);
-                    if (i == 0) {
-                        weakest = erasedBounds[i];
-                    } else {
-                        weakest = getWeakest(weakest, erasedBounds[i]);
-                    }
-                    // If we are erased to object, stop erasing...
-                    if (weakest == Object.class) {
-                        break;
-                    }
-                }
-                return weakest;
-            }
-            return getErasedType(bounds[0]);
-        } else {
-            throw new UnsupportedOperationException();
-        }
-    }
-
-    /**
-     * Determine the weakest parent of the two provided Classes.
-     *
-     * @param one one class to compare
-     * @param two the other class to compare
-     * @return the weakest parent Class
-     */
-    private static Class<?> getWeakest(Class<?> one, Class<?> two) {
-        if (one.isAssignableFrom(two)) {
-            return one;
-        } else if (two.isAssignableFrom(one)) {
-            return two;
-        }
-        // No luck on quick check... Look in interfaces.
-        Set<Class<?>> oneInterfaces = getFlattenedInterfaces(one);
-        Set<Class<?>> twoInterfaces = getFlattenedInterfaces(two);
-        // Keep only shared interfaces
-        oneInterfaces.retainAll(twoInterfaces);
-        Class<?> strongest = Object.class;
-        for (Class<?> cls : oneInterfaces) {
-            // There is a winning type...
-            if (strongest.isAssignableFrom(cls)) {
-                strongest = cls;
-            } else if (!cls.isAssignableFrom(strongest)) {
-                return Object.class;
-            }
-        }
-        // Will be Object.class if there were no shared interfaces (or shared interfaces were not compatible).
-        return strongest;
-    }
-
-    private static Set<Class<?>> getFlattenedInterfaces(Class<?> cls) {
-        final Set<Class<?>> set = new HashSet<>();
-        while (cls != null && cls != Object.class) {
-            for (Class<?> iface : cls.getInterfaces()) {
-                collectInterfaces(set, iface);
-            }
-            cls = cls.getSuperclass();
-        }
-        return set;
-    }
-
-    private static void collectInterfaces(final Collection<Class<?>> into, final Class<?> cls) {
-        if (into.add(cls)) {
-            for (final Class<?> iface : cls.getInterfaces()) {
-                if (into.add(iface)) {
-                    collectInterfaces(into, iface);
-                }
-            }
-        }
-    }
-
-
-    public static Class<?> classForName(String className) throws ClassNotFoundException {
-        Class<?> result = primitiveClassNameToClass.get(className);
-        if (result == null) {
-            return Class.forName(className);
-        } else {
-            return result;
-        }
-
-    }
-
     public static abstract class TypeBoxer<T> {
         public abstract T get(T result);
     }
@@ -837,7 +608,7 @@ public class TypeUtils {
                 }
             };
         } else {
-            return (TypeBoxer<T>) new TypeBoxer<Object>() {
+            return new TypeBoxer<>() {
                 @Override
                 public Object get(Object result) {
                     return result;

--- a/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/TypeUtils.java
@@ -372,17 +372,6 @@ public class TypeUtils {
     }
 
     /**
-     * Whether the class is equal to one of the six numeric primitives: float, double, int, long, short, or byte.
-     *
-     * @param c class
-     * @return true if {@code c} is a numeric primitive, false otherwise
-     */
-    public static boolean isPrimitiveNumeric(@NotNull final Class<?> c) {
-        return c == double.class || c == float.class
-                || c == int.class || c == long.class || c == short.class || c == byte.class;
-    }
-
-    /**
      * Whether the class is equal to char.class.
      *
      * @param c class

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/AggregationProcessor.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/AggregationProcessor.java
@@ -125,7 +125,7 @@ import static io.deephaven.engine.table.impl.by.IterativeChunkedAggregationOpera
 import static io.deephaven.engine.table.impl.by.RollupConstants.*;
 import static io.deephaven.util.QueryConstants.*;
 import static io.deephaven.util.type.TypeUtils.getBoxedType;
-import static io.deephaven.util.type.TypeUtils.isNumeric;
+import static io.deephaven.util.type.NumericTypeUtils.isNumeric;
 
 /**
  * Conversion tool to generate an {@link AggregationContextFactory} for a collection of {@link Aggregation

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.preview;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
+import io.deephaven.util.type.NumericTypeUtils;
 import io.deephaven.vector.Vector;
 import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.select.FunctionalColumn;
@@ -155,7 +156,7 @@ public class ColumnPreviewManager {
         return type.isPrimitive()
                 || io.deephaven.util.type.TypeUtils.isBoxedType(type)
                 || io.deephaven.util.type.TypeUtils.isString(type)
-                || io.deephaven.util.type.TypeUtils.isBigNumeric(type)
+                || NumericTypeUtils.isBigNumeric(type)
                 || TypeUtils.isDateTime(type)
                 || isOnWhiteList(type);
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
@@ -6,12 +6,12 @@ package io.deephaven.engine.table.impl.preview;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
+import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.type.NumericTypeUtils;
 import io.deephaven.vector.Vector;
 import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.select.FunctionalColumn;
 import io.deephaven.engine.table.impl.select.SelectColumn;
-import io.deephaven.util.type.TypeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jpy.PyListWrapper;
 
@@ -157,7 +157,7 @@ public class ColumnPreviewManager {
                 || io.deephaven.util.type.TypeUtils.isBoxedType(type)
                 || io.deephaven.util.type.TypeUtils.isString(type)
                 || NumericTypeUtils.isBigNumeric(type)
-                || TypeUtils.isDateTime(type)
+                || DateTimeUtils.isDateTime(type)
                 || isOnWhiteList(type);
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
@@ -6,7 +6,6 @@ package io.deephaven.engine.table.impl.preview;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
-import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.type.NumericTypeUtils;
 import io.deephaven.vector.Vector;
 import io.deephaven.engine.table.impl.BaseTable;
@@ -15,6 +14,8 @@ import io.deephaven.engine.table.impl.select.SelectColumn;
 import org.apache.commons.lang3.StringUtils;
 import org.jpy.PyListWrapper;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -157,7 +158,7 @@ public class ColumnPreviewManager {
                 || io.deephaven.util.type.TypeUtils.isBoxedType(type)
                 || io.deephaven.util.type.TypeUtils.isString(type)
                 || NumericTypeUtils.isBigNumeric(type)
-                || DateTimeUtils.isDateTime(type)
+                || Instant.class == type || ZonedDateTime.class == type
                 || isOnWhiteList(type);
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestNumericTypeUtils.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestNumericTypeUtils.java
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.util;
+
+import io.deephaven.util.type.NumericTypeUtils;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestNumericTypeUtils {
+
+    @Test
+    public void testIsType() {
+        assertFalse(NumericTypeUtils.isBoxedNumeric(Instant.class));
+        assertFalse(NumericTypeUtils.isBoxedNumeric(Date.class));
+        assertFalse(NumericTypeUtils.isBoxedNumeric(int.class));
+        assertTrue(NumericTypeUtils.isBoxedNumeric(Double.class));
+
+        assertFalse(NumericTypeUtils.isNumeric(Instant.class));
+        assertFalse(NumericTypeUtils.isNumeric(Date.class));
+        assertTrue(NumericTypeUtils.isNumeric(int.class));
+        assertTrue(NumericTypeUtils.isNumeric(Double.class));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestNumericTypeUtils.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestNumericTypeUtils.java
@@ -16,6 +16,11 @@ public class TestNumericTypeUtils {
 
     @Test
     public void testIsType() {
+        assertFalse(NumericTypeUtils.isPrimitiveNumeric(Instant.class));
+        assertFalse(NumericTypeUtils.isPrimitiveNumeric(Date.class));
+        assertTrue(NumericTypeUtils.isPrimitiveNumeric(int.class));
+        assertFalse(NumericTypeUtils.isPrimitiveNumeric(Double.class));
+
         assertFalse(NumericTypeUtils.isBoxedNumeric(Instant.class));
         assertFalse(NumericTypeUtils.isBoxedNumeric(Date.class));
         assertFalse(NumericTypeUtils.isBoxedNumeric(int.class));

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
@@ -128,11 +128,6 @@ public class TestTypeUtils extends TestCase {
     }
 
     public void testIsType() {
-        assertFalse(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(Instant.class));
-        assertFalse(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(Date.class));
-        assertTrue(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(int.class));
-        assertFalse(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(Double.class));
-
         assertFalse(io.deephaven.util.type.TypeUtils.isCharacter(Instant.class));
         assertFalse(io.deephaven.util.type.TypeUtils.isCharacter(Date.class));
         assertFalse(io.deephaven.util.type.TypeUtils.isCharacter(int.class));

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
@@ -4,7 +4,6 @@
 package io.deephaven.engine.util;
 
 import io.deephaven.base.verify.Require;
-import io.deephaven.util.type.NumericTypeUtils;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -133,16 +132,6 @@ public class TestTypeUtils extends TestCase {
         assertFalse(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(Date.class));
         assertTrue(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(int.class));
         assertFalse(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(Double.class));
-
-        assertFalse(NumericTypeUtils.isBoxedNumeric(Instant.class));
-        assertFalse(NumericTypeUtils.isBoxedNumeric(Date.class));
-        assertFalse(NumericTypeUtils.isBoxedNumeric(int.class));
-        assertTrue(NumericTypeUtils.isBoxedNumeric(Double.class));
-
-        assertFalse(NumericTypeUtils.isNumeric(Instant.class));
-        assertFalse(NumericTypeUtils.isNumeric(Date.class));
-        assertTrue(NumericTypeUtils.isNumeric(int.class));
-        assertTrue(NumericTypeUtils.isNumeric(Double.class));
 
         assertFalse(io.deephaven.util.type.TypeUtils.isCharacter(Instant.class));
         assertFalse(io.deephaven.util.type.TypeUtils.isCharacter(Date.class));

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
@@ -7,7 +7,6 @@ import io.deephaven.base.verify.Require;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
@@ -161,10 +160,5 @@ public class TestTypeUtils extends TestCase {
         assertFalse(io.deephaven.util.type.TypeUtils.isBoxedChar(int.class));
         assertFalse(io.deephaven.util.type.TypeUtils.isBoxedChar(char.class));
         assertTrue(io.deephaven.util.type.TypeUtils.isBoxedChar(Character.class));
-    }
-
-    public void testObjectToString() throws IOException {
-        assertNull(io.deephaven.util.type.TypeUtils.objectToString(null)); // null input
-        assertEquals("STRING", io.deephaven.util.type.TypeUtils.objectToString("STRING")); // non null input
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestTypeUtils.java
@@ -4,6 +4,7 @@
 package io.deephaven.engine.util;
 
 import io.deephaven.base.verify.Require;
+import io.deephaven.util.type.NumericTypeUtils;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -133,15 +134,15 @@ public class TestTypeUtils extends TestCase {
         assertTrue(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(int.class));
         assertFalse(io.deephaven.util.type.TypeUtils.isPrimitiveNumeric(Double.class));
 
-        assertFalse(io.deephaven.util.type.TypeUtils.isBoxedNumeric(Instant.class));
-        assertFalse(io.deephaven.util.type.TypeUtils.isBoxedNumeric(Date.class));
-        assertFalse(io.deephaven.util.type.TypeUtils.isBoxedNumeric(int.class));
-        assertTrue(io.deephaven.util.type.TypeUtils.isBoxedNumeric(Double.class));
+        assertFalse(NumericTypeUtils.isBoxedNumeric(Instant.class));
+        assertFalse(NumericTypeUtils.isBoxedNumeric(Date.class));
+        assertFalse(NumericTypeUtils.isBoxedNumeric(int.class));
+        assertTrue(NumericTypeUtils.isBoxedNumeric(Double.class));
 
-        assertFalse(io.deephaven.util.type.TypeUtils.isNumeric(Instant.class));
-        assertFalse(io.deephaven.util.type.TypeUtils.isNumeric(Date.class));
-        assertTrue(io.deephaven.util.type.TypeUtils.isNumeric(int.class));
-        assertTrue(io.deephaven.util.type.TypeUtils.isNumeric(Double.class));
+        assertFalse(NumericTypeUtils.isNumeric(Instant.class));
+        assertFalse(NumericTypeUtils.isNumeric(Date.class));
+        assertTrue(NumericTypeUtils.isNumeric(int.class));
+        assertTrue(NumericTypeUtils.isNumeric(Double.class));
 
         assertFalse(io.deephaven.util.type.TypeUtils.isCharacter(Instant.class));
         assertFalse(io.deephaven.util.type.TypeUtils.isCharacter(Date.class));

--- a/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
+++ b/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
@@ -201,16 +201,6 @@ public class DateTimeUtils {
      */
     public static final double YEARS_PER_NANO_AVG = 1. / (double) YEAR_AVG;
 
-    /**
-     * Whether the class is an {@link Instant} or a {@link ZonedDateTime}.
-     *
-     * @param type The class.
-     * @return true if the type is a DateTime: {@link ZonedDateTime} or {@link Instant}.
-     */
-    public static boolean isDateTime(Class<?> type) {
-        return Instant.class == type || ZonedDateTime.class == type;
-    }
-
     // endregion
 
     // region Overflow / Underflow

--- a/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
+++ b/engine/time/src/main/java/io/deephaven/time/DateTimeUtils.java
@@ -201,6 +201,16 @@ public class DateTimeUtils {
      */
     public static final double YEARS_PER_NANO_AVG = 1. / (double) YEAR_AVG;
 
+    /**
+     * Whether the class is an {@link Instant} or a {@link ZonedDateTime}.
+     *
+     * @param type The class.
+     * @return true if the type is a DateTime: {@link ZonedDateTime} or {@link Instant}.
+     */
+    public static boolean isDateTime(Class<?> type) {
+        return Instant.class == type || ZonedDateTime.class == type;
+    }
+
     // endregion
 
     // region Overflow / Underflow

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -41,7 +41,6 @@ import io.deephaven.engine.util.ColumnFormatting;
 import io.deephaven.engine.util.input.InputTableUpdater;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
-import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.type.TypeUtils;
 import io.deephaven.vector.Vector;
 import io.grpc.stub.StreamObserver;
@@ -683,7 +682,7 @@ public class BarrageUtil {
 
     private static boolean isTypeNativelySupported(final Class<?> typ) {
         if (typ.isPrimitive() || TypeUtils.isBoxedType(typ) || supportedTypes.contains(typ)
-                || Vector.class.isAssignableFrom(typ) || DateTimeUtils.isDateTime(typ)) {
+                || Vector.class.isAssignableFrom(typ) || Instant.class == typ || ZonedDateTime.class == typ) {
             return true;
         }
         if (typ.isArray()) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -41,6 +41,7 @@ import io.deephaven.engine.util.ColumnFormatting;
 import io.deephaven.engine.util.input.InputTableUpdater;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
+import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.type.TypeUtils;
 import io.deephaven.vector.Vector;
 import io.grpc.stub.StreamObserver;
@@ -682,7 +683,7 @@ public class BarrageUtil {
 
     private static boolean isTypeNativelySupported(final Class<?> typ) {
         if (typ.isPrimitive() || TypeUtils.isBoxedType(typ) || supportedTypes.contains(typ)
-                || Vector.class.isAssignableFrom(typ) || TypeUtils.isDateTime(typ)) {
+                || Vector.class.isAssignableFrom(typ) || DateTimeUtils.isDateTime(typ)) {
             return true;
         }
         if (typ.isArray()) {

--- a/server/src/main/java/io/deephaven/server/table/ops/ColumnStatisticsGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/ColumnStatisticsGrpcImpl.java
@@ -22,8 +22,8 @@ import io.deephaven.server.table.stats.ChunkedNumericalStatsKernel;
 import io.deephaven.server.table.stats.ChunkedStatsKernel;
 import io.deephaven.server.table.stats.DateTimeChunkedStats;
 import io.deephaven.server.table.stats.ObjectChunkedStats;
+import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.type.NumericTypeUtils;
-import io.deephaven.util.type.TypeUtils;
 import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableObject;
 
@@ -68,7 +68,7 @@ public class ColumnStatisticsGrpcImpl extends GrpcTableOperation<ColumnStatistic
         // Based on the column type, make a stats function and get a column source
         final ChunkedStatsKernel statsFunc;
         final ColumnSource<?> columnSource;
-        if (TypeUtils.isDateTime(type)) {
+        if (DateTimeUtils.isDateTime(type)) {
             // Instant/ZonedDateTime only look at max/min and count
             statsFunc = new DateTimeChunkedStats();
 

--- a/server/src/main/java/io/deephaven/server/table/ops/ColumnStatisticsGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/ColumnStatisticsGrpcImpl.java
@@ -22,7 +22,6 @@ import io.deephaven.server.table.stats.ChunkedNumericalStatsKernel;
 import io.deephaven.server.table.stats.ChunkedStatsKernel;
 import io.deephaven.server.table.stats.DateTimeChunkedStats;
 import io.deephaven.server.table.stats.ObjectChunkedStats;
-import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.type.NumericTypeUtils;
 import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -68,19 +67,12 @@ public class ColumnStatisticsGrpcImpl extends GrpcTableOperation<ColumnStatistic
         // Based on the column type, make a stats function and get a column source
         final ChunkedStatsKernel statsFunc;
         final ColumnSource<?> columnSource;
-        if (DateTimeUtils.isDateTime(type)) {
-            // Instant/ZonedDateTime only look at max/min and count
+        if (type == Instant.class) {
             statsFunc = new DateTimeChunkedStats();
-
-            // Reinterpret the column to read only long values
-            if (Instant.class.isAssignableFrom(type)) {
-                columnSource = ReinterpretUtils.instantToLongSource(table.getColumnSource(columnName));
-            } else if (ZonedDateTime.class.isAssignableFrom(type)) {
-                columnSource = ReinterpretUtils.zonedDateTimeToLongSource(table.getColumnSource(columnName));
-            } else {
-                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
-                        "DateTime columns must be Instant or ZonedDateTime");
-            }
+            columnSource = ReinterpretUtils.instantToLongSource(table.getColumnSource(columnName));
+        } else if (type == ZonedDateTime.class) {
+            statsFunc = new DateTimeChunkedStats();
+            columnSource = ReinterpretUtils.zonedDateTimeToLongSource(table.getColumnSource(columnName));
         } else if (NumericTypeUtils.isNumeric(type)) {
             // Numeric types have a variety of statistics recorded
             statsFunc = ChunkedNumericalStatsKernel.makeChunkedNumericalStats(type);

--- a/server/src/main/java/io/deephaven/server/table/ops/ColumnStatisticsGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/ColumnStatisticsGrpcImpl.java
@@ -22,6 +22,7 @@ import io.deephaven.server.table.stats.ChunkedNumericalStatsKernel;
 import io.deephaven.server.table.stats.ChunkedStatsKernel;
 import io.deephaven.server.table.stats.DateTimeChunkedStats;
 import io.deephaven.server.table.stats.ObjectChunkedStats;
+import io.deephaven.util.type.NumericTypeUtils;
 import io.deephaven.util.type.TypeUtils;
 import org.apache.commons.lang3.mutable.Mutable;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -80,7 +81,7 @@ public class ColumnStatisticsGrpcImpl extends GrpcTableOperation<ColumnStatistic
                 throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                         "DateTime columns must be Instant or ZonedDateTime");
             }
-        } else if (TypeUtils.isNumeric(type)) {
+        } else if (NumericTypeUtils.isNumeric(type)) {
             // Numeric types have a variety of statistics recorded
             statsFunc = ChunkedNumericalStatsKernel.makeChunkedNumericalStats(type);
             columnSource = table.getColumnSource(columnName);


### PR DESCRIPTION
Removed some unused methods, rewrote some implementations to avoid reflection where unnecessary, removed ObjectInputStream/ObjectOutputStream usage. 

BREAKING CHANGES: Moved isBoxedNumeric, isNumeric, isBigNumeric to NumericTypeUtils, removed @IsDateTime, removed other reflective methods from TypeUtils and ArrayTypeUtils.
Partial #188