### PR TITLE
chore: bump jmh to 1.37

### DIFF
--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -124,6 +124,10 @@ jmh {
     jmhVersion = libs.versions.jmh.get()
 }
 
+jmhJar {
+    zip64 = true
+}
+
 // No need to assemble the jar by default on build
 // assemble.dependsOn(jmhJar)
 check.dependsOn(jmhClasses)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ jmock = "2.12.0"
 junit = "5.7.2"
 junit4 = "4.13.2"
 testcontainers = "1.19.8"
-jmh = "1.35"
+jmh = "1.37"
 spockframework = "2.0-groovy-3.0"
 
 [libraries]


### PR DESCRIPTION
In addition, the JARs zip64 needed to be set to true to ensure that the jar could actually be built (the increase of DH engine dependencies has caused the JMH fat jar to have >64k entries).