### PR TITLE
fix: correctly produce Kafka JSON nulls for int fields

### DIFF
--- a/extensions/kafka/src/main/java/io/deephaven/kafka/publish/JsonKeyOrValueSerializer.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/publish/JsonKeyOrValueSerializer.java
@@ -214,7 +214,7 @@ public class JsonKeyOrValueSerializer implements KeyOrValueSerializer<String> {
             @Override
             void outputField(final int ii, final ObjectNode node, final IntChunk<Values> inputChunk) {
                 final int raw = inputChunk.get(ii);
-                if (raw == QueryConstants.NULL_SHORT) {
+                if (raw == QueryConstants.NULL_INT) {
                     if (outputNulls) {
                         node.putNull(childNodeFieldName);
                     }


### PR DESCRIPTION
This fixes what was likely a copy-paste error, where the Kafka JSON producing logic checked for `NULL_SHORT` for int fields. None of the other field types were mishandled. It's worth noting that the json producer will omit null fields by default, and to explicitly output a JSON null (`{..., "myIntField": null, ...}`), the `boolean outputNulls` must be set to `true` (exposed as `output_nulls` in python).

Fixes #5701
Cherry-pick of #5702