### PR TITLE
refactor!: Extract factory interface for ChunkInputStreamGenerators

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/ChunkListInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/ChunkListInputStreamGenerator.java
@@ -19,7 +19,8 @@ public class ChunkListInputStreamGenerator implements SafeCloseable {
     private final List<ChunkInputStreamGenerator> generators;
     private final ChunkInputStreamGenerator emptyGenerator;
 
-    public ChunkListInputStreamGenerator(Class<?> type, Class<?> componentType, List<Chunk<Values>> data,
+    public ChunkListInputStreamGenerator(ChunkInputStreamGenerator.Factory factory, Class<?> type,
+            Class<?> componentType, List<Chunk<Values>> data,
             ChunkType chunkType) {
         // create an input stream generator for each chunk
         ChunkInputStreamGenerator[] generators = new ChunkInputStreamGenerator[data.size()];
@@ -27,12 +28,12 @@ public class ChunkListInputStreamGenerator implements SafeCloseable {
         long rowOffset = 0;
         for (int i = 0; i < data.size(); ++i) {
             final Chunk<Values> valuesChunk = data.get(i);
-            generators[i] = ChunkInputStreamGenerator.makeInputStreamGenerator(chunkType, type, componentType,
+            generators[i] = factory.makeInputStreamGenerator(chunkType, type, componentType,
                     valuesChunk, rowOffset);
             rowOffset += valuesChunk.size();
         }
         this.generators = Arrays.asList(generators);
-        emptyGenerator = ChunkInputStreamGenerator.makeInputStreamGenerator(
+        emptyGenerator = factory.makeInputStreamGenerator(
                 chunkType, type, componentType, chunkType.getEmptyChunk(), 0);
     }
 

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkInputStreamGenerator.java
@@ -10,7 +10,6 @@ import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.util.pools.PoolableChunk;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BooleanChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BooleanChunkReader.java
@@ -138,4 +138,14 @@ public class BooleanChunkReader implements ChunkReader {
             chunk.fillWithNullValue(offset + ei, pendingSkips);
         }
     }
+
+    /**
+     * Returns the number of longs needed to represent a single bit per element.
+     *
+     * @param numElements the number of rows
+     * @return number of longs needed to represent numElements bits rounded up to the nearest long
+     */
+    private static int getNumLongsForBitPackOfSize(final int numElements) {
+        return ((numElements + 63) / 64);
+    }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ChunkInputStreamGenerator.java
@@ -3,181 +3,47 @@
 //
 package io.deephaven.extensions.barrage.chunk;
 
-import com.google.common.base.Charsets;
-import io.deephaven.chunk.ObjectChunk;
-import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.attributes.Values;
-import io.deephaven.chunk.util.pools.PoolableChunk;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.extensions.barrage.util.DefensiveDrainable;
 import io.deephaven.extensions.barrage.util.StreamReaderOptions;
-import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.util.SafeCloseable;
-import io.deephaven.vector.Vector;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
 
 public interface ChunkInputStreamGenerator extends SafeCloseable {
     long MS_PER_DAY = 24 * 60 * 60 * 1000L;
     long MIN_LOCAL_DATE_VALUE = QueryConstants.MIN_LONG / MS_PER_DAY;
     long MAX_LOCAL_DATE_VALUE = QueryConstants.MAX_LONG / MS_PER_DAY;
 
-    static <T> ChunkInputStreamGenerator makeInputStreamGenerator(
-            final ChunkType chunkType,
-            final Class<T> type,
-            final Class<?> componentType,
-            final Chunk<Values> chunk,
-            final long rowOffset) {
-        // TODO (deephaven-core#5453): pass in ArrowType to enable ser/deser of single java class in multiple formats
-        switch (chunkType) {
-            case Boolean:
-                throw new UnsupportedOperationException("Booleans are reinterpreted as bytes");
-            case Char:
-                return new CharChunkInputStreamGenerator(chunk.asCharChunk(), Character.BYTES, rowOffset);
-            case Byte:
-                if (type == Boolean.class || type == boolean.class) {
-                    // internally we represent booleans as bytes, but the wire format respects arrow's specification
-                    return new BooleanChunkInputStreamGenerator(chunk.asByteChunk(), rowOffset);
-                }
-                return new ByteChunkInputStreamGenerator(chunk.asByteChunk(), Byte.BYTES, rowOffset);
-            case Short:
-                return new ShortChunkInputStreamGenerator(chunk.asShortChunk(), Short.BYTES, rowOffset);
-            case Int:
-                return new IntChunkInputStreamGenerator(chunk.asIntChunk(), Integer.BYTES, rowOffset);
-            case Long:
-                return new LongChunkInputStreamGenerator(chunk.asLongChunk(), Long.BYTES, rowOffset);
-            case Float:
-                return new FloatChunkInputStreamGenerator(chunk.asFloatChunk(), Float.BYTES, rowOffset);
-            case Double:
-                return new DoubleChunkInputStreamGenerator(chunk.asDoubleChunk(), Double.BYTES, rowOffset);
-            case Object:
-                if (type.isArray()) {
-                    if (componentType == byte.class) {
-                        return new VarBinaryChunkInputStreamGenerator<>(chunk.asObjectChunk(), rowOffset,
-                                (out, item) -> out.write((byte[]) item));
-                    } else {
-                        return new VarListChunkInputStreamGenerator<>(type, chunk.asObjectChunk(), rowOffset);
-                    }
-                }
-                if (Vector.class.isAssignableFrom(type)) {
-                    // noinspection unchecked
-                    return new VectorChunkInputStreamGenerator(
-                            (Class<Vector<?>>) type, componentType, chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == String.class) {
-                    return new VarBinaryChunkInputStreamGenerator<String>(chunk.asObjectChunk(), rowOffset,
-                            (out, str) -> out.write(str.getBytes(Charsets.UTF_8)));
-                }
-                if (type == BigInteger.class) {
-                    return new VarBinaryChunkInputStreamGenerator<BigInteger>(chunk.asObjectChunk(), rowOffset,
-                            (out, item) -> out.write(item.toByteArray()));
-                }
-                if (type == BigDecimal.class) {
-                    return new VarBinaryChunkInputStreamGenerator<BigDecimal>(chunk.asObjectChunk(), rowOffset,
-                            (out, item) -> {
-                                final BigDecimal normal = item.stripTrailingZeros();
-                                final int v = normal.scale();
-                                // Write as little endian, arrow endianness.
-                                out.write(0xFF & v);
-                                out.write(0xFF & (v >> 8));
-                                out.write(0xFF & (v >> 16));
-                                out.write(0xFF & (v >> 24));
-                                out.write(normal.unscaledValue().toByteArray());
-                            });
-                }
-                if (type == Instant.class) {
-                    // This code path is utilized for arrays and vectors of Instant, which cannot be reinterpreted.
-                    ObjectChunk<Instant, Values> objChunk = chunk.asObjectChunk();
-                    WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(objChunk.size());
-                    for (int i = 0; i < objChunk.size(); ++i) {
-                        outChunk.set(i, DateTimeUtils.epochNanos(objChunk.get(i)));
-                    }
-                    if (chunk instanceof PoolableChunk) {
-                        ((PoolableChunk) chunk).close();
-                    }
-                    return new LongChunkInputStreamGenerator(outChunk, Long.BYTES, rowOffset);
-                }
-                if (type == ZonedDateTime.class) {
-                    // This code path is utilized for arrays and vectors of Instant, which cannot be reinterpreted.
-                    ObjectChunk<ZonedDateTime, Values> objChunk = chunk.asObjectChunk();
-                    WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(objChunk.size());
-                    for (int i = 0; i < objChunk.size(); ++i) {
-                        outChunk.set(i, DateTimeUtils.epochNanos(objChunk.get(i)));
-                    }
-                    if (chunk instanceof PoolableChunk) {
-                        ((PoolableChunk) chunk).close();
-                    }
-                    return new LongChunkInputStreamGenerator(outChunk, Long.BYTES, rowOffset);
-                }
-                if (type == Boolean.class) {
-                    return BooleanChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == Byte.class) {
-                    return ByteChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == Character.class) {
-                    return CharChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == Double.class) {
-                    return DoubleChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == Float.class) {
-                    return FloatChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == Integer.class) {
-                    return IntChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == Long.class) {
-                    return LongChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == Short.class) {
-                    return ShortChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
-                }
-                if (type == LocalDate.class) {
-                    return LongChunkInputStreamGenerator.<LocalDate>convertWithTransform(chunk.asObjectChunk(),
-                            rowOffset, date -> {
-                                if (date == null) {
-                                    return QueryConstants.NULL_LONG;
-                                }
-                                final long epochDay = date.toEpochDay();
-                                if (epochDay < MIN_LOCAL_DATE_VALUE || epochDay > MAX_LOCAL_DATE_VALUE) {
-                                    throw new IllegalArgumentException("Date out of range: " + date + " (" + epochDay
-                                            + " not in [" + MIN_LOCAL_DATE_VALUE + ", " + MAX_LOCAL_DATE_VALUE + "])");
-                                }
-                                return epochDay * MS_PER_DAY;
-                            });
-                }
-                if (type == LocalTime.class) {
-                    return LongChunkInputStreamGenerator.<LocalTime>convertWithTransform(chunk.asObjectChunk(),
-                            rowOffset, time -> {
-                                if (time == null) {
-                                    return QueryConstants.NULL_LONG;
-                                }
-                                final long nanoOfDay = time.toNanoOfDay();
-                                if (nanoOfDay < 0) {
-                                    throw new IllegalArgumentException("Time out of range: " + time);
-                                }
-                                return nanoOfDay;
-                            });
-                }
-                // TODO (core#936): support column conversion modes
-
-                return new VarBinaryChunkInputStreamGenerator<>(chunk.asObjectChunk(), rowOffset,
-                        (out, item) -> out.write(item.toString().getBytes(Charsets.UTF_8)));
-            default:
-                throw new UnsupportedOperationException();
-        }
+    /**
+     * Creator of {@link ChunkInputStreamGenerator} instances.
+     * <p>
+     * This API may not be stable, while the JS API's usages of it are implemented.
+     */
+    interface Factory {
+        /**
+         * Returns an instance capable of writing the given chunk
+         *
+         * @param chunkType the type of the chunk to be written
+         * @param type the Java type of the column being written
+         * @param componentType the Java type of data in an array/vector, or null if irrelevant
+         * @param chunk the chunk that will be written out to an input stream
+         * @param rowOffset the offset into the chunk to start writing from
+         * @return an instance capable of serializing the given chunk
+         * @param <T> the type of data in the column
+         */
+        <T> ChunkInputStreamGenerator makeInputStreamGenerator(
+                final ChunkType chunkType,
+                final Class<T> type,
+                final Class<?> componentType,
+                final Chunk<Values> chunk,
+                final long rowOffset);
     }
 
     /**

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkInputStreamGeneratorFactory.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkInputStreamGeneratorFactory.java
@@ -1,0 +1,178 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.extensions.barrage.chunk;
+
+import com.google.common.base.Charsets;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.pools.PoolableChunk;
+import io.deephaven.time.DateTimeUtils;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.vector.Vector;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+
+import static io.deephaven.extensions.barrage.chunk.ChunkInputStreamGenerator.MAX_LOCAL_DATE_VALUE;
+import static io.deephaven.extensions.barrage.chunk.ChunkInputStreamGenerator.MIN_LOCAL_DATE_VALUE;
+import static io.deephaven.extensions.barrage.chunk.ChunkInputStreamGenerator.MS_PER_DAY;
+
+/**
+ * JVM implementation of ChunkInputStreamGenerator.Factory, suitable for use in Java clients and servers.
+ */
+public class DefaultChunkInputStreamGeneratorFactory implements ChunkInputStreamGenerator.Factory {
+    public static final DefaultChunkInputStreamGeneratorFactory INSTANCE =
+            new DefaultChunkInputStreamGeneratorFactory();
+
+    @Override
+    public <T> ChunkInputStreamGenerator makeInputStreamGenerator(ChunkType chunkType, Class<T> type,
+            Class<?> componentType, Chunk<Values> chunk, long rowOffset) {
+        // TODO (deephaven-core#5453): pass in ArrowType to enable ser/deser of single java class in multiple formats
+        switch (chunkType) {
+            case Boolean:
+                throw new UnsupportedOperationException("Booleans are reinterpreted as bytes");
+            case Char:
+                return new CharChunkInputStreamGenerator(chunk.asCharChunk(), Character.BYTES, rowOffset);
+            case Byte:
+                if (type == Boolean.class || type == boolean.class) {
+                    // internally we represent booleans as bytes, but the wire format respects arrow's specification
+                    return new BooleanChunkInputStreamGenerator(chunk.asByteChunk(), rowOffset);
+                }
+                return new ByteChunkInputStreamGenerator(chunk.asByteChunk(), Byte.BYTES, rowOffset);
+            case Short:
+                return new ShortChunkInputStreamGenerator(chunk.asShortChunk(), Short.BYTES, rowOffset);
+            case Int:
+                return new IntChunkInputStreamGenerator(chunk.asIntChunk(), Integer.BYTES, rowOffset);
+            case Long:
+                return new LongChunkInputStreamGenerator(chunk.asLongChunk(), Long.BYTES, rowOffset);
+            case Float:
+                return new FloatChunkInputStreamGenerator(chunk.asFloatChunk(), Float.BYTES, rowOffset);
+            case Double:
+                return new DoubleChunkInputStreamGenerator(chunk.asDoubleChunk(), Double.BYTES, rowOffset);
+            case Object:
+                if (type.isArray()) {
+                    if (componentType == byte.class) {
+                        return new VarBinaryChunkInputStreamGenerator<>(chunk.asObjectChunk(), rowOffset,
+                                (out, item) -> out.write((byte[]) item));
+                    } else {
+                        return new VarListChunkInputStreamGenerator<>(this, type, chunk.asObjectChunk(), rowOffset);
+                    }
+                }
+                if (Vector.class.isAssignableFrom(type)) {
+                    // noinspection unchecked
+                    return new VectorChunkInputStreamGenerator(this,
+                            (Class<Vector<?>>) type, componentType, chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == String.class) {
+                    return new VarBinaryChunkInputStreamGenerator<String>(chunk.asObjectChunk(), rowOffset,
+                            (out, str) -> out.write(str.getBytes(Charsets.UTF_8)));
+                }
+                if (type == BigInteger.class) {
+                    return new VarBinaryChunkInputStreamGenerator<BigInteger>(chunk.asObjectChunk(), rowOffset,
+                            (out, item) -> out.write(item.toByteArray()));
+                }
+                if (type == BigDecimal.class) {
+                    return new VarBinaryChunkInputStreamGenerator<BigDecimal>(chunk.asObjectChunk(), rowOffset,
+                            (out, item) -> {
+                                final BigDecimal normal = item.stripTrailingZeros();
+                                final int v = normal.scale();
+                                // Write as little endian, arrow endianness.
+                                out.write(0xFF & v);
+                                out.write(0xFF & (v >> 8));
+                                out.write(0xFF & (v >> 16));
+                                out.write(0xFF & (v >> 24));
+                                out.write(normal.unscaledValue().toByteArray());
+                            });
+                }
+                if (type == Instant.class) {
+                    // This code path is utilized for arrays and vectors of Instant, which cannot be reinterpreted.
+                    ObjectChunk<Instant, Values> objChunk = chunk.asObjectChunk();
+                    WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(objChunk.size());
+                    for (int i = 0; i < objChunk.size(); ++i) {
+                        outChunk.set(i, DateTimeUtils.epochNanos(objChunk.get(i)));
+                    }
+                    if (chunk instanceof PoolableChunk) {
+                        ((PoolableChunk) chunk).close();
+                    }
+                    return new LongChunkInputStreamGenerator(outChunk, Long.BYTES, rowOffset);
+                }
+                if (type == ZonedDateTime.class) {
+                    // This code path is utilized for arrays and vectors of Instant, which cannot be reinterpreted.
+                    ObjectChunk<ZonedDateTime, Values> objChunk = chunk.asObjectChunk();
+                    WritableLongChunk<Values> outChunk = WritableLongChunk.makeWritableChunk(objChunk.size());
+                    for (int i = 0; i < objChunk.size(); ++i) {
+                        outChunk.set(i, DateTimeUtils.epochNanos(objChunk.get(i)));
+                    }
+                    if (chunk instanceof PoolableChunk) {
+                        ((PoolableChunk) chunk).close();
+                    }
+                    return new LongChunkInputStreamGenerator(outChunk, Long.BYTES, rowOffset);
+                }
+                if (type == Boolean.class) {
+                    return BooleanChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == Byte.class) {
+                    return ByteChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == Character.class) {
+                    return CharChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == Double.class) {
+                    return DoubleChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == Float.class) {
+                    return FloatChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == Integer.class) {
+                    return IntChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == Long.class) {
+                    return LongChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == Short.class) {
+                    return ShortChunkInputStreamGenerator.convertBoxed(chunk.asObjectChunk(), rowOffset);
+                }
+                if (type == LocalDate.class) {
+                    return LongChunkInputStreamGenerator.<LocalDate>convertWithTransform(chunk.asObjectChunk(),
+                            rowOffset, date -> {
+                                if (date == null) {
+                                    return QueryConstants.NULL_LONG;
+                                }
+                                final long epochDay = date.toEpochDay();
+                                if (epochDay < MIN_LOCAL_DATE_VALUE || epochDay > MAX_LOCAL_DATE_VALUE) {
+                                    throw new IllegalArgumentException("Date out of range: " + date + " (" + epochDay
+                                            + " not in [" + MIN_LOCAL_DATE_VALUE + ", " + MAX_LOCAL_DATE_VALUE + "])");
+                                }
+                                return epochDay * MS_PER_DAY;
+                            });
+                }
+                if (type == LocalTime.class) {
+                    return LongChunkInputStreamGenerator.<LocalTime>convertWithTransform(chunk.asObjectChunk(),
+                            rowOffset, time -> {
+                                if (time == null) {
+                                    return QueryConstants.NULL_LONG;
+                                }
+                                final long nanoOfDay = time.toNanoOfDay();
+                                if (nanoOfDay < 0) {
+                                    throw new IllegalArgumentException("Time out of range: " + time);
+                                }
+                                return nanoOfDay;
+                            });
+                }
+                // TODO (core#936): support column conversion modes
+
+                return new VarBinaryChunkInputStreamGenerator<>(chunk.asObjectChunk(), rowOffset,
+                        (out, item) -> out.write(item.toString().getBytes(Charsets.UTF_8)));
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReadingFactory.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReadingFactory.java
@@ -22,9 +22,9 @@ import java.util.Arrays;
 import static io.deephaven.extensions.barrage.chunk.ChunkInputStreamGenerator.MS_PER_DAY;
 
 /**
- * JVM implementation of ChunkReadingFactory, suitable for use in Java clients and servers. This default implementations
- * may not round trip flight types correctly, but will round trip Deephaven table definitions and table data. Neither of
- * these is a required/expected property of being a Flight/Barrage/Deephaven client.
+ * JVM implementation of {@link ChunkReader.Factory}, suitable for use in Java clients and servers. This default
+ * implementation may not round trip flight types in a stable way, but will round trip Deephaven table definitions and
+ * table data. Neither of these is a required/expected property of being a Flight/Barrage/Deephaven client.
  */
 public final class DefaultChunkReadingFactory implements ChunkReader.Factory {
     public static final ChunkReader.Factory INSTANCE = new DefaultChunkReadingFactory();

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarListChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VarListChunkInputStreamGenerator.java
@@ -21,22 +21,22 @@ import io.deephaven.extensions.barrage.chunk.array.ArrayExpansionKernel;
 import io.deephaven.util.mutable.MutableInt;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.DataInput;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Iterator;
-import java.util.PrimitiveIterator;
 
 public class VarListChunkInputStreamGenerator<T> extends BaseChunkInputStreamGenerator<ObjectChunk<T, Values>> {
     private static final String DEBUG_NAME = "VarListChunkInputStreamGenerator";
 
+    private final Factory factory;
     private final Class<T> type;
 
     private WritableIntChunk<ChunkPositions> offsets;
     private ChunkInputStreamGenerator innerGenerator;
 
-    VarListChunkInputStreamGenerator(final Class<T> type, final ObjectChunk<T, Values> chunk, final long rowOffset) {
+    VarListChunkInputStreamGenerator(ChunkInputStreamGenerator.Factory factory, final Class<T> type,
+            final ObjectChunk<T, Values> chunk, final long rowOffset) {
         super(chunk, 0, rowOffset);
+        this.factory = factory;
         this.type = type;
     }
 
@@ -56,7 +56,7 @@ public class VarListChunkInputStreamGenerator<T> extends BaseChunkInputStreamGen
         offsets = WritableIntChunk.makeWritableChunk(chunk.size() + 1);
 
         final WritableChunk<Values> innerChunk = kernel.expand(chunk, offsets);
-        innerGenerator = ChunkInputStreamGenerator.makeInputStreamGenerator(
+        innerGenerator = factory.makeInputStreamGenerator(
                 chunkType, myType, myComponentType, innerChunk, 0);
     }
 

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VectorChunkInputStreamGenerator.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/VectorChunkInputStreamGenerator.java
@@ -29,16 +29,19 @@ public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
     private static final String DEBUG_NAME = "VarListChunkInputStreamGenerator";
 
     private final Class<?> componentType;
+    private final Factory factory;
 
     private WritableIntChunk<ChunkPositions> offsets;
     private ChunkInputStreamGenerator innerGenerator;
 
     VectorChunkInputStreamGenerator(
+            final ChunkInputStreamGenerator.Factory factory,
             final Class<Vector<?>> type,
             final Class<?> componentType,
             final ObjectChunk<Vector<?>, Values> chunk,
             final long rowOffset) {
         super(chunk, 0, rowOffset);
+        this.factory = factory;
         this.componentType = VectorExpansionKernel.getComponentType(type, componentType);
     }
 
@@ -53,7 +56,7 @@ public class VectorChunkInputStreamGenerator extends BaseChunkInputStreamGenerat
         offsets = WritableIntChunk.makeWritableChunk(chunk.size() + 1);
 
         final WritableChunk<Values> innerChunk = kernel.expand(chunk, offsets);
-        innerGenerator = ChunkInputStreamGenerator.makeInputStreamGenerator(
+        innerGenerator = factory.makeInputStreamGenerator(
                 chunkType, componentType, innerComponentType, innerChunk, 0);
     }
 

--- a/extensions/barrage/src/test/java/io/deephaven/extensions/barrage/chunk/BarrageColumnRoundTripTest.java
+++ b/extensions/barrage/src/test/java/io/deephaven/extensions/barrage/chunk/BarrageColumnRoundTripTest.java
@@ -681,8 +681,9 @@ public class BarrageColumnRoundTripTest extends RefreshingTableTestCase {
         data.copyFromChunk(srcData, 0, 0, srcData.size());
 
         try (SafeCloseable ignored = data;
-                ChunkInputStreamGenerator generator = ChunkInputStreamGenerator.makeInputStreamGenerator(
-                        chunkType, type, type.getComponentType(), srcData, 0)) {
+                ChunkInputStreamGenerator generator =
+                        DefaultChunkInputStreamGeneratorFactory.INSTANCE.makeInputStreamGenerator(
+                                chunkType, type, type.getComponentType(), srcData, 0)) {
             // full sub logic
             try (final BarrageProtoUtil.ExposedByteArrayOutputStream baos =
                     new BarrageProtoUtil.ExposedByteArrayOutputStream();


### PR DESCRIPTION
Rather than relying on a static method to create CISG instances, extracts a factory so that the JS client can provide its own implementation of how CISG instances should be built.

Also cleans up ChunkReader/ChunkInputStreamGenerator split a bit more, since for now JS can only use the former.

BREAKING CHANGES: Removes ChunkInputStreamGenerator.makeInputStreamGenerator, use the default factory instance instead.
Partial #188