### PR TITLE
perf: PercentileTypeHelpers, use explicit comparison operator

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/BooleanPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/BooleanPercentileTypeHelper.java
@@ -104,7 +104,7 @@ public class BooleanPercentileTypeHelper implements SsmChunkedPercentileOperator
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final Object testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = ObjectComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -115,11 +115,4 @@ public class BooleanPercentileTypeHelper implements SsmChunkedPercentileOperator
         return hi;
     }
 
-    private static int doComparison(Object lhs, Object rhs) {
-        return ObjectComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(Object lhs, Object rhs) {
-        return doComparison(lhs, rhs) > 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/BytePercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/BytePercentileTypeHelper.java
@@ -107,7 +107,7 @@ public class BytePercentileTypeHelper implements SsmChunkedPercentileOperator.Pe
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final byte testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = ByteComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -116,13 +116,5 @@ public class BytePercentileTypeHelper implements SsmChunkedPercentileOperator.Pe
         }
 
         return hi;
-    }
-
-    private static int doComparison(byte lhs, byte rhs) {
-        return ByteComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(byte lhs, byte rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/CharPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/CharPercentileTypeHelper.java
@@ -103,7 +103,7 @@ public class CharPercentileTypeHelper implements SsmChunkedPercentileOperator.Pe
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final char testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = CharComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -112,13 +112,5 @@ public class CharPercentileTypeHelper implements SsmChunkedPercentileOperator.Pe
         }
 
         return hi;
-    }
-
-    private static int doComparison(char lhs, char rhs) {
-        return CharComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(char lhs, char rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/DoublePercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/DoublePercentileTypeHelper.java
@@ -107,7 +107,7 @@ public class DoublePercentileTypeHelper implements SsmChunkedPercentileOperator.
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final double testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = DoubleComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -116,13 +116,5 @@ public class DoublePercentileTypeHelper implements SsmChunkedPercentileOperator.
         }
 
         return hi;
-    }
-
-    private static int doComparison(double lhs, double rhs) {
-        return DoubleComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(double lhs, double rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/FloatPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/FloatPercentileTypeHelper.java
@@ -107,7 +107,7 @@ public class FloatPercentileTypeHelper implements SsmChunkedPercentileOperator.P
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final float testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = FloatComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -116,13 +116,5 @@ public class FloatPercentileTypeHelper implements SsmChunkedPercentileOperator.P
         }
 
         return hi;
-    }
-
-    private static int doComparison(float lhs, float rhs) {
-        return FloatComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(float lhs, float rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/InstantPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/InstantPercentileTypeHelper.java
@@ -102,7 +102,7 @@ public class InstantPercentileTypeHelper implements SsmChunkedPercentileOperator
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final long testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = LongComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -113,11 +113,4 @@ public class InstantPercentileTypeHelper implements SsmChunkedPercentileOperator
         return hi;
     }
 
-    private static int doComparison(long lhs, long rhs) {
-        return LongComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(long lhs, long rhs) {
-        return doComparison(lhs, rhs) > 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/IntPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/IntPercentileTypeHelper.java
@@ -107,7 +107,7 @@ public class IntPercentileTypeHelper implements SsmChunkedPercentileOperator.Per
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final int testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = IntComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -116,13 +116,5 @@ public class IntPercentileTypeHelper implements SsmChunkedPercentileOperator.Per
         }
 
         return hi;
-    }
-
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(int lhs, int rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/LongPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/LongPercentileTypeHelper.java
@@ -107,7 +107,7 @@ public class LongPercentileTypeHelper implements SsmChunkedPercentileOperator.Pe
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final long testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = LongComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -116,13 +116,5 @@ public class LongPercentileTypeHelper implements SsmChunkedPercentileOperator.Pe
         }
 
         return hi;
-    }
-
-    private static int doComparison(long lhs, long rhs) {
-        return LongComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(long lhs, long rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/ObjectPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/ObjectPercentileTypeHelper.java
@@ -109,7 +109,7 @@ public class ObjectPercentileTypeHelper implements SsmChunkedPercentileOperator.
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final Object testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = ObjectComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -118,13 +118,5 @@ public class ObjectPercentileTypeHelper implements SsmChunkedPercentileOperator.
         }
 
         return hi;
-    }
-
-    private static int doComparison(Object lhs, Object rhs) {
-        return ObjectComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(Object lhs, Object rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/ShortPercentileTypeHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ssmpercentile/ShortPercentileTypeHelper.java
@@ -107,7 +107,7 @@ public class ShortPercentileTypeHelper implements SsmChunkedPercentileOperator.P
         while (lo < hi) {
             final int mid = (lo + hi) >>> 1;
             final short testValue = valuesToSearch.get(mid);
-            final boolean moveHi = gt(testValue, searchValue);
+            final boolean moveHi = ShortComparisons.gt(testValue, searchValue);
             if (moveHi) {
                 hi = mid;
             } else {
@@ -116,13 +116,5 @@ public class ShortPercentileTypeHelper implements SsmChunkedPercentileOperator.P
         }
 
         return hi;
-    }
-
-    private static int doComparison(short lhs, short rhs) {
-        return ShortComparisons.compare(lhs, rhs);
-    }
-
-    private static boolean gt(short lhs, short rhs) {
-        return doComparison(lhs, rhs) > 0;
     }
 }


### PR DESCRIPTION
The logic is identical, but this provides the JVM a more specific target to optimize.