### PR TITLE
perf: SortCheck, use explicit comparison operator

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ByteReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ByteReverseSortCheck.java
@@ -38,12 +38,8 @@ public class ByteReverseSortCheck implements SortCheck {
 
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
-    private static int doComparison(byte lhs, byte rhs) {
-        return -1 * ByteComparisons.compare(lhs, rhs);
+    private static boolean leq(byte lhs, byte rhs) {
+        return ByteComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(byte lhs, byte rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ByteSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ByteSortCheck.java
@@ -36,12 +36,8 @@ public class ByteSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(byte lhs, byte rhs) {
-        return ByteComparisons.compare(lhs, rhs);
+    private static boolean leq(byte lhs, byte rhs) {
+        return ByteComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(byte lhs, byte rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/CharReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/CharReverseSortCheck.java
@@ -38,12 +38,8 @@ public class CharReverseSortCheck implements SortCheck {
 
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
-    private static int doComparison(char lhs, char rhs) {
-        return -1 * CharComparisons.compare(lhs, rhs);
+    private static boolean leq(char lhs, char rhs) {
+        return CharComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(char lhs, char rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/CharSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/CharSortCheck.java
@@ -32,12 +32,8 @@ public class CharSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(char lhs, char rhs) {
-        return CharComparisons.compare(lhs, rhs);
+    private static boolean leq(char lhs, char rhs) {
+        return CharComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(char lhs, char rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/DoubleReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/DoubleReverseSortCheck.java
@@ -38,12 +38,8 @@ public class DoubleReverseSortCheck implements SortCheck {
 
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
-    private static int doComparison(double lhs, double rhs) {
-        return -1 * DoubleComparisons.compare(lhs, rhs);
+    private static boolean leq(double lhs, double rhs) {
+        return DoubleComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(double lhs, double rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/DoubleSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/DoubleSortCheck.java
@@ -36,12 +36,8 @@ public class DoubleSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(double lhs, double rhs) {
-        return DoubleComparisons.compare(lhs, rhs);
+    private static boolean leq(double lhs, double rhs) {
+        return DoubleComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(double lhs, double rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/FloatReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/FloatReverseSortCheck.java
@@ -38,12 +38,8 @@ public class FloatReverseSortCheck implements SortCheck {
 
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
-    private static int doComparison(float lhs, float rhs) {
-        return -1 * FloatComparisons.compare(lhs, rhs);
+    private static boolean leq(float lhs, float rhs) {
+        return FloatComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(float lhs, float rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/FloatSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/FloatSortCheck.java
@@ -36,12 +36,8 @@ public class FloatSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(float lhs, float rhs) {
-        return FloatComparisons.compare(lhs, rhs);
+    private static boolean leq(float lhs, float rhs) {
+        return FloatComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(float lhs, float rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/IntReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/IntReverseSortCheck.java
@@ -38,12 +38,8 @@ public class IntReverseSortCheck implements SortCheck {
 
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
-    private static int doComparison(int lhs, int rhs) {
-        return -1 * IntComparisons.compare(lhs, rhs);
+    private static boolean leq(int lhs, int rhs) {
+        return IntComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(int lhs, int rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/IntSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/IntSortCheck.java
@@ -36,12 +36,8 @@ public class IntSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(int lhs, int rhs) {
-        return IntComparisons.compare(lhs, rhs);
+    private static boolean leq(int lhs, int rhs) {
+        return IntComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(int lhs, int rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/LongReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/LongReverseSortCheck.java
@@ -38,12 +38,8 @@ public class LongReverseSortCheck implements SortCheck {
 
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
-    private static int doComparison(long lhs, long rhs) {
-        return -1 * LongComparisons.compare(lhs, rhs);
+    private static boolean leq(long lhs, long rhs) {
+        return LongComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(long lhs, long rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/LongSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/LongSortCheck.java
@@ -36,12 +36,8 @@ public class LongSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(long lhs, long rhs) {
-        return LongComparisons.compare(lhs, rhs);
+    private static boolean leq(long lhs, long rhs) {
+        return LongComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(long lhs, long rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ObjectReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ObjectReverseSortCheck.java
@@ -8,9 +8,6 @@
 
 package io.deephaven.engine.table.impl.sortcheck;
 
-import java.util.Objects;
-import io.deephaven.util.compare.ObjectComparisons;
-
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.util.compare.ObjectComparisons;
 import io.deephaven.chunk.ObjectChunk;
@@ -40,13 +37,9 @@ public class ObjectReverseSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    // descending comparison
-    private static int doComparison(Object lhs, Object rhs) {
-        return ObjectComparisons.compare(rhs, lhs);
+    // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
+    private static boolean leq(Object lhs, Object rhs) {
+        return ObjectComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(Object lhs, Object rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ObjectSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ObjectSortCheck.java
@@ -36,12 +36,8 @@ public class ObjectSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(Object lhs, Object rhs) {
-        return ObjectComparisons.compare(lhs, rhs);
+    private static boolean leq(Object lhs, Object rhs) {
+        return ObjectComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(Object lhs, Object rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ShortReverseSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ShortReverseSortCheck.java
@@ -38,12 +38,8 @@ public class ShortReverseSortCheck implements SortCheck {
 
     // region comparison functions
     // note that this is a descending kernel, thus the comparisons here are backwards (e.g., the lt function is in terms of the sort direction, so is implemented by gt)
-    private static int doComparison(short lhs, short rhs) {
-        return -1 * ShortComparisons.compare(lhs, rhs);
+    private static boolean leq(short lhs, short rhs) {
+        return ShortComparisons.geq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(short lhs, short rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ShortSortCheck.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sortcheck/ShortSortCheck.java
@@ -36,12 +36,8 @@ public class ShortSortCheck implements SortCheck {
     }
 
     // region comparison functions
-    private static int doComparison(short lhs, short rhs) {
-        return ShortComparisons.compare(lhs, rhs);
+    private static boolean leq(short lhs, short rhs) {
+        return ShortComparisons.leq(lhs, rhs);
     }
     // endregion comparison functions
-
-    private static boolean leq(short lhs, short rhs) {
-        return doComparison(lhs, rhs) <= 0;
-    }
 }

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSortCheck.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSortCheck.java
@@ -44,11 +44,7 @@ public class ReplicateSortCheck {
                 simpleFixup(ascendingNameToDescendingName(path, FileUtils.readLines(file, Charset.defaultCharset())),
                         "initialize last", "MIN_VALUE", "MAX_VALUE");
 
-        if (path.contains("Object")) {
-            lines = ReplicateSortKernel.fixupObjectComparisons(lines, false);
-        } else {
-            lines = ReplicateSortKernel.invertComparisons(lines);
-        }
+        lines = ReplicateSortKernel.invertComparisons(lines);
 
         FileUtils.writeLines(new File(descendingPath), lines);
     }


### PR DESCRIPTION
The logic is identical, but this provides the JVM a more specific target to optimize.

This is only used in verifying sorts, not in any actual operation.