### PR TITLE
perf: Blink / AddOnly SortedFirstOrLast, use explicit comparison operator

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ByteAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ByteAddOnlySortedFirstOrLastChunkedOperator.java
@@ -93,12 +93,16 @@ public class ByteAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFirs
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final byte value = values.get(start + ii);
-            final int comparison = ByteComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? ByteComparisons.leq(value, bestValue)
+                        : ByteComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? ByteComparisons.geq(value, bestValue)
+                        : ByteComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ByteBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ByteBlinkSortedFirstOrLastChunkedOperator.java
@@ -113,13 +113,10 @@ public class ByteBlinkSortedFirstOrLastChunkedOperator extends CopyingPermutedBl
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final byte value = values.get(chunkPos);
-            final int comparison = ByteComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? ByteComparisons.lt(value, bestValue)
+                    : ByteComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/CharAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/CharAddOnlySortedFirstOrLastChunkedOperator.java
@@ -89,12 +89,16 @@ public class CharAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFirs
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final char value = values.get(start + ii);
-            final int comparison = CharComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? CharComparisons.leq(value, bestValue)
+                        : CharComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? CharComparisons.geq(value, bestValue)
+                        : CharComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/CharBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/CharBlinkSortedFirstOrLastChunkedOperator.java
@@ -109,13 +109,10 @@ public class CharBlinkSortedFirstOrLastChunkedOperator extends CopyingPermutedBl
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final char value = values.get(chunkPos);
-            final int comparison = CharComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? CharComparisons.lt(value, bestValue)
+                    : CharComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/DoubleAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/DoubleAddOnlySortedFirstOrLastChunkedOperator.java
@@ -93,12 +93,16 @@ public class DoubleAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFi
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final double value = values.get(start + ii);
-            final int comparison = DoubleComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? DoubleComparisons.leq(value, bestValue)
+                        : DoubleComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? DoubleComparisons.geq(value, bestValue)
+                        : DoubleComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/DoubleBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/DoubleBlinkSortedFirstOrLastChunkedOperator.java
@@ -113,13 +113,10 @@ public class DoubleBlinkSortedFirstOrLastChunkedOperator extends CopyingPermuted
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final double value = values.get(chunkPos);
-            final int comparison = DoubleComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? DoubleComparisons.lt(value, bestValue)
+                    : DoubleComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FloatAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FloatAddOnlySortedFirstOrLastChunkedOperator.java
@@ -93,12 +93,16 @@ public class FloatAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFir
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final float value = values.get(start + ii);
-            final int comparison = FloatComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? FloatComparisons.leq(value, bestValue)
+                        : FloatComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? FloatComparisons.geq(value, bestValue)
+                        : FloatComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FloatBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FloatBlinkSortedFirstOrLastChunkedOperator.java
@@ -113,13 +113,10 @@ public class FloatBlinkSortedFirstOrLastChunkedOperator extends CopyingPermutedB
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final float value = values.get(chunkPos);
-            final int comparison = FloatComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? FloatComparisons.lt(value, bestValue)
+                    : FloatComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/IntAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/IntAddOnlySortedFirstOrLastChunkedOperator.java
@@ -93,12 +93,16 @@ public class IntAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFirst
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final int value = values.get(start + ii);
-            final int comparison = IntComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? IntComparisons.leq(value, bestValue)
+                        : IntComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? IntComparisons.geq(value, bestValue)
+                        : IntComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/IntBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/IntBlinkSortedFirstOrLastChunkedOperator.java
@@ -113,13 +113,10 @@ public class IntBlinkSortedFirstOrLastChunkedOperator extends CopyingPermutedBli
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final int value = values.get(chunkPos);
-            final int comparison = IntComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? IntComparisons.lt(value, bestValue)
+                    : IntComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/LongAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/LongAddOnlySortedFirstOrLastChunkedOperator.java
@@ -93,12 +93,16 @@ public class LongAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFirs
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final long value = values.get(start + ii);
-            final int comparison = LongComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? LongComparisons.leq(value, bestValue)
+                        : LongComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? LongComparisons.geq(value, bestValue)
+                        : LongComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/LongBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/LongBlinkSortedFirstOrLastChunkedOperator.java
@@ -113,13 +113,10 @@ public class LongBlinkSortedFirstOrLastChunkedOperator extends CopyingPermutedBl
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final long value = values.get(chunkPos);
-            final int comparison = LongComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? LongComparisons.lt(value, bestValue)
+                    : LongComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ObjectAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ObjectAddOnlySortedFirstOrLastChunkedOperator.java
@@ -93,12 +93,16 @@ public class ObjectAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFi
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final Object value = values.get(start + ii);
-            final int comparison = ObjectComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? ObjectComparisons.leq(value, bestValue)
+                        : ObjectComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? ObjectComparisons.geq(value, bestValue)
+                        : ObjectComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ObjectBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ObjectBlinkSortedFirstOrLastChunkedOperator.java
@@ -113,13 +113,10 @@ public class ObjectBlinkSortedFirstOrLastChunkedOperator extends CopyingPermuted
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final Object value = values.get(chunkPos);
-            final int comparison = ObjectComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? ObjectComparisons.lt(value, bestValue)
+                    : ObjectComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ShortAddOnlySortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ShortAddOnlySortedFirstOrLastChunkedOperator.java
@@ -93,12 +93,16 @@ public class ShortAddOnlySortedFirstOrLastChunkedOperator extends BaseAddOnlyFir
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final long index = indices.get(start + ii);
             final short value = values.get(start + ii);
-            final int comparison = ShortComparisons.compare(value, bestValue);
-            // @formatter:off
-            final boolean better =
-                    ( isFirst && (comparison < 0 || (comparison == 0 && index < bestIndex))) ||
-                    (!isFirst && (comparison > 0 || (comparison == 0 && index > bestIndex)))  ;
-            // @formatter:on
+            final boolean better;
+            if (isFirst) {
+                better = index < bestIndex
+                        ? ShortComparisons.leq(value, bestValue)
+                        : ShortComparisons.lt(value, bestValue);
+            } else {
+                better = index > bestIndex
+                        ? ShortComparisons.geq(value, bestValue)
+                        : ShortComparisons.gt(value, bestValue);
+            }
             if (better) {
                 bestIndex = index;
                 bestValue = value;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ShortBlinkSortedFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ShortBlinkSortedFirstOrLastChunkedOperator.java
@@ -113,13 +113,10 @@ public class ShortBlinkSortedFirstOrLastChunkedOperator extends CopyingPermutedB
         for (int ii = newDestination ? 1 : 0; ii < length; ++ii) {
             final int chunkPos = start + ii;
             final short value = values.get(chunkPos);
-            final int comparison = ShortComparisons.compare(value, bestValue);
-            // @formatter:off
             // No need to compare relative row keys. A stream's logical row set is always monotonically increasing.
-            final boolean better =
-                    ( isFirst && comparison <  0) ||
-                    (!isFirst && comparison >= 0)  ;
-            // @formatter:on
+            final boolean better = isFirst
+                    ? ShortComparisons.lt(value, bestValue)
+                    : ShortComparisons.geq(value, bestValue);
             if (better) {
                 bestChunkPos = chunkPos;
                 bestValue = value;


### PR DESCRIPTION
This is handling a subset of SortedFirstOrLast operators; the general case which goes through `io.deephaven.engine.table.impl.by.SortedFirstOrLastChunkedOperator` / `SegmentedSortedArray` is a larger change that should land independently.

The logic is identical, but this provides the JVM a more specific target to optimize.