### PR TITLE
fix: Downgrade web UI to patch version v0.85.3

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,10 +2,10 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.86.1
-ARG GRID_VERSION=0.86.0
-ARG CHART_VERSION=0.86.0
-ARG WIDGET_VERSION=0.86.1
+ARG WEB_VERSION=0.85.3
+ARG GRID_VERSION=0.85.0
+ARG CHART_VERSION=0.85.0
+ARG WIDGET_VERSION=0.85.3
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
- Release notes: https://github.com/deephaven/web-client-ui/releases/tag/v0.85.3
- Fixes #5825
  - Branched off 0.85.2 and cherry-picked fixes for this release only, leaving out new features (including the new Partitioned Table handling)