### PR TITLE
fix: update snapshot_when doc with trigger table being append-only requirement when history is requested.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -2389,7 +2389,9 @@ public class QueryTable extends BaseTable<QueryTable> {
     private Table snapshotHistory(final String nuggetName, final Table baseTable,
             Collection<? extends JoinAddition> stampColumns) {
         return QueryPerformanceRecorder.withNugget(nuggetName, baseTable.sizeForInstrumentation(),
-                () -> maybeViewForSnapshot(stampColumns).snapshotHistoryInternal(baseTable));
+                () -> ((QueryTable) withAttributes(Map.of(APPEND_ONLY_TABLE_ATTRIBUTE, TRUE)))
+                        .maybeViewForSnapshot(stampColumns)
+                        .snapshotHistoryInternal(baseTable));
     }
 
     private Table snapshotHistoryInternal(final Table baseTable) {

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -725,6 +725,10 @@ class Table(JObjectWrapper):
         table. The "stamp key" is the last row of the trigger_table, limited by the stamp_cols. If trigger_table is
         empty, the "stamp key" will be represented by NULL values.
 
+        Note: the trigger_table must be append-only when the history flag is set to True. If the trigger_table is not
+        append-only and has modified or removed rows in its updates, the result snapshot table will be put in a failure
+        state and become unusable.
+
         Args:
             trigger_table (Table): the trigger table
             stamp_cols (Union[str, Sequence[str]): The columns from trigger_table that form the "stamp key", may be
@@ -737,7 +741,7 @@ class Table(JObjectWrapper):
             history (bool): Whether the resulting table should keep history, default is False. A history table appends a
                 full snapshot of this table and the "stamp key" as opposed to updating existing rows. The history flag
                 is currently incompatible with initial and incremental: when history is True, incremental and initial
-                must be False. Note that the trigger_table must be append-only when history is set to True.
+                must be False.
 
         Returns:
             a new table
@@ -745,9 +749,6 @@ class Table(JObjectWrapper):
         Raises:
             DHError
         """
-        if history and not trigger_table.attributes().get(_JTable.APPEND_ONLY_TABLE_ATTRIBUTE, False):
-            raise DHError(message="The trigger table must be append-only when history is set to True.")
-
         try:
             options = _JSnapshotWhenOptions.of(initial, incremental, history, to_sequence(stamp_cols))
             with auto_locking_ctx(self, trigger_table):

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -737,7 +737,7 @@ class Table(JObjectWrapper):
             history (bool): Whether the resulting table should keep history, default is False. A history table appends a
                 full snapshot of this table and the "stamp key" as opposed to updating existing rows. The history flag
                 is currently incompatible with initial and incremental: when history is True, incremental and initial
-                must be False.
+                must be False. Note that the trigger_table must be append-only when history is set to True.
 
         Returns:
             a new table
@@ -745,6 +745,9 @@ class Table(JObjectWrapper):
         Raises:
             DHError
         """
+        if history and not trigger_table.attributes().get(_JTable.APPEND_ONLY_TABLE_ATTRIBUTE, False):
+            raise DHError(message="The trigger table must be append-only when history is set to True.")
+
         try:
             options = _JSnapshotWhenOptions.of(initial, incremental, history, to_sequence(stamp_cols))
             with auto_locking_ctx(self, trigger_table):

--- a/table-api/src/main/java/io/deephaven/api/snapshot/SnapshotWhenOptions.java
+++ b/table-api/src/main/java/io/deephaven/api/snapshot/SnapshotWhenOptions.java
@@ -39,7 +39,8 @@ public abstract class SnapshotWhenOptions {
         INCREMENTAL,
         /**
          * Whether the resulting table should keep history. A history table appends a full snapshot of {@code base} and
-         * the "stamp key" as opposed to updating existing rows.
+         * the "stamp key" as opposed to updating existing rows. When this flag is used, the trigger table must be
+         * append-only.
          *
          * <p>
          * Note: this flag is currently incompatible with {@link #INITIAL} and {@link #INCREMENTAL}.


### PR DESCRIPTION
Fixes #5841