### PR TITLE
feat: Add nightly publishing job for SNAPSHOT jars

### DIFF
--- a/.github/workflows/nightly-publish-ci.yml
+++ b/.github/workflows/nightly-publish-ci.yml
@@ -1,0 +1,66 @@
+name: Nightly Publish CI
+
+on:
+  schedule:
+    # 1AM EST == 5AM UTC
+    - cron:  '0 5 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  nightly-publish:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 11
+        id: setup-java-11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Setup JDK 17
+        id: setup-java-17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Set JAVA_HOME
+        run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
+
+      - name: Setup gradle properties
+        run: |
+          .github/scripts/gradle-properties.sh >> gradle.properties
+          cat gradle.properties
+
+      - name: Publish to OSSRH snapshots repository
+        # We are not worried here about using --no-parallel (as we are with release publishing), since publishing
+        # snapshots does not even create staging repositories.
+        run: ./gradlew publish
+        env:
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CI_AT_DEEPHAVEN_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingRequired: true
+
+      - name: Slack Nightly Failure
+        uses: slackapi/slack-github-action@v1.26.0
+        id: slack-nightly-failure
+        if: failure()
+        with:
+          payload: |
+            {
+              "slack_message": "Nightly publish failure @ ${{ github.head_ref }} ${{ github.sha }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
@@ -63,12 +63,16 @@ class PublishingTools {
         }
     }
 
+    static boolean isSnapshot(Project project) {
+        return ((String)project.version).endsWith('-SNAPSHOT')
+    }
+
     static void setupRepositories(Project project) {
         PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)
         publishingExtension.repositories { repoHandler ->
             repoHandler.maven { MavenArtifactRepository repo ->
                 repo.name = REPO_NAME
-                repo.url = ((String)project.version).endsWith('SNAPSHOT') ? SNAPSHOT_REPO : RELEASE_REPO
+                repo.url = isSnapshot(project) ? SNAPSHOT_REPO : RELEASE_REPO
                 // ossrhUsername, ossrhPassword
                 repo.credentials(PasswordCredentials)
             }
@@ -145,7 +149,9 @@ class PublishingTools {
                     throw new IllegalStateException('Release error: env CI must be true')
                 }
                 def actualGithubRef = System.getenv('GITHUB_REF')
-                def expectedGithubRef = "refs/heads/release/v${p.version}"
+                def expectedGithubRef = isSnapshot(p)
+                        ? 'refs/heads/main'
+                        : "refs/heads/release/v${p.version}".toString()
                 if (actualGithubRef != expectedGithubRef) {
                     throw new IllegalStateException("Release error: env GITHUB_REF '${actualGithubRef}' does not match expected '${expectedGithubRef}'. Bad tag? Bump version?")
                 }


### PR DESCRIPTION
This adds a nightly job, run against `refs/heads/main`, that publishes SNAPSHOT jars to https://s01.oss.sonatype.org/content/repositories/snapshots/io/deephaven/. This may help in ensuring our publishing pipeline is working as intended in the face of potential OSSRH changes, https://central.sonatype.org/news/archive/. This may also be useful for downstream consumers to validate compile compatibility with future deephaven-core releases.

This does _not_ add nightly publishing of non-jar artifacts; neither python wheels nor npm artifacts are released at this time.