### PR TITLE
fix!: Update Iceberg snapshots table to use `Instant` timestamps.

### DIFF
--- a/extensions/iceberg/s3/src/test/java/io/deephaven/iceberg/util/IcebergToolsTest.java
+++ b/extensions/iceberg/s3/src/test/java/io/deephaven/iceberg/util/IcebergToolsTest.java
@@ -168,7 +168,7 @@ public abstract class IcebergToolsTest {
         Table table = adapter.listSnapshotsAsTable(tableIdentifier);
         Assert.eq(table.size(), "table.size()", 4, "4 snapshots for sales/sales_multi");
         Assert.eqTrue(table.getColumnSource("Id").getType().equals(long.class), "id column type");
-        Assert.eqTrue(table.getColumnSource("TimestampMs").getType().equals(long.class), "timestamp_ms column type");
+        Assert.eqTrue(table.getColumnSource("Timestamp").getType().equals(Instant.class), "timestamp column type");
         Assert.eqTrue(table.getColumnSource("Operation").getType().equals(String.class), "operation column type");
         Assert.eqTrue(table.getColumnSource("Summary").getType().equals(Map.class), "summary column type");
         Assert.eqTrue(table.getColumnSource("SnapshotObject").getType().equals(Snapshot.class),

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergCatalogAdapter.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergCatalogAdapter.java
@@ -15,7 +15,6 @@ import io.deephaven.engine.table.impl.locations.impl.StandaloneTableKey;
 import io.deephaven.engine.table.impl.locations.impl.TableLocationKeyFinder;
 import io.deephaven.engine.table.impl.locations.util.TableDataRefreshService;
 import io.deephaven.engine.table.impl.sources.InMemoryColumnSource;
-import io.deephaven.engine.table.impl.sources.ReinterpretUtils;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedTableComponentFactoryImpl;
 import io.deephaven.engine.updategraph.UpdateSourceRegistrar;
 import io.deephaven.iceberg.layout.IcebergFlatLayout;
@@ -312,8 +311,8 @@ public class IcebergCatalogAdapter {
         columnSourceMap.put("Id", InMemoryColumnSource.getImmutableMemoryColumnSource(idArr, long.class, null));
 
         final long[] timestampArr = new long[(int) size];
-        columnSourceMap.put("Timestamp", ReinterpretUtils.longToInstantSource(
-                InMemoryColumnSource.getImmutableMemoryColumnSource(timestampArr, long.class, null)));
+        columnSourceMap.put("Timestamp",
+                InMemoryColumnSource.getImmutableMemoryColumnSource(timestampArr, Instant.class, null));
 
         final String[] operatorArr = new String[(int) size];
         columnSourceMap.put("Operation",


### PR DESCRIPTION
New snapshot table view:
<img width="1346" alt="image" src="https://github.com/user-attachments/assets/a4ff6984-cca5-4558-b1e1-a3bd488438a1">

<img width="622" alt="image" src="https://github.com/user-attachments/assets/72125c34-245b-488e-9d26-2cb26ad46ece">
