### PR TITLE
fix: NPE in reading parquet TIMESTAMP_MILLIS and TIMESTAMP_MICROS columns

### DIFF
--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
@@ -302,7 +302,7 @@ public class ParquetFileReader {
 
             if (schemaElement.isSetConverted_type()) {
                 final LogicalTypeAnnotation originalType = getLogicalTypeAnnotation(
-                        schemaElement.converted_type, schemaElement.logicalType, schemaElement);
+                        schemaElement.converted_type, schemaElement);
                 final LogicalTypeAnnotation newOriginalType = schemaElement.isSetLogicalType()
                         && getLogicalTypeAnnotation(schemaElement.logicalType) != null
                                 ? getLogicalTypeAnnotation(schemaElement.logicalType)
@@ -405,8 +405,9 @@ public class ParquetFileReader {
         return org.apache.parquet.schema.ColumnOrder.undefined();
     }
 
-    private static LogicalTypeAnnotation getLogicalTypeAnnotation(final ConvertedType convertedType,
-            final LogicalType logicalType, final SchemaElement schemaElement) throws ParquetFileReaderException {
+    private static LogicalTypeAnnotation getLogicalTypeAnnotation(
+            final ConvertedType convertedType,
+            final SchemaElement schemaElement) throws ParquetFileReaderException {
         switch (convertedType) {
             case UTF8:
                 return LogicalTypeAnnotation.stringType();
@@ -430,12 +431,13 @@ public class ParquetFileReader {
             case TIME_MICROS:
                 return LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MICROS);
             case TIMESTAMP_MILLIS:
-                // Converted type doesn't have isAdjustedToUTC parameter, so use the information from logical type
-                return LogicalTypeAnnotation.timestampType(isAdjustedToUTC(logicalType),
-                        LogicalTypeAnnotation.TimeUnit.MILLIS);
+                // TIMESTAMP_MILLIS is always adjusted to UTC
+                // ref: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+                return LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS);
             case TIMESTAMP_MICROS:
-                return LogicalTypeAnnotation.timestampType(isAdjustedToUTC(logicalType),
-                        LogicalTypeAnnotation.TimeUnit.MICROS);
+                // TIMESTAMP_MICROS is always adjusted to UTC
+                // ref: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+                return LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS);
             case INTERVAL:
                 return LogicalTypeAnnotation.IntervalLogicalTypeAnnotation.getInstance();
             case INT_8:

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/S3ParquetRemoteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/S3ParquetRemoteTest.java
@@ -36,7 +36,7 @@ public class S3ParquetRemoteTest {
     public final EngineCleanup framework = new EngineCleanup();
 
     @Test
-    public void readSampleParquetFilesFromPublicS3() {
+    public void readSampleParquetFilesFromPublicS3Part1() {
         Assume.assumeTrue("Skipping test because s3 testing disabled.", ENABLE_REMOTE_S3_TESTING);
         final S3Instructions s3Instructions = S3Instructions.builder()
                 .regionName("us-east-2")
@@ -69,6 +69,21 @@ public class S3ParquetRemoteTest {
         ParquetTools.readTable(
                 "s3://aws-public-blockchain/v1.0/btc/transactions/date=2023-11-13/part-00000-da3a3c27-700d-496d-9c41-81281388eca8-c000.snappy.parquet",
                 readInstructions).head(10).select();
+    }
+
+    @Test
+    public void readSampleParquetFilesFromPublicS3Part2() {
+        Assume.assumeTrue("Skipping test because s3 testing disabled.", ENABLE_REMOTE_S3_TESTING);
+        final S3Instructions s3Instructions = S3Instructions.builder()
+                .regionName("eu-west-3")
+                .readTimeout(Duration.ofSeconds(60))
+                .credentials(Credentials.anonymous())
+                .build();
+        final ParquetInstructions readInstructions = new ParquetInstructions.Builder()
+                .setSpecialInstructions(s3Instructions)
+                .build();
+        readTable("s3://datasets-documentation/pypi/2023/pypi_66_7_29.snappy.parquet", readInstructions)
+                .head(10).select();
     }
 
     @Test


### PR DESCRIPTION
Closes #5875

TIMESTAMP_MILLIS and TIMESTAMP_MICROS  column types store UTC adjusted timestamp values ([ref](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#:~:text=Deprecated%20timestamp%20ConvertedType-,TIMESTAMP_MILLIS,-is%20the%20deprecated)), but the current code was querying about UTC adjustment from the logical type. This could lead to a NPE. 