### PR TITLE
Direct iceberg table reading

### DIFF
--- a/extensions/iceberg/s3/build.gradle
+++ b/extensions/iceberg/s3/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     runtimeOnly libs.awssdk.sts
     runtimeOnly libs.awssdk.glue
 
+    compileOnly libs.autoservice
+    annotationProcessor libs.autoservice.compiler
+
     testImplementation libs.testcontainers
     testImplementation libs.testcontainers.junit.jupiter
     testImplementation libs.testcontainers.localstack

--- a/extensions/iceberg/s3/src/main/java/io/deephaven/extensions/s3/CredentialsPropertyAdapterInternal.java
+++ b/extensions/iceberg/s3/src/main/java/io/deephaven/extensions/s3/CredentialsPropertyAdapterInternal.java
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.extensions.s3;
+
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+import java.util.Map;
+
+public final class CredentialsPropertyAdapterInternal {
+
+    public static void adapt(Credentials credentials, Map<String, String> propertiesOut) {
+        if (credentials instanceof BasicCredentials) {
+            propertiesOut.put(S3FileIOProperties.ACCESS_KEY_ID, ((BasicCredentials) credentials).accessKeyId());
+            propertiesOut.put(S3FileIOProperties.SECRET_ACCESS_KEY, ((BasicCredentials) credentials).secretAccessKey());
+        } else if (credentials == Credentials.anonymous()) {
+            propertiesOut.put(AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER,
+                    AnonymousCredentialsProvider.class.getName());
+        } else if (credentials == Credentials.defaultCredentials()) {
+            propertiesOut.put(AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER,
+                    DefaultCredentialsProvider.class.getName());
+        } else {
+            throw new IllegalStateException("Unexpected credentials: " + credentials);
+        }
+    }
+}

--- a/extensions/iceberg/s3/src/main/java/io/deephaven/iceberg/util/internal/S3InstructionsPropertyAdapter.java
+++ b/extensions/iceberg/s3/src/main/java/io/deephaven/iceberg/util/internal/S3InstructionsPropertyAdapter.java
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.iceberg.util.internal;
+
+import com.google.auto.service.AutoService;
+import io.deephaven.extensions.s3.CredentialsPropertyAdapterInternal;
+import io.deephaven.extensions.s3.S3Instructions;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+
+import java.net.URI;
+import java.util.Map;
+
+@AutoService(io.deephaven.iceberg.util.internal.PropertyAdapter.class)
+public final class S3InstructionsPropertyAdapter implements PropertyAdapter {
+
+    public static void adapt(S3Instructions instructions, Map<String, String> propertiesOut) {
+        instructions.regionName().ifPresent(region -> propertiesOut.put(AwsClientProperties.CLIENT_REGION, region));
+        CredentialsPropertyAdapterInternal.adapt(instructions.credentials(), propertiesOut);
+        instructions.endpointOverride().map(URI::toString)
+                .ifPresent(uri -> propertiesOut.put(S3FileIOProperties.ENDPOINT, uri));
+    }
+
+    public S3InstructionsPropertyAdapter() {}
+
+    @Override
+    public void adapt(Object dataInstructions, Map<String, String> propertiesOut) {
+        if (dataInstructions instanceof S3Instructions) {
+            adapt((S3Instructions) dataInstructions, propertiesOut);
+        }
+    }
+}

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergCatalogAdapter.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergCatalogAdapter.java
@@ -17,6 +17,7 @@ import io.deephaven.engine.table.impl.locations.util.TableDataRefreshService;
 import io.deephaven.engine.table.impl.sources.InMemoryColumnSource;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedTableComponentFactoryImpl;
 import io.deephaven.engine.updategraph.UpdateSourceRegistrar;
+import io.deephaven.engine.util.TableTools;
 import io.deephaven.iceberg.layout.IcebergFlatLayout;
 import io.deephaven.iceberg.layout.IcebergKeyValuePartitionedLayout;
 import io.deephaven.iceberg.location.IcebergTableLocationFactory;
@@ -437,19 +438,31 @@ public class IcebergCatalogAdapter {
             @NotNull final TableIdentifier tableIdentifier,
             @Nullable final Snapshot tableSnapshot,
             @Nullable final IcebergInstructions instructions) {
-
         // Load the table from the catalog.
         final org.apache.iceberg.Table table = catalog.loadTable(tableIdentifier);
 
         // Do we want the latest or a specific snapshot?
         final Snapshot snapshot = tableSnapshot != null ? tableSnapshot : table.currentSnapshot();
-        final Schema schema = table.schemas().get(snapshot.schemaId());
 
-        // Load the partitioning schema.
-        final org.apache.iceberg.PartitionSpec partitionSpec = table.spec();
+        // If no snapshots, use the table schema
+        final Schema schema = snapshot != null ? table.schemas().get(snapshot.schemaId()) : table.schema();
 
         // Get default instructions if none are provided
         final IcebergInstructions userInstructions = instructions == null ? IcebergInstructions.DEFAULT : instructions;
+
+        return snapshot == null
+                ? readTableNoSnapshot(schema, table, userInstructions)
+                : readTableSnapshot(schema, table, userInstructions, snapshot, fileIO);
+    }
+
+    static TableDefinition tableDefinition(
+            @NotNull final Schema schema,
+            @NotNull final org.apache.iceberg.Table table,
+            @NotNull final IcebergInstructions userInstructions,
+            long snapshotId) {
+
+        // Load the partitioning schema.
+        final org.apache.iceberg.PartitionSpec partitionSpec = table.spec();
 
         // Get the user supplied table definition.
         final TableDefinition userTableDef = userInstructions.tableDefinition().orElse(null);
@@ -463,9 +476,8 @@ public class IcebergCatalogAdapter {
         for (final Map.Entry<String, String> entry : userInstructions.columnRenames().entrySet()) {
             final String destinationName = entry.getValue();
             if (!NameValidator.isValidColumnName(destinationName)) {
-                throw new TableDataException(
-                        String.format("%s:%d - invalid column name provided (%s)", table, snapshot.snapshotId(),
-                                destinationName));
+                throw new TableDataException(String.format("%s:%d - invalid column name provided (%s)", table,
+                        snapshotId, destinationName));
             }
             // Add these renames to the legalized list.
             legalizedColumnRenames.put(entry.getKey(), destinationName);
@@ -514,6 +526,20 @@ public class IcebergCatalogAdapter {
             // Use the snapshot schema as the table definition.
             tableDef = icebergTableDef;
         }
+        return tableDef;
+    }
+
+    static Table readTableSnapshot(
+            @NotNull final Schema schema,
+            @NotNull final org.apache.iceberg.Table table,
+            @NotNull final IcebergInstructions instructions,
+            @NotNull final Snapshot snapshot,
+            @NotNull final FileIO fileIO) {
+
+        // Load the partitioning schema.
+        final org.apache.iceberg.PartitionSpec partitionSpec = table.spec();
+
+        final TableDefinition tableDef = tableDefinition(schema, table, instructions, snapshot.snapshotId());
 
         final String description;
         final TableLocationKeyFinder<IcebergTableLocationKey> keyFinder;
@@ -522,11 +548,11 @@ public class IcebergCatalogAdapter {
 
         if (partitionSpec.isUnpartitioned()) {
             // Create the flat layout location key finder
-            keyFinder = new IcebergFlatLayout(tableDef, table, snapshot, fileIO, userInstructions);
+            keyFinder = new IcebergFlatLayout(tableDef, table, snapshot, fileIO, instructions);
         } else {
             // Create the partitioning column location key finder
             keyFinder = new IcebergKeyValuePartitionedLayout(tableDef, table, snapshot, fileIO, partitionSpec,
-                    userInstructions);
+                    instructions);
         }
 
         refreshService = null;
@@ -547,6 +573,13 @@ public class IcebergCatalogAdapter {
                 updateSourceRegistrar);
 
         return result;
+    }
+
+    static Table readTableNoSnapshot(
+            @NotNull final Schema schema,
+            @NotNull final org.apache.iceberg.Table table,
+            @NotNull final IcebergInstructions userInstructions) {
+        return TableTools.newTable(tableDefinition(schema, table, userInstructions, -1));
     }
 
     /**

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTools.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTools.java
@@ -3,8 +3,22 @@
 //
 package io.deephaven.iceberg.util;
 
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.iceberg.util.internal.PropertyAdapter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.ResolvingFileIO;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Tools for accessing tables in the Iceberg table format.
@@ -15,5 +29,86 @@ public abstract class IcebergTools {
             final Catalog catalog,
             final FileIO fileIO) {
         return new IcebergCatalogAdapter(catalog, fileIO);
+    }
+
+    public static Table readStatic(
+            String metadataFileLocation,
+            IcebergInstructions instructions,
+            Map<String, String> properties,
+            Map<String, String> hadoopProperties,
+            boolean adaptProperties) {
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+        if (instructions != null && adaptProperties) {
+            final Object dataInstructions = instructions.dataInstructions().orElse(null);
+            if (dataInstructions != null) {
+                PropertyAdapter.serviceLoaderAdapt(dataInstructions, properties);
+            }
+        }
+        final Configuration hadoopConf = new Configuration();
+        if (hadoopProperties != null) {
+            for (Entry<String, String> e : hadoopProperties.entrySet()) {
+                hadoopConf.set(e.getKey(), e.getValue());
+            }
+        }
+        return readStatic(metadataFileLocation, instructions, properties, hadoopConf);
+    }
+
+    public static Table readStatic(
+            String metadataFileLocation,
+            IcebergInstructions instructions,
+            Map<String, String> properties,
+            Configuration hadoopConf) {
+        // final HadoopTables tables = new HadoopTables(hadoopConf);
+        // final org.apache.iceberg.Table table = tables.load(uri);
+        final FileIO fileIO = CatalogUtil.loadFileIO(ResolvingFileIO.class.getName(), properties, hadoopConf);
+        final BaseTable table =
+                new BaseTable(new StaticTableOperations(metadataFileLocation, fileIO), metadataFileLocation);
+        final Snapshot snapshot = table.currentSnapshot();
+        final Schema schema = snapshot == null ? table.schema() : table.schemas().get(snapshot.schemaId());
+        return snapshot == null
+                ? IcebergCatalogAdapter.readTableNoSnapshot(schema, table, instructions)
+                : IcebergCatalogAdapter.readTableSnapshot(schema, table, instructions, table.currentSnapshot(), fileIO);
+    }
+
+    public static TableDefinition readStaticDefinition(
+            String metadataFileLocation,
+            IcebergInstructions instructions,
+            Map<String, String> properties,
+            Map<String, String> hadoopProperties,
+            boolean adaptProperties) {
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+        if (instructions != null && adaptProperties) {
+            final Object dataInstructions = instructions.dataInstructions().orElse(null);
+            if (dataInstructions != null) {
+                PropertyAdapter.serviceLoaderAdapt(dataInstructions, properties);
+            }
+        }
+        final Configuration hadoopConf = new Configuration();
+        if (hadoopProperties != null) {
+            for (Entry<String, String> e : hadoopProperties.entrySet()) {
+                hadoopConf.set(e.getKey(), e.getValue());
+            }
+        }
+        return readStaticDefinition(metadataFileLocation, instructions, properties, hadoopConf);
+    }
+
+    public static TableDefinition readStaticDefinition(
+            String metadataFileLocation,
+            IcebergInstructions instructions,
+            Map<String, String> properties,
+            Configuration hadoopConf) {
+        // final HadoopTables tables = new HadoopTables(hadoopConf);
+        // final org.apache.iceberg.Table table = tables.load(uri);
+        final FileIO fileIO = CatalogUtil.loadFileIO(ResolvingFileIO.class.getName(), properties, hadoopConf);
+        final BaseTable table =
+                new BaseTable(new StaticTableOperations(metadataFileLocation, fileIO), metadataFileLocation);
+        final Snapshot snapshot = table.currentSnapshot();
+        final Schema schema = snapshot == null ? table.schema() : table.schemas().get(snapshot.schemaId());
+        return IcebergCatalogAdapter.tableDefinition(schema, table, instructions,
+                snapshot == null ? -1 : snapshot.snapshotId());
     }
 }

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/internal/PropertyAdapter.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/internal/PropertyAdapter.java
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.iceberg.util.internal;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+
+public interface PropertyAdapter {
+
+    static void serviceLoaderAdapt(Object dataInstructions, Map<String, String> propertiesOut) {
+        for (PropertyAdapter propertyAdapter : ServiceLoader.load(PropertyAdapter.class)) {
+            propertyAdapter.adapt(dataInstructions, propertiesOut);
+        }
+    }
+
+    void adapt(Object dataInstructions, Map<String, String> propertiesOut);
+}

--- a/py/server/deephaven/experimental/iceberg.py
+++ b/py/server/deephaven/experimental/iceberg.py
@@ -12,12 +12,13 @@ from deephaven.column import Column
 from deephaven.dtypes import DType
 from deephaven.experimental import s3
 
-from deephaven.jcompat import j_table_definition
+from deephaven.jcompat import j_table_definition, j_hashmap
 
 from deephaven.table import Table
 
 _JIcebergInstructions = jpy.get_type("io.deephaven.iceberg.util.IcebergInstructions")
 _JIcebergCatalogAdapter = jpy.get_type("io.deephaven.iceberg.util.IcebergCatalogAdapter")
+_JIcebergTools = jpy.get_type("io.deephaven.iceberg.util.IcebergTools")
 
 # IcebergToolsS3 is an optional library
 try:
@@ -250,3 +251,35 @@ def adapter_aws_glue(
     except Exception as e:
         raise DHError(e, "Failed to build Iceberg Catalog Adapter") from e
 
+def read_static_table(
+        metadata_file_location: str,
+        instructions: Optional[IcebergInstructions] = None,
+        properties: Optional[Dict[str, str]] = None,
+        hadoop_properties: Optional[Dict[str, str]] = None,
+        adapt_properties: bool = True,
+) -> Table:
+    return Table(
+        _JIcebergTools.readStatic(
+            metadata_file_location,
+            instructions.j_object if instructions else None,
+            j_hashmap(properties) if properties else None,
+            j_hashmap(hadoop_properties) if hadoop_properties else None,
+            adapt_properties,
+        )
+    )
+
+def read_static_table_definition(
+        metadata_file_location: str,
+        instructions: Optional[IcebergInstructions] = None,
+        properties: Optional[Dict[str, str]] = None,
+        hadoop_properties: Optional[Dict[str, str]] = None,
+        adapt_properties: bool = True,
+):
+    # todo: we don't have a python TableDefinition wrapper?
+    return _JIcebergTools.readStaticDefinition(
+        metadata_file_location,
+        instructions.j_object if instructions else None,
+        j_hashmap(properties) if properties else None,
+        j_hashmap(hadoop_properties) if hadoop_properties else None,
+        adapt_properties,
+    )


### PR DESCRIPTION
This adds support to read iceberg tables directly from a specific metadata file without the need for a catalog (although, a catalog _may_ be present).

At a minimum, this should be a very useful tool for debugging iceberg issues. In some cases, it may be the best way to read iceberg data as a catalog may not be supported. For example, clickhouse iceberg integration uses direct access without catalog support (no table name, no namespace, etc):

```
$ aws s3 ls --recursive --no-sign-request s3://datasets-documentation/ookla/iceberg/
2024-01-22 07:46:40          0 ookla/iceberg/
2024-01-22 08:48:38  611058150 ookla/iceberg/data/7XNeNQ/year_month_year=2019/20240122_164644_00156_m96dt-a29b72df-0432-46db-8194-7cb911f08800.parquet
2024-01-22 08:47:14  756200550 ookla/iceberg/data/87-7xw/year_month_year=2020/20240122_164644_00156_m96dt-63c79f23-dd64-4a7e-890b-700b722b5d03.parquet
2024-01-22 08:47:07  767259012 ookla/iceberg/data/Mmyt8A/year_month_year=2021/20240122_164644_00156_m96dt-bb51598a-6f86-4d19-9717-bcef163a4f05.parquet
2024-01-22 08:47:01  781589111 ookla/iceberg/data/X9Wyog/year_month_year=2022/20240122_164644_00156_m96dt-d27f1b84-bb50-4205-b323-990a32e18ff6.parquet
2024-01-22 08:47:01  836014231 ookla/iceberg/data/wRhLaA/year_month_year=2023/20240122_164644_00156_m96dt-e5ce13ef-f40c-4834-b032-39e403121d3c.parquet
2024-01-22 08:25:30       1968 ookla/iceberg/metadata/00000-6bfbd5a5-c431-4a41-98c8-12328da25947.metadata.json
2024-01-22 08:49:55       3107 ookla/iceberg/metadata/00001-ad43ea5c-fd93-474c-93eb-2e8400c925aa.metadata.json
2024-01-22 08:49:53       8347 ookla/iceberg/metadata/a3a81488-f4ec-42ad-9819-54527e7f6385-m0.avro
2024-01-22 08:49:54       4280 ookla/iceberg/metadata/snap-8326954415243093563-1-a3a81488-f4ec-42ad-9819-54527e7f6385.avro
```

```sql
SELECT
  *
FROM
  iceberg('https://datasets-documentation.s3.eu-west-3.amazonaws.com/ookla/iceberg/')
```

https://clickhouse.com/blog/exploring-global-internet-speeds-with-apache-iceberg-clickhouse
https://clickhouse.com/docs/en/sql-reference/table-functions/iceberg

With this PR, the equivalent in Deephaven would be:

```python
from deephaven.experimental import iceberg

ookla = iceberg.read_static_table(
    "s3://datasets-documentation/ookla/iceberg/metadata/00001-ad43ea5c-fd93-474c-93eb-2e8400c925aa.metadata.json"
)
```

(For ease of use, the bit more verbose version works out-of-the-box without relying on implicit AWS credentials:

```python
from deephaven.experimental import iceberg, s3
from datetime import timedelta

ookla = iceberg.read_static_table(
    "s3://datasets-documentation/ookla/iceberg/metadata/00001-ad43ea5c-fd93-474c-93eb-2e8400c925aa.metadata.json",
    instructions=iceberg.IcebergInstructions(
        data_instructions=s3.S3Instructions(
            region_name="eu-west-3",
            anonymous_access=True,
            read_timeout=timedelta(seconds=10),
        )
    ),
)
```
)

There's potential to extend this support to point to the root of the table location (like clickhouse supports) as opposed to a specific metadata file, ie, `s3://datasets-documentation/ookla/iceberg/`, but that would take some additional logic.
