### PR TITLE
fix: disable py-client-ticking tests

### DIFF
--- a/py/client-ticking/build.gradle
+++ b/py/client-ticking/build.gradle
@@ -175,6 +175,6 @@ def syncWheels = tasks.register('syncWheels', Sync) {
 
 assemble.dependsOn syncWheels
 
-check.dependsOn testPyClientTicking
+// check.dependsOn testPyClientTicking
 
 deephavenDocker.shouldLogIfTaskFails testPyClientTicking


### PR DESCRIPTION
This is a temporary fix meant to get CI back and running without out of disk errors.