### PR TITLE
fix: Re-enable py-client-ticking tests

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -14,6 +14,17 @@ jobs:
   checks:
     runs-on: ubuntu-22.04
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -22,6 +22,17 @@ jobs:
       group: ${{ matrix.gradle-task }}-${{ matrix.test-jvm-version }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/py/client-ticking/build.gradle
+++ b/py/client-ticking/build.gradle
@@ -175,6 +175,6 @@ def syncWheels = tasks.register('syncWheels', Sync) {
 
 assemble.dependsOn syncWheels
 
-// check.dependsOn testPyClientTicking
+check.dependsOn testPyClientTicking
 
 deephavenDocker.shouldLogIfTaskFails testPyClientTicking


### PR DESCRIPTION
This removes unneeded data from the CI runner to free up extra disk space using https://github.com/jlumbroso/free-disk-space. An emphasis has been placed on the speed of removal, and as such, a few of the defaults have been changed. Namely, docker image deletion and large misc packages have been explicitly set to false (as they are more complex than a simple `rm`). The tool cache deletion has also been set to false, as we might take advantage of that for java.

Fixes #5899