### PR TITLE
fix: update to setup-gradle

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -29,6 +29,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -88,11 +91,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Dockerfile and context
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: build-server
-          arguments: --scan outputVersion docker-server-slim:prepareDocker docker-server:prepareDockerAll
-          gradle-version: wrapper
+        run: ./gradlew --scan outputVersion docker-server-slim:prepareDocker docker-server:prepareDockerAll
 
       - name: Get Deephaven Version
         id: deephaven_version
@@ -158,6 +157,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -182,11 +184,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Dockerfile and context
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: build-web
-          arguments: --scan outputVersion docker-web-plugin-packager:prepareDocker
-          gradle-version: wrapper
+        run: ./gradlew --scan outputVersion docker-web-plugin-packager:prepareDocker
 
       - name: Get Deephaven Version
         id: deephaven_version

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -33,6 +33,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -42,11 +45,7 @@ jobs:
           cat gradle.properties
 
       - name: Check
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: checks
-          arguments: --scan --continue check
-          gradle-version: wrapper
+        run: ./gradlew --scan --continue check
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -76,6 +76,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -85,12 +88,8 @@ jobs:
           cat gradle.properties
 
       - name: All Javadoc
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: allJavadoc
-          arguments: --scan outputVersion combined-javadoc:allJavadoc
-          gradle-version: wrapper
-          
+        run: ./gradlew --scan outputVersion combined-javadoc:allJavadoc
+
       - name: Get Deephaven Version
         id: dhc-version
         run: echo "version=$(cat build/version)" >> $GITHUB_OUTPUT
@@ -139,6 +138,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -148,12 +150,8 @@ jobs:
           cat gradle.properties
 
       - name: Run typedoc on JS API
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: typedoc
-          arguments: --scan outputVersion :web-client-api:types:typedoc
-          gradle-version: wrapper
-          
+        run: ./gradlew --scan outputVersion :web-client-api:types:typedoc
+
       - name: Get Deephaven Version
         id: dhc-version
         run: echo "version=$(cat build/version)" >> $GITHUB_OUTPUT
@@ -202,6 +200,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -211,12 +212,8 @@ jobs:
           cat gradle.properties
 
       - name: Generate Python Docs
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: pythonDocs
-          arguments: --scan outputVersion sphinx:pythonDocs sphinx:pydeephavenDocs
-          gradle-version: wrapper
- 
+        run: ./gradlew --scan outputVersion sphinx:pythonDocs sphinx:pydeephavenDocs
+
       - name: Get Deephaven Version
         id: dhc-version
         run: echo "version=$(cat build/version)" >> $GITHUB_OUTPUT
@@ -285,6 +282,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -294,12 +294,8 @@ jobs:
           cat gradle.properties
 
       - name: Generate C++ Docs
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: cppDocs
-          arguments: --scan outputVersion sphinx:cppClientDocs sphinx:cppExamplesDocs
-          gradle-version: wrapper
-         
+        run: ./gradlew --scan outputVersion sphinx:cppClientDocs sphinx:cppExamplesDocs
+
       - name: Get Deephaven Version
         id: dhc-version
         run: echo "version=$(cat build/version)" >> $GITHUB_OUTPUT
@@ -360,6 +356,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -369,12 +368,8 @@ jobs:
           cat gradle.properties
 
       - name: Generate R Docs
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: rDocs
-          arguments: --scan outputVersion R:rClientSite
-          gradle-version: wrapper
-          
+        run: ./gradlew --scan outputVersion R:rClientSite
+
       - name: Get Deephaven Version
         id: dhc-version
         run: echo "version=$(cat build/version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -55,6 +55,9 @@ jobs:
           distribution: 'temurin'
           java-version: '22'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -64,11 +67,7 @@ jobs:
           cat gradle.properties
 
       - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: gradle-run
-          arguments: --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
-          gradle-version: wrapper
+        run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-image-check.yml
+++ b/.github/workflows/nightly-image-check.yml
@@ -20,6 +20,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -29,11 +32,7 @@ jobs:
           cat gradle.properties
 
       - name: Run gradle
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: image-compare
-          arguments: --continue pullImage compareImage
-          gradle-version: wrapper
+        run: ./gradlew --continue pullImage compareImage
 
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1.26.0

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -33,6 +33,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -51,20 +54,12 @@ jobs:
 
       - name: Build all artifacts, publish to Maven Local
         if: ${{ !startsWith(github.ref, 'refs/heads/release/v') }}
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: publish-local
-          arguments: server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publishToMavenLocal
-          gradle-version: wrapper
+        run: ./gradlew server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publishToMavenLocal
 
       - name: Build all artifacts, publish to Sonatype for staging to Maven Central
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: publish
-          # We need to be explicit here about no parallelism to ensure we don't create disjointed staging repositories.
-          arguments: --no-parallel server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publish
-          gradle-version: wrapper
+        # We need to be explicit here about no parallelism to ensure we don't create disjointed staging repositories.
+        run: ./gradlew --no-parallel server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publish
         env:
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -27,6 +27,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Set JAVA_HOME
         run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
 
@@ -36,12 +39,8 @@ jobs:
           cat gradle.properties
 
       - name: Quick Task
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: quick-task
-          # Even though quick includes spotlessCheck, we want to make sure it runs first and fails ASAP for quick feedback
-          arguments: --scan spotlessCheck quick
-          gradle-version: wrapper
+        # Even though quick includes spotlessCheck, we want to make sure it runs first and fails ASAP for quick feedback
+        run: ./gradlew --scan spotlessCheck quick
 
       - name: Upload JVM Error Logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tag-base-images.yml
+++ b/.github/workflows/tag-base-images.yml
@@ -29,6 +29,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Setup Crane
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         uses: imjasonh/setup-crane@v0.3
@@ -50,11 +53,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Crane scripts
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          job-id: crane-scripts
-          arguments: createCraneTagScript
-          gradle-version: wrapper
+        run: ./gradlew createCraneTagScript
 
       - name: Tag upstream images
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}


### PR DESCRIPTION
This upgrades from the no longer maintained action `burrunan/gradle-cache-action` to the gradle maintained action `gradle/actions/setup-gradle`. There is a different usage pattern; with `setup-gradle`, it is invoked first during setup as opposed to at the command site. We were also using job-ids with `burrunan/gradle-cache-action` to implicitly control cache prefixes; it is not clear if we actually need to separate caches, and so (for now), the default caching behavior of `gradle/actions/setup-gradle` is used, https://github.com/gradle/actions/blob/v3.5.0/docs/setup-gradle.md#caching-build-state-between-jobs. By default, the action will read from cache, but will only write to the cache for jobs on the `main` branch.

Fixes #5161