### PR TITLE
fix: x/y error in pydocs

### DIFF
--- a/py/server/deephaven/plot/figure.py
+++ b/py/server/deephaven/plot/figure.py
@@ -2437,7 +2437,7 @@ class Figure(JObjectWrapper):
         self,
         name: str = None,
     ) -> Figure:
-        """Creates a new Axes which shares the x-Axis with the current Axes. For example, this is used for creating plots with a common x-axis but two different y-axes.
+        """Creates a new Axes which shares the x-Axis with the current Axes. For example, this is used for creating plots with a common y-axis but two different x-axes.
 
         Args:
             name (str): name


### PR DESCRIPTION
Noticed that the description for `x_twin` and `y_twin` was the same in the pydocs. Now the description matches the method's behavior.