### PR TITLE
feat: detect piped union

### DIFF
--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: pip install vermin==1.6.0
 
       - name: Verify minimum version support
-        run: vermin -t=3.8 --no-tips --eval-annotations --violations py/server/deephaven py/client py/client-ticking py/embedded-server
+        run: vermin -t=3.8 --no-tips --eval-annotations --violations --feature fstring-self-doc --feature union-types py/server/deephaven py/client py/client-ticking py/embedded-server


### PR DESCRIPTION
This allows vermin to correctly warn us if we are using the piped union syntax. Useful to prevent issues like https://github.com/deephaven/deephaven-core/issues/5912 in the future. In addition, self-documenting fstrings will be reported. Both of these features are labelled as "unstable"; if vermin ever produces a false positive, we can re-consider the inclusion of these features.

For example, it would have produced the following error:

```
Detecting python files..
Analyzing 247 files using 24 processes..
!2, 3.10     /home/devin/dev/deephaven/deephaven-core/py/server/deephaven/_table_reader.py
  union types as `X | Y` require !2, 3.10

Minimum required versions: 3.10
Incompatible versions:     2
Target versions not met:   3.8
```

Here is the documentation for these feature flags:

```
  [--feature <name>] ...
        Some features are disabled by default due to being unstable:
          fstring-self-doc - [Unstable] Detect self-documenting fstrings. Can in
                             some cases wrongly report fstrings as self-documenting.
          union-types      - [Unstable] Detect union types `X | Y`. Can in some cases
                             wrongly report union types due to having to employ heuristics.
```