### PR TITLE
fix: update R DESCRIPTION file to include URL

### DIFF
--- a/R/build.gradle
+++ b/R/build.gradle
@@ -179,7 +179,7 @@ def rClientSite = Docker.registerDockerTask(project, 'rClientSite') {
         runCommand("mkdir -p ${prefix}/src/rdeephaven/docs")
         runCommand('''echo "status = tryCatch(" \
                            "   {" \
-                           "      install.packages('pkgdown', repos='https://cran.r-project.org'); "
+                           "      install.packages('pkgdown', repos='https://cran.r-project.org'); " \
                            "      0" \
                            "   }," \
                            "  error=function(e) 1," \

--- a/R/build.gradle
+++ b/R/build.gradle
@@ -179,10 +179,7 @@ def rClientSite = Docker.registerDockerTask(project, 'rClientSite') {
         runCommand("mkdir -p ${prefix}/src/rdeephaven/docs")
         runCommand('''echo "status = tryCatch(" \
                            "   {" \
-                           "      install.packages('devtools'); " \
-                           "      require(devtools); " \
-                           "      remove.packages('pkgdown'); " \
-                           "      devtools::install_version('pkgdown', version='2.0.0', repos='https://cran.r-project.org'); " \
+                           "      install.packages('pkgdown', repos='https://cran.r-project.org'); "
                            "      0" \
                            "   }," \
                            "  error=function(e) 1," \

--- a/R/rdeephaven/DESCRIPTION
+++ b/R/rdeephaven/DESCRIPTION
@@ -5,6 +5,7 @@ Version: 0.36.0
 Date: 2023-05-12
 Author: Deephaven Data Labs
 Maintainer: Alex Peters <alexpeters@deephaven.io>
+URL: https://deephaven.io/core/client-api/r/
 Description: The `rdeephaven` package provides an R API for communicating with the Deephaven server and working with Deephaven tables.
              In this release, we support connecting to the Deephaven server with three authentication methods including anonymous,
              username/password, and general key/value authentication. Once the connection has been established, we provide the tools to


### PR DESCRIPTION
Add the URL for Deephaven's RDoc to the `DESCRIPTION` file of the `rdeephaven` package. This change is newly required by `pkgdown` 2.1.0.
https://github.com/deephaven/deephaven-core/pull/5729 provided a temporary fix for this break, and this PR also reverts that temporary fix.