### PR TITLE
fix: document and update WritableChunk and CompactKernel

### DIFF
--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableBooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableBooleanChunk.java
@@ -11,7 +11,6 @@ import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.util.pools.MultiChunkPool;
 
 import io.deephaven.util.type.TypeUtils;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 // region FillWithNullValueImports
@@ -172,8 +171,20 @@ public class WritableBooleanChunk<ATTR extends Any> extends BooleanChunk<ATTR> i
         sort(0, size);
     }
 
-    // region sort
-    // endregion sort
+    @Override
+    public final void sort(int start, int length) {
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
+    }
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableByteChunk.java
@@ -209,15 +209,20 @@ public class WritableByteChunk<ATTR extends Any> extends ByteChunk<ATTR> impleme
         sort(0, size);
     }
 
-    // region sort
     @Override
     public final void sort(int start, int length) {
-        Arrays.sort(data, offset + start, offset + start + length);
-
-        // region SortFixup
-        // endregion SortFixup
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java
@@ -205,39 +205,20 @@ public class WritableCharChunk<ATTR extends Any> extends CharChunk<ATTR> impleme
         sort(0, size);
     }
 
-    // region sort
     @Override
     public final void sort(int start, int length) {
-        Arrays.sort(data, offset + start, offset + start + length);
-
-        // region SortFixup
-        if (length <= 1) {
-            return;
-        }
-
-        int foundLeft = Arrays.binarySearch(data, start, start + length, NULL_CHAR);
-        if (foundLeft < 0) {
-            return;
-        }
-
-        int foundRight = foundLeft;
-        while (foundLeft > start && data[foundLeft - 1] == NULL_CHAR) {
-            foundLeft--;
-        }
-
-        // If the nulls are already the leftmost thing, we are done.
-        if (foundLeft > 0) {
-            while (foundRight < start + length - 1 && data[foundRight + 1] == NULL_CHAR) {
-                foundRight++;
-            }
-
-            final int nullCount = foundRight - foundLeft + 1;
-            System.arraycopy(data, start, data, start + nullCount, foundLeft - start);
-            Arrays.fill(data, start, start + nullCount, NULL_CHAR);
-        }
-        // endregion SortFixup
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableChunk.java
@@ -92,20 +92,36 @@ public interface WritableChunk<ATTR extends Any> extends Chunk<ATTR>, PoolableCh
     int internalCapacity(long password);
 
     /**
-     * Sort this chunk in-place using Java's primitive defined ordering.
-     * <p>
-     * Of note is that nulls or NaNs are not sorted according to Deephaven ordering rules.
+     * Sort this chunk using Deephaven-defined ordering; that is, nulls first (and NaNs last for floating-point types).
+     * The one exception is -0.0 and 0.0 for floating-point types; where the Deephaven-defined ordering treats these as
+     * equal, this sort will treat {@code -0.0 < 0.0}.
      */
     void sort();
 
     /**
-     * Sort this chunk in-place using Java's primitive defined ordering.
-     * <p>
-     * Of note is that nulls or NaNs are not sorted according to Deephaven ordering rules.
+     * Sort this chunk's subset using Deephaven-defined ordering; that is, nulls first (and NaNs last for floating-point
+     * types). The one exception is -0.0 and 0.0 for floating-point types; where the Deephaven-defined ordering treats
+     * these as equal, this sort will treat {@code -0.0 < 0.0}.
      */
-    default void sort(int start, int length) {
-        throw new UnsupportedOperationException();
-    }
+    void sort(int start, int length);
+
+    /**
+     * Sort this chunk using Arrays-defined ordering. This is equivalent to Deephaven-defined ordering (with a
+     * floating-point exception for {@code -0.0 < 0.0}) when ignoring nulls (and NaNs for floating-point types). Callers
+     * should only use this when they know the array does not contain nulls (and NaNs for floating-point types), or when
+     * the caller plans to explicitly exclude nulls (and NaNs for floating-point types) after sorting, or when the
+     * caller does not actually care about the sorting order (for example, is using sort as a means of grouping data).
+     */
+    void sortUnsafe();
+
+    /**
+     * Sort this chunk's subset using Arrays-defined ordering. This is equivalent to Deephaven-defined ordering (with a
+     * floating-point exception for {@code -0.0 < 0.0}) when ignoring nulls (and NaNs for floating-point types). Callers
+     * should only use this when they know the array does not contain nulls (and NaNs for floating-point types), or when
+     * the caller plans to explicitly exclude nulls (and NaNs for floating-point types) after sorting, or when the
+     * caller does not actually care about the sorting order (for example, is using sort as a means of grouping data).
+     */
+    void sortUnsafe(int start, int length);
 
     default WritableByteChunk<ATTR> asWritableByteChunk() {
         return (WritableByteChunk<ATTR>) this;

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableChunkImpl.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableChunkImpl.java
@@ -1,0 +1,268 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.chunk;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+import static io.deephaven.util.QueryConstants.NULL_CHAR;
+import static io.deephaven.util.QueryConstants.NULL_DOUBLE;
+import static io.deephaven.util.QueryConstants.NULL_FLOAT;
+
+final class WritableChunkImpl {
+
+    private static final float FLOAT_AFTER_NULL = Math.nextUp(NULL_FLOAT);
+    private static final double DOUBLE_AFTER_NULL = Math.nextUp(NULL_DOUBLE);
+
+    private static final int NULL_FLOAT_BITS = Float.floatToIntBits(NULL_FLOAT);
+    private static final int FLOAT_AFTER_NULL_BITS = Float.floatToIntBits(FLOAT_AFTER_NULL);
+
+    private static final long NULL_DOUBLE_BITS = Double.doubleToLongBits(NULL_DOUBLE);
+    private static final long DOUBLE_AFTER_NULL_BITS = Double.doubleToLongBits(DOUBLE_AFTER_NULL);
+
+    public static void sort(boolean[] data, int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static void sortUnsafe(boolean[] data, int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static void sortUnsafe(char[] data, int fromIndex, int toIndex) {
+        Arrays.sort(data, fromIndex, toIndex);
+    }
+
+    public static void sort(char[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+        // We need to "fix-up" the nulls (Character.MAX_VALUE) from end of subset to beginning of subset.
+        // [ (...,) data_1, ..., data_m, NULL_CHAR_1, ..., NULL_CHAR_n (,...) ]
+        // ->
+        // [ (...,) NULL_CHAR_1, ..., NULL_CHAR_n, data_1, ..., data_m (,...) ]
+        if (toIndex - fromIndex <= 1) {
+            // size 0 or 1, already sorted
+            return;
+        }
+        if (data[fromIndex] == NULL_CHAR) {
+            // all are NULL_CHAR, already sorted
+            return;
+        }
+        if (data[toIndex - 1] != NULL_CHAR) {
+            // none are NULL_CHAR, already sorted
+            return;
+        }
+        // We know first position is not NULL_CHAR; we don't want to exclude the last position, b/c it may be the
+        // only NULL_CHAR.
+        final int firstNullIx = binarySearchFirst(data, fromIndex + 1, toIndex, NULL_CHAR);
+        assert firstNullIx > 0;
+        final int nullCount = toIndex - firstNullIx;
+        System.arraycopy(data, fromIndex, data, fromIndex + nullCount, toIndex - fromIndex - nullCount);
+        Arrays.fill(data, fromIndex, fromIndex + nullCount, NULL_CHAR);
+    }
+
+    public static void sortUnsafe(byte[] data, int fromIndex, int toIndex) {
+        Arrays.sort(data, fromIndex, toIndex);
+    }
+
+    public static void sort(byte[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+    }
+
+    public static void sortUnsafe(short[] data, int fromIndex, int toIndex) {
+        Arrays.sort(data, fromIndex, toIndex);
+    }
+
+    public static void sort(short[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+    }
+
+    public static void sortUnsafe(int[] data, int fromIndex, int toIndex) {
+        Arrays.sort(data, fromIndex, toIndex);
+    }
+
+    public static void sort(int[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+    }
+
+    public static void sortUnsafe(long[] data, int fromIndex, int toIndex) {
+        Arrays.sort(data, fromIndex, toIndex);
+    }
+
+    public static void sort(long[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+    }
+
+    public static void sortUnsafe(float[] data, int fromIndex, int toIndex) {
+        Arrays.sort(data, fromIndex, toIndex);
+    }
+
+    public static void sort(float[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+        // We need to "fix-up" null (-Float.MAX_VALUE) vs -Infinity, which we know will be at the beginning of the
+        // subset
+        // [ (...,) -Inf_1, ..., -Inf_m, NULL_FLOAT_1, ..., NULL_FLOAT_m, ..., (,...)]
+        // ->
+        // [ (...,) NULL_FLOAT_1, ..., NULL_FLOAT_m, -Inf_1, ..., -Inf_n, ..., (,...)]
+        if (toIndex - fromIndex <= 1) {
+            // size 0 or 1, already sorted
+            return;
+        }
+        if (data[fromIndex] != Float.NEGATIVE_INFINITY) {
+            // Only chance that NULL_FLOAT is mis-sorted is when -Infinity is present, and we know that only happens
+            // when it's in the first position
+            return;
+        }
+        final int firstNullIx = binarySearchFirst(data, fromIndex + 1, toIndex, NULL_FLOAT, NULL_FLOAT_BITS);
+        if (firstNullIx < 0) {
+            // No NULL_FLOAT
+            return;
+        }
+        final int negInfCount = firstNullIx - fromIndex;
+        final int nullCount;
+        {
+            final int firstFloatAfterNull = binarySearchFirst(data, firstNullIx + 1, toIndex, FLOAT_AFTER_NULL,
+                    FLOAT_AFTER_NULL_BITS);
+            final int lastNullIx = (firstFloatAfterNull >= 0 ? firstFloatAfterNull : -firstFloatAfterNull - 1) - 1;
+            nullCount = lastNullIx - firstNullIx + 1;
+        }
+        final int size = Math.min(nullCount, negInfCount);
+        Arrays.fill(data, fromIndex, fromIndex + size, NULL_FLOAT);
+        {
+            final int negInfToIndex = fromIndex + nullCount + negInfCount;
+            Arrays.fill(data, negInfToIndex - size, negInfToIndex, Float.NEGATIVE_INFINITY);
+        }
+    }
+
+    public static void sortUnsafe(double[] data, int fromIndex, int toIndex) {
+        Arrays.sort(data, fromIndex, toIndex);
+    }
+
+    public static void sort(double[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+        // We need to "fix-up" null (-Double.MAX_VALUE) vs -Infinity, which we know will be at the beginning of the
+        // subset
+        // [ (...,) -Inf_1, ..., -Inf_m, NULL_DOUBLE_1, ..., NULL_DOUBLE_m, ..., (,...)]
+        // ->
+        // [ (...,) NULL_DOUBLE_1, ..., NULL_DOUBLE_m, -Inf_1, ..., -Inf_n, ..., (,...)]
+        if (toIndex - fromIndex <= 1) {
+            // size 0 or 1, already sorted
+            return;
+        }
+        if (data[fromIndex] != Double.NEGATIVE_INFINITY) {
+            // Only chance that NULL_DOUBLE is mis-sorted is when -Infinity is present, and we know that only happens
+            // when it's in the first position
+            return;
+        }
+        final int firstNullIx = binarySearchFirst(data, fromIndex + 1, toIndex, NULL_DOUBLE, NULL_DOUBLE_BITS);
+        if (firstNullIx < 0) {
+            // No NULL_DOUBLE
+            return;
+        }
+        final int negInfCount = firstNullIx - fromIndex;
+        final int nullCount;
+        {
+            final int firstDoubleAfterNull = binarySearchFirst(data, firstNullIx + 1, toIndex, DOUBLE_AFTER_NULL,
+                    DOUBLE_AFTER_NULL_BITS);
+            final int lastNullIx = (firstDoubleAfterNull >= 0 ? firstDoubleAfterNull : -firstDoubleAfterNull - 1) - 1;
+            nullCount = lastNullIx - firstNullIx + 1;
+        }
+        final int size = Math.min(nullCount, negInfCount);
+        Arrays.fill(data, fromIndex, fromIndex + size, NULL_DOUBLE);
+        {
+            final int negInfToIndex = fromIndex + nullCount + negInfCount;
+            Arrays.fill(data, negInfToIndex - size, negInfToIndex, Double.NEGATIVE_INFINITY);
+        }
+    }
+
+    private static final Comparator<Comparable<Object>> COMPARATOR = Comparator.nullsFirst(Comparator.naturalOrder());
+
+    public static <T> void sort(T[] data, int fromIndex, int toIndex) {
+        sortUnsafe(data, fromIndex, toIndex);
+    }
+
+    public static <T> void sortUnsafe(T[] data, int fromIndex, int toIndex) {
+        // noinspection unchecked
+        Arrays.sort(data, fromIndex, toIndex, (Comparator<? super T>) COMPARATOR);
+    }
+
+    private static int binarySearchFirst(char[] a, int fromIndex, int toIndex, char key) {
+        int low = fromIndex;
+        int high = toIndex - 1;
+        while (low <= high) {
+            final int mid = (low + high) >>> 1;
+            final char midVal = a[mid];
+            if (midVal < key) {
+                low = mid + 1;
+            } else if (midVal > key) {
+                high = mid - 1;
+            } else if (low != mid) {
+                // This is where we differ from Arrays.binarySearch;
+                // we continue searching downwards to find the first instance.
+                high = mid;
+            } else {
+                return mid;
+            }
+        }
+        return -(low + 1);
+    }
+
+    private static int binarySearchFirst(float[] a, int fromIndex, int toIndex, float key, int keyBits) {
+        int low = fromIndex;
+        int high = toIndex - 1;
+        while (low <= high) {
+            final int mid = (low + high) >>> 1;
+            final float midVal = a[mid];
+            if (midVal < key) {
+                low = mid + 1;
+            } else if (midVal > key) {
+                high = mid - 1;
+            } else {
+                final int midBits = Float.floatToIntBits(midVal);
+                if (midBits < keyBits) {
+                    // (-0.0, 0.0) or (!NaN, NaN)
+                    low = mid + 1;
+                } else if (midBits > keyBits) {
+                    // (0.0, -0.0) or (NaN, !NaN)
+                    high = mid - 1;
+                } else if (low != mid) {
+                    // This is where we differ from Arrays.binarySearch;
+                    // we continue searching downwards to find the first instance.
+                    high = mid;
+                } else {
+                    return mid;
+                }
+            }
+        }
+        return -(low + 1);
+    }
+
+    private static int binarySearchFirst(double[] a, int fromIndex, int toIndex, double key, long keyBits) {
+        int low = fromIndex;
+        int high = toIndex - 1;
+        while (low <= high) {
+            final int mid = (low + high) >>> 1;
+            final double midVal = a[mid];
+            if (midVal < key) {
+                low = mid + 1;
+            } else if (midVal > key) {
+                high = mid - 1;
+            } else {
+                final long midBits = Double.doubleToLongBits(midVal);
+                if (midBits < keyBits) {
+                    // (-0.0, 0.0) or (!NaN, NaN)
+                    low = mid + 1;
+                } else if (midBits > keyBits) {
+                    // (0.0, -0.0) or (NaN, !NaN)
+                    high = mid - 1;
+                } else if (low != mid) {
+                    // This is where we differ from Arrays.binarySearch;
+                    // we continue searching downwards to find the first instance.
+                    high = mid;
+                } else {
+                    return mid;
+                }
+            }
+        }
+        return -(low + 1);
+    }
+}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableDoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableDoubleChunk.java
@@ -209,15 +209,20 @@ public class WritableDoubleChunk<ATTR extends Any> extends DoubleChunk<ATTR> imp
         sort(0, size);
     }
 
-    // region sort
     @Override
     public final void sort(int start, int length) {
-        Arrays.sort(data, offset + start, offset + start + length);
-
-        // region SortFixup
-        // endregion SortFixup
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableFloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableFloatChunk.java
@@ -209,15 +209,20 @@ public class WritableFloatChunk<ATTR extends Any> extends FloatChunk<ATTR> imple
         sort(0, size);
     }
 
-    // region sort
     @Override
     public final void sort(int start, int length) {
-        Arrays.sort(data, offset + start, offset + start + length);
-
-        // region SortFixup
-        // endregion SortFixup
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableIntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableIntChunk.java
@@ -209,15 +209,20 @@ public class WritableIntChunk<ATTR extends Any> extends IntChunk<ATTR> implement
         sort(0, size);
     }
 
-    // region sort
     @Override
     public final void sort(int start, int length) {
-        Arrays.sort(data, offset + start, offset + start + length);
-
-        // region SortFixup
-        // endregion SortFixup
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableLongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableLongChunk.java
@@ -209,15 +209,20 @@ public class WritableLongChunk<ATTR extends Any> extends LongChunk<ATTR> impleme
         sort(0, size);
     }
 
-    // region sort
     @Override
     public final void sort(int start, int length) {
-        Arrays.sort(data, offset + start, offset + start + length);
-
-        // region SortFixup
-        // endregion SortFixup
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableObjectChunk.java
@@ -7,14 +7,8 @@
 // @formatter:off
 package io.deephaven.chunk;
 
-import io.deephaven.util.compare.ObjectComparisons;
-import java.util.Comparator;
-
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.util.pools.MultiChunkPool;
-
-import io.deephaven.util.type.TypeUtils;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 // region FillWithNullValueImports
@@ -180,15 +174,20 @@ public class WritableObjectChunk<T, ATTR extends Any> extends ObjectChunk<T, ATT
         sort(0, size);
     }
 
-    // region sort
-    private static final Comparator<Comparable<Object>> COMPARATOR = Comparator.nullsFirst(Comparator.naturalOrder());
-
     @Override
     public final void sort(int start, int length) {
-        //noinspection unchecked
-        Arrays.sort(data, offset + start, offset + start + length, (Comparator<? super T>) COMPARATOR);
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/main/java/io/deephaven/chunk/WritableShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/WritableShortChunk.java
@@ -209,15 +209,20 @@ public class WritableShortChunk<ATTR extends Any> extends ShortChunk<ATTR> imple
         sort(0, size);
     }
 
-    // region sort
     @Override
     public final void sort(int start, int length) {
-        Arrays.sort(data, offset + start, offset + start + length);
-
-        // region SortFixup
-        // endregion SortFixup
+        WritableChunkImpl.sort(data, offset + start, offset + start + length);
     }
-    // endregion sort
+
+    @Override
+    public final void sortUnsafe() {
+        sortUnsafe(0, size);
+    }
+
+    @Override
+    public final void sortUnsafe(int start, int length) {
+        WritableChunkImpl.sortUnsafe(data, offset + start, offset + start + length);
+    }
 
     @Override
     public void close() {}

--- a/engine/chunk/src/test/java/io/deephaven/chunk/WritableCharChunkSortTest.java
+++ b/engine/chunk/src/test/java/io/deephaven/chunk/WritableCharChunkSortTest.java
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.chunk;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.util.compare.CharComparisons;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+
+public class WritableCharChunkSortTest {
+
+    private static final char[] SPECIAL_VALUES = new char[] {
+            QueryConstants.NULL_CHAR,
+            Character.MIN_VALUE,
+            Character.MIN_VALUE + 1,
+            Character.MAX_VALUE - 1
+    };
+
+    @Test
+    public void presorted() {
+        final char[] x = SPECIAL_VALUES.clone();
+        Assert.eqTrue(isSorted(x, 0, x.length), "isSorted(x, 0, x.length)");
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void sortFixesNull() {
+        final char[] x = new char[] {
+                Character.MIN_VALUE,
+                Character.MIN_VALUE + 1,
+                Character.MAX_VALUE - 1,
+                QueryConstants.NULL_CHAR,
+        };
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void biasedBruteSort() {
+        final int maxArraySize = 3;
+        // Any changes to sort logic should be manually verified with a larger number of iterations
+        final int numIters = 1000000;
+        final long seed = System.currentTimeMillis();
+        System.out.println("Seed: " + seed);
+        final Random r = new Random(seed);
+        for (int arraySize = 3; arraySize <= maxArraySize; arraySize *= 2) {
+            final char[] x = new char[arraySize];
+            for (int i = 0; i < numIters; ++i) {
+                final int a1 = r.nextInt(arraySize);
+                final int a2 = r.nextInt(arraySize);
+                final int fromInclusive = Math.min(a1, a2);
+                final int toExclusive = Math.max(a1, a2);
+                biasedFill(r, x, fromInclusive, toExclusive);
+                sort(x, fromInclusive, toExclusive);
+                {
+                    // A bit of extra testing
+                    biasedFill(r, x, 0, fromInclusive);
+                    sort(x, 0, fromInclusive);
+
+                    biasedFill(r, x, toExclusive, arraySize);
+                    sort(x, toExclusive, arraySize);
+
+                    sort(x, 0, arraySize);
+                }
+            }
+        }
+    }
+
+    private static void sort(char[] x, int fromInclusive, int toExclusive) {
+        // noinspection resource
+        final WritableCharChunk<Any> chunk = WritableCharChunk.writableChunkWrap(x);
+        chunk.sort(fromInclusive, toExclusive - fromInclusive);
+        Assert.eqTrue(isSorted(x, fromInclusive, toExclusive), "isSorted(x, fromInclusive, toExclusive)");
+    }
+
+    // The crux of this test is centered around the correctness of this method.
+    private static boolean isSorted(char[] x, int fromInclusive, int toExclusive) {
+        for (int i = fromInclusive + 1; i < toExclusive; ++i) {
+            final char a = x[i - 1];
+            final char b = x[i];
+            if (CharComparisons.gt(a, b)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void biasedFill(Random r, char[] x, int fromInclusive, int toExclusive) {
+        for (int i = fromInclusive; i < toExclusive; i++) {
+            x[i] = biased(r);
+        }
+    }
+
+    private static char biased(Random r) {
+        final int x = r.nextInt(128);
+        if (x < 32) {
+            return special(r);
+        }
+        return (char) r.nextInt();
+    }
+
+    private static char special(Random r) {
+        return SPECIAL_VALUES[r.nextInt(SPECIAL_VALUES.length)];
+    }
+}

--- a/engine/chunk/src/test/java/io/deephaven/chunk/WritableDoubleChunkSortTest.java
+++ b/engine/chunk/src/test/java/io/deephaven/chunk/WritableDoubleChunkSortTest.java
@@ -1,0 +1,176 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.chunk;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.util.compare.DoubleComparisons;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+
+public class WritableDoubleChunkSortTest {
+
+    private static final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0);
+    private static final long ZERO_BITS = Double.doubleToLongBits(0.0);
+
+    private static final double[] SPECIAL_VALUES = new double[] {
+            QueryConstants.NULL_DOUBLE,
+            Double.NEGATIVE_INFINITY,
+            Math.nextUp(QueryConstants.NULL_DOUBLE),
+            -Double.MIN_NORMAL,
+            -0.0,
+            0.0,
+            Double.MIN_NORMAL,
+            Math.nextDown(Double.MAX_VALUE),
+            Double.MAX_VALUE,
+            Double.POSITIVE_INFINITY,
+            Double.NaN,
+    };
+
+    @Test
+    public void presorted() {
+        final double[] x = SPECIAL_VALUES.clone();
+        Assert.eqTrue(isSorted(x, 0, x.length), "isSorted(x, 0, x.length)");
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void sortFixesZero() {
+        final double[] x = new double[] {
+                QueryConstants.NULL_DOUBLE,
+                Double.NEGATIVE_INFINITY,
+                Math.nextUp(QueryConstants.NULL_DOUBLE),
+                -Double.MIN_NORMAL,
+                0.0,
+                -0.0,
+                Double.MIN_NORMAL,
+                Math.nextDown(Double.MAX_VALUE),
+                Double.MAX_VALUE,
+                Double.POSITIVE_INFINITY,
+                Double.NaN,
+        };
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void sortFixesNull() {
+        final double[] x = new double[] {
+                Double.NEGATIVE_INFINITY,
+                QueryConstants.NULL_DOUBLE,
+                Math.nextUp(QueryConstants.NULL_DOUBLE),
+                -Double.MIN_NORMAL,
+                0.0,
+                -0.0,
+                Double.MIN_NORMAL,
+                Math.nextDown(Double.MAX_VALUE),
+                Double.MAX_VALUE,
+                Double.POSITIVE_INFINITY,
+                Double.NaN,
+        };
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void sortFixesNaN() {
+        final double[] x = new double[] {
+                Double.NaN,
+                QueryConstants.NULL_DOUBLE,
+                Double.NEGATIVE_INFINITY,
+                Math.nextUp(QueryConstants.NULL_DOUBLE),
+                -Double.MIN_NORMAL,
+                -0.0,
+                0.0,
+                Double.MIN_NORMAL,
+                Math.nextDown(Double.MAX_VALUE),
+                Double.MAX_VALUE,
+                Double.POSITIVE_INFINITY,
+        };
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void zeros() {
+        // This is really a test of our test, giving a bit more confidence that isSorted is correct
+        Assert.eqFalse(isSorted(new double[] {0.0, -0.0}, 0, 2), "isSorted(new double[] { 0.0, -0.0 }, 0, 2)");
+    }
+
+    @Test
+    public void biasedBruteSort() {
+        final int maxArraySize = 32768;
+        // Any changes to sort logic should be manually verified with a larger number of iterations
+        final int numIters = 100;
+        final long seed = System.currentTimeMillis();
+        System.out.println("Seed: " + seed);
+        final Random r = new Random(seed);
+        for (int arraySize = 2; arraySize <= maxArraySize; arraySize *= 2) {
+            final double[] x = new double[arraySize];
+            for (int i = 0; i < numIters; ++i) {
+                final int a1 = r.nextInt(arraySize);
+                final int a2 = r.nextInt(arraySize);
+                final int fromInclusive = Math.min(a1, a2);
+                final int toExclusive = Math.max(a1, a2);
+                biasedFill(r, x, fromInclusive, toExclusive);
+                sort(x, fromInclusive, toExclusive);
+                {
+                    // A bit of extra testing
+                    biasedFill(r, x, 0, fromInclusive);
+                    sort(x, 0, fromInclusive);
+
+                    biasedFill(r, x, toExclusive, arraySize);
+                    sort(x, toExclusive, arraySize);
+
+                    sort(x, 0, arraySize);
+                }
+            }
+        }
+    }
+
+    private static void sort(double[] x, int fromInclusive, int toExclusive) {
+        // noinspection resource
+        final WritableDoubleChunk<Any> chunk = WritableDoubleChunk.writableChunkWrap(x);
+        chunk.sort(fromInclusive, toExclusive - fromInclusive);
+        Assert.eqTrue(isSorted(x, fromInclusive, toExclusive), "isSorted(x, fromInclusive, toExclusive)");
+    }
+
+    // The crux of this test is centered around the correctness of this method.
+    private static boolean isSorted(double[] x, int fromInclusive, int toExclusive) {
+        for (int i = fromInclusive + 1; i < toExclusive; ++i) {
+            final double a = x[i - 1];
+            final double b = x[i];
+            if (DoubleComparisons.gt(a, b)
+                    || (Double.doubleToLongBits(a) == ZERO_BITS && Double.doubleToLongBits(b) == NEG_ZERO_BITS)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void biasedFill(Random r, double[] x, int fromInclusive, int toExclusive) {
+        for (int i = fromInclusive; i < toExclusive; i++) {
+            x[i] = biased(r);
+        }
+    }
+
+    private static double biased(Random r) {
+        final int x = r.nextInt(128);
+        if (x < 32) {
+            return special(r);
+        }
+        if (x < 64) {
+            return Double.doubleToLongBits(r.nextInt());
+        }
+        return r.nextDouble();
+    }
+
+    private static double special(Random r) {
+        return SPECIAL_VALUES[r.nextInt(SPECIAL_VALUES.length)];
+    }
+}

--- a/engine/chunk/src/test/java/io/deephaven/chunk/WritableFloatChunkSortTest.java
+++ b/engine/chunk/src/test/java/io/deephaven/chunk/WritableFloatChunkSortTest.java
@@ -1,0 +1,176 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.chunk;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.chunk.attributes.Any;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.util.compare.FloatComparisons;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+
+public class WritableFloatChunkSortTest {
+
+    private static final long NEG_ZERO_BITS = Float.floatToIntBits(-0.0f);
+    private static final long ZERO_BITS = Float.floatToIntBits(0.0f);
+
+    private static final float[] SPECIAL_VALUES = new float[] {
+            QueryConstants.NULL_FLOAT,
+            Float.NEGATIVE_INFINITY,
+            Math.nextUp(QueryConstants.NULL_FLOAT),
+            -Float.MIN_NORMAL,
+            -0.0f,
+            0.0f,
+            Float.MIN_NORMAL,
+            Math.nextDown(Float.MAX_VALUE),
+            Float.MAX_VALUE,
+            Float.POSITIVE_INFINITY,
+            Float.NaN,
+    };
+
+    @Test
+    public void presorted() {
+        final float[] x = SPECIAL_VALUES.clone();
+        Assert.eqTrue(isSorted(x, 0, x.length), "isSorted(x, 0, x.length)");
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void sortFixesZero() {
+        final float[] x = new float[] {
+                QueryConstants.NULL_FLOAT,
+                Float.NEGATIVE_INFINITY,
+                Math.nextUp(QueryConstants.NULL_FLOAT),
+                -Float.MIN_NORMAL,
+                0.0f,
+                -0.0f,
+                Float.MIN_NORMAL,
+                Math.nextDown(Float.MAX_VALUE),
+                Float.MAX_VALUE,
+                Float.POSITIVE_INFINITY,
+                Float.NaN,
+        };
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void sortFixesNull() {
+        final float[] x = new float[] {
+                Float.NEGATIVE_INFINITY,
+                QueryConstants.NULL_FLOAT,
+                Math.nextUp(QueryConstants.NULL_FLOAT),
+                -Float.MIN_NORMAL,
+                0.0f,
+                -0.0f,
+                Float.MIN_NORMAL,
+                Math.nextDown(Float.MAX_VALUE),
+                Float.MAX_VALUE,
+                Float.POSITIVE_INFINITY,
+                Float.NaN,
+        };
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void sortFixesNaN() {
+        final float[] x = new float[] {
+                Float.NaN,
+                QueryConstants.NULL_FLOAT,
+                Float.NEGATIVE_INFINITY,
+                Math.nextUp(QueryConstants.NULL_FLOAT),
+                -Float.MIN_NORMAL,
+                -0.0f,
+                0.0f,
+                Float.MIN_NORMAL,
+                Math.nextDown(Float.MAX_VALUE),
+                Float.MAX_VALUE,
+                Float.POSITIVE_INFINITY,
+        };
+        sort(x, 0, x.length);
+        Assert.eqTrue(Arrays.equals(x, SPECIAL_VALUES), "Arrays.equals");
+    }
+
+    @Test
+    public void zeros() {
+        // This is really a test of our test, giving a bit more confidence that isSorted is correct
+        Assert.eqFalse(isSorted(new float[] {0.0f, -0.0f}, 0, 2), "isSorted(new float[] { 0.0f, -0.0f }, 0, 2)");
+    }
+
+    @Test
+    public void biasedBruteSort() {
+        final int maxArraySize = 32768;
+        // Any changes to sort logic should be manually verified with a larger number of iterations
+        final int numIters = 100;
+        final long seed = System.currentTimeMillis();
+        System.out.println("Seed: " + seed);
+        final Random r = new Random(seed);
+        for (int arraySize = 2; arraySize <= maxArraySize; arraySize *= 2) {
+            final float[] x = new float[arraySize];
+            for (int i = 0; i < numIters; ++i) {
+                final int a1 = r.nextInt(arraySize);
+                final int a2 = r.nextInt(arraySize);
+                final int fromInclusive = Math.min(a1, a2);
+                final int toExclusive = Math.max(a1, a2);
+                biasedFill(r, x, fromInclusive, toExclusive);
+                sort(x, fromInclusive, toExclusive);
+                {
+                    // A bit of extra testing
+                    biasedFill(r, x, 0, fromInclusive);
+                    sort(x, 0, fromInclusive);
+
+                    biasedFill(r, x, toExclusive, arraySize);
+                    sort(x, toExclusive, arraySize);
+
+                    sort(x, 0, arraySize);
+                }
+            }
+        }
+    }
+
+    private static void sort(float[] x, int fromInclusive, int toExclusive) {
+        // noinspection resource
+        final WritableFloatChunk<Any> chunk = WritableFloatChunk.writableChunkWrap(x);
+        chunk.sort(fromInclusive, toExclusive - fromInclusive);
+        Assert.eqTrue(isSorted(x, fromInclusive, toExclusive), "isSorted(x, fromInclusive, toExclusive)");
+    }
+
+    // The crux of this test is centered around the correctness of this method.
+    private static boolean isSorted(float[] x, int fromInclusive, int toExclusive) {
+        for (int i = fromInclusive + 1; i < toExclusive; ++i) {
+            final float a = x[i - 1];
+            final float b = x[i];
+            if (FloatComparisons.gt(a, b)
+                    || (Float.floatToIntBits(a) == ZERO_BITS && Float.floatToIntBits(b) == NEG_ZERO_BITS)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void biasedFill(Random r, float[] x, int fromInclusive, int toExclusive) {
+        for (int i = fromInclusive; i < toExclusive; i++) {
+            x[i] = biased(r);
+        }
+    }
+
+    private static float biased(Random r) {
+        final int x = r.nextInt(128);
+        if (x < 32) {
+            return special(r);
+        }
+        if (x < 64) {
+            return Float.floatToIntBits(r.nextInt());
+        }
+        return r.nextFloat();
+    }
+
+    private static float special(Random r) {
+        return SPECIAL_VALUES[r.nextInt(SPECIAL_VALUES.length)];
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/BooleanChunkedAddOnlyMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/BooleanChunkedAddOnlyMinMaxOperator.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Iterative average operator.
+ * Iterative add only min max operator.
  */
 class BooleanChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregationOperator {
     private final BooleanArraySource resultColumn = new BooleanArraySource();
@@ -31,7 +31,7 @@ class BooleanChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregation
         this.name = name;
     }
 
-    private Boolean min(ObjectChunk<Boolean, ?> values, MutableInt chunkNonNull, int chunkStart, int chunkEnd) {
+    private static Boolean min(ObjectChunk<Boolean, ?> values, MutableInt chunkNonNull, int chunkStart, int chunkEnd) {
         int nonNull = 0;
         Boolean value = QueryConstants.NULL_BOOLEAN;
         for (int ii = chunkStart; ii < chunkEnd; ++ii) {
@@ -48,7 +48,7 @@ class BooleanChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregation
         return value;
     }
 
-    private Boolean max(ObjectChunk<Boolean, ?> values, MutableInt chunkNonNull, int chunkStart, int chunkEnd) {
+    private static Boolean max(ObjectChunk<Boolean, ?> values, MutableInt chunkNonNull, int chunkStart, int chunkEnd) {
         int nonNull = 0;
         Boolean value = QueryConstants.NULL_BOOLEAN;
         for (int ii = chunkStart; ii < chunkEnd; ++ii) {
@@ -65,12 +65,12 @@ class BooleanChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregation
         return value;
     }
 
-    private Boolean min(Boolean a, Boolean b) {
-        return ObjectComparisons.lt(a, b) ? a : b;
+    private static Boolean min(Boolean a, Boolean b) {
+        return ObjectComparisons.leq(a, b) ? a : b;
     }
 
-    private Boolean max(Boolean a, Boolean b) {
-        return ObjectComparisons.gt(a, b) ? a : b;
+    private static Boolean max(Boolean a, Boolean b) {
+        return ObjectComparisons.geq(a, b) ? a : b;
     }
 
     @Override
@@ -126,7 +126,7 @@ class BooleanChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregation
             // that it is in fact empty and we should use the value from the chunk
             result = chunkValue;
         } else {
-            result = minimum ? min(chunkValue, oldValue) : max(chunkValue, oldValue);
+            result = minimum ? min(oldValue, chunkValue) : max(oldValue, chunkValue);
         }
         if (oldValue == null || !Objects.equals(result, oldValue)) {
             resultColumn.set(destination, result);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FloatChunkedAddOnlyMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FloatChunkedAddOnlyMinMaxOperator.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * Iterative average operator.
+ * Iterative add only min max operator.
  */
 class FloatChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregationOperator {
     private final FloatArraySource resultColumn;
@@ -42,46 +42,48 @@ class FloatChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregationOp
         // endregion resultColumn initialization
     }
 
-    private float min(FloatChunk<?> values, MutableInt chunkNonNull, int chunkStart, int chunkEnd) {
-        int nonNull = 0;
+    private static float min(FloatChunk<?> values, MutableInt chunkNonNullNan, int chunkStart, int chunkEnd) {
+        int nonNullNan = 0;
         float value = QueryConstants.NULL_FLOAT;
         for (int ii = chunkStart; ii < chunkEnd; ++ii) {
             final float candidate = values.get(ii);
-            if (candidate != QueryConstants.NULL_FLOAT) {
-                if (nonNull++ == 0) {
-                    value = candidate;
-                } else if (FloatComparisons.lt(candidate, value)) {
-                    value = candidate;
-                }
+            if (MinMaxHelper.isNullOrNan(candidate)) {
+                continue;
+            }
+            if (nonNullNan++ == 0) {
+                value = candidate;
+            } else if (FloatComparisons.lt(candidate, value)) {
+                value = candidate;
             }
         }
-        chunkNonNull.set(nonNull);
+        chunkNonNullNan.set(nonNullNan);
         return value;
     }
 
-    private float max(FloatChunk<?> values, MutableInt chunkNonNull, int chunkStart, int chunkEnd) {
-        int nonNull = 0;
+    private static float max(FloatChunk<?> values, MutableInt chunkNonNullNan, int chunkStart, int chunkEnd) {
+        int nonNullNan = 0;
         float value = QueryConstants.NULL_FLOAT;
         for (int ii = chunkStart; ii < chunkEnd; ++ii) {
             final float candidate = values.get(ii);
-            if (candidate != QueryConstants.NULL_FLOAT) {
-                if (nonNull++ == 0) {
-                    value = candidate;
-                } else if (FloatComparisons.gt(candidate, value)) {
-                    value = candidate;
-                }
+            if (MinMaxHelper.isNullOrNan(candidate)) {
+                continue;
+            }
+            if (nonNullNan++ == 0) {
+                value = candidate;
+            } else if (FloatComparisons.gt(candidate, value)) {
+                value = candidate;
             }
         }
-        chunkNonNull.set(nonNull);
+        chunkNonNullNan.set(nonNullNan);
         return value;
     }
 
-    private float min(float a, float b) {
-        return FloatComparisons.lt(a, b) ? a : b;
+    private static float min(float a, float b) {
+        return FloatComparisons.leq(a, b) ? a : b;
     }
 
-    private float max(float a, float b) {
-        return FloatComparisons.gt(a, b) ? a : b;
+    private static float max(float a, float b) {
+        return FloatComparisons.geq(a, b) ? a : b;
     }
 
     @Override
@@ -135,22 +137,22 @@ class FloatChunkedAddOnlyMinMaxOperator implements IterativeChunkedAggregationOp
         if (chunkSize == 0) {
             return false;
         }
-        final MutableInt chunkNonNull = new MutableInt(0);
+        final MutableInt chunkNonNullNan = new MutableInt(0);
         final int chunkEnd = chunkStart + chunkSize;
-        final float chunkValue = minimum ? min(values, chunkNonNull, chunkStart, chunkEnd)
-                : max(values, chunkNonNull, chunkStart, chunkEnd);
-        if (chunkNonNull.get() == 0) {
+        final float chunkValue = minimum ? min(values, chunkNonNullNan, chunkStart, chunkEnd)
+                : max(values, chunkNonNullNan, chunkStart, chunkEnd);
+        if (chunkNonNullNan.get() == 0) {
             return false;
         }
 
         final float result;
         final float oldValue = resultColumn.getUnsafe(destination);
-        if (oldValue == QueryConstants.NULL_FLOAT) {
-            // we exclude nulls from the min/max calculation, therefore if the value in our min/max is null we know
-            // that it is in fact empty and we should use the value from the chunk
+        if (MinMaxHelper.isNullOrNan(oldValue)) {
+            // we exclude nulls (and NaNs) from the min/max calculation, therefore if the value in our min/max is null
+            // or NaN we know that it is in fact empty and we should use the value from the chunk
             result = chunkValue;
         } else {
-            result = minimum ? min(chunkValue, oldValue) : max(chunkValue, oldValue);
+            result = minimum ? min(oldValue, chunkValue) : max(oldValue, chunkValue);
         }
         if (!FloatComparisons.eq(result, oldValue)) {
             resultColumn.set(destination, result);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/MinMaxHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/MinMaxHelper.java
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.by;
+
+import io.deephaven.util.QueryConstants;
+
+final class MinMaxHelper {
+
+    public static boolean isNullOrNan(byte x) {
+        return x == QueryConstants.NULL_BYTE;
+    }
+
+    public static boolean isNullOrNan(char x) {
+        return x == QueryConstants.NULL_CHAR;
+    }
+
+    public static boolean isNullOrNan(short x) {
+        return x == QueryConstants.NULL_SHORT;
+    }
+
+    public static boolean isNullOrNan(int x) {
+        return x == QueryConstants.NULL_INT;
+    }
+
+    public static boolean isNullOrNan(long x) {
+        return x == QueryConstants.NULL_LONG;
+    }
+
+    public static boolean isNullOrNan(float x) {
+        return x == QueryConstants.NULL_FLOAT || Float.isNaN(x);
+    }
+
+    public static boolean isNullOrNan(double x) {
+        return x == QueryConstants.NULL_DOUBLE || Double.isNaN(x);
+    }
+
+    public static boolean isNullOrNan(Object o) {
+        return o == null;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/BooleanCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/BooleanCompactKernel.java
@@ -43,14 +43,14 @@ public class BooleanCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableBooleanChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableBooleanChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableBooleanChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableBooleanChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableBooleanChunk<? extends Values> valueChunk,
@@ -67,15 +67,16 @@ public class BooleanCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableBooleanChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableBooleanChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
         int trueValues = 0;        int falseValues = 0;        final int end = start + length;        for (int rpos = start; rpos < end; ++rpos) {            final boolean nextValue = valueChunk.get(rpos);            if (nextValue) {                trueValues++;            }            else {                falseValues++;            }        }
@@ -89,11 +90,5 @@ public class BooleanCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(boolean value) {
-        // region shouldIgnore
-        return false;
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/ByteCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/ByteCompactKernel.java
@@ -45,14 +45,14 @@ public class ByteCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableByteChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableByteChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableByteChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableByteChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableByteChunk<? extends Values> valueChunk,
@@ -69,24 +69,29 @@ public class ByteCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableByteChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableByteChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         byte lastValue = NULL_BYTE;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final byte nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !ByteComparisons.eq(nextValue, lastValue)) {
@@ -99,11 +104,5 @@ public class ByteCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(byte value) {
-        // region shouldIgnore
-        return value == NULL_BYTE;
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/CharCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/CharCompactKernel.java
@@ -41,14 +41,14 @@ public class CharCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableCharChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableCharChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableCharChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableCharChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableCharChunk<? extends Values> valueChunk,
@@ -65,24 +65,29 @@ public class CharCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableCharChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableCharChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         char lastValue = NULL_CHAR;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final char nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !CharComparisons.eq(nextValue, lastValue)) {
@@ -95,11 +100,5 @@ public class CharCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(char value) {
-        // region shouldIgnore
-        return value == NULL_CHAR;
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/CompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/CompactKernel.java
@@ -20,8 +20,9 @@ public interface CompactKernel {
     void compact(WritableChunk<? extends Any> values, BooleanChunk<Any> retainValues);
 
     /**
-     * Sort valuesChunk, eliminate duplicates, and write the number of times a value occurred into the parallel slot
-     * within counts. null values are removed from the chunk.
+     * Sort valuesChunk in Deephaven-order (with a floating-point exception for {@code -0.0 < 0.0}), eliminate
+     * duplicates, and write the number of times a value occurred into the parallel slot within counts. null and NaN
+     * values are removed from the chunk.
      *
      * @param valueChunk a chunk of values, input and output
      * @param counts an output chunk parallel to valueChunk with the number of times a value occurred
@@ -32,19 +33,20 @@ public interface CompactKernel {
     }
 
     /**
-     * Sort valuesChunk, eliminate duplicates, and write the number of times a value occurred into the parallel slot
-     * within counts.
+     * Sort valuesChunk in Deephaven-order (with a floating-point exception for {@code -0.0 < 0.0}), eliminate
+     * duplicates, and write the number of times a value occurred into the parallel slot within counts.
      *
      * @param valueChunk a chunk of values, input and output
      * @param counts an output chunk parallel to valueChunk with the number of times a value occurred
-     * @param countNull if the compaction should count nulls or not
+     * @param countNullAndNan if the compaction should count nulls and NaNs or not
      */
     void compactAndCount(WritableChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, boolean countNull);
+            WritableIntChunk<ChunkLengths> counts, boolean countNullAndNan);
 
     /**
-     * For each run in valuesChunk, sort it, eliminate duplicates, and write the number of times a value occurred into
-     * the parallel slot within counts. null values are removed from the chunk.
+     * For each run in valuesChunk, sort it in Deephaven-order (with a floating-point exception for {@code -0.0 < 0.0}),
+     * eliminate duplicates, and write the number of times a value occurred into the parallel slot within counts. null
+     * and NaN values are removed from the chunk.
      *
      * @param valueChunk a chunk of values, input and output
      * @param counts an output chunk parallel to valueChunk with the number of times a value occurred
@@ -58,18 +60,18 @@ public interface CompactKernel {
     }
 
     /**
-     * For each run in valuesChunk, sort it, eliminate duplicates, and write the number of times a value occurred into
-     * the parallel slot within counts.
+     * For each run in valuesChunk, sort it in Deephaven-order (with a floating-point exception for {@code -0.0 < 0.0}),
+     * eliminate duplicates, and write the number of times a value occurred into the parallel slot within counts.
      *
      * @param valueChunk a chunk of values, input and output
      * @param counts an output chunk parallel to valueChunk with the number of times a value occurred
      * @param startPositions the start of each run
      * @param lengths the length of each run, input and output
-     * @param countNull if the compaction should count nulls or not
+     * @param countNullAndNan if the compaction should count nulls and NaNs or not
      */
     void compactAndCount(WritableChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull);
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan);
 
     static CompactKernel makeCompact(ChunkType chunkType) {
         switch (chunkType) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/CompactKernelImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/CompactKernelImpl.java
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.util.compact;
+
+import io.deephaven.util.QueryConstants;
+
+final class CompactKernelImpl {
+    public static boolean isNullOrNan(byte x) {
+        return x == QueryConstants.NULL_BYTE;
+    }
+
+    public static boolean isNullOrNan(char x) {
+        return x == QueryConstants.NULL_CHAR;
+    }
+
+    public static boolean isNullOrNan(short x) {
+        return x == QueryConstants.NULL_SHORT;
+    }
+
+    public static boolean isNullOrNan(int x) {
+        return x == QueryConstants.NULL_INT;
+    }
+
+    public static boolean isNullOrNan(long x) {
+        return x == QueryConstants.NULL_LONG;
+    }
+
+    public static boolean isNullOrNan(float x) {
+        return x == QueryConstants.NULL_FLOAT || Float.isNaN(x);
+    }
+
+    public static boolean isNullOrNan(double x) {
+        return x == QueryConstants.NULL_DOUBLE || Double.isNaN(x);
+    }
+
+    public static boolean isNullOrNan(Object o) {
+        return o == null;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/DoubleCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/DoubleCompactKernel.java
@@ -45,14 +45,14 @@ public class DoubleCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableDoubleChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableDoubleChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableDoubleChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableDoubleChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableDoubleChunk<? extends Values> valueChunk,
@@ -69,24 +69,29 @@ public class DoubleCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableDoubleChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableDoubleChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         double lastValue = NULL_DOUBLE;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final double nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !DoubleComparisons.eq(nextValue, lastValue)) {
@@ -99,11 +104,5 @@ public class DoubleCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(double value) {
-        // region shouldIgnore
-        return value == NULL_DOUBLE || Double.isNaN(value);
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/FloatCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/FloatCompactKernel.java
@@ -45,14 +45,14 @@ public class FloatCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableFloatChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableFloatChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableFloatChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableFloatChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableFloatChunk<? extends Values> valueChunk,
@@ -69,24 +69,29 @@ public class FloatCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableFloatChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableFloatChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         float lastValue = NULL_FLOAT;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final float nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !FloatComparisons.eq(nextValue, lastValue)) {
@@ -99,11 +104,5 @@ public class FloatCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(float value) {
-        // region shouldIgnore
-        return value == NULL_FLOAT || Float.isNaN(value);
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/IntCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/IntCompactKernel.java
@@ -45,14 +45,14 @@ public class IntCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableIntChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableIntChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableIntChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableIntChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableIntChunk<? extends Values> valueChunk,
@@ -69,24 +69,29 @@ public class IntCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableIntChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableIntChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         int lastValue = NULL_INT;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final int nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !IntComparisons.eq(nextValue, lastValue)) {
@@ -99,11 +104,5 @@ public class IntCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(int value) {
-        // region shouldIgnore
-        return value == NULL_INT;
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/LongCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/LongCompactKernel.java
@@ -45,14 +45,14 @@ public class LongCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableLongChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableLongChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableLongChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableLongChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableLongChunk<? extends Values> valueChunk,
@@ -69,24 +69,29 @@ public class LongCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableLongChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableLongChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         long lastValue = NULL_LONG;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final long nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !LongComparisons.eq(nextValue, lastValue)) {
@@ -99,11 +104,5 @@ public class LongCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(long value) {
-        // region shouldIgnore
-        return value == NULL_LONG;
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/ObjectCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/ObjectCompactKernel.java
@@ -44,14 +44,14 @@ public class ObjectCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableObjectChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableObjectChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableObjectChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableObjectChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static <T> void compactAndCount(WritableObjectChunk<T, ? extends Values> valueChunk,
@@ -68,24 +68,29 @@ public class ObjectCompactKernel implements CompactKernel {
 
     public static <T> void compactAndCount(WritableObjectChunk<T, ? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static <T> int compactAndCount(WritableObjectChunk<T, ? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         Object lastValue = null;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final T nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !ObjectComparisons.eq(nextValue, lastValue)) {
@@ -98,11 +103,5 @@ public class ObjectCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(Object value) {
-        // region shouldIgnore
-        return value == null;
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/ShortCompactKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/compact/ShortCompactKernel.java
@@ -45,14 +45,14 @@ public class ShortCompactKernel implements CompactKernel {
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            boolean countNull) {
-        compactAndCount(valueChunk.asWritableShortChunk(), counts, countNull);
+            boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableShortChunk(), counts, countNullAndNan);
     }
 
     @Override
     public void compactAndCount(WritableChunk<? extends Values> valueChunk, WritableIntChunk<ChunkLengths> counts,
-            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
-        compactAndCount(valueChunk.asWritableShortChunk(), counts, startPositions, lengths, countNull);
+            IntChunk<ChunkPositions> startPositions, WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
+        compactAndCount(valueChunk.asWritableShortChunk(), counts, startPositions, lengths, countNullAndNan);
     }
 
     public static void compactAndCount(WritableShortChunk<? extends Values> valueChunk,
@@ -69,24 +69,29 @@ public class ShortCompactKernel implements CompactKernel {
 
     public static void compactAndCount(WritableShortChunk<? extends Values> valueChunk,
             WritableIntChunk<ChunkLengths> counts, IntChunk<ChunkPositions> startPositions,
-            WritableIntChunk<ChunkLengths> lengths, boolean countNull) {
+            WritableIntChunk<ChunkLengths> lengths, boolean countNullAndNan) {
         for (int ii = 0; ii < startPositions.size(); ++ii) {
-            final int newSize = compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNull);
+            final int newSize =
+                    compactAndCount(valueChunk, counts, startPositions.get(ii), lengths.get(ii), countNullAndNan);
             lengths.set(ii, newSize);
         }
     }
 
     public static int compactAndCount(WritableShortChunk<? extends Values> valueChunk,
-            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNull) {
+            WritableIntChunk<ChunkLengths> counts, final int start, final int length, boolean countNullAndNan) {
         int wpos = -1;
         // region compactAndCount
-        valueChunk.sort(start, length);
+        if (countNullAndNan) {
+            valueChunk.sort(start, length);
+        } else {
+            valueChunk.sortUnsafe(start, length);
+        }
         short lastValue = NULL_SHORT;
         int currentCount = -1;
         final int end = start + length;
         for (int rpos = start; rpos < end; ++rpos) {
             final short nextValue = valueChunk.get(rpos);
-            if (!countNull && shouldIgnore(nextValue)) {
+            if (!countNullAndNan && CompactKernelImpl.isNullOrNan(nextValue)) {
                 continue;
             }
             if (wpos == -1 || !ShortComparisons.eq(nextValue, lastValue)) {
@@ -99,11 +104,5 @@ public class ShortCompactKernel implements CompactKernel {
         }
         // endregion compactAndCount
         return wpos + 1;
-    }
-
-    private static boolean shouldIgnore(short value) {
-        // region shouldIgnore
-        return value == NULL_SHORT;
-        // endregion shouldIgnore
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTestFormulaStaticMethods.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTestFormulaStaticMethods.java
@@ -509,40 +509,40 @@ public class QueryTableAggregationTestFormulaStaticMethods {
     }
 
     public static double minDouble(DoubleVector values) {
-        if (values.size() == 0) {
+        if (values.isEmpty()) {
             return QueryConstants.NULL_DOUBLE;
         }
         double min = 0;
         int count = 0;
         for (int ii = 0; ii < values.size(); ++ii) {
             final double v = values.get(ii);
-            if (v != QueryConstants.NULL_DOUBLE) { // TODO: the existing aggregator doesn't handle this &&
-                                                   // !Double.isNaN(v)) {
-                if (count++ == 0) {
-                    min = v;
-                } else if (DoubleComparisons.lt(v, min)) {
-                    min = v;
-                }
+            if (v == QueryConstants.NULL_DOUBLE || Double.isNaN(v)) {
+                continue;
+            }
+            if (count++ == 0) {
+                min = v;
+            } else if (DoubleComparisons.lt(v, min)) {
+                min = v;
             }
         }
         return count == 0 ? QueryConstants.NULL_DOUBLE : min;
     }
 
     public static double maxDouble(DoubleVector values) {
-        if (values.size() == 0) {
+        if (values.isEmpty()) {
             return QueryConstants.NULL_DOUBLE;
         }
         double min = 0;
         int count = 0;
         for (int ii = 0; ii < values.size(); ++ii) {
             final double v = values.get(ii);
-            if (v != QueryConstants.NULL_DOUBLE) { // TODO: the existing aggregator doesn't handle this &&
-                                                   // !Double.isNaN(v)) {
-                if (count++ == 0) {
-                    min = v;
-                } else if (DoubleComparisons.gt(v, min)) {
-                    min = v;
-                }
+            if (v == QueryConstants.NULL_DOUBLE || Double.isNaN(v)) {
+                continue;
+            }
+            if (count++ == 0) {
+                min = v;
+            } else if (DoubleComparisons.gt(v, min)) {
+                min = v;
             }
         }
         return count == 0 ? QueryConstants.NULL_DOUBLE : min;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxAggTestBase.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxAggTestBase.java
@@ -1,0 +1,159 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.chunk.util.pools.ChunkPoolReleaseTracking;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.test.types.OutOfBandTest;
+import io.deephaven.util.QueryConstants;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(OutOfBandTest.class)
+public abstract class QueryTableMaxAggTestBase {
+
+    static final String S1 = "S1";
+
+    @Rule
+    public final EngineCleanup base = new EngineCleanup();
+
+    @Before
+    public void setUp() throws Exception {
+        ChunkPoolReleaseTracking.enableStrict();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ChunkPoolReleaseTracking.checkAndDisable();
+    }
+
+    public abstract Table max(char[] source);
+
+    public abstract Table max(float[] source);
+
+    public abstract Table max(double[] source);
+
+    @Test
+    public void testEmptyChar() {
+        assertThat(max(new char[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyFloat() {
+        assertThat(max(new float[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyDouble() {
+        assertThat(max(new double[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testAllNullChar() {
+        check(QueryConstants.NULL_CHAR, new char[] {QueryConstants.NULL_CHAR});
+    }
+
+    @Test
+    public void testAllNullFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {QueryConstants.NULL_FLOAT});
+    }
+
+    @Test
+    public void testAllNullDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {QueryConstants.NULL_DOUBLE});
+    }
+
+    @Test
+    public void testSkipsNullChar() {
+        check(Character.MIN_VALUE, new char[] {QueryConstants.NULL_CHAR, Character.MIN_VALUE});
+    }
+
+    @Test
+    public void testSkipsNullFloat() {
+        check(Float.NEGATIVE_INFINITY, new float[] {QueryConstants.NULL_FLOAT, Float.NEGATIVE_INFINITY});
+    }
+
+    @Test
+    public void testSkipsNullDouble() {
+        check(Double.NEGATIVE_INFINITY, new double[] {QueryConstants.NULL_DOUBLE, Double.NEGATIVE_INFINITY});
+    }
+
+    @Test
+    public void testSkipsNanFloat() {
+        check(Float.NEGATIVE_INFINITY, new float[] {Float.NEGATIVE_INFINITY, Float.NaN});
+    }
+
+    @Test
+    public void testSkipsNanDouble() {
+        check(Double.NEGATIVE_INFINITY, new double[] {Double.NEGATIVE_INFINITY, Double.NaN});
+    }
+
+    @Test
+    public void testNegZeroFirstFloat() {
+        check(-0.0f, new float[] {-0.0f, 0.0f});
+    }
+
+    @Test
+    public void testNegZeroFirstDouble() {
+        check(-0.0, new double[] {-0.0, 0.0});
+    }
+
+    @Test
+    public void testZeroFirstFloat() {
+        check(0.0f, new float[] {0.0f, -0.0f});
+    }
+
+    @Test
+    public void testZeroFirstDouble() {
+        check(0.0, new double[] {0.0, -0.0});
+    }
+
+    @Test
+    public void testAllNaNFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {Float.NaN});
+    }
+
+    @Test
+    public void testAllNaNDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {Double.NaN});
+    }
+
+    public void check(char expected, char[] data) {
+        assertThat(charValue(max(data))).isEqualTo(expected);
+    }
+
+    public void check(float expected, float[] data) {
+        at(floatValue(max(data))).isEqualTo(expected);
+    }
+
+    public void check(double expected, double[] data) {
+        at(doubleValue(max(data))).isEqualTo(expected);
+    }
+
+    private static char charValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, char.class).getChar(x.getRowSet().firstRowKey());
+    }
+
+    private static float floatValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, float.class).getFloat(x.getRowSet().firstRowKey());
+    }
+
+    private static double doubleValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, double.class).getDouble(x.getRowSet().firstRowKey());
+    }
+
+    private static AbstractDoubleAssert<?> at(double x) {
+        return assertThat(x).usingComparator(Double::compareTo);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxBlinkAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxBlinkAggTest.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Test;
+
+public class QueryTableMaxBlinkAggTest extends QueryTableMaxAggTestBase {
+
+    @Override
+    public Table max(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.maxBy();
+    }
+
+    @Override
+    public Table max(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.maxBy();
+    }
+
+    @Override
+    public Table max(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.maxBy();
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxGroupedFormulaAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxGroupedFormulaAggTest.java
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.util.QueryConstants;
+import org.junit.Test;
+
+public class QueryTableMaxGroupedFormulaAggTest extends QueryTableMaxAggTestBase {
+
+    @Override
+    public Table max(char[] source) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table max(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).groupBy().update("S1=max(S1)");
+    }
+
+    @Override
+    public Table max(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).groupBy().update("S1=max(S1)");
+    }
+
+    @Override
+    public void testEmptyChar() {
+        // not supported
+    }
+
+    @Override
+    public void testAllNullChar() {
+        // not supported
+    }
+
+    @Override
+    public void testSkipsNullChar() {
+        // not supported
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxRefreshingAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxRefreshingAggTest.java
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Test;
+
+public class QueryTableMaxRefreshingAggTest extends QueryTableMaxAggTestBase {
+
+    @Override
+    public Table max(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        return x.maxBy();
+    }
+
+    @Override
+    public Table max(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        return x.maxBy();
+    }
+
+    @Override
+    public Table max(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        return x.maxBy();
+    }
+
+    // we are _okay_ with refreshing case returning -0.0; it is using sort under the covers, but that is "ok"
+
+    @Test
+    public void testZeroFirstFloat() {
+        check(-0.0f, new float[] {0.0f, -0.0f});
+    }
+
+    @Test
+    public void testZeroFirstDouble() {
+        check(-0.0, new double[] {0.0, -0.0});
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxStaticAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMaxStaticAggTest.java
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Test;
+
+public class QueryTableMaxStaticAggTest extends QueryTableMaxAggTestBase {
+
+    @Override
+    public Table max(char[] source) {
+        return TableTools.newTable(TableTools.charCol(S1, source)).maxBy();
+    }
+
+    @Override
+    public Table max(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).maxBy();
+    }
+
+    @Override
+    public Table max(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).maxBy();
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianAggTestBase.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianAggTestBase.java
@@ -1,0 +1,189 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.chunk.util.pools.ChunkPoolReleaseTracking;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.test.types.OutOfBandTest;
+import io.deephaven.util.QueryConstants;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(OutOfBandTest.class)
+public abstract class QueryTableMedianAggTestBase {
+
+    static final String S1 = "S1";
+
+    @Rule
+    public final EngineCleanup base = new EngineCleanup();
+
+    @Before
+    public void setUp() throws Exception {
+        ChunkPoolReleaseTracking.enableStrict();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ChunkPoolReleaseTracking.checkAndDisable();
+    }
+
+    public abstract Table median(char[] source);
+
+    public abstract Table median(float[] source);
+
+    public abstract Table median(double[] source);
+
+    @Test
+    public void testEmptyChar() {
+        assertThat(median(new char[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyFloat() {
+        assertThat(median(new float[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyDouble() {
+        assertThat(median(new double[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testSplitChar() {
+        check('b', new char[] {'a', 'b'});
+    }
+
+    @Test
+    public void testSplitFloat() {
+        check(0.5f, new float[] {0.0f, 1.0f});
+    }
+
+    @Test
+    public void testSplitDouble() {
+        check(0.5, new double[] {0.0, 1.0});
+    }
+
+    @Test
+    public void testChar() {
+        check('b', new char[] {'a', 'b', 'z'});
+    }
+
+    @Test
+    public void testFloat() {
+        check(0.42f, new float[] {0.0f, 0.42f, 1.0f});
+    }
+
+    @Test
+    public void testDouble() {
+        check(0.42, new double[] {0.0, 0.42, 1.0});
+    }
+
+    @Test
+    public void testAllNullChar() {
+        check(QueryConstants.NULL_CHAR, new char[] {QueryConstants.NULL_CHAR});
+    }
+
+    @Test
+    public void testAllNullFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {QueryConstants.NULL_FLOAT});
+    }
+
+    @Test
+    public void testAllNullDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {QueryConstants.NULL_DOUBLE});
+    }
+
+    @Test
+    public void testSkipsNullChar() {
+        check('a', new char[] {QueryConstants.NULL_CHAR, QueryConstants.NULL_CHAR, 'a'});
+    }
+
+    @Test
+    public void testSkipsNullFloat() {
+        check(0.0f, new float[] {QueryConstants.NULL_FLOAT, QueryConstants.NULL_FLOAT, 0.0f});
+    }
+
+    @Test
+    public void testSkipsNullDouble() {
+        check(0.0, new double[] {QueryConstants.NULL_DOUBLE, QueryConstants.NULL_DOUBLE, 0.0});
+    }
+
+    @Test
+    public void testSkipsNanFloat() {
+        check(0.0f, new float[] {Float.NaN, Float.NaN, 0.0f});
+    }
+
+    @Test
+    public void testSkipsNanDouble() {
+        check(0.0, new double[] {Double.NaN, Double.NaN, 0.0});
+    }
+
+    @Test
+    public void testNegZeroFirstFloat() {
+        check(-0.0f, new float[] {-0.0f, 0.0f, 0.0f});
+    }
+
+    @Test
+    public void testNegZeroFirstDouble() {
+        check(-0.0, new double[] {-0.0, 0.0, 0.0});
+    }
+
+    @Test
+    public void testZeroFirstFloat() {
+        check(-0.0f, new float[] {0.0f, -0.0f, -0.0f});
+    }
+
+    @Test
+    public void testZeroFirstDouble() {
+        check(-0.0, new double[] {0.0, -0.0, -0.0});
+    }
+
+    @Test
+    public void testAllNaNFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {Float.NaN});
+    }
+
+    @Test
+    public void testAllNaNDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {Double.NaN});
+    }
+
+    public void check(char expected, char[] data) {
+        assertThat(charValue(median(data))).isEqualTo(expected);
+    }
+
+    public void check(float expected, float[] data) {
+        at(floatValue(median(data))).isEqualTo(expected);
+    }
+
+    public void check(double expected, double[] data) {
+        at(doubleValue(median(data))).isEqualTo(expected);
+    }
+
+    private static char charValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, char.class).getChar(x.getRowSet().firstRowKey());
+    }
+
+    private static float floatValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, float.class).getFloat(x.getRowSet().firstRowKey());
+    }
+
+    private static double doubleValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, double.class).getDouble(x.getRowSet().firstRowKey());
+    }
+
+    private static AbstractDoubleAssert<?> at(double x) {
+        return assertThat(x).usingComparator(Double::compareTo);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianBlinkAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianBlinkAggTest.java
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableMedianBlinkAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.medianBy();
+    }
+
+    @Override
+    public Table median(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.medianBy();
+    }
+
+    @Override
+    public Table median(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.medianBy();
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianGroupedFormulaAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianGroupedFormulaAggTest.java
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Assume;
+import org.junit.Ignore;
+
+@Ignore
+public class QueryTableMedianGroupedFormulaAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        // Assumptions.assumeThat()
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table median(float[] source) {
+        // todo: need to fix numeric so median(float) -> float?
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table median(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).groupBy().update("S1=median(S1)");
+    }
+
+    @Override
+    public void testEmptyChar() {}
+
+    @Override
+    public void testSplitChar() {}
+
+    @Override
+    public void testChar() {}
+
+    @Override
+    public void testAllNullChar() {}
+
+    @Override
+    public void testSkipsNullChar() {}
+
+    @Override
+    public void testEmptyFloat() {}
+
+    @Override
+    public void testSplitFloat() {}
+
+    @Override
+    public void testFloat() {}
+
+    @Override
+    public void testAllNullFloat() {}
+
+    @Override
+    public void testSkipsNullFloat() {}
+
+    @Override
+    public void testSkipsNanFloat() {}
+
+    @Override
+    public void testNegZeroFirstFloat() {}
+
+    @Override
+    public void testZeroFirstFloat() {}
+
+    @Override
+    public void testAllNaNFloat() {}
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianRefreshingAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianRefreshingAggTest.java
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Test;
+
+public class QueryTableMedianRefreshingAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        return x.medianBy();
+    }
+
+    @Override
+    public Table median(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        return x.medianBy();
+    }
+
+    @Override
+    public Table median(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        return x.medianBy();
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianStaticAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianStaticAggTest.java
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableMedianStaticAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        return TableTools.newTable(TableTools.charCol(S1, source)).medianBy();
+    }
+
+    @Override
+    public Table median(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).medianBy();
+    }
+
+    @Override
+    public Table median(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).medianBy();
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileBlinkAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileBlinkAggTest.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.spec.AggSpec;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableMedianViaPercentileBlinkAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggAllBy(AggSpec.percentile(0.5, true));
+    }
+
+    @Override
+    public Table median(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggAllBy(AggSpec.percentile(0.5, true));
+    }
+
+    @Override
+    public Table median(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggAllBy(AggSpec.percentile(0.5, true));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileGroupedFormulaAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileGroupedFormulaAggTest.java
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Ignore;
+
+@Ignore
+public class QueryTableMedianViaPercentileGroupedFormulaAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        // Assumptions.assumeThat()
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table median(float[] source) {
+        // todo: need to fix numeric so median(float) -> float?
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table median(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).groupBy().update("S1=percentile(0.5, S1)");
+    }
+
+    @Override
+    public void testEmptyChar() {}
+
+    @Override
+    public void testSplitChar() {}
+
+    @Override
+    public void testChar() {}
+
+    @Override
+    public void testAllNullChar() {}
+
+    @Override
+    public void testSkipsNullChar() {}
+
+    @Override
+    public void testEmptyFloat() {}
+
+    @Override
+    public void testSplitFloat() {}
+
+    @Override
+    public void testFloat() {}
+
+    @Override
+    public void testAllNullFloat() {}
+
+    @Override
+    public void testSkipsNullFloat() {}
+
+    @Override
+    public void testSkipsNanFloat() {}
+
+    @Override
+    public void testNegZeroFirstFloat() {}
+
+    @Override
+    public void testZeroFirstFloat() {}
+
+    @Override
+    public void testAllNaNFloat() {}
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileRefreshingAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileRefreshingAggTest.java
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.spec.AggSpec;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableMedianViaPercentileRefreshingAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggAllBy(AggSpec.percentile(0.5, true));
+    }
+
+    @Override
+    public Table median(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggAllBy(AggSpec.percentile(0.5, true));
+    }
+
+    @Override
+    public Table median(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggAllBy(AggSpec.percentile(0.5, true));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileStaticAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMedianViaPercentileStaticAggTest.java
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.spec.AggSpec;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableMedianViaPercentileStaticAggTest extends QueryTableMedianAggTestBase {
+
+    @Override
+    public Table median(char[] source) {
+        return TableTools.newTable(TableTools.charCol(S1, source)).aggAllBy(AggSpec.percentile(0.5, true));
+    }
+
+    @Override
+    public Table median(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).aggAllBy(AggSpec.percentile(0.5, true));
+    }
+
+    @Override
+    public Table median(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).aggAllBy(AggSpec.percentile(0.5, true));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinAggTestBase.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinAggTestBase.java
@@ -1,0 +1,164 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.chunk.util.pools.ChunkPoolReleaseTracking;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.test.types.OutOfBandTest;
+import io.deephaven.util.QueryConstants;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(OutOfBandTest.class)
+public abstract class QueryTableMinAggTestBase {
+
+    static final String S1 = "S1";
+
+    @Rule
+    public final EngineCleanup base = new EngineCleanup();
+
+    @Before
+    public void setUp() throws Exception {
+        ChunkPoolReleaseTracking.enableStrict();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ChunkPoolReleaseTracking.checkAndDisable();
+    }
+
+    public abstract Table min(char[] source);
+
+    public abstract Table min(float[] source);
+
+    public abstract Table min(double[] source);
+
+    @Test
+    public void testEmptyChar() {
+        assertThat(min(new char[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyFloat() {
+        assertThat(min(new float[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyDouble() {
+        assertThat(min(new double[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testAllNullChar() {
+        check(QueryConstants.NULL_CHAR, new char[] {QueryConstants.NULL_CHAR});
+    }
+
+    @Test
+    public void testAllNullFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {QueryConstants.NULL_FLOAT});
+    }
+
+    @Test
+    public void testAllNullDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {QueryConstants.NULL_DOUBLE});
+    }
+
+    @Test
+    public void testSkipsNullChar() {
+        check((char) (Character.MAX_VALUE - 1), new char[] {QueryConstants.NULL_CHAR, Character.MAX_VALUE - 1});
+    }
+
+    @Test
+    public void testSkipsNullFloat() {
+        check(Float.POSITIVE_INFINITY, new float[] {QueryConstants.NULL_FLOAT, Float.POSITIVE_INFINITY});
+    }
+
+    @Test
+    public void testSkipsNullDouble() {
+        check(Double.POSITIVE_INFINITY, new double[] {QueryConstants.NULL_DOUBLE, Double.POSITIVE_INFINITY});
+    }
+
+    @Test
+    public void testSkipsNanFloat() {
+        check(Float.POSITIVE_INFINITY, new float[] {Float.POSITIVE_INFINITY, Float.NaN});
+    }
+
+    @Test
+    public void testSkipsNanDouble() {
+        check(Double.POSITIVE_INFINITY, new double[] {Double.POSITIVE_INFINITY, Double.NaN});
+    }
+
+    @Test
+    public void testNegZeroFirstFloat() {
+        check(-0.0f, new float[] {-0.0f, 0.0f});
+    }
+
+    @Test
+    public void testNegZeroFirstDouble() {
+        check(-0.0, new double[] {-0.0, 0.0});
+    }
+
+    @Test
+    public void testZeroFirstFloat() {
+        check(0.0f, new float[] {0.0f, -0.0f});
+    }
+
+    @Test
+    public void testZeroFirstDouble() {
+        check(0.0, new double[] {0.0, -0.0});
+    }
+
+    @Test
+    public void testAllNaNFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {Float.NaN});
+    }
+
+    @Test
+    public void testAllNaNDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {Double.NaN});
+    }
+
+    public void check(char expected, char[] data) {
+        assertThat(charValue(min(data))).isEqualTo(expected);
+    }
+
+    public void check(float expected, float[] data) {
+        at(floatValue(min(data))).isEqualTo(expected);
+    }
+
+    public void check(double expected, double[] data) {
+        at(doubleValue(min(data))).isEqualTo(expected);
+    }
+
+    private static char charValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, char.class).getChar(x.getRowSet().firstRowKey());
+    }
+
+    private static float floatValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, float.class).getFloat(x.getRowSet().firstRowKey());
+    }
+
+    private static double doubleValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, double.class).getDouble(x.getRowSet().firstRowKey());
+    }
+
+    private static AbstractFloatAssert<?> at(float x) {
+        return assertThat(x).usingComparator(Float::compareTo);
+    }
+
+    private static AbstractDoubleAssert<?> at(double x) {
+        return assertThat(x).usingComparator(Double::compareTo);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinBlinkAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinBlinkAggTest.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Test;
+
+public class QueryTableMinBlinkAggTest extends QueryTableMinAggTestBase {
+
+    @Override
+    public Table min(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.minBy();
+    }
+
+    @Override
+    public Table min(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.minBy();
+    }
+
+    @Override
+    public Table min(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.minBy();
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinGroupedFormulaAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinGroupedFormulaAggTest.java
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.util.QueryConstants;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class QueryTableMinGroupedFormulaAggTest extends QueryTableMinAggTestBase {
+
+    @Override
+    public Table min(char[] source) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table min(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).groupBy().update("S1=min(S1)");
+    }
+
+    @Override
+    public Table min(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).groupBy().update("S1=min(S1)");
+    }
+
+    @Override
+    public void testEmptyChar() {
+        // not supported
+    }
+
+    @Override
+    public void testAllNullChar() {
+        // not supported
+    }
+
+    @Override
+    public void testSkipsNullChar() {
+        // not supported
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinRefreshingAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinRefreshingAggTest.java
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import io.deephaven.util.QueryConstants;
+import org.junit.Test;
+
+public class QueryTableMinRefreshingAggTest extends QueryTableMinAggTestBase {
+
+    @Override
+    public Table min(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        return x.minBy();
+    }
+
+    @Override
+    public Table min(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        return x.minBy();
+    }
+
+    @Override
+    public Table min(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        return x.minBy();
+    }
+
+    // we are _okay_ with refreshing case returning -0.0; it is using sort under the covers, but that is "ok"
+
+    @Test
+    public void testZeroFirstFloat() {
+        check(-0.0f, new float[] {0.0f, -0.0f});
+    }
+
+    @Test
+    public void testZeroFirstDouble() {
+        check(-0.0, new double[] {0.0, -0.0});
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinStaticAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableMinStaticAggTest.java
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Test;
+
+public class QueryTableMinStaticAggTest extends QueryTableMinAggTestBase {
+
+    @Override
+    public Table min(char[] source) {
+        return TableTools.newTable(TableTools.charCol(S1, source)).minBy();
+    }
+
+    @Override
+    public Table min(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).minBy();
+    }
+
+    @Override
+    public Table min(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).minBy();
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstAggTestBase.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstAggTestBase.java
@@ -1,0 +1,157 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.chunk.util.pools.ChunkPoolReleaseTracking;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.test.types.OutOfBandTest;
+import io.deephaven.util.QueryConstants;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(OutOfBandTest.class)
+public abstract class QueryTableSortedFirstAggTestBase {
+
+    static final String S1 = "S1";
+
+    @Rule
+    public final EngineCleanup base = new EngineCleanup();
+
+    @Before
+    public void setUp() throws Exception {
+        ChunkPoolReleaseTracking.enableStrict();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ChunkPoolReleaseTracking.checkAndDisable();
+    }
+
+    public abstract Table sortedFirst(char[] source);
+
+    public abstract Table sortedFirst(float[] source);
+
+    public abstract Table sortedFirst(double[] source);
+
+    @Test
+    public void testEmptyChar() {
+        assertThat(sortedFirst(new char[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyFloat() {
+        assertThat(sortedFirst(new float[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyDouble() {
+        assertThat(sortedFirst(new double[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testAllNullChar() {
+        check(QueryConstants.NULL_CHAR, new char[] {QueryConstants.NULL_CHAR});
+    }
+
+    @Test
+    public void testAllNullFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {QueryConstants.NULL_FLOAT});
+    }
+
+    @Test
+    public void testAllNullDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {QueryConstants.NULL_DOUBLE});
+    }
+
+    @Test
+    public void testAllNaNFloat() {
+        check(Float.NaN, new float[] {Float.NaN});
+    }
+
+    @Test
+    public void testAllNaNDouble() {
+        check(Double.NaN, new double[] {Double.NaN});
+    }
+
+    @Test
+    public void testValuesChar() {
+        check(QueryConstants.NULL_CHAR,
+                new char[] {QueryConstants.NULL_CHAR, Character.MIN_VALUE, Character.MAX_VALUE - 1});
+    }
+
+    @Test
+    public void testValuesFloat() {
+        check(QueryConstants.NULL_FLOAT,
+                new float[] {QueryConstants.NULL_FLOAT, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.NaN});
+    }
+
+    @Test
+    public void testValuesDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {QueryConstants.NULL_DOUBLE, Double.NEGATIVE_INFINITY,
+                Double.POSITIVE_INFINITY, Double.NaN});
+    }
+
+    @Test
+    public void testNegZeroFirstFloat() {
+        check(-0.0f, new float[] {-0.0f, 0.0f});
+    }
+
+    @Test
+    public void testNegZeroFirstDouble() {
+        check(-0.0, new double[] {-0.0, 0.0});
+    }
+
+    @Test
+    public void testZeroFirstFloat() {
+        check(0.0f, new float[] {0.0f, -0.0f});
+    }
+
+    @Test
+    public void testZeroFirstDouble() {
+        check(0.0, new double[] {0.0, -0.0});
+    }
+
+    public void check(char expected, char[] data) {
+        assertThat(charValue(sortedFirst(data))).isEqualTo(expected);
+    }
+
+    public void check(float expected, float[] data) {
+        at(floatValue(sortedFirst(data))).isEqualTo(expected);
+    }
+
+    public void check(double expected, double[] data) {
+        at(doubleValue(sortedFirst(data))).isEqualTo(expected);
+    }
+
+    private static char charValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, char.class).getChar(x.getRowSet().firstRowKey());
+    }
+
+    private static double floatValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, float.class).getFloat(x.getRowSet().firstRowKey());
+    }
+
+    private static double doubleValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, double.class).getDouble(x.getRowSet().firstRowKey());
+    }
+
+    private static AbstractFloatAssert<?> at(float x) {
+        return assertThat(x).usingComparator(Float::compareTo);
+    }
+
+    private static AbstractDoubleAssert<?> at(double x) {
+        return assertThat(x).usingComparator(Double::compareTo);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstBlinkAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstBlinkAggTest.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.Aggregation;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableSortedFirstBlinkAggTest extends QueryTableSortedFirstAggTestBase {
+
+    @Override
+    public Table sortedFirst(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+
+    @Override
+    public Table sortedFirst(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+
+    @Override
+    public Table sortedFirst(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstRefreshingAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstRefreshingAggTest.java
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.Aggregation;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableSortedFirstRefreshingAggTest extends QueryTableSortedFirstAggTestBase {
+
+    @Override
+    public Table sortedFirst(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+
+    @Override
+    public Table sortedFirst(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+
+    @Override
+    public Table sortedFirst(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstStaticAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedFirstStaticAggTest.java
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.Aggregation;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableSortedFirstStaticAggTest extends QueryTableSortedFirstAggTestBase {
+    @Override
+    public Table sortedFirst(char[] source) {
+        return TableTools.newTable(TableTools.charCol(S1, source)).aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+
+    @Override
+    public Table sortedFirst(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+
+    @Override
+    public Table sortedFirst(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).aggBy(Aggregation.AggSortedFirst(S1, S1));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastAggTestBase.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastAggTestBase.java
@@ -1,0 +1,157 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.chunk.util.pools.ChunkPoolReleaseTracking;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.test.types.OutOfBandTest;
+import io.deephaven.util.QueryConstants;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(OutOfBandTest.class)
+public abstract class QueryTableSortedLastAggTestBase {
+
+    static final String S1 = "S1";
+
+    @Rule
+    public final EngineCleanup base = new EngineCleanup();
+
+    @Before
+    public void setUp() throws Exception {
+        ChunkPoolReleaseTracking.enableStrict();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ChunkPoolReleaseTracking.checkAndDisable();
+    }
+
+    public abstract Table sortedLast(char[] source);
+
+    public abstract Table sortedLast(float[] source);
+
+    public abstract Table sortedLast(double[] source);
+
+    @Test
+    public void testEmptyChar() {
+        assertThat(sortedLast(new char[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyFloat() {
+        assertThat(sortedLast(new float[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testEmptyDouble() {
+        assertThat(sortedLast(new double[0]).isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testAllNullChar() {
+        check(QueryConstants.NULL_CHAR, new char[] {QueryConstants.NULL_CHAR});
+    }
+
+    @Test
+    public void testAllNullFloat() {
+        check(QueryConstants.NULL_FLOAT, new float[] {QueryConstants.NULL_FLOAT});
+    }
+
+    @Test
+    public void testAllNullDouble() {
+        check(QueryConstants.NULL_DOUBLE, new double[] {QueryConstants.NULL_DOUBLE});
+    }
+
+    @Test
+    public void testAllNaNFloat() {
+        check(Float.NaN, new float[] {Float.NaN});
+    }
+
+    @Test
+    public void testAllNaNDouble() {
+        check(Double.NaN, new double[] {Double.NaN});
+    }
+
+    @Test
+    public void testValuesChar() {
+        check((char) (Character.MAX_VALUE - 1),
+                new char[] {QueryConstants.NULL_CHAR, Character.MIN_VALUE, Character.MAX_VALUE - 1});
+    }
+
+    @Test
+    public void testValuesFloat() {
+        check(Float.NaN,
+                new float[] {QueryConstants.NULL_FLOAT, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.NaN});
+    }
+
+    @Test
+    public void testValuesDouble() {
+        check(Double.NaN, new double[] {QueryConstants.NULL_DOUBLE, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                Double.NaN});
+    }
+
+    @Test
+    public void testNegZeroFirstFloat() {
+        check(0.0f, new float[] {-0.0f, 0.0f});
+    }
+
+    @Test
+    public void testNegZeroFirstDouble() {
+        check(0.0, new double[] {-0.0, 0.0});
+    }
+
+    @Test
+    public void testZeroFirstFloat() {
+        check(-0.0f, new float[] {0.0f, -0.0f});
+    }
+
+    @Test
+    public void testZeroFirstDouble() {
+        check(-0.0, new double[] {0.0, -0.0});
+    }
+
+    public void check(char expected, char[] data) {
+        assertThat(charValue(sortedLast(data))).isEqualTo(expected);
+    }
+
+    public void check(float expected, float[] data) {
+        at(floatValue(sortedLast(data))).isEqualTo(expected);
+    }
+
+    public void check(double expected, double[] data) {
+        at(doubleValue(sortedLast(data))).isEqualTo(expected);
+    }
+
+    private static char charValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, char.class).getChar(x.getRowSet().firstRowKey());
+    }
+
+    private static double floatValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, float.class).getFloat(x.getRowSet().firstRowKey());
+    }
+
+    private static double doubleValue(Table x) {
+        assertThat(x.size()).isEqualTo(1);
+        return x.getColumnSource(S1, double.class).getDouble(x.getRowSet().firstRowKey());
+    }
+
+    private static AbstractFloatAssert<?> at(float x) {
+        return assertThat(x).usingComparator(Float::compareTo);
+    }
+
+    private static AbstractDoubleAssert<?> at(double x) {
+        return assertThat(x).usingComparator(Double::compareTo);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastBlinkAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastBlinkAggTest.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.Aggregation;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableSortedLastBlinkAggTest extends QueryTableSortedLastAggTestBase {
+
+    @Override
+    public Table sortedLast(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+
+    @Override
+    public Table sortedLast(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+
+    @Override
+    public Table sortedLast(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        ((QueryTable) x).setAttribute(Table.BLINK_TABLE_ATTRIBUTE, true);
+        return x.aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastRefreshingAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastRefreshingAggTest.java
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.Aggregation;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableSortedLastRefreshingAggTest extends QueryTableSortedLastAggTestBase {
+
+    @Override
+    public Table sortedLast(char[] source) {
+        final Table x = TableTools.newTable(TableTools.charCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+
+    @Override
+    public Table sortedLast(float[] source) {
+        final Table x = TableTools.newTable(TableTools.floatCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+
+    @Override
+    public Table sortedLast(double[] source) {
+        final Table x = TableTools.newTable(TableTools.doubleCol(S1, source));
+        x.setRefreshing(true);
+        return x.aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastStaticAggTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableSortedLastStaticAggTest.java
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.api.agg.Aggregation;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.util.TableTools;
+
+public class QueryTableSortedLastStaticAggTest extends QueryTableSortedLastAggTestBase {
+    @Override
+    public Table sortedLast(char[] source) {
+        return TableTools.newTable(TableTools.charCol(S1, source)).aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+
+    @Override
+    public Table sortedLast(float[] source) {
+        return TableTools.newTable(TableTools.floatCol(S1, source)).aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+
+    @Override
+    public Table sortedLast(double[] source) {
+        return TableTools.newTable(TableTools.doubleCol(S1, source)).aggBy(Aggregation.AggSortedLast(S1, S1));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/compact/CharCompactKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/compact/CharCompactKernelTest.java
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.util.compact;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.WritableCharChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.attributes.ChunkLengths;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.hashing.IntChunkEquals;
+import io.deephaven.util.QueryConstants;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class CharCompactKernelTest {
+
+    @Test
+    public void emptyTest() {
+        check(new char[0], true, new char[0], new int[0]);
+        check(new char[0], false, new char[0], new int[0]);
+    }
+
+    @Test
+    public void compactAndCount() {
+        check(
+                new char[] {Character.MIN_VALUE, 'a', QueryConstants.NULL_CHAR},
+                true,
+                new char[] {QueryConstants.NULL_CHAR, Character.MIN_VALUE, 'a'},
+                new int[] {1, 1, 1});
+        check(
+                new char[] {Character.MIN_VALUE, 'a', QueryConstants.NULL_CHAR},
+                false,
+                new char[] {Character.MIN_VALUE, 'a'},
+                new int[] {1, 1});
+    }
+
+    private static void check(char[] input, boolean countNullNan, char[] expectedSorted, int[] expectedCounts) {
+        try (final WritableIntChunk<ChunkLengths> counts = WritableIntChunk.makeWritableChunk(input.length)) {
+            final WritableCharChunk<Values> chunk = WritableCharChunk.writableChunkWrap(input);
+            CharCompactKernel.compactAndCount(chunk, counts, countNullNan);
+            // can't use ChunkEquals b/c that treats -0.0 == 0.0
+            Assert.eqTrue(
+                    Arrays.equals(input, 0, chunk.size(), expectedSorted, 0, expectedSorted.length),
+                    "Arrays.equals(input, 0, chunk.size(), expectedSorted, 0, expectedSorted.length)");
+            Assert.eqTrue(
+                    IntChunkEquals.equalReduce(counts, IntChunk.chunkWrap(expectedCounts)),
+                    "IntChunkEquals.equalReduce(counts, IntChunk.chunkWrap(expectedCounts))");
+        }
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/compact/DoubleCompactKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/compact/DoubleCompactKernelTest.java
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.util.compact;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.WritableDoubleChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.attributes.ChunkLengths;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.hashing.IntChunkEquals;
+import io.deephaven.util.QueryConstants;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class DoubleCompactKernelTest {
+
+    @Test
+    public void emptyTest() {
+        check(new double[0], true, new double[0], new int[0]);
+        check(new double[0], false, new double[0], new int[0]);
+    }
+
+    @Test
+    public void compactAndCount() {
+        check(new double[] {
+                0.0, -0.0, QueryConstants.NULL_DOUBLE, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY},
+                true,
+                new double[] {QueryConstants.NULL_DOUBLE, Double.NEGATIVE_INFINITY, -0.0, Double.POSITIVE_INFINITY,
+                        Double.NaN},
+                new int[] {1, 1, 2, 1, 1});
+        check(new double[] {
+                0.0, -0.0, QueryConstants.NULL_DOUBLE, Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY},
+                false,
+                new double[] {Double.NEGATIVE_INFINITY, -0.0, Double.POSITIVE_INFINITY},
+                new int[] {1, 2, 1});
+    }
+
+    private static void check(double[] input, boolean countNullNan, double[] expectedSorted, int[] expectedCounts) {
+        try (final WritableIntChunk<ChunkLengths> counts = WritableIntChunk.makeWritableChunk(input.length)) {
+            final WritableDoubleChunk<Values> chunk = WritableDoubleChunk.writableChunkWrap(input);
+            DoubleCompactKernel.compactAndCount(chunk, counts, countNullNan);
+            // can't use ChunkEquals b/c that treats -0.0 == 0.0
+            Assert.eqTrue(
+                    Arrays.equals(input, 0, chunk.size(), expectedSorted, 0, expectedSorted.length),
+                    "Arrays.equals(input, 0, chunk.size(), expectedSorted, 0, expectedSorted.length)");
+            Assert.eqTrue(
+                    IntChunkEquals.equalReduce(counts, IntChunk.chunkWrap(expectedCounts)),
+                    "IntChunkEquals.equalReduce(counts, IntChunk.chunkWrap(expectedCounts))");
+        }
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/util/compact/FloatCompactKernelTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/util/compact/FloatCompactKernelTest.java
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.util.compact;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.WritableFloatChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.attributes.ChunkLengths;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.chunk.util.hashing.IntChunkEquals;
+import io.deephaven.util.QueryConstants;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class FloatCompactKernelTest {
+
+    @Test
+    public void emptyTest() {
+        check(new float[0], true, new float[0], new int[0]);
+        check(new float[0], false, new float[0], new int[0]);
+    }
+
+    @Test
+    public void compactAndCount() {
+        check(new float[] {
+                0.0f, -0.0f, QueryConstants.NULL_FLOAT, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY},
+                true,
+                new float[] {QueryConstants.NULL_FLOAT, Float.NEGATIVE_INFINITY, -0.0f, Float.POSITIVE_INFINITY,
+                        Float.NaN},
+                new int[] {1, 1, 2, 1, 1});
+        check(new float[] {
+                0.0f, -0.0f, QueryConstants.NULL_FLOAT, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY},
+                false,
+                new float[] {Float.NEGATIVE_INFINITY, -0.0f, Float.POSITIVE_INFINITY},
+                new int[] {1, 2, 1});
+    }
+
+    private static void check(float[] input, boolean countNullNan, float[] expectedSorted, int[] expectedCounts) {
+        try (final WritableIntChunk<ChunkLengths> counts = WritableIntChunk.makeWritableChunk(input.length)) {
+            final WritableFloatChunk<Values> chunk = WritableFloatChunk.writableChunkWrap(input);
+            FloatCompactKernel.compactAndCount(chunk, counts, countNullNan);
+            // can't use ChunkEquals b/c that treats -0.0 == 0.0
+            Assert.eqTrue(
+                    Arrays.equals(input, 0, chunk.size(), expectedSorted, 0, expectedSorted.length),
+                    "Arrays.equals(input, 0, chunk.size(), expectedSorted, 0, expectedSorted.length)");
+            Assert.eqTrue(
+                    IntChunkEquals.equalReduce(counts, IntChunk.chunkWrap(expectedCounts)),
+                    "IntChunkEquals.equalReduce(counts, IntChunk.chunkWrap(expectedCounts))");
+        }
+    }
+}

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
@@ -655,14 +655,7 @@ public class ReplicateSourcesAndChunks {
     }
 
     private static void replicateWritableChunks() throws IOException {
-        final List<String> files =
-                charToAllButBoolean(TASK, "engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java");
-        for (String fileName : files) {
-            final File classFile = new File(fileName);
-            List<String> lines = FileUtils.readLines(classFile, Charset.defaultCharset());
-            lines = ReplicationUtils.removeRegion(lines, "SortFixup");
-            FileUtils.writeLines(classFile, lines);
-        }
+        charToAllButBoolean(TASK, "engine/chunk/src/main/java/io/deephaven/chunk/WritableCharChunk.java");
         replicateWritableBooleanChunks();
         replicateWritableObjectChunks();
     }
@@ -681,7 +674,6 @@ public class ReplicateSourcesAndChunks {
                 ReplicationUtils.removeRegion(writableBooleanChunkClassLines, "FillWithNullValueImports");
         writableBooleanChunkClassLines =
                 ReplicationUtils.removeRegion(writableBooleanChunkClassLines, "FillWithNullValueImpl");
-        writableBooleanChunkClassLines = ReplicationUtils.removeRegion(writableBooleanChunkClassLines, "sort");
         FileUtils.writeLines(writableBooleanChunkClassFile, writableBooleanChunkClassLines);
     }
 


### PR DESCRIPTION
The WritableChunk documentation and implementation was update to more accurately reflect the desired behavior. A "fix-up" stage for floating point types was introduced. A sortUnsafe method was introduced to skip the "fix-up" stage for callers who do not need the "fix-up".

The CompactKernel documentation and implementation was updated to more accurately reflect the desired behavior.

The add-only min max operators were updated to ignore NaN values.

Fixes #5824