### PR TITLE
fix(r-client): add missing R package dependencies for building R client in its README.

### DIFF
--- a/R/rdeephaven/README.md
+++ b/R/rdeephaven/README.md
@@ -118,7 +118,7 @@ Currently, the R client is only supported on Ubuntu 20.04 or 22.04 and must be b
 4. Start an R console inside the rdeephaven directory. In that console, install the dephaven client dependencies
    (since we are building from source, dependencies will not be automatically pulled in):
    ```r
-   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr', 'knitr'))
+   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr', 'xml2', 'rmarkdown', 'knitr'))
    ```
    Then, exit the R console with `quit()`. From the rdeephaven directory, build and install the R client:
    ```r

--- a/R/rdeephaven/README.md
+++ b/R/rdeephaven/README.md
@@ -118,7 +118,7 @@ Currently, the R client is only supported on Ubuntu 20.04 or 22.04 and must be b
 4. Start an R console inside the rdeephaven directory. In that console, install the dephaven client dependencies
    (since we are building from source, dependencies will not be automatically pulled in):
    ```r
-   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr'))
+   install.packages(c('Rcpp', 'arrow', 'R6', 'dplyr', 'knitr'))
    ```
    Then, exit the R console with `quit()`. From the rdeephaven directory, build and install the R client:
    ```r


### PR DESCRIPTION
We need knitr, xml2 and rmarkdown.

Otherwise, in a fresh install of R on an ubuntu 22.04 machine while trying to follow the instructions in `R/README.md`:

```
cfs@pifilca 19:28:20 ~/dh/oss1/deephaven-core/R
$ R CMD build rdeephaven && R CMD INSTALL --no-multiarch --with-keep.source rdeephaven_*.tar.gz && rm rdeephaven_*.tar.gz
* checking for file ‘rdeephaven/DESCRIPTION’ ... OK
* preparing ‘rdeephaven’:
* checking DESCRIPTION meta-information ... OK
* cleaning src
Warning in system2(command, args, stdout = NULL, stderr = NULL, ...) :
  error in running command
Error in loadVignetteBuilder(pkgdir, TRUE) :
  vignette builder 'knitr' not found
Execution halted
```

Tried adding just knitr but still got fialures, we still miss `xml2` and `rmarkdown`.  So add all 3.

```
cfs@pifilca 19:40:15 ~/dh/oss1/deephaven-core/R
$ R CMD build rdeephaven && R CMD INSTALL --no-multiarch --with-keep.source rdeephaven_*.tar.gz && rm rdeephaven_*.tar.gz
* checking for file ‘rdeephaven/DESCRIPTION’ ... OK
* preparing ‘rdeephaven’:
* checking DESCRIPTION meta-information ... OK
* cleaning src
Warning in system2(command, args, stdout = NULL, stderr = NULL, ...) :
  error in running command
* installing the package to build vignettes
* creating vignettes ... ERROR
--- re-building ‘agg_by.Rmd’ using rmarkdown
Error: processing vignette 'agg_by.Rmd' failed with diagnostics:
there is no package called ‘rmarkdown’
--- failed re-building ‘agg_by.Rmd’

--- re-building ‘rdeephaven.Rmd’ using rmarkdown
Error: processing vignette 'rdeephaven.Rmd' failed with diagnostics:
there is no package called ‘rmarkdown’
--- failed re-building ‘rdeephaven.Rmd’

--- re-building ‘update_by.Rmd’ using rmarkdown
Error: processing vignette 'update_by.Rmd' failed with diagnostics:
there is no package called ‘rmarkdown’
--- failed re-building ‘update_by.Rmd’

SUMMARY: processing the following files failed:
  ‘agg_by.Rmd’ ‘rdeephaven.Rmd’ ‘update_by.Rmd’

Error: Vignette re-building failed.
Execution halted
```