### PR TITLE
feat: Throw exception when writing array/vector of big decimals to parquet

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
@@ -175,9 +175,13 @@ public class TypeInfos {
             final RowSet rowSet,
             final Map<String, ? extends ColumnSource<?>> columnSourceMap,
             @NotNull final ParquetInstructions instructions) {
-        final Class<?> dataType = column.getDataType();
-        if (BigDecimal.class.equals(dataType)) {
+        if (BigDecimal.class.equals(column.getDataType())) {
             return bigDecimalTypeInfo(computedCache, column, rowSet, columnSourceMap);
+        }
+        if (BigDecimal.class.equals(column.getComponentType())) {
+            throw new UnsupportedOperationException("Writing arrays/vector columns for big decimals is currently not " +
+                    "supported");
+            // TODO(deephaven-core#4612): Add support for this
         }
         return lookupTypeInfo(column, instructions);
     }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -1480,6 +1480,29 @@ public final class ParquetTableReadWriteTest {
     }
 
     @Test
+    public void testBigDecimalArrayColumn() {
+        final Table bdArrayTable = TableTools.emptyTable(10000).select(Selectable.from(List.of(
+                "someBigDecimalArrayColumn = new java.math.BigDecimal[] {i % 10 == 0 ? null : " +
+                        "java.math.BigDecimal.valueOf(ii).stripTrailingZeros()}")));
+        final File dest = new File(rootFile + File.separator + "testBigDecimalArrayColumn.parquet");
+        try {
+            ParquetTools.writeTable(bdArrayTable, dest.getPath());
+            fail("Expected exception because writing arrays of big decimal column types is not supported");
+        } catch (final RuntimeException e) {
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+        }
+
+        // Convert array to vector table
+        final Table bdVectorTable = arrayToVectorTable(bdArrayTable);
+        try {
+            ParquetTools.writeTable(bdVectorTable, dest.getPath());
+            fail("Expected exception because writing vectors of big decimal column types is not supported");
+        } catch (final RuntimeException e) {
+            assertTrue(e.getCause() instanceof UnsupportedOperationException);
+        }
+    }
+
+    @Test
     public void testArrayColumns() {
         ArrayList<String> columns =
                 new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
Related to #4612 