### PR TITLE
fix: Test for proper clock settings before running clock tests

### DIFF
--- a/engine/time/src/test/java/io/deephaven/time/TestDateTimeUtils.java
+++ b/engine/time/src/test/java/io/deephaven/time/TestDateTimeUtils.java
@@ -1933,23 +1933,17 @@ public class TestDateTimeUtils extends BaseArrayTestCase {
             TestCase.assertEquals(Instant.ofEpochSecond(0, (nanos / DateTimeUtils.MILLI) * DateTimeUtils.MILLI),
                     DateTimeUtils.nowMillisResolution());
 
-            // occasionally the following tests fail due to the clock resolution or a system pause,
-            // so run them multiple times
-            boolean isClockOk = false;
-            for (int i = 0; i < 10; i++) {
-                isClockOk |= Math.abs(Clock.system().currentTimeNanos()
-                        - DateTimeUtils.epochNanos(DateTimeUtils.nowSystem())) < 1_000_000L;
-            }
-            TestCase.assertTrue(isClockOk);
+            // Occasionally tests fail because of invalid clocks on the test system
+            final LocalDate startDate = LocalDate.of(1990, 1, 1);
+            final LocalDate currentDate = DateTimeUtils.toLocalDate(
+                    DateTimeUtils.epochNanosToInstant(Clock.system().currentTimeNanos()), DateTimeUtils.timeZone());
+            assertTrue("Checking for a valid date on the test system: currentDate=" + currentDate,
+                    currentDate.isAfter(startDate));
 
-            // occasionally the following tests fail due to the clock resolution or a system pause,
-            // so run them multiple times
-            boolean isMillisClockOk = false;
-            for (int i = 0; i < 10; i++) {
-                isMillisClockOk |= Math.abs(Clock.system().currentTimeNanos()
-                        - DateTimeUtils.epochNanos(DateTimeUtils.nowSystemMillisResolution())) < 1_000_000L;
-            }
-            TestCase.assertTrue(isMillisClockOk);
+            TestCase.assertTrue(Math.abs(Clock.system().currentTimeNanos()
+                    - DateTimeUtils.epochNanos(DateTimeUtils.nowSystem())) < 1_000_000L);
+            TestCase.assertTrue(Math.abs(Clock.system().currentTimeNanos()
+                    - DateTimeUtils.epochNanos(DateTimeUtils.nowSystemMillisResolution())) < 1_000_000L);
 
             TestCase.assertEquals(DateTimeUtils.formatDate(Instant.ofEpochSecond(0, nanos), TZ_AL),
                     DateTimeUtils.today(TZ_AL));

--- a/engine/time/src/test/java/io/deephaven/time/TestDateTimeUtils.java
+++ b/engine/time/src/test/java/io/deephaven/time/TestDateTimeUtils.java
@@ -1933,10 +1933,23 @@ public class TestDateTimeUtils extends BaseArrayTestCase {
             TestCase.assertEquals(Instant.ofEpochSecond(0, (nanos / DateTimeUtils.MILLI) * DateTimeUtils.MILLI),
                     DateTimeUtils.nowMillisResolution());
 
-            TestCase.assertTrue(Math.abs(Clock.system().currentTimeNanos()
-                    - DateTimeUtils.epochNanos(DateTimeUtils.nowSystem())) < 1_000_000L);
-            TestCase.assertTrue(Math.abs(Clock.system().currentTimeNanos()
-                    - DateTimeUtils.epochNanos(DateTimeUtils.nowSystemMillisResolution())) < 1_000_000L);
+            // occasionally the following tests fail due to the clock resolution or a system pause,
+            // so run them multiple times
+            boolean isClockOk = false;
+            for (int i = 0; i < 10; i++) {
+                isClockOk |= Math.abs(Clock.system().currentTimeNanos()
+                        - DateTimeUtils.epochNanos(DateTimeUtils.nowSystem())) < 1_000_000L;
+            }
+            TestCase.assertTrue(isClockOk);
+
+            // occasionally the following tests fail due to the clock resolution or a system pause,
+            // so run them multiple times
+            boolean isMillisClockOk = false;
+            for (int i = 0; i < 10; i++) {
+                isMillisClockOk |= Math.abs(Clock.system().currentTimeNanos()
+                        - DateTimeUtils.epochNanos(DateTimeUtils.nowSystemMillisResolution())) < 1_000_000L;
+            }
+            TestCase.assertTrue(isMillisClockOk);
 
             TestCase.assertEquals(DateTimeUtils.formatDate(Instant.ofEpochSecond(0, nanos), TZ_AL),
                     DateTimeUtils.today(TZ_AL));

--- a/engine/time/src/test/java/io/deephaven/time/calendar/TestStaticCalendarMethods.java
+++ b/engine/time/src/test/java/io/deephaven/time/calendar/TestStaticCalendarMethods.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.time.calendar;
 
+import io.deephaven.base.clock.Clock;
 import io.deephaven.base.testing.BaseArrayTestCase;
 import io.deephaven.time.DateTimeUtils;
 
@@ -106,6 +107,12 @@ public class TestStaticCalendarMethods extends BaseArrayTestCase {
         excludes.add("description");
         excludes.add("firstValidDate");
         excludes.add("lastValidDate");
+
+        // Occasionally tests fail because of invalid clocks on the test system
+        final LocalDate startDate = LocalDate.of(1990, 1, 1);
+        final LocalDate currentDate = DateTimeUtils.todayLocalDate();
+        assertTrue("Checking for a valid date on the test system: currentDate=" + currentDate,
+                currentDate.isAfter(startDate));
 
         for (Method m1 : BusinessCalendar.class.getMethods()) {
             if (m1.getDeclaringClass() == Object.class ||


### PR DESCRIPTION
Clock tests occasionally fail when the system clock is improperly set.  Test the system clock's setting before performing more tests.  This does not resolve the problem, but it provides clear evidence of the root cause of intermittent clock test failures.