### PR TITLE
fix: For failure in reading dictionary encoded parquet strings

### DIFF
--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnChunkReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnChunkReaderImpl.java
@@ -267,10 +267,7 @@ final class ColumnChunkReaderImpl implements ColumnChunkReader {
                 final long dataOffset = ch.position();
                 nextHeaderOffset = dataOffset + pageHeader.getCompressed_page_size();
                 final PageType pageType = pageHeader.type;
-                if (pageType == PageType.DICTIONARY_PAGE && headerOffset == columnChunk.meta_data.getData_page_offset()
-                        && columnChunk.meta_data.getDictionary_page_offset() == 0) {
-                    // https://stackoverflow.com/questions/55225108/why-is-dictionary-page-offset-0-for-plain-dictionary-encoding
-                    // Skip the dictionary page and jump to the data page
+                if (pageType == PageType.DICTIONARY_PAGE) {
                     return next(holder.get());
                 }
                 if (pageType != PageType.DATA_PAGE && pageType != PageType.DATA_PAGE_V2) {

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnChunkReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnChunkReaderImpl.java
@@ -268,6 +268,7 @@ final class ColumnChunkReaderImpl implements ColumnChunkReader {
                 nextHeaderOffset = dataOffset + pageHeader.getCompressed_page_size();
                 final PageType pageType = pageHeader.type;
                 if (pageType == PageType.DICTIONARY_PAGE) {
+                    // Skip the dictionary page and jump to the data page
                     return next(holder.get());
                 }
                 if (pageType != PageType.DATA_PAGE && pageType != PageType.DATA_PAGE_V2) {

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/S3ParquetRemoteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/S3ParquetRemoteTest.java
@@ -87,6 +87,20 @@ public class S3ParquetRemoteTest {
     }
 
     @Test
+    public void readSampleParquetFilesFromPublicS3Part3() {
+        Assume.assumeTrue("Skipping test because s3 testing disabled.", ENABLE_REMOTE_S3_TESTING);
+        final S3Instructions s3Instructions = S3Instructions.builder()
+                .regionName("us-east-1")
+                .readTimeout(Duration.ofSeconds(60))
+                .credentials(Credentials.anonymous())
+                .build();
+        final ParquetInstructions readInstructions = new ParquetInstructions.Builder()
+                .setSpecialInstructions(s3Instructions)
+                .build();
+        readTable("s3://redshift-downloads/redset/serverless/full.parquet", readInstructions).head(10).select();
+    }
+
+    @Test
     public void readKeyValuePartitionedParquetFromPublicS3() {
         Assume.assumeTrue("Skipping test because s3 testing disabled.", ENABLE_REMOTE_S3_TESTING);
         final S3Instructions s3Instructions = S3Instructions.builder()


### PR DESCRIPTION
@jjbrosnan pointed out a failure in reading parquet file  s3://redshift-downloads/redset/serverless/full.parquet from S3.
The error looked like:

```
Caused by: java.lang.IllegalStateException: Expected data page, but got DICTIONARY_PAGE at offset 2557056 for file s3://redshift-downloads/redset/serverless/full.parquet
	at io.deephaven.parquet.base.ColumnChunkReaderImpl$ColumnPageReaderIteratorImpl.next(ColumnChunkReaderImpl.java:280)
	at io.deephaven.parquet.table.pagestore.VariablePageSizeColumnChunkPageStore.extendOnePage(VariablePageSizeColumnChunkPageStore.java:76)
	at io.deephaven.parquet.table.pagestore.VariablePageSizeColumnChunkPageStore.fillToRow(VariablePageSizeColumnChunkPageStore.java:111)
	at io.deephaven.parquet.table.pagestore.VariablePageSizeColumnChunkPageStore.getPageContainingImpl(VariablePageSizeColumnChunkPageStore.java:169)
	at io.deephaven.parquet.table.pagestore.VariablePageSizeColumnChunkPageStore.getPageContaining(VariablePageSizeColumnChunkPageStore.java:150)
	... 27 more
```

This PR adds a fix where parquet reading code was not detecting dictionary page properly for files which don't have offset indexes.