### PR TITLE
feat: Support `remove_blink` to remove blink table semantics in server-side Python

### DIFF
--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -818,13 +818,10 @@ class Table(JObjectWrapper):
 
     def remove_blink(self) -> Table:
         """Returns a new version of this table without specialized blink table aggregation semantics."""
-        if self.is_blink:
-            try:
-                return Table(j_table=self.j_table.removeBlink())
-            except Exception as e:
-                raise DHError(e, "failed to remove blink table semantics.") from e
-        else:
-            raise RuntimeError("Table is not a blink table, so blink table semantics cannot be removed.")
+        try:
+            return Table(j_table=self.j_table.removeBlink())
+        except Exception as e:
+            raise DHError(e, "failed to remove blink table semantics.") from e
 
     def snapshot(self) -> Table:
         """Returns a static snapshot table.

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -817,11 +817,8 @@ class Table(JObjectWrapper):
         return Table(j_table=self.j_table.flatten())
 
     def remove_blink(self) -> Table:
-        """Returns a new version of this table without specialized blink table aggregation semantics."""
-        try:
-            return Table(j_table=self.j_table.removeBlink())
-        except Exception as e:
-            raise DHError(e, "failed to remove blink table semantics.") from e
+        """Returns a non-blink child table, or this table if it is not a blink table."""
+        return Table(j_table=self.j_table.removeBlink())
 
     def snapshot(self) -> Table:
         """Returns a static snapshot table.

--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -816,6 +816,16 @@ class Table(JObjectWrapper):
         """Returns a new version of this table with a flat row set, i.e. from 0 to number of rows - 1."""
         return Table(j_table=self.j_table.flatten())
 
+    def remove_blink(self) -> Table:
+        """Returns a new version of this table without specialized blink table aggregation semantics."""
+        if self.is_blink:
+            try:
+                return Table(j_table=self.j_table.removeBlink())
+            except Exception as e:
+                raise DHError(e, "failed to remove blink table semantics.") from e
+        else:
+            raise RuntimeError("Table is not a blink table, so blink table semantics cannot be removed.")
+
     def snapshot(self) -> Table:
         """Returns a static snapshot table.
 

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -930,6 +930,12 @@ class TableTestCase(BaseTestCase):
         self.assertEqual(len(attrs), len(rt_attrs) + 1)
         self.assertIn("BlinkTable", set(attrs.keys()) - set(rt_attrs.keys()))
 
+    def test_remove_blink(self):
+        t_blink = time_table("PT1s", blink_table=True).update("X = ii")
+        t_no_blink = t_blink.remove_blink()
+        self.assertEqual(t_blink.is_blink, True)
+        self.assertEqual(t_no_blink.is_blink, False)
+
     def test_grouped_column_as_arg(self):
         t1 = empty_table(100).update(
             ["id = i % 10", "Person = random() > 0.5 ? true : random() > 0.5 ? false : true"]).sort(

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -931,10 +931,13 @@ class TableTestCase(BaseTestCase):
         self.assertIn("BlinkTable", set(attrs.keys()) - set(rt_attrs.keys()))
 
     def test_remove_blink(self):
-        t_blink = time_table("PT1s", blink_table=True).update("X = ii")
+        t_blink = time_table("PT1s", blink_table=True)
         t_no_blink = t_blink.remove_blink()
         self.assertEqual(t_blink.is_blink, True)
         self.assertEqual(t_no_blink.is_blink, False)
+
+        with self.assertRaises(RuntimeError):
+            t_no_blink.remove_blink()
 
     def test_grouped_column_as_arg(self):
         t1 = empty_table(100).update(

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -936,9 +936,6 @@ class TableTestCase(BaseTestCase):
         self.assertEqual(t_blink.is_blink, True)
         self.assertEqual(t_no_blink.is_blink, False)
 
-        with self.assertRaises(RuntimeError):
-            t_no_blink.remove_blink()
-
     def test_grouped_column_as_arg(self):
         t1 = empty_table(100).update(
             ["id = i % 10", "Person = random() > 0.5 ? true : random() > 0.5 ? false : true"]).sort(


### PR DESCRIPTION
`removeBlink` is used by the Java API to disable the specialized aggregation semantics that blink tables implement. This wrapper adds the functionality to disable those semantics from the Python API.