### PR TITLE
feat: Expose Python/Groovy version to clients

### DIFF
--- a/java-client/session-examples/build.gradle
+++ b/java-client/session-examples/build.gradle
@@ -49,6 +49,7 @@ application.applicationDistribution.into('bin') {
     from(createApplication('message-stream-send-receive', 'io.deephaven.client.examples.MessageStreamSendReceive'))
     from(createApplication('filter-table', 'io.deephaven.client.examples.FilterTable'))
     from(createApplication('create-shared-id', 'io.deephaven.client.examples.CreateSharedId'))
+    from(createApplication('print-configuration-constants', 'io.deephaven.client.examples.PrintConfigurationConstants'))
 
     fileMode = 0755
 }

--- a/java-client/session-examples/src/main/java/io/deephaven/client/examples/PrintConfigurationConstants.java
+++ b/java-client/session-examples/src/main/java/io/deephaven/client/examples/PrintConfigurationConstants.java
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.client.examples;
+
+import io.deephaven.client.impl.Session;
+import io.deephaven.proto.backplane.grpc.ConfigValue;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.util.Map.Entry;
+
+@Command(name = "print-configuration-constants", mixinStandardHelpOptions = true,
+        description = "Print configuration constants", version = "0.1.0")
+class PrintConfigurationConstants extends SingleSessionExampleBase {
+
+    @Override
+    protected void execute(Session session) throws Exception {
+        for (Entry<String, ConfigValue> entry : session.getConfigurationConstants().get().entrySet()) {
+            System.out.println(entry.getKey() + "=" + entry.getValue().getStringValue());
+        }
+    }
+
+    public static void main(String[] args) {
+        int execute = new CommandLine(new PrintConfigurationConstants()).execute(args);
+        System.exit(execute);
+    }
+}

--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -62,9 +62,9 @@ web.webgl.editable=true
 authentication.client.configuration.list=AuthHandlers
 
 # List of configuration properties to provide to authenticated clients, so they can interact with the server.
-client.configuration.list=java.version,deephaven.version,barrage.version,http.session.durationMs,file.separator,web.storage.layout.directory,web.storage.notebook.directory,web.webgl,web.webgl.editable
+client.configuration.list=java.version,deephaven.version,barrage.version,groovy.version,python.version,http.session.durationMs,file.separator,web.storage.layout.directory,web.storage.notebook.directory,web.webgl,web.webgl.editable
 
 # Version list to add to the configuration property list. Each `=`-delimited pair denotes a short name for a versioned
 # jar, and a class that is found in that jar. Any such keys will be made available to the client.configuration.list
 # as <key>.version.
-client.version.list=deephaven=io.deephaven.engine.table.Table,barrage=io.deephaven.barrage.flatbuf.BarrageMessageWrapper
+client.version.list=deephaven=io.deephaven.engine.table.Table,barrage=io.deephaven.barrage.flatbuf.BarrageMessageWrapper,groovy=groovy.lang.GroovyShell


### PR DESCRIPTION
* Sets `groovy.version` configuration property, as sourced from class `groovy.lang.GroovyShell`.
* Sets `python.version` configuration property, as sourced from python code `platform.python_version()`
* Adds `groovy.version` and `python.version` to `client.configuration.list` in dh-defaults.prop (to be returned to client as part of `ConfigService.GetConfigurationConstants` gRPC)
* Adds `io.deephaven.client.examples.PrintConfigurationConstants` to invoke and print out results of `ConfigService.GetConfigurationConstants`

Fixes #5938