### PR TITLE
chore: bump docker images

### DIFF
--- a/docker/registry/cpp-clients-multi-base/gradle.properties
+++ b/docker/registry/cpp-clients-multi-base/gradle.properties
@@ -1,5 +1,5 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/cpp-clients-multi-base:latest
 # When the image version changes, remember to update cpp-client/build-dependencies.sh to match the image's content
-deephaven.registry.imageId=ghcr.io/deephaven/cpp-clients-multi-base@sha256:5b39f286d94a335890314577faf9211bd1b72299efa328f917ddab92c99a437e
+deephaven.registry.imageId=ghcr.io/deephaven/cpp-clients-multi-base@sha256:852925d8939b19344f15b9e752e9ed82724c7009f75df8a33912d85cb73e630e
 deephaven.registry.platform=linux/amd64

--- a/docker/registry/fedora/gradle.properties
+++ b/docker/registry/fedora/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=fedora:39
-deephaven.registry.imageId=fedora@sha256:e8792bee618a8d1c2ca8fbcf641ceb828d1b6b69bfac1ff70792f8bd5ed10ddd
+deephaven.registry.imageId=fedora@sha256:2922a1237abbb7f8517018e4f5d7a82a618f6ec09f386799e8595f9e1c39f021

--- a/docker/registry/go/gradle.properties
+++ b/docker/registry/go/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=golang:1
-deephaven.registry.imageId=golang@sha256:829eff99a4b2abffe68f6a3847337bf6455d69d17e49ec1a97dac78834754bd6
+deephaven.registry.imageId=golang@sha256:613a108a4a4b1dfb6923305db791a19d088f77632317cfc3446825c54fb862cd

--- a/docker/registry/localstack/gradle.properties
+++ b/docker/registry/localstack/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=localstack/localstack:3
-deephaven.registry.imageId=localstack/localstack@sha256:54fcf172f6ff70909e1e26652c3bb4587282890aff0d02c20aa7695469476ac0
+deephaven.registry.imageId=localstack/localstack@sha256:231148e6d60d040441ee0b418ab181eaedf30d18bca23ce5b44dfb863c40fb7c

--- a/docker/registry/manylinux2014_x86_64/gradle.properties
+++ b/docker/registry/manylinux2014_x86_64/gradle.properties
@@ -1,4 +1,4 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=quay.io/pypa/manylinux2014_x86_64:latest
-deephaven.registry.imageId=quay.io/pypa/manylinux2014_x86_64@sha256:07a0f9d59d8d075bb4f84dffc5dd76d991b90d7e4f315d1ef9f48a4f04390b71
+deephaven.registry.imageId=quay.io/pypa/manylinux2014_x86_64@sha256:545ae43918a0b5a871a09ccb4421c68230a109a21d99cd6f4806b2e4c34543d2
 deephaven.registry.platform=linux/amd64

--- a/docker/registry/minio/gradle.properties
+++ b/docker/registry/minio/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=minio/minio:latest
-deephaven.registry.imageId=minio/minio@sha256:77ff9f7e12549d269990b167fa21da010fa8b0beb40d6064569b8887e37c456b
+deephaven.registry.imageId=minio/minio@sha256:6f23072e3e222e64fe6f86b31a7f7aca971e5129e55cbccef649b109b8e651a1

--- a/docker/registry/node/gradle.properties
+++ b/docker/registry/node/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=node:20
-deephaven.registry.imageId=node@sha256:a4d1de4c7339eabcf78a90137dfd551b798829e3ef3e399e0036ac454afa1291
+deephaven.registry.imageId=node@sha256:445acd9b2ef7e9de665424053bf95652e0b8995ef36500557d48faf29300170a

--- a/docker/registry/node/gradle.properties
+++ b/docker/registry/node/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=node:20
-deephaven.registry.imageId=node@sha256:445acd9b2ef7e9de665424053bf95652e0b8995ef36500557d48faf29300170a
+deephaven.registry.imageId=node@sha256:a4d1de4c7339eabcf78a90137dfd551b798829e3ef3e399e0036ac454afa1291

--- a/docker/registry/protoc-base/gradle.properties
+++ b/docker/registry/protoc-base/gradle.properties
@@ -1,5 +1,5 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/protoc-base:latest
-deephaven.registry.imageId=ghcr.io/deephaven/protoc-base@sha256:a7f819be945c058a96079960c94fea0ca04c6189aa92c0ed45fcf4131ecbbf23
+deephaven.registry.imageId=ghcr.io/deephaven/protoc-base@sha256:70f31806515b4d160ab6ddf9b7b6612441b5918b0f1c5586ee2cc9ad8a4c81da
 # TODO(deephaven-base-images#54): arm64 native image for cpp-client-base
 deephaven.registry.platform=linux/amd64

--- a/docker/registry/python/gradle.properties
+++ b/docker/registry/python/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=python:3.10
-deephaven.registry.imageId=python@sha256:d47cb1b09be409a0cb5efeb01dd3ff5d44a5e28d371fa1a736c8928ab72fffd2
+deephaven.registry.imageId=python@sha256:09447073b9603858602b4a725ad92e4fd4c8f6979768cee295afae67fd997718

--- a/docker/registry/server-base/gradle.properties
+++ b/docker/registry/server-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:3304ec00e18bf86aee18b3491c7d92b326773deacfd98d1556facaddb1957a63
+deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:66f8cecdac170dfb8bf284e41684480359a15443dc5a5b8a1efc95987f3ddcb5

--- a/docker/registry/slim-base/gradle.properties
+++ b/docker/registry/slim-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-slim-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:ba5ce0113b246c50179e4355564f202840319f09a95cd921158c9042a528e03f
+deephaven.registry.imageId=ghcr.io/deephaven/server-slim-base@sha256:0605678d4961227fa0a8e83c0c8b030f56e581c070504dcca49a44a9ab43d8f0

--- a/docker/server-jetty/src/main/server-jetty/requirements.txt
+++ b/docker/server-jetty/src/main/server-jetty/requirements.txt
@@ -2,7 +2,7 @@ adbc-driver-manager==1.1.0
 adbc-driver-postgresql==1.1.0
 connectorx==0.3.3; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
-importlib_resources==6.4.0
+importlib_resources==6.4.3
 java-utilities==0.3.0
 jedi==0.19.1
 jpy==0.18.0

--- a/docker/server/src/main/server-netty/requirements.txt
+++ b/docker/server/src/main/server-netty/requirements.txt
@@ -2,7 +2,7 @@ adbc-driver-manager==1.1.0
 adbc-driver-postgresql==1.1.0
 connectorx==0.3.3; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
-importlib_resources==6.4.0
+importlib_resources==6.4.3
 java-utilities==0.3.0
 jedi==0.19.1
 jpy==0.18.0

--- a/py/client-ticking/README.md
+++ b/py/client-ticking/README.md
@@ -72,7 +72,7 @@ cd ${DHROOT}/py/client-ticking
 ```sh
 # Ensure the DHCPP environment variable is set per the instructions above
 rm -rf build dist  # Ensure we clean the remnants of any pre-existing build.
-DEEPHAVEN_VERSION=$(../../gradlew :printVersion -q) CFLAGS="-I${DHCPP}/include" LDFLAGS="-L${DHCPP}/lib" python3 setup.py build_ext -i
+DEEPHAVEN_VERSION=$(../../gradlew :printVersion -q) CPPFLAGS="-I${DHCPP}/include" LDFLAGS="-L${DHCPP}/lib" python3 setup.py build_ext -i
 ```
 
 #### Install pydeephaven-ticking

--- a/py/client-ticking/pyClientTickingWheel/entrypoint.sh
+++ b/py/client-ticking/pyClientTickingWheel/entrypoint.sh
@@ -13,7 +13,7 @@ rm -f ./*.cpp ./*.so
 PATH="/opt/python/${PYTHON_TAG}/bin:$PATH"
 
 MAKEFLAGS="-j${NCPUS}" \
-  CFLAGS="-I${DHCPP}/include" \
+  CPPFLAGS="-I${DHCPP}/include" \
   LDFLAGS="-L${DHCPP}/lib" \
   DEEPHAVEN_VERSION="${DEEPHAVEN_VERSION}" \
   python setup.py build_ext -i


### PR DESCRIPTION
The environment variable for building py-client-ticking needed to be updated from `CFLAGS` TO `CPPFLAGS`; this change was necessary because the newer version of setuptools in the manylinux base image seems to no longer include `CFLAGS`.