### PR TITLE
fix: Provide a warning when running autocomplete in a way that could segfault

### DIFF
--- a/py/server/deephaven_internal/auto_completer/__init__.py
+++ b/py/server/deephaven_internal/auto_completer/__init__.py
@@ -19,7 +19,16 @@ later, we may add slow mode, which uses both static and interpreted completion m
 from ._completer import Completer, Mode
 from jedi import preload_module, Interpreter
 
+
 jedi_settings = Completer()
 # warm jedi up a little. We could probably off-thread this.
 preload_module("deephaven")
 Interpreter("", []).complete(1, 0)
+
+
+def set_max_recursion_limit(limit: int) -> None:
+    """
+    Utility method to raise/lower the limit that our autocompletion will impose on Python 3.9 and 3.10.
+    """
+    from . import _completer
+    _completer.MAX_RECURSION_LIMIT = limit


### PR DESCRIPTION
Simple mitigation for jedi setting the recursion limit too high for Python 3.9 and 3.10 to correctly handle RecursionErrors. This prevents a segfault for a known bug in jedi, and only applies in cases where we know the bug can take place.

Technically it is possible for these python versions to crash in this way without autocomplete or numpy, but it first would require the recursion limit to be raised, so the fix only applies when autocomplete is used.

The `deephaven_internal.autocompleter` module has a `set_max_recursion_limit` method to define a different max recursion limit for an application, in case the default of 2000 is not sufficient for all cases.

Fixes #5878
Backport #5954