### PR TITLE
fix(cpp-client): Fix certain error messages

### DIFF
--- a/cpp-client/deephaven/dhcore/src/utility/utility_platform_specific.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility_platform_specific.cc
@@ -39,7 +39,8 @@ std::string GetHostname() {
   addrinfo *info;
   const int r = getaddrinfo(hostname, nullptr, &hints, &info);
   if (r != 0 || info == nullptr) {
-    throw std::runtime_error(DEEPHAVEN_LOCATION_STR("getaddrinfo failed: ") + gai_strerror(r));
+    auto message = fmt::format("getaddrinfo failed: {}", gai_strerror(r));
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
   // Of all the alternatives, pick the longest.
   std::size_t maxlen = std::strlen(info->ai_canonname);
@@ -62,9 +63,8 @@ std::string GetHostname() {
   const int r = gethostname(hostname, sizeof(hostname));
   if (r != 0) {
     int lasterr = WSAGetLastError();
-    throw std::runtime_error(
-       DEEPHAVEN_LOCATION_STR("gethostname failed: error code ") +
-       std::to_string(lasterr));
+    auto message = fmt::format("gethostname failed: error code {}", lasterr);
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
   return std::string(hostname);
 #else


### PR DESCRIPTION
The string concatenation was happening in the wrong place, so the original code was producing messages like

```
due to unexpected exception with message:
  gethostname failed: error code : class std::basic_string<char,struct std::
  char_traits<char>,class std::allocator<char> > __cdecl deephaven::dhcore::
  utility::GetHostname(void)@C:\Users\kosak\git\deephaven-core\cpp-client\
  deephaven\dhcore\src\utility\utility_platform_specific.cc:6710093
```

In the above the Windows error code is "10093" and the line number is "67".

The original code was mashing together both into 6710093

