### PR TITLE
feat: log session ID and user-agent

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyServerModule.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyServerModule.java
@@ -8,6 +8,7 @@ import dagger.Module;
 import dagger.Provides;
 import io.deephaven.plugin.js.JsPluginRegistration;
 import io.deephaven.server.config.ServerConfig;
+import io.deephaven.server.grpc.UserAgentContext;
 import io.deephaven.server.runner.GrpcServer;
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
@@ -42,6 +43,8 @@ public interface JettyServerModule {
         final ServletServerBuilder serverBuilder = new ServletServerBuilder();
         services.forEach(serverBuilder::addService);
         interceptors.forEach(serverBuilder::intercept);
+        serverBuilder.intercept(UserAgentContext.interceptor());
+        serverBuilder.intercept(new JettyCertInterceptor());
 
         // create a custom executor service, just like grpc would use, so that grpc doesn't shut it down ahead
         // of when we are ready
@@ -62,8 +65,6 @@ public interface JettyServerModule {
         serverBuilder.maxInboundMessageSize(maxMessageSize);
 
         serverBuilder.directExecutor();
-
-        serverBuilder.intercept(new JettyCertInterceptor());
 
         return serverBuilder.buildServletAdapter();
     }

--- a/server/netty/src/main/java/io/deephaven/server/netty/NettyServerModule.java
+++ b/server/netty/src/main/java/io/deephaven/server/netty/NettyServerModule.java
@@ -9,6 +9,7 @@ import dagger.Provides;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.grpc.MTlsCertificate;
 import io.deephaven.server.config.ServerConfig;
+import io.deephaven.server.grpc.UserAgentContext;
 import io.deephaven.server.plugin.js.JsPluginNoopConsumerModule;
 import io.deephaven.server.runner.GrpcServer;
 import io.deephaven.ssl.config.SSLConfig;
@@ -51,6 +52,7 @@ public interface NettyServerModule {
 
         services.forEach(serverBuilder::addService);
         interceptors.forEach(serverBuilder::intercept);
+        serverBuilder.intercept(UserAgentContext.interceptor());
         serverBuilder.intercept(MTlsCertificate.DEFAULT_INTERCEPTOR);
         serverBuilder.maxInboundMessageSize(serverConfig.maxInboundMessageSize());
         if (serverConfig.ssl().isPresent()) {

--- a/server/src/main/java/io/deephaven/server/grpc/UserAgentContext.java
+++ b/server/src/main/java/io/deephaven/server/grpc/UserAgentContext.java
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.grpc;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+import java.util.Optional;
+
+public final class UserAgentContext {
+
+    private static final String USER_AGENT_HEADER = "user-agent";
+
+    private static final Metadata.Key<String> USER_AGENT_HEADER_KEY =
+            Metadata.Key.of(USER_AGENT_HEADER, Metadata.ASCII_STRING_MARSHALLER);
+
+    private static final Context.Key<String> USER_AGENT_CONTEXT_KEY =
+            Context.key(UserAgentContext.class.getSimpleName());
+
+    /**
+     * A server interceptor that adds the metadata header {@value USER_AGENT_HEADER} into the call's context, making it
+     * retrievable via {@link #get(Context)}.
+     *
+     * @return the server interceptor
+     */
+    public static ServerInterceptor interceptor() {
+        return Interceptor.USER_AGENT_INTERCEPTOR;
+    }
+
+    /**
+     * Gets the user-agent from the current {@code context}. Used in combination with {@link #interceptor()}.
+     *
+     * @param context the context
+     * @return the user-agent
+     */
+    public static Optional<String> get(Context context) {
+        return Optional.ofNullable(USER_AGENT_CONTEXT_KEY.get(context));
+    }
+
+    private enum Interceptor implements ServerInterceptor {
+        USER_AGENT_INTERCEPTOR;
+
+        @Override
+        public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
+                ServerCallHandler<ReqT, RespT> next) {
+            final String userAgent = headers.get(USER_AGENT_HEADER_KEY);
+            if (userAgent == null) {
+                return next.startCall(call, headers);
+            }
+            final Context newContext = Context.current().withValue(USER_AGENT_CONTEXT_KEY, userAgent);
+            return Contexts.interceptCall(newContext, call, headers, next);
+        }
+    }
+}

--- a/server/src/main/java/io/deephaven/server/session/SessionListenerLogger.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionListenerLogger.java
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.session;
+
+import io.deephaven.configuration.Configuration;
+import io.deephaven.internal.log.LoggerFactory;
+import io.deephaven.io.log.LogLevel;
+import io.deephaven.io.logger.Logger;
+import io.deephaven.server.grpc.UserAgentContext;
+import io.grpc.Context;
+
+import javax.inject.Inject;
+
+/**
+ * Logs {@link SessionState#getSessionId() session ID} and {@link UserAgentContext#get(Context) user-agent} on session
+ * creation. The configuration property "SessionListenerLogger.level" can be set to change the logging level, by default
+ * is {@link LogLevel#INFO}.
+ */
+public final class SessionListenerLogger implements SessionListener {
+    private static final Logger log = LoggerFactory.getLogger(SessionListenerLogger.class);
+    private final LogLevel level;
+
+    @Inject
+    public SessionListenerLogger() {
+        level = LogLevel.valueOf(Configuration.getInstance().getStringForClassWithDefault(SessionListenerLogger.class,
+                "level", LogLevel.INFO.getName()));
+    }
+
+    @Override
+    public void onSessionCreate(SessionState session) {
+        log.getEntry(level)
+                .append("onSessionCreated, id=")
+                .append(session.getSessionId())
+                .append(", userAgent=")
+                .append(UserAgentContext.get(Context.current()).orElse(null))
+                .endl();
+    }
+}

--- a/server/src/main/java/io/deephaven/server/session/SessionModule.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionModule.java
@@ -6,15 +6,11 @@ package io.deephaven.server.session;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
-import dagger.multibindings.ElementsIntoSet;
 import dagger.multibindings.IntoSet;
 import io.deephaven.server.auth.AuthorizationProvider;
 import io.deephaven.server.util.AuthorizationWrappedGrpcBinding;
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
-
-import java.util.Collections;
-import java.util.Set;
 
 @Module
 public interface SessionModule {
@@ -39,9 +35,7 @@ public interface SessionModule {
     @IntoSet
     TicketResolver bindSharedTicketResolver(SharedTicketResolver resolver);
 
-    @Provides
-    @ElementsIntoSet
-    static Set<SessionListener> primeSessionListeners() {
-        return Collections.emptySet();
-    }
+    @Binds
+    @IntoSet
+    SessionListener bindsSessionListenerLogger(SessionListenerLogger listener);
 }

--- a/server/src/test/java/io/deephaven/server/session/UserAgentTest.java
+++ b/server/src/test/java/io/deephaven/server/session/UserAgentTest.java
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.session;
+
+import io.deephaven.proto.backplane.grpc.AuthenticationConstantsRequest;
+import io.deephaven.server.grpc.UserAgentContext;
+import io.deephaven.server.runner.DeephavenApiServerSingleUnauthenticatedBase;
+import io.deephaven.server.runner.RpcServerStateInterceptor.RpcServerState;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserAgentTest extends DeephavenApiServerSingleUnauthenticatedBase {
+
+    @Test
+    public void userAgentContext() throws InterruptedException, TimeoutException {
+        final RpcServerState state = serverStateInterceptor().newRpcServerState();
+        // Any RPC will work
+        // noinspection ResultOfMethodCallIgnored
+        channel()
+                .configBlocking()
+                .withInterceptors(state.clientInterceptor())
+                .getAuthenticationConstants(AuthenticationConstantsRequest.getDefaultInstance());
+        state.awaitServerInvokeFinished(Duration.ZERO);
+        assertThat(UserAgentContext.get(state.getCapturedContext()).orElse(null))
+                .startsWith("ServerBuilderInProcessModule grpc-java-inprocess/");
+    }
+}

--- a/server/test-utils/src/main/java/io/deephaven/server/runner/DeephavenApiServerSingleUnauthenticatedBase.java
+++ b/server/test-utils/src/main/java/io/deephaven/server/runner/DeephavenApiServerSingleUnauthenticatedBase.java
@@ -16,4 +16,8 @@ public abstract class DeephavenApiServerSingleUnauthenticatedBase extends Deepha
         super.setUp();
         channel = createChannel();
     }
+
+    public DeephavenChannel channel() {
+        return channel;
+    }
 }

--- a/server/test-utils/src/main/java/io/deephaven/server/runner/RpcServerStateInterceptor.java
+++ b/server/test-utils/src/main/java/io/deephaven/server/runner/RpcServerStateInterceptor.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class RpcServerStateInterceptor implements ServerInterceptor {
 
     @dagger.Module
-    interface Module {
+    public interface Module {
         @Binds
         @IntoSet
         ServerInterceptor bindsInterceptor(RpcServerStateInterceptor interceptor);
@@ -86,6 +86,7 @@ public final class RpcServerStateInterceptor implements ServerInterceptor {
         private final AtomicReference<ClientInterceptor> clientInterceptor;
 
         private MethodDescriptor<?, ?> methodDescriptor;
+        private Context context;
 
         RpcServerState(String id) {
             this.startCall = new CountDownLatch(1);
@@ -136,6 +137,10 @@ public final class RpcServerStateInterceptor implements ServerInterceptor {
             }
         }
 
+        public Context getCapturedContext() {
+            return context;
+        }
+
         <RespT, ReqT> Listener<ReqT> intercept(ServerCall<ReqT, RespT> call, Metadata headers,
                 ServerCallHandler<ReqT, RespT> next) {
             final Context context = Context.current();
@@ -145,7 +150,7 @@ public final class RpcServerStateInterceptor implements ServerInterceptor {
             // client, in which case we might end up saving call, headers, context, or listener.
             // this.call = call;
             // this.headers = headers;
-            // this.context = context;
+            this.context = context;
             // this.listener = listener;
             // startCall happens in interceptCall
             startCall.countDown();

--- a/server/test-utils/src/main/java/io/deephaven/server/runner/ServerBuilderInProcessModule.java
+++ b/server/test-utils/src/main/java/io/deephaven/server/runner/ServerBuilderInProcessModule.java
@@ -5,8 +5,8 @@ package io.deephaven.server.runner;
 
 import dagger.Module;
 import dagger.Provides;
-import dagger.Reusable;
 import io.deephaven.extensions.barrage.util.DefensiveDrainable;
+import io.deephaven.server.grpc.UserAgentContext;
 import io.grpc.BindableService;
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.ManagedChannelBuilder;
@@ -47,14 +47,15 @@ public class ServerBuilderInProcessModule {
 
         services.forEach(builder::addService);
         interceptors.forEach(builder::intercept);
+        builder.intercept(UserAgentContext.interceptor());
 
         return GrpcServer.of(builder.build());
     }
 
     @Provides
-    @Reusable
     static ManagedChannelBuilder<?> channelBuilder(@Named("serverName") String serverName) {
-        return InProcessChannelBuilder.forName(serverName);
+        return InProcessChannelBuilder.forName(serverName)
+                .userAgent(ServerBuilderInProcessModule.class.getSimpleName());
     }
 
     /**

--- a/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -37,6 +37,7 @@ import io.deephaven.extensions.barrage.util.BarrageUtil;
 import io.deephaven.io.logger.LogBuffer;
 import io.deephaven.io.logger.LogBufferGlobal;
 import io.deephaven.plugin.Registration;
+import io.deephaven.proto.backplane.grpc.AuthenticationConstantsRequest;
 import io.deephaven.proto.backplane.grpc.ExportNotification;
 import io.deephaven.proto.backplane.grpc.SortTableRequest;
 import io.deephaven.proto.backplane.grpc.WrappedAuthenticationRequest;
@@ -49,10 +50,13 @@ import io.deephaven.server.auth.AuthorizationProvider;
 import io.deephaven.server.config.ConfigServiceModule;
 import io.deephaven.server.console.ConsoleModule;
 import io.deephaven.server.console.ScopeTicketResolver;
+import io.deephaven.server.grpc.UserAgentContext;
 import io.deephaven.server.log.LogModule;
 import io.deephaven.server.plugin.PluginsModule;
 import io.deephaven.server.runner.GrpcServer;
 import io.deephaven.server.runner.MainHelper;
+import io.deephaven.server.runner.RpcServerStateInterceptor;
+import io.deephaven.server.runner.RpcServerStateInterceptor.RpcServerState;
 import io.deephaven.server.session.*;
 import io.deephaven.server.table.TableModule;
 import io.deephaven.server.test.TestAuthModule.FakeBearer;
@@ -104,6 +108,7 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -133,6 +138,7 @@ public abstract class FlightMessageRoundTripTest {
             TestAuthModule.class,
             ObfuscatingErrorTransformerModule.class,
             PluginsModule.class,
+            RpcServerStateInterceptor.Module.class,
     })
     public static class FlightTestModule {
         @IntoSet
@@ -227,6 +233,8 @@ public abstract class FlightMessageRoundTripTest {
         TestAuthorizationProvider authorizationProvider();
 
         Registration.Callback registration();
+
+        RpcServerStateInterceptor serverStateInterceptor();
     }
 
     private LogBuffer logBuffer;
@@ -285,6 +293,7 @@ public abstract class FlightMessageRoundTripTest {
         clientChannel = ManagedChannelBuilder.forTarget("localhost:" + localPort)
                 .usePlaintext()
                 .intercept(new TestAuthClientInterceptor(currentSession.getExpiration().token.toString()))
+                .userAgent(FlightMessageRoundTripTest.class.getSimpleName())
                 .build();
 
         clientScheduler = Executors.newSingleThreadScheduledExecutor();
@@ -1401,5 +1410,21 @@ public abstract class FlightMessageRoundTripTest {
             Assert.eq(arr[2][0], "arr[2][0]", 42.42);
             Assert.eq(arr[2][1], "arr[2][1]", 43.43);
         }
+    }
+
+    @Test
+    public void userAgentContext() throws InterruptedException, TimeoutException {
+        final RpcServerState state = component.serverStateInterceptor().newRpcServerState();
+        // Any RPC method will be OK
+        // noinspection ResultOfMethodCallIgnored
+        clientSession.channel()
+                .configBlocking()
+                .withInterceptors(state.clientInterceptor())
+                .getAuthenticationConstants(AuthenticationConstantsRequest.getDefaultInstance());
+        state.awaitServerInvokeFinished(Duration.ZERO);
+        final String userAgent = UserAgentContext.get(state.getCapturedContext()).orElse(null);
+        Assert.neqNull(userAgent, "userAgent");
+        final boolean userAgentStartsWith = userAgent.startsWith("FlightMessageRoundTripTest grpc-java-netty/");
+        Assert.eqTrue(userAgentStartsWith, "userAgentStartsWith");
     }
 }


### PR DESCRIPTION
Logs the session ID and user-agent (if set) on session creation. Technically, the user-agent could change with each RPC call, but that is not something that clients typically do. For contexts where logging every session is too spammy, the configuration property `SessionListenerLogger.level` can be used to set the appropriate log level.

Note, the user agent interceptor is not able to be bound to `Set<ServerInterceptor>` as it causes an undefined ordering with respect to `SessionServiceInterceptor`; we need to ensure that the user agent interceptor is applied before the session service interceptor.

Server component of #5704