### PR TITLE
fix(cpp-client): Bump arrow version (fixes Windows build)

### DIFF
--- a/cpp-client/deephaven/vcpkg.json
+++ b/cpp-client/deephaven/vcpkg.json
@@ -11,7 +11,7 @@
   ],
 
   "overrides": [
-    { "name": "arrow", "version": "16.0.0" },
+    { "name": "arrow", "version": "16.1.0#1" },
     { "name": "protobuf", "version": "4.25.1" }
   ]
 }


### PR DESCRIPTION
One of the arrow source files is missing an `#include <string>`.
I'm guessing Linux builds don't care because they pick it up, transitively, somewhere else.
Unfortunately, Windows builds fail.
The folks at vcpkg seem to have figured this out and have provided a patch in port version 1 of arrow 16.1.0 (hence 16.1.0#1)
