### PR TITLE
fix: Authentication changes to better support FlightSQL clients

### DIFF
--- a/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
@@ -76,11 +76,9 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
         // handle the scenario where authentication headers initialized a session
         SessionState session = sessionService.getOptionalSession();
         if (session != null) {
-            // We should immediately reply, since some clients will not even send a message on the stream. Do not close
-            // to avoid hitting https://github.com/envoyproxy/envoy/issues/30149.
-            GrpcUtil.safelyOnNext(responseObserver, Flight.HandshakeResponse.newBuilder()
-                    .setPayload(session.getExpiration().getTokenAsByteString())
-                    .build());
+            // Do not reply over the stream, some clients will break if they receive a message here - but since the
+            // session was already created, our "200 OK" will include the Bearer response already. Do not close
+            // yet to avoid hitting https://github.com/envoyproxy/envoy/issues/30149.
             return new StreamObserver<>() {
                 @Override
                 public void onNext(Flight.HandshakeRequest value) {

--- a/server/src/main/java/io/deephaven/server/session/SessionService.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionService.java
@@ -4,6 +4,7 @@
 package io.deephaven.server.session;
 
 import com.github.f4b6a3.uuid.UuidCreator;
+import com.github.f4b6a3.uuid.exception.InvalidUuidException;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.ByteString;
@@ -333,7 +334,7 @@ public class SessionService {
                 if (session != null) {
                     return session;
                 }
-            } catch (IllegalArgumentException ignored) {
+            } catch (IllegalArgumentException | InvalidUuidException ignored) {
             }
         }
 


### PR DESCRIPTION
Handshake calls previously required the client to send at least one message before sending a response, even if the required auth information was included in headers, now the server will respond and close the stream right away. This change could cause problems for older DH clients (specifically JS and Go clients), but the fix for this was released in 0.36.

Bearer authentication would fail if the token wasn't in the form of a UUID, even if an alternative authentication handler was going to accept the token.

Some Flight clients are unable to send auth types other than Basic and Bearer, our authentication interceptor can now support the auth type as a space-separated prefix of the auth token.

Fixes #5922