### PR TITLE
fix: Remove dependency on particular repo for package installation

### DIFF
--- a/R/build.gradle
+++ b/R/build.gradle
@@ -138,7 +138,7 @@ def rClientDoc = Docker.registerDockerTask(project, 'rClientDoc') {
                    ''')
         runCommand('''echo "status = tryCatch(" \
                            "   {" \
-                           "      install.packages('roxygen2', repos='https://cran.r-project.org'); " \
+                           "      install.packages('roxygen2'); " \
                            "      0" \
                            "   }," \
                            "  error=function(e) 1," \
@@ -179,7 +179,7 @@ def rClientSite = Docker.registerDockerTask(project, 'rClientSite') {
         runCommand("mkdir -p ${prefix}/src/rdeephaven/docs")
         runCommand('''echo "status = tryCatch(" \
                            "   {" \
-                           "      install.packages('pkgdown', repos='https://cran.r-project.org'); " \
+                           "      install.packages('pkgdown'); " \
                            "      0" \
                            "   }," \
                            "  error=function(e) 1," \


### PR DESCRIPTION
We have run into issues several times in the past with depending on a particular repo for downloading packages that the R client depends on. These servers occasionally go down, and then we start failing CI. Removing these explicit dependencies allows `install.packages` to pick a working repo from which to download packages.