### PR TITLE
fix: Don't recreate JS TreeTable subscriptions when viewport changes

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -599,13 +599,24 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
                     viewTicket.release();
                     viewTicket = null;
                 }
-            case SUBSCRIPTION:
+
+                // In all of the above cases, we replace the subscription
                 if (stream != null) {
                     stream.then(stream -> {
                         stream.close();
                         return null;
                     });
                     stream = null;
+                }
+                break;
+            case SUBSCRIPTION:
+                // If it exists, adjust the existing subscription, otherwise create a new one
+                if (stream != null) {
+                    stream.then(subscription -> {
+                        subscription.setViewport(firstRow, lastRow, Js.uncheckedCast(columns), (double) updateInterval);
+                        return null;
+                    });
+                    return;
                 }
         }
 


### PR DESCRIPTION
Resolves an issue where subscription recreation would release an export ticket that was still needed for the next subscription.

Also improves tree viewport performance by sending changes instead of waiting for a new subscription to exist.

Fixes #6053