### PR TITLE
feat: Pivot table

### DIFF
--- a/py/server/deephaven/experimental/pivot.py
+++ b/py/server/deephaven/experimental/pivot.py
@@ -6,9 +6,24 @@ from deephaven import time_table, empty_table, numpy as dhnp
 from deephaven.table import Table, multi_join, MultiJoinTable
 
 
-# Instead of legalizing the column name, it would be preferable to assign known names, and index them by the names table; using some kind of display name.
-# We don't know that we'll actually replace stuff to be unique here, which means this is not actually correct.
 def _legalize_column(s: str) -> str:
+    """Legalize a column name.
+
+    Args:
+        s (str): The column name to legalize.
+
+    Returns:
+        str: The legalized column name.
+
+    Raises:
+        ValueError: If the column name is empty.
+    """
+
+    #TODO: This is not a good way to legalize a column name.  It is not guaranteed to be unique.
+    # Instead of legalizing the column name, it would be preferable to assign known names, and index them by the names table;
+    # using some kind of display name.  We don't know that we'll actually replace stuff to be unique here,
+    # which means this is not actually correct.
+
     if re.match("^[_a-zA-Z][_a-zA-Z0-9]*$", s):
         return s
     if re.match("^[_a-zA-Z].*$", s):
@@ -20,20 +35,21 @@ def _do_multijoin(partitions_table, row_column_names: list[str], col_column_name
                   value_column_name: str) -> MultiJoinTable:
     # Define the columns for a multi-join
 
-    keys = partitions_table.keys()
+    #TODO: this stuff is not synchronized
 
+    #TODO: this does not handle key changes in the constituent tables.  It should.
+    keys = partitions_table.keys()
     key_values = dhnp.to_numpy(table=keys, cols=[col_column_name])
 
     if len(key_values) == 0:
         return empty_table(0)
 
     tables = []
-    ki = 0
 
-    for con in partitions_table.constituent_tables:
+    for ki, con in enumerate(partitions_table.constituent_tables):
         tables.append(
-            con.view(row_column_names + ["%s=%s" % (_legalize_column(str(key_values[ki][0])), value_column_name)]))
-        ki = ki + 1
+            con.view(row_column_names + [f"{_legalize_column(str(key_values[ki][0]))}={value_column_name}"])
+        )
 
     return multi_join(input=tables, on=row_column_names).table()
 
@@ -43,6 +59,9 @@ def pivot(source: Table, row_column_names: list[str], col_column_name: str, valu
     partitioned_source = source.partition_by(col_column_name)
     pvt = _do_multijoin(partitioned_source, row_column_names, col_column_name, value_column_name)
     return pvt
+
+
+#TODO: delete below here
 
 # # Java wrappers
 random_class = jpy.get_type("java.util.Random")

--- a/py/server/deephaven/experimental/pivot.py
+++ b/py/server/deephaven/experimental/pivot.py
@@ -6,6 +6,7 @@ from deephaven import time_table, empty_table
 from deephaven.table import Table, PartitionedTable, multi_join
 from deephaven.numpy import to_numpy
 from deephaven.update_graph import auto_locking_ctx
+from deephaven.jcompat import to_sequence
 
 def _legalize_column(s: str) -> str:
     """Legalize a column name.
@@ -57,10 +58,10 @@ def _do_multijoin(partitions_table: PartitionedTable, row_cols: list[str], colum
     return multi_join(input=tables, on=row_cols).table()
 
 
-#TODO: handle list or value for row_column_names
-def pivot(source: Table, row_cols: list[str], column_col: str, value_col: str) -> Table:
+def pivot(table: Table, row_cols: Union[str, Sequence[str]], column_col: str, value_col: str) -> Table:
     # Partition the source by column
-    partitioned_source = source.partition_by(column_col)
+    row_cols = list(to_sequence(row_cols))
+    partitioned_source = table.partition_by(column_col)
     pvt = _do_multijoin(partitioned_source, row_cols, column_col, value_col)
     return pvt
 

--- a/py/server/deephaven/experimental/pivot.py
+++ b/py/server/deephaven/experimental/pivot.py
@@ -1,0 +1,68 @@
+import jpy
+import random
+from deephaven.table import Table
+from deephaven import time_table, empty_table
+import deephaven.table
+from deephaven.table import multi_join
+from deephaven import numpy as dhnp
+import re
+from deephaven.server.executors import submit_task
+from typing import Sequence, List, Union, Protocol
+
+# Instead of legalizing the column name, it would be preferable to assign known names, and index them by the names table; using some kind of display name.
+# We don't know that we'll actually replace stuff to be unique here, which means this is not actually correct.
+def legalize_column(s : str):
+    if re.match("^[_a-zA-Z][_a-zA-Z0-9]*$", s):
+        return s
+    if re.match("^[_a-zA-Z].*$", s):
+        return re.sub("[^_a-zA-Z0-9]", "_", s)
+    return "_" + re.sub("[^_a-zA-Z0-9]", "_", s)
+
+def do_multijoin(partitions_table, row_column_names : list[str], col_column_name : str, value_column_name : str):
+    # Define the columns for a multi-join
+
+    keys = partitions_table.keys()
+
+    key_values = dhnp.to_numpy(table=keys, cols=[col_column_name])
+
+    if len(key_values) == 0:
+        return empty_table(0)
+
+    tables = []
+    ki = 0
+
+    for con in partitions_table.constituent_tables:
+        tables.append(con.view(row_column_names + ["%s=%s" % (legalize_column(str(key_values[ki][0])), value_column_name)]))
+        ki = ki + 1
+
+    return multi_join(input=tables, on=row_column_names).table()
+
+def pivot(source, row_column_names : list[str], col_column_name : str, value_column_name : str):
+    # Partition the source by column
+    partitioned_source=source.partition_by(col_column_name)
+    pvt = do_multijoin(partitioned_source, row_column_names, col_column_name, value_column_name)
+    return pvt
+
+
+# # Java wrappers
+# random_class = jpy.get_type("java.util.Random")
+# random_inst = random_class(0)
+# 
+# y=empty_table(1000).select(["Row=ii%10", "Col=(int)((ii/10) % 30)", "Sentinel=random_inst.nextDouble()"]).where("Sentinel > 0.3")
+# 
+# # first part of the pivot is getting unique row and column values
+# ys = y.sum_by(["Row", "Col"])
+# 
+# pvt=pivot(ys, ["Row"], "Col", "Sentinel")
+# 
+# # we have no real sector data, but it is nice for an example
+# #sectors = ["Apples", "Bananas", "Carrots", "Eggplant", "Fig"]
+# #sec_map = dict()
+# #def get_sector(sym : str) -> str:
+#     #if not sym in sec_map:
+#         #sec_map[sym] = sectors[random.randint(0, 2)]
+#     #return sec_map[sym]
+# 
+# feedos=db.live_table("FeedOS", "EquityTradeL1").where("Date=today()")
+# feedos_agg=feedos.view(["LocalCodeStr", "Dollars=Price*Size", "Size", "MarketId"]).sum_by(["LocalCodeStr", "MarketId"])#.update("Sector=get_sector(LocalCodeStr)")
+# fp = pivot(feedos_agg, ["MarketId"], "LocalCodeStr", "Dollars")

--- a/py/server/deephaven/experimental/pivot.py
+++ b/py/server/deephaven/experimental/pivot.py
@@ -6,7 +6,7 @@
 
 from typing import Sequence, Union, Optional, Callable, Any
 import re
-from deephaven import empty_table
+from deephaven import DHError, empty_table
 from deephaven.table import Table, PartitionedTable, multi_join
 from deephaven.numpy import to_numpy
 from deephaven.update_graph import auto_locking_ctx

--- a/py/server/deephaven/experimental/pivot.py
+++ b/py/server/deephaven/experimental/pivot.py
@@ -34,8 +34,8 @@ def _legalize_column(s: str) -> str:
 #TODO: redo all parameter names
 #TODO: pydoc
 
-def _do_multijoin(partitions_table: PartitionedTable, row_column_names: list[str], col_column_name: str,
-                  value_column_name: str) -> Table:
+def _do_multijoin(partitions_table: PartitionedTable, row_cols: list[str], column_col: str,
+                  value_col: str) -> Table:
     # Define the columns for a multi-join
 
     #TODO: this stuff is not synchronized
@@ -44,24 +44,24 @@ def _do_multijoin(partitions_table: PartitionedTable, row_column_names: list[str
     with auto_locking_ctx(partitions_table):
         #TODO: this does not handle key changes in the constituent tables.  It should.
         keys = partitions_table.keys()
-        key_values = to_numpy(table=keys, cols=[col_column_name])
+        key_values = to_numpy(table=keys, cols=[column_col])
 
         if len(key_values) == 0:
             return empty_table(0)
 
         tables = [
-            con.view(row_column_names + [f"{_legalize_column(str(key_values[ki][0]))}={value_column_name}"])
+            con.view(row_cols + [f"{_legalize_column(str(key_values[ki][0]))}={value_col}"])
                 for ki, con in enumerate(partitions_table.constituent_tables)
         ]
 
-    return multi_join(input=tables, on=row_column_names).table()
+    return multi_join(input=tables, on=row_cols).table()
 
 
 #TODO: handle list or value for row_column_names
-def pivot(source: Table, row_column_names: list[str], col_column_name: str, value_column_name: str) -> Table:
+def pivot(source: Table, row_cols: list[str], column_col: str, value_col: str) -> Table:
     # Partition the source by column
-    partitioned_source = source.partition_by(col_column_name)
-    pvt = _do_multijoin(partitioned_source, row_column_names, col_column_name, value_column_name)
+    partitioned_source = source.partition_by(column_col)
+    pvt = _do_multijoin(partitioned_source, row_cols, column_col, value_col)
     return pvt
 
 

--- a/py/server/deephaven/experimental/pivot.py
+++ b/py/server/deephaven/experimental/pivot.py
@@ -1,3 +1,5 @@
+"""This module defines functions for creating pivot tables."""
+
 from typing import Sequence, List, Union, Protocol
 import random
 import re
@@ -7,6 +9,7 @@ from deephaven.table import Table, PartitionedTable, multi_join
 from deephaven.numpy import to_numpy
 from deephaven.update_graph import auto_locking_ctx
 from deephaven.jcompat import to_sequence
+
 
 def _legalize_column(s: str) -> str:
     """Legalize a column name.
@@ -21,7 +24,7 @@ def _legalize_column(s: str) -> str:
         ValueError: If the column name is empty.
     """
 
-    #TODO: This is not a good way to legalize a column name.  It is not guaranteed to be unique.
+    # TODO: This is not a good way to legalize a column name.  It is not guaranteed to be unique.
     # Instead of legalizing the column name, it would be preferable to assign known names, and index them by the names table;
     # using some kind of display name.  We don't know that we'll actually replace stuff to be unique here,
     # which means this is not actually correct.
@@ -31,8 +34,6 @@ def _legalize_column(s: str) -> str:
     if re.match("^[_a-zA-Z].*$", s):
         return re.sub("[^_a-zA-Z0-9]", "_", s)
     return "_" + re.sub("[^_a-zA-Z0-9]", "_", s)
-
-#TODO: pydoc
 
 
 def pivot(table: Table, row_cols: Union[str, Sequence[str]], column_col: str, value_col: str) -> Table:
@@ -56,7 +57,7 @@ def pivot(table: Table, row_cols: Union[str, Sequence[str]], column_col: str, va
 
     # Locking to ensure that the partitioned table doesn't change while creating the query
     with auto_locking_ctx(ptable):
-        #TODO: this does not handle key changes in the constituent tables.  It should.
+        # TODO: this does not handle key changes in the constituent tables.  It should.
         keys = ptable.keys()
         key_values = to_numpy(table=keys, cols=[column_col])
 
@@ -65,24 +66,25 @@ def pivot(table: Table, row_cols: Union[str, Sequence[str]], column_col: str, va
 
         tables = [
             con.view(row_cols + [f"{_legalize_column(str(key_values[ki][0]))}={value_col}"])
-                for ki, con in enumerate(ptable.constituent_tables)
+            for ki, con in enumerate(ptable.constituent_tables)
         ]
 
     return multi_join(input=tables, on=row_cols).table()
 
 
-#TODO: delete below here
+# TODO: delete below here
 
 # # Java wrappers
 random_class = jpy.get_type("java.util.Random")
 random_inst = random_class(0)
 
-y=empty_table(1000).select(["Row=ii%10", "Col=(int)((ii/10) % 30)", "Sentinel=random_inst.nextDouble()"]).where("Sentinel > 0.3")
+y = empty_table(1000).select(["Row=ii%10", "Col=(int)((ii/10) % 30)", "Sentinel=random_inst.nextDouble()"]).where(
+    "Sentinel > 0.3")
 
 # first part of the pivot is getting unique row and column values
 ys = y.sum_by(["Row", "Col"])
 
-pvt=pivot(ys, ["Row"], "Col", "Sentinel")
+pvt = pivot(ys, ["Row"], "Col", "Sentinel")
 # 
 # # we have no real sector data, but it is nice for an example
 # #sectors = ["Apples", "Bananas", "Carrots", "Eggplant", "Fig"]

--- a/py/server/tests/test_pivot.py
+++ b/py/server/tests/test_pivot.py
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+#
+
+from tests.testbase import BaseTestCase
+from deephaven import new_table
+from deephaven.column import int_col
+from deephaven.experimental.pivot import pivot
+
+
+class PivotTestCase(BaseTestCase):
+
+    def test_pivot_1_row(self):
+        input = new_table([
+            int_col("Row", [1, 2, 3, 1, 2, 3]),
+            int_col("Col", [1, 1, 1, 2, 2, 2]),
+            int_col("Value", [10, 20, 30, 40, 50, 60])
+        ])
+
+        with self.subTest("pivot - 1 row col"):
+            p = pivot(input, "Row", "Col", "Value")
+
+            target = new_table([
+                int_col("Row", [1, 2, 3]),
+                int_col("_1", [10, 20, 30]),
+                int_col("_2", [40, 50, 60]),
+            ])
+
+            d = table_diff(p, target)
+            self.assertEqual(d, "")
+
+        with self.subTest("pivot - 1 row col - value_to_col_name"):
+            p = pivot(input, "Row", "Col", "Value", value_to_col_name=lambda x: f"Col_{x}")
+
+            target = new_table([
+                int_col("Row", [1, 2, 3]),
+                int_col("Col_1", [10, 20, 30]),
+                int_col("Col_2", [40, 50, 60]),
+            ])
+
+            d = table_diff(p, target)
+            self.assertEqual(d, "")
+
+    def test_pivot_2_row(self):
+        input = new_table([
+            int_col("Row1", [1, 2, 2, 1, 2, 2]),
+            int_col("Row2", [1, 2, 3, 1, 2, 3]),
+            int_col("Col", [1, 1, 1, 2, 2, 2]),
+            int_col("Value", [10, 20, 30, 40, 50, 60])
+        ])
+
+        with self.subTest("pivot - 2 row col"):
+            p = pivot(input, ["Row1", "Row2"], "Col", "Value")
+
+            target = new_table([
+                int_col("Row1", [1, 2, 2]),
+                int_col("Row2", [1, 2, 3]),
+                int_col("_1", [10, 20, 30]),
+                int_col("_2", [40, 50, 60]),
+            ])
+
+            d = table_diff(p, target)
+            self.assertEqual(d, "")
+
+        with self.subTest("pivot - 2 row col - value_to_col_name"):
+            p = pivot(input, ["Row1", "Row2"], "Col", "Value", value_to_col_name=lambda x: f"Col_{x}")
+
+            target = new_table([
+                int_col("Row1", [1, 2, 2]),
+                int_col("Row2", [1, 2, 3]),
+                int_col("Col_1", [10, 20, 30]),
+                int_col("Col_2", [40, 50, 60]),
+            ])
+
+            d = table_diff(p, target)
+            self.assertEqual(d, "")
+
+    def test_pivot_errors(self):
+        input = new_table([
+            int_col("Row", [1, 2, 3, 1, 2, 3]),
+            int_col("Col", [1, 1, 1, 2, 2, 2]),
+            int_col("Value", [10, 20, 30, 40, 50, 60])
+        ])
+
+        with self.subTest("pivot - non-string col_name"):
+            with self.assertRaises(DHError) as cm:
+                p = pivot(input, "Row", "Col", "Value", value_to_col_name=lambda x: 1.0)
+            self.assertIn("Value does not map to a string", str(cm.exception))
+
+        with self.subTest("pivot - invalid col_name"):
+            with self.assertRaises(DHError) as cm:
+                p = pivot(input, "Row", "Col", "Value", value_to_col_name=lambda x: f".{x}#")
+            self.assertIn("Value maps to an invalid column name", str(cm.exception))
+
+        with self.subTest("pivot - duplicate col_name"):
+            with self.assertRaises(DHError) as cm:
+                p = pivot(input, "Row", "Col", "Value", value_to_col_name=lambda x: "Col")
+            self.assertIn("Value maps to a duplicate column name", str(cm.exception))

--- a/py/server/tests/test_pivot.py
+++ b/py/server/tests/test_pivot.py
@@ -3,9 +3,10 @@
 #
 
 from tests.testbase import BaseTestCase
-from deephaven import new_table
+from deephaven import DHError, new_table
 from deephaven.column import int_col
 from deephaven.experimental.pivot import pivot
+from deephaven.table import table_diff
 
 
 class PivotTestCase(BaseTestCase):


### PR DESCRIPTION
Add support for computing pivot tables.

Example:
```python
from deephaven import empty_table

y = empty_table(1000).select(["Row=ii%10", "Col=(int)((ii/10) % 30)", "Sentinel=random()"]).where(
    "Sentinel > 0.3")
ys = y.sum_by(["Row", "Col"])

pvt = pivot(ys, ["Row"], "Col", "Sentinel")
pvt2 = pivot(ys, "Row", "Col", "Sentinel", lambda x: f"Col_{x}")
```