### PR TITLE
fix: JS charts should handle shifts, read subscription data by key

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
@@ -298,7 +298,7 @@ public abstract class AbstractTableSubscription extends HasEventHandling {
     }
 
     /**
-     * TableData type for both viewports and full table subscriptions.
+     * TableData type for full table subscriptions.
      */
     @TsIgnore
     public static class SubscriptionEventData extends UpdateEventData implements ViewportData, SubscriptionTableData {
@@ -327,6 +327,28 @@ public abstract class AbstractTableSubscription extends HasEventHandling {
             return fullRowSet;
         }
     }
+
+    /**
+     * TableData type for viewport subscriptions.
+     */
+    @TsIgnore
+    public static class ViewportEventData extends SubscriptionEventData {
+        public ViewportEventData(WebBarrageSubscription subscription, int rowStyleColumn, JsArray<Column> columns,
+                                     RangeSet added, RangeSet removed, RangeSet modified, ShiftedRange[] shifted) {
+            super(subscription, rowStyleColumn, columns, added, removed, modified, shifted);
+        }
+
+        @Override
+        public Any getData(long key, Column column) {
+            return super.getData(fullRowSet.getRange().get(key), column);
+        }
+
+        @Override
+        public Format getFormat(long index, Column column) {
+            return super.getFormat(fullRowSet.getRange().get(index), column);
+        }
+    }
+
 
     /**
      * Base type to allow trees to extend from here separately from tables.
@@ -403,7 +425,7 @@ public abstract class AbstractTableSubscription extends HasEventHandling {
 
         @Override
         public Any getData(long key, Column column) {
-            return subscription.getData(fullRowSet.getRange().get(key), column.getIndex());
+            return subscription.getData(key, column.getIndex());
         }
 
         @Override
@@ -413,24 +435,23 @@ public abstract class AbstractTableSubscription extends HasEventHandling {
 
         @Override
         public Format getFormat(long index, Column column) {
-            long key = fullRowSet.getRange().get(index);
             long cellColors = 0;
             long rowColors = 0;
             String numberFormat = null;
             String formatString = null;
             if (column.getStyleColumnIndex() != null) {
-                LongWrapper wrapper = subscription.getData(key, column.getStyleColumnIndex()).uncheckedCast();
+                LongWrapper wrapper = subscription.getData(index, column.getStyleColumnIndex()).uncheckedCast();
                 cellColors = wrapper == null ? 0 : wrapper.getWrapped();
             }
             if (rowStyleColumn != NO_ROW_FORMAT_COLUMN) {
-                LongWrapper wrapper = subscription.getData(key, column.getStyleColumnIndex()).uncheckedCast();
+                LongWrapper wrapper = subscription.getData(index, column.getStyleColumnIndex()).uncheckedCast();
                 rowColors = wrapper == null ? 0 : wrapper.getWrapped();
             }
             if (column.getFormatStringColumnIndex() != null) {
-                numberFormat = subscription.getData(key, column.getFormatStringColumnIndex()).uncheckedCast();
+                numberFormat = subscription.getData(index, column.getFormatStringColumnIndex()).uncheckedCast();
             }
             if (column.getFormatStringColumnIndex() != null) {
-                formatString = subscription.getData(key, column.getFormatStringColumnIndex()).uncheckedCast();
+                formatString = subscription.getData(index, column.getFormatStringColumnIndex()).uncheckedCast();
             }
             return new Format(cellColors, rowColors, numberFormat, formatString);
         }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
@@ -334,7 +334,7 @@ public abstract class AbstractTableSubscription extends HasEventHandling {
     @TsIgnore
     public static class ViewportEventData extends SubscriptionEventData {
         public ViewportEventData(WebBarrageSubscription subscription, int rowStyleColumn, JsArray<Column> columns,
-                                     RangeSet added, RangeSet removed, RangeSet modified, ShiftedRange[] shifted) {
+                RangeSet added, RangeSet removed, RangeSet modified, ShiftedRange[] shifted) {
             super(subscription, rowStyleColumn, columns, added, removed, modified, shifted);
         }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -139,7 +139,7 @@ public class TableViewportSubscription extends AbstractTableSubscription {
         if (rowsAdded.size() != rowsRemoved.size() && originalActive) {
             fireEventWithDetail(JsTable.EVENT_SIZECHANGED, size());
         }
-        UpdateEventData detail = new SubscriptionEventData(barrageSubscription, rowStyleColumn, getColumns(), rowsAdded,
+        UpdateEventData detail = new ViewportEventData(barrageSubscription, rowStyleColumn, getColumns(), rowsAdded,
                 rowsRemoved, totalMods, shifted);
 
         detail.setOffset(this.viewportRowSet.getFirstRow());

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/FigureSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/FigureSubscription.java
@@ -258,11 +258,11 @@ public final class FigureSubscription {
             this.currentData = new ChartData(table);
             sub.addEventListener(TableSubscription.EVENT_UPDATED, e -> {
                 // refire with specifics for the columns that we're watching here, after updating data arrays
-                AbstractTableSubscription.UpdateEventData subscriptionUpdateData =
-                        (AbstractTableSubscription.UpdateEventData) e.detail;
+                AbstractTableSubscription.SubscriptionEventData subscriptionUpdateData =
+                        (AbstractTableSubscription.SubscriptionEventData) e.detail;
                 currentData.update(subscriptionUpdateData);
 
-                CustomEventInit event = CustomEventInit.create();
+                CustomEventInit<DataUpdateEvent> event = CustomEventInit.create();
                 event.setDetail(new DataUpdateEvent(includedSeries.toArray(new JsSeries[0]), currentData,
                         subscriptionUpdateData));
                 figure.fireEvent(JsFigure.EVENT_UPDATED, event);
@@ -271,7 +271,7 @@ public final class FigureSubscription {
                     firstEventFired = true;
 
                     if (downsampleAxisRange != null) {
-                        CustomEventInit successInit = CustomEventInit.create();
+                        CustomEventInit<Object[]> successInit = CustomEventInit.create();
                         successInit.setDetail(includedSeries.toArray());
                         figure.fireEvent(JsFigure.EVENT_DOWNSAMPLEFINISHED, successInit);
                     }

--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
@@ -668,6 +668,9 @@ public class RangeSet {
         if (key == 0) {
             return getFirstRow();
         }
+        if (key >= size()) {
+            return -1;
+        }
         ensureCardinalityCache();
 
         int pos = Arrays.binarySearch(cardinality, key);

--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
@@ -400,6 +400,22 @@ public class RangeSet {
         return sortedRanges.iterator();
     }
 
+    public Iterator<Range> reverseRangeIterator() {
+        return new Iterator<>() {
+            int i = sortedRanges.size();
+
+            @Override
+            public boolean hasNext() {
+                return i > 0;
+            }
+
+            @Override
+            public Range next() {
+                return sortedRanges.get(--i);
+            }
+        };
+    }
+
     public PrimitiveIterator.OfLong indexIterator() {
         if (isEmpty()) {
             return LongStream.empty().iterator();
@@ -664,6 +680,67 @@ public class RangeSet {
         return result;
     }
 
+    /**
+     *
+     * @param keys
+     * @return
+     */
+    public RangeSet invert(RangeSet keys) {
+        if (keys.isEmpty()) {
+            return empty();
+        }
+        if (isEmpty()) {
+            throw new IllegalArgumentException("Keys not found: " + keys);
+        }
+        ensureCardinalityCache();
+
+        List<Range> positions = new ArrayList<>();
+
+        int from = 0;
+
+        Iterator<Range> keysIter = keys.rangeIterator();
+        long startPos = -1;
+        long endPos = Long.MIN_VALUE;
+        while (keysIter.hasNext()) {
+            Range nextKeyRange = keysIter.next();
+
+            int index = Collections.binarySearch(sortedRanges.subList(from, sortedRanges.size()), nextKeyRange);
+            if (index < 0) {
+                index = -index - 2;// examine the previous element
+            }
+            index += from;
+            if (index < 0) {
+                throw new IllegalArgumentException("Key " + nextKeyRange.getFirst() + " not found");
+            }
+            Range target = sortedRanges.get(index);
+
+            long newStartPos =
+                    (index == 0 ? 0 : this.cardinality[index - 1]) + (nextKeyRange.getFirst() - target.getFirst());
+            if (newStartPos - 1 == endPos) {
+                // nothing to do, only grow the existing range
+                // endPos = newStartPos + (nextKeyRange.size() - 1);
+            } else {
+                // append the existing range and start a new one
+                if (endPos != Long.MIN_VALUE) {
+                    positions.add(new Range(startPos, endPos));
+                }
+
+                startPos = newStartPos;
+                // endPos = startPos + (nextKeyRange.size() - 1);
+            }
+            endPos = newStartPos + (nextKeyRange.size() - 1);
+
+            from = index;
+        }
+        assert endPos != Long.MIN_VALUE;
+        positions.add(new Range(startPos, endPos));
+
+        RangeSet result = RangeSet.fromSortedRanges(positions.toArray(new Range[0]));
+        assert result.size() == keys.size();
+        return result;
+    }
+
+
     public long get(long key) {
         if (key == 0) {
             return getFirstRow();
@@ -673,7 +750,7 @@ public class RangeSet {
         }
         ensureCardinalityCache();
 
-        int pos = Arrays.binarySearch(cardinality, key);
+        int pos = Arrays.binarySearch(cardinality, 0, sortedRanges.size(), key);
 
         if (pos >= 0) {
             return sortedRanges.get(pos + 1).getFirst();

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
@@ -565,6 +565,9 @@ public class RangeSetTest {
         for (int i = 0; i < rows.length; i++) {
             assertEquals("i=" + i, rows[i], initialRange.get(i));
         }
+        assertEquals(-1, initialRange.get(rows.length));
+        assertEquals(-1, initialRange.get(rows.length + 1));
+        assertEquals(-1, initialRange.get(rows.length + 100));
 
         initialRange.removeRange(new Range(0, 1));
     }

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 
@@ -634,5 +635,43 @@ public class RangeSetTest {
                 new ShiftedRange(new Range(29022, 29024), -1),
                 new ShiftedRange(new Range(29026, 29026), -2),
         });
+    }
+
+    @Test
+    public void testInvert() {
+        RangeSet r = RangeSet.ofItems(4, 5, 7, 9, 10);
+
+        assertEquals(RangeSet.ofRange(0, 4), r.invert(r));
+        assertEquals(RangeSet.empty(), r.invert(RangeSet.empty()));
+        assertEquals(RangeSet.ofItems(0, 2, 4), r.invert(RangeSet.ofItems(4, 7, 10)));
+        assertEquals(RangeSet.ofItems(1, 2, 3), r.invert(RangeSet.ofItems(5, 7, 9)));
+
+        RangeSet positions = RangeSet.ofItems(18, 37, 83, 88);
+        RangeSet keys = RangeSet.fromSortedRanges(new Range[]{
+                        new Range(1073739467, 1073739511), new Range(1073739568, 1073739639), new Range(1073739700, 1073739767),
+                        new Range(1073739828, 1073739895), new Range(1073739956, 1073740023), new Range(1073740083, 1073740151),
+                        new Range(1073740214, 1073740279), new Range(1073740342, 1073740407), new Range(1073740464, 1073740535),
+                        new Range(1073740597, 1073740663), new Range(1073740725, 1073740791), new Range(1073740851, 1073740924),
+                        new Range(1073740937, 1073741052), new Range(1073741063, 1073741180), new Range(1073741189, 1073741308),
+                        new Range(1073741310, 1073741436), new Range(1073741440, 1073741564), new Range(1073741569, 1073741692),
+                        new Range(1073741696, 1073741948), new Range(1073741968, 1073742065), new Range(1073742096, 1073742184),
+                        new Range(1073742224, 1073742325), new Range(1073742352, 1073742454), new Range(1073742480, 1073742579),
+                        new Range(1073742608, 1073742702), new Range(1073742736, 1073742840), new Range(1073742864, 1073742967),
+                        new Range(1073742992, 1073743084), new Range(1073743120, 1073743218), new Range(1073743248, 1073743348),
+                        new Range(1073743376, 1073743465), new Range(1073743504, 1073743597), new Range(1073743632, 1073743741),
+                        new Range(1073743760, 1073743869), new Range(1073743888, 1073743912)
+                }
+        );
+        RangeSet selected = RangeSet.ofItems(1073739485, 1073739504, 1073739606, 1073739611);
+        PrimitiveIterator.OfLong selectedIter = selected.indexIterator();
+        PrimitiveIterator.OfLong positionsIter = positions.indexIterator();
+        while (selectedIter.hasNext()) {
+            assert positionsIter.hasNext();
+            long s = selectedIter.nextLong();
+            long p = positionsIter.nextLong();
+            assertEquals(s, keys.get(p));
+        }
+        assert !positionsIter.hasNext();
+        assertEquals(positions, keys.invert(selected));
     }
 }

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
@@ -647,21 +647,20 @@ public class RangeSetTest {
         assertEquals(RangeSet.ofItems(1, 2, 3), r.invert(RangeSet.ofItems(5, 7, 9)));
 
         RangeSet positions = RangeSet.ofItems(18, 37, 83, 88);
-        RangeSet keys = RangeSet.fromSortedRanges(new Range[]{
-                        new Range(1073739467, 1073739511), new Range(1073739568, 1073739639), new Range(1073739700, 1073739767),
-                        new Range(1073739828, 1073739895), new Range(1073739956, 1073740023), new Range(1073740083, 1073740151),
-                        new Range(1073740214, 1073740279), new Range(1073740342, 1073740407), new Range(1073740464, 1073740535),
-                        new Range(1073740597, 1073740663), new Range(1073740725, 1073740791), new Range(1073740851, 1073740924),
-                        new Range(1073740937, 1073741052), new Range(1073741063, 1073741180), new Range(1073741189, 1073741308),
-                        new Range(1073741310, 1073741436), new Range(1073741440, 1073741564), new Range(1073741569, 1073741692),
-                        new Range(1073741696, 1073741948), new Range(1073741968, 1073742065), new Range(1073742096, 1073742184),
-                        new Range(1073742224, 1073742325), new Range(1073742352, 1073742454), new Range(1073742480, 1073742579),
-                        new Range(1073742608, 1073742702), new Range(1073742736, 1073742840), new Range(1073742864, 1073742967),
-                        new Range(1073742992, 1073743084), new Range(1073743120, 1073743218), new Range(1073743248, 1073743348),
-                        new Range(1073743376, 1073743465), new Range(1073743504, 1073743597), new Range(1073743632, 1073743741),
-                        new Range(1073743760, 1073743869), new Range(1073743888, 1073743912)
-                }
-        );
+        RangeSet keys = RangeSet.fromSortedRanges(new Range[] {
+                new Range(1073739467, 1073739511), new Range(1073739568, 1073739639), new Range(1073739700, 1073739767),
+                new Range(1073739828, 1073739895), new Range(1073739956, 1073740023), new Range(1073740083, 1073740151),
+                new Range(1073740214, 1073740279), new Range(1073740342, 1073740407), new Range(1073740464, 1073740535),
+                new Range(1073740597, 1073740663), new Range(1073740725, 1073740791), new Range(1073740851, 1073740924),
+                new Range(1073740937, 1073741052), new Range(1073741063, 1073741180), new Range(1073741189, 1073741308),
+                new Range(1073741310, 1073741436), new Range(1073741440, 1073741564), new Range(1073741569, 1073741692),
+                new Range(1073741696, 1073741948), new Range(1073741968, 1073742065), new Range(1073742096, 1073742184),
+                new Range(1073742224, 1073742325), new Range(1073742352, 1073742454), new Range(1073742480, 1073742579),
+                new Range(1073742608, 1073742702), new Range(1073742736, 1073742840), new Range(1073742864, 1073742967),
+                new Range(1073742992, 1073743084), new Range(1073743120, 1073743218), new Range(1073743248, 1073743348),
+                new Range(1073743376, 1073743465), new Range(1073743504, 1073743597), new Range(1073743632, 1073743741),
+                new Range(1073743760, 1073743869), new Range(1073743888, 1073743912)
+        });
         RangeSet selected = RangeSet.ofItems(1073739485, 1073739504, 1073739606, 1073739611);
         PrimitiveIterator.OfLong selectedIter = selected.indexIterator();
         PrimitiveIterator.OfLong positionsIter = positions.indexIterator();


### PR DESCRIPTION
Only viewport subscriptions should read data (and formatting) by
position. Also fixes an error where -1 was not returned when an invalid
position was checked in a RangeSet.

Fixes #6074
Fixes #2435