### PR TITLE
chore: Bump commons-text to 1.12.0

### DIFF
--- a/engine/context/build.gradle
+++ b/engine/context/build.gradle
@@ -19,8 +19,6 @@ dependencies {
 
     implementation libs.f4b6a3.uuid.creator
 
-    implementation libs.commons.text
-
     compileOnly project(':util-immutables')
     annotationProcessor libs.immutables.value
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ commons-compress = "1.26.0"
 commons-io = "2.11.0"
 commons-lang3 = "3.12.0"
 commons-math3 = "3.6.1"
-commons-text = "1.10.0"
+commons-text = "1.12.0"
 # confluent and confluent-kafak-clients should be kept in-sync
 confluent = "7.6.0"
 confluent-kafka-clients = "7.6.0-ccs"


### PR DESCRIPTION
Bumps commons-text from 1.10.0 to 1.12.0, which contain a number of bug fixes.

Also, removes an unused dependency on commons-text from engine-context.

See https://commons.apache.org/proper/commons-text/changes-report.html#a1.11.0
See https://commons.apache.org/proper/commons-text/changes-report.html#a1.12.0