### PR TITLE
feat(cpp-client): Additional Cython support for LocalDate and LocalTime

### DIFF
--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
@@ -247,4 +247,6 @@ private:
 using BooleanArrayColumnSource = GenericArrayColumnSource<bool>;
 using StringArrayColumnSource = GenericArrayColumnSource<std::string>;
 using DateTimeArrayColumnSource = GenericArrayColumnSource<DateTime>;
+using LocalDateArrayColumnSource = GenericArrayColumnSource<LocalDate>;
+using LocalTimeArrayColumnSource = GenericArrayColumnSource<LocalTime>;
 }  // namespace deephaven::dhcore::column

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -342,6 +342,21 @@ struct DeephavenTraits<LocalTime> {
  */
 class DateTime {
 public:
+  using rep_t = int64_t;
+
+  /**
+   * This method exists to document and enforce an assumption in Cython, namely that this
+   * class has the same representation as an int64_t. This constexpr method always returns
+   * true (or fails to compile).
+   */
+  static constexpr bool IsBlittableToInt64() {
+    static_assert(
+        std::is_trivially_copyable_v<DateTime> &&
+        std::has_unique_object_representations_v<DateTime> &&
+        std::is_same_v<rep_t, std::int64_t>);
+    return true;
+  }
+
   /**
    * Converts nanoseconds-since-UTC-epoch to DateTime. The Deephaven null value sentinel is
    * turned into DateTime(0).
@@ -431,6 +446,21 @@ private:
  */
 class LocalDate {
 public:
+  using rep_t = int64_t;
+
+  /**
+   * This method exists to document and enforce an assumption in Cython, namely that this
+   * class has the same representation as an int64_t. This constexpr method always returns
+   * true (or fails to compile).
+   */
+  static constexpr bool IsBlittableToInt64() {
+    static_assert(
+        std::is_trivially_copyable_v<LocalDate> &&
+            std::has_unique_object_representations_v<LocalDate> &&
+            std::is_same_v<rep_t, std::int64_t>);
+    return true;
+  }
+
   /**
    * Creates an instance of LocalDate from the specified year, month, and day.
    */
@@ -488,6 +518,21 @@ private:
  */
 class LocalTime {
 public:
+  using rep_t = int64_t;
+
+  /**
+   * This method exists to document and enforce an assumption in Cython, namely that this
+   * class has the same representation as an int64_t. This constexpr method always returns
+   * true (or fails to compile).
+   */
+  static constexpr bool IsBlittableToInt64() {
+    static_assert(
+        std::is_trivially_copyable_v<LocalTime> &&
+            std::has_unique_object_representations_v<LocalTime> &&
+            std::is_same_v<rep_t, std::int64_t>);
+    return true;
+  }
+
   /**
    * Creates an instance of LocalTime from the specified hour, minute, and second.
    */

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
@@ -20,6 +20,10 @@ public:
       const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements);
   static std::shared_ptr<ColumnSource> CreateDateTimeColumnSource(const int64_t *data_begin, const int64_t *data_end,
       const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements);
+  static std::shared_ptr<ColumnSource> CreateLocalDateColumnSource(const int64_t *data_begin, const int64_t *data_end,
+      const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements);
+  static std::shared_ptr<ColumnSource> CreateLocalTimeColumnSource(const int64_t *data_begin, const int64_t *data_end,
+      const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements);
 
   static ElementTypeId::Enum GetElementTypeId(const ColumnSource &column_source);
 };

--- a/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
@@ -15,6 +15,8 @@ using deephaven::dhcore::column::BooleanArrayColumnSource;
 using deephaven::dhcore::column::ColumnSource;
 using deephaven::dhcore::column::ColumnSourceVisitor;
 using deephaven::dhcore::column::DateTimeArrayColumnSource;
+using deephaven::dhcore::column::LocalDateArrayColumnSource;
+using deephaven::dhcore::column::LocalTimeArrayColumnSource;
 using deephaven::dhcore::column::StringArrayColumnSource;
 
 namespace deephaven::dhcore::utility {
@@ -63,6 +65,34 @@ CythonSupport::CreateDateTimeColumnSource(const int64_t *data_begin, const int64
   }
   populateArrayFromPackedData(validity_begin, nulls.get(), num_elements, true);
   return DateTimeArrayColumnSource::CreateFromArrays(std::move(elements), std::move(nulls),
+      num_elements);
+}
+
+std::shared_ptr<ColumnSource>
+CythonSupport::CreateLocalDateColumnSource(const int64_t *data_begin, const int64_t *data_end,
+    const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements) {
+  auto elements = std::make_unique<LocalDate[]>(num_elements);
+  auto nulls = std::make_unique<bool[]>(num_elements);
+
+  for (size_t i = 0; i != num_elements; ++i) {
+    elements[i] = LocalDate(data_begin[i]);
+  }
+  populateArrayFromPackedData(validity_begin, nulls.get(), num_elements, true);
+  return LocalDateArrayColumnSource::CreateFromArrays(std::move(elements), std::move(nulls),
+      num_elements);
+}
+
+std::shared_ptr<ColumnSource>
+CythonSupport::CreateLocalTimeColumnSource(const int64_t *data_begin, const int64_t *data_end,
+    const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements) {
+  auto elements = std::make_unique<LocalTime[]>(num_elements);
+  auto nulls = std::make_unique<bool[]>(num_elements);
+
+  for (size_t i = 0; i != num_elements; ++i) {
+    elements[i] = LocalTime(data_begin[i]);
+  }
+  populateArrayFromPackedData(validity_begin, nulls.get(), num_elements, true);
+  return LocalTimeArrayColumnSource::CreateFromArrays(std::move(elements), std::move(nulls),
       num_elements);
 }
 


### PR DESCRIPTION
This PR adds the methods `CreateLocalDateColumnSource` and `CreateLocalTimeColumnSource` for the benefit of Cython.

Also it adds the constexpr method `IsBlittableToInt64` to `DateTime`, `LocalDate`, and `LocalTime`. This method always returns true (and in fact will fail to compile otherwise). It is useful so that the Cython can have `static_assert`s that confirm that this is tgrue.
