### PR TITLE
feat: Support all java.lang.Math in the query language

### DIFF
--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3393,7 +3393,23 @@ public class Numeric {
     //TODO NEW STUFF --- delete this line
 
     /**
-     * Returns the arc tangent of a value; the returned angle is in the range -pi/2 through pi/2.
+     * Returns the angle theta from the conversion of rectangular coordinates (x, y) to polar coordinates (r, theta).
+     * This method computes the phase theta by computing an arc tangent of y/x in the range of -pi to pi.
+     * Special cases:
+     * <ul>
+     *   <li>If either argument is NaN, then the result is NaN.</li>
+     *   <li>If the first argument is positive zero and the second argument is positive, or the first argument is positive and finite and the second argument is positive infinity, then the result is positive zero.</li>
+     *   <li>If the first argument is negative zero and the second argument is positive, or the first argument is negative and finite and the second argument is positive infinity, then the result is negative zero.</li>
+     *   <li>If the first argument is positive zero and the second argument is negative, or the first argument is positive and finite and the second argument is negative infinity, then the result is the double value closest to pi.</li>
+     *   <li>If the first argument is negative zero and the second argument is negative, or the first argument is negative and finite and the second argument is negative infinity, then the result is the double value closest to -pi.</li>
+     *   <li>If the first argument is positive and the second argument is positive zero or negative zero, or the first argument is positive infinity and the second argument is finite, then the result is the double value closest to pi/2.</li>
+     *   <li>If the first argument is negative and the second argument is positive zero or negative zero, or the first argument is negative infinity and the second argument is finite, then the result is the double value closest to -pi/2.</li>
+     *   <li>If both arguments are positive infinity, then the result is the double value closest to pi/4.</li>
+     *   <li>If the first argument is positive infinity and the second argument is negative infinity, then the result is the double value closest to 3*pi/4.</li>
+     *   <li>If the first argument is negative infinity and the second argument is positive infinity, then the result is the double value closest to -pi/4.</li>
+     *   <li>If both arguments are negative infinity, then the result is the double value closest to -3*pi/4.</li>
+     * </ul>
+     * The computed result must be within 2 ulps of the exact result. Results must be semi-monotonic.
      *
      * @param y the ordinate coordinate
      * @param x the abscissa coordinate

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3663,15 +3663,42 @@ public class Numeric {
       * @param x the value.
       * @return the natural logarithm of the sum of the argument and 1.  If the value is null, returns null.
       */
-      static public double log1p(${pt.primitive} x) {
+     static public double log1p(${pt.primitive} x) {
         if(isNull(x)) {
             return NULL_DOUBLE;
         }
 
         return Math.log1p(x);
-      }
+     }
 
-        //TODO:  multiplyExact
+     <#if pt.valueType.isInteger>
+     /**
+      * Returns the product of the arguments, throwing an exception if the result overflows.
+      *
+      * @param x the first value.
+      * @param y the second value.
+      * @return the result of multiplying the arguments.  If either value is null, returns null.
+      * @throws ArithmeticException if the result overflows.
+      */
+     static public ${pt.primitive} multiplyExact(${pt.primitive} x, ${pt.primitive} y) {
+         if (isNull(x) || isNull(y)) {
+             return ${pt.null};
+         }
+
+         <#if pt.primitive == "byte" || pt.primitive == "short">
+         int val = Math.multiplyExact(x, y);
+
+         if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            throw new ArithmeticException("Overflow: " + x + " * " + y);
+         }
+
+         return (${pt.primitive}) val;
+         <#else>
+         return Math.multiplyExact(x, y);
+         </#if>
+     }
+     </#if>
+
         //TODO:  negateExact
         //TODO:  nextAfter
         //TODO:  nextDown

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3966,7 +3966,24 @@ public class Numeric {
     }
     </#if>
 
-        //TODO:  ulp
+    <#if pt.valueType.isFloat>
+    /**
+     * Returns the size of an ulp of the argument. An ulp, unit in the last place, of a double value is the positive
+     * distance between this floating-point value and the double value next larger in magnitude.
+     * Note that for non-NaN x, ulp(-x) == ulp(x).
+     *
+     * @param x the value.
+     * @return the size of an ulp of the argument.  If the value is null, returns null.
+     */
+    static public ${pt.primitive} ulp(${pt.primitive} x) {
+        if(isNull(x)) {
+            return ${pt.null};
+        }
+
+        return Math.ulp(x);
+    }
+    </#if>
+
         //TODO:  E (constant)
         //TODO:  PI (constant)
         

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3895,7 +3895,77 @@ public class Numeric {
         return Math.toRadians(x);
     }
 
-        //TODO:  toIntExact
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the value of the argument as an int, throwing an exception if the value overflows an int.
+     *
+     * @param x the value.
+     * @return the value as an int.  If either value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public int toIntExact(${pt.primitive} x) {
+        if (isNull(x)) {
+            return NULL_INT;
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short" || pt.primitive == "int" >
+        return x;
+        <#else>
+        return Math.toIntExact(x);
+        </#if>
+    }
+    </#if>
+
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the value of the argument as a short, throwing an exception if the value overflows a short.
+     *
+     * @param x the value.
+     * @return the value as a short.  If either value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public short toShortExact(${pt.primitive} x) {
+        if (isNull(x)) {
+            return NULL_SHORT;
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short" >
+        return x;
+        <#else>
+        if (x > Short.MAX_VALUE || x < Short.MIN_VALUE) {
+            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a short" + x);
+        }
+
+        return (short) x;
+        </#if>
+    }
+    </#if>
+
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the value of the argument as a byte, throwing an exception if the value overflows a byte.
+     *
+     * @param x the value.
+     * @return the value as a byte.  If either value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public short toByteExact(${pt.primitive} x) {
+        if (isNull(x)) {
+            return NULL_BYTE;
+        }
+
+        <#if pt.primitive == "byte" >
+        return x;
+        <#else>
+        if (x > Byte.MAX_VALUE || x < Byte.MIN_VALUE) {
+            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a byte" + x);
+        }
+
+        return (byte) x;
+        </#if>
+    }
+    </#if>
+
         //TODO:  ulp
         //TODO:  E (constant)
         //TODO:  PI (constant)

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3667,7 +3667,13 @@ public class Numeric {
 
          return (${pt.primitive}) val;
          <#else>
-         return Math.multiplyExact(x, y);
+        ${pt.primitive} val = Math.multiplyExact(x, y);
+
+        if ( isNull(val) ) {
+            throw new ArithmeticException("Overflow: " + x + " * " + y);
+        }
+
+        return val;
          </#if>
      }
      </#if>
@@ -3694,7 +3700,7 @@ public class Numeric {
 
         return (${pt.primitive}) val;
         <#else>
-        if (x == ${pt.minValue}) {
+        if (x == ${pt.maxValue}) {
             throw new ArithmeticException("Overflow: " + x);
         }
 
@@ -3719,7 +3725,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short">
         int val = Math.decrementExact(x);
 
-        if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+        if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val) ) {
             throw new ArithmeticException("Overflow: " + x);
         }
 

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3593,6 +3593,23 @@ public class Numeric {
         return Math.hypot(x, y);
     }
 
+    <#if pt.valueType.isFloat>
+    /**
+     * Returns the IEEE 754 remainder of the division of the arguments.
+     *
+     * @param x the dividend.
+     * @param y the divisor.
+     * @return the IEEE 754 remainder of the division of the arguments.  If either value is null, returns null.
+     */
+    static public ${pt.primitive} IEEEremainder(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return ${pt.null};
+        }
+
+        return (${pt.primitive}) Math.IEEEremainder(x, y);
+    }
+    </#if>
+
         //TODO:  IEEEremainder
         //TODO:  incrementExact
         //TODO:  log10

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3482,7 +3482,7 @@ public class Numeric {
     }
 
     /**
-     * Returns the base 10 logarithm of a double value.
+     * Returns the base 10 logarithm of a value.
      *
      * @param x the value.
      * @return the base 10 logarithm of the value.  If the value is null, returns null.
@@ -3984,8 +3984,8 @@ public class Numeric {
 
     <#if pt.valueType.isFloat>
     /**
-     * Returns the size of an ulp of the argument. An ulp, unit in the last place, of a double value is the positive
-     * distance between this floating-point value and the double value next larger in magnitude.
+     * Returns the size of an ulp of the argument. An ulp, unit in the last place, of a value is the positive
+     * distance between this floating-point value and the value next larger in magnitude.
      * Note that for non-NaN x, ulp(-x) == ulp(x).
      *
      * @param x the value.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3390,41 +3390,7 @@ public class Numeric {
         return compare(v1 == null ? ${pt.null} : v1, v2 == null ? ${pt.null} : v2);
     }
 
-
-
-    //////////////////////////////// NEW //////////////////////////////////////
-    // TODO: document these
-    //TODO: group similar methods
-
-    <#if pt.valueType.isInteger>
-    /**
-     * Returns the sum of its arguments, throwing an exception if the result overflows.
-     *
-     * @param x the first value.
-     * @param y the second value.
-     * @return the result of adding the arguments.  If either value is null, returns null.
-     * @throws ArithmeticException if the result overflows.
-     */
-    static public ${pt.primitive} addExact(${pt.primitive} x, ${pt.primitive} y) {
-        if (isNull(x) || isNull(y)) {
-            return ${pt.null};
-        }
-
-        <#if pt.primitive == "byte" || pt.primitive == "short">
-        int val = Math.addExact(x, y);
-
-        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
-            //TODO: Should overflows return NULL or throw an exception?
-            throw new ArithmeticException("Overflow: " + x + " + " + y);
-        }
-
-        return (${pt.primitive}) val;
-        <#else>
-        //TODO: Should overflows return NULL or throw an exception?
-        return Math.addExact(x, y);
-        </#if>
-    }
-    </#if>
+    //TODO NEW STUFF --- delete this line
 
     /**
      * Returns the arc tangent of a value; the returned angle is in the range -pi/2 through pi/2.
@@ -3457,92 +3423,6 @@ public class Numeric {
     }
 
     /**
-     * Returns the first argument with the sign of the second argument.
-     *
-     * @param magnitude the value to return
-     * @param sign the sign for the return value
-     * @return the value with the magnitude of the first argument and the sign of the second argument.
-     *    If either value is null, returns null.
-     */
-    static public ${pt.primitive} copySign(${pt.primitive} magnitude, ${pt.primitive} sign) {
-        if (isNull(magnitude) || isNull(sign)) {
-            return ${pt.null};
-        }
-
-        <#if pt.valueType.isFloat >
-        return Math.copySign(magnitude, sign);
-        <#else>
-        return (${pt.primitive}) ((magnitude < 0 ? -magnitude : magnitude) * (sign < 0 ? -1 : 1));
-        </#if>
-    }
-
-    <#if pt.valueType.isInteger>
-    /**
-     * Returns the argument decremented by one, throwing an exception if the result overflows.
-     *
-     * @param x the value to decrement.
-     * @return the result of decrementing by one.  If the value is null, returns null.
-     * @throws ArithmeticException if the result overflows.
-     */
-    static public ${pt.primitive} decrementExact(${pt.primitive} x) {
-        if (isNull(x)) {
-            return ${pt.null};
-        }
-
-        <#if pt.primitive == "byte" || pt.primitive == "short">
-        int val = Math.decrementExact(x);
-
-        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
-            //TODO: Should overflows return NULL or throw an exception?
-            throw new ArithmeticException("Overflow: " + x);
-        }
-
-        return (${pt.primitive}) val;
-        <#else>
-        if (x == ${pt.minValue}) {
-            throw new ArithmeticException("Overflow: " + x);
-        }
-
-        //TODO: Should overflows return NULL or throw an exception?
-        return Math.decrementExact(x);
-        </#if>
-    }
-    </#if>
-
-    <#if pt.valueType.isInteger>
-    /**
-     * Returns the argument incremented by one, throwing an exception if the result overflows.
-     *
-     * @param x the value to increment.
-     * @return the result of increment by one.  If the value is null, returns null.
-     * @throws ArithmeticException if the result overflows.
-     */
-    static public ${pt.primitive} incrementExact(${pt.primitive} x) {
-        if (isNull(x)) {
-            return ${pt.null};
-        }
-
-        <#if pt.primitive == "byte" || pt.primitive == "short">
-        int val = Math.incrementExact(x);
-
-        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
-            //TODO: Should overflows return NULL or throw an exception?
-            throw new ArithmeticException("Overflow: " + x);
-        }
-
-        return (${pt.primitive}) val;
-        <#else>
-        if (x == ${pt.minValue}) {
-            throw new ArithmeticException("Overflow: " + x);
-        }
-
-        //TODO: Should overflows return NULL or throw an exception?
-        return Math.incrementExact(x);
-        </#if>
-    }
-    </#if>
-
-    /**
      * Returns the hyperbolic cosine.
      *
      * @param x the value
@@ -3569,6 +3449,295 @@ public class Numeric {
 
         return Math.expm1(x);
      }
+
+    /**
+     * Returns the hypotenuse of a right-angled triangle, sqrt(x2 +y2), without intermediate overflow or underflow.
+     *
+     * @param x the first value.
+     * @param y the second value.
+     * @return the hypotenuse of a right-angled triangle.  If either value is null, returns null.
+     */
+    static public double hypot(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.hypot(x, y);
+    }
+
+    /**
+     * Returns the base 10 logarithm of a double value.
+     *
+     * @param x the value.
+     * @return the base 10 logarithm of the value.  If the value is null, returns null.
+     */
+     static public double log10(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.log10(x);
+     }
+
+     /**
+      * Returns the natural logarithm of the sum of the argument and 1.
+      *
+      * @param x the value.
+      * @return the natural logarithm of the sum of the argument and 1.  If the value is null, returns null.
+      */
+     static public double log1p(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.log1p(x);
+     }
+
+     <#if pt.valueType.isFloat >
+     /**
+      * Returns x × 2^scaleFactor rounded as if performed by a single correctly rounded floating-point multiply to a
+      * member of the ${pt.primitive} value set.
+      *
+      * @param x the value.
+      * @param scaleFactor the scale factor.
+      * @return x × 2scaleFactor rounded as if performed by a single correctly rounded floating-point multiply to a
+      *     member of the double value set.  If the either value is null, returns null.
+      */
+     static public ${pt.primitive} scalb(${pt.primitive} x, int scaleFactor) {
+        if(isNull(x) || isNull(scaleFactor)) {
+            return ${pt.null};
+        }
+
+        return Math.scalb(x, scaleFactor);
+     }
+     </#if>
+
+     /**
+      * Returns the hyperbolic sine of a value.
+      *
+      * @param x the value
+      * @return the hyperbolic sine of the value.  If the value is null, returns null.
+      */
+     static public double sinh(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.sinh(x);
+     }
+
+     /**
+      * Returns the hyperbolic tangent of a value.
+      *
+      * @param x the value
+      * @return the hyperbolic tangent of the value.  If the value is null, returns null.
+      */
+     static public double tanh(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.tanh(x);
+     }
+
+    /**
+     * Returns the first argument with the sign of the second argument.
+     *
+     * @param magnitude the value to return
+     * @param sign the sign for the return value
+     * @return the value with the magnitude of the first argument and the sign of the second argument.
+     *    If either value is null, returns null.
+     */
+    static public ${pt.primitive} copySign(${pt.primitive} magnitude, ${pt.primitive} sign) {
+        if (isNull(magnitude) || isNull(sign)) {
+            return ${pt.null};
+        }
+
+        <#if pt.valueType.isFloat >
+        return Math.copySign(magnitude, sign);
+        <#else>
+        return (${pt.primitive}) ((magnitude < 0 ? -magnitude : magnitude) * (sign < 0 ? -1 : 1));
+        </#if>
+    }
+
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the sum of its arguments, throwing an exception if the result overflows.
+     *
+     * @param x the first value.
+     * @param y the second value.
+     * @return the result of adding the arguments.  If either value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} addExact(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return ${pt.null};
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+        int val = Math.addExact(x, y);
+
+        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            throw new ArithmeticException("Overflow: " + x + " + " + y);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        return Math.addExact(x, y);
+        </#if>
+    }
+    </#if>
+
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the difference of its arguments, throwing an exception if the result overflows.
+     *
+     * @param x the first value.
+     * @param y the second value.
+     * @return the result of subtracting the arguments.  If either value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} subtractExact(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return ${pt.null};
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+            int val = Math.subtractExact(x, y);
+
+            if( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
+            throw new ArithmeticException("Overflow: " + x + " + " + y);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        ${pt.primitive} val = Math.subtractExact(x, y);
+
+        if( isNull(val) ) {
+            throw new ArithmeticException("Overflow: " + x + " + " + y);
+        }
+
+        return val;
+        </#if>
+    }
+    </#if>
+
+     <#if pt.valueType.isInteger>
+     /**
+      * Returns the product of the arguments, throwing an exception if the result overflows.
+      *
+      * @param x the first value.
+      * @param y the second value.
+      * @return the result of multiplying the arguments.  If either value is null, returns null.
+      * @throws ArithmeticException if the result overflows.
+      */
+     static public ${pt.primitive} multiplyExact(${pt.primitive} x, ${pt.primitive} y) {
+         if (isNull(x) || isNull(y)) {
+             return ${pt.null};
+         }
+
+         <#if pt.primitive == "byte" || pt.primitive == "short">
+         int val = Math.multiplyExact(x, y);
+
+         if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            throw new ArithmeticException("Overflow: " + x + " * " + y);
+         }
+
+         return (${pt.primitive}) val;
+         <#else>
+         return Math.multiplyExact(x, y);
+         </#if>
+     }
+     </#if>
+
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the argument incremented by one, throwing an exception if the result overflows.
+     *
+     * @param x the value to increment.
+     * @return the result of increment by one.  If the value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} incrementExact(${pt.primitive} x) {
+        if (isNull(x)) {
+            return ${pt.null};
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+        int val = Math.incrementExact(x);
+
+        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        if (x == ${pt.minValue}) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return Math.incrementExact(x);
+        </#if>
+    }
+    </#if>
+
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the argument decremented by one, throwing an exception if the result overflows.
+     *
+     * @param x the value to decrement.
+     * @return the result of decrementing by one.  If the value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} decrementExact(${pt.primitive} x) {
+        if (isNull(x)) {
+            return ${pt.null};
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+        int val = Math.decrementExact(x);
+
+        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        if (x == ${pt.minValue}) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return Math.decrementExact(x);
+        </#if>
+    }
+    </#if>
+
+     <#if pt.valueType.isInteger>
+     /**
+      * Returns the negation of the argument, throwing an exception if the result overflows.
+      *
+      * @param x the value to negate.
+      * @return the negation of the argument.  If the value is null, returns null.
+      * @throws ArithmeticException if the result overflows.
+      */
+     public static ${pt.primitive} negateExact(${pt.primitive} x) {
+         if (isNull(x)) {
+             return ${pt.null};
+         }
+
+         <#if pt.primitive == "byte" || pt.primitive == "short">
+         int val = Math.negateExact(x);
+
+         if( val > ${pt.maxValue} || val < ${pt.minValue}) {
+            throw new ArithmeticException("Overflow: -" + x);
+         }
+
+         return (${pt.primitive}) val;
+         <#else>
+         return Math.negateExact(x);
+         </#if>
+     }
+     </#if>
 
     <#if pt.valueType.isInteger>
      /**
@@ -3623,20 +3792,7 @@ public class Numeric {
     }
     </#if>
 
-    /**
-     * Returns the hypotenuse of a right-angled triangle, sqrt(x2 +y2), without intermediate overflow or underflow.
-     *
-     * @param x the first value.
-     * @param y the second value.
-     * @return the hypotenuse of a right-angled triangle.  If either value is null, returns null.
-     */
-    static public double hypot(${pt.primitive} x, ${pt.primitive} y) {
-        if (isNull(x) || isNull(y)) {
-            return NULL_DOUBLE;
-        }
 
-        return Math.hypot(x, y);
-    }
 
     <#if pt.valueType.isFloat>
     /**
@@ -3655,88 +3811,9 @@ public class Numeric {
     }
     </#if>
 
-    /**
-     * Returns the base 10 logarithm of a double value.
-     *
-     * @param x the value.
-     * @return the base 10 logarithm of the value.  If the value is null, returns null.
-     */
-     static public double log10(${pt.primitive} x) {
-        if(isNull(x)) {
-            return NULL_DOUBLE;
-        }
 
-        return Math.log10(x);
-     }
 
-     /**
-      * Returns the natural logarithm of the sum of the argument and 1.
-      *
-      * @param x the value.
-      * @return the natural logarithm of the sum of the argument and 1.  If the value is null, returns null.
-      */
-     static public double log1p(${pt.primitive} x) {
-        if(isNull(x)) {
-            return NULL_DOUBLE;
-        }
 
-        return Math.log1p(x);
-     }
-
-     <#if pt.valueType.isInteger>
-     /**
-      * Returns the product of the arguments, throwing an exception if the result overflows.
-      *
-      * @param x the first value.
-      * @param y the second value.
-      * @return the result of multiplying the arguments.  If either value is null, returns null.
-      * @throws ArithmeticException if the result overflows.
-      */
-     static public ${pt.primitive} multiplyExact(${pt.primitive} x, ${pt.primitive} y) {
-         if (isNull(x) || isNull(y)) {
-             return ${pt.null};
-         }
-
-         <#if pt.primitive == "byte" || pt.primitive == "short">
-         int val = Math.multiplyExact(x, y);
-
-         if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
-            throw new ArithmeticException("Overflow: " + x + " * " + y);
-         }
-
-         return (${pt.primitive}) val;
-         <#else>
-         return Math.multiplyExact(x, y);
-         </#if>
-     }
-     </#if>
-
-     <#if pt.valueType.isInteger>
-     /**
-      * Returns the negation of the argument, throwing an exception if the result overflows.
-      *
-      * @param x the value to negate.
-      * @return the negation of the argument.  If the value is null, returns null.
-      * @throws ArithmeticException if the result overflows.
-      */
-     public static ${pt.primitive} negateExact(${pt.primitive} x) {
-         if (isNull(x)) {
-             return ${pt.null};
-         }
-
-         <#if pt.primitive == "byte" || pt.primitive == "short">
-         int val = Math.negateExact(x);
-
-         if( val > ${pt.maxValue} || val < ${pt.minValue}) {
-            throw new ArithmeticException("Overflow: -" + x);
-         }
-
-         return (${pt.primitive}) val;
-         <#else>
-         return Math.negateExact(x);
-         </#if>
-     }
-     </#if>
 
      <#if pt.valueType.isFloat>
      /**
@@ -3793,90 +3870,6 @@ public class Numeric {
         return isNull(next) ? Math.nextDown(next) : next;
      }
      </#if>
-
-     <#if pt.valueType.isFloat >
-     /**
-      * Returns x × 2^scaleFactor rounded as if performed by a single correctly rounded floating-point multiply to a
-      * member of the ${pt.primitive} value set.
-      *
-      * @param x the value.
-      * @param scaleFactor the scale factor.
-      * @return x × 2scaleFactor rounded as if performed by a single correctly rounded floating-point multiply to a
-      *     member of the double value set.  If the either value is null, returns null.
-      */
-     static public ${pt.primitive} scalb(${pt.primitive} x, int scaleFactor) {
-        if(isNull(x) || isNull(scaleFactor)) {
-            return ${pt.null};
-        }
-
-        return Math.scalb(x, scaleFactor);
-     }
-     </#if>
-
-     /**
-      * Returns the hyperbolic sine of a value.
-      *
-      * @param x the value
-      * @return the hyperbolic sine of the value.  If the value is null, returns null.
-      */
-     static public double sinh(${pt.primitive} x) {
-        if(isNull(x)) {
-            return NULL_DOUBLE;
-        }
-
-        return Math.sinh(x);
-     }
-
-    <#if pt.valueType.isInteger>
-    /**
-     * Returns the difference of its arguments, throwing an exception if the result overflows.
-     *
-     * @param x the first value.
-     * @param y the second value.
-     * @return the result of subtracting the arguments.  If either value is null, returns null.
-     * @throws ArithmeticException if the result overflows.
-     */
-    static public ${pt.primitive} subtractExact(${pt.primitive} x, ${pt.primitive} y) {
-        if (isNull(x) || isNull(y)) {
-            return ${pt.null};
-        }
-
-        <#if pt.primitive == "byte" || pt.primitive == "short">
-            int val = Math.subtractExact(x, y);
-
-            if( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
-            //TODO: Should overflows return NULL or throw an exception?
-            throw new ArithmeticException("Overflow: " + x + " + " + y);
-        }
-
-        return (${pt.primitive}) val;
-        <#else>
-        ${pt.primitive} val = Math.subtractExact(x, y);
-
-        if( isNull(val) ) {
-            //TODO: Should overflows return NULL or throw an exception?
-            throw new ArithmeticException("Overflow: " + x + " + " + y);
-        }
-
-        //TODO: Should overflows return NULL or throw an exception?
-        return val;
-        </#if>
-    }
-    </#if>
-
-     /**
-      * Returns the hyperbolic tangent of a value.
-      *
-      * @param x the value
-      * @return the hyperbolic tangent of the value.  If the value is null, returns null.
-      */
-     static public double tanh(${pt.primitive} x) {
-        if(isNull(x)) {
-            return NULL_DOUBLE;
-        }
-
-        return Math.tanh(x);
-     }
 
     /**
      * Converts an angle measured in radians to an approximately equivalent angle measured in degrees.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3824,7 +3824,6 @@ public class Numeric {
       * Returns the unbiased exponent used in the representation of the argument.
       *
       * @param x the value.
-      * @param y the divisor.
       * @return the unbiased exponent used in the representation of the argument.  If the value is null, returns null.
       */
     static public int getExponent(${pt.primitive} x) {

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3467,7 +3467,7 @@ public class Numeric {
      }
 
     /**
-     * Returns the hypotenuse of a right-angled triangle, sqrt(x2 +y2), without intermediate overflow or underflow.
+     * Returns the hypotenuse of a right-angled triangle, sqrt(x^2 +y^2), without intermediate overflow or underflow.
      *
      * @param x the first value.
      * @param y the second value.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -10,6 +10,7 @@ import io.deephaven.engine.primitive.iterator.*;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 
 import java.util.Arrays;
+import java.lang.Math;
 
 import static io.deephaven.base.CompareUtils.compare;
 import static io.deephaven.util.QueryConstants.*;
@@ -3378,6 +3379,73 @@ public class Numeric {
         return compare(v1 == null ? ${pt.null} : v1, v2 == null ? ${pt.null} : v2);
     }
 
+
+
+    //////////////////////////////// NEW //////////////////////////////////////
+    // TODO: document these
+
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the sum of its arguments, throwing an exception if the result overflows.
+     *
+     * @param x the first value.
+     * @param y the second value.
+     * @return the result of adding the arguments.  If either value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} addExact(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return ${pt.null};
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+        int val = Math.addExact(x, y);
+
+        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            //TODO: Should overflows return NULL or throw an exception?
+            throw new ArithmeticException("Overflow: " + x + " + " + y);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        //TODO: Should overflows return NULL or throw an exception?
+        return Math.addExact(x, y);
+        </#if>
+    }
+    </#if>
+
+
+
+        //TODO:  atan2
+        //TODO:  cbrt
+        //TODO:  copySign
+        //TODO:  decrementExact
+        //TODO:  expm2
+        //TODO:  floorDiv
+        //TODO:  floorMod
+        //TODO:  getExponent
+        //TODO:  hypot
+        //TODO:  IEEEremainder
+        //TODO:  incrementExact
+        //TODO:  log10
+        //TODO:  log1p
+        //TODO:  multiplyExact
+        //TODO:  negateExact
+        //TODO:  nextAfter
+        //TODO:  nextDown
+        //TODO:  nextUp
+        //TODO:  scalb
+        //TODO:  sinh
+        //TODO:  subtractExact
+        //TODO:  tanh
+        //TODO:  toDegrees
+        //TODO:  toIntExact
+        //TODO:  toRadians
+        //TODO:  ulp
+        //TODO:  E (constant)
+        //TODO:  PI (constant)
+        
+        
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3957,7 +3957,13 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short" || pt.primitive == "int" >
         return x;
         <#else>
-        return Math.toIntExact(x);
+        ${pt.primitive} val = Math.toIntExact(x);
+
+        if ( isNull(val) ) {
+            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in an int" + x);
+        }
+
+        return val;
         </#if>
     }
     </#if>
@@ -3978,11 +3984,13 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short" >
         return x;
         <#else>
-        if (x > Short.MAX_VALUE || x < Short.MIN_VALUE) {
+        ${pt.primitive} val = (short) x;
+
+        if (x > Short.MAX_VALUE || x < Short.MIN_VALUE || isNull(val) ) {
             throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a short" + x);
         }
 
-        return (short) x;
+        return val;
         </#if>
     }
     </#if>
@@ -4003,11 +4011,13 @@ public class Numeric {
         <#if pt.primitive == "byte" >
         return x;
         <#else>
-        if (x > Byte.MAX_VALUE || x < Byte.MIN_VALUE) {
+        ${pt.primitive} val = (byte) x;
+
+        if (x > Byte.MAX_VALUE || x < Byte.MIN_VALUE || isNull(val) ) {
             throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a byte" + x);
         }
 
-        return (byte) x;
+        return val;
         </#if>
     }
     </#if>

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3599,7 +3599,13 @@ public class Numeric {
 
         return (${pt.primitive}) val;
         <#else>
-        return Math.addExact(x, y);
+        ${pt.primitive} val = Math.addExact(x, y);
+
+        if ( isNull(val) ) {
+            throw new ArithmeticException("Overflow: " + x + " + " + y);
+        }
+
+        return val;
         </#if>
     }
     </#if>
@@ -3655,7 +3661,7 @@ public class Numeric {
          <#if pt.primitive == "byte" || pt.primitive == "short">
          int val = Math.multiplyExact(x, y);
 
-         if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+         if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val) ) {
             throw new ArithmeticException("Overflow: " + x + " * " + y);
          }
 
@@ -3682,7 +3688,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short">
         int val = Math.incrementExact(x);
 
-        if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+        if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val) ) {
             throw new ArithmeticException("Overflow: " + x);
         }
 

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3958,7 +3958,7 @@ public class Numeric {
         final int val = Math.toIntExact(x);
 
         if ( isNull(val) ) {
-            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in an int" + x);
+            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in an int " + x);
         }
 
         return val;
@@ -3985,7 +3985,7 @@ public class Numeric {
         final short val = (short) x;
 
         if (x > Short.MAX_VALUE || x < Short.MIN_VALUE || isNull(val) ) {
-            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a short" + x);
+            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a short " + x);
         }
 
         return val;
@@ -4012,7 +4012,7 @@ public class Numeric {
         final byte val = (byte) x;
 
         if (x > Byte.MAX_VALUE || x < Byte.MIN_VALUE || isNull(val) ) {
-            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a byte" + x);
+            throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a byte " + x);
         }
 
         return val;

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3726,7 +3726,62 @@ public class Numeric {
      }
      </#if>
 
-        //TODO:  nextAfter
+     <#if pt.valueType.isFloat>
+     /**
+      * Returns the floating-point number adjacent to the first argument in the direction of the second argument.
+      *
+      * @param start the starting value.
+      * @param direction the direction.
+      * @return the floating-point number adjacent to the first argument in the direction of the second argument.
+      *    If either value is null, returns null.
+      */
+     static public ${pt.primitive} nextAfter(${pt.primitive} start, ${pt.primitive} direction) {
+        if (isNull(start) || isNull(direction)) {
+            return ${pt.null};
+        }
+
+        return Math.nextAfter(start, direction);
+     }
+     </#if>
+
+     <#if pt.valueType.isFloat>
+     /**
+      * Returns the floating-point number adjacent to the argument in the direction of positive infinity.
+      *
+      * @param x the value.
+      * @return the floating-point number adjacent to the argument in the direction of positive infinity.
+      *    If the value is null, returns null.
+      */
+     static public ${pt.primitive} nextUp(${pt.primitive} x) {
+        if(isNull(x)) {
+            return ${pt.null};
+        }
+
+        // skip over nulls
+        ${pt.primitive} next = Math.nextUp(x);
+        return isNull(next) ? Math.nextUp(next) : next;
+     }
+     </#if>
+
+     <#if pt.valueType.isFloat>
+     /**
+      * Returns the floating-point number adjacent to the argument in the direction of negative infinity.
+      *
+      * @param x the value.
+      * @return the floating-point number adjacent to the argument in the direction of negative infinity.
+      *    If the value is null, returns null.
+      */
+     static public ${pt.primitive} nextDown(${pt.primitive} x) {
+        if(isNull(x)) {
+            return ${pt.null};
+        }
+
+        // skip over nulls
+        ${pt.primitive} next = Math.nextDown(x);
+        return isNull(next) ? Math.nextDown(next) : next;
+     }
+     </#if>
+
         //TODO:  nextDown
         //TODO:  nextUp
         //TODO:  scalb

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3853,7 +3853,20 @@ public class Numeric {
     }
     </#if>
 
-        //TODO:  tanh
+     /**
+      * Returns the hyperbolic tangent of a value.
+      *
+      * @param x the value
+      * @return the hyperbolic tangent of the value.  If the value is null, returns null.
+      */
+     static public double tanh(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.tanh(x);
+     }
+
         //TODO:  toDegrees
         //TODO:  toIntExact
         //TODO:  toRadians

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3995,10 +3995,6 @@ public class Numeric {
     }
     </#if>
 
-        //TODO:  E (constant)
-        //TODO:  PI (constant)
-        
-        
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3497,6 +3497,12 @@ public class Numeric {
     }
     </#if>
 
+    /**
+     * Returns the hyperbolic cosine.
+     *
+     * @param x the value
+     * @returns the hyperbolic cosine of the value.  If the value is null, returns null.
+     */
     static public double cosh(${pt.primitive} x) {
         if(isNull(x)) {
             return NULL_DOUBLE;

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3699,7 +3699,33 @@ public class Numeric {
      }
      </#if>
 
-        //TODO:  negateExact
+     <#if pt.valueType.isInteger>
+     /**
+      * Returns the negation of the argument, throwing an exception if the result overflows.
+      *
+      * @param x the value to negate.
+      * @return the negation of the argument.  If the value is null, returns null.
+      * @throws ArithmeticException if the result overflows.
+      */
+     public static ${pt.primitive} negateExact(${pt.primitive} x) {
+         if (isNull(x)) {
+             return ${pt.null};
+         }
+
+         <#if pt.primitive == "byte" || pt.primitive == "short">
+         int val = Math.negateExact(x);
+
+         if( val > ${pt.maxValue} || val < ${pt.minValue}) {
+            throw new ArithmeticException("Overflow: -" + x);
+         }
+
+         return (${pt.primitive}) val;
+         <#else>
+         return Math.negateExact(x);
+         </#if>
+     }
+     </#if>
+
         //TODO:  nextAfter
         //TODO:  nextDown
         //TODO:  nextUp

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3957,7 +3957,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short" || pt.primitive == "int" >
         return x;
         <#else>
-        ${pt.primitive} val = Math.toIntExact(x);
+        final int val = Math.toIntExact(x);
 
         if ( isNull(val) ) {
             throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in an int" + x);
@@ -3984,7 +3984,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short" >
         return x;
         <#else>
-        ${pt.primitive} val = (short) x;
+        final short val = (short) x;
 
         if (x > Short.MAX_VALUE || x < Short.MIN_VALUE || isNull(val) ) {
             throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a short" + x);
@@ -4011,7 +4011,7 @@ public class Numeric {
         <#if pt.primitive == "byte" >
         return x;
         <#else>
-        ${pt.primitive} val = (byte) x;
+        final byte val = (byte) x;
 
         if (x > Byte.MAX_VALUE || x < Byte.MIN_VALUE || isNull(val) ) {
             throw new ArithmeticException("Overflow: ${pt.primitive} value will not fit in a byte" + x);

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3497,6 +3497,39 @@ public class Numeric {
     }
     </#if>
 
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the argument incremented by one, throwing an exception if the result overflows.
+     *
+     * @param x the value to increment.
+     * @return the result of increment by one.  If the value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} incrementExact(${pt.primitive} x) {
+        if (isNull(x)) {
+            return ${pt.null};
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+        int val = Math.incrementExact(x);
+
+        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            //TODO: Should overflows return NULL or throw an exception?
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        if (x == ${pt.minValue}) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        //TODO: Should overflows return NULL or throw an exception?
+        return Math.incrementExact(x);
+        </#if>
+    }
+    </#if>
+
     /**
      * Returns the hyperbolic cosine.
      *
@@ -3610,8 +3643,6 @@ public class Numeric {
     }
     </#if>
 
-        //TODO:  IEEEremainder
-        //TODO:  incrementExact
         //TODO:  log10
         //TODO:  log1p
         //TODO:  multiplyExact

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3777,7 +3777,7 @@ public class Numeric {
          ${pt.primitive} val = Math.negateExact(x);
 
          if ( isNull(val) ) {
-             throw new ArithmeticException("Overflow: -" + x");
+             throw new ArithmeticException("Overflow: -" + x);
          }
 
          return val;

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3464,8 +3464,40 @@ public class Numeric {
         </#if>
     }
 
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the argument decremented by one, throwing an exception if the result overflows.
+     *
+     * @param x the value to decrement.
+     * @return the result of decrementing by one.  If the value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} decrementExact(${pt.primitive} x) {
+        if (isNull(x)) {
+            return ${pt.null};
+        }
 
-        //TODO:  decrementExact
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+        int val = Math.decrementExact(x);
+
+        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+            //TODO: Should overflows return NULL or throw an exception?
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        if (x == ${pt.minValue}) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        //TODO: Should overflows return NULL or throw an exception?
+        return Math.decrementExact(x);
+        </#if>
+    }
+    </#if>
+
+
         //TODO:  expm2
         //TODO:  floorDiv
         //TODO:  floorMod

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3561,8 +3561,23 @@ public class Numeric {
     }
     </#if>
 
+    <#if pt.valueType.isFloat>
+     /**
+      * Returns the unbiased exponent used in the representation of the argument.
+      *
+      * @param x the value.
+      * @param y the divisor.
+      * @return the unbiased exponent used in the representation of the argument.  If the value is null, returns null.
+      */
+    static public int getExponent(${pt.primitive} x) {
+        if (isNull(x)) {
+            return NULL_INT;
+        }
 
-        //TODO:  getExponent
+        return Math.getExponent(x);
+    }
+    </#if>
+
         //TODO:  hypot
         //TODO:  IEEEremainder
         //TODO:  incrementExact

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3593,7 +3593,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short">
         int val = Math.addExact(x, y);
 
-        if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+        if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val) ) {
             throw new ArithmeticException("Overflow: " + x + " + " + y);
         }
 
@@ -3619,9 +3619,9 @@ public class Numeric {
         }
 
         <#if pt.primitive == "byte" || pt.primitive == "short">
-            int val = Math.subtractExact(x, y);
+        int val = Math.subtractExact(x, y);
 
-            if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
+        if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
             throw new ArithmeticException("Overflow: " + x + " + " + y);
         }
 

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3383,6 +3383,7 @@ public class Numeric {
 
     //////////////////////////////// NEW //////////////////////////////////////
     // TODO: document these
+    //TODO: group similar methods
 
     <#if pt.valueType.isInteger>
     /**
@@ -3815,7 +3816,43 @@ public class Numeric {
         return Math.sinh(x);
      }
 
-        //TODO:  subtractExact
+    <#if pt.valueType.isInteger>
+    /**
+     * Returns the difference of its arguments, throwing an exception if the result overflows.
+     *
+     * @param x the first value.
+     * @param y the second value.
+     * @return the result of subtracting the arguments.  If either value is null, returns null.
+     * @throws ArithmeticException if the result overflows.
+     */
+    static public ${pt.primitive} subtractExact(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return ${pt.null};
+        }
+
+        <#if pt.primitive == "byte" || pt.primitive == "short">
+            int val = Math.subtractExact(x, y);
+
+            if( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
+            //TODO: Should overflows return NULL or throw an exception?
+            throw new ArithmeticException("Overflow: " + x + " + " + y);
+        }
+
+        return (${pt.primitive}) val;
+        <#else>
+        ${pt.primitive} val = Math.subtractExact(x, y);
+
+        if( isNull(val) ) {
+            //TODO: Should overflows return NULL or throw an exception?
+            throw new ArithmeticException("Overflow: " + x + " + " + y);
+        }
+
+        //TODO: Should overflows return NULL or throw an exception?
+        return val;
+        </#if>
+    }
+    </#if>
+
         //TODO:  tanh
         //TODO:  toDegrees
         //TODO:  toIntExact

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3867,7 +3867,20 @@ public class Numeric {
         return Math.tanh(x);
      }
 
-        //TODO:  toDegrees
+    /**
+     * Converts an angle measured in radians to an approximately equivalent angle measured in degrees.
+     *
+     * @param x the angle in radians
+     * @return the measurement of the angle x in degrees.  If the value is null, returns null.
+     */
+    static public double toDegrees(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.toDegrees(x);
+    }
+
         //TODO:  toIntExact
         //TODO:  toRadians
         //TODO:  ulp

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3657,7 +3657,20 @@ public class Numeric {
         return Math.log10(x);
      }
 
-        //TODO:  log1p
+     /**
+      * Returns the natural logarithm of the sum of the argument and 1.
+      *
+      * @param x the value.
+      * @return the natural logarithm of the sum of the argument and 1.  If the value is null, returns null.
+      */
+      static public double log1p(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.log1p(x);
+      }
+
         //TODO:  multiplyExact
         //TODO:  negateExact
         //TODO:  nextAfter

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3578,7 +3578,21 @@ public class Numeric {
     }
     </#if>
 
-        //TODO:  hypot
+    /**
+     * Returns the hypotenuse of a right-angled triangle, sqrt(x2 +y2), without intermediate overflow or underflow.
+     *
+     * @param x the first value.
+     * @param y the second value.
+     * @return the hypotenuse of a right-angled triangle.  If either value is null, returns null.
+     */
+    static public double hypot(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.hypot(x, y);
+    }
+
         //TODO:  IEEEremainder
         //TODO:  incrementExact
         //TODO:  log10

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3525,7 +3525,25 @@ public class Numeric {
         return Math.expm1(x);
      }
 
-        //TODO:  floorDiv
+    <#if pt.valueType.isInteger>
+     /**
+      * Returns the largest (closest to positive infinity) int value that is less than or equal to the
+      * algebraic quotient.
+      *
+      * @param x the dividend.
+      * @param y the divisor.
+      * @returns the largest (closest to positive infinity) int value that is less than or equal to the
+      *    algebraic quotient.  If either value is null, returns null.
+      */
+    static public ${pt.primitive} floorDiv(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return ${pt.null};
+        }
+
+        return (${pt.primitive}) Math.floorDiv(x, y);
+    }
+    </#if>
+
         //TODO:  floorMod
         //TODO:  getExponent
         //TODO:  hypot

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -24,6 +24,17 @@ import static io.deephaven.function.Cast.castDouble;
 @SuppressWarnings({"RedundantCast", "unused", "ManualMinMaxCalculation"})
 public class Numeric {
 
+    //////////////////////////// Constants ////////////////////////////
+
+    /**
+     * The double value that is closer than any other to e, the base of the natural logarithms.
+     */
+    static public final double E = Math.E;
+
+    /**
+     * The double value that is closer than any other to pi, the ratio of the circumference of a circle to its diameter.
+     */
+    static public final double PI = Math.PI;
 
     //////////////////////////// Object ////////////////////////////
 

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3465,7 +3465,7 @@ public class Numeric {
      }
 
     /**
-     * Returns the hypotenuse of a right-angled triangle, sqrt(x^2 +y^2), without intermediate overflow or underflow.
+     * Returns the hypotenuse of a right-angled triangle, sqrt(x^2 + y^2), without intermediate overflow or underflow.
      *
      * @param x the first value.
      * @param y the second value.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3444,10 +3444,27 @@ public class Numeric {
         return Math.cbrt(x);
     }
 
+    /**
+     * Returns the first argument with the sign of the second argument.
+     *
+     * @param magnitude the value to return
+     * @param sign the sign for the return value
+     * @return the value with the magnitude of the first argument and the sign of the second argument.
+     *    If either value is null, returns null.
+     */
+    static public ${pt.primitive} copySign(${pt.primitive} magnitude, ${pt.primitive} sign) {
+        if (isNull(magnitude) || isNull(sign)) {
+            return ${pt.null};
+        }
+
+        <#if pt.valueType.isFloat >
+        return Math.copySign(magnitude, sign);
+        <#else>
+        return (${pt.primitive}) ((magnitude < 0 ? -magnitude : magnitude) * (sign < 0 ? -1 : 1));
+        </#if>
+    }
 
 
-        //TODO:  cbrt
-        //TODO:  copySign
         //TODO:  decrementExact
         //TODO:  expm2
         //TODO:  floorDiv

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3704,7 +3704,13 @@ public class Numeric {
             throw new ArithmeticException("Overflow: " + x);
         }
 
-        return Math.incrementExact(x);
+        ${pt.primitive} val = Math.incrementExact(x);
+
+        if ( isNull(val) ) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return val;
         </#if>
     }
     </#if>
@@ -3735,7 +3741,13 @@ public class Numeric {
             throw new ArithmeticException("Overflow: " + x);
         }
 
-        return Math.decrementExact(x);
+        ${pt.primitive} val = Math.decrementExact(x);
+
+        if ( isNull(val) ) {
+            throw new ArithmeticException("Overflow: " + x);
+        }
+
+        return val;
         </#if>
     }
     </#if>
@@ -3756,13 +3768,19 @@ public class Numeric {
          <#if pt.primitive == "byte" || pt.primitive == "short">
          int val = Math.negateExact(x);
 
-         if ( val > ${pt.maxValue} || val < ${pt.minValue}) {
+         if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val) ) {
             throw new ArithmeticException("Overflow: -" + x);
          }
 
          return (${pt.primitive}) val;
          <#else>
-         return Math.negateExact(x);
+         ${pt.primitive} val = Math.negateExact(x);
+
+         if ( isNull(val) ) {
+             throw new ArithmeticException("Overflow: -" + x");
+         }
+
+         return val;
          </#if>
      }
      </#if>

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3881,8 +3881,21 @@ public class Numeric {
         return Math.toDegrees(x);
     }
 
+    /**
+     * Converts an angle measured in degrees to an approximately equivalent angle measured in radians.
+     *
+     * @param x the angle in degrees
+     * @return the measurement of the angle x in radians.  If the value is null, returns null.
+     */
+    static public double toRadians(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.toRadians(x);
+    }
+
         //TODO:  toIntExact
-        //TODO:  toRadians
         //TODO:  ulp
         //TODO:  E (constant)
         //TODO:  PI (constant)

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3622,7 +3622,7 @@ public class Numeric {
         int val = Math.subtractExact(x, y);
 
         if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
-            throw new ArithmeticException("Overflow: " + x + " + " + y);
+            throw new ArithmeticException("Overflow: " + x + " - " + y);
         }
 
         return (${pt.primitive}) val;
@@ -3630,7 +3630,7 @@ public class Numeric {
         ${pt.primitive} val = Math.subtractExact(x, y);
 
         if ( isNull(val) ) {
-            throw new ArithmeticException("Overflow: " + x + " + " + y);
+            throw new ArithmeticException("Overflow: " + x + " - " + y);
         }
 
         return val;

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3792,8 +3792,6 @@ public class Numeric {
     }
     </#if>
 
-
-
     <#if pt.valueType.isFloat>
     /**
      * Returns the IEEE 754 remainder of the division of the arguments.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3801,7 +3801,20 @@ public class Numeric {
      }
      </#if>
 
-        //TODO:  sinh
+     /**
+      * Returns the hyperbolic sine of a value.
+      *
+      * @param x the value
+      * @return the hyperbolic sine of the value.  If the value is null, returns null.
+      */
+     static public double sinh(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.sinh(x);
+     }
+
         //TODO:  subtractExact
         //TODO:  tanh
         //TODO:  toDegrees

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3511,8 +3511,20 @@ public class Numeric {
         return Math.cosh(x);
     }
 
+    /**
+     * Returns e^x -1.
+     *
+     * @param x the value
+     * @returns e^x-1.  If the value is null, returns null.
+     */
+     static public double expm1(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
 
-        //TODO:  expm2
+        return Math.expm1(x);
+     }
+
         //TODO:  floorDiv
         //TODO:  floorMod
         //TODO:  getExponent

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3445,7 +3445,7 @@ public class Numeric {
      * @return the hyperbolic cosine of the value.  If the value is null, returns null.
      */
     static public double cosh(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3459,7 +3459,7 @@ public class Numeric {
      * @return e^x-1.  If the value is null, returns null.
      */
      static public double expm1(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3488,7 +3488,7 @@ public class Numeric {
      * @return the base 10 logarithm of the value.  If the value is null, returns null.
      */
      static public double log10(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3502,7 +3502,7 @@ public class Numeric {
       * @return the natural logarithm of the sum of the argument and 1.  If the value is null, returns null.
       */
      static public double log1p(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3520,7 +3520,7 @@ public class Numeric {
       *     member of the double value set.  If the either value is null, returns null.
       */
      static public ${pt.primitive} scalb(${pt.primitive} x, int scaleFactor) {
-        if(isNull(x) || isNull(scaleFactor)) {
+        if (isNull(x) || isNull(scaleFactor)) {
             return ${pt.null};
         }
 
@@ -3535,7 +3535,7 @@ public class Numeric {
       * @return the hyperbolic sine of the value.  If the value is null, returns null.
       */
      static public double sinh(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3549,7 +3549,7 @@ public class Numeric {
       * @return the hyperbolic tangent of the value.  If the value is null, returns null.
       */
      static public double tanh(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3593,7 +3593,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short">
         int val = Math.addExact(x, y);
 
-        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+        if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
             throw new ArithmeticException("Overflow: " + x + " + " + y);
         }
 
@@ -3621,7 +3621,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short">
             int val = Math.subtractExact(x, y);
 
-            if( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
+            if ( val > ${pt.maxValue} || val < ${pt.minValue} || isNull(val)) {
             throw new ArithmeticException("Overflow: " + x + " + " + y);
         }
 
@@ -3629,7 +3629,7 @@ public class Numeric {
         <#else>
         ${pt.primitive} val = Math.subtractExact(x, y);
 
-        if( isNull(val) ) {
+        if ( isNull(val) ) {
             throw new ArithmeticException("Overflow: " + x + " + " + y);
         }
 
@@ -3655,7 +3655,7 @@ public class Numeric {
          <#if pt.primitive == "byte" || pt.primitive == "short">
          int val = Math.multiplyExact(x, y);
 
-         if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+         if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
             throw new ArithmeticException("Overflow: " + x + " * " + y);
          }
 
@@ -3682,7 +3682,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short">
         int val = Math.incrementExact(x);
 
-        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+        if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
             throw new ArithmeticException("Overflow: " + x);
         }
 
@@ -3713,7 +3713,7 @@ public class Numeric {
         <#if pt.primitive == "byte" || pt.primitive == "short">
         int val = Math.decrementExact(x);
 
-        if( val > ${pt.maxValue} || val < ${pt.minValue} ) {
+        if ( val > ${pt.maxValue} || val < ${pt.minValue} ) {
             throw new ArithmeticException("Overflow: " + x);
         }
 
@@ -3744,7 +3744,7 @@ public class Numeric {
          <#if pt.primitive == "byte" || pt.primitive == "short">
          int val = Math.negateExact(x);
 
-         if( val > ${pt.maxValue} || val < ${pt.minValue}) {
+         if ( val > ${pt.maxValue} || val < ${pt.minValue}) {
             throw new ArithmeticException("Overflow: -" + x);
          }
 
@@ -3854,7 +3854,7 @@ public class Numeric {
       *    If the value is null, returns null.
       */
      static public ${pt.primitive} nextUp(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return ${pt.null};
         }
 
@@ -3873,7 +3873,7 @@ public class Numeric {
       *    If the value is null, returns null.
       */
      static public ${pt.primitive} nextDown(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return ${pt.null};
         }
 
@@ -3890,7 +3890,7 @@ public class Numeric {
      * @return the measurement of the angle x in degrees.  If the value is null, returns null.
      */
     static public double toDegrees(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3904,7 +3904,7 @@ public class Numeric {
      * @return the measurement of the angle x in radians.  If the value is null, returns null.
      */
     static public double toRadians(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return NULL_DOUBLE;
         }
 
@@ -3992,7 +3992,7 @@ public class Numeric {
      * @return the size of an ulp of the argument.  If the value is null, returns null.
      */
     static public ${pt.primitive} ulp(${pt.primitive} x) {
-        if(isNull(x)) {
+        if (isNull(x)) {
             return ${pt.null};
         }
 

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3430,6 +3430,21 @@ public class Numeric {
         return Math.atan2(y, x);
     }
 
+    /**
+     * Returns the cube root of a value.
+     *
+     * @param x the value
+     * @return the cube root of the value.  If the value is null, returns null.
+     */
+    static public double cbrt(${pt.primitive} x) {
+        if (isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.cbrt(x);
+    }
+
+
 
         //TODO:  cbrt
         //TODO:  copySign

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3809,10 +3809,6 @@ public class Numeric {
     }
     </#if>
 
-
-
-
-
      <#if pt.valueType.isFloat>
      /**
       * Returns the floating-point number adjacent to the first argument in the direction of the second argument.
@@ -3827,7 +3823,9 @@ public class Numeric {
             return ${pt.null};
         }
 
-        return Math.nextAfter(start, direction);
+        // skip over nulls
+        ${pt.primitive} next = Math.nextAfter(start, direction);
+        return isNull(next) ? Math.nextAfter(next, direction) : next;
      }
      </#if>
 

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3390,8 +3390,6 @@ public class Numeric {
         return compare(v1 == null ? ${pt.null} : v1, v2 == null ? ${pt.null} : v2);
     }
 
-    //TODO NEW STUFF --- delete this line
-
     /**
      * Returns the angle theta from the conversion of rectangular coordinates (x, y) to polar coordinates (r, theta).
      * This method computes the phase theta by computing an arc tangent of y/x in the range of -pi to pi.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3453,7 +3453,7 @@ public class Numeric {
     }
 
     /**
-     * Returns e^x -1.
+     * Returns e^x - 1.
      *
      * @param x the value
      * @return e^x-1.  If the value is null, returns null.

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3414,9 +3414,23 @@ public class Numeric {
     }
     </#if>
 
+    /**
+     * Returns the arc tangent of a value; the returned angle is in the range -pi/2 through pi/2.
+     *
+     * @param y the ordinate coordinate
+     * @param x the abscissa coordinate
+     * @return the theta component of the point (r, theta) in polar coordinates that corresponds to the point (x, y) in
+     *    Cartesian coordinates.  If either value is null, returns null.
+     */
+    static public double atan2(${pt.primitive} y, ${pt.primitive} x) {
+        if (isNull(x) || isNull(y)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.atan2(y, x);
+    }
 
 
-        //TODO:  atan2
         //TODO:  cbrt
         //TODO:  copySign
         //TODO:  decrementExact

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3501,7 +3501,7 @@ public class Numeric {
      * Returns the hyperbolic cosine.
      *
      * @param x the value
-     * @returns the hyperbolic cosine of the value.  If the value is null, returns null.
+     * @return the hyperbolic cosine of the value.  If the value is null, returns null.
      */
     static public double cosh(${pt.primitive} x) {
         if(isNull(x)) {
@@ -3515,7 +3515,7 @@ public class Numeric {
      * Returns e^x -1.
      *
      * @param x the value
-     * @returns e^x-1.  If the value is null, returns null.
+     * @return e^x-1.  If the value is null, returns null.
      */
      static public double expm1(${pt.primitive} x) {
         if(isNull(x)) {
@@ -3532,7 +3532,7 @@ public class Numeric {
       *
       * @param x the dividend.
       * @param y the divisor.
-      * @returns the largest (closest to positive infinity) int value that is less than or equal to the
+      * @return the largest (closest to positive infinity) int value that is less than or equal to the
       *    algebraic quotient.  If either value is null, returns null.
       */
     static public ${pt.primitive} floorDiv(${pt.primitive} x, ${pt.primitive} y) {
@@ -3544,7 +3544,24 @@ public class Numeric {
     }
     </#if>
 
-        //TODO:  floorMod
+    <#if pt.valueType.isInteger>
+     /**
+      * Returns the floor modulus of the arguments.
+      *
+      * @param x the dividend.
+      * @param y the divisor.
+      * @return the floor modulus x.  If either value is null, returns null.
+      */
+    static public ${pt.primitive} floorMod(${pt.primitive} x, ${pt.primitive} y) {
+        if (isNull(x) || isNull(y)) {
+            return ${pt.null};
+        }
+
+        return (${pt.primitive}) Math.floorMod(x, y);
+    }
+    </#if>
+
+
         //TODO:  getExponent
         //TODO:  hypot
         //TODO:  IEEEremainder

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3782,9 +3782,25 @@ public class Numeric {
      }
      </#if>
 
-        //TODO:  nextDown
-        //TODO:  nextUp
-        //TODO:  scalb
+     <#if pt.valueType.isFloat >
+     /**
+      * Returns x × 2^scaleFactor rounded as if performed by a single correctly rounded floating-point multiply to a
+      * member of the ${pt.primitive} value set.
+      *
+      * @param x the value.
+      * @param scaleFactor the scale factor.
+      * @return x × 2scaleFactor rounded as if performed by a single correctly rounded floating-point multiply to a
+      *     member of the double value set.  If the either value is null, returns null.
+      */
+     static public ${pt.primitive} scalb(${pt.primitive} x, int scaleFactor) {
+        if(isNull(x) || isNull(scaleFactor)) {
+            return ${pt.null};
+        }
+
+        return Math.scalb(x, scaleFactor);
+     }
+     </#if>
+
         //TODO:  sinh
         //TODO:  subtractExact
         //TODO:  tanh

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3497,6 +3497,14 @@ public class Numeric {
     }
     </#if>
 
+    static public double cosh(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.cosh(x);
+    }
+
 
         //TODO:  expm2
         //TODO:  floorDiv

--- a/engine/function/src/templates/Numeric.ftl
+++ b/engine/function/src/templates/Numeric.ftl
@@ -3643,7 +3643,20 @@ public class Numeric {
     }
     </#if>
 
-        //TODO:  log10
+    /**
+     * Returns the base 10 logarithm of a double value.
+     *
+     * @param x the value.
+     * @return the base 10 logarithm of the value.  If the value is null, returns null.
+     */
+     static public double log10(${pt.primitive} x) {
+        if(isNull(x)) {
+            return NULL_DOUBLE;
+        }
+
+        return Math.log10(x);
+     }
+
         //TODO:  log1p
         //TODO:  multiplyExact
         //TODO:  negateExact

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1823,6 +1823,12 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}GetExponent(){
+        assertEquals(Math.getExponent(7), getExponent((${pt.primitive})7));
+        assertEquals(NULL_INT, getExponent(${pt.null}));
+    }
+    </#if>
 
     </#if>
     </#list>

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1883,6 +1883,14 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}NegateExact(){
+        assertEquals(Math.negateExact(7), negateExact((${pt.primitive})7));
+        assertEquals(${pt.null}, negateExact(${pt.null}));
+    }
+    </#if>
+
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1772,6 +1772,17 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, cbrt(${pt.null}));
     }
 
+    public void test${pt.boxed}CopySign() {
+        assertEquals((${pt.primitive})-9, copySign((${pt.primitive})9, (${pt.primitive})-2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})9, (${pt.primitive})2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})9, (${pt.primitive})0));
+        assertEquals((${pt.primitive})-9, copySign((${pt.primitive})-9, (${pt.primitive})-2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})-9, (${pt.primitive})2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})-9, (${pt.primitive})0));
+        assertEquals((${pt.null}), copySign(${pt.null}, (${pt.primitive})-2));
+        assertEquals((${pt.null}), copySign((${pt.primitive})1, ${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1948,6 +1948,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, tanh(${pt.null}));
     }
 
+    public void test${pt.boxed}ToDegrees(){
+        assertEquals(Math.toDegrees((${pt.primitive})7), toDegrees((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, toDegrees(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1761,6 +1761,12 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    public void test${pt.boxed}Atan2(){
+        assertEquals(Math.atan2((${pt.primitive})1, (${pt.primitive})2), atan2((${pt.primitive})1, (${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, atan2(${pt.null}, (${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, atan2((${pt.primitive})2, ${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1815,6 +1815,15 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}FloorMod(){
+        assertEquals(Math.floorMod(7, 2), floorMod((${pt.primitive})7, (${pt.primitive})2));
+        assertEquals(${pt.null}, floorMod(${pt.null}, (${pt.primitive})2));
+        assertEquals(${pt.null}, floorMod((${pt.primitive})7, ${pt.null}));
+    }
+    </#if>
+
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1761,6 +1761,21 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}SubtractExact(){
+        assertEquals((${pt.primitive})1, subtractExact((${pt.primitive})3, (${pt.primitive})2));
+        assertEquals(${pt.null}, subtractExact(${pt.null}, (${pt.primitive})2));
+        assertEquals(${pt.null}, subtractExact((${pt.primitive})2, ${pt.null}));
+
+        try {
+        subtractExact((${pt.primitive})${pt.minValue}, (${pt.primitive})1);
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+    }
+    </#if>
+
     public void test${pt.boxed}Atan2(){
         assertEquals(Math.atan2((${pt.primitive})1, (${pt.primitive})2), atan2((${pt.primitive})1, (${pt.primitive})2));
         assertEquals(NULL_DOUBLE, atan2(${pt.null}, (${pt.primitive})2));

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1807,6 +1807,14 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, expm1(${pt.null}));
     }
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}FloorDiv(){
+        assertEquals(Math.floorDiv(7, 2), floorDiv((${pt.primitive})7, (${pt.primitive})2));
+        assertEquals(${pt.null}, floorDiv(${pt.null}, (${pt.primitive})2));
+        assertEquals(${pt.null}, floorDiv((${pt.primitive})7, ${pt.null}));
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1783,6 +1783,20 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals((${pt.null}), copySign((${pt.primitive})1, ${pt.null}));
     }
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}DecrementExact(){
+        assertEquals((${pt.primitive})1, decrementExact((${pt.primitive})2));
+        assertEquals(${pt.null}, decrementExact(${pt.null}));
+
+        try {
+            decrementExact((${pt.primitive})${pt.minValue});
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1830,6 +1830,12 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    public void test${pt.boxed}Hypot(){
+        assertEquals(Math.hypot(7, 3), hypot((${pt.primitive})7, (${pt.primitive})3));
+        assertEquals(NULL_DOUBLE, hypot(${pt.null}, (${pt.primitive})3));
+        assertEquals(NULL_DOUBLE, hypot((${pt.primitive})7, ${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1937,6 +1937,10 @@ public class TestNumeric extends BaseArrayTestCase {
     public void test${pt.boxed}NextAfter(){
         assertEquals(Math.nextAfter((${pt.primitive})7, (${pt.primitive})8), nextAfter((${pt.primitive})7, (${pt.primitive})8));
         assertEquals(Math.nextAfter((${pt.primitive})7, (${pt.primitive})-8), nextAfter((${pt.primitive})7, (${pt.primitive})-8));
+
+        assertEquals(Math.nextUp(${pt.null}), nextAfter(Math.nextDown(${pt.null}), (${pt.primitive})8));
+        assertEquals(Math.nextDown(${pt.null}), nextAfter(Math.nextUp(${pt.null}), ${pt.boxed}.NEGATIVE_INFINITY));
+
         assertEquals(${pt.null}, nextAfter(${pt.null}, (${pt.primitive})8));
         assertEquals(${pt.null}, nextAfter((${pt.primitive}) 7, ${pt.null}));
     }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1933,8 +1933,6 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
-
-
     <#if pt.valueType.isFloat >
     public void test${pt.boxed}NextAfter(){
         assertEquals(Math.nextAfter((${pt.primitive})7, (${pt.primitive})8), nextAfter((${pt.primitive})7, (${pt.primitive})8));

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1858,6 +1858,11 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    public void test${pt.boxed}Log10(){
+        assertEquals(Math.log10(7), log10((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, log10(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -19,6 +19,16 @@ import static io.deephaven.function.Numeric.*;
 @SuppressWarnings({"RedundantCast", "RedundantArrayCreation", "PointlessArithmeticExpression", "ConstantConditions", "SimplifiableAssertion", "Convert2Diamond"})
 public class TestNumeric extends BaseArrayTestCase {
 
+    //////////////////////////// Constants ////////////////////////////
+
+    public void testE() {
+        assertEquals(Math.E, E, 0.0);
+    }
+
+    public void testPI() {
+        assertEquals(Math.PI, PI, 0.0);
+    }
+
     //////////////////////////// Object ////////////////////////////
 
     public void testObjMin() {

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1958,6 +1958,54 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, toRadians(${pt.null}));
     }
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}ToIntExact(){
+        assertEquals(Math.toIntExact((${pt.primitive})7), toIntExact((${pt.primitive})7));
+        assertEquals(NULL_INT, toIntExact(${pt.null}));
+
+        <#if pt.primitive == "long" >
+        try{
+            toIntExact((${pt.primitive})${pt.maxValue});
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+        </#if>
+    }
+    </#if>
+
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}ToShortExact(){
+        assertEquals((short)7, toShortExact((${pt.primitive})7));
+        assertEquals(NULL_SHORT, toShortExact(${pt.null}));
+
+        <#if pt.primitive == "int" || pt.primitive == "long" >
+        try{
+            toShortExact((${pt.primitive})${pt.maxValue});
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+        </#if>
+    }
+    </#if>
+
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}ToByteExact(){
+        assertEquals((byte)3, toByteExact((${pt.primitive})3));
+        assertEquals(NULL_BYTE, toByteExact(${pt.null}));
+
+        <#if pt.primitive == "short" || pt.primitive == "int" || pt.primitive == "long" >
+        try{
+            toByteExact((${pt.primitive})${pt.maxValue});
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+        </#if>
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1943,6 +1943,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, sinh(${pt.null}));
     }
 
+    public void test${pt.boxed}Tanh(){
+        assertEquals(Math.tanh((${pt.primitive})7), tanh((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, tanh(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1836,6 +1836,14 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, hypot((${pt.primitive})7, ${pt.null}));
     }
 
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}IEEEremainder(){
+        assertEquals((${pt.primitive}) Math.IEEEremainder(71, 3), IEEEremainder((${pt.primitive})71, (${pt.primitive})3));
+        assertEquals(${pt.null}, IEEEremainder(${pt.null}, (${pt.primitive})3));
+        assertEquals(${pt.null}, IEEEremainder((${pt.primitive})71, ${pt.null}));
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1746,6 +1746,21 @@ public class TestNumeric extends BaseArrayTestCase {
 
     </#if>
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}AddExact(){
+        assertEquals((${pt.primitive})3, addExact((${pt.primitive})1, (${pt.primitive})2));
+        assertEquals(${pt.null}, addExact(${pt.null}, (${pt.primitive})2));
+        assertEquals(${pt.null}, addExact((${pt.primitive})2, ${pt.null}));
+
+        try {
+            addExact((${pt.primitive})${pt.maxValue}, (${pt.primitive})1);
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1863,6 +1863,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, log10(${pt.null}));
     }
 
+    public void test${pt.boxed}Log1p(){
+        assertEquals(Math.log1p(7), log1p((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, log1p(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1797,6 +1797,20 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}IncrementExact(){
+        assertEquals((${pt.primitive})3, incrementExact((${pt.primitive})2));
+        assertEquals(${pt.null}, incrementExact(${pt.null}));
+
+        try {
+            incrementExact((${pt.primitive})${pt.maxValue});
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+    }
+    </#if>
+
     public void test${pt.boxed}Cosh(){
         assertEquals(Math.cosh((${pt.primitive})2), cosh((${pt.primitive})2));
         assertEquals(NULL_DOUBLE, cosh(${pt.null}));

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1953,6 +1953,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, toDegrees(${pt.null}));
     }
 
+    public void test${pt.boxed}ToRadians(){
+        assertEquals(Math.toRadians((${pt.primitive})7), toRadians((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, toRadians(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1890,6 +1890,30 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}NextAfter(){
+        assertEquals(Math.nextAfter((${pt.primitive})7, (${pt.primitive})8), nextAfter((${pt.primitive})7, (${pt.primitive})8));
+        assertEquals(Math.nextAfter((${pt.primitive})7, (${pt.primitive})-8), nextAfter((${pt.primitive})7, (${pt.primitive})-8));
+        assertEquals(${pt.null}, nextAfter(${pt.null}, (${pt.primitive})8));
+        assertEquals(${pt.null}, nextAfter((${pt.primitive}) 7, ${pt.null}));
+    }
+    </#if>
+
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}NextUp(){
+        assertEquals(Math.nextUp((${pt.primitive})7), nextUp((${pt.primitive})7));
+        assertEquals(Math.nextUp(${pt.null}), nextUp(Math.nextDown(${pt.null})));
+        assertEquals(${pt.null}, nextUp(${pt.null}));
+    }
+    </#if>
+
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}NextDown(){
+        assertEquals(Math.nextDown((${pt.primitive})7), nextDown((${pt.primitive})7));
+        assertEquals(Math.nextDown(${pt.null}), nextDown(Math.nextUp(${pt.null})));
+        assertEquals(${pt.null}, nextDown(${pt.null}));
+    }
+    </#if>
 
     </#if>
     </#list>

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1767,6 +1767,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, atan2((${pt.primitive})2, ${pt.null}));
     }
 
+    public void test${pt.boxed}Cbrt(){
+        assertEquals(Math.cbrt((${pt.primitive})2), cbrt((${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, cbrt(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1797,6 +1797,11 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    public void test${pt.boxed}Cosh(){
+        assertEquals(Math.cosh((${pt.primitive})2), cosh((${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, cosh(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1923,6 +1923,11 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    public void test${pt.boxed}Sinh(){
+        assertEquals(Math.sinh((${pt.primitive})7), sinh((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, sinh(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1756,6 +1756,72 @@ public class TestNumeric extends BaseArrayTestCase {
 
     </#if>
 
+    public void test${pt.boxed}Atan2(){
+        assertEquals(Math.atan2((${pt.primitive})1, (${pt.primitive})2), atan2((${pt.primitive})1, (${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, atan2(${pt.null}, (${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, atan2((${pt.primitive})2, ${pt.null}));
+    }
+
+    public void test${pt.boxed}Cbrt(){
+        assertEquals(Math.cbrt((${pt.primitive})2), cbrt((${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, cbrt(${pt.null}));
+    }
+
+    public void test${pt.boxed}Cosh(){
+        assertEquals(Math.cosh((${pt.primitive})2), cosh((${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, cosh(${pt.null}));
+    }
+
+    public void test${pt.boxed}Expm1(){
+        assertEquals(Math.expm1((${pt.primitive})2), expm1((${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, expm1(${pt.null}));
+    }
+
+    public void test${pt.boxed}Hypot(){
+        assertEquals(Math.hypot(7, 3), hypot((${pt.primitive})7, (${pt.primitive})3));
+        assertEquals(NULL_DOUBLE, hypot(${pt.null}, (${pt.primitive})3));
+        assertEquals(NULL_DOUBLE, hypot((${pt.primitive})7, ${pt.null}));
+    }
+
+    public void test${pt.boxed}Log10(){
+        assertEquals(Math.log10(7), log10((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, log10(${pt.null}));
+    }
+
+    public void test${pt.boxed}Log1p(){
+        assertEquals(Math.log1p(7), log1p((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, log1p(${pt.null}));
+    }
+
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}Scalb(){
+        assertEquals(Math.scalb((${pt.primitive})7, 3), scalb((${pt.primitive})7, 3));
+        assertEquals(${pt.null}, scalb(${pt.null}, 3));
+        assertEquals(${pt.null}, scalb((${pt.primitive})7, NULL_INT));
+    }
+    </#if>
+
+    public void test${pt.boxed}Sinh(){
+        assertEquals(Math.sinh((${pt.primitive})7), sinh((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, sinh(${pt.null}));
+    }
+
+    public void test${pt.boxed}Tanh(){
+        assertEquals(Math.tanh((${pt.primitive})7), tanh((${pt.primitive})7));
+        assertEquals(NULL_DOUBLE, tanh(${pt.null}));
+    }
+
+    public void test${pt.boxed}CopySign() {
+        assertEquals((${pt.primitive})-9, copySign((${pt.primitive})9, (${pt.primitive})-2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})9, (${pt.primitive})2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})9, (${pt.primitive})0));
+        assertEquals((${pt.primitive})-9, copySign((${pt.primitive})-9, (${pt.primitive})-2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})-9, (${pt.primitive})2));
+        assertEquals((${pt.primitive})9, copySign((${pt.primitive})-9, (${pt.primitive})0));
+        assertEquals((${pt.null}), copySign(${pt.null}, (${pt.primitive})-2));
+        assertEquals((${pt.null}), copySign((${pt.primitive})1, ${pt.null}));
+    }
+
     <#if pt.valueType.isInteger >
     public void test${pt.boxed}AddExact(){
         assertEquals((${pt.primitive})3, addExact((${pt.primitive})1, (${pt.primitive})2));
@@ -1786,35 +1852,14 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
-    public void test${pt.boxed}Atan2(){
-        assertEquals(Math.atan2((${pt.primitive})1, (${pt.primitive})2), atan2((${pt.primitive})1, (${pt.primitive})2));
-        assertEquals(NULL_DOUBLE, atan2(${pt.null}, (${pt.primitive})2));
-        assertEquals(NULL_DOUBLE, atan2((${pt.primitive})2, ${pt.null}));
-    }
-
-    public void test${pt.boxed}Cbrt(){
-        assertEquals(Math.cbrt((${pt.primitive})2), cbrt((${pt.primitive})2));
-        assertEquals(NULL_DOUBLE, cbrt(${pt.null}));
-    }
-
-    public void test${pt.boxed}CopySign() {
-        assertEquals((${pt.primitive})-9, copySign((${pt.primitive})9, (${pt.primitive})-2));
-        assertEquals((${pt.primitive})9, copySign((${pt.primitive})9, (${pt.primitive})2));
-        assertEquals((${pt.primitive})9, copySign((${pt.primitive})9, (${pt.primitive})0));
-        assertEquals((${pt.primitive})-9, copySign((${pt.primitive})-9, (${pt.primitive})-2));
-        assertEquals((${pt.primitive})9, copySign((${pt.primitive})-9, (${pt.primitive})2));
-        assertEquals((${pt.primitive})9, copySign((${pt.primitive})-9, (${pt.primitive})0));
-        assertEquals((${pt.null}), copySign(${pt.null}, (${pt.primitive})-2));
-        assertEquals((${pt.null}), copySign((${pt.primitive})1, ${pt.null}));
-    }
-
     <#if pt.valueType.isInteger >
-    public void test${pt.boxed}DecrementExact(){
-        assertEquals((${pt.primitive})1, decrementExact((${pt.primitive})2));
-        assertEquals(${pt.null}, decrementExact(${pt.null}));
+    public void test${pt.boxed}MultiplyExact(){
+        assertEquals((${pt.primitive})6, multiplyExact((${pt.primitive})3, (${pt.primitive})2));
+        assertEquals(${pt.null}, multiplyExact(${pt.null}, (${pt.primitive})2));
+        assertEquals(${pt.null}, multiplyExact((${pt.primitive})2, ${pt.null}));
 
         try {
-            decrementExact((${pt.primitive})${pt.minValue});
+            multiplyExact((${pt.primitive})${pt.maxValue}, (${pt.primitive})2);
             fail("Overflow");
         } catch(ArithmeticException e){
             // pass
@@ -1836,15 +1881,26 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
-    public void test${pt.boxed}Cosh(){
-        assertEquals(Math.cosh((${pt.primitive})2), cosh((${pt.primitive})2));
-        assertEquals(NULL_DOUBLE, cosh(${pt.null}));
-    }
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}DecrementExact(){
+        assertEquals((${pt.primitive})1, decrementExact((${pt.primitive})2));
+        assertEquals(${pt.null}, decrementExact(${pt.null}));
 
-    public void test${pt.boxed}Expm1(){
-        assertEquals(Math.expm1((${pt.primitive})2), expm1((${pt.primitive})2));
-        assertEquals(NULL_DOUBLE, expm1(${pt.null}));
+        try {
+            decrementExact((${pt.primitive})${pt.minValue});
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
     }
+    </#if>
+
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}NegateExact(){
+        assertEquals(Math.negateExact(7), negateExact((${pt.primitive})7));
+        assertEquals(${pt.null}, negateExact(${pt.null}));
+    }
+    </#if>
 
     <#if pt.valueType.isInteger >
     public void test${pt.boxed}FloorDiv(){
@@ -1869,12 +1925,6 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
-    public void test${pt.boxed}Hypot(){
-        assertEquals(Math.hypot(7, 3), hypot((${pt.primitive})7, (${pt.primitive})3));
-        assertEquals(NULL_DOUBLE, hypot(${pt.null}, (${pt.primitive})3));
-        assertEquals(NULL_DOUBLE, hypot((${pt.primitive})7, ${pt.null}));
-    }
-
     <#if pt.valueType.isFloat >
     public void test${pt.boxed}IEEEremainder(){
         assertEquals((${pt.primitive}) Math.IEEEremainder(71, 3), IEEEremainder((${pt.primitive})71, (${pt.primitive})3));
@@ -1883,37 +1933,7 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
-    public void test${pt.boxed}Log10(){
-        assertEquals(Math.log10(7), log10((${pt.primitive})7));
-        assertEquals(NULL_DOUBLE, log10(${pt.null}));
-    }
 
-    public void test${pt.boxed}Log1p(){
-        assertEquals(Math.log1p(7), log1p((${pt.primitive})7));
-        assertEquals(NULL_DOUBLE, log1p(${pt.null}));
-    }
-
-    <#if pt.valueType.isInteger >
-    public void test${pt.boxed}MultiplyExact(){
-        assertEquals((${pt.primitive})6, multiplyExact((${pt.primitive})3, (${pt.primitive})2));
-        assertEquals(${pt.null}, multiplyExact(${pt.null}, (${pt.primitive})2));
-        assertEquals(${pt.null}, multiplyExact((${pt.primitive})2, ${pt.null}));
-
-        try {
-            multiplyExact((${pt.primitive})${pt.maxValue}, (${pt.primitive})2);
-            fail("Overflow");
-        } catch(ArithmeticException e){
-            // pass
-        }
-    }
-    </#if>
-
-    <#if pt.valueType.isInteger >
-    public void test${pt.boxed}NegateExact(){
-        assertEquals(Math.negateExact(7), negateExact((${pt.primitive})7));
-        assertEquals(${pt.null}, negateExact(${pt.null}));
-    }
-    </#if>
 
     <#if pt.valueType.isFloat >
     public void test${pt.boxed}NextAfter(){
@@ -1939,24 +1959,6 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(${pt.null}, nextDown(${pt.null}));
     }
     </#if>
-
-    <#if pt.valueType.isFloat >
-    public void test${pt.boxed}Scalb(){
-        assertEquals(Math.scalb((${pt.primitive})7, 3), scalb((${pt.primitive})7, 3));
-        assertEquals(${pt.null}, scalb(${pt.null}, 3));
-        assertEquals(${pt.null}, scalb((${pt.primitive})7, NULL_INT));
-    }
-    </#if>
-
-    public void test${pt.boxed}Sinh(){
-        assertEquals(Math.sinh((${pt.primitive})7), sinh((${pt.primitive})7));
-        assertEquals(NULL_DOUBLE, sinh(${pt.null}));
-    }
-
-    public void test${pt.boxed}Tanh(){
-        assertEquals(Math.tanh((${pt.primitive})7), tanh((${pt.primitive})7));
-        assertEquals(NULL_DOUBLE, tanh(${pt.null}));
-    }
 
     public void test${pt.boxed}ToDegrees(){
         assertEquals(Math.toDegrees((${pt.primitive})7), toDegrees((${pt.primitive})7));

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1868,6 +1868,21 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, log1p(${pt.null}));
     }
 
+    <#if pt.valueType.isInteger >
+    public void test${pt.boxed}MultiplyExact(){
+        assertEquals((${pt.primitive})6, multiplyExact((${pt.primitive})3, (${pt.primitive})2));
+        assertEquals(${pt.null}, multiplyExact(${pt.null}, (${pt.primitive})2));
+        assertEquals(${pt.null}, multiplyExact((${pt.primitive})2, ${pt.null}));
+
+        try {
+            multiplyExact((${pt.primitive})${pt.maxValue}, (${pt.primitive})2);
+            fail("Overflow");
+        } catch(ArithmeticException e){
+            // pass
+        }
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1802,6 +1802,11 @@ public class TestNumeric extends BaseArrayTestCase {
         assertEquals(NULL_DOUBLE, cosh(${pt.null}));
     }
 
+    public void test${pt.boxed}Expm1(){
+        assertEquals(Math.expm1((${pt.primitive})2), expm1((${pt.primitive})2));
+        assertEquals(NULL_DOUBLE, expm1(${pt.null}));
+    }
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -1915,6 +1915,14 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}Scalb(){
+        assertEquals(Math.scalb((${pt.primitive})7, 3), scalb((${pt.primitive})7, 3));
+        assertEquals(${pt.null}, scalb(${pt.null}, 3));
+        assertEquals(${pt.null}, scalb((${pt.primitive})7, NULL_INT));
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/function/src/templates/TestNumeric.ftl
+++ b/engine/function/src/templates/TestNumeric.ftl
@@ -2006,6 +2006,13 @@ public class TestNumeric extends BaseArrayTestCase {
     }
     </#if>
 
+    <#if pt.valueType.isFloat >
+    public void test${pt.boxed}Ulp(){
+        assertEquals(Math.ulp((${pt.primitive})7), ulp((${pt.primitive})7));
+        assertEquals(${pt.null}, ulp(${pt.null}));
+    }
+    </#if>
+
     </#if>
     </#list>
 }

--- a/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
+++ b/engine/table/src/main/java/io/deephaven/libs/GroovyStaticImports.java
@@ -43,6 +43,12 @@ import java.util.Comparator;
  * @see io.deephaven.function
  */
 public class GroovyStaticImports {
+    /** @see io.deephaven.function.Numeric#IEEEremainder(double,double) */
+    public static  double IEEEremainder( double x, double y ) {return Numeric.IEEEremainder( x, y );}
+
+    /** @see io.deephaven.function.Numeric#IEEEremainder(float,float) */
+    public static  float IEEEremainder( float x, float y ) {return Numeric.IEEEremainder( x, y );}
+
     /** @see io.deephaven.function.Numeric#abs(byte) */
     public static  byte abs( byte value ) {return Numeric.abs( value );}
 
@@ -133,6 +139,18 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#acos(short) */
     public static  double acos( short value ) {return Numeric.acos( value );}
 
+    /** @see io.deephaven.function.Numeric#addExact(byte,byte) */
+    public static  byte addExact( byte x, byte y ) {return Numeric.addExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#addExact(int,int) */
+    public static  int addExact( int x, int y ) {return Numeric.addExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#addExact(long,long) */
+    public static  long addExact( long x, long y ) {return Numeric.addExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#addExact(short,short) */
+    public static  short addExact( short x, short y ) {return Numeric.addExact( x, y );}
+
     /** @see io.deephaven.function.Logic#and(java.lang.Boolean[]) */
     public static  java.lang.Boolean and( java.lang.Boolean... values ) {return Logic.and( values );}
 
@@ -207,6 +225,24 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Numeric#atan(short) */
     public static  double atan( short value ) {return Numeric.atan( value );}
+
+    /** @see io.deephaven.function.Numeric#atan2(byte,byte) */
+    public static  double atan2( byte y, byte x ) {return Numeric.atan2( y, x );}
+
+    /** @see io.deephaven.function.Numeric#atan2(double,double) */
+    public static  double atan2( double y, double x ) {return Numeric.atan2( y, x );}
+
+    /** @see io.deephaven.function.Numeric#atan2(float,float) */
+    public static  double atan2( float y, float x ) {return Numeric.atan2( y, x );}
+
+    /** @see io.deephaven.function.Numeric#atan2(int,int) */
+    public static  double atan2( int y, int x ) {return Numeric.atan2( y, x );}
+
+    /** @see io.deephaven.function.Numeric#atan2(long,long) */
+    public static  double atan2( long y, long x ) {return Numeric.atan2( y, x );}
+
+    /** @see io.deephaven.function.Numeric#atan2(short,short) */
+    public static  double atan2( short y, short x ) {return Numeric.atan2( y, x );}
 
     /** @see io.deephaven.function.Numeric#avg(byte[]) */
     public static  double avg( byte... values ) {return Numeric.avg( values );}
@@ -562,6 +598,24 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Cast#castLong(short,boolean) */
     public static  long castLong( short value, boolean checkFidelity ) {return Cast.castLong( value, checkFidelity );}
 
+    /** @see io.deephaven.function.Numeric#cbrt(byte) */
+    public static  double cbrt( byte x ) {return Numeric.cbrt( x );}
+
+    /** @see io.deephaven.function.Numeric#cbrt(double) */
+    public static  double cbrt( double x ) {return Numeric.cbrt( x );}
+
+    /** @see io.deephaven.function.Numeric#cbrt(float) */
+    public static  double cbrt( float x ) {return Numeric.cbrt( x );}
+
+    /** @see io.deephaven.function.Numeric#cbrt(int) */
+    public static  double cbrt( int x ) {return Numeric.cbrt( x );}
+
+    /** @see io.deephaven.function.Numeric#cbrt(long) */
+    public static  double cbrt( long x ) {return Numeric.cbrt( x );}
+
+    /** @see io.deephaven.function.Numeric#cbrt(short) */
+    public static  double cbrt( short x ) {return Numeric.cbrt( x );}
+
     /** @see io.deephaven.function.Numeric#ceil(byte) */
     public static  double ceil( byte value ) {return Numeric.ceil( value );}
 
@@ -717,6 +771,24 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Numeric#containsNonFinite(short[]) */
     public static  boolean containsNonFinite( short... values ) {return Numeric.containsNonFinite( values );}
+
+    /** @see io.deephaven.function.Numeric#copySign(byte,byte) */
+    public static  byte copySign( byte magnitude, byte sign ) {return Numeric.copySign( magnitude, sign );}
+
+    /** @see io.deephaven.function.Numeric#copySign(double,double) */
+    public static  double copySign( double magnitude, double sign ) {return Numeric.copySign( magnitude, sign );}
+
+    /** @see io.deephaven.function.Numeric#copySign(float,float) */
+    public static  float copySign( float magnitude, float sign ) {return Numeric.copySign( magnitude, sign );}
+
+    /** @see io.deephaven.function.Numeric#copySign(int,int) */
+    public static  int copySign( int magnitude, int sign ) {return Numeric.copySign( magnitude, sign );}
+
+    /** @see io.deephaven.function.Numeric#copySign(long,long) */
+    public static  long copySign( long magnitude, long sign ) {return Numeric.copySign( magnitude, sign );}
+
+    /** @see io.deephaven.function.Numeric#copySign(short,short) */
+    public static  short copySign( short magnitude, short sign ) {return Numeric.copySign( magnitude, sign );}
 
     /** @see io.deephaven.function.Numeric#cor(byte[],byte[]) */
     public static  double cor( byte[] values0, byte[] values1 ) {return Numeric.cor( values0, values1 );}
@@ -1167,6 +1239,24 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Numeric#cos(short) */
     public static  double cos( short value ) {return Numeric.cos( value );}
+
+    /** @see io.deephaven.function.Numeric#cosh(byte) */
+    public static  double cosh( byte x ) {return Numeric.cosh( x );}
+
+    /** @see io.deephaven.function.Numeric#cosh(double) */
+    public static  double cosh( double x ) {return Numeric.cosh( x );}
+
+    /** @see io.deephaven.function.Numeric#cosh(float) */
+    public static  double cosh( float x ) {return Numeric.cosh( x );}
+
+    /** @see io.deephaven.function.Numeric#cosh(int) */
+    public static  double cosh( int x ) {return Numeric.cosh( x );}
+
+    /** @see io.deephaven.function.Numeric#cosh(long) */
+    public static  double cosh( long x ) {return Numeric.cosh( x );}
+
+    /** @see io.deephaven.function.Numeric#cosh(short) */
+    public static  double cosh( short x ) {return Numeric.cosh( x );}
 
     /** @see io.deephaven.function.Basic#count(byte[]) */
     public static  long count( byte... values ) {return Basic.count( values );}
@@ -2122,6 +2212,18 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#cumsum(io.deephaven.vector.ShortVector) */
     public static  long[] cumsum( io.deephaven.vector.ShortVector values ) {return Numeric.cumsum( values );}
 
+    /** @see io.deephaven.function.Numeric#decrementExact(byte) */
+    public static  byte decrementExact( byte x ) {return Numeric.decrementExact( x );}
+
+    /** @see io.deephaven.function.Numeric#decrementExact(int) */
+    public static  int decrementExact( int x ) {return Numeric.decrementExact( x );}
+
+    /** @see io.deephaven.function.Numeric#decrementExact(long) */
+    public static  long decrementExact( long x ) {return Numeric.decrementExact( x );}
+
+    /** @see io.deephaven.function.Numeric#decrementExact(short) */
+    public static  short decrementExact( short x ) {return Numeric.decrementExact( x );}
+
     /** @see io.deephaven.function.Numeric#diff(int,byte[]) */
     public static  byte[] diff( int stride, byte... values ) {return Numeric.diff( stride, values );}
 
@@ -2311,6 +2413,24 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#exp(short) */
     public static  double exp( short value ) {return Numeric.exp( value );}
 
+    /** @see io.deephaven.function.Numeric#expm1(byte) */
+    public static  double expm1( byte x ) {return Numeric.expm1( x );}
+
+    /** @see io.deephaven.function.Numeric#expm1(double) */
+    public static  double expm1( double x ) {return Numeric.expm1( x );}
+
+    /** @see io.deephaven.function.Numeric#expm1(float) */
+    public static  double expm1( float x ) {return Numeric.expm1( x );}
+
+    /** @see io.deephaven.function.Numeric#expm1(int) */
+    public static  double expm1( int x ) {return Numeric.expm1( x );}
+
+    /** @see io.deephaven.function.Numeric#expm1(long) */
+    public static  double expm1( long x ) {return Numeric.expm1( x );}
+
+    /** @see io.deephaven.function.Numeric#expm1(short) */
+    public static  double expm1( short x ) {return Numeric.expm1( x );}
+
     /** @see io.deephaven.function.Basic#first(byte[]) */
     public static  byte first( byte... values ) {return Basic.first( values );}
 
@@ -2425,6 +2545,30 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#floor(short) */
     public static  double floor( short value ) {return Numeric.floor( value );}
 
+    /** @see io.deephaven.function.Numeric#floorDiv(byte,byte) */
+    public static  byte floorDiv( byte x, byte y ) {return Numeric.floorDiv( x, y );}
+
+    /** @see io.deephaven.function.Numeric#floorDiv(int,int) */
+    public static  int floorDiv( int x, int y ) {return Numeric.floorDiv( x, y );}
+
+    /** @see io.deephaven.function.Numeric#floorDiv(long,long) */
+    public static  long floorDiv( long x, long y ) {return Numeric.floorDiv( x, y );}
+
+    /** @see io.deephaven.function.Numeric#floorDiv(short,short) */
+    public static  short floorDiv( short x, short y ) {return Numeric.floorDiv( x, y );}
+
+    /** @see io.deephaven.function.Numeric#floorMod(byte,byte) */
+    public static  byte floorMod( byte x, byte y ) {return Numeric.floorMod( x, y );}
+
+    /** @see io.deephaven.function.Numeric#floorMod(int,int) */
+    public static  int floorMod( int x, int y ) {return Numeric.floorMod( x, y );}
+
+    /** @see io.deephaven.function.Numeric#floorMod(long,long) */
+    public static  long floorMod( long x, long y ) {return Numeric.floorMod( x, y );}
+
+    /** @see io.deephaven.function.Numeric#floorMod(short,short) */
+    public static  short floorMod( short x, short y ) {return Numeric.floorMod( x, y );}
+
     /** @see io.deephaven.function.Basic#forwardFill(byte[]) */
     public static  byte[] forwardFill( byte... values ) {return Basic.forwardFill( values );}
 
@@ -2472,6 +2616,30 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Basic#forwardFillObj(io.deephaven.vector.ObjectVector) */
     public static <T> T[] forwardFillObj( io.deephaven.vector.ObjectVector<T> values ) {return Basic.forwardFillObj( values );}
+
+    /** @see io.deephaven.function.Numeric#getExponent(double) */
+    public static  int getExponent( double x ) {return Numeric.getExponent( x );}
+
+    /** @see io.deephaven.function.Numeric#getExponent(float) */
+    public static  int getExponent( float x ) {return Numeric.getExponent( x );}
+
+    /** @see io.deephaven.function.Numeric#hypot(byte,byte) */
+    public static  double hypot( byte x, byte y ) {return Numeric.hypot( x, y );}
+
+    /** @see io.deephaven.function.Numeric#hypot(double,double) */
+    public static  double hypot( double x, double y ) {return Numeric.hypot( x, y );}
+
+    /** @see io.deephaven.function.Numeric#hypot(float,float) */
+    public static  double hypot( float x, float y ) {return Numeric.hypot( x, y );}
+
+    /** @see io.deephaven.function.Numeric#hypot(int,int) */
+    public static  double hypot( int x, int y ) {return Numeric.hypot( x, y );}
+
+    /** @see io.deephaven.function.Numeric#hypot(long,long) */
+    public static  double hypot( long x, long y ) {return Numeric.hypot( x, y );}
+
+    /** @see io.deephaven.function.Numeric#hypot(short,short) */
+    public static  double hypot( short x, short y ) {return Numeric.hypot( x, y );}
 
     /** @see io.deephaven.function.Basic#ifelse(java.lang.Boolean[],byte,byte) */
     public static  byte[] ifelse( java.lang.Boolean[] condition, byte trueCase, byte falseCase ) {return Basic.ifelse( condition, trueCase, falseCase );}
@@ -2643,6 +2811,18 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Basic#inRange(short,short,short) */
     public static  boolean inRange( short testedValue, short lowInclusiveValue, short highInclusiveValue ) {return Basic.inRange( testedValue, lowInclusiveValue, highInclusiveValue );}
+
+    /** @see io.deephaven.function.Numeric#incrementExact(byte) */
+    public static  byte incrementExact( byte x ) {return Numeric.incrementExact( x );}
+
+    /** @see io.deephaven.function.Numeric#incrementExact(int) */
+    public static  int incrementExact( int x ) {return Numeric.incrementExact( x );}
+
+    /** @see io.deephaven.function.Numeric#incrementExact(long) */
+    public static  long incrementExact( long x ) {return Numeric.incrementExact( x );}
+
+    /** @see io.deephaven.function.Numeric#incrementExact(short) */
+    public static  short incrementExact( short x ) {return Numeric.incrementExact( x );}
 
     /** @see io.deephaven.function.Numeric#indexOfMax(byte[]) */
     public static  long indexOfMax( byte... values ) {return Numeric.indexOfMax( values );}
@@ -2989,6 +3169,42 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#log(short) */
     public static  double log( short value ) {return Numeric.log( value );}
 
+    /** @see io.deephaven.function.Numeric#log10(byte) */
+    public static  double log10( byte x ) {return Numeric.log10( x );}
+
+    /** @see io.deephaven.function.Numeric#log10(double) */
+    public static  double log10( double x ) {return Numeric.log10( x );}
+
+    /** @see io.deephaven.function.Numeric#log10(float) */
+    public static  double log10( float x ) {return Numeric.log10( x );}
+
+    /** @see io.deephaven.function.Numeric#log10(int) */
+    public static  double log10( int x ) {return Numeric.log10( x );}
+
+    /** @see io.deephaven.function.Numeric#log10(long) */
+    public static  double log10( long x ) {return Numeric.log10( x );}
+
+    /** @see io.deephaven.function.Numeric#log10(short) */
+    public static  double log10( short x ) {return Numeric.log10( x );}
+
+    /** @see io.deephaven.function.Numeric#log1p(byte) */
+    public static  double log1p( byte x ) {return Numeric.log1p( x );}
+
+    /** @see io.deephaven.function.Numeric#log1p(double) */
+    public static  double log1p( double x ) {return Numeric.log1p( x );}
+
+    /** @see io.deephaven.function.Numeric#log1p(float) */
+    public static  double log1p( float x ) {return Numeric.log1p( x );}
+
+    /** @see io.deephaven.function.Numeric#log1p(int) */
+    public static  double log1p( int x ) {return Numeric.log1p( x );}
+
+    /** @see io.deephaven.function.Numeric#log1p(long) */
+    public static  double log1p( long x ) {return Numeric.log1p( x );}
+
+    /** @see io.deephaven.function.Numeric#log1p(short) */
+    public static  double log1p( short x ) {return Numeric.log1p( x );}
+
     /** @see io.deephaven.function.Numeric#lowerBin(byte,byte) */
     public static  byte lowerBin( byte value, byte interval ) {return Numeric.lowerBin( value, interval );}
 
@@ -3198,6 +3414,48 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Numeric#minObj(io.deephaven.vector.ObjectVector) */
     public static <T extends java.lang.Comparable<T>> T minObj( io.deephaven.vector.ObjectVector<T> values ) {return Numeric.minObj( values );}
+
+    /** @see io.deephaven.function.Numeric#multiplyExact(byte,byte) */
+    public static  byte multiplyExact( byte x, byte y ) {return Numeric.multiplyExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#multiplyExact(int,int) */
+    public static  int multiplyExact( int x, int y ) {return Numeric.multiplyExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#multiplyExact(long,long) */
+    public static  long multiplyExact( long x, long y ) {return Numeric.multiplyExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#multiplyExact(short,short) */
+    public static  short multiplyExact( short x, short y ) {return Numeric.multiplyExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#negateExact(byte) */
+    public static  byte negateExact( byte x ) {return Numeric.negateExact( x );}
+
+    /** @see io.deephaven.function.Numeric#negateExact(int) */
+    public static  int negateExact( int x ) {return Numeric.negateExact( x );}
+
+    /** @see io.deephaven.function.Numeric#negateExact(long) */
+    public static  long negateExact( long x ) {return Numeric.negateExact( x );}
+
+    /** @see io.deephaven.function.Numeric#negateExact(short) */
+    public static  short negateExact( short x ) {return Numeric.negateExact( x );}
+
+    /** @see io.deephaven.function.Numeric#nextAfter(double,double) */
+    public static  double nextAfter( double start, double direction ) {return Numeric.nextAfter( start, direction );}
+
+    /** @see io.deephaven.function.Numeric#nextAfter(float,float) */
+    public static  float nextAfter( float start, float direction ) {return Numeric.nextAfter( start, direction );}
+
+    /** @see io.deephaven.function.Numeric#nextDown(double) */
+    public static  double nextDown( double x ) {return Numeric.nextDown( x );}
+
+    /** @see io.deephaven.function.Numeric#nextDown(float) */
+    public static  float nextDown( float x ) {return Numeric.nextDown( x );}
+
+    /** @see io.deephaven.function.Numeric#nextUp(double) */
+    public static  double nextUp( double x ) {return Numeric.nextUp( x );}
+
+    /** @see io.deephaven.function.Numeric#nextUp(float) */
+    public static  float nextUp( float x ) {return Numeric.nextUp( x );}
 
     /** @see io.deephaven.function.Logic#not(java.lang.Boolean[]) */
     public static  java.lang.Boolean[] not( java.lang.Boolean... values ) {return Logic.not( values );}
@@ -3943,6 +4201,12 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#round(short) */
     public static  long round( short value ) {return Numeric.round( value );}
 
+    /** @see io.deephaven.function.Numeric#scalb(double,int) */
+    public static  double scalb( double x, int scaleFactor ) {return Numeric.scalb( x, scaleFactor );}
+
+    /** @see io.deephaven.function.Numeric#scalb(float,int) */
+    public static  float scalb( float x, int scaleFactor ) {return Numeric.scalb( x, scaleFactor );}
+
     /** @see io.deephaven.function.Numeric#sequence(byte,byte,byte) */
     public static  byte[] sequence( byte start, byte end, byte step ) {return Numeric.sequence( start, end, step );}
 
@@ -3996,6 +4260,24 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Numeric#sin(short) */
     public static  double sin( short value ) {return Numeric.sin( value );}
+
+    /** @see io.deephaven.function.Numeric#sinh(byte) */
+    public static  double sinh( byte x ) {return Numeric.sinh( x );}
+
+    /** @see io.deephaven.function.Numeric#sinh(double) */
+    public static  double sinh( double x ) {return Numeric.sinh( x );}
+
+    /** @see io.deephaven.function.Numeric#sinh(float) */
+    public static  double sinh( float x ) {return Numeric.sinh( x );}
+
+    /** @see io.deephaven.function.Numeric#sinh(int) */
+    public static  double sinh( int x ) {return Numeric.sinh( x );}
+
+    /** @see io.deephaven.function.Numeric#sinh(long) */
+    public static  double sinh( long x ) {return Numeric.sinh( x );}
+
+    /** @see io.deephaven.function.Numeric#sinh(short) */
+    public static  double sinh( short x ) {return Numeric.sinh( x );}
 
     /** @see io.deephaven.function.Sort#sort(byte[]) */
     public static  byte[] sort( byte... values ) {return Sort.sort( values );}
@@ -4255,6 +4537,18 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#ste(io.deephaven.vector.ShortVector) */
     public static  double ste( io.deephaven.vector.ShortVector values ) {return Numeric.ste( values );}
 
+    /** @see io.deephaven.function.Numeric#subtractExact(byte,byte) */
+    public static  byte subtractExact( byte x, byte y ) {return Numeric.subtractExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#subtractExact(int,int) */
+    public static  int subtractExact( int x, int y ) {return Numeric.subtractExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#subtractExact(long,long) */
+    public static  long subtractExact( long x, long y ) {return Numeric.subtractExact( x, y );}
+
+    /** @see io.deephaven.function.Numeric#subtractExact(short,short) */
+    public static  short subtractExact( short x, short y ) {return Numeric.subtractExact( x, y );}
+
     /** @see io.deephaven.function.Numeric#sum(byte[]) */
     public static  long sum( byte... values ) {return Numeric.sum( values );}
 
@@ -4309,6 +4603,96 @@ public class GroovyStaticImports {
     /** @see io.deephaven.function.Numeric#tan(short) */
     public static  double tan( short value ) {return Numeric.tan( value );}
 
+    /** @see io.deephaven.function.Numeric#tanh(byte) */
+    public static  double tanh( byte x ) {return Numeric.tanh( x );}
+
+    /** @see io.deephaven.function.Numeric#tanh(double) */
+    public static  double tanh( double x ) {return Numeric.tanh( x );}
+
+    /** @see io.deephaven.function.Numeric#tanh(float) */
+    public static  double tanh( float x ) {return Numeric.tanh( x );}
+
+    /** @see io.deephaven.function.Numeric#tanh(int) */
+    public static  double tanh( int x ) {return Numeric.tanh( x );}
+
+    /** @see io.deephaven.function.Numeric#tanh(long) */
+    public static  double tanh( long x ) {return Numeric.tanh( x );}
+
+    /** @see io.deephaven.function.Numeric#tanh(short) */
+    public static  double tanh( short x ) {return Numeric.tanh( x );}
+
+    /** @see io.deephaven.function.Numeric#toByteExact(byte) */
+    public static  short toByteExact( byte x ) {return Numeric.toByteExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toByteExact(int) */
+    public static  short toByteExact( int x ) {return Numeric.toByteExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toByteExact(long) */
+    public static  short toByteExact( long x ) {return Numeric.toByteExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toByteExact(short) */
+    public static  short toByteExact( short x ) {return Numeric.toByteExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toDegrees(byte) */
+    public static  double toDegrees( byte x ) {return Numeric.toDegrees( x );}
+
+    /** @see io.deephaven.function.Numeric#toDegrees(double) */
+    public static  double toDegrees( double x ) {return Numeric.toDegrees( x );}
+
+    /** @see io.deephaven.function.Numeric#toDegrees(float) */
+    public static  double toDegrees( float x ) {return Numeric.toDegrees( x );}
+
+    /** @see io.deephaven.function.Numeric#toDegrees(int) */
+    public static  double toDegrees( int x ) {return Numeric.toDegrees( x );}
+
+    /** @see io.deephaven.function.Numeric#toDegrees(long) */
+    public static  double toDegrees( long x ) {return Numeric.toDegrees( x );}
+
+    /** @see io.deephaven.function.Numeric#toDegrees(short) */
+    public static  double toDegrees( short x ) {return Numeric.toDegrees( x );}
+
+    /** @see io.deephaven.function.Numeric#toIntExact(byte) */
+    public static  int toIntExact( byte x ) {return Numeric.toIntExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toIntExact(int) */
+    public static  int toIntExact( int x ) {return Numeric.toIntExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toIntExact(long) */
+    public static  int toIntExact( long x ) {return Numeric.toIntExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toIntExact(short) */
+    public static  int toIntExact( short x ) {return Numeric.toIntExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toRadians(byte) */
+    public static  double toRadians( byte x ) {return Numeric.toRadians( x );}
+
+    /** @see io.deephaven.function.Numeric#toRadians(double) */
+    public static  double toRadians( double x ) {return Numeric.toRadians( x );}
+
+    /** @see io.deephaven.function.Numeric#toRadians(float) */
+    public static  double toRadians( float x ) {return Numeric.toRadians( x );}
+
+    /** @see io.deephaven.function.Numeric#toRadians(int) */
+    public static  double toRadians( int x ) {return Numeric.toRadians( x );}
+
+    /** @see io.deephaven.function.Numeric#toRadians(long) */
+    public static  double toRadians( long x ) {return Numeric.toRadians( x );}
+
+    /** @see io.deephaven.function.Numeric#toRadians(short) */
+    public static  double toRadians( short x ) {return Numeric.toRadians( x );}
+
+    /** @see io.deephaven.function.Numeric#toShortExact(byte) */
+    public static  short toShortExact( byte x ) {return Numeric.toShortExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toShortExact(int) */
+    public static  short toShortExact( int x ) {return Numeric.toShortExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toShortExact(long) */
+    public static  short toShortExact( long x ) {return Numeric.toShortExact( x );}
+
+    /** @see io.deephaven.function.Numeric#toShortExact(short) */
+    public static  short toShortExact( short x ) {return Numeric.toShortExact( x );}
+
     /** @see io.deephaven.function.Numeric#tstat(byte[]) */
     public static  double tstat( byte... values ) {return Numeric.tstat( values );}
 
@@ -4362,6 +4746,12 @@ public class GroovyStaticImports {
 
     /** @see io.deephaven.function.Numeric#tstat(io.deephaven.vector.ShortVector) */
     public static  double tstat( io.deephaven.vector.ShortVector values ) {return Numeric.tstat( values );}
+
+    /** @see io.deephaven.function.Numeric#ulp(double) */
+    public static  double ulp( double x ) {return Numeric.ulp( x );}
+
+    /** @see io.deephaven.function.Numeric#ulp(float) */
+    public static  float ulp( float x ) {return Numeric.ulp( x );}
 
     /** @see io.deephaven.function.Basic#unbox(java.lang.Byte[]) */
     public static  byte[] unbox( java.lang.Byte... values ) {return Basic.unbox( values );}


### PR DESCRIPTION

Newly supported methods and constants:

- [ ] addExact
- [ ] atan2
- [ ] cbrt
- [ ] copySign
- [ ] cosh
- [ ] decrementExact
- [ ] expm1
- [ ] floorDiv
- [ ] floorMod
- [ ] getExponent
- [ ] hypot
- [ ] IEEEremainder
- [ ] incrementExact
- [ ] log10
- [ ] log1p
- [ ] multiplyExact
- [ ] negateExact
- [ ] nextAfter
- [ ] nextDown
- [ ] nextUp
- [ ] scalb
- [ ] sinh
- [ ] subtractExact
- [ ] tanh
- [ ] toDegrees
- [ ] toRadians
- [ ] toIntExact
- [ ] toShortExact
- [ ] toByteExact
- [ ] ulp
- [ ] E (constant)
- [ ] PI (constant)

Resolves #5995.