### PR TITLE
fix: BaseTable#awaitUpdate Could Account for Exclusive Lock Wait Time

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -525,11 +525,25 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
     @Override
     public boolean awaitUpdate(long timeout) throws InterruptedException {
-        final MutableBoolean result = new MutableBoolean(false);
-        updateGraph.exclusiveLock().doLocked(
-                () -> result.setValue(ensureCondition().await(timeout, TimeUnit.MILLISECONDS)));
 
-        return result.booleanValue();
+        final long startTime = System.nanoTime();
+        if (!updateGraph.exclusiveLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+            // Usually, users will already be holding the exclusive lock when calling this method. If they are not and
+            // cannot acquire the lock within the timeout, we should return false now.
+            return false;
+        }
+        timeout -= (System.nanoTime() - startTime) / 1_000_000;
+
+        boolean result;
+        try {
+            // Note that we must reacquire the exclusive lock before returning from await. This deadline may be
+            // exceeded if the thread must wait to reacquire the lock.
+            result = ensureCondition().await(timeout, TimeUnit.MILLISECONDS);
+        } finally {
+            updateGraph.exclusiveLock().unlock();
+        }
+
+        return result;
     }
 
     private Condition ensureCondition() {


### PR DESCRIPTION
This is a best effort timeout, and users typically already hold the exclusive lock on the way in. Added a few comments to make behavior less mysterious for non-dh readers.