### PR TITLE
fix: Fix protobuf doc deployment

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -426,7 +426,7 @@ jobs:
           cat gradle.properties
 
       - name: Generate Protobuf Docs
-        run: ./gradlew generateProtobuf
+        run: ./gradlew --scan outputVersion :proto:proto-backplane-grpc:generateProtobuf
 
       - name: Get Deephaven Version
         id: dhc-version


### PR DESCRIPTION
The recent PR to add protobuf documentation deployment to GHA failed to use an important Gradle flag, resulting in the artifact being misnamed.