### PR TITLE
fix: JS Barrage snapshots must overwrite server viewport

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -383,9 +383,12 @@ public class TableViewportSubscription extends AbstractTableSubscription {
                 if (message != null) {
                     // Replace rowsets with flat versions
                     long resultSize = message.rowsIncluded.size();
-                    message.rowsAdded = RangeSet.ofRange(rowsReceived.get(), rowsReceived.get() + resultSize - 1);
-                    message.rowsIncluded = message.rowsAdded;
-                    rowsReceived.add(resultSize);
+                    if (resultSize != 0) {
+                        message.rowsAdded = RangeSet.ofRange(rowsReceived.get(), rowsReceived.get() + resultSize - 1);
+                        message.rowsIncluded = message.rowsAdded;
+                        message.snapshotRowSet = null;
+                        rowsReceived.add(resultSize);
+                    }
 
                     // Update our table data with the complete message
                     snapshot.applyUpdates(message);
@@ -420,8 +423,14 @@ public class TableViewportSubscription extends AbstractTableSubscription {
             doExchange.onEnd(status -> {
                 if (status.isOk()) {
                     // notify the caller that the snapshot is finished
+                    RangeSet result;
+                    if (rowsReceived.get() != 0) {
+                        result = RangeSet.ofRange(0, rowsReceived.get() - 1);
+                    } else {
+                        result = RangeSet.empty();
+                    }
                     resolve.onInvoke(new SubscriptionEventData(snapshot, rowStyleColumn, Js.uncheckedCast(columns),
-                            RangeSet.ofRange(0, rowsReceived.get() - 1),
+                            result,
                             RangeSet.empty(),
                             RangeSet.empty(),
                             null));

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
@@ -438,6 +438,8 @@ public class ViewportTestGwt extends AbstractAsyncGwtTestCase {
         connect(tables)
                 .then(table("big"))
                 .<Object>then(table -> {
+                    delayTestFinish(20_001);
+
                     Column[] all = Js.uncheckedCast(table.getColumns());
                     // This table is static and non-flat, to make sure our calls will make sense to get data.
                     // Subscribe to a viewport, and grab some rows in a snapshot


### PR DESCRIPTION
Also fixed an error when the table (or viewport) is empty.

Fixes #6138