### PR TITLE
fix: Ensure ParquetInstruction's TableDefinition is set for ParquetTableLocation

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/location/IcebergTableParquetLocationKey.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/location/IcebergTableParquetLocationKey.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * {@link TableLocationKey} implementation for use with data stored in Iceberg tables in the parquet format.
@@ -36,7 +37,8 @@ public class IcebergTableParquetLocationKey extends ParquetTableLocationKey impl
             @Nullable final Map<String, Comparable<?>> partitions,
             @NotNull final ParquetInstructions readInstructions) {
         super(fileUri, order, partitions, readInstructions);
-        this.readInstructions = readInstructions;
+        this.readInstructions = Objects.requireNonNull(readInstructions);
+        ParquetInstructions.ensureDefinition(readInstructions);
     }
 
     @Override

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -36,6 +36,18 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
     private static volatile String defaultCompressionCodecName = CompressionCodecName.SNAPPY.toString();
 
     /**
+     * Throws an exception if {@link ParquetInstructions#getTableDefinition()} is empty.
+     *
+     * @param parquetInstructions the parquet instructions
+     * @throws IllegalArgumentException if there is not a table definition
+     */
+    public static void ensureDefinition(ParquetInstructions parquetInstructions) {
+        if (parquetInstructions.getTableDefinition().isEmpty()) {
+            throw new IllegalArgumentException("Table definition must be provided");
+        }
+    }
+
+    /**
      * Set the default for {@link #getCompressionCodecName()}.
      *
      * @deprecated Use {@link Builder#setCompressionCodecName(String)} instead.

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -78,7 +78,8 @@ public class ParquetTableLocation extends AbstractTableLocation {
             @NotNull final ParquetTableLocationKey tableLocationKey,
             @NotNull final ParquetInstructions readInstructions) {
         super(tableKey, tableLocationKey, false);
-        this.readInstructions = readInstructions;
+        this.readInstructions = Objects.requireNonNull(readInstructions);
+        ParquetInstructions.ensureDefinition(readInstructions);
         final ParquetMetadata parquetMetadata;
         // noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (tableLocationKey) {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocationFactory.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocationFactory.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Objects;
 
 import static io.deephaven.parquet.base.ParquetFileReader.FILE_URI_SCHEME;
 
@@ -25,7 +26,8 @@ public final class ParquetTableLocationFactory implements TableLocationFactory<T
     private final ParquetInstructions readInstructions;
 
     public ParquetTableLocationFactory(@NotNull final ParquetInstructions readInstructions) {
-        this.readInstructions = readInstructions;
+        this.readInstructions = Objects.requireNonNull(readInstructions);
+        ParquetInstructions.ensureDefinition(readInstructions);
     }
 
     @Override

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -408,6 +408,7 @@ public final class ParquetTableReadWriteTest {
         final TableDefinition definition = TableDefinition.of(
                 ColumnDefinition.ofInt("someInt"),
                 ColumnDefinition.ofString("someString"));
+        final ParquetInstructions instructions = EMPTY.withTableDefinition(definition);
         final Table testTable =
                 ((QueryTable) TableTools.emptyTable(10).select("someInt = i", "someString  = `foo`")
                         .where("i % 2 == 0").groupBy("someString").ungroup("someInt")
@@ -431,8 +432,8 @@ public final class ParquetTableReadWriteTest {
                 StandaloneTableKey.getInstance(),
                 new ParquetTableLocationKey(
                         convertToURI(dest, false),
-                        0, Map.of(), EMPTY),
-                EMPTY);
+                        0, Map.of(), instructions),
+                instructions);
         assertEquals(tableLocation.getSortedColumns(), List.of(SortColumn.desc(ColumnName.of("someInt"))));
 
         final ParquetTableLocation index1Location = new ParquetTableLocation(
@@ -440,8 +441,8 @@ public final class ParquetTableReadWriteTest {
                 new ParquetTableLocationKey(
                         convertToURI(new File(rootFile,
                                 ParquetTools.getRelativeIndexFilePath(dest.getName(), "someString")), false),
-                        0, Map.of(), EMPTY),
-                EMPTY);
+                        0, Map.of(), instructions),
+                instructions);
         assertEquals(index1Location.getSortedColumns(), List.of(SortColumn.asc(ColumnName.of("someString"))));
         final Table index1Table = DataIndexer.getDataIndex(fromDisk, "someString").table();
         assertTableEquals(index1Table, index1Table.sort("someString"));
@@ -451,8 +452,8 @@ public final class ParquetTableReadWriteTest {
                 new ParquetTableLocationKey(
                         convertToURI(new File(rootFile,
                                 ParquetTools.getRelativeIndexFilePath(dest.getName(), "someInt", "someString")), false),
-                        0, Map.of(), EMPTY),
-                EMPTY);
+                        0, Map.of(), instructions),
+                instructions);
         assertEquals(index2Location.getSortedColumns(), List.of(
                 SortColumn.asc(ColumnName.of("someInt")),
                 SortColumn.asc(ColumnName.of("someString"))));


### PR DESCRIPTION
Fixes an inconsistency between `ParquetTools#readSingleFileTable` and `ParquetTools#readTable` in regards to whether they set the TableDefinition in the ParquetInstructions after inference.

This is done as part of an effort towards #6128.