### PR TITLE
fix: Fix Iceberg JDBC tests on Java 23

### DIFF
--- a/extensions/iceberg/build.gradle
+++ b/extensions/iceberg/build.gradle
@@ -58,6 +58,31 @@ dependencies {
     testImplementation project(':engine-test-utils')
 }
 
+/**
+ * We are setting up a "security-manage-allow" tag to add the system property `-Djava.security.manager=allow`
+ * to the tests that need it for Java 23+. Otherwise, the following exception is thrown:
+ *
+ * java.lang.UnsupportedOperationException: getSubject is supported only if a security manager is allowed
+ *   at java.base/javax.security.auth.Subject.getSubject(Subject.java:347)
+ *   at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:588)
+ *
+ * See https://issues.apache.org/jira/browse/HADOOP-19212
+ * See https://jdk.java.net/23/release-notes#JDK-8296244
+ */
+
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags("security-manager-allow")
+    }
 }
+
+def testSecurityManagerAllow = tasks.register('testSecurityManagerAllow', Test) {
+    useJUnitPlatform {
+        includeTags("security-manager-allow")
+    }
+    if (it.javaLauncher.get().metadata.languageVersion >= JavaLanguageVersion.of(23)) {
+        it.systemProperty("java.security.manager", "allow")
+    }
+}
+
+check.dependsOn testSecurityManagerAllow

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/PyIceberg1Test.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/PyIceberg1Test.java
@@ -15,6 +15,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This test shows that we can integrate with data written by <a href="https://py.iceberg.apache.org/">pyiceberg</a>.
  * See TESTING.md and generate-pyiceberg-1.py for more details.
  */
+@Tag("security-manager-allow")
 public class PyIceberg1Test {
     private static final Namespace NAMESPACE = Namespace.of("dh-default");
     private static final TableIdentifier CITIES_ID = TableIdentifier.of(NAMESPACE, "cities");

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/CatalogAdapterBase.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/CatalogAdapterBase.java
@@ -10,12 +10,13 @@ import io.deephaven.iceberg.util.IcebergTools;
 import org.apache.iceberg.catalog.Catalog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 
-
+@Tag("security-manager-allow")
 public abstract class CatalogAdapterBase {
 
     protected IcebergCatalogAdapter catalogAdapter;


### PR DESCRIPTION
The Iceberg JDBC tests are failing in Java 23, with the (abbreviated) failure:

```
java.lang.UnsupportedOperationException: getSubject is supported only if a security manager is allowed
	at java.base/javax.security.auth.Subject.getSubject(Subject.java:347)
	at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:588)
	at org.apache.iceberg.hadoop.Util.getFs(Util.java:56)
        ...
	at org.apache.iceberg.hadoop.HadoopInputFile.fromLocation(HadoopInputFile.java:56)
	at io.deephaven.iceberg.PyIceberg1Test.catalogInfo(PyIceberg1Test.java:58)
```

This adds a targetted JUnit 5 tag that will run the specific tests with the system property `-Djava.security.manager=allow`, and only on Java 23+.

See https://issues.apache.org/jira/browse/HADOOP-19212

See https://jdk.java.net/23/release-notes#JDK-8296244