### PR TITLE
chore: Fix broken links in markdown.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Over time, forks will get out of sync with the upstream repository.  To stay up 
 * Follow these directions on [Syncing A Fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork).
 
 ## Building and Running
-For instructions on building and running, see [Build and launch from source](https://deephaven.io/core/docs/how-to-guides/launch-build/).
+For instructions on building and running, see [Build and launch from source](https://deephaven.io/core/docs/getting-started/launch-build/).
 
 ## Creating a Pull Request
 Pull requests can be created through the GitHub website or through the GitHub CLI.

--- a/R/rdeephaven/README.md
+++ b/R/rdeephaven/README.md
@@ -23,11 +23,11 @@ The R Client provides the following functionalities:
    -   Construct and execute complex queries
    -   Retrieve references to tables on the server
    -   Pull table data into an [Arrow RecordBatchReader](https://arrow.apache.org/docs/r/reference/RecordBatchReader.html),
-an [Arrow Table](https://arrow.apache.org/docs/r/reference/Table.html),
+an [Arrow Table](https://arrow.apache.org/docs/6.0/r/reference/Table.html),
 a [dplyr Tibble](https://tibble.tidyverse.org),
 or an [R Data Frame](https://stat.ethz.ch/R-manual/R-devel/library/base/html/data.frame.html)
    -   Create new tables on the server from an [Arrow RecordBatchReader](https://arrow.apache.org/docs/r/reference/RecordBatchReader.html),
-an [Arrow Table](https://arrow.apache.org/docs/r/reference/Table.html),
+an [Arrow Table](https://arrow.apache.org/docs/6.0/r/reference/Table.html),
 a [dplyr Tibble](https://tibble.tidyverse.org),
 or an [R Data Frame](https://stat.ethz.ch/R-manual/R-devel/library/base/html/data.frame.html)
    -   Call Deephaven table methods with familiar R functions

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Deephaven's client APIs use [gRPC](https://grpc.io/), [protobuf](https://github.
 The following list contains documentation links for installation instructions and more:
 
 - Python
-  - [Run from Docker](https://deephaven.io/core/docs/tutorials/quickstart/)
-  - [pip-installed](https://deephaven.io/core/docs/tutorials/quickstart-pip/)
+  - [Run from Docker](https://deephaven.io/core/docs/getting-started/quickstart/)
+  - [pip-installed](https://deephaven.io/core/docs/getting-started/pip-install/)
 - Groovy
-  - [Run from Docker](https://deephaven.io/core/groovy/docs/tutorials/quickstart/)
+  - [Run from Docker](https://deephaven.io/core/docs/getting-started/quickstart/)
 - [Python client](https://pypi.org/project/pydeephaven/)
 - [Java client](https://deephaven.io/core/docs/how-to-guides/java-client/)
-- [JS client](https://deephaven.io/core/docs/reference/js-api/documentation/)
+- [JS client](https://deephaven.io/core/client-api/javascript/modules/dh.html)
 - [Go client](https://pkg.go.dev/github.com/deephaven/deephaven-core/go)
 - [R client](https://github.com/deephaven/deephaven-core/blob/main/R/rdeephaven/README.md)
 
@@ -52,7 +52,7 @@ The Deephaven server can be installed and instantiated [from Docker](#from-docke
 
 ### From Docker
 
-This is the easiest way to get started with Deephaven. For complete instructions, see our [quickstart for Docker](https://deephaven.io/core/docs/tutorials/quickstart/). The table below shows installation dependencies.
+This is the easiest way to get started with Deephaven. For complete instructions, see our [quickstart for Docker](https://deephaven.io/core/docs/getting-started/quickstart/). The table below shows installation dependencies.
 
 | Dependency     | Version  | OS      | Required/Recommended |
 | -------------- | -------- | --------| -------------------- |
@@ -77,7 +77,7 @@ docker run --rm --name deephaven -p 10000:10000 ghcr.io/deephaven/server:latest
 docker run --rm name deephaven -p 10000:10000 ghcr.io/deephaven/server-slim:latest
 ```
 
-Users who wish to customize their deployment should use Docker Compose. Deephaven offers a multitude of pre-made [docker-compose.yml files](https://deephaven.io/core/docs/tutorials/quickstart/#choose-a-deployment) to choose from. To get started, all that's required is to download a file, pull the images, and start the server.
+Users who wish to customize their deployment should use Docker Compose. Deephaven offers a multitude of pre-made [docker-compose.yml files](https://deephaven.io/core/docs/getting-started/docker-install/#choose-a-deployment) to choose from. To get started, all that's required is to download a file, pull the images, and start the server.
 
 **Python with Docker Compose**
 
@@ -127,7 +127,7 @@ The input arguments to `Server` specify to bind to the Deephaven server on port 
 
 ### Built from source
 
-Users who wish to modify source code and contribute to the project should build Deephaven from source. For complete instructions, see [How to build Deephaven from source](https://deephaven.io/core/docs/how-to-guides/launch-build/).
+Users who wish to modify source code and contribute to the project should build Deephaven from source. For complete instructions, see [How to build Deephaven from source](https://deephaven.io/core/docs/getting-started/launch-build/).
 
 Building and running Deephaven requires a few software packages.
 

--- a/containers/groovy-examples/README.md
+++ b/containers/groovy-examples/README.md
@@ -10,7 +10,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-groovy--java-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-groovy--java-with-example-data).  For full instructions to work with Deephaven, see the [Quickstart](https://deephaven.io/core/groovy/docs/tutorials/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-examples-redpanda/README.md
+++ b/containers/python-examples-redpanda/README.md
@@ -11,7 +11,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For instructions on launching and using Kafka in Deephaven, see[How to connect to a Kafka stream](https://deephaven.io/core/groovy/docs/how-to-guides/data-import-export/kafka-stream/). For instructions on getting started with Deephaven, see the [Quickstart](https://deephaven.io/core/docs/tutorials/quickstart).
+For instructions on launching and using Kafka in Deephaven, see[How to connect to a Kafka stream](https://deephaven.io/core/groovy/docs/how-to-guides/data-import-export/kafka-stream/). For instructions on getting started with Deephaven, see the [Quickstart](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-examples/All-AI/README.md
+++ b/containers/python-examples/All-AI/README.md
@@ -14,7 +14,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-examples/NLTK/README.md
+++ b/containers/python-examples/NLTK/README.md
@@ -11,7 +11,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-examples/PyTorch/README.md
+++ b/containers/python-examples/PyTorch/README.md
@@ -11,7 +11,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-examples/SciKit-Learn/README.md
+++ b/containers/python-examples/SciKit-Learn/README.md
@@ -11,7 +11,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-examples/TensorFlow/README.md
+++ b/containers/python-examples/TensorFlow/README.md
@@ -11,7 +11,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-examples/base/README.md
+++ b/containers/python-examples/base/README.md
@@ -10,7 +10,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python-redpanda/README.md
+++ b/containers/python-redpanda/README.md
@@ -10,7 +10,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For instructions on launching and using Kafka, see [How to connect to a Kafka stream](https://deephaven.io/core/docs/how-to-guides/data-import-export/kafka-stream/). For instructions on getting started with Deephaven, see the [Quickstart](https://deephaven.io/core/docs/tutorials/quickstart).
+For instructions on launching and using Kafka, see [How to connect to a Kafka stream](https://deephaven.io/core/docs/how-to-guides/data-import-export/kafka-stream/). For instructions on getting started with Deephaven, see the [Quickstart](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python/All-AI/README.md
+++ b/containers/python/All-AI/README.md
@@ -13,7 +13,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python/NLTK/README.md
+++ b/containers/python/NLTK/README.md
@@ -10,7 +10,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python/PyTorch/README.md
+++ b/containers/python/PyTorch/README.md
@@ -10,7 +10,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python/SciKit-Learn/README.md
+++ b/containers/python/SciKit-Learn/README.md
@@ -10,7 +10,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python/TensorFlow/README.md
+++ b/containers/python/TensorFlow/README.md
@@ -10,7 +10,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core#launch-python-with-example-data).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/containers/python/base/README.md
+++ b/containers/python/base/README.md
@@ -9,7 +9,7 @@ A Docker Compose deployment for [Deephaven](https://deephaven.io).
 
 ## Launch Deephaven
 
-For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/tutorials/quickstart).
+For launch instructions, see the [README](https://github.com/deephaven/deephaven-core/#launch-python).  For full instructions to work with Deephaven, see the [Quick start](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 To launch Deephaven, execute the following in your deployment directory:
 

--- a/cpp-client/README.md
+++ b/cpp-client/README.md
@@ -17,7 +17,7 @@ To actually use Deephaven, for example running these examples and unit
 tests, you will eventually need to have a server running. If you have
 an existing server running Deephaven Core, you should be able to
 connect to that. However, if you don't have one, you can follow the
-instructions here: https://deephaven.io/core/docs/how-to-guides/launch-build/.
+instructions [here](https://deephaven.io/core/docs/getting-started/launch-build/).
 
 Note that it is only possible to build a server on Linux. Building a server on
 Windows is not currently supported.

--- a/csharp/ExcelAddIn/README.md
+++ b/csharp/ExcelAddIn/README.md
@@ -19,7 +19,7 @@ run it.
 
 If you don't have a Deephaven Community Core server installation,
 you can use these instructions to build one.
-https://deephaven.io/core/docs/how-to-guides/launch-build/
+https://deephaven.io/core/docs/getting-started/launch-build/
 
 Note that it is only possible to build a server on Linux. Building a server
 on Windows is not currently supported.

--- a/debezium/demo/README.md
+++ b/debezium/demo/README.md
@@ -29,9 +29,8 @@ How to run
 ==========
 
 First, if you are building from sources, follow the instructions
-in https://deephaven.io/core/docs/how-to-guides/launch-build,
-and ensure you can launch a regular version of Deephaven
-as per the instructions there.  Once that works, stop that
+[here](https://deephaven.io/core/docs/getting-started/launch-build/) and ensure you can launch a regular version of 
+Deephaven as per the instructions there.  Once that works, stop that
 Deephaven instance, and continue below.
 
 Start docker compose with the compose file in this

--- a/docker/web-plugin-packager/README.md
+++ b/docker/web-plugin-packager/README.md
@@ -4,7 +4,7 @@ web-plugin-packager is a docker image used to package JS plugins for the Deephav
 
 ## Usage
 
-First, follow the instructions to [Launch Deephaven from pre-built images](https://deephaven.io/core/docs/tutorials/quickstart/#set-up-your-deephaven-deployment).
+First, follow the instructions to [Launch Deephaven from pre-built images](https://deephaven.io/core/docs/getting-started/quickstart/#set-up-your-deephaven-deployment).
 
 Once you have the `docker-compose.yml` file pulled down, define your own web docker image in `web/Dockerfile` that includes the plugins you would like to use. 
 

--- a/server/jetty-app/README.md
+++ b/server/jetty-app/README.md
@@ -4,7 +4,7 @@ This README is oriented towards getting a server up for local development in a d
 
 If you wish to use Deephaven from a production environment, which is simpler but source code cannot be modified, see one of the following documents:
 
-- [Quickstart for Docker](https://deephaven.io/core/docs/tutorials/quickstart/)
+- [Quickstart for Docker](https://deephaven.io/core/docs/getting-started/quickstart/)
 - [How to configure the Deephaven native application](https://deephaven.io/core/docs/how-to-guides/configuration/native-application/)
 
 This README deals with general development for either the Python or Groovy server-side API. For Python-specific development instructions, see the [Python development README](../../py/README.md).


### PR DESCRIPTION
This fixes a slew of broken links. This PR does not address CI at all. That will be covered separately if we want to add the docs tool to core.