### PR TITLE
fix(py-client-test): Read PluginClients In Order; fix shared_ticket Ref

### DIFF
--- a/py/client/tests/test_plugin_client.py
+++ b/py/client/tests/test_plugin_client.py
@@ -90,7 +90,7 @@ plot3 = Figure().plot_xy(series_name="Random numbers", t=empty_table(30).update(
 
         with self.subTest("released Plugin object"):
             sub_session = Session()
-            # close top-level session's export to diable the shared ticket
+            # close top-level session's export to disable the shared ticket
             self.session.release(export_plugin_client)
             server_obj = ServerObject(type="Figure", ticket=shared_ticket)
             with self.assertRaises(Exception):

--- a/py/client/tests/test_plugin_client.py
+++ b/py/client/tests/test_plugin_client.py
@@ -46,6 +46,27 @@ plot3 = Figure().plot_xy(series_name="Random numbers", t=empty_table(30).update(
         plugin_client = self.session.plugin_client(self.session.exportable_objects["plot3"])
         self.assertIsNotNone(plugin_client)
 
+        with self.subTest("Fetchable in the Plugin object"):
+            payload, refs = next(plugin_client.resp_stream)
+            self.assertGreater(len(payload), 0)
+            self.assertGreater(len(refs), 0)
+            ref = refs[0]
+            self.assertEqual(ref.type, "Table")
+            fetched = ref.fetch()
+            self.assertIsNotNone(fetched)
+            self.assertEqual(fetched.size, 30)
+
+            # Publish the fetchable
+            tbl_shared_ticket = SharedTicket.random_ticket()
+            self.session.publish(ref, tbl_shared_ticket)
+
+            # Another session to use the shared fetchable
+            sub_session = Session()
+            sub_table = sub_session.fetch_table(tbl_shared_ticket)
+            self.assertIsNotNone(sub_table)
+            self.assertEqual(sub_table.size, 30)
+            sub_session.close()
+
         with self.subTest("Plugin object"):
             # First fetch the Plugin object, then publish it
             export_plugin_client = self.session.fetch(plugin_client)
@@ -67,34 +88,13 @@ plot3 = Figure().plot_xy(series_name="Random numbers", t=empty_table(30).update(
             sub_plugin_client.close()
             sub_session.close()
 
-        with self.subTest("Fetchable in the Plugin object"):
-            payload, refs = next(plugin_client.resp_stream)
-            self.assertGreater(len(payload), 0)
-            self.assertGreater(len(refs), 0)
-            ref = refs[0]
-            self.assertEqual(ref.type, "Table")
-            fetched = ref.fetch()
-            self.assertIsNotNone(fetched)
-            self.assertEqual(fetched.size, 30)
-
-            # Publish the fetchable
-            shared_ticket = SharedTicket.random_ticket()
-            self.session.publish(ref, shared_ticket)
-
-            # Another session to use the shared fetchable
-            sub_session = Session()
-            sub_table = sub_session.fetch_table(shared_ticket)
-            self.assertIsNotNone(sub_table)
-            self.assertEqual(sub_table.size, 30)
-            sub_session.close()
-
         with self.subTest("released Plugin object"):
             sub_session = Session()
-            server_obj = ServerObject(type="Figure", ticket=shared_ticket)
-            sub_plugin_client = sub_session.plugin_client(server_obj)
+            # close top-level session's export to diable the shared ticket
             self.session.release(export_plugin_client)
+            server_obj = ServerObject(type="Figure", ticket=shared_ticket)
             with self.assertRaises(Exception):
-                payload, refs = next(sub_plugin_client.resp_stream)
+                sub_plugin_client = sub_session.plugin_client(server_obj)
             sub_session.close()
 
         plugin_client.close()


### PR DESCRIPTION
This is related to investigation in #5996. Colin thinks he has the true final work around for the issue that we were able to reproduce. In the meantime, we'll swap the order of the tests to reduce the probability of it occurring.

I also adjusted one of the tests to hit the already-expired shared_ticket error case (it was failing for a different reason as the ticket referenced was a live table and not the shared ticket anymore.)

The ObjectService change is to adopt the proper pattern for ExportObject requirements. In this case it does not matter since all of those `dependencies` are new server-side exports that the client has not yet been told about; they'll be guaranteed to live until they've been written to the stream. BUT, for the sake of consistency we should manage the requirements as soon as we can.