### PR TITLE
feat: Allow parquet column access by field_id

### DIFF
--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
@@ -58,7 +58,7 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
     private final PageMaterializerFactory pageMaterializerFactory;
     private final ColumnDescriptor path;
     private final URI uri;
-    private final List<Type> fieldTypes;
+    private final List<Type> nonRequiredFields;
 
     /**
      * The offset for data following the page header in the file.
@@ -80,7 +80,7 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
      * @param materializerFactory The factory for creating {@link PageMaterializer}.
      * @param path The path of the column.
      * @param uri The uri of the parquet file.
-     * @param fieldTypes The types of the fields in the column.
+     * @param nonRequiredFields The types of the fields in the column.
      * @param dataOffset The offset for data following the page header in the file.
      * @param pageHeader The page header, should not be {@code null}.
      * @param numValues The number of values in the page.
@@ -93,7 +93,7 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
             final PageMaterializerFactory materializerFactory,
             final ColumnDescriptor path,
             final URI uri,
-            final List<Type> fieldTypes,
+            final List<Type> nonRequiredFields,
             final long dataOffset,
             final PageHeader pageHeader,
             final int numValues) {
@@ -104,7 +104,7 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
         this.pageMaterializerFactory = materializerFactory;
         this.path = path;
         this.uri = uri;
-        this.fieldTypes = fieldTypes;
+        this.nonRequiredFields = nonRequiredFields;
         this.dataOffset = dataOffset;
         this.pageHeader = Require.neqNull(pageHeader, "pageHeader");
         this.numValues = Require.geqZero(numValues, "numValues");
@@ -716,7 +716,7 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
         int currentRl = rlDecoder == null ? 0 : rlDecoder.currentValue();
 
         final LevelsController levelsController = new LevelsController(
-                fieldTypes.stream().map(Type::getRepetition).toArray(Type.Repetition[]::new));
+                nonRequiredFields.stream().map(Type::getRepetition).toArray(Type.Repetition[]::new));
         for (int valuesProcessed = 0; valuesProcessed < numValues;) {
             if (dlRangeSize == 0) {
                 dlDecoder.readNextRange();

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ColumnPageReaderImpl.java
@@ -80,7 +80,7 @@ final class ColumnPageReaderImpl implements ColumnPageReader {
      * @param materializerFactory The factory for creating {@link PageMaterializer}.
      * @param path The path of the column.
      * @param uri The uri of the parquet file.
-     * @param nonRequiredFields The types of the fields in the column.
+     * @param nonRequiredFields The types of the non-required fields in the column.
      * @param dataOffset The offset for data following the page header in the file.
      * @param pageHeader The page header, should not be {@code null}.
      * @param numValues The number of values in the page.

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
@@ -239,7 +239,6 @@ public class ParquetFileReader {
                 fileMetaData.getRow_groups().get(groupNumber),
                 channelsProvider,
                 rootURI,
-                type,
                 getSchema(),
                 version);
     }

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
@@ -12,13 +12,19 @@ import org.apache.parquet.format.Type;
 import org.apache.parquet.schema.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import shaded.parquet.org.apache.thrift.protocol.TSimpleJSONProtocol;
+import shaded.parquet.org.apache.thrift.transport.TIOStreamTransport;
+import shaded.parquet.org.apache.thrift.transport.TTransport;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 import static io.deephaven.parquet.base.ParquetUtils.MAGIC;
@@ -481,5 +487,13 @@ public class ParquetFileReader {
 
     public int rowGroupCount() {
         return fileMetaData.getRow_groups().size();
+    }
+
+    // Useful debugging utility
+    void writeFileMetadata(Path path) throws Exception {
+        try (final TTransport out = new TIOStreamTransport(new BufferedOutputStream(Files.newOutputStream(path)))) {
+            fileMetaData.write(new TSimpleJSONProtocol(out));
+            out.flush();
+        }
     }
 }

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetFileReader.java
@@ -39,7 +39,7 @@ public class ParquetFileReader {
      * If reading a single parquet file, root URI is the URI of the file, else the parent directory for a metadata file
      */
     private final URI rootURI;
-    private final MessageType type;
+    private final MessageType schema;
 
     /**
      * Make a {@link ParquetFileReader} for the supplied {@link File}. Wraps {@link IOException} as
@@ -102,7 +102,7 @@ public class ParquetFileReader {
                 fileMetaData = Util.readFileMetaData(in);
             }
         }
-        type = fromParquetSchema(fileMetaData.schema, fileMetaData.column_orders);
+        schema = fromParquetSchema(fileMetaData.schema, fileMetaData.column_orders);
     }
 
     /**
@@ -476,7 +476,7 @@ public class ParquetFileReader {
     }
 
     public MessageType getSchema() {
-        return type;
+        return schema;
     }
 
     public int rowGroupCount() {

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetTotalColumns.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/ParquetTotalColumns.java
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.parquet.base;
+
+import io.deephaven.util.annotations.InternalUseOnly;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.TypeVisitor;
+
+@InternalUseOnly
+public final class ParquetTotalColumns {
+
+    public static int of(Type type) {
+        final TotalColumnsVisitor visitor = new TotalColumnsVisitor();
+        type.accept(visitor);
+        return visitor.out;
+    }
+
+    public static int of(@SuppressWarnings("unused") PrimitiveType primitiveType) {
+        return 1;
+    }
+
+    public static int of(GroupType groupType) {
+        return groupType.getFields().stream().mapToInt(ParquetTotalColumns::of).sum();
+    }
+
+    public static int of(MessageType messageType) {
+        final int numColumns = of((GroupType) messageType);
+        // same size as messageType.getColumns().size(), but this is cheaper.
+        final int numPaths = messageType.getPaths().size();
+        if (numColumns != numPaths) {
+            throw new IllegalStateException(
+                    String.format("Inconsistent sizes, numColumns=%d, numPaths=%d", numColumns, numPaths));
+        }
+        return numColumns;
+    }
+
+    private static class TotalColumnsVisitor implements TypeVisitor {
+        private int out;
+
+        @Override
+        public void visit(GroupType groupType) {
+            out = of(groupType);
+        }
+
+        @Override
+        public void visit(MessageType messageType) {
+            out = of(messageType);
+        }
+
+        @Override
+        public void visit(PrimitiveType primitiveType) {
+            out = of(primitiveType);
+        }
+    }
+}

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/RowGroupReader.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/RowGroupReader.java
@@ -17,15 +17,16 @@ import java.util.List;
 public interface RowGroupReader {
     /**
      * Returns the accessor to a given Column Chunk. If {@code fieldId} is present, it will be matched over
-     * {@code path}.
+     * {@code parquetColumnNamePath}.
      *
      * @param columnName the name of the column
-     * @param path the full column path
+     * @param parquetColumnNamePath the full column parquetColumnNamePath
      * @param fieldId the field_id to fetch
      * @return the accessor to a given Column Chunk, or null if the column is not present in this Row Group
      */
     @Nullable
-    ColumnChunkReader getColumnChunk(@NotNull String columnName, @NotNull List<String> path, @Nullable Integer fieldId);
+    ColumnChunkReader getColumnChunk(@NotNull String columnName, @NotNull List<String> defaultPath,
+            @Nullable List<String> parquetColumnNamePath, @Nullable Integer fieldId);
 
     long numRows();
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/RowGroupReader.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/RowGroupReader.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.parquet.base;
 
+import io.deephaven.util.annotations.InternalUseOnly;
 import org.apache.parquet.format.RowGroup;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,16 +13,19 @@ import java.util.List;
 /**
  * Provides read access to a parquet Row Group
  */
+@InternalUseOnly
 public interface RowGroupReader {
     /**
-     * Returns the accessor to a given Column Chunk
+     * Returns the accessor to a given Column Chunk. If {@code fieldId} is present, it will be matched over
+     * {@code path}.
      *
      * @param columnName the name of the column
      * @param path the full column path
+     * @param fieldId the field_id to fetch
      * @return the accessor to a given Column Chunk, or null if the column is not present in this Row Group
      */
     @Nullable
-    ColumnChunkReader getColumnChunk(@NotNull String columnName, @NotNull List<String> path);
+    ColumnChunkReader getColumnChunk(@NotNull String columnName, @NotNull List<String> path, @Nullable Integer fieldId);
 
     long numRows();
 

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/RowGroupReaderImpl.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/base/RowGroupReaderImpl.java
@@ -4,7 +4,6 @@
 package io.deephaven.parquet.base;
 
 import io.deephaven.util.channel.SeekableChannelsProvider;
-import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.format.ColumnChunk;
 import org.apache.parquet.format.RowGroup;
 import org.apache.parquet.schema.MessageType;

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -485,6 +485,10 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         public void setFieldId(final int fieldId) {
+            if (this.fieldId != null) {
+                throw new IllegalArgumentException(
+                        String.format("Trying to set fieldId for columnName=%s more than once", columnName));
+            }
             this.fieldId = fieldId;
         }
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -797,9 +797,6 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         public Builder addColumnNameMapping(final String parquetColumnName, final String columnName) {
-            if (parquetColumnName.equals(columnName)) {
-                return this;
-            }
             final ColumnInstructions ci = getColumnInstructions(columnName);
             ci.setParquetColumnName(parquetColumnName);
             if (parquetColumnNameToInstructions == null) {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -865,10 +865,10 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
          * ({@code null}) values.
          *
          * <p>
-         * This field is not typically configured by end users.
+         * For writing, this will set the {@code field_id} in the proper Parquet {@code SchemaElement}.
          *
          * <p>
-         * For writing, this is not currently supported.
+         * This field is not typically configured by end users.
          */
         public Builder setFieldId(final String columnName, final int fieldId) {
             final ColumnInstructions ci = getColumnInstructions(columnName);

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -862,7 +862,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
          * In the case where a field id mapping is provided but no matching parquet column is found, the column will not
          * be inferred; and in the case where it's explicitly included as part of a
          * {@link #setTableDefinition(TableDefinition)}, the resulting column will contain the appropriate default
-         * ({@code null}) values.
+         * ({@code null}) values. In the case where there are multiple parquet columns with the same field_id, those
+         * parquet columns will not be resolvable via a field id.
          *
          * <p>
          * For writing, this will set the {@code field_id} in the proper Parquet {@code SchemaElement}.

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -171,7 +171,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
 
     public abstract String getColumnNameFromParquetColumnName(final String parquetColumnName);
 
-    public abstract String getColumnNameFromParquetFieldId(final int fieldId);
+    public abstract List<String> getColumnNamesFromParquetFieldId(final int fieldId);
 
     @Override
     public abstract String getCodecName(final String columnName);
@@ -291,9 +291,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         @Override
-        @Nullable
-        public String getColumnNameFromParquetFieldId(int fieldId) {
-            return null;
+        public List<String> getColumnNamesFromParquetFieldId(int fieldId) {
+            return List.of();
         }
 
         @Override
@@ -524,8 +523,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
                             .collect(Collectors.toUnmodifiableList());
         }
 
-        private String getOrDefault(final String columnName, final String defaultValue,
-                final Function<ColumnInstructions, String> fun) {
+        private <T> T getOrDefault(final String columnName, final T defaultValue,
+                final Function<ColumnInstructions, T> fun) {
             if (columnNameToInstructions == null) {
                 return defaultValue;
             }
@@ -566,17 +565,18 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         @Override
-        public String getColumnNameFromParquetFieldId(int fieldId) {
+        public List<String> getColumnNamesFromParquetFieldId(int fieldId) {
             if (columnNameToInstructions == null) {
-                return null;
+                return List.of();
             }
+            final List<String> out = new ArrayList<>();
             for (Entry<String, ColumnInstructions> e : columnNameToInstructions.entrySet()) {
                 final OptionalInt parquetFieldId = e.getValue().fieldId();
                 if (parquetFieldId.isPresent() && parquetFieldId.getAsInt() == fieldId) {
-                    return e.getKey();
+                    out.add(e.getKey());
                 }
             }
-            return null;
+            return out;
         }
 
         @Override
@@ -596,14 +596,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
 
         @Override
         public OptionalInt getFieldId(String columnName) {
-            if (columnNameToInstructions == null) {
-                return OptionalInt.empty();
-            }
-            final ColumnInstructions ci = columnNameToInstructions.get(columnName);
-            if (ci == null) {
-                return OptionalInt.empty();
-            }
-            return ci.fieldId();
+            return getOrDefault(columnName, OptionalInt.empty(), ColumnInstructions::fieldId);
         }
 
         @Override

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -167,6 +167,14 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         return (mapped != null) ? mapped : parquetColumnName;
     }
 
+    /**
+     * Returns the explicitly mapped parquet column name if set.
+     *
+     * @param columnName the Deephaven column name
+     * @return the parquet column name
+     */
+    public abstract Optional<String> getParquetColumnName(final String columnName);
+
     public abstract String getParquetColumnNameFromColumnNameOrDefault(final String columnName);
 
     public abstract String getColumnNameFromParquetColumnName(final String parquetColumnName);
@@ -279,6 +287,12 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
     }
 
     public static final ParquetInstructions EMPTY = new ParquetInstructions() {
+
+        @Override
+        public Optional<String> getParquetColumnName(String columnName) {
+            return Optional.empty();
+        }
+
         @Override
         public String getParquetColumnNameFromColumnNameOrDefault(final String columnName) {
             return columnName;
@@ -443,6 +457,10 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
             return parquetColumnName != null ? parquetColumnName : columnName;
         }
 
+        public Optional<String> getParquetColumnNameOpt() {
+            return Optional.ofNullable(parquetColumnName);
+        }
+
         public ColumnInstructions setParquetColumnName(final String parquetColumnName) {
             if (this.parquetColumnName != null && !this.parquetColumnName.equals(parquetColumnName)) {
                 throw new IllegalArgumentException(
@@ -571,6 +589,11 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
                 return defaultValue;
             }
             return fun.test(ci);
+        }
+
+        @Override
+        public Optional<String> getParquetColumnName(String columnName) {
+            return getOrDefault(columnName, Optional.empty(), ColumnInstructions::getParquetColumnNameOpt);
         }
 
         @Override

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -175,8 +175,9 @@ public class ParquetSchemaReader {
                         colName = columnNames.get(0);
                         break COL_NAME;
                     } else if (columnNames.size() > 1) {
-                        // TODO: how should we handle this? Ignore?
-                        // throw new IllegalArgumentException();
+                        throw new IllegalArgumentException(String.format(
+                                "Non-unique Field ID mapping provided; unable to infer TableDefinition for fieldId=%d, parquetColumnName=%s",
+                                fieldId.intValue(), parquetColumnName));
                     }
                 }
                 final String mappedName = readInstructions.getColumnNameFromParquetColumnName(parquetColumnName);

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -169,10 +169,14 @@ public class ParquetSchemaReader {
             final String colName;
             COL_NAME: {
                 if (fieldId != null) {
-                    final String mappedName = readInstructions.getColumnNameFromParquetFieldId(fieldId.intValue());
-                    if (mappedName != null) {
-                        colName = mappedName;
+                    final List<String> columnNames =
+                            readInstructions.getColumnNamesFromParquetFieldId(fieldId.intValue());
+                    if (columnNames.size() == 1) {
+                        colName = columnNames.get(0);
                         break COL_NAME;
+                    } else if (columnNames.size() > 1) {
+                        // TODO: how should we handle this? Ignore?
+                        // throw new IllegalArgumentException();
                     }
                 }
                 final String mappedName = readInstructions.getColumnNameFromParquetColumnName(parquetColumnName);

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -147,9 +147,8 @@ public class ParquetSchemaReader {
         };
         final ParquetMessageDefinition colDef = new ParquetMessageDefinition();
         final Map<String, String[]> parquetColumnNameToFirstPath = new HashMap<>();
-        final Map<Integer, Long> fieldIdCount = schema.getColumns()
+        final Map<Integer, Long> fieldIdCount = schema.getFields()
                 .stream()
-                .map(ColumnDescriptor::getPrimitiveType)
                 .map(Type::getId)
                 .filter(Objects::nonNull)
                 .map(ID::intValue)
@@ -199,6 +198,7 @@ public class ParquetSchemaReader {
                         colName = columnNames.get(0);
                         break COL_NAME;
                     } else if (columnNames.size() > 1) {
+                        // This limitation could likely be removed with a more thorough refactoring of the parquet code.
                         throw new IllegalArgumentException(String.format(
                                 "Non-unique Field ID mapping provided; unable to infer TableDefinition for fieldId=%d, parquetColumnName=%s",
                                 fieldId.intValue(), parquetColumnName));

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -155,7 +155,9 @@ public class ParquetSchemaReader {
                 .map(ID::intValue)
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         if (schema.getFieldCount() != schema.getColumns().size()) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(String.format(
+                    "Field count inconsistent with number of columns, schema.getFieldCount()=%d, schema.getColumns().size()=%d",
+                    schema.getFieldCount(), schema.getColumns().size()));
         }
         final Iterator<Type> fieldIt = schema.getFields().iterator();
         final Iterator<ColumnDescriptor> columnDescriptorIterator = schema.getColumns().iterator();

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
@@ -474,6 +474,7 @@ public class TypeInfos {
                 builder = getBuilder(isRequired(columnDefinition), false, dataType);
                 isRepeating = false;
             }
+            instructions.getFieldId(columnDefinition.getName()).ifPresent(builder::id);
             if (!isRepeating) {
                 return builder.named(parquetColumnName);
             }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/TypeInfos.java
@@ -13,11 +13,14 @@ import io.deephaven.util.codec.ExternalizableCodec;
 import io.deephaven.util.codec.SerializableCodec;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Type.Repetition;
 import org.apache.parquet.schema.Types;
+import org.apache.parquet.schema.Types.GroupBuilder;
 import org.apache.parquet.schema.Types.PrimitiveBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -474,11 +477,13 @@ public class TypeInfos {
                 builder = getBuilder(isRequired(columnDefinition), false, dataType);
                 isRepeating = false;
             }
-            instructions.getFieldId(columnDefinition.getName()).ifPresent(builder::id);
             if (!isRepeating) {
+                instructions.getFieldId(columnDefinition.getName()).ifPresent(builder::id);
                 return builder.named(parquetColumnName);
             }
-            return Types.buildGroup(Type.Repetition.OPTIONAL).addField(
+            final GroupBuilder<GroupType> groupBuilder = Types.buildGroup(Repetition.OPTIONAL);
+            instructions.getFieldId(columnDefinition.getName()).ifPresent(groupBuilder::id);
+            return groupBuilder.addField(
                     Types.buildGroup(Type.Repetition.REPEATED).addField(
                             builder.named("item")).named(parquetColumnName))
                     .as(LogicalTypeAnnotation.listType()).named(parquetColumnName);

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
@@ -76,17 +76,22 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
      * Construct a new {@link ParquetColumnLocation} for the specified {@link ParquetTableLocation} and column name.
      *
      * @param tableLocation The table location enclosing this column location
-     * @param parquetColumnName The Parquet file column name
+     * @param columnName The Deephaven column name
+     * @param parquetColumnName The Parquet file column name if explicitly set
      * @param columnChunkReaders The {@link ColumnChunkReader column chunk readers} for this location
      */
     ParquetColumnLocation(
             @NotNull final ParquetTableLocation tableLocation,
             @NotNull final String columnName,
-            @NotNull final String parquetColumnName,
+            @Nullable final String parquetColumnName,
             @Nullable final ColumnChunkReader[] columnChunkReaders) {
         super(tableLocation, columnName);
         this.parquetColumnName = parquetColumnName;
         this.columnChunkReaders = columnChunkReaders;
+    }
+
+    private String parquetColumnNameOrDefault() {
+        return parquetColumnName != null ? parquetColumnName : getName();
     }
 
     private PageCache<ATTR> ensurePageCache() {
@@ -311,8 +316,8 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
                                     ensurePageCache(),
                                     columnChunkReader,
                                     tl().getRegionParameters().regionMask,
-                                    makeToPage(tl().getColumnTypes().get(parquetColumnName),
-                                            tl().getReadInstructions(), parquetColumnName, columnChunkReader,
+                                    makeToPage(tl().getColumnTypes().get(parquetColumnNameOrDefault()),
+                                            tl().getReadInstructions(), parquetColumnNameOrDefault(), columnChunkReader,
                                             columnDefinition),
                                     columnDefinition);
                     pageStores[psi] = creatorResult.pageStore;

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetInstructionsTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetInstructionsTest.java
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.parquet.table;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class ParquetInstructionsTest {
+
+    @Test
+    public void setFieldId() {
+        final ParquetInstructions instructions = ParquetInstructions.builder()
+                .setFieldId("Foo", 42)
+                .setFieldId("Bar", 99)
+                .setFieldId("Baz", 99)
+                .build();
+
+        assertThat(instructions.getFieldId("Foo")).hasValue(42);
+        assertThat(instructions.getFieldId("Bar")).hasValue(99);
+        assertThat(instructions.getFieldId("Baz")).hasValue(99);
+        assertThat(instructions.getFieldId("Zap")).isEmpty();
+
+        assertThat(instructions.getColumnNamesFromParquetFieldId(42)).containsExactly("Foo");
+        assertThat(instructions.getColumnNamesFromParquetFieldId(99)).containsExactly("Bar", "Baz");
+        assertThat(instructions.getColumnNamesFromParquetFieldId(100)).isEmpty();
+    }
+
+    @Test
+    public void setFieldIdAlreadySet() {
+        try {
+            ParquetInstructions.builder()
+                    .setFieldId("Foo", 42)
+                    .setFieldId("Foo", 43)
+                    .build();
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessage("Trying to set fieldId for columnName=Foo more than once");
+        }
+    }
+
+    @Test
+    public void setFieldBadName() {
+        try {
+            ParquetInstructions.builder()
+                    .setFieldId("Not a legal column name", 42)
+                    .build();
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessageContaining("Invalid column name");
+        }
+    }
+
+    @Test
+    public void addColumnNameMapping() {
+        final ParquetInstructions instructions = ParquetInstructions.builder()
+                .addColumnNameMapping("Foo", "Foo")
+                .addColumnNameMapping("PARQUET COLUMN 2!", "Bar")
+                .addColumnNameMapping("ParquetColumn3", "Baz")
+                .build();
+
+        assertThat(instructions.getColumnNameFromParquetColumnName("Foo")).isEqualTo("Foo");
+        assertThat(instructions.getColumnNameFromParquetColumnName("PARQUET COLUMN 2!")).isEqualTo("Bar");
+        assertThat(instructions.getColumnNameFromParquetColumnName("ParquetColumn3")).isEqualTo("Baz");
+        assertThat(instructions.getColumnNameFromParquetColumnName("Does Not Exist")).isNull();
+
+        assertThat(instructions.getParquetColumnNameFromColumnNameOrDefault("Foo")).isEqualTo("Foo");
+        assertThat(instructions.getParquetColumnNameFromColumnNameOrDefault("Bar")).isEqualTo("PARQUET COLUMN 2!");
+        assertThat(instructions.getParquetColumnNameFromColumnNameOrDefault("Baz")).isEqualTo("ParquetColumn3");
+        assertThat(instructions.getParquetColumnNameFromColumnNameOrDefault("Zap")).isEqualTo("Zap");
+    }
+
+    @Test
+    public void addColumnNameMappingMultipleParquetColumnsToSameDeephavenColumn() {
+        try {
+            ParquetInstructions.builder()
+                    .addColumnNameMapping("ParquetColumn1", "Foo")
+                    .addColumnNameMapping("ParquetColumn2", "Foo")
+                    .build();
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessage(
+                    "Cannot add a mapping from parquetColumnName=ParquetColumn2: columnName=Foo already mapped to parquetColumnName=ParquetColumn1");
+        }
+    }
+
+    @Test
+    public void addColumnNameMappingSameParquetColumnToMultipleDeephavenColumns() {
+        // Note: this is a limitation that doesn't need to exist. Technically, we could allow a single physical
+        // parquet column to manifest as multiple Deephaven columns.
+        try {
+            ParquetInstructions.builder()
+                    .addColumnNameMapping("ParquetColumn1", "Foo")
+                    .addColumnNameMapping("ParquetColumn1", "Bar")
+                    .build();
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessage(
+                    "Cannot add new mapping from parquetColumnName=ParquetColumn1 to columnName=Bar: already mapped to columnName=Foo");
+        }
+    }
+
+    @Test
+    public void addColumnNameMappingBadName() {
+        try {
+            ParquetInstructions.builder()
+                    .addColumnNameMapping("SomeParquetColumnName", "Not a legal column name")
+                    .build();
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessageContaining("Invalid column name");
+        }
+    }
+}

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetInstructionsTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetInstructionsTest.java
@@ -30,6 +30,17 @@ public class ParquetInstructionsTest {
 
     @Test
     public void setFieldIdAlreadySet() {
+
+        // Setting the same fieldId on a given column name is "ok" if it's the same value, this is to be more consistent
+        // with how addColumnNameMapping works.
+        {
+            final ParquetInstructions instructions = ParquetInstructions.builder()
+                    .setFieldId("Foo", 42)
+                    .setFieldId("Foo", 42)
+                    .build();
+            assertThat(instructions.getFieldId("Foo")).hasValue(42);
+        }
+
         try {
             ParquetInstructions.builder()
                     .setFieldId("Foo", 42)
@@ -37,7 +48,7 @@ public class ParquetInstructionsTest {
                     .build();
             failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
         } catch (IllegalArgumentException e) {
-            assertThat(e).hasMessage("Trying to set fieldId for columnName=Foo more than once");
+            assertThat(e).hasMessage("Inconsistent fieldId for columnName=Foo, already set fieldId=42");
         }
     }
 

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetInstructionsTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetInstructionsTest.java
@@ -77,6 +77,11 @@ public class ParquetInstructionsTest {
         assertThat(instructions.getColumnNameFromParquetColumnName("ParquetColumn3")).isEqualTo("Baz");
         assertThat(instructions.getColumnNameFromParquetColumnName("Does Not Exist")).isNull();
 
+        assertThat(instructions.getParquetColumnName("Foo")).hasValue("Foo");
+        assertThat(instructions.getParquetColumnName("Bar")).hasValue("PARQUET COLUMN 2!");
+        assertThat(instructions.getParquetColumnName("Baz")).hasValue("ParquetColumn3");
+        assertThat(instructions.getParquetColumnName("Zap")).isEmpty();
+
         assertThat(instructions.getParquetColumnNameFromColumnNameOrDefault("Foo")).isEqualTo("Foo");
         assertThat(instructions.getParquetColumnNameFromColumnNameOrDefault("Bar")).isEqualTo("PARQUET COLUMN 2!");
         assertThat(instructions.getParquetColumnNameFromColumnNameOrDefault("Baz")).isEqualTo("ParquetColumn3");

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -662,18 +662,17 @@ public class TestParquetTools {
                     longCol(BAZ, 99, 101)), table);
         }
 
-        // TODO: file bug report
         // If only a partial id mapping is provided, only that will be "properly" mapped
-        // {
-        // final TableDefinition partialTD = TableDefinition.of(
-        // ColumnDefinition.ofLong("Id"),
-        // ColumnDefinition.ofString("column_53f0de5ae06f476eb82aa3f9294fcd05"));
-        // final ParquetInstructions partialInstructions = ParquetInstructions.builder()
-        // .addFieldId(bazCol.getName(), BAZ_ID)
-        // .build();
-        // final Table table = ParquetTools.readTable(file, partialInstructions);
-        // assertEquals(partialTD, table.getDefinition());
-        // }
+        {
+            final TableDefinition partialTD = TableDefinition.of(
+                    ColumnDefinition.ofLong(BAZ),
+                    ColumnDefinition.ofString("column_53f0de5ae06f476eb82aa3f9294fcd05"));
+            final ParquetInstructions partialInstructions = ParquetInstructions.builder()
+                    .setFieldId(BAZ, BAZ_ID)
+                    .build();
+            final Table table = ParquetTools.readTable(file, partialInstructions);
+            assertEquals(partialTD, table.getDefinition());
+        }
 
         // There are no errors if a field ID is configured but not found; it won't be inferred.
         {

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -33,6 +33,7 @@ import io.deephaven.vector.LongVectorDirect;
 import io.deephaven.vector.ObjectVector;
 import io.deephaven.vector.ObjectVectorDirect;
 import junit.framework.TestCase;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -744,15 +745,16 @@ public class TestParquetTools {
                         longCol(BAZ_DUPE, 99, 101)), table);
             }
 
-            // TODO: how should we handle this?
-            // {
-            // final Table table = ParquetTools.readTable(file, dupeInstructions);
-            // assertEquals(dupeTd, table.getDefinition());
-            // assertTableEquals(newTable(dupeTd,
-            // longCol(BAZ, 99, 101),
-            // stringCol(ZAP, "Foo", "Bar"),
-            // longCol(BAZ_DUPE, 99, 101)), table);
-            // }
+            // In the case where we have dupe field IDs and don't provide an explicit definition, we are preferring to
+            // fail during the inference step
+            {
+                try {
+                    ParquetTools.readTable(file, dupeInstructions);
+                    Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+                } catch (IllegalArgumentException e) {
+                    Assertions.assertThat(e).hasMessageContaining("Non-unique Field ID mapping provided");
+                }
+            }
         }
     }
 

--- a/extensions/parquet/table/src/test/resources/NestedStruct1.parquet
+++ b/extensions/parquet/table/src/test/resources/NestedStruct1.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3b0b28c657e8991f0ffa48aedb68f23d1a746da8ddeaa473dbee82a3f80c66c
+size 1019

--- a/extensions/parquet/table/src/test/resources/NestedStruct2.parquet
+++ b/extensions/parquet/table/src/test/resources/NestedStruct2.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6ea5e3b9a2d5907adf6ecc3909a6491a62e78c0ae7ca9516f96ad9d4db3432d
+size 1237

--- a/extensions/parquet/table/src/test/resources/ReferenceListParquetFieldIds.parquet
+++ b/extensions/parquet/table/src/test/resources/ReferenceListParquetFieldIds.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:037307d886a9eade2dca4982917eec86516686fdb2d33b66ec9e8724ee59aeb0
+size 843

--- a/extensions/parquet/table/src/test/resources/ReferencePartitionedFieldIds/Partition=0/table.parquet
+++ b/extensions/parquet/table/src/test/resources/ReferencePartitionedFieldIds/Partition=0/table.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f7c9501d597752d7295cd7b5f098336df5c67a341cceb583f661f2d0ac6d265
+size 1323

--- a/extensions/parquet/table/src/test/resources/ReferencePartitionedFieldIds/Partition=1/table.parquet
+++ b/extensions/parquet/table/src/test/resources/ReferencePartitionedFieldIds/Partition=1/table.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61fa98e653bb6d913c4828a53d92977d3c443796e616996d3fcec76821d89b92
+size 1323

--- a/extensions/parquet/table/src/test/resources/ReferenceSimpleParquetFieldIds.parquet
+++ b/extensions/parquet/table/src/test/resources/ReferenceSimpleParquetFieldIds.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:439904cfa5209c40a7c0c75c38e0835d7ce7af79a850ab270216dfff833ec0a8
+size 1315


### PR DESCRIPTION
This allows the the resolution of a parquet column by field_id instead of by its "path". This is a lower-level option that will not typically be used by end-users; as such, this option has not been plumbed through to python. This feature will be used in follow-up PRs in combination with Iceberg's field-ids to improve column mappings.

Writing support has also been added.

Fixes #6128