### PR TITLE
fix(py-test): Wait for Full Cycle Before Checking if SubTable Failed

### DIFF
--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -567,7 +567,10 @@ class TableTestCase(BaseTestCase):
             snapshot_hist = self.test_table.snapshot_when(t, history=True)
             self.assertFalse(snapshot_hist.j_table.isFailed())
         self.wait_ticking_table_update(t, row_count=10, timeout=2)
-        self.assertTrue(snapshot_hist.j_table.isFailed())
+        # we have not waited for a whole cycle yet, wait for the shared lock to guarantee cycle is over
+        # to ensure snapshot_hist has had the opportunity to process the update we just saw
+        with update_graph.shared_lock(t):
+            self.assertTrue(snapshot_hist.j_table.isFailed())
 
     def test_agg_all_by(self):
         test_table = empty_table(10)


### PR DESCRIPTION
This fixes the spurious CI failure from yesterday, which was caused by checking if a table failed before there was the guarantee that the PUG executed the update listener.

```
2024-10-02T06:26:34.9836763Z ======================================================================
2024-10-02T06:26:34.9837211Z FAIL [3.008s]: test_snapshot_when_with_history (tests.test_table.TableTestCase)
2024-10-02T06:26:34.9837607Z ----------------------------------------------------------------------
2024-10-02T06:26:34.9837829Z Traceback (most recent call last):
2024-10-02T06:26:34.9838342Z   File "/python/tests/test_table.py", line 570, in test_snapshot_when_with_history
2024-10-02T06:26:34.9838653Z     self.assertTrue(snapshot_hist.j_table.isFailed())
2024-10-02T06:26:34.9838883Z AssertionError: False is not true
```