### PR TITLE
fix: Connection errors should be correctly passed to the UI

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/HasEventHandling.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/HasEventHandling.java
@@ -190,18 +190,30 @@ public class HasEventHandling {
         }
     }
 
-    public boolean failureHandled(String failure) {
-        if (failure != null) {
-            if (hasListeners(CoreClient.EVENT_REQUEST_FAILED)) {
-                final CustomEventInit<String> event = CustomEventInit.create();
-                event.setDetail(failure);
-                fireEvent(CoreClient.EVENT_REQUEST_FAILED, event);
-            } else {
-                DomGlobal.console.error(logPrefix() + failure);
-            }
-            return true;
+    public <T> void fireCriticalEvent(String type) {
+        if (hasListeners(type)) {
+            fireEvent(type);
+        } else {
+            DomGlobal.console.error(logPrefix() + type, "(to prevent this log message, handle the " + type + " event)");
         }
-        return false;
+    }
+
+    public <T> void fireCriticalEvent(String type, CustomEventInit<T> init) {
+        if (hasListeners(type)) {
+            fireEvent(type, init);
+        } else {
+            DomGlobal.console.error(logPrefix(), init.getDetail(),
+                    "(to prevent this log message, handle the " + type + " event)");
+        }
+    }
+
+    public void failureHandled(String failure) {
+        if (failure == null) {
+            return;
+        }
+        final CustomEventInit<String> event = CustomEventInit.create();
+        event.setDetail(failure);
+        fireCriticalEvent(CoreClient.EVENT_REQUEST_FAILED, event);
     }
 
     public void suppressEvents() {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/QueryConnectable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/QueryConnectable.java
@@ -216,12 +216,7 @@ public abstract class QueryConnectable<Self extends QueryConnectable<Self>> exte
         fireEvent(QueryInfoConstants.EVENT_CONNECT);
 
         if (hasDisconnected) {
-            if (hasListeners(QueryInfoConstants.EVENT_RECONNECT)) {
-                fireEvent(QueryInfoConstants.EVENT_RECONNECT);
-            } else {
-                DomGlobal.console.log(logPrefix()
-                        + "Query reconnected (to prevent this log message, handle the EVENT_RECONNECT event)");
-            }
+            fireCriticalEvent(QueryInfoConstants.EVENT_RECONNECT);
         }
     }
 
@@ -245,12 +240,7 @@ public abstract class QueryConnectable<Self extends QueryConnectable<Self>> exte
 
         hasDisconnected = true;
 
-        if (hasListeners(QueryInfoConstants.EVENT_DISCONNECT)) {
-            this.fireEvent(QueryInfoConstants.EVENT_DISCONNECT);
-        } else {
-            DomGlobal.console.log(logPrefix()
-                    + "Query disconnected (to prevent this log message, handle the EVENT_DISCONNECT event)");
-        }
+        fireCriticalEvent(QueryInfoConstants.EVENT_DISCONNECT);
     }
 
     public abstract void notifyServerShutdown(TerminationNotificationResponse success);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -348,7 +348,7 @@ public class WorkerConnection {
                     state = State.Failed;
                     JsLog.debug("Failed to connect to worker.");
 
-                    final String failure = fail.toString();
+                    final String failure = String.valueOf(fail);
 
                     // notify all pending fetches that they failed
                     onOpen.forEach(c -> c.onFailure(failure));
@@ -386,7 +386,7 @@ public class WorkerConnection {
 
             // signal that the user needs to re-authenticate, make a new session
             // TODO (deephaven-core#3501) in theory we could make a new session for some auth types
-            info.fireEvent(CoreClient.EVENT_RECONNECT_AUTH_FAILED);
+            info.fireCriticalEvent(CoreClient.EVENT_RECONNECT_AUTH_FAILED);
         } else if (status.isTransportError()) {
             // fire deprecated event for now
             info.notifyConnectionError(status);
@@ -501,15 +501,15 @@ public class WorkerConnection {
                         metadata.delete(FLIGHT_AUTH_HEADER_NAME);
 
                         // Fire an event for the UI to attempt to re-auth
-                        info.fireEvent(CoreClient.EVENT_RECONNECT_AUTH_FAILED);
+                        info.fireCriticalEvent(CoreClient.EVENT_RECONNECT_AUTH_FAILED);
 
                         // We return here rather than continue and call checkStatus()
                         return Promise.reject("Authentication failed, please reconnect");
                     }
-                    checkStatus(ResponseStreamWrapper.Status.of(result.getStatus(), result.getMessage().toString(),
+                    checkStatus(ResponseStreamWrapper.Status.of(result.getStatus(), result.getStatusMessage(),
                             result.getTrailers()));
-                    if (result.getMessage() == null || result.getMessage().toString().isEmpty()) {
-                        return Promise.reject(result.getMessage());
+                    if (result.getStatusMessage() != null && !result.getStatusMessage().isEmpty()) {
+                        return Promise.reject(result.getStatusMessage());
                     } else {
                         return Promise.reject("Error occurred while authenticating, gRPC status " + result.getStatus());
                     }


### PR DESCRIPTION
Also guarded for nulls from other errors, and ensure that certain events would be logged even if they were not handled by the UI.

Fixes #6163