### PR TITLE
chore: remove superfluous TODO

### DIFF
--- a/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
+++ b/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
@@ -295,8 +295,6 @@ message ExportedTableCreationResponse {
   // size isn't known without scanning partitions. Typically, the client should filter the data by the
   // partitioning columns first.
   sint64 size = 6 [jstype=JS_STRING];
-
-  // TODO: attributes
 }
 
 message FetchTableRequest {


### PR DESCRIPTION
Attributes are included in the schema_header field, and do not need a TODO.