### PR TITLE
fix: Remove 'uri' as required Iceberg property

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTools.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTools.java
@@ -35,12 +35,12 @@ public abstract class IcebergTools {
      * {@code "org.apache.iceberg.rest.RESTCatalog"} or {@code "org.apache.iceberg.aws.glue.GlueCatalog")}. Choices for
      * {@code "type"} include {@code "hive"}, {@code "hadoop"}, {@code "rest"}, {@code "glue"}, {@code "nessie"},
      * {@code "jdbc"}.</li>
-     * <li>{@code "uri"} - the URI of the catalog.</li>
      * </ul>
      * <p>
      * Other common properties include:
      * </p>
      * <ul>
+     * <li>{@code "uri"} - the URI of the catalog.</li>
      * <li>{@code "warehouse"} - the location of the data warehouse.</li>
      * <li>{@code "client.region"} - the region of the AWS client.</li>
      * <li>{@code "s3.access-key-id"} - the S3 access key for reading files.</li>
@@ -76,12 +76,12 @@ public abstract class IcebergTools {
      * {@code "org.apache.iceberg.rest.RESTCatalog"} or {@code "org.apache.iceberg.aws.glue.GlueCatalog")}. Choices for
      * {@code "type"} include {@code "hive"}, {@code "hadoop"}, {@code "rest"}, {@code "glue"}, {@code "nessie"},
      * {@code "jdbc"}.</li>
-     * <li>{@code "uri"} - the URI of the catalog.</li>
      * </ul>
      * <p>
      * Other common properties include:
      * </p>
      * <ul>
+     * <li>{@code "uri"} - the URI of the catalog.</li>
      * <li>{@code "warehouse"} - the location of the data warehouse.</li>
      * <li>{@code "client.region"} - the region of the AWS client.</li>
      * <li>{@code "s3.access-key-id"} - the S3 access key for reading files.</li>
@@ -110,13 +110,11 @@ public abstract class IcebergTools {
                     String.format("Catalog type '%s' or implementation class '%s' is required",
                             CatalogUtil.ICEBERG_CATALOG_TYPE, CatalogProperties.CATALOG_IMPL));
         }
-        if (!properties.containsKey(CatalogProperties.URI)) {
-            throw new IllegalArgumentException(String.format("Catalog URI property '%s' is required",
-                    CatalogProperties.URI));
-        }
 
         final String catalogUri = properties.get(CatalogProperties.URI);
-        final String catalogName = name != null ? name : "IcebergCatalog-" + catalogUri;
+        final String catalogName = name != null
+                ? name
+                : "IcebergCatalog" + (catalogUri == null ? "" : "-" + catalogUri);
 
         // Load the Hadoop configuration with the provided properties
         final Configuration hadoopConf = new Configuration();

--- a/py/server/deephaven/experimental/iceberg.py
+++ b/py/server/deephaven/experimental/iceberg.py
@@ -263,9 +263,9 @@ def adapter(
             implementing Java class should be provided (e.g. `org.apache.iceberg.rest.RESTCatalog` or
             `org.apache.iceberg.aws.glue.GlueCatalog`). Choices for `type` include `hive`, `hadoop`, `rest`, `glue`,
             `nessie`, `jdbc`.
-    - `uri` - the URI of the catalog
 
     Other common properties include:
+    - `uri` - the URI of the catalog
     - `warehouse` - the root path of the data warehouse.
     - `client.region` - the region of the AWS client.
     - `s3.access-key-id` - the S3 access key for reading files.


### PR DESCRIPTION
For example, in the case of a Glue catalog, a 'uri' is not required.