### PR TITLE
docs: Add note about flag for protoc 3.12.x - 3.14.x

### DIFF
--- a/authorization/README.md
+++ b/authorization/README.md
@@ -57,3 +57,5 @@ DEEPHAVEN_VERSION=${DEEPHAVEN_VERSION}  PATH=authorization-codegen:$PATH protoc 
 
 ./gradlew :authorization:spotlessApply
 ```
+
+For protoc versions 3.12.x - 3.14.x, the `--experimental_allow_proto3_optional` flag is needed.


### PR DESCRIPTION
- The `--experimental_allow_proto3_optional` flag is needed to run the authorization code generation script (found in `authorization/README.md`) for protoc versions 3.12.x to 3.14.x