### PR TITLE
chore: Update dependabot pull request limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 99
     schedule:
       interval: "weekly"
     commit-message:
@@ -15,6 +16,7 @@ updates:
       - "stanbrub"
   - package-ecosystem: "gradle"
     directory: "/"
+    open-pull-requests-limit: 99
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
This will improve our ability to triage and process through all gradle version bumps without being limited by the current default of 5.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit