### PR TITLE
fix: Ensure surefire-action-report for nightly only runs on main

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Publish Test Results
         uses: scacap/action-surefire-report@v1
-        if: ${{ github.repository_owner == 'deephaven' }}
+        if: ${{ github.repository_owner == 'deephaven' && github.ref == 'refs/heads/main' }}
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
         with:


### PR DESCRIPTION
This fixes the errors currently observed due to the introduction of #6269 by making sure the step only runs on the main branch. For example, https://github.com/deephaven/deephaven-core/actions/runs/11485054757/job/31964249592 has the following log

```
Going to parse results form **/build/test-results/*/TEST-*.xml
Result: 9648 tests run, 37 skipped, 0 failed.
Posting status 'completed' with conclusion 'success' to refs/heads/dependabot/gradle/io.airlift-aircompressor-2.0.2 (sha: 7ab48f9cdc6674c3c6bba1f6fb3c82a39d0d854a)
Error: Resource not accessible by integration
```

In this case, action-surefire-report is trying to report against a SHA owned by the dependabot branch.