### PR TITLE
chore: Update lychee ignore file

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,5 +1,5 @@
-_localhost_
-_docs.deephaven.io_
+http://localhost:
+https://docs.deephaven.io/
 https://10.0.1.50:8123/iris/connection.json
 https://deephaven.io/core/release/vX.Y.Z/javadoc
 https://github.com/deephaven/deephaven.io

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The Deephaven server can be installed and instantiated [from Docker](#from-docke
 This is the easiest way to get started with Deephaven. For complete instructions, see our [quickstart for Docker](https://deephaven.io/core/docs/getting-started/quickstart/). The table below shows installation dependencies.
 
 | Dependency     | Version  | OS      | Required/Recommended |
-| -------------- | -------- | --------| -------------------- |
+| -------------- | -------- | ------- | -------------------- |
 | Docker         | ^20.10.8 | All     | Required             |
 | Docker compose | ^2       | All     | Recommended          |
 | Windows        | 10+      | Windows | Required             |
@@ -109,7 +109,7 @@ docker compose up
 
 ### pip-installed Deephaven
 
-Users who wish to use Python but not Docker should use [pip-installed Deephaven](https://deephaven.io/core/docs/tutorials/quickstart-pip/). For users with Windows operating systems, WSL is **not** required to use Deephaven this way.
+Users who wish to use Python but not Docker should use [pip-installed Deephaven](https://deephaven.io/core/docs/getting-started/pip-install/). For users with Windows operating systems, WSL is **not** required to use Deephaven this way.
 
 ```sh
 pip install --upgrade pip setuptools wheel
@@ -151,7 +151,7 @@ docker run hello-world
 ```
 
 > **_NOTE:_** Internally, the Java build process will use [Gradle Auto Provisioning](https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning)
-to download and use the appropriate Java version for building and testing.
+> to download and use the appropriate Java version for building and testing.
 
 > **_NOTE:_** On Windows, all commands must be run inside a WSL 2 terminal.
 
@@ -182,13 +182,14 @@ cd deephaven-core
 #### Debugging
 
 You can debug the server by adding the `-Pdebug` flag, and then attaching a debugger to port 5005. This can be used in conjunction with other flags. For example, if you wanted to debug a server and startup with Groovy:
+
 ```sh
 ./gradlew server-jetty-app:run -Pgroovy -Pdebug
 ```
 
 ## Get the authentication key
 
-Deephaven, by default, uses [pre-shared key authentication](https://deephaven.io/core/docs/how-to-guides/authentication/auth-psk/) to authenticate against unauthorized access. 
+Deephaven, by default, uses [pre-shared key authentication](https://deephaven.io/core/docs/how-to-guides/authentication/auth-psk/) to authenticate against unauthorized access.
 
 ### Deephaven run from Docker
 
@@ -269,12 +270,12 @@ t = left.join(right, "DeptID", "DeptName, DeptTelephone=Telephone")
 
 ## Resources
 
-* [Help!](https://github.com/deephaven/deephaven-core/discussions/969)
-* [Deephaven Community Slack](https://deephaven.io/slack)
-* [Discussions](https://github.com/deephaven/deephaven-core/discussions)
-* [Deephaven Community Core docs](https://deephaven.io/core/docs/)
-* [Java API docs](https://deephaven.io/core/javadoc/)
-* [Python API docs](https://deephaven.io/core/pydoc/)
+- [Help!](https://github.com/deephaven/deephaven-core/discussions/969)
+- [Deephaven Community Slack](https://deephaven.io/slack)
+- [Discussions](https://github.com/deephaven/deephaven-core/discussions)
+- [Deephaven Community Core docs](https://deephaven.io/core/docs/)
+- [Java API docs](https://deephaven.io/core/javadoc/)
+- [Python API docs](https://deephaven.io/core/pydoc/)
 
 ## Contributing
 


### PR DESCRIPTION
I was under the impression that to do substring matching, the tool would need asterisks via regex in the file. That didn't work. I found an example of another repo using this tool and looked at their lychee ignore file to find no asterisks.

This past weekend's runs failed on links that contained localhost and docs.deephaven.io. This should fix that.

There is a legit broken link in the run that will be fixed as part of this PR as well.