### PR TITLE
chore: Update gradle enterprise plugin to develocity plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.13.1'
+    id 'com.gradle.develocity' version '3.18.1'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 
@@ -466,14 +466,14 @@ buildCache {
     }
 }
 
-def isCiServer = System.getenv('CI') == 'true'
-if (isCiServer) {
-    gradleEnterprise {
-        buildScan {
-            termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-            termsOfServiceAgree = 'yes'
+develocity {
+    buildScan {
+        // buildScan will still publish when gradlew is explicitly invoked with `--scan`
+        publishing.onlyIf { false }
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
+        if(System.getenv('CI') == 'true') {
             tag('CI')
         }
     }
 }
-


### PR DESCRIPTION
The `com.gradle.enterprise` plugin has been deprecated in favor of the `com.gradle.develocity` plugin. This supersedes https://github.com/deephaven/deephaven-core/pull/6071.

See https://docs.gradle.com/develocity/gradle-plugin/legacy/#develocity_migration, https://docs.gradle.com/develocity/gradle-plugin/current/