### PR TITLE
fix: Deprecate and stop firing JS token refresh event

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/CoreClient.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/CoreClient.java
@@ -36,11 +36,12 @@ public class CoreClient extends HasEventHandling {
             EVENT_DISCONNECT = "disconnect",
             EVENT_RECONNECT = "reconnect",
             EVENT_RECONNECT_AUTH_FAILED = "reconnectauthfailed",
-            EVENT_REFRESH_TOKEN_UPDATED = "refreshtokenupdated",
             EVENT_REQUEST_FAILED = "requestfailed",
             EVENT_REQUEST_STARTED = "requeststarted",
             EVENT_REQUEST_SUCCEEDED = "requestsucceeded";
 
+    @Deprecated
+    public static final String EVENT_REFRESH_TOKEN_UPDATED = "refreshtokenupdated";
     public static final String LOGIN_TYPE_PASSWORD = "password",
             LOGIN_TYPE_ANONYMOUS = "anonymous";
 
@@ -48,10 +49,6 @@ public class CoreClient extends HasEventHandling {
 
     public CoreClient(String serverUrl, @TsTypeRef(ConnectOptions.class) @JsOptional Object connectOptions) {
         ideConnection = new IdeConnection(serverUrl, connectOptions);
-
-        // For now the only real connection is the IdeConnection, so we re-fire the auth token refresh
-        // event here for the UI to listen to
-        ideConnection.addEventListener(EVENT_REFRESH_TOKEN_UPDATED, this::fireEvent);
     }
 
     private <R> Promise<String[][]> getConfigs(Consumer<JsBiConsumer<Object, R>> rpcCall,

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -110,8 +110,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static io.deephaven.web.client.api.CoreClient.EVENT_REFRESH_TOKEN_UPDATED;
-
 /**
  * Non-exported class, manages the connection to a given worker server. Exported types like QueryInfo and Table will
  * refer to this, and allow us to try to keep track of how many open tables there are, so we can close the connection if
@@ -464,8 +462,6 @@ public class WorkerConnection {
                         if (!existing.getAt(0).equals(authorization.getAt(0))) {
                             // use this new token
                             metadata().set(FLIGHT_AUTH_HEADER_NAME, authorization);
-                            info.fireEvent(EVENT_REFRESH_TOKEN_UPDATED,
-                                    new JsRefreshToken(authorization.getAt(0), sessionTimeoutMs));
                         }
                     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/ide/IdeConnection.java
@@ -47,6 +47,7 @@ public class IdeConnection extends QueryConnectable<IdeConnection> {
      * @param serverUrl The url used when connecting to the server. Read-only.
      * @param connectOptions Optional Object
      */
+    @JsIgnore
     public IdeConnection(String serverUrl, Object connectOptions) {
         // Remove trailing slashes from the url
         this.serverUrl = serverUrl.replaceAll("/+$", "");


### PR DESCRIPTION
Also removed a constructor that was incorrectly left in place after deprecation was removed.

Partial #6133