### PR TITLE
chore: Update nightly slack job step

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Slack Nightly Failure
         uses: slackapi/slack-github-action@v1.27.0
         id: slack-nightly-failure
-        if: ${{ failure() && github.repository_owner == 'deephaven' }}
+        if: ${{ failure() && github.repository_owner == 'deephaven' && github.ref == 'refs/heads/main' }}
         with:
           payload: |
             {


### PR DESCRIPTION
This cleans up some slack job noise ("Error: Need to provide at least one botToken or webhookUrl") in cases of non main branch related failures by disabling the slack job step for anything but main; the slack secret is not available to PRs, so is only applicable right now during the scheduled nighly run.