### PR TITLE
revert: "fix(go): Disable Example_runScript for now because it breaks nightlies (#6318)"

### DIFF
--- a/go/pkg/client/example_run_script_test.go
+++ b/go/pkg/client/example_run_script_test.go
@@ -13,7 +13,7 @@ import (
 // and how you can use the script results in the client.
 //
 // This example requires a Deephaven server to connect to, so it will not work on pkg.go.dev.
-func disabled_Example_runScript() {
+func Example_runScript() {
 	// A context is used to set timeouts and deadlines for requests or cancel requests.
 	// If you don't have any specific requirements, context.Background() is a good default.
 	ctx := context.Background()


### PR DESCRIPTION
…nightlies (#6318)"

This reverts commit 6ffb6351ae1453e5794df034e78d4a4f965553a9.