### PR TITLE
revert: Roll back jetty upgrade, back to 11.0.20 from 11.0.24

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ javax-inject = "1"
 javax-validation = "2.0.1.Final"
 jdom2 = "2.0.6.1"
 jetbrains = "26.0.1"
-jetty = "11.0.24"
+jetty = "11.0.20"
 jpy = "0.18.0"
 jsinterop = "2.0.2"
 # google is annoying, and have different versions released for the same groupId


### PR DESCRIPTION
This reverts commit bc8366b426941033b23c6300420a16251c4f9ffd.

Fixes #6330