### PR TITLE
fix: Alows clients to expect that query performance results have been logged before they receive a response

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/GrpcUtil.java
@@ -14,7 +14,7 @@ import io.grpc.stub.StreamObserver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
+import java.util.function.Supplier;
 
 public class GrpcUtil {
     private static final Logger log = LoggerFactory.getLogger(GrpcUtil.class);
@@ -56,7 +56,7 @@ public class GrpcUtil {
      * @param message the last message to send on this stream before completing
      * @param <T> the type of message that the stream handles
      */
-    public static <T> void safelyComplete(StreamObserver<T> observer, T message) {
+    public static <T> void safelyOnNextAndComplete(StreamObserver<T> observer, T message) {
         safelyExecuteLocked(observer, () -> {
             observer.onNext(message);
             observer.onCompleted();

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -120,7 +120,7 @@ public class ArrowFlightUtil {
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(tableExport)
                     .onError(observer)
-                    .onSuccess(observer::onCompleted)
+                    .onSuccess(observer)
                     .submit(() -> {
                         metrics.queueNanos = System.nanoTime() - queueStartTm;
                         Object export = tableExport.get();
@@ -561,7 +561,7 @@ public class ArrowFlightUtil {
                                         }
                                     });
                                     if (newState == HalfClosedState.CLOSED) {
-                                        listener.onCompleted();
+                                        GrpcUtil.safelyComplete(listener);
                                     }
                                 })
                                 .submit(() -> {
@@ -631,7 +631,7 @@ public class ArrowFlightUtil {
                     }
                 });
                 if (newState == HalfClosedState.CLOSED) {
-                    listener.onCompleted();
+                    GrpcUtil.safelyComplete(listener);
                 }
             }
         }

--- a/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
+++ b/server/src/main/java/io/deephaven/server/arrow/ArrowFlightUtil.java
@@ -120,6 +120,7 @@ public class ArrowFlightUtil {
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(tableExport)
                     .onError(observer)
+                    .onSuccess(observer::onCompleted)
                     .submit(() -> {
                         metrics.queueNanos = System.nanoTime() - queueStartTm;
                         Object export = tableExport.get();
@@ -146,8 +147,6 @@ public class ArrowFlightUtil {
                         // shared code between `DoGet` and `BarrageSnapshotRequest`
                         BarrageUtil.createAndSendSnapshot(streamGeneratorFactory, table, null, null, false,
                                 DEFAULT_SNAPSHOT_DESER_OPTIONS, listener, metrics);
-
-                        listener.onCompleted();
                     });
         }
     }
@@ -544,6 +543,27 @@ public class ArrowFlightUtil {
                                 .queryPerformanceRecorder(queryPerformanceRecorder)
                                 .require(tableExport)
                                 .onError(listener)
+                                .onSuccess(() -> {
+                                    final HalfClosedState newState = halfClosedState.updateAndGet(current -> {
+                                        switch (current) {
+                                            case DONT_CLOSE:
+                                                // record that we have finished sending
+                                                return HalfClosedState.FINISHED_SENDING;
+                                            case CLIENT_HALF_CLOSED:
+                                                // since streaming has now finished, and client already half-closed,
+                                                // time to half close from server
+                                                return HalfClosedState.CLOSED;
+                                            case FINISHED_SENDING:
+                                            case CLOSED:
+                                                throw new IllegalStateException("Can't finish streaming twice");
+                                            default:
+                                                throw new IllegalStateException("Unknown state " + current);
+                                        }
+                                    });
+                                    if (newState == HalfClosedState.CLOSED) {
+                                        listener.onCompleted();
+                                    }
+                                })
                                 .submit(() -> {
                                     metrics.queueNanos = System.nanoTime() - queueStartTm;
                                     Object export = tableExport.get();
@@ -586,25 +606,6 @@ public class ArrowFlightUtil {
                                     BarrageUtil.createAndSendSnapshot(streamGeneratorFactory, table, columns, viewport,
                                             reverseViewport, snapshotOptAdapter.adapt(snapshotRequest), listener,
                                             metrics);
-                                    HalfClosedState newState = halfClosedState.updateAndGet(current -> {
-                                        switch (current) {
-                                            case DONT_CLOSE:
-                                                // record that we have finished sending
-                                                return HalfClosedState.FINISHED_SENDING;
-                                            case CLIENT_HALF_CLOSED:
-                                                // since streaming has now finished, and client already half-closed,
-                                                // time to half close from server
-                                                return HalfClosedState.CLOSED;
-                                            case FINISHED_SENDING:
-                                            case CLOSED:
-                                                throw new IllegalStateException("Can't finish streaming twice");
-                                            default:
-                                                throw new IllegalStateException("Unknown state " + current);
-                                        }
-                                    });
-                                    if (newState == HalfClosedState.CLOSED) {
-                                        listener.onCompleted();
-                                    }
                                 });
                     }
                 }
@@ -614,7 +615,7 @@ public class ArrowFlightUtil {
             public void close() {
                 // no work to do for DoGetRequest close
                 // possibly safely complete if finished sending data
-                HalfClosedState newState = halfClosedState.updateAndGet(current -> {
+                final HalfClosedState newState = halfClosedState.updateAndGet(current -> {
                     switch (current) {
                         case DONT_CLOSE:
                             // record that we have half closed

--- a/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
@@ -118,7 +118,7 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
         public void onNext(final Flight.HandshakeRequest value) {
             final AuthenticationRequestHandler.HandshakeResponseListener handshakeResponseListener =
                     (protocol, response) -> {
-                        GrpcUtil.safelyComplete(responseObserver, Flight.HandshakeResponse.newBuilder()
+                        GrpcUtil.safelyOnNextAndComplete(responseObserver, Flight.HandshakeResponse.newBuilder()
                                 .setProtocolVersion(protocol)
                                 .setPayload(ByteStringAccess.wrap(response))
                                 .build());
@@ -229,7 +229,7 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                         .require(export)
                         .onError(responseObserver)
                         .onSuccess((final Flight.FlightInfo resultFlightInfo) -> GrpcUtil
-                                .safelyComplete(responseObserver, resultFlightInfo))
+                                .safelyOnNextAndComplete(responseObserver, resultFlightInfo))
                         .submit(export::get);
                 return;
             }
@@ -274,7 +274,8 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                         .queryPerformanceRecorder(queryPerformanceRecorder)
                         .require(export)
                         .onError(responseObserver)
-                        .onSuccess((final Flight.SchemaResult resultSchema) -> GrpcUtil.safelyComplete(responseObserver,
+                        .onSuccess((final Flight.SchemaResult resultSchema) -> GrpcUtil.safelyOnNextAndComplete(
+                                responseObserver,
                                 resultSchema))
                         .submit(() -> Flight.SchemaResult.newBuilder()
                                 .setSchema(export.get().getSchema())

--- a/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/arrow/FlightServiceGrpcImpl.java
@@ -226,10 +226,8 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                         .queryPerformanceRecorder(queryPerformanceRecorder)
                         .require(export)
                         .onError(responseObserver)
-                        .submit(() -> {
-                            responseObserver.onNext(export.get());
-                            responseObserver.onCompleted();
-                        });
+                        .onSuccess(responseObserver::onCompleted)
+                        .submit(() -> responseObserver.onNext(export.get()));
                 return;
             }
 
@@ -273,12 +271,10 @@ public class FlightServiceGrpcImpl extends FlightServiceGrpc.FlightServiceImplBa
                         .queryPerformanceRecorder(queryPerformanceRecorder)
                         .require(export)
                         .onError(responseObserver)
-                        .submit(() -> {
-                            responseObserver.onNext(Flight.SchemaResult.newBuilder()
-                                    .setSchema(export.get().getSchema())
-                                    .build());
-                            responseObserver.onCompleted();
-                        });
+                        .onSuccess(responseObserver::onCompleted)
+                        .submit(() -> responseObserver.onNext(Flight.SchemaResult.newBuilder()
+                                .setSchema(export.get().getSchema())
+                                .build()));
                 return;
             }
 

--- a/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
@@ -140,7 +140,7 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
                 .submit(() -> {
                     final ScriptSession scriptSession = new DelegatingScriptSession(scriptSessionProvider.get());
 
-                    safelyComplete(responseObserver, StartConsoleResponse.newBuilder()
+                    GrpcUtil.safelyOnNextAndComplete(responseObserver, StartConsoleResponse.newBuilder()
                             .setResultId(request.getResultId())
                             .build());
 
@@ -188,7 +188,8 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
                     .requiresSerialQueue()
                     .require(exportedConsole)
                     .onError(responseObserver)
-                    .onSuccess((final ExecuteCommandResponse response) -> safelyComplete(responseObserver, response))
+                    .onSuccess((final ExecuteCommandResponse response) -> GrpcUtil
+                            .safelyOnNextAndComplete(responseObserver, response))
                     .submit(() -> {
                         final ScriptSession scriptSession = exportedConsole.get();
                         final ScriptSession.Changes changes = scriptSession.evaluateScript(request.getCode());
@@ -279,7 +280,8 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
                     .requiresSerialQueue()
                     .onError(responseObserver)
                     .onSuccess(
-                            () -> safelyComplete(responseObserver, BindTableToVariableResponse.getDefaultInstance()));
+                            () -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                                    BindTableToVariableResponse.getDefaultInstance()));
 
             if (request.hasConsoleId()) {
                 exportedConsole = ticketRouter.resolve(session, request.getConsoleId(), "consoleId");

--- a/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/console/ConsoleServiceGrpcImpl.java
@@ -278,7 +278,8 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .requiresSerialQueue()
                     .onError(responseObserver)
-                    .onSuccess(responseObserver::onCompleted);
+                    .onSuccess(
+                            () -> safelyComplete(responseObserver, BindTableToVariableResponse.getDefaultInstance()));
 
             if (request.hasConsoleId()) {
                 exportedConsole = ticketRouter.resolve(session, request.getConsoleId(), "consoleId");
@@ -294,7 +295,6 @@ public class ConsoleServiceGrpcImpl extends ConsoleServiceGrpc.ConsoleServiceImp
 
                 Table table = exportedTable.get();
                 queryScope.putParam(request.getVariableName(), table);
-                responseObserver.onNext(BindTableToVariableResponse.getDefaultInstance());
             });
         }
     }

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -22,6 +22,7 @@ import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.select.WhereFilter;
 import io.deephaven.extensions.barrage.util.ExportUtil;
+import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.*;
@@ -46,7 +47,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.deephaven.engine.table.impl.AbsoluteSortColumnConventions.baseColumnNameToAbsoluteName;
-import static io.deephaven.extensions.barrage.util.GrpcUtil.safelyComplete;
 
 public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGrpc.HierarchicalTableServiceImplBase {
 
@@ -89,7 +89,7 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(sourceTableExport)
                     .onError(responseObserver)
-                    .onSuccess((final RollupTable ignoredResult) -> safelyComplete(responseObserver,
+                    .onSuccess((final RollupTable ignoredResult) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
                             RollupResponse.getDefaultInstance()))
                     .submit(() -> {
                         final Table sourceTable = sourceTableExport.get();
@@ -146,7 +146,7 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(sourceTableExport)
                     .onError(responseObserver)
-                    .onSuccess((final TreeTable ignoredResult) -> safelyComplete(responseObserver,
+                    .onSuccess((final TreeTable ignoredResult) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
                             TreeResponse.getDefaultInstance()))
                     .submit(() -> {
                         final Table sourceTable = sourceTableExport.get();
@@ -208,7 +208,8 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(inputHierarchicalTableExport)
                     .onError(responseObserver)
-                    .onSuccess((final HierarchicalTable<?> ignoredResult) -> safelyComplete(responseObserver,
+                    .onSuccess((final HierarchicalTable<?> ignoredResult) -> GrpcUtil.safelyOnNextAndComplete(
+                            responseObserver,
                             HierarchicalTableApplyResponse.getDefaultInstance()))
                     .submit(() -> {
                         final HierarchicalTable<?> inputHierarchicalTable = inputHierarchicalTableExport.get();
@@ -398,7 +399,8 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
             resultExportBuilder
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .onError(responseObserver)
-                    .onSuccess((final HierarchicalTableView ignoredResult) -> safelyComplete(responseObserver,
+                    .onSuccess((final HierarchicalTableView ignoredResult) -> GrpcUtil.safelyOnNextAndComplete(
+                            responseObserver,
                             HierarchicalTableViewResponse.getDefaultInstance()))
                     .submit(() -> {
                         final Table keyTable = keyTableExport == null ? null : keyTableExport.get();
@@ -491,7 +493,7 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(hierarchicalTableExport)
                     .onError(responseObserver)
-                    .onSuccess((final Table transformedResult) -> safelyComplete(responseObserver,
+                    .onSuccess((final Table transformedResult) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
                             ExportUtil.buildTableCreationResponse(request.getResultTableId(), transformedResult)))
                     .submit(() -> {
                         final HierarchicalTable<?> hierarchicalTable = hierarchicalTableExport.get();

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableServiceGrpcImpl.java
@@ -85,10 +85,12 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
             final SessionState.ExportObject<Table> sourceTableExport =
                     ticketRouter.resolve(session, request.getSourceTableId(), "sourceTableId");
 
-            session.newExport(request.getResultRollupTableId(), "resultRollupTableId")
+            session.<RollupTable>newExport(request.getResultRollupTableId(), "resultRollupTableId")
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(sourceTableExport)
                     .onError(responseObserver)
+                    .onSuccess((final RollupTable ignoredResult) -> safelyComplete(responseObserver,
+                            RollupResponse.getDefaultInstance()))
                     .submit(() -> {
                         final Table sourceTable = sourceTableExport.get();
 
@@ -109,7 +111,6 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                             throw Exceptions.statusRuntimeException(
                                     Code.FAILED_PRECONDITION, "Not authorized to rollup hierarchical table");
                         }
-                        safelyComplete(responseObserver, RollupResponse.getDefaultInstance());
                         return transformedResult;
                     });
         }
@@ -141,10 +142,12 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
             final SessionState.ExportObject<Table> sourceTableExport =
                     ticketRouter.resolve(session, request.getSourceTableId(), "sourceTableId");
 
-            session.newExport(request.getResultTreeTableId(), "resultTreeTableId")
+            session.<TreeTable>newExport(request.getResultTreeTableId(), "resultTreeTableId")
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(sourceTableExport)
                     .onError(responseObserver)
+                    .onSuccess((final TreeTable ignoredResult) -> safelyComplete(responseObserver,
+                            TreeResponse.getDefaultInstance()))
                     .submit(() -> {
                         final Table sourceTable = sourceTableExport.get();
 
@@ -169,7 +172,6 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                             throw Exceptions.statusRuntimeException(
                                     Code.FAILED_PRECONDITION, "Not authorized to tree hierarchical table");
                         }
-                        safelyComplete(responseObserver, TreeResponse.getDefaultInstance());
                         return transformedResult;
                     });
         }
@@ -202,10 +204,12 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
             final SessionState.ExportObject<HierarchicalTable<?>> inputHierarchicalTableExport =
                     ticketRouter.resolve(session, request.getInputHierarchicalTableId(), "inputHierarchicalTableId");
 
-            session.newExport(request.getResultHierarchicalTableId(), "resultHierarchicalTableId")
+            session.<HierarchicalTable<?>>newExport(request.getResultHierarchicalTableId(), "resultHierarchicalTableId")
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(inputHierarchicalTableExport)
                     .onError(responseObserver)
+                    .onSuccess((final HierarchicalTable<?> ignoredResult) -> safelyComplete(responseObserver,
+                            HierarchicalTableApplyResponse.getDefaultInstance()))
                     .submit(() -> {
                         final HierarchicalTable<?> inputHierarchicalTable = inputHierarchicalTableExport.get();
 
@@ -274,7 +278,6 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                             throw Exceptions.statusRuntimeException(
                                     Code.FAILED_PRECONDITION, "Not authorized to apply to hierarchical table");
                         }
-                        safelyComplete(responseObserver, HierarchicalTableApplyResponse.getDefaultInstance());
                         return transformedResult;
                     });
         }
@@ -395,6 +398,8 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
             resultExportBuilder
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .onError(responseObserver)
+                    .onSuccess((final HierarchicalTableView ignoredResult) -> safelyComplete(responseObserver,
+                            HierarchicalTableViewResponse.getDefaultInstance()))
                     .submit(() -> {
                         final Table keyTable = keyTableExport == null ? null : keyTableExport.get();
                         final Object target = targetExport.get();
@@ -439,7 +444,6 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                             throw Exceptions.statusRuntimeException(
                                     Code.FAILED_PRECONDITION, "Not authorized to view hierarchical table");
                         }
-                        safelyComplete(responseObserver, HierarchicalTableViewResponse.getDefaultInstance());
                         return transformedResult;
                     });
         }
@@ -483,10 +487,12 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
             final SessionState.ExportObject<HierarchicalTable<?>> hierarchicalTableExport =
                     ticketRouter.resolve(session, request.getHierarchicalTableId(), "hierarchicalTableId");
 
-            session.newExport(request.getResultTableId(), "resultTableId")
+            session.<Table>newExport(request.getResultTableId(), "resultTableId")
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(hierarchicalTableExport)
                     .onError(responseObserver)
+                    .onSuccess((final Table transformedResult) -> safelyComplete(responseObserver,
+                            ExportUtil.buildTableCreationResponse(request.getResultTableId(), transformedResult)))
                     .submit(() -> {
                         final HierarchicalTable<?> hierarchicalTable = hierarchicalTableExport.get();
 
@@ -499,9 +505,6 @@ public class HierarchicalTableServiceGrpcImpl extends HierarchicalTableServiceGr
                                     Code.FAILED_PRECONDITION,
                                     "Not authorized to export source from hierarchical table");
                         }
-                        final ExportedTableCreationResponse response =
-                                ExportUtil.buildTableCreationResponse(request.getResultTableId(), transformedResult);
-                        safelyComplete(responseObserver, response);
                         return transformedResult;
                     });
         }

--- a/server/src/main/java/io/deephaven/server/object/ObjectServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/object/ObjectServiceGrpcImpl.java
@@ -274,7 +274,8 @@ public class ObjectServiceGrpcImpl extends ObjectServiceGrpc.ObjectServiceImplBa
                     .require(object)
                     .onError(responseObserver)
                     .onSuccess(
-                            (final FetchObjectResponse response) -> GrpcUtil.safelyComplete(responseObserver, response))
+                            (final FetchObjectResponse response) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                                    response))
                     .submit(() -> {
                         final Object o = object.get();
                         ObjectType objectTypeInstance = getObjectTypeInstance(type, o);

--- a/server/src/main/java/io/deephaven/server/partitionedtable/PartitionedTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/partitionedtable/PartitionedTableServiceGrpcImpl.java
@@ -9,6 +9,7 @@ import io.deephaven.engine.table.PartitionedTable;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
+import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
@@ -30,7 +31,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static io.deephaven.extensions.barrage.util.ExportUtil.buildTableCreationResponse;
-import static io.deephaven.extensions.barrage.util.GrpcUtil.safelyComplete;
 
 public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc.PartitionedTableServiceImplBase {
     private static final Logger log = LoggerFactory.getLogger(PartitionedTableServiceGrpcImpl.class);
@@ -71,8 +71,9 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(targetTable)
                     .onError(responseObserver)
-                    .onSuccess((final PartitionedTable ignoredResult) -> safelyComplete(responseObserver,
-                            PartitionByResponse.getDefaultInstance()))
+                    .onSuccess(
+                            (final PartitionedTable ignoredResult) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                                    PartitionByResponse.getDefaultInstance()))
                     .submit(() -> {
                         authWiring.checkPermissionPartitionBy(session.getAuthContext(), request,
                                 Collections.singletonList(targetTable.get()));
@@ -102,7 +103,7 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(partitionedTable)
                     .onError(responseObserver)
-                    .onSuccess((final Table merged) -> safelyComplete(responseObserver,
+                    .onSuccess((final Table merged) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
                             buildTableCreationResponse(request.getResultId(), merged)))
                     .submit(() -> {
                         final Table table = partitionedTable.get().table();
@@ -146,7 +147,7 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(partitionedTable, keys)
                     .onError(responseObserver)
-                    .onSuccess((final Table table) -> safelyComplete(responseObserver,
+                    .onSuccess((final Table table) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
                             buildTableCreationResponse(request.getResultId(), table)))
                     .submit(() -> {
                         Table table;

--- a/server/src/main/java/io/deephaven/server/partitionedtable/PartitionedTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/partitionedtable/PartitionedTableServiceGrpcImpl.java
@@ -67,16 +67,17 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
             final SessionState.ExportObject<Table> targetTable =
                     ticketRouter.resolve(session, request.getTableId(), "tableId");
 
-            session.newExport(request.getResultId(), "resultId")
+            session.<PartitionedTable>newExport(request.getResultId(), "resultId")
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(targetTable)
                     .onError(responseObserver)
+                    .onSuccess((final PartitionedTable ignoredResult) -> safelyComplete(responseObserver,
+                            PartitionByResponse.getDefaultInstance()))
                     .submit(() -> {
                         authWiring.checkPermissionPartitionBy(session.getAuthContext(), request,
                                 Collections.singletonList(targetTable.get()));
                         PartitionedTable partitionedTable = targetTable.get().partitionBy(request.getDropKeys(),
                                 request.getKeyColumnNamesList().toArray(String[]::new));
-                        safelyComplete(responseObserver, PartitionByResponse.getDefaultInstance());
                         return partitionedTable;
                     });
         }
@@ -97,10 +98,12 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
             final SessionState.ExportObject<PartitionedTable> partitionedTable =
                     ticketRouter.resolve(session, request.getPartitionedTable(), "partitionedTable");
 
-            session.newExport(request.getResultId(), "resultId")
+            session.<Table>newExport(request.getResultId(), "resultId")
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(partitionedTable)
                     .onError(responseObserver)
+                    .onSuccess((final Table merged) -> safelyComplete(responseObserver,
+                            buildTableCreationResponse(request.getResultId(), merged)))
                     .submit(() -> {
                         final Table table = partitionedTable.get().table();
                         authWiring.checkPermissionMerge(session.getAuthContext(), request,
@@ -116,9 +119,6 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
                             throw Exceptions.statusRuntimeException(
                                     Code.FAILED_PRECONDITION, "Not authorized to merge table.");
                         }
-                        final ExportedTableCreationResponse response =
-                                buildTableCreationResponse(request.getResultId(), merged);
-                        safelyComplete(responseObserver, response);
                         return merged;
                     });
         }
@@ -142,10 +142,12 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
             final SessionState.ExportObject<Table> keys =
                     ticketRouter.resolve(session, request.getKeyTableTicket(), "keyTable");
 
-            session.newExport(request.getResultId(), "resultId")
+            session.<Table>newExport(request.getResultId(), "resultId")
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(partitionedTable, keys)
                     .onError(responseObserver)
+                    .onSuccess((final Table table) -> safelyComplete(responseObserver,
+                            buildTableCreationResponse(request.getResultId(), table)))
                     .submit(() -> {
                         Table table;
                         Table keyTable = keys.get();
@@ -189,13 +191,10 @@ public class PartitionedTableServiceGrpcImpl extends PartitionedTableServiceGrpc
                             });
                         }
                         table = authorizationTransformation.transform(table);
-                        final ExportedTableCreationResponse response =
-                                buildTableCreationResponse(request.getResultId(), table);
                         if (table == null) {
                             throw Exceptions.statusRuntimeException(
                                     Code.FAILED_PRECONDITION, "Not authorized to get table.");
                         }
-                        safelyComplete(responseObserver, response);
                         return table;
                     });
         }

--- a/server/src/main/java/io/deephaven/server/session/SessionService.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionService.java
@@ -511,7 +511,7 @@ public class SessionService {
         }
 
         void sendMessage(final TerminationNotificationResponse response) {
-            GrpcUtil.safelyComplete(responseObserver, response);
+            GrpcUtil.safelyOnNextAndComplete(responseObserver, response);
         }
     }
 }

--- a/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
@@ -184,7 +184,7 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(source)
                     .onError(responseObserver)
-                    .onSuccess((final Object ignoredResult) -> GrpcUtil.safelyComplete(responseObserver,
+                    .onSuccess((final Object ignoredResult) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
                             ExportResponse.getDefaultInstance()))
                     .submit(source::get);
         }
@@ -219,7 +219,7 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
             Ticket resultId = request.getResultId();
 
             ticketRouter.publish(session, resultId, "resultId",
-                    () -> GrpcUtil.safelyComplete(responseObserver, PublishResponse.getDefaultInstance()),
+                    () -> GrpcUtil.safelyOnNextAndComplete(responseObserver, PublishResponse.getDefaultInstance()),
                     SessionState.toErrorHandler(sre -> GrpcUtil.safelyError(responseObserver, sre)),
                     source);
         }

--- a/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
@@ -184,11 +184,9 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(source)
                     .onError(responseObserver)
-                    .submit(() -> {
-                        final Object o = source.get();
-                        GrpcUtil.safelyComplete(responseObserver, ExportResponse.getDefaultInstance());
-                        return o;
-                    });
+                    .onSuccess((final Object ignoredResult) -> GrpcUtil.safelyComplete(responseObserver,
+                            ExportResponse.getDefaultInstance()))
+                    .submit(source::get);
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -1554,6 +1554,9 @@ public class SessionState {
          *
          * @param exportMain the callable that generates the export
          * @return the submitted export object
+         * @apiNote For exports used in RPC handling, it is recommended to use {@link #onSuccess onSuccess} for result
+         *          message (unary) and completion (unary or streaming) delivery, rather than from {@code exportMain}.
+         *          This allows clients to observe performance results more predictably.
          */
         public ExportObject<T> submit(final Callable<T> exportMain) {
             export.setWork(exportMain, errorHandler, successHandler, requiresSerialQueue);
@@ -1570,6 +1573,9 @@ public class SessionState {
          *
          * @param exportMain the runnable to execute once dependencies have resolved
          * @return the submitted export object
+         * @apiNote For exports used in RPC handling, it is recommended to use {@link #onSuccess onSuccess} for result
+         *          message (unary) and completion (unary or streaming) delivery, rather than from {@code exportMain}.
+         *          This allows clients to observe performance results more predictably.
          */
         public ExportObject<T> submit(final Runnable exportMain) {
             return submit(() -> {

--- a/server/src/main/java/io/deephaven/server/session/SessionState.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionState.java
@@ -417,7 +417,6 @@ public class SessionState {
      * the close() method be idempotent, but when combined with {@link #removeOnCloseCallback(Closeable)}, close() will
      * only be called once from this class.
      * <p>
-     * </p>
      * If called after the session has expired, this will throw, and the close() method on the provided instance will
      * not be called.
      *
@@ -436,7 +435,7 @@ public class SessionState {
 
     /**
      * Remove an on-close callback bound to the life of the session.
-     * <p/>
+     * <p>
      * A common pattern to use this will be for an object to try to remove itself, and if it succeeds, to call its own
      * {@link Closeable#close()}. If it fails, it can expect to have close() be called automatically.
      *
@@ -534,59 +533,37 @@ public class SessionState {
         private final SessionService.ErrorTransformer errorTransformer;
         private final SessionState session;
 
-        /**
-         * used to keep track of performance details either for aggregation or for the async ticket resolution
-         */
+        /** used to keep track of performance details either for aggregation or for the async ticket resolution */
         private QueryPerformanceRecorder queryPerformanceRecorder;
 
-        /**
-         * final result of export
-         */
+        /** final result of export */
         private volatile T result;
         private volatile ExportNotification.State state = ExportNotification.State.UNKNOWN;
         private volatile int exportListenerVersion = 0;
 
-        /**
-         * Indicates whether this export has already been well defined. This prevents export object reuse.
-         */
+        /** Indicates whether this export has already been well defined. This prevents export object reuse. */
         private boolean hasHadWorkSet = false;
 
-        /**
-         * This indicates whether or not this export should use the serial execution queue.
-         */
+        /** This indicates whether or not this export should use the serial execution queue. */
         private boolean requiresSerialQueue;
 
-        /**
-         * This is a reference of the work to-be-done. It is non-null only during the PENDING state.
-         */
+        /** This is a reference of the work to-be-done. It is non-null only during the PENDING state. */
         private Callable<T> exportMain;
-        /**
-         * This is a reference to the error handler to call if this item enters one of the failure states.
-         */
+        /** This is a reference to the error handler to call if this item enters one of the failure states. */
         @Nullable
         private ExportErrorHandler errorHandler;
-        /**
-         * This is a reference to the success handler to call if this item successfully exports.
-         */
+        /** This is a reference to the success handler to call if this item successfully exports. */
         @Nullable
         private Consumer<? super T> successHandler;
 
-        /**
-         * used to keep track of which children need notification on export completion
-         */
+        /** used to keep track of which children need notification on export completion */
         private List<ExportObject<?>> children = Collections.emptyList();
-        /**
-         * used to manage liveness of dependencies (to prevent a dependency from being released before it is used)
-         */
+        /** used to manage liveness of dependencies (to prevent a dependency from being released before it is used) */
         private List<ExportObject<?>> parents = Collections.emptyList();
 
-        /**
-         * used to detect when this object is ready for export (is visible for atomic int field updater)
-         */
+        /** used to detect when this object is ready for export (is visible for atomic int field updater) */
         private volatile int dependentCount = -1;
-        /**
-         * our first parent that was already released prior to having dependencies set if one exists
-         */
+        /** our first parent that was already released prior to having dependencies set if one exists */
         private ExportObject<?> alreadyDeadParent;
 
         @SuppressWarnings("unchecked")
@@ -594,9 +571,7 @@ public class SessionState {
                 AtomicIntegerFieldUpdater.newUpdater((Class<ExportObject<?>>) (Class<?>) ExportObject.class,
                         "dependentCount");
 
-        /**
-         * used to identify and propagate error details
-         */
+        /** used to identify and propagate error details */
         private String errorId;
         private String failedDependencyLogIdentity;
         private Exception caughtException;

--- a/server/src/main/java/io/deephaven/server/table/inputtables/InputTableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/inputtables/InputTableServiceGrpcImpl.java
@@ -29,7 +29,6 @@ import io.grpc.stub.StreamObserver;
 import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
-import java.io.IOException;
 import java.util.List;
 
 public class InputTableServiceGrpcImpl extends InputTableServiceGrpc.InputTableServiceImplBase {
@@ -99,7 +98,8 @@ public class InputTableServiceGrpcImpl extends InputTableServiceGrpc.InputTableS
                         inputTableUpdater.addAsync(tableToAdd, new InputTableStatusListener() {
                             @Override
                             public void onSuccess() {
-                                GrpcUtil.safelyComplete(responseObserver, AddTableResponse.getDefaultInstance());
+                                GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                                        AddTableResponse.getDefaultInstance());
                             }
 
                             @Override
@@ -164,7 +164,8 @@ public class InputTableServiceGrpcImpl extends InputTableServiceGrpc.InputTableS
                         inputTableUpdater.deleteAsync(tableToRemove, new InputTableStatusListener() {
                             @Override
                             public void onSuccess() {
-                                GrpcUtil.safelyComplete(responseObserver, DeleteTableResponse.getDefaultInstance());
+                                GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                                        DeleteTableResponse.getDefaultInstance());
                             }
 
                             @Override

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -12,7 +12,6 @@ import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.util.EngineMetrics;
 import io.deephaven.extensions.barrage.util.ExportUtil;
-import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.*;
@@ -47,9 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import static io.deephaven.extensions.barrage.util.GrpcUtil.safelyComplete;
-import static io.deephaven.extensions.barrage.util.GrpcUtil.safelyError;
-import static io.deephaven.extensions.barrage.util.GrpcUtil.safelyOnNext;
+import static io.deephaven.extensions.barrage.util.GrpcUtil.*;
 
 public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase {
 
@@ -460,7 +457,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(exportedTable)
                     .onError(responseObserver)
-                    .onSuccess((final SeekRowResponse response) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                    .onSuccess((final SeekRowResponse response) -> safelyOnNextAndComplete(responseObserver,
                             response))
                     .submit(() -> {
                         final Table table = exportedTable.get();
@@ -616,7 +613,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(export)
                     .onError(responseObserver)
-                    .onSuccess((final ExportedTableCreationResponse response) -> GrpcUtil.safelyOnNextAndComplete(
+                    .onSuccess((final ExportedTableCreationResponse response) -> safelyOnNextAndComplete(
                             responseObserver,
                             response))
                     .submit(() -> {
@@ -668,7 +665,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                     .require(dependencies)
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .onError(responseObserver)
-                    .onSuccess((final Table result) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                    .onSuccess((final Table result) -> safelyOnNextAndComplete(responseObserver,
                             ExportUtil.buildTableCreationResponse(resultId, result)))
                     .submit(() -> {
                         operation.checkPermission(request, dependencies);

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -12,6 +12,7 @@ import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.util.EngineMetrics;
 import io.deephaven.extensions.barrage.util.ExportUtil;
+import io.deephaven.extensions.barrage.util.GrpcUtil;
 import io.deephaven.internal.log.LoggerFactory;
 import io.deephaven.io.logger.Logger;
 import io.deephaven.proto.backplane.grpc.*;
@@ -459,7 +460,8 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(exportedTable)
                     .onError(responseObserver)
-                    .onSuccess((final SeekRowResponse response) -> safelyComplete(responseObserver, response))
+                    .onSuccess((final SeekRowResponse response) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
+                            response))
                     .submit(() -> {
                         final Table table = exportedTable.get();
                         authWiring.checkPermissionSeekRow(session.getAuthContext(), request,
@@ -614,7 +616,8 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(export)
                     .onError(responseObserver)
-                    .onSuccess((final ExportedTableCreationResponse response) -> safelyComplete(responseObserver,
+                    .onSuccess((final ExportedTableCreationResponse response) -> GrpcUtil.safelyOnNextAndComplete(
+                            responseObserver,
                             response))
                     .submit(() -> {
                         final Object obj = export.get();
@@ -665,7 +668,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                     .require(dependencies)
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .onError(responseObserver)
-                    .onSuccess((final Table result) -> safelyComplete(responseObserver,
+                    .onSuccess((final Table result) -> GrpcUtil.safelyOnNextAndComplete(responseObserver,
                             ExportUtil.buildTableCreationResponse(resultId, result)))
                     .submit(() -> {
                         operation.checkPermission(request, dependencies);

--- a/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/TableServiceGrpcImpl.java
@@ -455,10 +455,11 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
             final SessionState.ExportObject<Table> exportedTable =
                     ticketRouter.resolve(session, sourceId, "sourceId");
 
-            session.nonExport()
+            session.<SeekRowResponse>nonExport()
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(exportedTable)
                     .onError(responseObserver)
+                    .onSuccess((final SeekRowResponse response) -> safelyComplete(responseObserver, response))
                     .submit(() -> {
                         final Table table = exportedTable.get();
                         authWiring.checkPermissionSeekRow(session.getAuthContext(), request,
@@ -473,8 +474,7 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                                 request.getInsensitive(),
                                 request.getContains(),
                                 request.getIsBackward()).seek(table);
-                        SeekRowResponse.Builder rowResponse = SeekRowResponse.newBuilder();
-                        safelyComplete(responseObserver, rowResponse.setResultRow(result).build());
+                        return SeekRowResponse.newBuilder().setResultRow(result).build();
                     });
         }
     }
@@ -525,17 +525,16 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                 if (numRemaining > 0) {
                     return;
                 }
-
+                final StatusRuntimeException failure = firstFailure.get();
                 try (final SafeCloseable ignored2 = queryPerformanceRecorder.resumeQuery()) {
-                    final StatusRuntimeException failure = firstFailure.get();
-                    if (failure != null) {
-                        safelyError(responseObserver, failure);
-                    } else {
-                        safelyComplete(responseObserver);
-                    }
                     if (queryPerformanceRecorder.endQuery()) {
                         EngineMetrics.getInstance().logQueryProcessingResults(queryPerformanceRecorder, failure);
                     }
+                }
+                if (failure != null) {
+                    safelyError(responseObserver, failure);
+                } else {
+                    safelyComplete(responseObserver);
                 }
             };
 
@@ -611,23 +610,20 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
         try (final SafeCloseable ignored = queryPerformanceRecorder.startQuery()) {
             final SessionState.ExportObject<Object> export = ticketRouter.resolve(session, request, "request");
 
-            session.nonExport()
+            session.<ExportedTableCreationResponse>nonExport()
                     .queryPerformanceRecorder(queryPerformanceRecorder)
                     .require(export)
                     .onError(responseObserver)
+                    .onSuccess((final ExportedTableCreationResponse response) -> safelyComplete(responseObserver,
+                            response))
                     .submit(() -> {
                         final Object obj = export.get();
                         if (!(obj instanceof Table)) {
-                            responseObserver.onError(
-                                    Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION,
-                                            "Ticket is not a table"));
-                            return;
+                            throw Exceptions.statusRuntimeException(Code.FAILED_PRECONDITION, "Ticket is not a table");
                         }
                         authWiring.checkPermissionGetExportedTableCreationResponse(
                                 session.getAuthContext(), request, Collections.singletonList((Table) obj));
-                        final ExportedTableCreationResponse response =
-                                ExportUtil.buildTableCreationResponse(request, (Table) obj);
-                        safelyComplete(responseObserver, response);
+                        return ExportUtil.buildTableCreationResponse(request, (Table) obj);
                     });
         }
     }
@@ -665,17 +661,15 @@ public class TableServiceGrpcImpl extends TableServiceGrpc.TableServiceImplBase 
                     .map(ref -> resolveOneShotReference(session, ref))
                     .collect(Collectors.toList());
 
-            session.newExport(resultId, "resultId")
+            session.<Table>newExport(resultId, "resultId")
                     .require(dependencies)
-                    .onError(responseObserver)
                     .queryPerformanceRecorder(queryPerformanceRecorder)
+                    .onError(responseObserver)
+                    .onSuccess((final Table result) -> safelyComplete(responseObserver,
+                            ExportUtil.buildTableCreationResponse(resultId, result)))
                     .submit(() -> {
                         operation.checkPermission(request, dependencies);
-                        final Table result = operation.create(request, dependencies);
-                        final ExportedTableCreationResponse response =
-                                ExportUtil.buildTableCreationResponse(resultId, result);
-                        safelyComplete(responseObserver, response);
-                        return result;
+                        return operation.create(request, dependencies);
                     });
         }
     }


### PR DESCRIPTION
Defer response messaging to `onSuccess` for all `ExportBuilders` that use `QueryPerformanceRecorder`. This allows clients to expect that query performance results have been logged before they receive a response. 

Change summary:
* Adjust all `SessionState.ExportBuilder` uses that set a `QueryPerformanceRecorder` to use `onSuccess` for response delivery if possible
* Exclusions: `DoExchange` subscriptions and async input table operations
* Note: batch already used `onSuccess`, but completion now happens after performance results are reported
* Some cleanup to `GrpcUtil` usage