### PR TITLE
chore: Update .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,5 @@
 http://localhost:
+https://localhost:
 https://docs.deephaven.io/
 https://10.0.1.50:8123/iris/connection.json
 https://deephaven.io/core/release/vX.Y.Z/javadoc


### PR DESCRIPTION
Missed a localhost link that uses https. This fixes that. Nightly link checks should pass once this goes in.