### PR TITLE
chore: Update TableReference protobuf documentation

### DIFF
--- a/go/internal/proto/table/table.pb.go
+++ b/go/internal/proto/table/table.pb.go
@@ -762,8 +762,9 @@ type isTableReference_Ref interface {
 }
 
 type TableReference_Ticket struct {
-	// A ticket to resolve to get the table. To handle races correctly, we encourage this to be an export ticket, but
-	// technically any ticket type will suffice.
+	// A ticket to resolve to get the table. It's preferable to use export tickets in order to avoid races that are
+	// possible with tickets controlled by the server, but any ticket type will suffice as long as it resolves to a
+	// table.
 	Ticket *ticket.Ticket `protobuf:"bytes,1,opt,name=ticket,proto3,oneof"`
 }
 

--- a/go/internal/proto/table/table.pb.go
+++ b/go/internal/proto/table/table.pb.go
@@ -762,12 +762,14 @@ type isTableReference_Ref interface {
 }
 
 type TableReference_Ticket struct {
-	// an exported ticket
+	// A ticket to resolve to get the table. To handle races correctly, we encourage this to be an export ticket, but
+	// technically any ticket type will suffice.
 	Ticket *ticket.Ticket `protobuf:"bytes,1,opt,name=ticket,proto3,oneof"`
 }
 
 type TableReference_BatchOffset struct {
-	// an offset into a BatchRequest -- used to reference a result that will not be exported
+	// An offset into a BatchRequest's ops field, used to reference an intermediate operation which may not have been
+	// exported. Only valid to set when used in the context of a BatchRequest.
 	BatchOffset int32 `protobuf:"zigzag32,2,opt,name=batch_offset,json=batchOffset,proto3,oneof"`
 }
 

--- a/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
+++ b/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
@@ -276,9 +276,11 @@ service TableService {
 
 message TableReference {
   oneof ref {
-    // an exported ticket
+    // A ticket. In the case of a single-shot operation, this will often be an export id ticket.
     Ticket ticket = 1;
-    // an offset into a BatchRequest -- used to reference a result that will not be exported
+
+    // An offset into a BatchRequest's ops field, used to reference an intermediate operation which may not have been
+    // exported. Only valid to set when used in the context of a BatchRequest.
     sint32 batch_offset = 2;
   }
 }

--- a/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
+++ b/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
@@ -276,8 +276,9 @@ service TableService {
 
 message TableReference {
   oneof ref {
-    // A ticket to resolve to get the table. To handle races correctly, we encourage this to be an export ticket, but
-    // technically any ticket type will suffice.
+    // A ticket to resolve to get the table. It's preferable to use export tickets in order to avoid races that are
+    // possible with tickets controlled by the server, but any ticket type will suffice as long as it resolves to a
+    // table.
     Ticket ticket = 1;
 
     // An offset into a BatchRequest's ops field, used to reference an intermediate operation which may not have been

--- a/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
+++ b/proto/proto-backplane-grpc/src/main/proto/deephaven/proto/table.proto
@@ -276,7 +276,8 @@ service TableService {
 
 message TableReference {
   oneof ref {
-    // A ticket. In the case of a single-shot operation, this will often be an export id ticket.
+    // A ticket to resolve to get the table. To handle races correctly, we encourage this to be an export ticket, but
+    // technically any ticket type will suffice.
     Ticket ticket = 1;
 
     // An offset into a BatchRequest's ops field, used to reference an intermediate operation which may not have been


### PR DESCRIPTION
This clarifies that `ticket` does not need to be an export ticket, and that `batch_offset` will still work if it refers to an intermediate operation which has been exported.