### PR TITLE
fix: Correctly handle signature-less functions for Py UDF calls

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/PyCallableWrapper.java
@@ -56,6 +56,7 @@ public interface PyCallableWrapper {
     class Signature {
         private final List<Parameter> parameters;
         private final Class<?> returnType;
+        public static Signature EMPTY_SIGNATURE = new Signature(List.of(), null);
 
         public Signature(List<Parameter> parameters, Class<?> returnType) {
             this.parameters = parameters;

--- a/py/server/deephaven/_udf.py
+++ b/py/server/deephaven/_udf.py
@@ -485,7 +485,7 @@ def _parse_np_ufunc_signature(fn: numpy.ufunc) -> _ParsedSignature:
     return p_sig
 
 
-def _parse_signature(fn: Callable) -> _ParsedSignature:
+def _parse_signature(fn: Callable) -> Optional[_ParsedSignature]:
     """ Parse the signature of a function """
 
     if numba:
@@ -496,10 +496,14 @@ def _parse_signature(fn: Callable) -> _ParsedSignature:
         return _parse_np_ufunc_signature(fn)
     else:
         p_sig = _ParsedSignature(fn=fn)
-        if sys.version_info >= (3, 10):
-            sig = inspect.signature(fn, eval_str=True)  # novermin
-        else:
-            sig = inspect.signature(fn)
+        try:
+            if sys.version_info >= (3, 10):
+                sig = inspect.signature(fn, eval_str=True)  # novermin
+            else:
+                sig = inspect.signature(fn)
+        except ValueError:
+            # some built-in functions don't have a signature, neither do some functions from C extensions
+            return None
 
         for n, p in sig.parameters.items():
             # when from __future__ import annotations is used, the annotation is a string, we need to eval it to get
@@ -513,7 +517,7 @@ def _parse_signature(fn: Callable) -> _ParsedSignature:
         p_sig.ret_annotation = _parse_return_annotation(t)
         return p_sig
 
-def _udf_parser(fn: Callable):
+def _udf_parser(fn: Callable) -> Optional[Callable]:
     """A decorator that acts as a transparent translator for Python UDFs used in Deephaven query formulas between
     Python and Java. This decorator is intended for internal use by the Deephaven query engine and should not be used by
     users.
@@ -531,6 +535,9 @@ def _udf_parser(fn: Callable):
         return fn
 
     p_sig = _parse_signature(fn)
+    if p_sig is None:
+        return None
+
     return_array = p_sig.ret_annotation.has_array
     ret_np_char = p_sig.ret_annotation.encoded_type[-1]
     ret_dtype = dtypes.from_np_dtype(np.dtype(ret_np_char if ret_np_char != "X" else "O"))

--- a/py/server/tests/test_udf_scalar_args.py
+++ b/py/server/tests/test_udf_scalar_args.py
@@ -613,6 +613,12 @@ def test_udf(x: {np_type}) -> bool:
         self.assertRegex(str(w[-1].message), "numpy scalar type.*is used")
         self.assertEqual(10, t.to_string().count("true"))
 
+    def test_no_signature(self):
+        builtin_max = max
+        t = empty_table(10).update("X = (int) builtin_max(1, 2, 3)")
+        self.assertEqual(t.columns[0].data_type, dtypes.int32)
+        self.assertEqual(10, t.to_string().count("3"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/py/server/tests/test_vectorization.py
+++ b/py/server/tests/test_vectorization.py
@@ -342,5 +342,15 @@ def test_udf(col1, col2: np.ndarray[{_J_TYPE_NP_DTYPE_MAP[j_dtype]}]) -> np.ndar
             self.assertEqual(_udf.vectorized_count, 1)
             _udf.vectorized_count = 0
 
+    def test_no_signature_array(self):
+        builtin_max = max
+
+        t = empty_table(10).update(["X = i % 3", "Y = i % 2 == 0? `deephaven`: `rocks`"]).group_by("X").update("Y = Y.toArray()")
+        t1 = t.update(["X1 = builtin_max(Y)"])
+        self.assertEqual(t1.columns[2].data_type, dtypes.JObject)
+        self.assertEqual(_udf.vectorized_count, 0)
+        _udf.vectorized_count = 0
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #6349 