### PR TITLE
refactor: Removed out some unused Parquet APIs

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/MappedSchema.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/MappedSchema.java
@@ -26,21 +26,14 @@ class MappedSchema {
             final TableDefinition definition,
             final RowSet rowSet,
             final Map<String, ? extends ColumnSource<?>> columnSourceMap,
-            final ParquetInstructions instructions,
-            final ColumnDefinition<?>... extraColumns) {
+            final ParquetInstructions instructions) {
         final MessageTypeBuilder builder = Types.buildMessage();
         for (final ColumnDefinition<?> columnDefinition : definition.getColumns()) {
-            TypeInfos.TypeInfo typeInfo =
+            final TypeInfos.TypeInfo typeInfo =
                     getTypeInfo(computedCache, columnDefinition, rowSet, columnSourceMap, instructions);
-            Type schemaType = typeInfo.createSchemaType(columnDefinition, instructions);
+            final Type schemaType = typeInfo.createSchemaType(columnDefinition, instructions);
             builder.addField(schemaType);
         }
-
-        for (final ColumnDefinition<?> extraColumn : extraColumns) {
-            builder.addField(getTypeInfo(computedCache, extraColumn, rowSet, columnSourceMap, instructions)
-                    .createSchemaType(extraColumn, instructions));
-        }
-
         final MessageType schema = builder.named("root");
         return new MappedSchema(definition, schema);
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -36,13 +36,11 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
     public static final int DEFAULT_MAXIMUM_DICTIONARY_KEYS = 1 << 20;
     public static final int DEFAULT_MAXIMUM_DICTIONARY_SIZE = 1 << 20;
 
-    public static final int MIN_TARGET_PAGE_SIZE = 1 << 11; // 2KB
-    private static final int minTargetPageSize = Configuration.getInstance().getIntegerWithDefault(
-            "Parquet.minTargetPageSize", MIN_TARGET_PAGE_SIZE);
+    public static final int MIN_TARGET_PAGE_SIZE = Configuration.getInstance().getIntegerWithDefault(
+            "Parquet.minTargetPageSize", 1 << 11); // 2KB
 
-    public static final int DEFAULT_TARGET_PAGE_SIZE = 1 << 16; // 64KB
-    private static final int defaultTargetPageSize = Configuration.getInstance().getIntegerWithDefault(
-            "Parquet.defaultTargetPageSize", DEFAULT_TARGET_PAGE_SIZE);
+    public static final int DEFAULT_TARGET_PAGE_SIZE = Configuration.getInstance().getIntegerWithDefault(
+            "Parquet.defaultTargetPageSize", 1 << 16); // 64KB
 
     /**
      * Throws an exception if {@link ParquetInstructions#getTableDefinition()} is empty.
@@ -257,7 +255,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
 
         @Override
         public int getTargetPageSize() {
-            return defaultTargetPageSize;
+            return DEFAULT_TARGET_PAGE_SIZE;
         }
 
         @Override
@@ -620,7 +618,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         private int maximumDictionaryKeys = DEFAULT_MAXIMUM_DICTIONARY_KEYS;
         private int maximumDictionarySize = DEFAULT_MAXIMUM_DICTIONARY_SIZE;
         private boolean isLegacyParquet;
-        private int targetPageSize = defaultTargetPageSize;
+        private int targetPageSize = DEFAULT_TARGET_PAGE_SIZE;
         private boolean isRefreshing = DEFAULT_IS_REFRESHING;
         private Object specialInstructions;
         private boolean generateMetadataFiles = DEFAULT_GENERATE_METADATA_FILES;
@@ -804,8 +802,8 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
         }
 
         public Builder setTargetPageSize(final int targetPageSize) {
-            if (targetPageSize < minTargetPageSize) {
-                throw new IllegalArgumentException("Target page size should be >= " + minTargetPageSize);
+            if (targetPageSize < MIN_TARGET_PAGE_SIZE) {
+                throw new IllegalArgumentException("Target page size should be >= " + MIN_TARGET_PAGE_SIZE);
             }
             this.targetPageSize = targetPageSize;
             return this;

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetInstructions.java
@@ -11,6 +11,7 @@ import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
 import io.deephaven.parquet.base.ParquetUtils;
 import io.deephaven.util.annotations.VisibleForTesting;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,7 +33,7 @@ import java.util.stream.Collectors;
  */
 public abstract class ParquetInstructions implements ColumnToCodecMappings {
 
-    public static final String DEFAULT_COMPRESSION_CODEC_NAME = "SNAPPY";
+    public static final String DEFAULT_COMPRESSION_CODEC_NAME = CompressionCodecName.SNAPPY.toString();
     public static final int DEFAULT_MAXIMUM_DICTIONARY_KEYS = 1 << 20;
     public static final int DEFAULT_MAXIMUM_DICTIONARY_SIZE = 1 << 20;
 
@@ -48,7 +49,7 @@ public abstract class ParquetInstructions implements ColumnToCodecMappings {
      * @param parquetInstructions the parquet instructions
      * @throws IllegalArgumentException if there is not a table definition
      */
-    public static TableDefinition ensureDefinition(ParquetInstructions parquetInstructions) {
+    static TableDefinition ensureDefinition(final ParquetInstructions parquetInstructions) {
         return parquetInstructions.getTableDefinition()
                 .orElseThrow(() -> new IllegalArgumentException("Table definition must be provided"));
     }


### PR DESCRIPTION
Originally added in #5989, moved as a separate PR for ease of review/testing.

**Breaking Changes:**
- Removed optional paramater `extraColumns` from `io.deephaven.parquet.table.MappedSchema.create`
- Removed these methods;
	- `ParquetInstructions::setDefaultCompressionCodecName`
	- `ParquetInstructions::getDefaultCompressionCodecName`
	- `ParquetInstructions::setDefaultMaximumDictionaryKeys`
	- `ParquetInstructions::getDefaultMaximumDictionaryKeys`
	- `ParquetInstructions::setDefaultMaximumDictionarySize`
	- `ParquetInstructions::getDefaultMaximumDictionarySize`
	- `ParquetInstructions::setDefaultTargetPageSize`
	- `ParquetInstructions::getDefaultTargetPageSize`