### PR TITLE
feat!: provide key columns as scalars (vs. vectors) to `RollingFormula`

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperator.java
@@ -160,18 +160,45 @@ public abstract class UpdateByOperator {
     public abstract void initializeSources(@NotNull Table source, @Nullable RowRedirection rowRedirection);
 
     /**
+     * Initialize the bucket context for a cumulative operator and pass in the bucket key values. Most operators will
+     * not need the key values, but those that do can override this method.
+     */
+    public void initializeCumulativeWithKeyValues(
+            @NotNull final Context context,
+            final long firstUnmodifiedKey,
+            final long firstUnmodifiedTimestamp,
+            @NotNull final RowSet bucketRowSet,
+            @NotNull Object[] bucketKeyValues) {
+        initializeCumulative(context, firstUnmodifiedKey, firstUnmodifiedTimestamp, bucketRowSet);
+    }
+
+    /**
      * Initialize the bucket context for a cumulative operator
      */
-    public void initializeCumulative(@NotNull final Context context, final long firstUnmodifiedKey,
+    public void initializeCumulative(
+            @NotNull final Context context,
+            final long firstUnmodifiedKey,
             final long firstUnmodifiedTimestamp,
             @NotNull final RowSet bucketRowSet) {
         context.reset();
     }
 
     /**
+     * Initialize the bucket context for a windowed operator and pass in the bucket key values. Most operators will not
+     * need the key values, but those that do can override this method.
+     */
+    public void initializeRollingWithKeyValues(
+            @NotNull final Context context,
+            @NotNull final RowSet bucketRowSet,
+            @NotNull Object[] bucketKeyValues) {
+        initializeRolling(context, bucketRowSet);
+    }
+
+    /**
      * Initialize the bucket context for a windowed operator
      */
-    public void initializeRolling(@NotNull final Context context,
+    public void initializeRolling(
+            @NotNull final Context context,
             @NotNull final RowSet bucketRowSet) {
         context.reset();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
@@ -59,7 +59,7 @@ public class UpdateByOperatorFactory {
     private final MatchPair[] groupByColumns;
     @NotNull
     private final UpdateByControl control;
-    private Map<String, ColumnDefinition<?>> vectorColumnNameMap;
+    private Map<String, ColumnDefinition<?>> vectorColumnDefinitions;
 
     public UpdateByOperatorFactory(
             @NotNull final TableDefinition tableDef,
@@ -1437,7 +1437,6 @@ public class UpdateByOperatorFactory {
         private UpdateByOperator makeRollingFormulaMultiColumnOperator(
                 @NotNull final TableDefinition tableDef,
                 @NotNull final RollingFormulaSpec rs) {
-
             final long prevWindowScaleUnits = rs.revWindowScale().getTimeScaleUnits();
             final long fwdWindowScaleUnits = rs.fwdWindowScale().getTimeScaleUnits();
 
@@ -1446,21 +1445,24 @@ public class UpdateByOperatorFactory {
             // Create the colum
             final SelectColumn selectColumn = SelectColumn.of(Selectable.parse(rs.formula()));
 
-            // Get or create a column definition map where the definitions are vectors of the original column types.
-            if (vectorColumnNameMap == null) {
-                vectorColumnNameMap = new HashMap<>();
-                columnDefinitionMap.forEach((key, value) -> {
-                    final ColumnDefinition<?> columnDef = ColumnDefinition.fromGenericType(
-                            key,
-                            VectorFactory.forElementType(value.getDataType()).vectorType(),
-                            value.getDataType());
-                    vectorColumnNameMap.put(key, columnDef);
-                });
+            // Get or create a column definition map composed of vectors of the original column types (or scalars when
+            // part of the group_by columns).
+            final Set<String> groupByColumnSet =
+                    Arrays.stream(groupByColumns).map(MatchPair::rightColumn).collect(Collectors.toSet());
+            if (vectorColumnDefinitions == null) {
+                vectorColumnDefinitions = tableDef.getColumnStream().collect(Collectors.toMap(
+                        ColumnDefinition::getName,
+                        (final ColumnDefinition<?> cd) -> groupByColumnSet.contains(cd.getName())
+                                ? cd
+                                : ColumnDefinition.fromGenericType(
+                                        cd.getName(),
+                                        VectorFactory.forElementType(cd.getDataType()).vectorType(),
+                                        cd.getDataType())));
             }
 
-            // Get the input column names and data types from the formula.
-            final String[] inputColumnNames =
-                    selectColumn.initDef(vectorColumnNameMap, compilationProcessor).toArray(String[]::new);
+            // Get the input column names from the formula and provide them to the groupBy operator
+            final String[] allInputColumns =
+                    selectColumn.initDef(vectorColumnDefinitions, compilationProcessor).toArray(String[]::new);
             if (!selectColumn.getColumnArrays().isEmpty()) {
                 throw new IllegalArgumentException("RollingFormulaMultiColumnOperator does not support column arrays ("
                         + selectColumn.getColumnArrays() + ")");
@@ -1468,20 +1470,36 @@ public class UpdateByOperatorFactory {
             if (selectColumn.hasVirtualRowVariables()) {
                 throw new IllegalArgumentException("RollingFormula does not support virtual row variables");
             }
-            final Class<?>[] inputColumnTypes = new Class[inputColumnNames.length];
-            final Class<?>[] inputVectorTypes = new Class[inputColumnNames.length];
 
-            for (int i = 0; i < inputColumnNames.length; i++) {
-                final ColumnDefinition<?> columnDef = columnDefinitionMap.get(inputColumnNames[i]);
-                inputColumnTypes[i] = columnDef.getDataType();
-                inputVectorTypes[i] = vectorColumnNameMap.get(inputColumnNames[i]).getDataType();
+            final String[] inputKeyColumns = Arrays.stream(allInputColumns)
+                    .filter(groupByColumnSet::contains)
+                    .toArray(String[]::new);
+            final Class<?>[] inputKeyColumnTypes = new Class[inputKeyColumns.length];
+            final Class<?>[] inputKeyComponentTypes = new Class[inputKeyColumns.length];
+            for (int i = 0; i < inputKeyColumns.length; i++) {
+                final ColumnDefinition<?> columnDef = columnDefinitionMap.get(inputKeyColumns[i]);
+                inputKeyColumnTypes[i] = columnDef.getDataType();
+                inputKeyComponentTypes[i] = columnDef.getComponentType();
             }
+
+            final String[] inputNonKeyColumns = Arrays.stream(allInputColumns)
+                    .filter(col -> !groupByColumnSet.contains(col))
+                    .toArray(String[]::new);
+            final Class<?>[] inputNonKeyColumnTypes = new Class[inputNonKeyColumns.length];
+            final Class<?>[] inputNonKeyVectorTypes = new Class[inputNonKeyColumns.length];
+            for (int i = 0; i < inputNonKeyColumns.length; i++) {
+                final ColumnDefinition<?> columnDef = columnDefinitionMap.get(inputNonKeyColumns[i]);
+                inputNonKeyColumnTypes[i] = columnDef.getDataType();
+                inputNonKeyVectorTypes[i] = vectorColumnDefinitions.get(inputNonKeyColumns[i]).getDataType();
+            }
+
 
             final String[] affectingColumns;
             if (rs.revWindowScale().timestampCol() == null) {
-                affectingColumns = inputColumnNames;
+                affectingColumns = ArrayUtils.addAll(inputKeyColumns, inputNonKeyColumns);
             } else {
-                affectingColumns = ArrayUtils.add(inputColumnNames, rs.revWindowScale().timestampCol());
+                affectingColumns = ArrayUtils.add(ArrayUtils.addAll(inputKeyColumns, inputNonKeyColumns),
+                        rs.revWindowScale().timestampCol());
             }
 
             // Create a new column pair with the same name for the left and right columns
@@ -1494,9 +1512,12 @@ public class UpdateByOperatorFactory {
                     prevWindowScaleUnits,
                     fwdWindowScaleUnits,
                     selectColumn,
-                    inputColumnNames,
-                    inputColumnTypes,
-                    inputVectorTypes);
+                    inputKeyColumns,
+                    inputKeyColumnTypes,
+                    inputKeyComponentTypes,
+                    inputNonKeyColumns,
+                    inputNonKeyColumnTypes,
+                    inputNonKeyVectorTypes);
         }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
@@ -1460,7 +1460,7 @@ public class UpdateByOperatorFactory {
                                         cd.getDataType())));
             }
 
-            // Get the input column names from the formula and provide them to the groupBy operator
+            // Get the input column names from the formula and provide them to the rolling formula operator
             final String[] allInputColumns =
                     selectColumn.initDef(vectorColumnDefinitions, compilationProcessor).toArray(String[]::new);
             if (!selectColumn.getColumnArrays().isEmpty()) {
@@ -1494,10 +1494,9 @@ public class UpdateByOperatorFactory {
 
             final String[] affectingColumns;
             if (rs.revWindowScale().timestampCol() == null) {
-                affectingColumns = ArrayUtils.addAll(inputKeyColumns, inputNonKeyColumns);
+                affectingColumns = inputNonKeyColumns;
             } else {
-                affectingColumns = ArrayUtils.add(ArrayUtils.addAll(inputKeyColumns, inputNonKeyColumns),
-                        rs.revWindowScale().timestampCol());
+                affectingColumns = ArrayUtils.add(inputNonKeyColumns, rs.revWindowScale().timestampCol());
             }
 
             // Create a new column pair with the same name for the left and right columns

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindow.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindow.java
@@ -47,7 +47,8 @@ abstract class UpdateByWindow {
         protected final boolean timestampsModified;
         /** Whether this is the creation phase of this window */
         protected final boolean initialStep;
-
+        /** Store the key values for this bucket */
+        protected final Object[] bucketKeyValues;
 
         /** An array of ColumnSources for each underlying operator */
         protected ColumnSource<?>[] inputSources;
@@ -71,12 +72,14 @@ abstract class UpdateByWindow {
                 final TrackingRowSet timestampValidRowSet,
                 final boolean timestampsModified,
                 final int chunkSize,
-                final boolean initialStep) {
+                final boolean initialStep,
+                @NotNull final Object[] bucketKeyValues) {
             this.sourceRowSet = sourceRowSet;
             this.timestampColumnSource = timestampColumnSource;
             this.timestampSsa = timestampSsa;
             this.timestampValidRowSet = timestampValidRowSet;
             this.timestampsModified = timestampsModified;
+            this.bucketKeyValues = bucketKeyValues;
 
             workingChunkSize = chunkSize;
             this.initialStep = initialStep;
@@ -91,13 +94,15 @@ abstract class UpdateByWindow {
         }
     }
 
-    abstract UpdateByWindowBucketContext makeWindowContext(final TrackingRowSet sourceRowSet,
+    abstract UpdateByWindowBucketContext makeWindowContext(
+            final TrackingRowSet sourceRowSet,
             final ColumnSource<?> timestampColumnSource,
             final LongSegmentedSortedArray timestampSsa,
             final TrackingRowSet timestampValidRowSet,
             final boolean timestampsModified,
             final int chunkSize,
-            final boolean isInitializeStep);
+            final boolean isInitializeStep,
+            final Object[] bucketKeyValues);
 
     UpdateByWindow(final UpdateByOperator[] operators,
             final int[][] operatorInputSourceSlots,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowCumulative.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowCumulative.java
@@ -55,9 +55,17 @@ class UpdateByWindowCumulative extends UpdateByWindow {
             final TrackingRowSet timestampValidRowSet,
             final boolean timestampsModified,
             final int chunkSize,
-            final boolean isInitializeStep) {
-        return new UpdateByWindowBucketContext(sourceRowSet, timestampColumnSource, timestampSsa, timestampValidRowSet,
-                timestampsModified, chunkSize, isInitializeStep);
+            final boolean isInitializeStep,
+            final Object[] bucketKeyValues) {
+        return new UpdateByWindowBucketContext(
+                sourceRowSet,
+                timestampColumnSource,
+                timestampSsa,
+                timestampValidRowSet,
+                timestampsModified,
+                chunkSize,
+                isInitializeStep,
+                bucketKeyValues);
     }
 
     @Override
@@ -192,7 +200,8 @@ class UpdateByWindowCumulative extends UpdateByWindow {
                     continue;
                 }
                 UpdateByOperator cumOp = operators[opIdx];
-                cumOp.initializeCumulative(winOpContexts[ii], rowKey, timestamp, context.sourceRowSet);
+                cumOp.initializeCumulativeWithKeyValues(winOpContexts[ii], rowKey, timestamp, context.sourceRowSet,
+                        context.bucketKeyValues);
             }
 
             while (affectedIt.hasMore()) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowRollingBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowRollingBase.java
@@ -41,14 +41,16 @@ abstract class UpdateByWindowRollingBase extends UpdateByWindow {
                 final TrackingRowSet timestampValidRowSet,
                 final boolean timestampsModified,
                 final int chunkSize,
-                final boolean initialStep) {
+                final boolean initialStep,
+                final Object[] bucketKeyValues) {
             super(sourceRowSet,
                     timestampColumnSource,
                     timestampSsa,
                     timestampValidRowSet,
                     timestampsModified,
                     chunkSize,
-                    initialStep);
+                    initialStep,
+                    bucketKeyValues);
         }
 
         @Override
@@ -60,7 +62,7 @@ abstract class UpdateByWindowRollingBase extends UpdateByWindow {
     }
 
     UpdateByWindowRollingBase(@NotNull final UpdateByOperator[] operators,
-            @NotNull final int[][] operatorSourceSlots,
+            final int[][] operatorSourceSlots,
             final long prevUnits,
             final long fwdUnits,
             @Nullable final String timestampColumnName) {
@@ -152,7 +154,7 @@ abstract class UpdateByWindowRollingBase extends UpdateByWindow {
                     continue;
                 }
                 UpdateByOperator rollingOp = operators[opIdx];
-                rollingOp.initializeRolling(winOpContexts[ii], bucketRowSet);
+                rollingOp.initializeRollingWithKeyValues(winOpContexts[ii], bucketRowSet, context.bucketKeyValues);
             }
 
             int affectedChunkOffset = 0;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowRollingTicks.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowRollingTicks.java
@@ -30,9 +30,12 @@ class UpdateByWindowRollingTicks extends UpdateByWindowRollingBase {
         private RowSet affectedRowPositions;
         private RowSet influencerPositions;
 
-        UpdateByWindowTicksBucketContext(final TrackingRowSet sourceRowSet,
-                final int chunkSize, final boolean initialStep) {
-            super(sourceRowSet, null, null, null, false, chunkSize, initialStep);
+        UpdateByWindowTicksBucketContext(
+                final TrackingRowSet sourceRowSet,
+                final int chunkSize,
+                final boolean initialStep,
+                final Object[] bucketKeyValues) {
+            super(sourceRowSet, null, null, null, false, chunkSize, initialStep, bucketKeyValues);
         }
 
         @Override
@@ -77,14 +80,16 @@ class UpdateByWindowRollingTicks extends UpdateByWindowRollingBase {
     }
 
     @Override
-    UpdateByWindowBucketContext makeWindowContext(final TrackingRowSet sourceRowSet,
+    UpdateByWindowBucketContext makeWindowContext(
+            final TrackingRowSet sourceRowSet,
             final ColumnSource<?> timestampColumnSource,
             final LongSegmentedSortedArray timestampSsa,
             final TrackingRowSet timestampValidRowSet,
             final boolean timestampsModified,
             final int chunkSize,
-            final boolean isInitializeStep) {
-        return new UpdateByWindowTicksBucketContext(sourceRowSet, chunkSize, isInitializeStep);
+            final boolean isInitializeStep,
+            final Object[] bucketKeyValues) {
+        return new UpdateByWindowTicksBucketContext(sourceRowSet, chunkSize, isInitializeStep, bucketKeyValues);
     }
 
     private static WritableRowSet computeAffectedRowsTicks(final RowSet sourceSet, final RowSet invertedSubSet,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowRollingTime.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByWindowRollingTime.java
@@ -39,9 +39,10 @@ class UpdateByWindowRollingTime extends UpdateByWindowRollingBase {
                 final TrackingRowSet timestampValidRowSet,
                 final boolean timestampsModified,
                 final int chunkSize,
-                final boolean initialStep) {
+                final boolean initialStep,
+                final Object[] bucketKeyValues) {
             super(sourceRowSet, timestampColumnSource, timestampSsa, timestampValidRowSet, timestampsModified,
-                    chunkSize, initialStep);
+                    chunkSize, initialStep, bucketKeyValues);
         }
     }
 
@@ -72,9 +73,10 @@ class UpdateByWindowRollingTime extends UpdateByWindowRollingBase {
             final TrackingRowSet timestampValidRowSet,
             final boolean timestampsModified,
             final int chunkSize,
-            final boolean isInitializeStep) {
+            final boolean isInitializeStep,
+            final Object[] bucketKeyValues) {
         return new UpdateByWindowTimeBucketContext(sourceRowSet, timestampColumnSource, timestampSsa,
-                timestampValidRowSet, timestampsModified, chunkSize, isInitializeStep);
+                timestampValidRowSet, timestampsModified, chunkSize, isInitializeStep, bucketKeyValues);
     }
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
@@ -3,7 +3,6 @@
 //
 package io.deephaven.engine.table.impl.updateby;
 
-import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.api.updateby.UpdateByControl;
 import io.deephaven.engine.exceptions.CancellationException;
 import io.deephaven.engine.exceptions.TableInitializationException;
@@ -70,7 +69,7 @@ public class ZeroKeyUpdateByManager extends UpdateBy {
 
             // create an updateby bucket instance directly from the source table
             zeroKeyUpdateBy = new UpdateByBucketHelper(bucketDescription, source, windows, resultSources,
-                    timestampColumnName, control, (oe, se) -> deliverUpdateError(oe, se, true));
+                    timestampColumnName, control, (oe, se) -> deliverUpdateError(oe, se, true), new Object[0]);
             buckets.offer(zeroKeyUpdateBy);
 
             // make the source->result transformer
@@ -88,7 +87,7 @@ public class ZeroKeyUpdateByManager extends UpdateBy {
             zeroKeyUpdateBy = new UpdateByBucketHelper(bucketDescription, source, windows, resultSources,
                     timestampColumnName, control, (oe, se) -> {
                         throw new IllegalStateException("Update failure from static zero key updateBy");
-                    });
+                    }, new Object[0]);
             result = zeroKeyUpdateBy.result;
             buckets.offer(zeroKeyUpdateBy);
             sourceListener = null;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
@@ -13,6 +13,7 @@ import io.deephaven.engine.table.ModifiedColumnSet;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.util.RowRedirection;
+import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -69,7 +70,8 @@ public class ZeroKeyUpdateByManager extends UpdateBy {
 
             // create an updateby bucket instance directly from the source table
             zeroKeyUpdateBy = new UpdateByBucketHelper(bucketDescription, source, windows, resultSources,
-                    timestampColumnName, control, (oe, se) -> deliverUpdateError(oe, se, true), new Object[0]);
+                    timestampColumnName, control, (oe, se) -> deliverUpdateError(oe, se, true),
+                    ArrayTypeUtils.EMPTY_OBJECT_ARRAY);
             buckets.offer(zeroKeyUpdateBy);
 
             // make the source->result transformer
@@ -87,7 +89,7 @@ public class ZeroKeyUpdateByManager extends UpdateBy {
             zeroKeyUpdateBy = new UpdateByBucketHelper(bucketDescription, source, windows, resultSources,
                     timestampColumnName, control, (oe, se) -> {
                         throw new IllegalStateException("Update failure from static zero key updateBy");
-                    }, new Object[0]);
+                    }, ArrayTypeUtils.EMPTY_OBJECT_ARRAY);
             result = zeroKeyUpdateBy.result;
             buckets.offer(zeroKeyUpdateBy);
             sourceListener = null;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingformulamulticolumn/RollingFormulaMultiColumnOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingformulamulticolumn/RollingFormulaMultiColumnOperator.java
@@ -455,7 +455,6 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
     }
     // endregion value-setters
 
-
     @Override
     public void startTrackingPrev() {
         outputSource.startTrackingPrevValues();

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingformulamulticolumn/RollingFormulaMultiColumnOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingformulamulticolumn/RollingFormulaMultiColumnOperator.java
@@ -20,6 +20,7 @@ import io.deephaven.engine.table.impl.updateby.rollingformulamulticolumn.windowc
 import io.deephaven.engine.table.impl.util.ChunkUtils;
 import io.deephaven.engine.table.impl.util.RowRedirection;
 import io.deephaven.vector.Vector;
+import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,9 +33,14 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
     private static final int BUFFER_INITIAL_CAPACITY = 512;
 
     private final SelectColumn selectColumn;
-    private final String[] inputColumnNames;
-    private final Class<?>[] inputColumnTypes;
-    private final Class<?>[] inputVectorTypes;
+
+    private final String[] inputKeyColumnNames;
+    private final Class<?>[] inputKeyColumnTypes;
+    private final Class<?>[] inputKeyComponentTypes;
+
+    private final String[] inputNonKeyColumnNames;
+    private final Class<?>[] inputNonKeyColumnTypes;
+    private final Class<?>[] inputNonKeyVectorTypes;
 
     private WritableColumnSource<?> primitiveOutputSource;
     private WritableColumnSource<?> outputSource;
@@ -48,7 +54,10 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
         private final IntConsumer outputSetter;
         private final IntConsumer outputNullSetter;
 
+        private final SingleValueColumnSource<?>[] keyValueSources;
         private final RingBufferWindowConsumer[] inputConsumers;
+
+        private boolean keyValuesSet;
 
         @SuppressWarnings("unused")
         private Context(final int affectedChunkSize, final int influencerChunkSize) {
@@ -58,13 +67,14 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
             // Make a copy of the operator formula column.
             final SelectColumn contextSelectColumn = selectColumn.copy();
 
-            inputConsumers = new RingBufferWindowConsumer[inputColumnNames.length];
+            keyValueSources = new SingleValueColumnSource<?>[inputKeyColumnNames.length];
+            inputConsumers = new RingBufferWindowConsumer[inputNonKeyColumnNames.length];
 
             // To perform the calculation, we will leverage SelectColumn and for its input sources we create a set of
-            // SingleValueColumnSources, each containing a Vector of values. This vector will contain exactly the
-            // values from the input columns that are appropriate for output row given the window configuration.
-            // The formula column is evaluated once per output row and the result written to the output column
-            // source.
+            // SingleValueColumnSources, each containing a Vector of values (or a scalar when the source is a key).
+            // These sources will contain exactly the values from the input columns that are appropriate for the output
+            // row given the window configuration and state. The formula column is evaluated once per output row and
+            // the result written to the output column source.
 
             // The SingleValueColumnSources is backed by RingBuffers through use of a RingBufferVectorWrapper.
             // The underlying RingBuffer is updated with the values from the input columns with assistance from
@@ -72,10 +82,22 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
             // column data chunks into the RingBuffer.
 
             final Map<String, ColumnSource<?>> inputSources = new HashMap<>();
-            for (int i = 0; i < inputColumnNames.length; i++) {
-                final String inputColumnName = inputColumnNames[i];
-                final Class<?> inputColumnType = inputColumnTypes[i];
-                final Class<?> inputVectorType = inputVectorTypes[i];
+
+            for (int i = 0; i < inputKeyColumnNames.length; i++) {
+                final String inputColumnName = inputKeyColumnNames[i];
+                final Class<?> inputColumnType = inputKeyColumnTypes[i];
+                final Class<?> inputComponentType = inputKeyComponentTypes[i];
+
+                // Create a single value column source wrapping a scalar of the appropriate type for this key.
+                keyValueSources[i] =
+                        SingleValueColumnSource.getSingleValueColumnSource(inputColumnType, inputComponentType);
+                inputSources.put(inputColumnName, keyValueSources[i]);
+            }
+
+            for (int i = 0; i < inputNonKeyColumnNames.length; i++) {
+                final String inputColumnName = inputNonKeyColumnNames[i];
+                final Class<?> inputColumnType = inputNonKeyColumnTypes[i];
+                final Class<?> inputVectorType = inputNonKeyVectorTypes[i];
 
                 // Create and store the ring buffer for the input column.
                 final RingBuffer ringBuffer = RingBuffer.makeRingBuffer(
@@ -88,19 +110,15 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
                 final SingleValueColumnSource<Vector<?>> formulaInputSource =
                         (SingleValueColumnSource<Vector<?>>) SingleValueColumnSource
                                 .getSingleValueColumnSource(inputVectorType, inputColumnType);
-
                 final RingBufferVectorWrapper<?> wrapper = RingBufferVectorWrapper.makeRingBufferVectorWrapper(
                         ringBuffer,
                         inputColumnType);
-
                 formulaInputSource.set(wrapper);
-
                 inputSources.put(inputColumnName, formulaInputSource);
-
                 inputConsumers[i] = RingBufferWindowConsumer.create(ringBuffer);
             }
-            contextSelectColumn.initInputs(RowSetFactory.flat(1).toTracking(), inputSources);
 
+            contextSelectColumn.initInputs(RowSetFactory.flat(1).toTracking(), inputSources);
             final ColumnSource<?> formulaOutputSource =
                     ReinterpretUtils.maybeConvertToPrimitive(contextSelectColumn.getDataView());
 
@@ -110,8 +128,9 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
 
         @Override
         protected void setValueChunks(@NotNull Chunk<? extends Values>[] valueChunks) {
-            // Assign the influencer values chunks to the input consumers.
-            for (int i = 0; i < valueChunks.length; i++) {
+            // NOTE: the value chunks are supplied in the order of the response to `getInputColumnNames()` which we
+            // have set to non-key columns, then key columns.
+            for (int i = 0; i < inputConsumers.length; i++) {
                 inputConsumers[i].setInputChunk(valueChunks[i]);
             }
         }
@@ -164,6 +183,13 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
 
                 // push for this row
                 if (pushCount > 0) {
+                    if (!keyValuesSet) {
+                        for (int i = 0; i < keyValueSources.length; i++) {
+                            assignKeyValue(influencerValueChunkArr[i + inputNonKeyColumnNames.length],
+                                    ii, keyValueSources[i]);
+                        }
+                        keyValuesSet = true;
+                    }
                     for (RingBufferWindowConsumer consumer : inputConsumers) {
                         consumer.push(pushIndex, pushCount);
                     }
@@ -195,6 +221,7 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
             for (RingBufferWindowConsumer consumer : inputConsumers) {
                 consumer.reset();
             }
+            keyValuesSet = false;
             nullCount = 0;
         }
 
@@ -215,9 +242,12 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
      * @param reverseWindowScaleUnits The size of the reverse window in ticks (or nanoseconds when time-based)
      * @param forwardWindowScaleUnits The size of the forward window in ticks (or nanoseconds when time-based)
      * @param selectColumn The {@link SelectColumn} specifying the calculation to be performed
-     * @param inputColumnNames The names of the columns to be used as inputs
-     * @param inputColumnTypes The types of the columns to be used as inputs
-     * @param inputVectorTypes The vector types of the columns to be used as inputs
+     * @param inputKeyColumnNames The names of the key columns to be used as inputs
+     * @param inputKeyColumnTypes The types of the key columns to be used as inputs
+     * @param inputKeyComponentTypes The component types of the key columns to be used as inputs
+     * @param inputNonKeyColumnNames The names of the non-key columns to be used as inputs
+     * @param inputNonKeyColumnTypes The types of the non-key columns to be used as inputs
+     * @param inputNonKeyVectorTypes The vector types of the non-key columns to be used as inputs
      */
     public RollingFormulaMultiColumnOperator(
             @NotNull final MatchPair pair,
@@ -226,14 +256,20 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
             final long reverseWindowScaleUnits,
             final long forwardWindowScaleUnits,
             @NotNull final SelectColumn selectColumn,
-            @NotNull final String[] inputColumnNames,
-            @NotNull final Class<?>[] inputColumnTypes,
-            @NotNull final Class<?>[] inputVectorTypes) {
+            @NotNull final String[] inputKeyColumnNames,
+            @NotNull final Class<?>[] inputKeyColumnTypes,
+            @NotNull final Class<?>[] inputKeyComponentTypes,
+            @NotNull final String[] inputNonKeyColumnNames,
+            @NotNull final Class<?>[] inputNonKeyColumnTypes,
+            @NotNull final Class<?>[] inputNonKeyVectorTypes) {
         super(pair, affectingColumns, timestampColumnName, reverseWindowScaleUnits, forwardWindowScaleUnits, true);
         this.selectColumn = selectColumn;
-        this.inputColumnNames = inputColumnNames;
-        this.inputColumnTypes = inputColumnTypes;
-        this.inputVectorTypes = inputVectorTypes;
+        this.inputKeyColumnNames = inputKeyColumnNames;
+        this.inputKeyColumnTypes = inputKeyColumnTypes;
+        this.inputKeyComponentTypes = inputKeyComponentTypes;
+        this.inputNonKeyColumnNames = inputNonKeyColumnNames;
+        this.inputNonKeyColumnTypes = inputNonKeyColumnTypes;
+        this.inputNonKeyVectorTypes = inputNonKeyVectorTypes;
     }
 
     @Override
@@ -245,9 +281,12 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
                 reverseWindowScaleUnits,
                 forwardWindowScaleUnits,
                 selectColumn,
-                inputColumnNames,
-                inputColumnTypes,
-                inputVectorTypes);
+                inputKeyColumnNames,
+                inputKeyColumnTypes,
+                inputKeyComponentTypes,
+                inputNonKeyColumnNames,
+                inputNonKeyColumnTypes,
+                inputNonKeyVectorTypes);
     }
 
     @Override
@@ -273,6 +312,7 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
         outputChunkType = primitiveOutputSource.getChunkType();
     }
 
+    // region value-setters
     protected static IntConsumer getChunkSetter(
             final WritableChunk<? extends Values> valueChunk,
             final ColumnSource<?> formulaOutputSource) {
@@ -364,6 +404,58 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
         }
     }
 
+    /**
+     * This assigns the value at {@code index} in {@code valueChunk} to the {@code inputColumnSource}. This is not
+     * particularly efficient but is only be called once per bucket.
+     */
+    private static void assignKeyValue(
+            @NotNull final Chunk<?> valueChunk,
+            final int index,
+            @NotNull SingleValueColumnSource<?> inputColumnSource) {
+        final ChunkType chunkType = valueChunk.getChunkType();
+        switch (chunkType) {
+            case Boolean:
+                throw new IllegalStateException(
+                        "Input chunk type should not be Boolean but should have been reinterpreted to byte");
+            case Byte:
+                final ByteChunk<?> byteChunk = valueChunk.asByteChunk();
+                inputColumnSource.set(byteChunk.get(index));
+                break;
+            case Char:
+                final CharChunk<?> charChunk = valueChunk.asCharChunk();
+                inputColumnSource.set(charChunk.get(index));
+                break;
+            case Double:
+                final DoubleChunk<?> doubleChunk = valueChunk.asDoubleChunk();
+                inputColumnSource.set(doubleChunk.get(index));
+                break;
+            case Float:
+                final FloatChunk<?> floatChunk = valueChunk.asFloatChunk();
+                inputColumnSource.set(floatChunk.get(index));
+                break;
+            case Int:
+                final IntChunk<?> intChunk = valueChunk.asIntChunk();
+                inputColumnSource.set(intChunk.get(index));
+                break;
+            case Long:
+                final LongChunk<?> longChunk = valueChunk.asLongChunk();
+                inputColumnSource.set(longChunk.get(index));
+                break;
+            case Short:
+                final ShortChunk<?> shortChunk = valueChunk.asShortChunk();
+                inputColumnSource.set(shortChunk.get(index));
+                break;
+            default:
+                final ObjectChunk<Object, ?> objectChunk = valueChunk.asObjectChunk();
+                // noinspection unchecked
+                final ObjectSingleValueSource<Object> source = (ObjectSingleValueSource<Object>) inputColumnSource;
+                source.set(objectChunk.get(index));
+                break;
+        }
+    }
+    // endregion value-setters
+
+
     @Override
     public void startTrackingPrev() {
         outputSource.startTrackingPrevValues();
@@ -414,6 +506,7 @@ public class RollingFormulaMultiColumnOperator extends UpdateByOperator {
     @Override
     @NotNull
     protected String[] getInputColumnNames() {
-        return inputColumnNames;
+        // Non-key columns first, then key chunks
+        return ArrayUtils.addAll(inputNonKeyColumnNames, inputKeyColumnNames);
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingFormula.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingFormula.java
@@ -804,6 +804,15 @@ public class TestRollingFormula extends BaseUpdateByTest {
                 .update("out_val=sum(a) - max(b) + (Sym == null ? 0 : Sym.length())").dropColumns("a", "b");
 
         TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
+
+        // using the byte key column
+        actual = t.updateBy(UpdateByOperation.RollingFormula(prevTicks, postTicks,
+                "out_val=byteCol == null ? -1 : byteCol + sum(intCol) - max(longCol)"), "byteCol");
+        expected =
+                t.updateBy(UpdateByOperation.RollingGroup(prevTicks, postTicks, "a=intCol", "b=longCol"), "byteCol")
+                        .update("out_val=byteCol == null ? -1 : byteCol + sum(a) - max(b)").dropColumns("a", "b");
+
+        TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
     }
 
     private void doTestStaticBucketedTimed(boolean grouped, Duration prevTime, Duration postTime) {
@@ -978,6 +987,15 @@ public class TestRollingFormula extends BaseUpdateByTest {
                 "out_val=(Sym == null ? 0 : Sym.length()) + sum(intCol) - max(longCol)"), "Sym");
         expected = t.updateBy(UpdateByOperation.RollingGroup("ts", prevTime, postTime, "a=intCol", "b=longCol"), "Sym")
                 .update("out_val=(Sym == null ? 0 : Sym.length()) + sum(a) - max(b)").dropColumns("a", "b");
+
+        TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
+
+        // using the byte key column
+        actual = t.updateBy(UpdateByOperation.RollingFormula("ts", prevTime, postTime,
+                "out_val=byteCol == null ? -1 : byteCol + sum(intCol) - max(longCol)"), "byteCol");
+        expected =
+                t.updateBy(UpdateByOperation.RollingGroup("ts", prevTime, postTime, "a=intCol", "b=longCol"), "byteCol")
+                        .update("out_val=byteCol == null ? -1 : byteCol + sum(a) - max(b)").dropColumns("a", "b");
 
         TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
     }
@@ -1187,6 +1205,13 @@ public class TestRollingFormula extends BaseUpdateByTest {
                                 "Sym")
                         : t.updateBy(UpdateByOperation.RollingFormula(prevTicks, postTicks,
                                 "sum=min(intCol) + min(longCol) * max(doubleCol)"))),
+                EvalNugget.from(() -> bucketed
+                        ? t.updateBy(
+                                UpdateByOperation.RollingFormula(prevTicks, postTicks,
+                                        "out_col=Sym == null ? 0.0 : min(intCol) + min(longCol) * max(doubleCol)"),
+                                "Sym")
+                        : t.updateBy(UpdateByOperation.RollingFormula(prevTicks, postTicks,
+                                "out_col=true"))), // This is a dummy test, we care about the bucketed test
         };
 
         final Random billy = new Random(0xB177B177L);
@@ -1249,6 +1274,13 @@ public class TestRollingFormula extends BaseUpdateByTest {
                                 "Sym")
                         : t.updateBy(UpdateByOperation.RollingFormula("ts", prevTime, postTime,
                                 "sum=min(intCol) + min(longCol) * max(doubleCol)"))),
+                EvalNugget.from(() -> bucketed
+                        ? t.updateBy(
+                                UpdateByOperation.RollingFormula("ts", prevTime, postTime,
+                                        "out_col=Sym == null ? null : min(intCol) + min(longCol) * max(doubleCol)"),
+                                "Sym")
+                        : t.updateBy(UpdateByOperation.RollingFormula("ts", prevTime, postTime,
+                                "out_col=true"))), // This is a dummy test, we care about the bucketed test
         };
 
         final Random billy = new Random(0xB177B177L);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingFormula.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingFormula.java
@@ -797,6 +797,13 @@ public class TestRollingFormula extends BaseUpdateByTest {
 
         TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
 
+        // using the key column
+        actual = t.updateBy(UpdateByOperation.RollingFormula(prevTicks, postTicks,
+                "out_val=sum(intCol) - max(longCol) + (Sym == null ? 0 : Sym.length())"), "Sym");
+        expected = t.updateBy(UpdateByOperation.RollingGroup(prevTicks, postTicks, "a=intCol", "b=longCol"), "Sym")
+                .update("out_val=sum(a) - max(b) + (Sym == null ? 0 : Sym.length())").dropColumns("a", "b");
+
+        TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
     }
 
     private void doTestStaticBucketedTimed(boolean grouped, Duration prevTime, Duration postTime) {
@@ -963,6 +970,14 @@ public class TestRollingFormula extends BaseUpdateByTest {
         expected = t.updateBy(UpdateByOperation.RollingGroup("ts", prevTime, postTime,
                 "a=intCol", "b=longCol"), "Sym")
                 .update("out_val=a + b").dropColumns("a", "b");
+
+        TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
+
+        // using the key column
+        actual = t.updateBy(UpdateByOperation.RollingFormula("ts", prevTime, postTime,
+                "out_val=(Sym == null ? 0 : Sym.length()) + sum(intCol) - max(longCol)"), "Sym");
+        expected = t.updateBy(UpdateByOperation.RollingGroup("ts", prevTime, postTime, "a=intCol", "b=longCol"), "Sym")
+                .update("out_val=(Sym == null ? 0 : Sym.length()) + sum(a) - max(b)").dropColumns("a", "b");
 
         TstUtils.assertTableEquals(expected, actual, TableDiff.DiffItems.DoublesExact);
     }


### PR DESCRIPTION
### Example:

NOTE: `Sym` is a key column and is constant for each bucket. It is presented to the UDF as a string (not a vector).  `intCol` / `longCol` are vectors containing the window data.

```
t_out = t.updateBy(UpdateByOperation.RollingFormula(prevTicks, postTicks,
        "out_val=sum(intCol) - max(longCol) + (Sym == null ? 0 : Sym.length())"), "Sym");
```