### PR TITLE
fix: Use correct naming conventions for Parquet list

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/MappedSchema.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/MappedSchema.java
@@ -7,6 +7,7 @@ import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.util.annotations.VisibleForTesting;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
@@ -29,13 +30,22 @@ class MappedSchema {
             final ParquetInstructions instructions) {
         final MessageTypeBuilder builder = Types.buildMessage();
         for (final ColumnDefinition<?> columnDefinition : definition.getColumns()) {
-            final TypeInfos.TypeInfo typeInfo =
-                    getTypeInfo(computedCache, columnDefinition, rowSet, columnSourceMap, instructions);
-            final Type schemaType = typeInfo.createSchemaType(columnDefinition, instructions);
-            builder.addField(schemaType);
+            builder.addField(createType(computedCache, columnDefinition, rowSet, columnSourceMap, instructions));
         }
         final MessageType schema = builder.named("root");
         return new MappedSchema(definition, schema);
+    }
+
+    @VisibleForTesting
+    static Type createType(
+            final Map<String, Map<ParquetCacheTags, Object>> computedCache,
+            final ColumnDefinition<?> columnDefinition,
+            final RowSet rowSet,
+            final Map<String, ? extends ColumnSource<?>> columnSourceMap,
+            final ParquetInstructions instructions) {
+        final TypeInfos.TypeInfo typeInfo =
+                getTypeInfo(computedCache, columnDefinition, rowSet, columnSourceMap, instructions);
+        return typeInfo.createSchemaType(columnDefinition, instructions);
     }
 
     private final TableDefinition tableDefinition;

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/MappedSchemaTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/MappedSchemaTest.java
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.parquet.table;
+
+import io.deephaven.engine.table.ColumnDefinition;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MappedSchemaTest {
+
+    private static final String FOO = "Foo";
+
+    @Test
+    public void intType() {
+        PrimitiveType expected = Types.optional(PrimitiveTypeName.INT32)
+                .as(LogicalTypeAnnotation.intType(32))
+                .named(FOO);
+        assertThat(type(ColumnDefinition.ofInt(FOO))).isEqualTo(expected);
+    }
+
+    @Test
+    public void stringType() {
+        PrimitiveType expected = Types.optional(PrimitiveTypeName.BINARY)
+                .as(LogicalTypeAnnotation.stringType())
+                .named(FOO);
+        assertThat(type(ColumnDefinition.ofString(FOO))).isEqualTo(expected);
+    }
+
+    @Test
+    public void intListType() {
+        GroupType expected = Types.optionalList()
+                .optionalElement(PrimitiveTypeName.INT32)
+                .as(LogicalTypeAnnotation.intType(32))
+                .named(FOO);
+        assertThat(type(ColumnDefinition.fromGenericType(FOO, int[].class, int.class))).isEqualTo(expected);
+    }
+
+    @Test
+    public void stringListType() {
+        GroupType expected = Types.optionalList()
+                .optionalElement(PrimitiveTypeName.BINARY)
+                .as(LogicalTypeAnnotation.stringType())
+                .named(FOO);
+        assertThat(type(ColumnDefinition.fromGenericType(FOO, String[].class, String.class))).isEqualTo(expected);
+    }
+
+    private static Type type(ColumnDefinition<?> columnDefinition) {
+        return MappedSchema.createType(null, columnDefinition, null, null, ParquetInstructions.EMPTY);
+    }
+}


### PR DESCRIPTION
The Parquet format requires a LIST type with the inner element named `element` (as opposed to `item`) and requires the middle group to be named `list` (as opposed to a repeat of the outer group's name).

See https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists