### PR TITLE
fix: Close Jetty h2 streams with RST_STREAM and no error code

### DIFF
--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
@@ -121,9 +121,15 @@ final class AsyncServletOutputStreamWriter {
             transportState.runOnTransportThread(
                     () -> {
                         transportState.complete();
-                        asyncContext.complete();
+                        // asyncContext.complete();
                         log.fine("call completed");
                     });
+            // Jetty specific fix: When AsyncContext.complete() is called, Jetty sends a RST_STREAM with
+            // "cancel" error to the client, while other containers send "no error" in this case. Calling
+            // close() instead on the output stream still sends the RST_STREAM, but with "no error". Note
+            // that this does the opposite in at least Tomcat, so we're not going to upstream this change.
+            // See https://github.com/deephaven/deephaven-core/issues/6400
+            outputStream.close();
         };
         this.isReady = () -> outputStream.isReady();
     }


### PR DESCRIPTION
This is a Jetty-specific workaround to avoid irritating the Python gRPC client into failing calls that had already half-closed successfully.

See #6400
Fixes #5996