### PR TITLE
chore: Update projects that use Arrow 18 to require Java 11

### DIFF
--- a/java-client/flight-dagger/gradle.properties
+++ b/java-client/flight-dagger/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/java-client/flight/gradle.properties
+++ b/java-client/flight/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/java-client/session-dagger/gradle.properties
+++ b/java-client/session-dagger/gradle.properties
@@ -1,3 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-
-languageLevel=8

--- a/java-client/session/gradle.properties
+++ b/java-client/session/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/proto/proto-backplane-grpc-flight/gradle.properties
+++ b/proto/proto-backplane-grpc-flight/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/proto/proto-backplane-grpc/gradle.properties
+++ b/proto/proto-backplane-grpc/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8


### PR DESCRIPTION
These projects depend directly or indirectly on Arrow v18 jars, which are compiled to require Java 11. Gradle correctly fails to build if a project depending on one of these still tries to use Java 8.

Follow-up #6347