### PR TITLE
revert: RST_STREAM(cancel) fix for gRPC, this seems to be breaking JS gRPC client

### DIFF
--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
@@ -121,15 +121,9 @@ final class AsyncServletOutputStreamWriter {
             transportState.runOnTransportThread(
                     () -> {
                         transportState.complete();
-                        // asyncContext.complete();
+                        asyncContext.complete();
                         log.fine("call completed");
                     });
-            // Jetty specific fix: When AsyncContext.complete() is called, Jetty sends a RST_STREAM with
-            // "cancel" error to the client, while other containers send "no error" in this case. Calling
-            // close() instead on the output stream still sends the RST_STREAM, but with "no error". Note
-            // that this does the opposite in at least Tomcat, so we're not going to upstream this change.
-            // See https://github.com/deephaven/deephaven-core/issues/6400
-            outputStream.close();
         };
         this.isReady = () -> outputStream.isReady();
     }


### PR DESCRIPTION
This reverts commit 6ada0cb924963a12d12f7fa07ce9cc277ecf2bd9.

See #6401 
See #6400 
See #5996