### PR TITLE
fix: Ensure that most TableListener/MergedListener Notifications are processed while ensuring liveness; improve timeout handling in Table.awaitUpdate

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -922,7 +922,14 @@ public interface Table extends
      * {@link #getUpdateGraph() update graph}. It may be suitable to wait from another update graph if doing so does not
      * introduce any cycles.
      * <p>
-     * In some implementations, this call may also terminate in case of interrupt or spurious wakeup.
+     * Returns when this Table has delivered a notification (an update, or an error) since this method was invoked, or
+     * immediately if this Table has already {@link #isFailed() failed}. Implementations are not required to terminate
+     * on spurious wakeups; note, however, that this method cannot detect notifications delivered before it was invoked.
+     * <p>
+     * Callers that must not miss a notification should acquire the
+     * {@link io.deephaven.engine.updategraph.UpdateGraph#exclusiveLock() exclusive lock} of this Table's
+     * {@link #getUpdateGraph() update graph} before testing whatever condition they are waiting on, and hold it across
+     * their invocation of this method. Waiting releases the exclusive lock, and reacquires it before returning.
      *
      * @throws InterruptedException In the event this thread is interrupted
      * @see java.util.concurrent.locks.Condition#await()
@@ -936,9 +943,21 @@ public interface Table extends
      * {@link #getUpdateGraph() update graph}. It may be suitable to wait from another update graph if doing so does not
      * introduce any cycles.
      * <p>
-     * In some implementations, this call may also terminate in case of interrupt or spurious wakeup.
+     * Returns {@code true} when this Table has delivered a notification (an update, or an error) since this method was
+     * invoked, or immediately if this Table has already {@link #isFailed() failed}. Implementations are not required to
+     * terminate on spurious wakeups; note, however, that this method cannot detect notifications delivered before it
+     * was invoked.
+     * <p>
+     * Time spent acquiring the {@link io.deephaven.engine.updategraph.UpdateGraph#exclusiveLock() exclusive lock} of
+     * this Table's {@link #getUpdateGraph() update graph} counts against {@code timeoutMillis}, but note that
+     * reacquiring the exclusive lock after waiting may cause the timeout to be exceeded.
+     * <p>
+     * Callers that must not miss a notification should acquire the exclusive lock before testing whatever condition
+     * they are waiting on, and hold it across their invocation of this method. Waiting releases the exclusive lock, and
+     * reacquires it before returning.
      *
-     * @param timeoutMillis The maximum time to wait in milliseconds.
+     * @param timeoutMillis The maximum time to wait in milliseconds. Values less than or equal to zero result in no
+     *        waiting at all.
      * @return false if the timeout elapses without notification, true otherwise.
      * @throws InterruptedException In the event this thread is interrupted
      * @see java.util.concurrent.locks.Condition#await()

--- a/engine/api/src/main/java/io/deephaven/engine/table/Table.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/Table.java
@@ -938,12 +938,12 @@ public interface Table extends
      * <p>
      * In some implementations, this call may also terminate in case of interrupt or spurious wakeup.
      *
-     * @param timeout The maximum time to wait in milliseconds.
+     * @param timeoutMillis The maximum time to wait in milliseconds.
      * @return false if the timeout elapses without notification, true otherwise.
      * @throws InterruptedException In the event this thread is interrupted
      * @see java.util.concurrent.locks.Condition#await()
      */
-    boolean awaitUpdate(long timeout) throws InterruptedException;
+    boolean awaitUpdate(long timeoutMillis) throws InterruptedException;
 
     /**
      * Subscribe for updates to this table. {@code listener} will be invoked via the {@link NotificationQueue}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -580,11 +580,25 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
     @Override
     public boolean awaitUpdate(long timeout) throws InterruptedException {
-        final MutableBoolean result = new MutableBoolean(false);
-        updateGraph.exclusiveLock().doLocked(
-                () -> result.setValue(ensureCondition().await(timeout, TimeUnit.MILLISECONDS)));
 
-        return result.booleanValue();
+        final long startTime = System.nanoTime();
+        if (!updateGraph.exclusiveLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+            // Usually, users will already be holding the exclusive lock when calling this method. If they are not and
+            // cannot acquire the lock within the timeout, we should return false now.
+            return false;
+        }
+        timeout -= (System.nanoTime() - startTime) / 1_000_000;
+
+        boolean result;
+        try {
+            // Note that we must reacquire the exclusive lock before returning from await. This deadline may be
+            // exceeded if the thread must wait to reacquire the lock.
+            result = ensureCondition().await(timeout, TimeUnit.MILLISECONDS);
+        } finally {
+            updateGraph.exclusiveLock().unlock();
+        }
+
+        return result;
     }
 
     private Condition ensureCondition() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -42,7 +42,6 @@ import io.deephaven.io.logger.Logger;
 import io.deephaven.util.annotations.ReferentialIntegrity;
 import io.deephaven.util.datastructures.SimpleReferenceManager;
 import io.deephaven.util.datastructures.hash.IdentityKeyedObjectKey;
-import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -76,13 +75,22 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
     private static final Logger log = LoggerFactory.getLogger(BaseTable.class);
 
+    /**
+     * Maximum timeout accepted by {@link #awaitUpdate(long)}; longer timeouts are clamped to this value in order to
+     * avoid overflowing the deadline arithmetic used by the underlying lock and condition.
+     */
+    private static final long MAXIMUM_TIMEOUT_NANOS = TimeUnit.DAYS.toNanos(365);
+
+    @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<BaseTable, Condition> CONDITION_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(BaseTable.class, Condition.class, "updateGraphCondition");
 
+    @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<BaseTable, Collection> PARENTS_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(BaseTable.class, Collection.class, "parents");
     private static final Collection<Object> EMPTY_PARENTS = Collections.emptyList();
 
+    @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<BaseTable, Object> CHILD_LISTENER_REFERENCES_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(
                     BaseTable.class, Object.class, "childListenerReferences");
@@ -575,24 +583,52 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
 
     @Override
     public void awaitUpdate() throws InterruptedException {
-        updateGraph.exclusiveLock().doLocked(ensureCondition()::await);
+        final long startLastNotificationStep = lastNotificationStep;
+        if (isFailed) {
+            // A failed table will never deliver another notification; there's nothing to wait for.
+            return;
+        }
+        updateGraph.exclusiveLock().doLockedInterruptibly(() -> {
+            final Condition condition = ensureCondition();
+            while (!isFailed && startLastNotificationStep == lastNotificationStep) {
+                condition.await();
+            }
+        });
     }
 
     @Override
-    public boolean awaitUpdate(long timeoutMillis) throws InterruptedException {
-
-        final long startTime = System.nanoTime();
-        if (!updateGraph.exclusiveLock().tryLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
-            // Usually, users will already be holding the exclusive lock when calling this method. If they are not and
-            // cannot acquire the lock within the timeout, we should return false now.
-            return false;
+    public boolean awaitUpdate(final long timeoutMillis) throws InterruptedException {
+        final long startNanos = System.nanoTime();
+        final long startLastNotificationStep = lastNotificationStep;
+        if (isFailed) {
+            // A failed table will never deliver another notification; there's nothing to wait for. Report that this
+            // call did not time out, since the terminal notification either has been or will be delivered.
+            return true;
         }
-        timeoutMillis -= TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
 
+        // Clamp the timeout, so that the deadline arithmetic used by tryLock and awaitNanos cannot overflow. No need
+        // to validate non-positive timeouts: if remainingNanos <= 0, tryLock is guaranteed to not wait at all.
+        long remainingNanos = Math.min(TimeUnit.MILLISECONDS.toNanos(timeoutMillis), MAXIMUM_TIMEOUT_NANOS);
+        if (!updateGraph.exclusiveLock().tryLock(remainingNanos, TimeUnit.NANOSECONDS)) {
+            // Usually, callers will already be holding the exclusive lock when they invoke this method. If they are
+            // not, and cannot acquire it within the timeout, we've timed out unless a notification was delivered while
+            // we were waiting for the lock.
+            return isFailed || startLastNotificationStep != lastNotificationStep;
+        }
         try {
-            // Note that we must reacquire the exclusive lock before returning from await. This deadline may be
-            // exceeded if the thread must wait to reacquire the lock.
-            return ensureCondition().await(timeoutMillis, TimeUnit.MILLISECONDS);
+            // Charge the time spent acquiring the exclusive lock against the caller's timeout.
+            remainingNanos -= System.nanoTime() - startNanos;
+            final Condition condition = ensureCondition();
+            while (!isFailed && startLastNotificationStep == lastNotificationStep) {
+                if (remainingNanos <= 0) {
+                    return false;
+                }
+                // Note that awaiting must reacquire the exclusive lock before returning, and so the deadline may be
+                // exceeded if this thread has to wait for the lock. awaitNanos returns the remaining time, which is
+                // an estimate that accounts for spurious wakeups as well as signals.
+                remainingNanos = condition.awaitNanos(remainingNanos);
+            }
+            return true;
         } finally {
             updateGraph.exclusiveLock().unlock();
         }
@@ -881,60 +917,64 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
             updateToSend = update;
         }
 
-        if (updateToSend.empty()) {
+        try {
+            if (updateToSend.empty()) {
+                return;
+            }
+
+            Assert.neqNull(updateToSend.added(), "added");
+            Assert.neqNull(updateToSend.removed(), "removed");
+            Assert.neqNull(updateToSend.modified(), "modified");
+            Assert.neqNull(updateToSend.shifted(), "shifted");
+
+            if (isFlat()) {
+                Assert.assertion(getRowSet().isFlat(), "getRowSet().isFlat()", getRowSet(), "getRowSet()");
+            }
+            if (isAppendOnly() || isAddOnly()) {
+                Assert.assertion(updateToSend.removed().isEmpty(), "updateToSend.removed.empty()");
+                Assert.assertion(updateToSend.modified().isEmpty(), "updateToSend.modified.empty()");
+                Assert.assertion(updateToSend.shifted().empty(), "updateToSend.shifted.empty()");
+            }
+            if (isAppendOnly()) {
+                Assert.assertion(
+                        getRowSet().sizePrev() == 0
+                                || getRowSet().lastRowKeyPrev() < updateToSend.added().firstRowKey(),
+                        "getRowSet().lastRowKeyPrev() < updateToSend.added().firstRowKey()");
+            }
+            if (isBlink()) {
+                Assert.eq(updateToSend.added().size(), "added size", getRowSet().size(), "current table size");
+                Assert.eq(updateToSend.removed().size(), "removed size", getRowSet().sizePrev(),
+                        "previous table size");
+                Assert.assertion(updateToSend.modified().isEmpty(), "updateToSend.modified.isEmpty()");
+                Assert.assertion(updateToSend.shifted().empty(), "updateToSend.shifted.empty()");
+            }
+
+            // First validate that each rowSet is in a sane state.
+            if (VALIDATE_UPDATE_INDICES) {
+                updateToSend.added().validate();
+                updateToSend.removed().validate();
+                updateToSend.modified().validate();
+                updateToSend.shifted().validate();
+            }
+
+            if (VALIDATE_UPDATE_OVERLAPS) {
+                validateUpdateOverlaps(updateToSend);
+            }
+
+            // notify children
+            synchronized (this) {
+                lastNotificationStep = currentStep;
+                // Signal only after lastNotificationStep has been updated, so that threads awaiting an update are
+                // guaranteed to observe the new step when they wake up.
+                maybeSignal();
+
+                final NotificationQueue notificationQueue = getNotificationQueue();
+                forEachChildListenerReference((listenerRef, listener) -> notificationQueue
+                        .addNotification(listener.getNotification(updateToSend)));
+            }
+        } finally {
             updateToSend.release();
-            return;
         }
-
-        maybeSignal();
-
-        Assert.neqNull(updateToSend.added(), "added");
-        Assert.neqNull(updateToSend.removed(), "removed");
-        Assert.neqNull(updateToSend.modified(), "modified");
-        Assert.neqNull(updateToSend.shifted(), "shifted");
-
-        if (isFlat()) {
-            Assert.assertion(getRowSet().isFlat(), "getRowSet().isFlat()", getRowSet(), "getRowSet()");
-        }
-        if (isAppendOnly() || isAddOnly()) {
-            Assert.assertion(updateToSend.removed().isEmpty(), "updateToSend.removed.empty()");
-            Assert.assertion(updateToSend.modified().isEmpty(), "updateToSend.modified.empty()");
-            Assert.assertion(updateToSend.shifted().empty(), "updateToSend.shifted.empty()");
-        }
-        if (isAppendOnly()) {
-            Assert.assertion(
-                    getRowSet().sizePrev() == 0 || getRowSet().lastRowKeyPrev() < updateToSend.added().firstRowKey(),
-                    "getRowSet().lastRowKeyPrev() < updateToSend.added().firstRowKey()");
-        }
-        if (isBlink()) {
-            Assert.eq(updateToSend.added().size(), "added size", getRowSet().size(), "current table size");
-            Assert.eq(updateToSend.removed().size(), "removed size", getRowSet().sizePrev(), "previous table size");
-            Assert.assertion(updateToSend.modified().isEmpty(), "updateToSend.modified.isEmpty()");
-            Assert.assertion(updateToSend.shifted().empty(), "updateToSend.shifted.empty()");
-        }
-
-        // First validate that each rowSet is in a sane state.
-        if (VALIDATE_UPDATE_INDICES) {
-            updateToSend.added().validate();
-            updateToSend.removed().validate();
-            updateToSend.modified().validate();
-            updateToSend.shifted().validate();
-        }
-
-        if (VALIDATE_UPDATE_OVERLAPS) {
-            validateUpdateOverlaps(updateToSend);
-        }
-
-        // notify children
-        synchronized (this) {
-            lastNotificationStep = currentStep;
-
-            final NotificationQueue notificationQueue = getNotificationQueue();
-            forEachChildListenerReference((listenerRef, listener) -> notificationQueue
-                    .addNotification(listener.getNotification(updateToSend)));
-        }
-
-        updateToSend.release();
     }
 
     private void validateUpdateOverlaps(final TableUpdate update) {
@@ -1041,11 +1081,10 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
                 "updateGraph.clock().currentStep()");
 
         isFailed = true;
-        maybeSignal();
 
         synchronized (this) {
             lastNotificationStep = currentStep;
-
+            maybeSignal();
             final NotificationQueue notificationQueue = getNotificationQueue();
 
             forEachChildListenerReference((listenerRef, listener) -> notificationQueue
@@ -1090,7 +1129,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
      * Simplest appropriate legacy ShiftObliviousInstrumentedListener implementation for BaseTable and descendants. It's
      * expected that most use-cases will require overriding onUpdate() - the default implementation simply passes rowSet
      * updates through to the dependent's listeners.
-     *
+     * <p>
      * It is preferred to use {@link ListenerImpl} over {@link ShiftObliviousListenerImpl}
      */
     public static class ShiftObliviousListenerImpl extends ShiftObliviousInstrumentedListener {
@@ -1402,7 +1441,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
         }
         final Map<String, String> sourceDescriptions = new HashMap<>(oldDescriptions);
 
-        if (selectColumns != null && selectColumns.length != 0) {
+        if (selectColumns != null) {
             for (final SelectColumn sc : selectColumns) {
                 sourceDescriptions.remove(sc.getName());
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -579,26 +579,23 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
     }
 
     @Override
-    public boolean awaitUpdate(long timeout) throws InterruptedException {
+    public boolean awaitUpdate(long timeoutMillis) throws InterruptedException {
 
         final long startTime = System.nanoTime();
-        if (!updateGraph.exclusiveLock().tryLock(timeout, TimeUnit.MILLISECONDS)) {
+        if (!updateGraph.exclusiveLock().tryLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
             // Usually, users will already be holding the exclusive lock when calling this method. If they are not and
             // cannot acquire the lock within the timeout, we should return false now.
             return false;
         }
-        timeout -= (System.nanoTime() - startTime) / 1_000_000;
+        timeoutMillis -= TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
 
-        boolean result;
         try {
             // Note that we must reacquire the exclusive lock before returning from await. This deadline may be
             // exceeded if the thread must wait to reacquire the lock.
-            result = ensureCondition().await(timeout, TimeUnit.MILLISECONDS);
+            return ensureCondition().await(timeoutMillis, TimeUnit.MILLISECONDS);
         } finally {
             updateGraph.exclusiveLock().unlock();
         }
-
-        return result;
     }
 
     private Condition ensureCondition() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableListenerBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableListenerBase.java
@@ -317,7 +317,22 @@ public abstract class InstrumentedTableListenerBase extends LivenessArtifact
 
         void doRun(final Runnable invokeOnUpdate) {
             try {
-                doRunInternal(invokeOnUpdate);
+                final long currentStep = getUpdateGraph().clock().currentStep();
+                try {
+                    beforeRunNotification(currentStep);
+                    // Retain a reference during update processing to prevent interference from concurrent destroys
+                    if (!tryRetainReference()) {
+                        // This listener is no longer live, there's no point to doing any work for this notification
+                        return;
+                    }
+                    try {
+                        doRunInternal(invokeOnUpdate);
+                    } finally {
+                        dropReference();
+                    }
+                } finally {
+                    afterRunNotification(currentStep);
+                }
             } finally {
                 update.release();
             }
@@ -332,9 +347,7 @@ public abstract class InstrumentedTableListenerBase extends LivenessArtifact
                 entry.onUpdateStart(update.added(), update.removed(), update.modified(), update.shifted());
             }
 
-            final long currentStep = getUpdateGraph().clock().currentStep();
             try {
-                beforeRunNotification(currentStep);
                 invokeOnUpdate.run();
             } catch (Exception e) {
                 final LogEntry en = log.error().append("Uncaught exception for entry ");
@@ -370,7 +383,6 @@ public abstract class InstrumentedTableListenerBase extends LivenessArtifact
                 failed = true;
                 onFailure(e, entry);
             } finally {
-                afterRunNotification(currentStep);
                 if (entry != null) {
                     entry.onUpdateEnd();
                 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
@@ -366,61 +366,75 @@ public abstract class MergedListener extends LivenessArtifact implements Notific
 
         @Override
         public void run() {
-            final long currentStep = getUpdateGraph().clock().currentStep();
             try {
-                if (lastEnqueuedStep != currentStep) {
-                    // noinspection ConstantConditions
-                    throw Assert.statementNeverExecuted("Notification step mismatch: listener="
-                            + System.identityHashCode(MergedListener.this) + ": queuedNotificationStep="
-                            + lastEnqueuedStep + ", step=" + currentStep);
-                }
-
-                if (upstreamError != null) {
-                    propagateError(false, upstreamError, errorSourceEntry);
-                    return;
-                }
-
-                long added = 0;
-                long removed = 0;
-                long modified = 0;
-                long shifted = 0;
-
-                for (ListenerRecorder recorder : recorders) {
-                    if (recorder.getNotificationStep() == currentStep) {
-                        added += recorder.getAdded().size();
-                        removed += recorder.getRemoved().size();
-                        modified += recorder.getModified().size();
-                        shifted += recorder.getShifted().getEffectiveSize();
-                    }
-                }
-
-                if (entry != null) {
-                    entry.onUpdateStart(added, removed, modified, shifted);
-                }
+                final long currentStep = getUpdateGraph().clock().currentStep();
                 try {
-                    synchronized (MergedListener.this) {
-                        if (notificationStep == lastEnqueuedStep) {
-                            // noinspection ConstantConditions
-                            throw Assert.statementNeverExecuted("Multiple notifications in the same step: listener="
-                                    + System.identityHashCode(MergedListener.this) + ", queuedNotificationStep="
-                                    + lastEnqueuedStep);
-                        }
-                        notificationStep = lastEnqueuedStep;
+                    if (lastEnqueuedStep != currentStep) {
+                        // noinspection ConstantConditions
+                        throw Assert.statementNeverExecuted("Notification step mismatch: listener="
+                                + System.identityHashCode(MergedListener.this) + ": queuedNotificationStep="
+                                + lastEnqueuedStep + ", step=" + currentStep);
                     }
-                    process();
-                    getUpdateGraph().logDependencies()
-                            .append("MergedListener has completed execution ")
-                            .append(this).endl();
+                    // Retain a reference during update processing to prevent interference from concurrent destroys
+                    if (!tryRetainReference()) {
+                        // This listener is no longer live, there's no point to doing any work for this notification
+                        return;
+                    }
+                    try {
+                        runInternal(currentStep);
+                    } catch (Exception updateException) {
+                        handleUncaughtException(updateException);
+                    } finally {
+                        dropReference();
+                    }
                 } finally {
-                    if (entry != null) {
-                        entry.onUpdateEnd();
-                    }
+                    StepUpdater.forceUpdateRecordedStep(LAST_COMPLETED_STEP_UPDATER, MergedListener.this, currentStep);
                 }
-            } catch (Exception updateException) {
-                handleUncaughtException(updateException);
             } finally {
-                StepUpdater.forceUpdateRecordedStep(LAST_COMPLETED_STEP_UPDATER, MergedListener.this, currentStep);
                 releaseFromRecorders();
+            }
+        }
+
+        private void runInternal(final long currentStep) {
+            if (upstreamError != null) {
+                propagateError(false, upstreamError, errorSourceEntry);
+                return;
+            }
+            long added = 0;
+            long removed = 0;
+            long modified = 0;
+            long shifted = 0;
+
+            for (ListenerRecorder recorder : recorders) {
+                if (recorder.getNotificationStep() == currentStep) {
+                    added += recorder.getAdded().size();
+                    removed += recorder.getRemoved().size();
+                    modified += recorder.getModified().size();
+                    shifted += recorder.getShifted().getEffectiveSize();
+                }
+            }
+
+            if (entry != null) {
+                entry.onUpdateStart(added, removed, modified, shifted);
+            }
+            try {
+                synchronized (MergedListener.this) {
+                    if (notificationStep == lastEnqueuedStep) {
+                        // noinspection ConstantConditions
+                        throw Assert.statementNeverExecuted("Multiple notifications in the same step: listener="
+                                + System.identityHashCode(MergedListener.this) + ", queuedNotificationStep="
+                                + lastEnqueuedStep);
+                    }
+                    notificationStep = lastEnqueuedStep;
+                }
+                process();
+                getUpdateGraph().logDependencies()
+                        .append("MergedListener has completed execution ")
+                        .append(this).endl();
+            } finally {
+                if (entry != null) {
+                    entry.onUpdateEnd();
+                }
             }
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
@@ -375,6 +375,15 @@ public abstract class MergedListener extends LivenessArtifact implements Notific
                                 + System.identityHashCode(MergedListener.this) + ": queuedNotificationStep="
                                 + lastEnqueuedStep + ", step=" + currentStep);
                     }
+                    synchronized (MergedListener.this) {
+                        if (notificationStep == lastEnqueuedStep) {
+                            // noinspection ConstantConditions
+                            throw Assert.statementNeverExecuted("Multiple notifications in the same step: listener="
+                                    + System.identityHashCode(MergedListener.this) + ", queuedNotificationStep="
+                                    + lastEnqueuedStep);
+                        }
+                        notificationStep = lastEnqueuedStep;
+                    }
                     // Retain a reference during update processing to prevent interference from concurrent destroys
                     if (!tryRetainReference()) {
                         // This listener is no longer live, there's no point to doing any work for this notification
@@ -418,15 +427,6 @@ public abstract class MergedListener extends LivenessArtifact implements Notific
                 entry.onUpdateStart(added, removed, modified, shifted);
             }
             try {
-                synchronized (MergedListener.this) {
-                    if (notificationStep == lastEnqueuedStep) {
-                        // noinspection ConstantConditions
-                        throw Assert.statementNeverExecuted("Multiple notifications in the same step: listener="
-                                + System.identityHashCode(MergedListener.this) + ", queuedNotificationStep="
-                                + lastEnqueuedStep);
-                    }
-                    notificationStep = lastEnqueuedStep;
-                }
                 process();
                 getUpdateGraph().logDependencies()
                         .append("MergedListener has completed execution ")

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/TableAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/TableAdapter.java
@@ -373,7 +373,7 @@ public interface TableAdapter extends TableDefaults {
 
     @SuppressWarnings("RedundantThrows")
     @Override
-    default boolean awaitUpdate(long timeout) throws InterruptedException {
+    default boolean awaitUpdate(long timeoutMillis) throws InterruptedException {
         return throwUnsupported();
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/UncoalescedTable.java
@@ -448,8 +448,8 @@ public abstract class UncoalescedTable<IMPL_TYPE extends UncoalescedTable<IMPL_T
     }
 
     @Override
-    public boolean awaitUpdate(long timeout) throws InterruptedException {
-        return coalesce().awaitUpdate(timeout);
+    public boolean awaitUpdate(long timeoutMillis) throws InterruptedException {
+        return coalesce().awaitUpdate(timeoutMillis);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/BaseIncrementalReleaseFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/BaseIncrementalReleaseFilter.java
@@ -203,6 +203,10 @@ public abstract class BaseIncrementalReleaseFilter
         final long end = System.currentTimeMillis() + timeoutMillis;
         updateGraph.exclusiveLock().doLocked(() -> {
             while (releaseAllNanos == QueryConstants.NULL_LONG) {
+                if (listener.getTable().isFailed()) {
+                    throw new IllegalStateException(
+                            "Table failed before all rows were released, cannot wait for completion");
+                }
                 // This only works because we will never actually filter out a row from the result; in the general
                 // WhereFilter case, the result table may not update if not all rows are passed through
                 if (hasTimeout) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedInputTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/BaseArrayBackedInputTable.java
@@ -332,6 +332,10 @@ abstract class BaseArrayBackedInputTable extends UpdatableTable {
                 // We're holding the lock. currentTable had better be refreshing. Wait on its UGP condition
                 // in order to allow updates.
                 while (processedSequence < sequence) {
+                    if (BaseArrayBackedInputTable.this.isFailed()) {
+                        throw new IllegalStateException(
+                                "Input table failed before pending change " + sequence + " was processed");
+                    }
                     try {
                         BaseArrayBackedInputTable.this.awaitUpdate();
                     } catch (InterruptedException ignored) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/BaseTableAwaitUpdateTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/BaseTableAwaitUpdateTest.java
@@ -1,0 +1,357 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.testutil.ControlledUpdateGraph;
+import io.deephaven.engine.testutil.TstUtils;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static io.deephaven.engine.testutil.TstUtils.i;
+import static io.deephaven.engine.util.TableTools.intCol;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for {@link BaseTable#awaitUpdate()} and {@link BaseTable#awaitUpdate(long)}.
+ */
+public class BaseTableAwaitUpdateTest {
+
+    /**
+     * Timeout used for waits that we expect to elapse. Short enough to keep these tests fast, long enough that we can
+     * reliably distinguish "waited for the timeout" from "returned immediately".
+     */
+    private static final long ELAPSING_TIMEOUT_MILLIS = 250;
+
+    /**
+     * Timeout used for waits that we expect to be satisfied by a notification. Long enough that a slow machine won't
+     * cause a spurious timeout.
+     */
+    private static final long SATISFIED_TIMEOUT_MILLIS = 60_000;
+
+    /**
+     * Timeout used when joining threads that we expect to have finished, or to finish promptly.
+     */
+    private static final long JOIN_TIMEOUT_MILLIS = 30_000;
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    private ControlledUpdateGraph updateGraph;
+    private QueryTable source;
+    private QueryTable unrelated;
+    private long nextRowKey;
+
+    @Before
+    public void setUp() {
+        updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+        source = TstUtils.testRefreshingTable(i(0).toTracking(), intCol("Sentinel", 0));
+        unrelated = TstUtils.testRefreshingTable(i(0).toTracking(), intCol("Sentinel", 0));
+        nextRowKey = 1;
+    }
+
+    @Test
+    public void testTimeoutElapsesWithoutNotification() {
+        final Waiter waiter = Waiter.timed(source, ELAPSING_TIMEOUT_MILLIS);
+        waiter.join();
+        assertEquals(Boolean.FALSE, waiter.result);
+        assertWaitedForTimeout(waiter, ELAPSING_TIMEOUT_MILLIS);
+    }
+
+    @Test
+    public void testNonPositiveTimeoutDoesNotWait() {
+        for (final long timeoutMillis : new long[] {0, -1}) {
+            final Waiter waiter = Waiter.timed(source, timeoutMillis);
+            waiter.join();
+            assertEquals("timeoutMillis=" + timeoutMillis, Boolean.FALSE, waiter.result);
+            assertTrue("timeoutMillis=" + timeoutMillis + ", elapsedNanos=" + waiter.elapsedNanos,
+                    waiter.elapsedNanos < TimeUnit.MILLISECONDS.toNanos(ELAPSING_TIMEOUT_MILLIS));
+        }
+    }
+
+    @Test
+    public void testTimedWaitReturnsOnNotification() {
+        final Waiter waiter = Waiter.timed(source, SATISFIED_TIMEOUT_MILLIS);
+        waiter.awaitBlocked();
+        tick(source);
+        waiter.join();
+        assertEquals(Boolean.TRUE, waiter.result);
+    }
+
+    @Test
+    public void testUntimedWaitReturnsOnNotification() {
+        final Waiter waiter = Waiter.untimed(source);
+        waiter.awaitBlocked();
+
+        // An update to some other table on the same update graph must not terminate the wait.
+        tick(unrelated);
+        assertTrue("waiter finished without an update to source", waiter.isAlive());
+
+        tick(source);
+        waiter.join();
+    }
+
+    @Test
+    public void testTimedWaitIgnoresCyclesWithoutNotification() {
+        final Waiter waiter = Waiter.timed(source, ELAPSING_TIMEOUT_MILLIS);
+        waiter.awaitBlocked();
+        updateGraph.runWithinUnitTestCycle(() -> {
+        });
+        tick(unrelated);
+        waiter.join();
+        assertEquals(Boolean.FALSE, waiter.result);
+        assertWaitedForTimeout(waiter, ELAPSING_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * A notification delivered while the waiter is still trying to acquire the exclusive lock must not be missed. This
+     * is the common case for the unit test update graph, which holds the exclusive lock for the duration of a cycle.
+     */
+    @Test
+    public void testNotificationWhileAcquiringLockIsNotMissed() {
+        final Waiter waiter;
+        updateGraph.startCycleForUnitTests();
+        boolean cycleCompleted = false;
+        try {
+            waiter = Waiter.timed(source, SATISFIED_TIMEOUT_MILLIS);
+            // The cycle holds the exclusive lock, so the waiter cannot be doing anything but waiting for it.
+            waiter.awaitBlocked();
+            addRow(source);
+            updateGraph.completeCycleForUnitTests();
+            cycleCompleted = true;
+        } finally {
+            if (!cycleCompleted) {
+                updateGraph.completeCycleForUnitTests();
+            }
+        }
+        waiter.join();
+        assertEquals(Boolean.TRUE, waiter.result);
+    }
+
+    /**
+     * Time spent waiting for the exclusive lock must be charged against the caller's timeout, rather than blocking
+     * indefinitely before beginning to wait for a notification.
+     */
+    @Test
+    public void testLockWaitIsChargedAgainstTimeout() throws InterruptedException {
+        final CountDownLatch locked = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+        final Thread holder = new Thread(() -> {
+            try {
+                updateGraph.exclusiveLock().doLockedInterruptibly(() -> {
+                    locked.countDown();
+                    release.await();
+                });
+            } catch (InterruptedException ignored) {
+            }
+        }, "exclusive-lock-holder");
+        holder.setDaemon(true);
+        holder.start();
+        try {
+            locked.await();
+            // The holder thread will keep the exclusive lock until we count down release, below, so the waiter can
+            // never acquire it. It must nonetheless return (false) once its timeout has elapsed.
+            final Waiter waiter = Waiter.timed(source, ELAPSING_TIMEOUT_MILLIS);
+            waiter.join();
+            assertEquals(Boolean.FALSE, waiter.result);
+            assertWaitedForTimeout(waiter, ELAPSING_TIMEOUT_MILLIS);
+        } finally {
+            release.countDown();
+            holder.join(JOIN_TIMEOUT_MILLIS);
+            assertFalse(holder.isAlive());
+        }
+    }
+
+    /**
+     * The caller's exclusive lock must be intact when {@code awaitUpdate} returns, even though awaiting releases it.
+     */
+    @Test
+    public void testWaitWhileHoldingExclusiveLock() {
+        final boolean[] heldBefore = new boolean[1];
+        final boolean[] heldAfter = new boolean[1];
+        final Waiter waiter = new Waiter("await-holding-lock",
+                (resultSink) -> updateGraph.exclusiveLock().doLockedInterruptibly(() -> {
+                    heldBefore[0] = updateGraph.exclusiveLock().isHeldByCurrentThread();
+                    resultSink.accept(source.awaitUpdate(SATISFIED_TIMEOUT_MILLIS));
+                    heldAfter[0] = updateGraph.exclusiveLock().isHeldByCurrentThread();
+                }));
+        waiter.awaitBlocked();
+        tick(source);
+        waiter.join();
+        assertEquals(Boolean.TRUE, waiter.result);
+        assertTrue("exclusive lock was not held before awaitUpdate", heldBefore[0]);
+        assertTrue("exclusive lock was not held after awaitUpdate returned", heldAfter[0]);
+    }
+
+    @Test
+    public void testUntimedWaitReturnsOnFailure() {
+        final Waiter waiter = Waiter.untimed(source);
+        waiter.awaitBlocked();
+        failSource();
+        waiter.join();
+    }
+
+    @Test
+    public void testTimedWaitReturnsOnFailure() {
+        final Waiter waiter = Waiter.timed(source, SATISFIED_TIMEOUT_MILLIS);
+        waiter.awaitBlocked();
+        failSource();
+        waiter.join();
+        assertEquals(Boolean.TRUE, waiter.result);
+    }
+
+    @Test
+    public void testWaitOnFailedTableDoesNotBlock() {
+        failSource();
+        assertTrue(source.isFailed());
+
+        final Waiter timedWaiter = Waiter.timed(source, SATISFIED_TIMEOUT_MILLIS);
+        timedWaiter.join();
+        assertEquals(Boolean.TRUE, timedWaiter.result);
+        assertTrue("elapsedNanos=" + timedWaiter.elapsedNanos,
+                timedWaiter.elapsedNanos < TimeUnit.MILLISECONDS.toNanos(SATISFIED_TIMEOUT_MILLIS));
+
+        final Waiter untimedWaiter = Waiter.untimed(source);
+        untimedWaiter.join();
+    }
+
+    @Test
+    public void testInterruptDuringWaitReleasesLock() {
+        final Waiter waiter = Waiter.timed(source, SATISFIED_TIMEOUT_MILLIS);
+        waiter.awaitBlocked();
+        waiter.thread.interrupt();
+        waiter.joinIgnoringError();
+        assertNull(waiter.result);
+        assertTrue("error=" + waiter.error, waiter.error instanceof InterruptedException);
+        // The exclusive lock must not have been leaked; if it was, this cycle would never start.
+        tick(source);
+    }
+
+    private void addRow(final QueryTable table) {
+        final long rowKey = nextRowKey++;
+        TstUtils.addToTable(table, i(rowKey), intCol("Sentinel", (int) rowKey));
+        table.notifyListeners(i(rowKey), i(), i());
+    }
+
+    private void tick(final QueryTable table) {
+        updateGraph.runWithinUnitTestCycle(() -> addRow(table));
+    }
+
+    private void failSource() {
+        updateGraph.runWithinUnitTestCycle(
+                () -> source.notifyListenersOnError(new RuntimeException("test failure"), null));
+    }
+
+    private static void assertWaitedForTimeout(final Waiter waiter, final long timeoutMillis) {
+        assertTrue("elapsedNanos=" + waiter.elapsedNanos + ", timeoutMillis=" + timeoutMillis,
+                waiter.elapsedNanos >= TimeUnit.MILLISECONDS.toNanos(timeoutMillis));
+    }
+
+    private static void waitForState(final Thread thread, final Thread.State... acceptable) {
+        final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(JOIN_TIMEOUT_MILLIS);
+        while (true) {
+            final Thread.State state = thread.getState();
+            for (final Thread.State candidate : acceptable) {
+                if (state == candidate) {
+                    return;
+                }
+            }
+            if (System.nanoTime() - deadlineNanos > 0) {
+                fail("Thread " + thread.getName() + " never reached an acceptable state, state=" + state);
+            }
+            Thread.yield();
+        }
+    }
+
+    private interface WaitAction {
+        void await(Consumer<Boolean> resultSink) throws InterruptedException;
+    }
+
+    /**
+     * Runs an {@code awaitUpdate} invocation on its own thread, recording the outcome.
+     */
+    private static class Waiter {
+
+        private final Thread thread;
+
+        /**
+         * The result of {@link Table#awaitUpdate(long)}, or {@code null} if the wait is unfinished, threw, or was the
+         * {@link Table#awaitUpdate()} overload.
+         */
+        private volatile Boolean result;
+        private volatile long elapsedNanos = -1;
+        private volatile Throwable error;
+
+        private static Waiter untimed(final QueryTable table) {
+            return new Waiter("await-update", (resultSink) -> table.awaitUpdate());
+        }
+
+        private static Waiter timed(final QueryTable table, final long timeoutMillis) {
+            return new Waiter("await-update-" + timeoutMillis,
+                    (resultSink) -> resultSink.accept(table.awaitUpdate(timeoutMillis)));
+        }
+
+        private Waiter(final String name, final WaitAction action) {
+            thread = new Thread(() -> {
+                final long startNanos = System.nanoTime();
+                try {
+                    action.await((theResult) -> result = theResult);
+                } catch (Throwable t) {
+                    error = t;
+                } finally {
+                    elapsedNanos = System.nanoTime() - startNanos;
+                }
+            }, name);
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        /**
+         * Wait until this waiter's thread is parked, which guarantees that it has observed the table's notification
+         * step, and is either waiting for the exclusive lock or waiting for a notification.
+         */
+        private void awaitBlocked() {
+            waitForState(thread, Thread.State.WAITING, Thread.State.TIMED_WAITING);
+        }
+
+        private boolean isAlive() {
+            return thread.isAlive();
+        }
+
+        /**
+         * Join this waiter's thread, and re-throw any error it encountered.
+         */
+        private void join() {
+            joinIgnoringError();
+            if (error != null) {
+                throw new AssertionError("Waiter " + thread.getName() + " failed", error);
+            }
+        }
+
+        /**
+         * Join this waiter's thread, without regard for whether it completed normally.
+         */
+        private void joinIgnoringError() {
+            try {
+                thread.join(JOIN_TIMEOUT_MILLIS);
+            } catch (InterruptedException e) {
+                throw new AssertionError("Interrupted while joining waiter " + thread.getName(), e);
+            }
+            if (thread.isAlive()) {
+                fail("Waiter " + thread.getName() + " did not finish within " + JOIN_TIMEOUT_MILLIS + " ms");
+            }
+        }
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestTimeSeriesFilter.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestTimeSeriesFilter.java
@@ -5,6 +5,8 @@ package io.deephaven.engine.table.impl.select;
 
 import io.deephaven.api.filter.Filter;
 import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.liveness.LivenessReferent;
+import io.deephaven.engine.liveness.ReferenceCountedLivenessReferent;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.rowset.WritableRowSet;
@@ -25,10 +27,7 @@ import java.lang.ref.WeakReference;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.deephaven.engine.testutil.TstUtils.*;
@@ -159,7 +158,7 @@ public class TestTimeSeriesFilter extends RefreshingTableTestCase {
         final TimeSeriesFilter exclusionFilter =
                 TimeSeriesFilter.newBuilder().columnName("Date").period("PT01:00:00").clock(testClock).invert(true)
                         .build();
-        final ArrayList<WeakReference<TimeSeriesFilter>> filtersToRefresh = new ArrayList<>();
+        final List<WeakReference<TimeSeriesFilter>> filtersToRefresh = Collections.synchronizedList(new ArrayList<>());
 
         final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
         EvalNugget[] en = makeNuggets(table, inclusionFilter, filtersToRefresh, updateGraph, exclusionFilter);
@@ -201,7 +200,7 @@ public class TestTimeSeriesFilter extends RefreshingTableTestCase {
         final TimeSeriesFilter exclusionFilter =
                 TimeSeriesFilter.newBuilder().columnName("Date").period("PT01:00:00").clock(testClock).invert(true)
                         .build();
-        final ArrayList<WeakReference<TimeSeriesFilter>> filtersToRefresh = new ArrayList<>();
+        final List<WeakReference<TimeSeriesFilter>> filtersToRefresh = Collections.synchronizedList(new ArrayList<>());
 
         EvalNugget[] en = makeNuggets(table, inclusionFilter, filtersToRefresh, updateGraph, exclusionFilter);
 
@@ -223,18 +222,36 @@ public class TestTimeSeriesFilter extends RefreshingTableTestCase {
     }
 
     private static EvalNugget @NotNull [] makeNuggets(QueryTable table, TimeSeriesFilter inclusionFilter,
-            ArrayList<WeakReference<TimeSeriesFilter>> filtersToRefresh, ControlledUpdateGraph updateGraph,
+            List<WeakReference<TimeSeriesFilter>> filtersToRefresh, ControlledUpdateGraph updateGraph,
             TimeSeriesFilter exclusionFilter) {
         final Table withInstant = table.update("Date=DateTimeUtils.epochNanosToInstant(Date.getTime() * 1000000L)");
         return new EvalNugget[] {
                 EvalNugget.from(() -> {
                     final TimeSeriesFilter inclusionCopy = inclusionFilter.copy();
-                    filtersToRefresh.add(new WeakReference<>(inclusionCopy));
+                    final WeakReference<TimeSeriesFilter> filterRef = new WeakReference<>(inclusionCopy);
+                    final LivenessReferent sentinel = new ReferenceCountedLivenessReferent() {
+                        @Override
+                        public void destroy() {
+                            super.destroy();
+                            filtersToRefresh.remove(filterRef);
+                        }
+                    };
+                    inclusionCopy.manage(sentinel);
+                    filtersToRefresh.add(filterRef);
                     return updateGraph.exclusiveLock().computeLocked(() -> withInstant.where(inclusionCopy));
                 }),
                 EvalNugget.from(() -> {
                     final TimeSeriesFilter exclusionCopy = exclusionFilter.copy();
-                    filtersToRefresh.add(new WeakReference<>(exclusionCopy));
+                    final WeakReference<TimeSeriesFilter> filterRef = new WeakReference<>(exclusionCopy);
+                    final LivenessReferent sentinel = new ReferenceCountedLivenessReferent() {
+                        @Override
+                        public void destroy() {
+                            super.destroy();
+                            filtersToRefresh.remove(filterRef);
+                        }
+                    };
+                    exclusionCopy.manage(sentinel);
+                    filtersToRefresh.add(filterRef);
                     return updateGraph.exclusiveLock().computeLocked(() -> withInstant.where(exclusionCopy));
                 }),
         };


### PR DESCRIPTION
Two closely-related fixes to notification processing, kept in one PR because they interact: the first can cause a notification to never be delivered, and the second changes `awaitUpdate` from "wakes on any signal" to "wakes on an actual notification" — which is what turns a never-delivered notification into a hang.

### 1. Listeners stay live for the duration of a notification

`InstrumentedTableListenerBase.NotificationBase` and `MergedListener.MergedNotification` now retain a reference to their listener across the whole notification — validation, update processing, and error propagation — so a concurrent `destroy()` cannot pull state out from under an in-flight notification. If the listener is already dead when its notification runs, the work is skipped rather than performed against a destroyed artifact. `MergedListener` still records `notificationStep` on the skipped path, so a skipped step is not mistaken for a missing one.

`InstrumentedTableListenerBase.ErrorNotification` gets the same guard: it reaches the same listener-owned state via `onFailure` → `notifyListenersOnError`.

Because the retention is taken at the top of the notification rather than around the processing call alone, the existing `try`/`catch`/`finally` structure is otherwise unchanged — in particular, assertion failures still route through `handleUncaughtException` → `propagateError`, failing the result table rather than escaping into the notification processor.

### 2. `Table.awaitUpdate` waits for an actual notification

`BaseTable.awaitUpdate()` and `awaitUpdate(long)` now loop until this table's `lastNotificationStep` actually advances (or the table fails), instead of returning on any signal or spurious wakeup. `maybeSignal()` moved inside the `synchronized` block and after `lastNotificationStep` is assigned, so a woken waiter is guaranteed to observe the new step.

Timeout handling is tightened to match:

- Time spent acquiring the update graph's exclusive lock is charged against the caller's timeout, rather than blocking indefinitely before the wait begins.
- A non-positive timeout never waits, and never touches the exclusive lock. (Note that `Condition.await(0, unit)` and `Object.wait(0)` would instead wait forever, and a zero-timeout `tryLock` still makes an untimed acquisition attempt.)
- The untimed overload is now interruptible while acquiring the lock.

The `Table.awaitUpdate` javadoc is rewritten to state the contract: what the return value means, that callers who must not miss a notification should hold the exclusive lock across the call, and that reacquiring the lock after waiting may exceed the timeout.

`BaseIncrementalReleaseFilter.waitForCompletion` and `BaseArrayBackedInputTable` now test `isFailed()` in their wait loops. Under the old semantics a failed table's spurious wakeups let them make progress; under the new semantics they must test for failure explicitly or spin. `waitForCompletion` also drops its hand-rolled remaining-timeout arithmetic, which the new `awaitUpdate` contract makes redundant, and computes its deadline from the monotonic `System.nanoTime()` rather than `System.currentTimeMillis()`, so that waiting is insensitive to wall clock adjustments. (`nanoTime` has an arbitrary origin, so the deadline addition may overflow; that is unavoidable and harmless, since the remaining-time subtraction wraps with it.)

### Behavior changes to be aware of

- **`awaitUpdate` on a failed table returns immediately instead of blocking.** A failed table will never deliver another notification, so blocking was never going to terminate. A caller that loops on `awaitUpdate` without testing for failure goes from hanging to spinning, in Java and Python alike (`Table.isFailed()` / `Table.is_failed`); both looping callers in this repo are fixed above. Release note required.
- An empty update still does not advance `lastNotificationStep`, and so does not satisfy `awaitUpdate`. This matches the documented "has delivered a notification".
- `Table.awaitUpdate(long)`'s parameter is renamed `timeout` → `timeoutMillis`, which ripples to `TableAdapter` and `UncoalescedTable`.

### Testing

New `BaseTableAwaitUpdateTest` covers both overloads: notification wake-up, failure wake-up, timeout elapse, non-positive timeouts (contended and uncontended), lock-wait accounting, interrupt handling, and holding the exclusive lock across the call.

`TestTimeSeriesFilter` is fixed to drop filters from previous validation rounds deterministically when they are destroyed, instead of depending on GC to clear a `WeakReference`. The liveness sentinel that does this is held strongly for as long as the filter it watches, since `manage` only retains its referents weakly, and the list of filters to refresh is snapshotted under its monitor before iteration.



