### PR TITLE
fix: Close Jetty h2 streams with RST_STREAM and no error code 

### DIFF
--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
@@ -121,9 +121,15 @@ final class AsyncServletOutputStreamWriter {
             transportState.runOnTransportThread(
                     () -> {
                         transportState.complete();
-                        asyncContext.complete();
+                        // asyncContext.complete();
                         log.fine("call completed");
                     });
+            // Jetty specific fix: When AsyncContext.complete() is called, Jetty sends a RST_STREAM with
+            // "cancel" error to the client, while other containers send "no error" in this case. Calling
+            // close() instead on the output stream still sends the RST_STREAM, but with "no error". Note
+            // that this does the opposite in at least Tomcat, so we're not going to upstream this change.
+            // See https://github.com/deephaven/deephaven-core/issues/6400
+            outputStream.close();
         };
         this.isReady = () -> outputStream.isReady();
     }

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
@@ -121,15 +121,9 @@ final class AsyncServletOutputStreamWriter {
             transportState.runOnTransportThread(
                     () -> {
                         transportState.complete();
-                        // asyncContext.complete();
+                        asyncContext.complete();
                         log.fine("call completed");
                     });
-            // Jetty specific fix: When AsyncContext.complete() is called, Jetty sends a RST_STREAM with
-            // "cancel" error to the client, while other containers send "no error" in this case. Calling
-            // close() instead on the output stream still sends the RST_STREAM, but with "no error". Note
-            // that this does the opposite in at least Tomcat, so we're not going to upstream this change.
-            // See https://github.com/deephaven/deephaven-core/issues/6400
-            outputStream.close();
         };
         this.isReady = () -> outputStream.isReady();
     }

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletRequest.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletRequest.java
@@ -58,6 +58,8 @@ public class GrpcWebServletRequest extends HttpServletRequestWrapper {
     public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
             throws IllegalStateException {
         AsyncContext delegate = super.startAsync(servletRequest, servletResponse);
+        // Note that this anonymous class has no purpose while our workaround for
+        // https://github.com/deephaven/deephaven-core/issues/6400 is in place.
         return new DelegatingAsyncContext(delegate) {
             private void safelyComplete() {
                 try {

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletResponse.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/web/GrpcWebServletResponse.java
@@ -60,7 +60,7 @@ public class GrpcWebServletResponse extends HttpServletResponseWrapper {
     public synchronized GrpcWebOutputStream getOutputStream() throws IOException {
         if (outputStream == null) {
             // Provide our own output stream instance, so we can control/monitor the write listener
-            outputStream = new GrpcWebOutputStream(super.getOutputStream());
+            outputStream = new GrpcWebOutputStream(super.getOutputStream(), this);
         }
         return outputStream;
     }


### PR DESCRIPTION
This is a Jetty-specific workaround to avoid irritating the Python gRPC
client into failing calls that had already half-closed successfully.

Since we're now using ServletOutputStream.close() in place of AsyncContext.complete(), we need to apply the same wrapping for trailers to close() - that is, when the stream is clsoed, we can't rely on the servlet container sending our trailers because grpc-web trailers are actually a DATA frame which must be explicitly written.

See #6400
Fixes #5996
Reapplies #6401