### PR TITLE
fix: Credentials Resolution Bug in S3 Reads

### DIFF
--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/ResolvingCredentials.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/ResolvingCredentials.java
@@ -26,13 +26,6 @@ import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 enum ResolvingCredentials implements AwsSdkV2Credentials {
     INSTANCE;
 
-    private static final AwsCredentialsProviderChain PROVIDER_CHAIN = AwsCredentialsProviderChain.builder()
-            .credentialsProviders(
-                    DefaultCredentialsProvider.create(),
-                    AnonymousCredentialsProvider.create())
-            .reuseLastProviderEnabled(false) // Don't cache because this chain is a shared static instance
-            .build();
-
     @Override
     public final AwsCredentialsProvider awsV2CredentialsProvider(@NotNull final S3Instructions instructions) {
         if (instructions.profileName().isPresent()
@@ -40,6 +33,11 @@ enum ResolvingCredentials implements AwsSdkV2Credentials {
                 || instructions.credentialsFilePath().isPresent()) {
             return ProfileCredentials.INSTANCE.awsV2CredentialsProvider(instructions);
         }
-        return PROVIDER_CHAIN;
+        return AwsCredentialsProviderChain.builder()
+                .credentialsProviders(
+                        DefaultCredentialsProvider.create(),
+                        AnonymousCredentialsProvider.create())
+                .reuseLastProviderEnabled(true)
+                .build();
     }
 }


### PR DESCRIPTION
Closes #6435 

**Context:**
S3 reads require AWS credentials, typically provided via a credentials provider. If no provider is explicitly set, the system defaults to resolving credentials from number of sources like environment variables, credentials files, etc.

**Issue:**
When no credentials provider was set by user, credentials were unnecessarily being resolved on every read instead of reusing resolved credentials. This caused delays in table snapshot processing for S3.