### PR TITLE
fix: Expose TableSubscription.close() to JS

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableSubscription.java
@@ -60,4 +60,12 @@ public final class TableSubscription extends AbstractTableSubscription {
     public JsArray<Column> getColumns() {
         return super.getColumns();
     }
+
+    /**
+     * Close the subscription. Need to redefine here so this is exposed to JS.
+     */
+    @Override
+    public void close() {
+        super.close();
+    }
 }


### PR DESCRIPTION
- The close() method is only on `AbstractTableSubscription`, and it appears that it doesn't automatically get added to the JS API even though `TableSubscription` is defined as a `JsType`
- Explicitly add the method to `TableSubscription` as well.
- Fixes https://github.com/deephaven/deephaven-core/issues/6447
