### PR TITLE
fix: Expose TableSubscription.close() to JS (#6446)

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
@@ -29,6 +29,7 @@ import io.deephaven.web.client.state.ClientTableState;
 import io.deephaven.web.shared.data.RangeSet;
 import io.deephaven.web.shared.data.ShiftedRange;
 import io.deephaven.web.shared.fu.JsRunnable;
+import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
 import jsinterop.base.Any;
 import jsinterop.base.Js;
@@ -51,6 +52,7 @@ import java.util.BitSet;
  * exposed to api consumers, rather than wrapping in a Table type, as it handles the barrage stream and provides events
  * that client code can listen to.
  */
+@TsIgnore
 public abstract class AbstractTableSubscription extends HasEventHandling {
     /**
      * Indicates that some new data is available on the client, either an initial snapshot or a delta update. The
@@ -534,6 +536,7 @@ public abstract class AbstractTableSubscription extends HasEventHandling {
     /**
      * Stops the subscription on the server.
      */
+    @JsMethod
     public void close() {
         state.unretain(this);
         if (doExchange != null) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableSubscription.java
@@ -60,12 +60,4 @@ public final class TableSubscription extends AbstractTableSubscription {
     public JsArray<Column> getColumns() {
         return super.getColumns();
     }
-
-    /**
-     * Close the subscription. Need to redefine here so this is exposed to JS.
-     */
-    @Override
-    public void close() {
-        super.close();
-    }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableSubscription.java
@@ -60,4 +60,12 @@ public final class TableSubscription extends AbstractTableSubscription {
     public JsArray<Column> getColumns() {
         return super.getColumns();
     }
+
+    /**
+     * Close the subscription. Need to redefine here so this is exposed to JS.
+     */
+    @Override
+    public void close() {
+        super.close();
+    }
 }


### PR DESCRIPTION
- The close() method is only on `AbstractTableSubscription`, and it appears that it doesn't automatically get added to the JS API even though `TableSubscription` is defined as a `JsType`
- Explicitly add the method to `TableSubscription` as well.
- Fixes https://github.com/deephaven/deephaven-core/issues/6447