### PR TITLE
fix: Update web version 0.99.1 (#6449)

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,10 +2,10 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.99.0
+ARG WEB_VERSION=0.99.1
 ARG GRID_VERSION=0.99.0
 ARG CHART_VERSION=0.99.0
-ARG WIDGET_VERSION=0.99.0
+ARG WIDGET_VERSION=0.99.1
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
- Fix Meter variants not working correctly Release notes
https://github.com/deephaven/web-client-ui/releases/tag/v0.99.1 .