### PR TITLE
fix: erroneous QueryCompiler retry when nothing unaccounted for

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
@@ -1004,7 +1004,7 @@ public class QueryCompilerImpl implements QueryCompiler, LogOutputAppendable {
             }
         });
 
-        return wantRetry;
+        return wantRetry && !toRetry.isEmpty();
     }
 
     /**


### PR DESCRIPTION
Fixes #6216.

I discovered how to reproduce this by accident (my script was mid-write). Using a debugger I found that the retry list was empty, meaning that all of the non-failing items were successfully written to disk.