### PR TITLE
fix: Boxed primitives trigger ClassCastException in ArrayPreview for protobuf repeated fields (#6434)

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ArrayPreview.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ArrayPreview.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.engine.table.impl.preview;
 
+import io.deephaven.util.type.TypeUtils;
 import io.deephaven.vector.Vector;
 import io.deephaven.vector.VectorFactory;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +35,9 @@ public class ArrayPreview implements PreviewType {
         if (componentType == boolean.class) {
             return new ArrayPreview(convertToString((boolean[]) array));
         }
-        return new ArrayPreview(VectorFactory.forElementType(componentType)
+        // Boxed primitives need the Object wrapper.
+        final Class<?> elementType = TypeUtils.isBoxedType(componentType) ? Object.class : componentType;
+        return new ArrayPreview(VectorFactory.forElementType(elementType)
                 .vectorWrap(array)
                 .toString(ARRAY_SIZE_CUTOFF));
     }


### PR DESCRIPTION
The fix is taken from code in
https://github.com/deephaven/deephaven-core/pull/6065. That branch has been in WIP state for several months and we need this fix for DHE.
fixes https://github.com/deephaven/deephaven-core/issues/6433