### PR TITLE
fix: Update Web version v0.99.2, fix table plugins props

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,10 +2,10 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=0.99.1
+ARG WEB_VERSION=0.99.2
 ARG GRID_VERSION=0.99.0
 ARG CHART_VERSION=0.99.0
-ARG WIDGET_VERSION=0.99.1
+ARG WIDGET_VERSION=0.99.2
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
- Deprecated props were not being passed to table plugins anymore, breaking existing plugins
- Just continue to pass the deprecated props through until they have been replaced
