### PR TITLE
chore: code cleanup, properly scope rpcWrapper context detach

### DIFF
--- a/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/session/SessionServiceGrpcImpl.java
@@ -508,9 +508,9 @@ public class SessionServiceGrpcImpl extends SessionServiceGrpc.SessionServiceImp
                 // Indicates a very serious failure; debateable whether we should even try to send close.
                 safeClose(call, Status.INTERNAL, new Metadata(), false);
                 throw error;
-            } finally {
-                context.detach(previous);
             }
+        } finally {
+            context.detach(previous);
         }
     }
 


### PR DESCRIPTION
This is a very small code change that correctly scopes a context detach call. Technically this could be considered a "fix", but it very unlikely to matter in practice given that session.getExecutionContext.open() is unlikely to fail.