### PR TITLE
fix: erroneous QueryCompiler retry when nothing unaccounted for

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
@@ -1004,7 +1004,7 @@ public class QueryCompilerImpl implements QueryCompiler, LogOutputAppendable {
             }
         });
 
-        return wantRetry;
+        return wantRetry && !toRetry.isEmpty();
     }
 
     /**


### PR DESCRIPTION
This is the 0.37.1 branch PR fix for #6216 (merged in #6451).