### PR TITLE
chore: Give link checker write permissions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: ${{ github.repository_owner == 'deephaven' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The nightly link checker hasn't been able to write issues because I missed this in my original YAML file.