### PR TITLE
chore: Bump jpy requirements

### DIFF
--- a/py/embedded-server/setup.py
+++ b/py/embedded-server/setup.py
@@ -64,7 +64,7 @@ setup(
     keywords='Deephaven Development',
     python_requires='>=3.8',
     install_requires=[
-        'jpy>=1.0.0',
+        'jpy>=1.1.0',
         'java-utilities',
         f"deephaven-core[autocomplete]=={_version}",
         'click>=8.1.7',

--- a/py/server/setup.py
+++ b/py/server/setup.py
@@ -57,7 +57,7 @@ setup(
     keywords='Deephaven Development',
     python_requires='>=3.8',
     install_requires=[
-        'jpy>=1.0.0',
+        'jpy>=1.1.0',
         'deephaven-plugin>=0.6.0',
         'numpy',
         'pandas>=1.5.0',


### PR DESCRIPTION
Follow-up to #6525 (likely should have been there to begin with)

Cherry-pick of #6529