### PR TITLE
fix: Ensure that DataIndexes produced by a RegionedColumnSourceManager are retained by the DataIndexer

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/RemappedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/RemappedDataIndex.java
@@ -7,6 +7,7 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.DataIndex;
 import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.indexer.DataIndexer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
  * A {@link AbstractDataIndex} that remaps the key columns of another {@link AbstractDataIndex}. Used to implement
  * {@link io.deephaven.engine.table.DataIndex#remapKeyColumns(Map)}.
  */
-public class RemappedDataIndex extends AbstractDataIndex {
+public class RemappedDataIndex extends AbstractDataIndex implements DataIndexer.RetainableDataIndex {
 
     private final AbstractDataIndex sourceIndex;
     private final Map<ColumnSource<?>, ColumnSource<?>> oldToNewColumnMap;
@@ -108,5 +109,10 @@ public class RemappedDataIndex extends AbstractDataIndex {
     @Override
     public boolean isValid() {
         return sourceIndex.isValid();
+    }
+
+    @Override
+    public boolean shouldRetain() {
+        return DataIndexer.RetainableDataIndex.shouldRetain(sourceIndex);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
@@ -19,6 +19,7 @@ import io.deephaven.engine.table.impl.ForkJoinPoolOperationInitializer;
 import io.deephaven.engine.table.impl.by.AggregationProcessor;
 import io.deephaven.engine.table.impl.by.AggregationRowLookup;
 import io.deephaven.engine.table.impl.dataindex.AbstractDataIndex;
+import io.deephaven.engine.table.impl.indexer.DataIndexer;
 import io.deephaven.engine.table.impl.locations.TableLocation;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.select.FunctionalColumn;
@@ -43,7 +44,7 @@ import java.util.stream.IntStream;
  *           source table".
  */
 @InternalUseOnly
-class MergedDataIndex extends AbstractDataIndex {
+class MergedDataIndex extends AbstractDataIndex implements DataIndexer.RetainableDataIndex {
 
     private static final String LOCATION_DATA_INDEX_TABLE_COLUMN_NAME = "__DataIndexTable";
 
@@ -238,5 +239,10 @@ class MergedDataIndex extends AbstractDataIndex {
             }
         }
         return isValid = true;
+    }
+
+    @Override
+    public boolean shouldRetain() {
+        return true;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/PartitioningColumnDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/PartitioningColumnDataIndex.java
@@ -17,6 +17,7 @@ import io.deephaven.engine.table.impl.BaseTable;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.dataindex.AbstractDataIndex;
+import io.deephaven.engine.table.impl.indexer.DataIndexer;
 import io.deephaven.engine.table.impl.sources.ArrayBackedColumnSource;
 import io.deephaven.engine.table.impl.sources.ObjectArraySource;
 import io.deephaven.engine.table.impl.sources.ReinterpretUtils;
@@ -30,7 +31,7 @@ import java.util.Map;
 /**
  * DataIndex over a partitioning column of a {@link Table} backed by a {@link RegionedColumnSourceManager}.
  */
-class PartitioningColumnDataIndex<KEY_TYPE> extends AbstractDataIndex {
+class PartitioningColumnDataIndex<KEY_TYPE> extends AbstractDataIndex implements DataIndexer.RetainableDataIndex {
 
     private static final int KEY_NOT_FOUND = (int) RowSequence.NULL_ROW_KEY;
 
@@ -316,6 +317,11 @@ class PartitioningColumnDataIndex<KEY_TYPE> extends AbstractDataIndex {
 
     @Override
     public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldRetain() {
         return true;
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableTest.java
@@ -964,6 +964,43 @@ public class QueryTableTest extends QueryTableTestBase {
         }
     }
 
+    public void testIndexRetentionThroughGC() {
+        final Table childTable;
+
+        // We don't need this liveness scope for liveness management, but rather to opt out of the enclosing scope's
+        // enforceStrongReachability
+        try (final SafeCloseable ignored = LivenessScopeStack.open()) {
+            final Map<String, Object> retained = new HashMap<>();
+            final Random random = new Random(0);
+            final int size = 500;
+            final QueryTable parentTable = getTable(false, size, random,
+                    initColumnInfos(new String[] {"S1", "S2"},
+                            new SetGenerator<>("aa", "bb", "cc", "dd", "AA", "BB", "CC", "DD"),
+                            new SetGenerator<>("aaa", "bbb", "ccc", "ddd", "AAA", "BBB", "CCC", "DDD")));
+
+            // Explicitly retain the index references.
+            retained.put("di1", DataIndexer.getOrCreateDataIndex(parentTable, "S1"));
+            retained.put("di2", DataIndexer.getOrCreateDataIndex(parentTable, "S2"));
+            childTable = parentTable.update("isEven = ii % 2 == 0");
+
+            // While retained, the indexes will survive GC
+            System.gc();
+
+            // While the references are held, the parent and child tables should have the indexes.
+            Assert.assertTrue(DataIndexer.hasDataIndex(parentTable, "S1"));
+            Assert.assertTrue(DataIndexer.hasDataIndex(parentTable, "S2"));
+            Assert.assertTrue(DataIndexer.hasDataIndex(childTable, "S1"));
+            Assert.assertTrue(DataIndexer.hasDataIndex(childTable, "S2"));
+
+            // Explicitly release the references.
+            retained.clear();
+        }
+        // After a GC, the child table should not have the indexes.
+        System.gc();
+        Assert.assertFalse(DataIndexer.hasDataIndex(childTable, "S1"));
+        Assert.assertFalse(DataIndexer.hasDataIndex(childTable, "S2"));
+    }
+
     public void testStringMatchFilterIndexed() {
         // MatchFilters (currently) only use indexes on initial creation but this incremental test will recreate
         // index-enabled match filtered tables and compare them against incremental non-indexed filtered tables.


### PR DESCRIPTION
Cherry-pick of #6528