### PR TITLE
chore: Update workflow runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   server:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
           push: false
 
   web-plugin-packager:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   checks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   CLAssistant:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'deephaven' }}
     steps:
       - name: "CLA Assistant"

--- a/.github/workflows/conventional-pr-check.yml
+++ b/.github/workflows/conventional-pr-check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pr-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title

--- a/.github/workflows/create-docs-issues.yml
+++ b/.github/workflows/create-docs-issues.yml
@@ -12,7 +12,7 @@ jobs:
   create-docs-ticket:
     # Only on merged PRs that contain the DocumentationNeeded flag
     if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'DocumentationNeeded')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   dependency-submission:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   makedirs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Make Directories
         run: |
@@ -32,7 +32,7 @@ jobs:
   symlink:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v') }}
     needs: [javadoc, typedoc, pydoc, cppdoc, rdoc, protodoc]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Make Symlinks
         run: |
@@ -53,7 +53,7 @@ jobs:
           remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
   javadoc:
     needs: [makedirs]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: javadoc-${{ github.workflow }}-${{ github.ref }}
       # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
@@ -115,7 +115,7 @@ jobs:
 
   typedoc:
     needs: [makedirs]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: typedoc-${{ github.workflow }}-${{ github.ref }}
       # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
@@ -177,7 +177,7 @@ jobs:
 
   pydoc:
     needs: [makedirs]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: pydoc-${{ github.workflow }}-${{ github.ref }}
       # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
@@ -266,7 +266,7 @@ jobs:
 
   cppdoc:
     needs: [makedirs]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: cppdoc-${{ github.workflow }}-${{ github.ref }}
       # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
@@ -340,7 +340,7 @@ jobs:
 
   rdoc:
     needs: [makedirs]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: rdoc-${{ github.workflow }}-${{ github.ref }}
       # We don't want to cancel in-progress jobs against main because that might leave the upload in a bad state.
@@ -399,7 +399,7 @@ jobs:
 
   protodoc:
     needs: [makedirs]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: protodoc-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/label-check-ci.yml
+++ b/.github/workflows/label-check-ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   doc-labels:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         run: .github/scripts/check-doc-labels.sh
 
   releasenotes-labels:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     if: ${{ github.repository_owner == 'deephaven' }}

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -17,7 +17,7 @@ jobs:
         gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
         test-jvm-version: ['11', '17', '21', '23']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ matrix.gradle-task }}-${{ matrix.test-jvm-version }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/nightly-image-check.yml
+++ b/.github/workflows/nightly-image-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   compare:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'deephaven' }}
     steps:
       - name: Checkout

--- a/.github/workflows/publish-check-ci.yml
+++ b/.github/workflows/publish-check-ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   # Job based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
   publish-check-ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # Unfortunately, the official actions/download-artifact action is very limited in scope.
       # Can't use it yet in this context, https://github.com/actions/download-artifact/issues/60

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   quick:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
           if-no-files-found: ignore
 
   verify-python-min-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/tag-base-images.yml
+++ b/.github/workflows/tag-base-images.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   tag-base-images:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-web.yml
+++ b/.github/workflows/update-web.yml
@@ -4,7 +4,7 @@ name: Update web version
 on: workflow_dispatch
 jobs:
   update-web:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout latest
         uses: actions/checkout@v4


### PR DESCRIPTION
Github actions is finally moving `ubuntu-latest` to `ubuntu-24.04`, https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/. While we would be "okay" to stay on `22.04`, we should strive to build / pin to the most modern version.