### PR TITLE
fix(cpp-client): use std::getline for reading passwords

### DIFF
--- a/cpp-client/deephaven/dhcore/src/utility/utility.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility.cc
@@ -172,7 +172,7 @@ std::string ObjectId(const std::string &class_short_name, void *this_ptr) {
 std::string ReadPasswordFromStdinNoEcho() {
   SetStdinEcho(false);
   std::string password;
-  std::cin >> password;
+  std::getline(std::cin, password);
   SetStdinEcho(true);
   return password;
 }


### PR DESCRIPTION
Previously we were using `std::cin >> s` which has enough unintuitive behaviors (skipping leading whitespace, stopping at first nonleading whitespace) that we decided it was better to use `std::getline`