### PR TITLE
test: Simple ChartData tests for JS API

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/ChartData.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/ChartData.java
@@ -72,7 +72,7 @@ public class ChartData {
 
     private void replaceDataRange(SubscriptionTableData tableData, Range positions) {
         RangeSet keys = tableData.getFullIndex().getRange()
-                .subsetForPositions(RangeSet.ofRange(positions.getFirst(), positions.getLast()), true);
+                .subsetForPositions(RangeSet.ofRange(positions.getFirst(), positions.getLast()), false);
         // we don't touch the indexes at all, only need to walk each column and replace values in this range
         for (Entry<String, Map<JsFunction<Any, Any>, JsArray<Any>>> columnMap : cachedData.entrySet()) {
             Column col = table.findColumn(columnMap.getKey());

--- a/web/client-api/src/test/java/io/deephaven/web/ClientIntegrationTestSuite.java
+++ b/web/client-api/src/test/java/io/deephaven/web/ClientIntegrationTestSuite.java
@@ -9,6 +9,7 @@ import io.deephaven.web.client.api.grpc.GrpcTransportTestGwt;
 import io.deephaven.web.client.api.storage.JsStorageServiceTestGwt;
 import io.deephaven.web.client.api.subscription.ConcurrentTableTestGwt;
 import io.deephaven.web.client.api.subscription.ViewportTestGwt;
+import io.deephaven.web.client.api.widget.plot.ChartDataTestGwt;
 import io.deephaven.web.client.fu.LazyPromiseTestGwt;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -32,6 +33,7 @@ public class ClientIntegrationTestSuite extends GWTTestSuite {
         suite.addTestSuite(InputTableTestGwt.class);
         suite.addTestSuite(ColumnStatisticsTestGwt.class);
         suite.addTestSuite(GrpcTransportTestGwt.class);
+        suite.addTestSuite(ChartDataTestGwt.class);
 
         // This should be a unit test, but it requires a browser environment to run on GWT 2.9
         // GWT 2.9 doesn't have proper bindings for Promises in HtmlUnit, so we need to use the IntegrationTest suite

--- a/web/client-api/src/test/java/io/deephaven/web/CustomTransportTest.gwt.xml
+++ b/web/client-api/src/test/java/io/deephaven/web/CustomTransportTest.gwt.xml
@@ -1,0 +1,4 @@
+<module>
+    <!-- This test runs in its own module to avoid risking poisoning other tests with its broken custom transports -->
+    <inherits name="io.deephaven.web.DeephavenIntegrationTest" />
+</module>

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/grpc/GrpcTransportTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/grpc/GrpcTransportTestGwt.java
@@ -16,7 +16,8 @@ import jsinterop.base.JsPropertyMap;
 public class GrpcTransportTestGwt extends AbstractAsyncGwtTestCase {
     @Override
     public String getModuleName() {
-        return "io.deephaven.web.DeephavenIntegrationTest";
+        // This test runs in its own module to avoid risking poisoning other tests with its broken custom transports
+        return "io.deephaven.web.CustomTransportTest";
     }
 
     /**

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
@@ -1,0 +1,87 @@
+package io.deephaven.web.client.api.widget.plot;
+
+import elemental2.promise.Promise;
+import io.deephaven.web.client.api.AbstractAsyncGwtTestCase;
+import io.deephaven.web.client.api.subscription.AbstractTableSubscription;
+import io.deephaven.web.client.api.subscription.TableSubscription;
+
+public class ChartDataTestGwt extends AbstractAsyncGwtTestCase {
+    private final AbstractAsyncGwtTestCase.TableSourceBuilder tables = new AbstractAsyncGwtTestCase.TableSourceBuilder()
+            .script("from deephaven import time_table")
+            .script("appending_table", "time_table('PT0.1s').update([\"A = i % 2\", \"B = `` + A\"])")
+            .script("updating_table", "appending_table.last_by('A')");
+
+    @Override
+    public String getModuleName() {
+        return "io.deephaven.web.DeephavenIntegrationTest";
+    }
+
+    public void testAppendingChartData() {
+        connect(tables)
+                .then(table("appending_table"))
+                .then(table -> {
+                    ChartData chartData = new ChartData(table);
+                    TableSubscription sub = table.subscribe(table.getColumns());
+
+                    // Handle at least one event with data
+                    int[] count = {0};
+
+                    return new Promise<AbstractTableSubscription.SubscriptionEventData>((resolve, reject) -> {
+                        delayTestFinish(12301);
+                        sub.addEventListener(TableSubscription.EVENT_UPDATED, event -> {
+                            AbstractTableSubscription.SubscriptionEventData data = (AbstractTableSubscription.SubscriptionEventData) event.getDetail();
+                            chartData.update(data);
+
+                            if (count[0] > 0) {
+                                // Don't test on the first update, could still be empty
+                                assertTrue(chartData.getColumn("A", arr -> arr, data).length > 0);
+
+                                resolve.onInvoke(data);
+                            }
+                            count[0]++;
+                        });
+                    }).then(data -> {
+                        sub.close();
+                        table.close();
+                        return Promise.resolve(data);
+                    });
+                })
+                .then(this::finish).catch_(this::report);
+    }
+
+    public void testModifiedChartData() {
+        connect(tables)
+                .then(table("updating_table"))
+                .then(table -> {
+                    ChartData chartData = new ChartData(table);
+                    TableSubscription sub = table.subscribe(table.getColumns());
+
+                    int[] count = {0};
+                    return new Promise<AbstractTableSubscription.SubscriptionEventData>((resolve, reject) -> {
+                        delayTestFinish(12302);
+                        sub.addEventListener(TableSubscription.EVENT_UPDATED, event -> {
+
+                            AbstractTableSubscription.SubscriptionEventData data = (AbstractTableSubscription.SubscriptionEventData) event.getDetail();
+
+                            chartData.update(data);
+                            if (count[0] > 0) {
+                                // Don't test on the first update, could still be empty
+                                assertTrue(chartData.getColumn("A", arr -> arr, data).length > 0);
+                            }
+
+                            if (count[0] > 2) {
+                                // We've seen at least three updates, and must have modified rows at least once
+                                resolve.onInvoke((AbstractTableSubscription.SubscriptionEventData) event.getDetail());
+                            }
+                            count[0]++;
+                        });
+                    })
+                            .then(data -> {
+                                sub.close();
+                                table.close();
+                                return Promise.resolve(data);
+                            });
+                })
+                .then(this::finish).catch_(this::report);
+    }
+}

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
@@ -1,3 +1,6 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
 package io.deephaven.web.client.api.widget.plot;
 
 import elemental2.promise.Promise;
@@ -29,7 +32,8 @@ public class ChartDataTestGwt extends AbstractAsyncGwtTestCase {
                     return new Promise<AbstractTableSubscription.SubscriptionEventData>((resolve, reject) -> {
                         delayTestFinish(12301);
                         sub.addEventListener(TableSubscription.EVENT_UPDATED, event -> {
-                            AbstractTableSubscription.SubscriptionEventData data = (AbstractTableSubscription.SubscriptionEventData) event.getDetail();
+                            AbstractTableSubscription.SubscriptionEventData data =
+                                    (AbstractTableSubscription.SubscriptionEventData) event.getDetail();
                             chartData.update(data);
 
                             if (count[0] > 0) {
@@ -61,7 +65,8 @@ public class ChartDataTestGwt extends AbstractAsyncGwtTestCase {
                         delayTestFinish(12302);
                         sub.addEventListener(TableSubscription.EVENT_UPDATED, event -> {
 
-                            AbstractTableSubscription.SubscriptionEventData data = (AbstractTableSubscription.SubscriptionEventData) event.getDetail();
+                            AbstractTableSubscription.SubscriptionEventData data =
+                                    (AbstractTableSubscription.SubscriptionEventData) event.getDetail();
 
                             chartData.update(data);
                             if (count[0] > 0) {


### PR DESCRIPTION
Also fixed a testing issue discovered where custom transport tests can cause other tests to accidentally reuse that transport, receive bad data from the "server".

Follow-up #6546