### PR TITLE
feat: Add j_collection_to_list() in jcompat.py

### DIFF
--- a/py/server/deephaven/jcompat.py
+++ b/py/server/deephaven/jcompat.py
@@ -100,7 +100,7 @@ def j_list_to_list(jlist) -> List[Any]:
     return [wrap_j_object(jlist.get(i)) for i in range(jlist.size())]
 
 
-def j_collection_to_list(jcollection) -> list[Any]:
+def j_collection_to_list(jcollection) -> List[Any]:
     """Converts a java Collection to a python list."""
     if not jcollection:
         return []

--- a/py/server/deephaven/jcompat.py
+++ b/py/server/deephaven/jcompat.py
@@ -100,6 +100,19 @@ def j_list_to_list(jlist) -> List[Any]:
     return [wrap_j_object(jlist.get(i)) for i in range(jlist.size())]
 
 
+def j_collection_to_list(jcollection) -> list[Any]:
+    """Converts a java Collection to a python list."""
+    if not jcollection:
+        return []
+
+    res = []
+    it = jcollection.iterator()
+    while it.hasNext():
+        res.append(wrap_j_object(it.next()))
+
+    return res
+
+
 T = TypeVar("T")
 R = TypeVar("R")
 

--- a/py/server/tests/test_jcompat.py
+++ b/py/server/tests/test_jcompat.py
@@ -5,12 +5,13 @@
 import unittest
 
 from deephaven import dtypes
-from deephaven.jcompat import j_function, j_lambda, AutoCloseable
+from deephaven.jcompat import j_function, j_lambda, AutoCloseable, j_array_list, j_collection_to_list, j_hashset
 from tests.testbase import BaseTestCase
 
 import jpy
 
 _JSharedContext = jpy.get_type("io.deephaven.engine.table.SharedContext")
+
 
 class JCompatTestCase(BaseTestCase):
     def test_j_function(self):
@@ -25,6 +26,7 @@ class JCompatTestCase(BaseTestCase):
     def test_j_lambda(self):
         def int_to_str(v: int) -> str:
             return str(v)
+
         j_func = j_lambda(int_to_str, jpy.get_type('java.util.function.Function'), dtypes.string)
 
         r = j_func.apply(10)
@@ -35,6 +37,15 @@ class JCompatTestCase(BaseTestCase):
         with auto_closeable:
             self.assertEqual(auto_closeable.closed, False)
         self.assertEqual(auto_closeable.closed, True)
+
+    def test_j_collection_to_list(self):
+        lst = [2, 1, 3]
+        j_list = j_array_list(lst)
+        self.assertEqual(lst, j_collection_to_list(j_list))
+
+        s = set(lst)
+        j_set = j_hashset(s)
+        self.assertEqual(s, set(j_collection_to_list(j_set)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6515 

This new function, unlike the existing j_list_to_list(), j_map_to_dict(), covers Set and can be used when the concrete collection type is unknown.