### PR TITLE
ci: Publish jsapi-types patch release with v0.36 tag

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -112,5 +112,5 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.DEEPHAVENBOT_NPM_TOKEN }}
-        run: npm publish --provenance --tag latest web/client-api/types/build/deephaven-jsapi-types-*.tgz
+        run: npm publish --provenance --tag v0.36 web/client-api/types/build/deephaven-jsapi-types-*.tgz
         continue-on-error: true


### PR DESCRIPTION
- Should no longer clobber the `latest` tag
- `rc/v0.36.x` workaround for #5572