### PR TITLE
fix: Add semi-required "webhook-type" to slack actions

### DIFF
--- a/.github/workflows/create-docs-issues.yml
+++ b/.github/workflows/create-docs-issues.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVREL }}
         with:
+          webhook-type: webhook-trigger
           payload: |
             {
               "repository": "${{ github.repository }}",

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -104,9 +104,10 @@ jobs:
         id: slack-nightly-failure
         if: ${{ failure() && github.repository_owner == 'deephaven' && github.ref == 'refs/heads/main' }}
         with:
+          webhook-type: webhook-trigger
           payload: |
             {
-              "slack_message": "Nightly build failure in ${{ matrix.gradle-task }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.head_ref }} ${{ github.sha }}"
+              "slack_message": "Nightly build failure in ${{ matrix.gradle-task }} on Java ${{ matrix.test-jvm-version }} @ ${{ github.head_ref }} ${{ github.sha }}" ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}

--- a/.github/workflows/nightly-image-check.yml
+++ b/.github/workflows/nightly-image-check.yml
@@ -41,5 +41,5 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DHC_NOTIFY }}
         with:
-          webhook-type: incoming-webhook
+          webhook-type: webhook-trigger
           payload: '{"repository": "${{ github.repository }}", "message": "${{ github.workflow }}/${{ github.job }} failure, some image is out of date", "link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'

--- a/.github/workflows/nightly-image-check.yml
+++ b/.github/workflows/nightly-image-check.yml
@@ -41,4 +41,5 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DHC_NOTIFY }}
         with:
+          webhook-type: incoming-webhook
           payload: '{"repository": "${{ github.repository }}", "message": "${{ github.workflow }}/${{ github.job }} failure, some image is out of date", "link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'

--- a/.github/workflows/nightly-publish-ci.yml
+++ b/.github/workflows/nightly-publish-ci.yml
@@ -59,9 +59,10 @@ jobs:
         id: slack-nightly-failure
         if: failure()
         with:
+          webhook-type: webhook-trigger
           payload: |
             {
-              "slack_message": "Nightly publish failure @ ${{ github.head_ref }} ${{ github.sha }}"
+              "slack_message": "Nightly publish failure @ ${{ github.head_ref }} ${{ github.sha }} ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}


### PR DESCRIPTION
Our slack actions appear all to be workflows, assigned the webhook-trigger accordingly.

Also added build summary URLs for nightly check and publish.

Follow-up #6384