### PR TITLE
perf: DH-18300: Improve DataIndex performance.

### DIFF
--- a/Base/src/main/java/io/deephaven/base/AtomicUtil.java
+++ b/Base/src/main/java/io/deephaven/base/AtomicUtil.java
@@ -5,6 +5,7 @@ package io.deephaven.base;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 public abstract class AtomicUtil {
 
@@ -266,5 +267,45 @@ public abstract class AtomicUtil {
             update = expect & ~mask;
         } while (!i.compareAndSet(expect, update));
         return update;
+    }
+
+    /**
+     * Sets the field to the minimum of the current value and the passed in value
+     * 
+     * @param o the object to update
+     * @param fu the field updater
+     * @param value the value that is a candidate for the minumum
+     * @return true if the minimum was set
+     * @param <T> the type of o
+     */
+    public static <T> boolean setMin(final T o, final AtomicLongFieldUpdater<T> fu, final long value) {
+        long current = fu.get(o);
+        while (current > value) {
+            if (fu.compareAndSet(o, current, value)) {
+                return true;
+            }
+            current = fu.get(o);
+        }
+        return false;
+    }
+
+    /**
+     * Sets the field to the maximum of the current value and the passed in value
+     * 
+     * @param o the object to update
+     * @param fu the field updater
+     * @param value the value that is a candidate for the maximum
+     * @return true if the maximum was set
+     * @param <T> the type of o
+     */
+    public static <T> boolean setMax(final T o, final AtomicLongFieldUpdater<T> fu, final long value) {
+        long current = fu.get(o);
+        while (value > current) {
+            if (fu.compareAndSet(o, current, value)) {
+                return true;
+            }
+            current = fu.get(o);
+        }
+        return false;
     }
 }

--- a/Base/src/main/java/io/deephaven/base/stats/ThreadSafeCounter.java
+++ b/Base/src/main/java/io/deephaven/base/stats/ThreadSafeCounter.java
@@ -8,36 +8,22 @@ import java.util.function.LongFunction;
 // --------------------------------------------------------------------
 
 /**
- * A statistic where each value represents a additive quantity, and thus the sum of the values <U>does</U> have meaning.
- * Examples include event counts and processing duration. If the sum of the values <I>does not</I> have a useful
- * interpretation, use {@link State} instead.
+ * A statistic where each value represents an additive quantity, and thus the sum of the values <U>does</U> have
+ * meaning. Examples include event counts and processing duration. If the sum of the values <I>does not</I> have a
+ * useful interpretation, use {@link State} instead.
  * <UL>
  * <LI>{@link #increment} updates the counter, recording a single value. This is the most common usage. ({@link #sample}
  * does exactly the same thing but is a poor verb to use with a Counter.)
- * <LI>{@link #incrementFromSample} updates the counter, recording a value that is the difference between this sample
- * and the last sample. (The first call just sets the "last" sample and does not record a value.) For example, this can
- * be used to CPU usage rate when only a running total is available by periodically sampling the running total.
  * </UL>
  */
 public class ThreadSafeCounter extends ThreadSafeValue {
 
-    public static final char TYPE_TAG = 'C';
-
-    public ThreadSafeCounter(long now) {
+    public ThreadSafeCounter(final long now) {
         super(now);
     }
 
-    long previousSample = Long.MIN_VALUE;
-
-    public void incrementFromSample(long n) {
-        if (Long.MIN_VALUE != previousSample) {
-            sample(n - previousSample);
-        }
-        previousSample = n;
-    }
-
     public char getTypeTag() {
-        return TYPE_TAG;
+        return Counter.TYPE_TAG;
     }
 
     public static final LongFunction<ThreadSafeCounter> FACTORY = ThreadSafeCounter::new;

--- a/Base/src/main/java/io/deephaven/base/stats/ThreadSafeCounter.java
+++ b/Base/src/main/java/io/deephaven/base/stats/ThreadSafeCounter.java
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.base.stats;
+
+import java.util.function.LongFunction;
+
+// --------------------------------------------------------------------
+
+/**
+ * A statistic where each value represents a additive quantity, and thus the sum of the values <U>does</U> have meaning.
+ * Examples include event counts and processing duration. If the sum of the values <I>does not</I> have a useful
+ * interpretation, use {@link State} instead.
+ * <UL>
+ * <LI>{@link #increment} updates the counter, recording a single value. This is the most common usage. ({@link #sample}
+ * does exactly the same thing but is a poor verb to use with a Counter.)
+ * <LI>{@link #incrementFromSample} updates the counter, recording a value that is the difference between this sample
+ * and the last sample. (The first call just sets the "last" sample and does not record a value.) For example, this can
+ * be used to CPU usage rate when only a running total is available by periodically sampling the running total.
+ * </UL>
+ */
+public class ThreadSafeCounter extends ThreadSafeValue {
+
+    public static final char TYPE_TAG = 'C';
+
+    public ThreadSafeCounter(long now) {
+        super(now);
+    }
+
+    long previousSample = Long.MIN_VALUE;
+
+    public void incrementFromSample(long n) {
+        if (Long.MIN_VALUE != previousSample) {
+            sample(n - previousSample);
+        }
+        previousSample = n;
+    }
+
+    public char getTypeTag() {
+        return TYPE_TAG;
+    }
+
+    public static final LongFunction<ThreadSafeCounter> FACTORY = ThreadSafeCounter::new;
+}

--- a/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
+++ b/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
@@ -7,6 +7,14 @@ import io.deephaven.base.AtomicUtil;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
+/**
+ * A thread-safe extension of the {@link Value} class.
+ *
+ * <p>
+ * The {@link #sample(long)} method uses atomic CAS operations, so may introduce contention compared to the unsafe Value
+ * version of sample.
+ * </p>
+ */
 public abstract class ThreadSafeValue extends Value {
     private static final AtomicLongFieldUpdater<Value> N_UPDATER = AtomicLongFieldUpdater.newUpdater(Value.class, "n");
     private static final AtomicLongFieldUpdater<Value> SUM_UPDATER =

--- a/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
+++ b/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
@@ -16,15 +16,6 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
  * </p>
  */
 public abstract class ThreadSafeValue extends Value {
-    private static final AtomicLongFieldUpdater<Value> N_UPDATER = AtomicLongFieldUpdater.newUpdater(Value.class, "n");
-    private static final AtomicLongFieldUpdater<Value> SUM_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "sum");
-    private static final AtomicLongFieldUpdater<Value> SUM2_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "sum2");
-    private static final AtomicLongFieldUpdater<Value> MAX_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "max");
-    private static final AtomicLongFieldUpdater<Value> MIN_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "min");
 
     public ThreadSafeValue(long now) {
         super(now);
@@ -35,16 +26,12 @@ public abstract class ThreadSafeValue extends Value {
     }
 
     @Override
-    public void sample(final long x) {
-        N_UPDATER.incrementAndGet(this);
-        SUM_UPDATER.addAndGet(this, x);
-        SUM2_UPDATER.addAndGet(this, x * x);
-        last = x;
-        if (x > max) {
-            AtomicUtil.setMax(this, MAX_UPDATER, x);
-        }
-        if (x < min) {
-            AtomicUtil.setMin(this, MIN_UPDATER, x);
-        }
+    public synchronized void sample(final long x) {
+        super.sample(x);
+    }
+
+    @Override
+    public synchronized String toString() {
+        return super.toString();
     }
 }

--- a/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
+++ b/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
@@ -11,8 +11,8 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
  * A thread-safe extension of the {@link Value} class.
  *
  * <p>
- * The {@link #sample(long)} method is synchronized, so may introduce contention compared to the unsafe Value
- * version of sample.
+ * The {@link #sample(long)} method is synchronized, so may introduce contention compared to the unsafe Value version of
+ * sample.
  * </p>
  */
 public abstract class ThreadSafeValue extends Value {

--- a/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
+++ b/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.base.stats;
+
+import io.deephaven.base.AtomicUtil;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+public abstract class ThreadSafeValue extends Value {
+    private static final AtomicLongFieldUpdater<Value> N_UPDATER = AtomicLongFieldUpdater.newUpdater(Value.class, "n");
+    private static final AtomicLongFieldUpdater<Value> SUM_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(Value.class, "sum");
+    private static final AtomicLongFieldUpdater<Value> SUM2_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(Value.class, "sum2");
+    private static final AtomicLongFieldUpdater<Value> MAX_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(Value.class, "max");
+    private static final AtomicLongFieldUpdater<Value> MIN_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(Value.class, "min");
+
+    public ThreadSafeValue(long now) {
+        super(now);
+    }
+
+    protected ThreadSafeValue(History history) {
+        super(history);
+    }
+
+    @Override
+    public void sample(final long x) {
+        N_UPDATER.incrementAndGet(this);
+        SUM_UPDATER.addAndGet(this, x);
+        SUM2_UPDATER.addAndGet(this, x * x);
+        last = x;
+        if (x > max) {
+            AtomicUtil.setMax(this, MAX_UPDATER, x);
+        }
+        if (x < min) {
+            AtomicUtil.setMin(this, MIN_UPDATER, x);
+        }
+    }
+}

--- a/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
+++ b/Base/src/main/java/io/deephaven/base/stats/ThreadSafeValue.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
  * A thread-safe extension of the {@link Value} class.
  *
  * <p>
- * The {@link #sample(long)} method uses atomic CAS operations, so may introduce contention compared to the unsafe Value
+ * The {@link #sample(long)} method is synchronized, so may introduce contention compared to the unsafe Value
  * version of sample.
  * </p>
  */

--- a/Base/src/main/java/io/deephaven/base/stats/Value.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Value.java
@@ -5,8 +5,8 @@ package io.deephaven.base.stats;
 
 public abstract class Value {
     /**
-     * The sample(long) method is not thread safe; and you can get wrong answers out of it.
-     * If you require safety, you should instead use a ThreadSafeValue.
+     * The sample(long) method is not thread safe; and you can get wrong answers out of it. If you require safety, you
+     * should instead use a ThreadSafeValue.
      */
     protected long n = 0;
     protected long last = 0;

--- a/Base/src/main/java/io/deephaven/base/stats/Value.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Value.java
@@ -8,12 +8,12 @@ public abstract class Value {
      * These members are volatile, the sample(long) method is not thread safe; and you can get wrong answers out of it.
      * If you require safety, you should instead use a ThreadSafeValue.
      */
-    protected volatile long n = 0;
-    protected volatile long last = 0;
-    protected volatile long sum = 0;
-    protected volatile long sum2 = 0;
-    protected volatile long max = Long.MIN_VALUE;
-    protected volatile long min = Long.MAX_VALUE;
+    protected long n = 0;
+    protected long last = 0;
+    protected long sum = 0;
+    protected long sum2 = 0;
+    protected long max = Long.MIN_VALUE;
+    protected long min = Long.MAX_VALUE;
 
     private boolean alwaysUpdated = false;
 
@@ -54,7 +54,6 @@ public abstract class Value {
         this.history = history;
     }
 
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
     public void sample(final long x) {
         n++;
         last = x;
@@ -111,8 +110,7 @@ public abstract class Value {
             final double avg = (double) sum / n;
             return String.format("Value{n=%,d, sum=%,d, max=%,d, min=%,d, avg=%,.3f, std=%,.3f}", n, sum, max, min, avg,
                     std);
-        } else {
-            return String.format("Value{n=%,d}", n);
         }
+        return String.format("Value{n=%,d}", n);
     }
 }

--- a/Base/src/main/java/io/deephaven/base/stats/Value.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Value.java
@@ -5,7 +5,7 @@ package io.deephaven.base.stats;
 
 public abstract class Value {
     /**
-     * These members are volatile, the sample(long) method is not thread safe; and you can get wrong answers out of it.
+     * The sample(long) method is not thread safe; and you can get wrong answers out of it.
      * If you require safety, you should instead use a ThreadSafeValue.
      */
     protected long n = 0;

--- a/Base/src/main/java/io/deephaven/base/stats/Value.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Value.java
@@ -57,9 +57,9 @@ public abstract class Value {
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
     public void sample(final long x) {
         n++;
+        last = x;
         sum += x;
         sum2 += x * x;
-        last = x;
         if (x > max) {
             max = x;
         }

--- a/Base/src/main/java/io/deephaven/base/stats/Value.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Value.java
@@ -74,7 +74,7 @@ public abstract class Value {
             AtomicUtil.setMax(this, MAX_UPDATER, x);
         }
         if (x < min) {
-            AtomicUtil.setMin(this, MAX_UPDATER, x);
+            AtomicUtil.setMin(this, MIN_UPDATER, x);
         }
     }
 
@@ -116,10 +116,6 @@ public abstract class Value {
 
     @Override
     public String toString() {
-        final DecimalFormat format = new DecimalFormat("#,###");
-        final DecimalFormat avgFormat = new DecimalFormat("#,###.###");
-
-
         if (n > 0) {
             final double std = Math.sqrt(n > 1 ? (sum2 - ((double) sum * sum / (double) n)) / (n - 1) : Double.NaN);
             final double avg = (double) sum / n;

--- a/Base/src/main/java/io/deephaven/base/stats/Value.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Value.java
@@ -9,16 +9,6 @@ import java.text.DecimalFormat;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 public abstract class Value {
-    private static final AtomicLongFieldUpdater<Value> N_UPDATER = AtomicLongFieldUpdater.newUpdater(Value.class, "n");
-    private static final AtomicLongFieldUpdater<Value> SUM_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "sum");
-    private static final AtomicLongFieldUpdater<Value> SUM2_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "sum2");
-    private static final AtomicLongFieldUpdater<Value> MAX_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "max");
-    private static final AtomicLongFieldUpdater<Value> MIN_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(Value.class, "min");
-
     protected volatile long n = 0;
     protected volatile long last = 0;
     protected volatile long sum = 0;
@@ -65,16 +55,17 @@ public abstract class Value {
         this.history = history;
     }
 
-    public void sample(long x) {
-        N_UPDATER.incrementAndGet(this);
-        SUM_UPDATER.addAndGet(this, x);
-        SUM2_UPDATER.addAndGet(this, x * x);
+    @SuppressWarnings("NonAtomicOperationOnVolatileField")
+    public void sample(final long x) {
+        n++;
+        sum += x;
+        sum2 += x * x;
         last = x;
         if (x > max) {
-            AtomicUtil.setMax(this, MAX_UPDATER, x);
+            max = x;
         }
         if (x < min) {
-            AtomicUtil.setMin(this, MIN_UPDATER, x);
+            min = x;
         }
     }
 

--- a/Base/src/main/java/io/deephaven/base/stats/Value.java
+++ b/Base/src/main/java/io/deephaven/base/stats/Value.java
@@ -3,12 +3,11 @@
 //
 package io.deephaven.base.stats;
 
-import io.deephaven.base.AtomicUtil;
-
-import java.text.DecimalFormat;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
 public abstract class Value {
+    /**
+     * These members are volatile, the sample(long) method is not thread safe; and you can get wrong answers out of it.
+     * If you require safety, you should instead use a ThreadSafeValue.
+     */
     protected volatile long n = 0;
     protected volatile long last = 0;
     protected volatile long sum = 0;

--- a/Base/src/test/java/io/deephaven/base/stats/TestValue.java
+++ b/Base/src/test/java/io/deephaven/base/stats/TestValue.java
@@ -51,9 +51,16 @@ public class TestValue extends TestCase {
     }
 
     public void testToString() {
+        // this is purposefully a heisentest, this should make it fail if it is really broken
+        for (int ii = 0; ii < 10; ++ii) {
+            doTestToString();
+        }
+    }
+
+    public void doTestToString() {
         // we are testing toString, but also creating a pile of threads to exercise some of the AtomicFieldUpdater
         // behavior of the value
-        final Counter counter = Counter.FACTORY.apply(0L);
+        final Value counter = ThreadSafeCounter.FACTORY.apply(0L);
 
         final String emptyString = counter.toString();
         assertEquals("Value{n=0}", emptyString);

--- a/Base/src/test/java/io/deephaven/base/stats/TestValue.java
+++ b/Base/src/test/java/io/deephaven/base/stats/TestValue.java
@@ -5,6 +5,7 @@ package io.deephaven.base.stats;
 
 import junit.framework.TestCase;
 
+import java.util.concurrent.Semaphore;
 import java.util.function.LongFunction;
 
 // --------------------------------------------------------------------
@@ -47,6 +48,37 @@ public class TestValue extends TestCase {
         assertEquals(4, counter.getMax());
 
         checkValue(Counter.FACTORY);
+    }
+
+    public void testToString() {
+        // we are testing toString, but also creating a pile of threads to exercise some of the AtomicFieldUpdater
+        // behavior of the value
+        final Counter counter = Counter.FACTORY.apply(0L);
+
+        final String emptyString = counter.toString();
+        assertEquals("Value{n=0}", emptyString);
+
+        final Semaphore semaphore = new Semaphore(0);
+        final Semaphore completion = new Semaphore(0);
+        final int n = 100;
+        for (int ii = 0; ii < n; ++ii) {
+            final int fii = ii;
+            new Thread(() -> {
+                semaphore.acquireUninterruptibly();
+                counter.sample(fii);
+                completion.release();
+            }).start();
+        }
+        semaphore.release(100);
+        completion.acquireUninterruptibly(100);
+
+        assertEquals(n, counter.getN());
+        assertEquals(((n - 1) * n) / 2, counter.getSum());
+        assertEquals(0, counter.getMin());
+        assertEquals(99, counter.getMax());
+
+        final String asString = counter.toString();
+        assertEquals("Value{n=100, sum=4,950, max=99, min=0, avg=49.500, std=29.011}", asString);
     }
 
     // ----------------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,11 @@ For more information, see:
 * [gh pr create](https://cli.github.com/manual/gh_pr_create)
 * [CLI In Use](https://cli.github.com/manual/examples.html)
 
+## Labels
+
+- Each pull request msut have a `ReleaseNotesNeeded` label if a user can perceive the changes.  Build or testing-only changes should have a `NoReleaseNotesNeeded` label.
+- Each pull request must have a `DocumentationNeeded` label if the user guide should be updated.  Pull requests that do not require a user guide update should have a `NoDocumentationNeeded` label.
+
 ## Styleguide
 The [styleguide](style/README.md) is applied globally to the entire project, except for generated code that gets checked in.
 To apply the styleguide, run `./gradlew spotlessApply`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ For more information, see:
 
 ## Labels
 
-- Each pull request msut have a `ReleaseNotesNeeded` label if a user can perceive the changes.  Build or testing-only changes should have a `NoReleaseNotesNeeded` label.
+- Each pull request must have a `ReleaseNotesNeeded` label if a user can perceive the changes.  Build or testing-only changes should have a `NoReleaseNotesNeeded` label.
 - Each pull request must have a `DocumentationNeeded` label if the user guide should be updated.  Pull requests that do not require a user guide update should have a `NoDocumentationNeeded` label.
 
 ## Styleguide

--- a/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
@@ -102,6 +102,8 @@ public interface BasicDataIndex extends LivenessReferent {
     /**
      * Get the {@link RowSet} {@link ColumnSource} of the index {@link #table() table}.
      *
+     * @param options required for building the Index table this ColumnSource is retrieved from
+     *
      * @return The {@link RowSet} {@link ColumnSource}
      */
     @FinalDefault

--- a/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
@@ -102,7 +102,7 @@ public interface BasicDataIndex extends LivenessReferent {
     /**
      * Get the {@link RowSet} {@link ColumnSource} of the index {@link #table() table}.
      *
-     * @param options required for building the Index table this ColumnSource is retrieved from
+     * @param options parameters for controlling how the the table will be built (if necessary) in order to retrieve the result {@link RowSet} {@link ColumnSource}
      *
      * @return The {@link RowSet} {@link ColumnSource}
      */

--- a/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
@@ -96,16 +96,43 @@ public interface BasicDataIndex extends LivenessReferent {
     @FinalDefault
     @NotNull
     default ColumnSource<RowSet> rowSetColumn() {
-        return table().getColumnSource(rowSetColumnName(), RowSet.class);
+        return rowSetColumn(DataIndexOptions.DEFAULT);
+    }
+
+    /**
+     * Get the {@link RowSet} {@link ColumnSource} of the index {@link #table() table}.
+     *
+     * @return The {@link RowSet} {@link ColumnSource}
+     */
+    @FinalDefault
+    @NotNull
+    default ColumnSource<RowSet> rowSetColumn(final DataIndexOptions options) {
+        return table(options).getColumnSource(rowSetColumnName(), RowSet.class);
     }
 
     /**
      * Get the {@link Table} backing this data index.
+     *
+     * <p>
+     * The returned table is fully in-memory, equivalent to {@link #table(DataIndexOptions)} with default options.
+     * </p>
      * 
      * @return The {@link Table}
      */
     @NotNull
-    Table table();
+    default Table table() {
+        return table(DataIndexOptions.DEFAULT);
+    }
+
+    /**
+     * Get the {@link Table} backing this data index.
+     *
+     * @param options parameters to control the returned table
+     *
+     * @return The {@link Table}
+     */
+    @NotNull
+    Table table(DataIndexOptions options);
 
     /**
      * Whether the index {@link #table()} {@link Table#isRefreshing() is refreshing}. Some transformations will force
@@ -115,4 +142,5 @@ public interface BasicDataIndex extends LivenessReferent {
      *         otherwise
      */
     boolean isRefreshing();
+
 }

--- a/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/BasicDataIndex.java
@@ -102,7 +102,8 @@ public interface BasicDataIndex extends LivenessReferent {
     /**
      * Get the {@link RowSet} {@link ColumnSource} of the index {@link #table() table}.
      *
-     * @param options parameters for controlling how the the table will be built (if necessary) in order to retrieve the result {@link RowSet} {@link ColumnSource}
+     * @param options parameters for controlling how the the table will be built (if necessary) in order to retrieve the
+     *        result {@link RowSet} {@link ColumnSource}
      *
      * @return The {@link RowSet} {@link ColumnSource}
      */

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndex.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndex.java
@@ -48,7 +48,12 @@ public interface DataIndex extends BasicDataIndex {
      * @return A function that provides map-like lookup of index {@link #table()} row keys from an index lookup key
      */
     @NotNull
-    RowKeyLookup rowKeyLookup();
+    default RowKeyLookup rowKeyLookup() {
+        return rowKeyLookup(DataIndexOptions.DEFAULT);
+    }
+
+    @NotNull
+    RowKeyLookup rowKeyLookup(DataIndexOptions options);
 
     /**
      * Return a {@link RowKeyLookup lookup function} function of index row keys for this index. If

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndex.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndex.java
@@ -57,7 +57,7 @@ public interface DataIndex extends BasicDataIndex {
      * {@code true}, this lookup function is only guaranteed to be accurate for the current cycle. Lookup keys should be
      * in the order of the index's key columns.
      *
-     * @param options required for building the table, if required by this RowKeyLookup
+     * @param options parameters for building the table, if required by this RowKeyLookup
      *
      * @return A function that provides map-like lookup of index {@link #table()} row keys from an index lookup key
      */

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndex.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndex.java
@@ -52,6 +52,15 @@ public interface DataIndex extends BasicDataIndex {
         return rowKeyLookup(DataIndexOptions.DEFAULT);
     }
 
+    /**
+     * Build a {@link RowKeyLookup lookup function} of row keys for this index. If {@link #isRefreshing()} is
+     * {@code true}, this lookup function is only guaranteed to be accurate for the current cycle. Lookup keys should be
+     * in the order of the index's key columns.
+     *
+     * @param options required for building the table, if required by this RowKeyLookup
+     *
+     * @return A function that provides map-like lookup of index {@link #table()} row keys from an index lookup key
+     */
     @NotNull
     RowKeyLookup rowKeyLookup(DataIndexOptions options);
 

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
@@ -10,21 +10,30 @@ import org.immutables.value.Value;
 /**
  * Options for controlling the function of a {@link DataIndex}.
  *
- * <p>
- * Presently, this is used for the {@link Table#where(Filter)} operation to more efficiently handle data index matches,
- * without necessarily reading all RowSet information from disk across partitions.
- * </p>
  */
 @Value.Immutable
 @BuildableStyle
 public interface DataIndexOptions {
+    /**
+     * Static default options, which uses a full table.
+     */
     DataIndexOptions DEFAULT = DataIndexOptions.builder().build();
+
+    /**
+     * Static options that uses a partial table instead of the full table.
+     */
+    DataIndexOptions USE_PARTIAL_TABLE = DataIndexOptions.builder().operationUsesPartialTable(true).build();
 
     /**
      * Does this operation use only a subset of the DataIndex?
      *
      * <p>
      * The DataIndex implementation may use this hint to defer work for some row sets.
+     * </p>
+     *
+     * <p>
+     * Presently, this is used for the {@link Table#where(Filter)} operation to hint that work for computing
+     * {@link io.deephaven.engine.rowset.RowSet RowSets} for non-matching keys should be deferred.
      * </p>
      *
      * @return if this operation is only going to use a subset of this data index

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
@@ -20,7 +20,7 @@ public interface DataIndexOptions {
     DataIndexOptions DEFAULT = DataIndexOptions.builder().build();
 
     /**
-     * Static options that uses a partial table instead of the full table.
+     * Static options for operations that use a partial table instead of the full table.
      */
     DataIndexOptions USING_PARTIAL_TABLE = DataIndexOptions.builder().operationUsesPartialTable(true).build();
 

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
@@ -15,7 +15,7 @@ import org.immutables.value.Value;
 @BuildableStyle
 public interface DataIndexOptions {
     /**
-     * Static default options, which uses a full table.
+     * Static default options, which expect that operations will use the full table.
      */
     DataIndexOptions DEFAULT = DataIndexOptions.builder().build();
 

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
@@ -22,7 +22,7 @@ public interface DataIndexOptions {
     /**
      * Static options that uses a partial table instead of the full table.
      */
-    DataIndexOptions USE_PARTIAL_TABLE = DataIndexOptions.builder().operationUsesPartialTable(true).build();
+    DataIndexOptions USING_PARTIAL_TABLE = DataIndexOptions.builder().operationUsesPartialTable(true).build();
 
     /**
      * Does this operation use only a subset of the DataIndex?

--- a/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/DataIndexOptions.java
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table;
+
+import io.deephaven.annotations.BuildableStyle;
+import io.deephaven.api.filter.Filter;
+import org.immutables.value.Value;
+
+/**
+ * Options for controlling the function of a {@link DataIndex}.
+ *
+ * <p>
+ * Presently, this is used for the {@link Table#where(Filter)} operation to more efficiently handle data index matches,
+ * without necessarily reading all RowSet information from disk across partitions.
+ * </p>
+ */
+@Value.Immutable
+@BuildableStyle
+public interface DataIndexOptions {
+    DataIndexOptions DEFAULT = DataIndexOptions.builder().build();
+
+    /**
+     * Does this operation use only a subset of the DataIndex?
+     *
+     * <p>
+     * The DataIndex implementation may use this hint to defer work for some row sets.
+     * </p>
+     *
+     * @return if this operation is only going to use a subset of this data index
+     */
+    @Value.Default
+    default boolean operationUsesPartialTable() {
+        return false;
+    }
+
+    /**
+     * Create a new builder for a {@link DataIndexOptions}.
+     * 
+     * @return
+     */
+    static Builder builder() {
+        return ImmutableDataIndexOptions.builder();
+    }
+
+    /**
+     * The builder interface to construct a {@link DataIndexOptions}.
+     */
+    interface Builder {
+        /**
+         * Set whether this operation only uses a subset of the data index.
+         *
+         * @param usesPartialTable true if this operation only uses a partial table
+         * @return this builder
+         */
+        Builder operationUsesPartialTable(boolean usesPartialTable);
+
+        /**
+         * Build the {@link DataIndexOptions}.
+         * 
+         * @return an immutable DataIndexOptions structure.
+         */
+        DataIndexOptions build();
+    }
+}

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/GroupByBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/GroupByBenchmark.java
@@ -38,9 +38,6 @@ public class GroupByBenchmark {
     @Param({"Historical"})
     private String tableType;
 
-    @Param({"operator"})
-    private String mode;
-
     @Param({"String", "Int", "Composite"})
     private String keyType;
 
@@ -122,17 +119,6 @@ public class GroupByBenchmark {
         state = new TableBenchmarkState(BenchmarkTools.stripName(params.getBenchmark()), params.getWarmup().getCount());
 
         table = bmt.getTable().coalesce().dropColumns("PartCol");
-
-        switch (mode) {
-            case "chunked":
-                QueryTable.USE_OLDER_CHUNKED_BY = true;
-                break;
-            case "operator":
-                QueryTable.USE_OLDER_CHUNKED_BY = false;
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown mode " + mode);
-        }
     }
 
     @TearDown(Level.Trial)

--- a/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/LastByBenchmark.java
+++ b/engine/benchmark/src/benchmark/java/io/deephaven/benchmark/engine/LastByBenchmark.java
@@ -59,9 +59,6 @@ public class LastByBenchmark {
     @Param({"1"})
     private int valueCount;
 
-    @Param({"true"})
-    private boolean tracked;
-
     private Table table;
 
     private String keyName;
@@ -171,8 +168,6 @@ public class LastByBenchmark {
         state = new TableBenchmarkState(BenchmarkTools.stripName(params.getBenchmark()), params.getWarmup().getCount());
 
         table = bmt.getTable().coalesce().dropColumns("PartCol");
-
-        QueryTable.TRACKED_FIRST_BY = QueryTable.TRACKED_LAST_BY = tracked;
     }
 
     @TearDown(Level.Trial)

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
@@ -5,6 +5,7 @@ package io.deephaven.engine.table.impl;
 
 import io.deephaven.base.stats.Counter;
 import io.deephaven.base.stats.Stats;
+import io.deephaven.base.stats.ThreadSafeCounter;
 import io.deephaven.base.stats.Value;
 import io.deephaven.base.string.cache.CharSequenceUtils;
 import io.deephaven.base.verify.Assert;
@@ -70,14 +71,14 @@ public abstract class AbstractColumnSource<T> implements
      * Duration of match() calls using a DataIndex (also provides the count).
      */
     public static final Value INDEX_FILTER_MILLIS =
-            Stats.makeItem("AbstractColumnSource", "indexFilter", Counter.FACTORY,
+            Stats.makeItem("AbstractColumnSource", "indexFilter", ThreadSafeCounter.FACTORY,
                     "Duration of match() with a DataIndex in millis")
                     .getValue();
     /**
      * Duration of match() calls using a chunk filter (i.e. no DataIndex).
      */
     public static final Value CHUNK_FILTER_MILLIS =
-            Stats.makeItem("AbstractColumnSource", "chunkFilter", Counter.FACTORY,
+            Stats.makeItem("AbstractColumnSource", "chunkFilter", ThreadSafeCounter.FACTORY,
                     "Duration of match() without a DataIndex in millis")
                     .getValue();
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
@@ -3,7 +3,6 @@
 //
 package io.deephaven.engine.table.impl;
 
-import io.deephaven.base.stats.Counter;
 import io.deephaven.base.stats.Stats;
 import io.deephaven.base.stats.ThreadSafeCounter;
 import io.deephaven.base.stats.Value;
@@ -70,15 +69,15 @@ public abstract class AbstractColumnSource<T> implements
     /**
      * Duration of match() calls using a DataIndex (also provides the count).
      */
-    public static final Value INDEX_FILTER_MILLIS =
-            Stats.makeItem("AbstractColumnSource", "indexFilter", ThreadSafeCounter.FACTORY,
+    private static final Value INDEX_FILTER_MILLIS =
+            Stats.makeItem("AbstractColumnSource", "indexFilterMillis", ThreadSafeCounter.FACTORY,
                     "Duration of match() with a DataIndex in millis")
                     .getValue();
     /**
      * Duration of match() calls using a chunk filter (i.e. no DataIndex).
      */
-    public static final Value CHUNK_FILTER_MILLIS =
-            Stats.makeItem("AbstractColumnSource", "chunkFilter", ThreadSafeCounter.FACTORY,
+    private static final Value CHUNK_FILTER_MILLIS =
+            Stats.makeItem("AbstractColumnSource", "chunkFilterMillis", ThreadSafeCounter.FACTORY,
                     "Duration of match() without a DataIndex in millis")
                     .getValue();
 
@@ -178,7 +177,7 @@ public abstract class AbstractColumnSource<T> implements
             @NotNull final RowSet rowsetToFilter,
             final Object[] keys) {
         final DataIndexOptions partialOption =
-                USE_PARTIAL_TABLE_DATA_INDEX ? DataIndexOptions.USE_PARTIAL_TABLE : DataIndexOptions.DEFAULT;
+                USE_PARTIAL_TABLE_DATA_INDEX ? DataIndexOptions.USING_PARTIAL_TABLE : DataIndexOptions.DEFAULT;
 
         final Table indexTable = dataIndex.table(partialOption);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
@@ -3,6 +3,9 @@
 //
 package io.deephaven.engine.table.impl;
 
+import io.deephaven.base.stats.Counter;
+import io.deephaven.base.stats.Stats;
+import io.deephaven.base.stats.Value;
 import io.deephaven.base.string.cache.CharSequenceUtils;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.Chunk;
@@ -10,12 +13,14 @@ import io.deephaven.chunk.LongChunk;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.rowset.*;
 import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.DataIndex;
+import io.deephaven.engine.table.DataIndexOptions;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.chunkfillers.ChunkFiller;
 import io.deephaven.engine.table.impl.chunkfilter.ChunkFilter;
@@ -34,11 +39,47 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 
 public abstract class AbstractColumnSource<T> implements
         ColumnSource<T>,
         DefaultChunkSource.WithPrev<Values> {
+
+    /**
+     * For a {@link #match(boolean, boolean, boolean, DataIndex, RowSet, Object...)} call that uses a DataIndex, by
+     * default we do not force the entire DataIndex to be loaded into memory. This is because many
+     * {@link io.deephaven.engine.table.impl.select.MatchFilter}s are highly selective and only need to instantiate a
+     * single RowSet value rather than the complete DataIndex for the entire table. When the Configuration property
+     * "AbstractColumnSource.usePartialDataIndex" is set to false, the query engine materializes the entire DataIndex
+     * table for the match call.
+     */
+    public static boolean USE_PARTIAL_TABLE_DATA_INDEX = Configuration.getInstance()
+            .getBooleanWithDefault("AbstractColumnSource.usePartialDataIndex", true);
+    /**
+     * After generating a DataIndex table and identifying which row keys are responsive to the filter, the result Index
+     * can be built in serial or in parallel. By default, the index is built in parallel which may take advantage of
+     * using more threads for I/O of the index data structure. Parallel builds do require more setup and thread
+     * synchronization, so they can be disabled by setting the Configuration property
+     * "AbstractColumnSource.useParallelIndexBuild" to false.
+     */
+    public static boolean USE_PARALLEL_INDEX_BUILD = Configuration.getInstance()
+            .getBooleanWithDefault("AbstractColumnSource.useParallelIndexBuild", true);
+
+    /**
+     * Duration of match() calls using a DataIndex (also provides the count).
+     */
+    public static final Value indexFilter =
+            Stats.makeItem("AbstractColumnSource", "indexFilter", Counter.FACTORY,
+                    "Duration of match() with a DataIndex in nanos")
+                    .getValue();
+    /**
+     * Duration of match() calls using a chunk filter (i.e. no DataIndex).
+     */
+    public static final Value chunkFilter =
+            Stats.makeItem("AbstractColumnSource", "chunkFilter", Counter.FACTORY,
+                    "Duration of match() without a DataIndex in nanos")
+                    .getValue();
 
     /**
      * Minimum average run length in an {@link RowSequence} that should trigger {@link Chunk}-filling by key ranges
@@ -47,6 +88,13 @@ public abstract class AbstractColumnSource<T> implements
     public static final long USE_RANGES_AVERAGE_RUN_LENGTH = 5;
 
     private static final int CHUNK_SIZE = 1 << 11;
+
+    /**
+     * The match operation does not use the complete table, it just picks out the relevant indices so there is no reason
+     * to actually read it fully.
+     */
+    private static final DataIndexOptions PARTIAL_TABLE_DATA_INDEX =
+            DataIndexOptions.builder().operationUsesPartialTable(true).build();
 
     protected final Class<T> type;
     protected final Class<?> componentType;
@@ -115,82 +163,134 @@ public abstract class AbstractColumnSource<T> implements
             final boolean usePrev,
             final boolean caseInsensitive,
             @Nullable final DataIndex dataIndex,
-            @NotNull final RowSet mapper,
+            @NotNull final RowSet rowsetToFilter,
             final Object... keys) {
+        if (dataIndex == null) {
+            return doChunkFilter(invertMatch, usePrev, caseInsensitive, rowsetToFilter, keys);
+        }
+        final long t0 = System.nanoTime();
+        try {
+            return doDataIndexFilter(invertMatch, usePrev, caseInsensitive, dataIndex, rowsetToFilter, keys);
+        } finally {
+            final long t1 = System.nanoTime();
+            indexFilter.sample(t1 - t0);
+        }
+    }
 
-        if (dataIndex != null) {
-            final Table indexTable = dataIndex.table();
-            final RowSet matchingIndexRows;
-            if (caseInsensitive && type == String.class) {
-                // Linear scan through the index table, accumulating index row keys for case-insensitive matches
-                final RowSetBuilderSequential matchingIndexRowsBuilder = RowSetFactory.builderSequential();
+    private WritableRowSet doDataIndexFilter(final boolean invertMatch,
+            final boolean usePrev,
+            final boolean caseInsensitive,
+            @NotNull final DataIndex dataIndex,
+            @NotNull final RowSet rowsetToFilter,
+            final Object[] keys) {
+        final DataIndexOptions partialOption =
+                USE_PARTIAL_TABLE_DATA_INDEX ? PARTIAL_TABLE_DATA_INDEX : DataIndexOptions.DEFAULT;
 
-                // noinspection rawtypes
-                final KeyedObjectHashSet keySet = new KeyedObjectHashSet<>(new CIStringKey());
-                // noinspection unchecked
-                Collections.addAll(keySet, keys);
+        final Table indexTable = dataIndex.table(partialOption);
 
-                final RowSet indexRowSet = usePrev ? indexTable.getRowSet().prev() : indexTable.getRowSet();
-                final ColumnSource<?> indexKeySource =
-                        indexTable.getColumnSource(dataIndex.keyColumnNames().get(0), String.class);
+        final RowSet matchingIndexRows;
+        if (caseInsensitive && type == String.class) {
+            // Linear scan through the index table, accumulating index row keys for case-insensitive matches
+            final RowSetBuilderSequential matchingIndexRowsBuilder = RowSetFactory.builderSequential();
 
-                final int chunkSize = (int) Math.min(CHUNK_SIZE, indexRowSet.size());
-                try (final RowSequence.Iterator indexRowSetIterator = indexRowSet.getRowSequenceIterator();
-                        final GetContext indexKeyGetContext = indexKeySource.makeGetContext(chunkSize)) {
-                    while (indexRowSetIterator.hasMore()) {
-                        final RowSequence chunkIndexRows = indexRowSetIterator.getNextRowSequenceWithLength(chunkSize);
-                        final ObjectChunk<String, ? extends Values> chunkKeys = (usePrev
-                                ? indexKeySource.getPrevChunk(indexKeyGetContext, chunkIndexRows)
-                                : indexKeySource.getChunk(indexKeyGetContext, chunkIndexRows)).asObjectChunk();
-                        final LongChunk<OrderedRowKeys> chunkRowKeys = chunkIndexRows.asRowKeyChunk();
-                        final int thisChunkSize = chunkKeys.size();
-                        for (int ii = 0; ii < thisChunkSize; ++ii) {
-                            final String key = chunkKeys.get(ii);
-                            if (keySet.containsKey(key)) {
-                                matchingIndexRowsBuilder.appendKey(chunkRowKeys.get(ii));
-                            }
+            // noinspection rawtypes
+            final KeyedObjectHashSet keySet = new KeyedObjectHashSet<>(new CIStringKey());
+            // noinspection unchecked
+            Collections.addAll(keySet, keys);
+
+            final RowSet indexRowSet = usePrev ? indexTable.getRowSet().prev() : indexTable.getRowSet();
+            final ColumnSource<?> indexKeySource =
+                    indexTable.getColumnSource(dataIndex.keyColumnNames().get(0), String.class);
+
+            final int chunkSize = (int) Math.min(CHUNK_SIZE, indexRowSet.size());
+            try (final RowSequence.Iterator indexRowSetIterator = indexRowSet.getRowSequenceIterator();
+                    final GetContext indexKeyGetContext = indexKeySource.makeGetContext(chunkSize)) {
+                while (indexRowSetIterator.hasMore()) {
+                    final RowSequence chunkIndexRows = indexRowSetIterator.getNextRowSequenceWithLength(chunkSize);
+                    final ObjectChunk<String, ? extends Values> chunkKeys = (usePrev
+                            ? indexKeySource.getPrevChunk(indexKeyGetContext, chunkIndexRows)
+                            : indexKeySource.getChunk(indexKeyGetContext, chunkIndexRows)).asObjectChunk();
+                    final LongChunk<OrderedRowKeys> chunkRowKeys = chunkIndexRows.asRowKeyChunk();
+                    final int thisChunkSize = chunkKeys.size();
+                    for (int ii = 0; ii < thisChunkSize; ++ii) {
+                        final String key = chunkKeys.get(ii);
+                        if (keySet.containsKey(key)) {
+                            matchingIndexRowsBuilder.appendKey(chunkRowKeys.get(ii));
                         }
                     }
                 }
-                matchingIndexRows = matchingIndexRowsBuilder.build();
-            } else {
-                // Use the lookup function to get the index row keys for the matching keys
-                final RowSetBuilderRandom matchingIndexRowsBuilder = RowSetFactory.builderRandom();
-
-                final DataIndex.RowKeyLookup rowKeyLookup = dataIndex.rowKeyLookup();
-                for (Object key : keys) {
-                    final long rowKey = rowKeyLookup.apply(key, usePrev);
-                    if (rowKey != RowSequence.NULL_ROW_KEY) {
-                        matchingIndexRowsBuilder.addKey(rowKey);
-                    }
-                }
-                matchingIndexRows = matchingIndexRowsBuilder.build();
             }
+            matchingIndexRows = matchingIndexRowsBuilder.build();
+        } else {
+            // Use the lookup function to get the index row keys for the matching keys
+            final RowSetBuilderRandom matchingIndexRowsBuilder = RowSetFactory.builderRandom();
 
-            try (final SafeCloseable ignored = matchingIndexRows) {
-                final WritableRowSet filtered = invertMatch ? mapper.copy() : RowSetFactory.empty();
-                if (matchingIndexRows.isNonempty()) {
-                    final ColumnSource<RowSet> indexRowSetSource = usePrev
-                            ? dataIndex.rowSetColumn().getPrevSource()
-                            : dataIndex.rowSetColumn();
+            final DataIndex.RowKeyLookup rowKeyLookup = dataIndex.rowKeyLookup(partialOption);
+            for (final Object key : keys) {
+                final long rowKey = rowKeyLookup.apply(key, usePrev);
+                if (rowKey != RowSequence.NULL_ROW_KEY) {
+                    matchingIndexRowsBuilder.addKey(rowKey);
+                }
+            }
+            matchingIndexRows = matchingIndexRowsBuilder.build();
+        }
+
+        try (final SafeCloseable ignored = matchingIndexRows) {
+            final WritableRowSet filtered = invertMatch ? rowsetToFilter.copy() : RowSetFactory.empty();
+            if (matchingIndexRows.isNonempty()) {
+                final ColumnSource<RowSet> indexRowSetSource = usePrev
+                        ? dataIndex.rowSetColumn(partialOption).getPrevSource()
+                        : dataIndex.rowSetColumn(partialOption);
+
+                if (USE_PARALLEL_INDEX_BUILD) {
+                    final long[] rowKeyArray = new long[matchingIndexRows.intSize()];
+                    matchingIndexRows.toRowKeyArray(rowKeyArray);
+                    Arrays.stream(rowKeyArray).parallel().forEach((final long rowKey) -> {
+                        final RowSet matchingRowSet = indexRowSetSource.get(rowKey);
+                        assert matchingRowSet != null;
+                        if (invertMatch) {
+                            synchronized (filtered) {
+                                filtered.remove(matchingRowSet);
+                            }
+                        } else {
+                            try (final RowSet intersected = matchingRowSet.intersect(rowsetToFilter)) {
+                                synchronized (filtered) {
+                                    filtered.insert(intersected);
+                                }
+                            }
+                        }
+                    });
+                } else {
                     try (final CloseableIterator<RowSet> matchingIndexRowSetIterator =
                             ChunkedColumnIterator.make(indexRowSetSource, matchingIndexRows)) {
                         matchingIndexRowSetIterator.forEachRemaining((final RowSet matchingRowSet) -> {
                             if (invertMatch) {
                                 filtered.remove(matchingRowSet);
                             } else {
-                                try (final RowSet intersected = matchingRowSet.intersect(mapper)) {
+                                try (final RowSet intersected = matchingRowSet.intersect(rowsetToFilter)) {
                                     filtered.insert(intersected);
                                 }
                             }
                         });
                     }
                 }
-                return filtered;
             }
-        } else {
-            return ChunkFilter.applyChunkFilter(mapper, this, usePrev,
+            return filtered;
+        }
+    }
+
+    private WritableRowSet doChunkFilter(final boolean invertMatch,
+            final boolean usePrev,
+            final boolean caseInsensitive,
+            @NotNull final RowSet rowsetToFilter,
+            final Object[] keys) {
+        final long t0 = System.nanoTime();
+        try {
+            return ChunkFilter.applyChunkFilter(rowsetToFilter, this, usePrev,
                     ChunkMatchFilterFactory.getChunkFilter(type, caseInsensitive, invertMatch, keys));
+        } finally {
+            final long t1 = System.nanoTime();
+            chunkFilter.sample(t1 - t0);
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/JoinControl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/JoinControl.java
@@ -59,6 +59,10 @@ public class JoinControl {
 
     @Nullable
     DataIndex dataIndexToUse(Table table, ColumnSource<?>[] sources) {
+        // Configuration property that serves as an escape hatch
+        if (!QueryTable.USE_DATA_INDEX_FOR_JOINS) {
+            return null;
+        }
         final DataIndexer indexer = DataIndexer.existingOf(table.getRowSet());
         return indexer == null ? null
                 : LivenessScopeStack.computeEnclosed(

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -212,8 +212,8 @@ public class QueryTable extends BaseTable<QueryTable> {
             Configuration.getInstance().getBooleanWithDefault("QueryTable.useDataIndexForAggregation", true);
 
     /**
-     * If the Configuration property "QueryTable.useDataIndexForJoins" is set to true (default), then permit
-     * naturalJoin and aj to use a data index, when applicable. If false, data indexes are not used even if present.
+     * If the Configuration property "QueryTable.useDataIndexForJoins" is set to true (default), then permit naturalJoin
+     * and aj to use a data index, when applicable. If false, data indexes are not used even if present.
      */
     public static boolean USE_DATA_INDEX_FOR_JOINS =
             Configuration.getInstance().getBooleanWithDefault("QueryTable.useDataIndexForJoins", true);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -211,6 +211,13 @@ public class QueryTable extends BaseTable<QueryTable> {
     public static boolean USE_DATA_INDEX_FOR_AGGREGATION =
             Configuration.getInstance().getBooleanWithDefault("QueryTable.useDataIndexForAggregation", true);
 
+    /**
+     * If the Configuration property "QueryTable.useDataIndexForJoins" is set to true (default), then permit
+     * naturalJoin and aj to use a data index, when applicable. If false, data indexes are not used even if present.
+     */
+    public static boolean USE_DATA_INDEX_FOR_JOINS =
+            Configuration.getInstance().getBooleanWithDefault("QueryTable.useDataIndexForJoins", true);
+
 
     /**
      * For a static select(), we would prefer to flatten the table to avoid using memory unnecessarily (because the data
@@ -279,16 +286,6 @@ public class QueryTable extends BaseTable<QueryTable> {
     public static long MINIMUM_PARALLEL_SNAPSHOT_ROWS =
             Configuration.getInstance().getLongWithDefault("QueryTable.minimumParallelSnapshotRows", 1L << 20);
 
-    // Whether we should track the entire RowSet of firstBy and lastBy operations
-    @VisibleForTesting
-    public static boolean TRACKED_LAST_BY =
-            Configuration.getInstance().getBooleanWithDefault("QueryTable.trackLastBy", false);
-    @VisibleForTesting
-    public static boolean TRACKED_FIRST_BY =
-            Configuration.getInstance().getBooleanWithDefault("QueryTable.trackFirstBy", false);
-
-    @VisibleForTesting
-    public static boolean USE_OLDER_CHUNKED_BY = false;
     @VisibleForTesting
     public static boolean USE_CHUNKED_CROSS_JOIN =
             Configuration.getInstance().getBooleanWithDefault("QueryTable.chunkedJoin", true);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/RemappedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/RemappedDataIndex.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.dataindex;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.DataIndex;
+import io.deephaven.engine.table.DataIndexOptions;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.indexer.DataIndexer;
 import org.jetbrains.annotations.NotNull;
@@ -91,14 +92,14 @@ public class RemappedDataIndex extends AbstractDataIndex implements DataIndexer.
 
     @Override
     @NotNull
-    public Table table() {
-        return sourceIndex.table();
+    public Table table(final DataIndexOptions options) {
+        return sourceIndex.table(options);
     }
 
     @Override
     @NotNull
-    public RowKeyLookup rowKeyLookup() {
-        return sourceIndex.rowKeyLookup();
+    public RowKeyLookup rowKeyLookup(final DataIndexOptions options) {
+        return sourceIndex.rowKeyLookup(options);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/StandaloneDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/StandaloneDataIndex.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.dataindex;
 import io.deephaven.engine.liveness.LivenessArtifact;
 import io.deephaven.engine.table.BasicDataIndex;
 import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.DataIndexOptions;
 import io.deephaven.engine.table.Table;
 import org.jetbrains.annotations.NotNull;
 
@@ -63,7 +64,7 @@ public class StandaloneDataIndex extends LivenessArtifact implements BasicDataIn
 
     @Override
     @NotNull
-    public Table table() {
+    public Table table(final DataIndexOptions unused) {
         return table;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TableBackedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TableBackedDataIndex.java
@@ -9,6 +9,7 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.DataIndexOptions;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.by.*;
@@ -83,7 +84,7 @@ public class TableBackedDataIndex extends AbstractDataIndex {
 
     @Override
     @NotNull
-    public Table table() {
+    public Table table(final DataIndexOptions unused) {
         Table localIndexTable;
         if ((localIndexTable = indexTable) != null) {
             return localIndexTable;
@@ -136,8 +137,8 @@ public class TableBackedDataIndex extends AbstractDataIndex {
 
     @Override
     @NotNull
-    public RowKeyLookup rowKeyLookup() {
-        table();
+    public RowKeyLookup rowKeyLookup(final DataIndexOptions options) {
+        table(options);
         return (final Object key, final boolean usePrev) -> {
             // Pass the object to the aggregation lookup, then return the resulting row key. This index will be
             // correct in prev or current space because of the aggregation's hash-based lookup.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TransformedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/dataindex/TransformedDataIndex.java
@@ -10,11 +10,7 @@ import io.deephaven.engine.liveness.LivenessArtifact;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.WritableRowSet;
-import io.deephaven.engine.table.BasicDataIndex;
-import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.engine.table.DataIndex;
-import io.deephaven.engine.table.DataIndexTransformer;
-import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.ForkJoinPoolOperationInitializer;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
 import io.deephaven.engine.table.impl.select.FunctionalColumn;
@@ -72,7 +68,7 @@ public class TransformedDataIndex extends LivenessArtifact implements BasicDataI
 
     @Override
     @NotNull
-    public Table table() {
+    public Table table(final DataIndexOptions unused) {
         Table localIndexTable;
         if ((localIndexTable = indexTable) != null) {
             return localIndexTable;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/analyzers/SelectColumnLayer.java
@@ -191,7 +191,10 @@ final public class SelectColumnLayer extends SelectOrViewColumnLayer {
             // If we have shifts, that makes everything nasty; so we do not want to deal with it
             final boolean hasShifts = upstream.shifted().nonempty();
 
-            final boolean serialTableOperationsSafe = updateGraph.serialTableOperationsSafe()
+            // liveResultOwner is only null when we are static; in the static case there is no need to
+            // worry about serial table operation checking
+            final boolean serialTableOperationsSafe = liveResultOwner == null
+                    || updateGraph.serialTableOperationsSafe()
                     || updateGraph.sharedLock().isHeldByCurrentThread()
                     || updateGraph.exclusiveLock().isHeldByCurrentThread();
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
@@ -237,10 +237,10 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
                     final RowSet computedResult;
                     try {
                         if (USE_PARALLEL_LAZY_FETCH) {
-                            //noinspection DataFlowIssue
+                            // noinspection DataFlowIssue
                             computedResult = mergeRowSetsParallel(rowKey, inputRowSets);
                         } else {
-                            //noinspection DataFlowIssue
+                            // noinspection DataFlowIssue
                             computedResult = mergeRowSetsSerial(rowKey, inputRowSets);
                         }
                     } catch (Exception e) {
@@ -266,7 +266,7 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
             final PartitionedTable partitionedTable;
             if (lazyPartitionedTable != null) {
                 // We are synchronized, and can begin processing from the PartitionedTable rather than starting from
-                // scratch.  The first step is to force our rowsets into memory, in parallel.
+                // scratch. The first step is to force our rowsets into memory, in parallel.
                 partitionedTable = lazyPartitionedTable.transform(t -> t.update(ROW_SET_COLUMN_NAME));
             } else {
                 partitionedTable = buildPartitionedTable(lazyRowsetMerge);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
@@ -253,9 +253,9 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
         }
     }
 
-    private Table buildTable(final boolean lazyRowsetMerge) {
+    private Table buildTable(final boolean lazyRowSetMerge) {
         if (lazyTable != null) {
-            if (lazyRowsetMerge) {
+            if (lazyRowSetMerge) {
                 return lazyTable;
             }
         }
@@ -268,7 +268,7 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
                 // scratch. The first step is to force our rowsets into memory, in parallel.
                 partitionedTable = lazyPartitionedTable.transform(t -> t.update(ROW_SET_COLUMN_NAME));
             } else {
-                partitionedTable = buildPartitionedTable(lazyRowsetMerge);
+                partitionedTable = buildPartitionedTable(lazyRowSetMerge);
             }
 
             // Merge all the location index tables into a single table
@@ -278,7 +278,7 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
             lookupFunction = AggregationProcessor.getRowLookup(groupedByKeyColumns);
 
             final Table combined;
-            if (lazyRowsetMerge) {
+            if (lazyRowSetMerge) {
                 final ColumnSource<ObjectVector<RowSet>> vectorColumnSource =
                         groupedByKeyColumns.getColumnSource(ROW_SET_COLUMN_NAME);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
@@ -53,8 +53,9 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
     /**
      * The duration in nanos to build a DataIndex table.
      */
-    public static final Value BUILD_INDEX_TABLE_MILLIS = Stats
-            .makeItem("DataIndex", "buildTable", ThreadSafeCounter.FACTORY, "Duration in millis of building an index")
+    private static final Value BUILD_INDEX_TABLE_MILLIS = Stats
+            .makeItem("MergedDataIndex", "buildTableMillis", ThreadSafeCounter.FACTORY,
+                    "Duration in millis of building an index")
             .getValue();
 
     /**

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
@@ -86,8 +86,7 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
     private volatile Table indexTable;
 
     /**
-     * A lazy version of the table. This value is never set if indexTable is set. Can be converted to indexTable by
-     * selecting the RowSet column.
+     * A lazy version of the table. This value is never set if indexTable is set.
      */
     private volatile Table lazyTable;
 
@@ -370,7 +369,7 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
         } else {
             // pull the key columns into memory while we are parallel; but do not read all the RowSets
             final Table withInMemoryKeyColumns = coalesced.update(keyColumnNames);
-            return withInMemoryKeyColumns.update(List.of(SelectColumn.ofStateless(shiftFunction)));
+            return withInMemoryKeyColumns.updateView(List.of(SelectColumn.ofStateless(shiftFunction)));
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
@@ -6,8 +6,8 @@ package io.deephaven.engine.table.impl.sources.regioned;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.api.ColumnName;
 import io.deephaven.api.Selectable;
-import io.deephaven.base.stats.Counter;
 import io.deephaven.base.stats.Stats;
+import io.deephaven.base.stats.ThreadSafeCounter;
 import io.deephaven.base.stats.Value;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.Require;
@@ -54,7 +54,8 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
      * The duration in nanos to build a DataIndex table.
      */
     public static final Value BUILD_INDEX_TABLE_MILLIS = Stats
-            .makeItem("DataIndex", "buildTable", Counter.FACTORY, "Duration in millis of building an index").getValue();
+            .makeItem("DataIndex", "buildTable", ThreadSafeCounter.FACTORY, "Duration in millis of building an index")
+            .getValue();
 
     /**
      * When merging row sets from multiple component DataIndex structures, reading each individual component can be

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/MergedDataIndex.java
@@ -266,7 +266,8 @@ class MergedDataIndex extends AbstractDataIndex implements DataIndexer.Retainabl
             if (lazyPartitionedTable != null) {
                 // We are synchronized, and can begin processing from the PartitionedTable rather than starting from
                 // scratch. The first step is to force our rowsets into memory, in parallel.
-                partitionedTable = lazyPartitionedTable.transform(t -> t.update(ROW_SET_COLUMN_NAME));
+                partitionedTable = lazyPartitionedTable.transform(t -> ForkJoinPoolOperationInitializer
+                        .ensureParallelizable(() -> t.update(ROW_SET_COLUMN_NAME)).get());
             } else {
                 partitionedTable = buildPartitionedTable(lazyRowSetMerge);
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/PartitioningColumnDataIndex.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/PartitioningColumnDataIndex.java
@@ -8,6 +8,7 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.Require;
 import io.deephaven.engine.rowset.*;
 import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.DataIndexOptions;
 import io.deephaven.engine.table.ModifiedColumnSet;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableUpdate;
@@ -300,13 +301,13 @@ class PartitioningColumnDataIndex<KEY_TYPE> extends AbstractDataIndex implements
 
     @Override
     @NotNull
-    public Table table() {
+    public Table table(final DataIndexOptions unused) {
         return indexTable;
     }
 
     @Override
     @NotNull
-    public RowKeyLookup rowKeyLookup() {
+    public RowKeyLookup rowKeyLookup(final DataIndexOptions unusedOptions) {
         return (final Object key, final boolean usePrev) -> keyPositionMap.get(key);
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
@@ -462,7 +462,8 @@ public class TestRegionedColumnSourceManager extends RefreshingTableTestCase {
         captureIndexes(SUT.initialize());
 
         // Force us to build the merged index *before* we check satisfaction
-        // the checkIndexes method will call table() a second time with the DEFAULT options; which exercises lazy conversion
+        // the checkIndexes method will call table() a second time with the DEFAULT options; which exercises lazy
+        // conversion
         capturedGroupingColumnIndex.table(options);
 
         checkIndexes();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
@@ -388,6 +388,15 @@ public class TestRegionedColumnSourceManager extends RefreshingTableTestCase {
 
     @Test
     public void testStaticBasics() {
+        testStaticBasics(DataIndexOptions.DEFAULT);
+    }
+
+    @Test
+    public void testStaticBasicsPartial() {
+        testStaticBasics(DataIndexOptions.USING_PARTIAL_TABLE);
+    }
+
+    private void testStaticBasics(final DataIndexOptions options) {
         SUT = new RegionedColumnSourceManager(false, componentFactory, ColumnToCodecMappings.EMPTY, columnDefinitions);
         assertEquals(makeColumnSourceMap(), SUT.getColumnSources());
 
@@ -451,7 +460,10 @@ public class TestRegionedColumnSourceManager extends RefreshingTableTestCase {
         }
 
         captureIndexes(SUT.initialize());
-        capturedGroupingColumnIndex.table(); // Force us to build the merged index *before* we check satisfaction
+
+        // Force us to build the merged index *before* we check satisfaction
+        // the checkIndexes method will call table() a second time with the DEFAULT options; which exercises lazy conversion
+        capturedGroupingColumnIndex.table(options);
 
         checkIndexes();
         assertEquals(Arrays.asList(tableLocation1A, tableLocation1B), SUT.includedLocations());

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
@@ -482,7 +482,7 @@ public class TestRegionedColumnSourceManager extends RefreshingTableTestCase {
         }
 
         @Override
-        public @NotNull Table table() {
+        public @NotNull Table table(DataIndexOptions ignored) {
             return table;
         }
 


### PR DESCRIPTION
DataIndex, particularly when used for where() filters had missing parallelization opportunities; and would read more data than strictly necessary to satisfy the filter.