### PR TITLE
fix: JS clients must not release tickets for pending operations

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -374,8 +374,8 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
         }).then(result -> {
             ClientTableState state = new ClientTableState(connection,
                     new TableTicket(viewTicket.ticket().getTicket_asU8()), (callback, newState, metadata) -> {
-                callback.apply("fail, trees dont reconnect like this", null);
-            }, "");
+                        callback.apply("fail, trees dont reconnect like this", null);
+                    }, "");
             state.retain(JsTreeTable.this);
             ExportedTableCreationResponse def = new ExportedTableCreationResponse();
             HierarchicalTableDescriptor treeDescriptor =


### PR DESCRIPTION
When a necessary operation is still running, clients must not release upstream tickets. This has mostly worked by the server running fast enough or by the websocket transport serializing operations in a way that we can't always rely on.

Testing this is difficult to reliably do - the ticket has some manual steps that generally make it possible to see the issue, and we're exploring other options to make bugs like this more obvious. At this time, there is no good way to put an integration test in that verifies correct behavior efficiently.

Fixes #6056
Fixes DH-18486