### PR TITLE
feat(cpp-client): Honor Arrow TimeUnit when converting Timestamp and Time64 to ColumnSource

### DIFF
--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -74,6 +74,7 @@ set(ALL_FILES
     include/private/deephaven/client/impl/util.h
 
     src/arrowutil/arrow_client_table.cc
+    src/arrowutil/arrow_column_source.cc
     include/private/deephaven/client/arrowutil/arrow_client_table.h
     include/private/deephaven/client/arrowutil/arrow_column_source.h
     include/private/deephaven/client/arrowutil/arrow_value_converter.h
@@ -107,6 +108,7 @@ set(ALL_FILES
     src/utility/table_maker.cc
 
     include/public/deephaven/client/utility/arrow_util.h
+    include/public/deephaven/client/utility/internal_types.h
     include/public/deephaven/client/utility/misc_types.h
     include/public/deephaven/client/utility/table_maker.h
 )

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/internal_types.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/internal_types.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#pragma once
+
+#include <arrow/flight/types.h>
+
+namespace deephaven::client::utility {
+/**
+ * For Deephaven use only
+ */
+namespace internal {
+/**
+ * This class exists only for the benefit of the unit tests. Our normal DateTime class has a
+ * native time resolution of nanoseconds. This class allows our unit tests to upload a
+ * DateTime having a different time unit so we can confirm that the client and server both handle
+ * it correctly.
+ */
+template<arrow::TimeUnit::type UNIT>
+struct InternalDateTime {
+  explicit InternalDateTime(int64_t value) : value_(value) {}
+
+  int64_t value_ = 0;
+};
+
+/**
+ * This class exists only for the benefit of the unit tests. Our normal LocalTime class has a
+ * native time resolution of nanoseconds. This class allows our unit tests to upload a
+ * LocalTime having a different time unit so we can confirm that the client and server both handle
+ * it correctly.
+ */
+template<arrow::TimeUnit::type UNIT>
+struct InternalLocalTime {
+  // Arrow Time64 only supports micro and nano units
+  static_assert(UNIT == arrow::TimeUnit::MICRO || UNIT == arrow::TimeUnit::NANO);
+
+  explicit InternalLocalTime(int64_t value) : value_(value) {}
+
+  int64_t value_ = 0;
+};
+}  // namespace internal
+} // namespace deephaven::client::utility

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
@@ -19,6 +19,9 @@
 
 #include "deephaven/client/client.h"
 #include "deephaven/client/utility/arrow_util.h"
+#include "deephaven/client/utility/internal_types.h"
+#include "deephaven/client/utility/misc_types.h"
+#include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/third_party/fmt/format.h"
 
@@ -353,6 +356,38 @@ struct TypeConverterTraits<std::optional<T>> {
   }
   static std::string_view GetDeephavenTypeName() {
     return TypeConverterTraits<T>::GetDeephavenTypeName();
+  }
+};
+
+template<arrow::TimeUnit::type UNIT>
+struct TypeConverterTraits<deephaven::client::utility::internal::InternalDateTime<UNIT>> {
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return arrow::timestamp(UNIT, "UTC");
+  }
+  static arrow::TimestampBuilder GetBuilder() {
+    return arrow::TimestampBuilder(GetDataType(), arrow::default_memory_pool());
+  }
+  static int64_t Reinterpret(const deephaven::client::utility::internal::InternalDateTime<UNIT> &o) {
+    return o.value_;
+  }
+  static std::string_view GetDeephavenTypeName() {
+    return "java.time.ZonedDateTime";
+  }
+};
+
+template<arrow::TimeUnit::type UNIT>
+struct TypeConverterTraits<deephaven::client::utility::internal::InternalLocalTime<UNIT>> {
+  static std::shared_ptr<arrow::DataType> GetDataType() {
+    return arrow::time64(UNIT);
+  }
+  static arrow::Time64Builder GetBuilder() {
+    return arrow::Time64Builder(GetDataType(), arrow::default_memory_pool());
+  }
+  static int64_t Reinterpret(const deephaven::client::utility::internal::InternalLocalTime<UNIT> &o) {
+    return o.value_;
+  }
+  static std::string_view GetDeephavenTypeName() {
+    return "java.time.LocalTime";
   }
 };
 

--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_column_source.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_column_source.cc
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/client/arrowutil/arrow_column_source.h"
+#include "deephaven/client/utility/arrow_util.h"
+
+using deephaven::client::utility::OkOrThrow;
+
+namespace deephaven::client::arrowutil {
+namespace internal {
+
+namespace {
+struct NanoScaleFactorVisitor final : public arrow::TypeVisitor {
+  size_t result_ = 1;
+
+  arrow::Status Visit(const arrow::Int8Type  &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::FloatType &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::StringType &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::TimestampType &type) final {
+    result_ = ScaleFromUnit(type.unit());
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Date64Type &/*type*/) final {
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Time64Type &type) final {
+    result_ = ScaleFromUnit(type.unit());
+    return arrow::Status::OK();
+  }
+
+  static size_t ScaleFromUnit(arrow::TimeUnit::type unit) {
+    switch (unit) {
+      case arrow::TimeUnit::SECOND: return 1'000'000'000;
+      case arrow::TimeUnit::MILLI: return 1'000'000;
+      case arrow::TimeUnit::MICRO: return 1'000;
+      case arrow::TimeUnit::NANO: return 1;
+      default: {
+        auto message = fmt::format("Unhandled arrow::TimeUnit {}", static_cast<size_t>(unit));
+        throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+      }
+    }
+  }
+};
+}  // namespace
+
+size_t CalcTimeNanoScaleFactor(const arrow::Array &array) {
+  NanoScaleFactorVisitor visitor;
+  OkOrThrow(DEEPHAVEN_LOCATION_EXPR(array.type()->Accept(&visitor)));
+  return visitor.result_;
+}
+}  // namespace internal
+}  // namespace deephaven::client::arrowutil

--- a/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
@@ -81,12 +81,7 @@ struct ArrowToElementTypeId final : public arrow::TypeVisitor {
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::TimestampType &type) final {
-    if (type.unit() != arrow::TimeUnit::NANO) {
-      auto message = fmt::format("Expected TimestampType with nano units, got {}",
-          type.ToString());
-      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
-    }
+  arrow::Status Visit(const arrow::TimestampType &/*type*/) final {
     type_id_ = ElementTypeId::kTimestamp;
     return arrow::Status::OK();
   }
@@ -96,12 +91,7 @@ struct ArrowToElementTypeId final : public arrow::TypeVisitor {
     return arrow::Status::OK();
   }
 
-  arrow::Status Visit(const arrow::Time64Type &type) final {
-    if (type.unit() != arrow::TimeUnit::NANO) {
-      auto message = fmt::format("Expected Time64Type with nano units, got {}",
-          type.ToString());
-      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
-    }
+  arrow::Status Visit(const arrow::Time64Type &/*type*/) final {
     type_id_ = ElementTypeId::kLocalTime;
     return arrow::Status::OK();
   }

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -541,7 +541,6 @@ public:
   /**
    * Converts nanoseconds-since-start-of-day to LocalTime. The Deephaven null value sentinel is
    * turned into LocalTime(0).
-   * TODO(kosak): find out null convention
    * @param nanos Nanoseconds since the start of the day.
    * @return The corresponding LocalTime.
    */
@@ -579,7 +578,6 @@ private:
     return !(lhs == rhs);
   }
 };
-
 }  // namespace deephaven::dhcore
 
 template<> struct fmt::formatter<deephaven::dhcore::DateTime> : ostream_formatter {};

--- a/cpp-client/deephaven/tests/CMakeLists.txt
+++ b/cpp-client/deephaven/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(dhclient_tests
         src/table_test.cc
         src/test_util.cc
         src/ticking_test.cc
+        src/time_unit_test.cc
         src/ungroup_test.cc
         src/update_by_test.cc
         src/utility_test.cc

--- a/cpp-client/deephaven/tests/src/time_unit_test.cc
+++ b/cpp-client/deephaven/tests/src/time_unit_test.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016-2024 Deephaven Data Labs and Patent Pending
+ */
+#include <iostream>
+#include "deephaven/third_party/catch.hpp"
+#include "deephaven/tests/test_util.h"
+#include "deephaven/client/utility/internal_types.h"
+#include "deephaven/client/utility/misc_types.h"
+#include "deephaven/dhcore/container/row_sequence.h"
+#include "deephaven/dhcore/types.h"
+
+using deephaven::client::Client;
+using deephaven::client::TableHandle;
+using deephaven::client::utility::TableMaker;
+using deephaven::client::utility::internal::InternalDateTime;
+using deephaven::client::utility::internal::InternalLocalTime;
+using deephaven::dhcore::DateTime;
+using deephaven::dhcore::DeephavenConstants;
+using deephaven::dhcore::LocalDate;
+using deephaven::dhcore::LocalTime;
+using deephaven::dhcore::chunk::BooleanChunk;
+using deephaven::dhcore::chunk::DateTimeChunk;
+using deephaven::dhcore::chunk::LocalTimeChunk;
+using deephaven::dhcore::container::RowSequence;
+
+namespace deephaven::client::tests {
+TEST_CASE("Uploaded Arrow Timestamp units get normalized to nanos at FillChunk time", "[timeunit]") {
+  auto tm = TableMakerForTests::Create();
+
+  std::vector<std::optional<InternalDateTime<arrow::TimeUnit::SECOND>>> dt_sec;
+  std::vector<std::optional<InternalDateTime<arrow::TimeUnit::MILLI>>> dt_milli;
+  std::vector<std::optional<InternalDateTime<arrow::TimeUnit::MICRO>>> dt_micro;
+  std::vector<std::optional<InternalDateTime<arrow::TimeUnit::NANO>>> dt_nano;
+
+  // First row: one second (in various units)
+  dt_sec.emplace_back(1);
+  dt_milli.emplace_back(1'000);
+  dt_micro.emplace_back(1'000'000);
+  dt_nano.emplace_back(1'000'000'000);
+
+  // Second row: null
+  dt_sec.emplace_back();
+  dt_milli.emplace_back();
+  dt_micro.emplace_back();
+  dt_nano.emplace_back();
+
+  TableMaker maker;
+  maker.AddColumn("dt_sec", dt_sec);
+  maker.AddColumn("dt_milli", dt_milli);
+  maker.AddColumn("dt_micro", dt_micro);
+  maker.AddColumn("dt_nano", dt_nano);
+  auto t = maker.MakeTable(tm.Client().GetManager());
+
+  std::cout << t.Stream(true) << '\n';
+
+  auto client_table = t.ToClientTable();
+
+  auto rs = RowSequence::CreateSequential(0, 2);
+  auto dest = DateTimeChunk::Create(2);
+  auto nulls = BooleanChunk::Create(2);
+
+  auto expected = DateTime::FromNanos(1'000'000'000);
+
+  for (size_t i = 0; i != client_table->NumColumns(); ++i) {
+    auto col = client_table->GetColumn(i);
+    col->FillChunk(*rs, &dest, &nulls);
+
+    CHECK(expected == dest.data()[0]);
+    CHECK(false == nulls.data()[0]);
+
+    CHECK(true == nulls.data()[1]);
+  }
+}
+
+TEST_CASE("Uploaded Arrow Time64 units get normalized to nanos at FillChunk time", "[timeunit][.hidden]") {
+  auto tm = TableMakerForTests::Create();
+
+  std::vector<std::optional<InternalLocalTime<arrow::TimeUnit::MICRO>>> lt_micro;
+  std::vector<std::optional<InternalLocalTime<arrow::TimeUnit::NANO>>> lt_nano;
+
+  // First row: one second (in various units)
+  lt_micro.emplace_back(1'000'000);
+  lt_nano.emplace_back(1'000'000'000);
+
+  // Second row: null
+  lt_micro.emplace_back();
+  lt_nano.emplace_back();
+
+  TableMaker maker;
+  maker.AddColumn("lt_micro", lt_micro);
+  maker.AddColumn("lt_nano", lt_nano);
+  auto t = maker.MakeTable(tm.Client().GetManager());
+
+  std::cout << t.Stream(true) << '\n';
+
+  auto client_table = t.ToClientTable();
+
+  auto rs = RowSequence::CreateSequential(0, 2);
+  auto dest = LocalTimeChunk::Create(2);
+  auto nulls = BooleanChunk::Create(2);
+
+  auto expected = LocalTime::FromNanos(1'000'000'000);
+
+  for (size_t i = 0; i != client_table->NumColumns(); ++i) {
+    auto col = client_table->GetColumn(i);
+    col->FillChunk(*rs, &dest, &nulls);
+
+    CHECK(expected == dest.data()[0]);
+    CHECK(false == nulls.data()[0]);
+
+    CHECK(true == nulls.data()[1]);
+  }
+}
+}  // namespace deephaven::client::tests


### PR DESCRIPTION
This PR has adds two tests but leaves one disabled. The disabled one will fail on the main branch; that is why it is disabled.

To run all the tests, execute this command.
```
./gradlew :cpp-client:testCppClient
```

Then, if you rebase this branch onto your `nate/nightly/barrage_types` branch, you can re-enable the disabled test by editing the file `cpp-client/deephaven/tests/src/time_unit_test.cc` and removing the tag `[.hidden]`. Currently that tag is at line 75.

You should then be able to run all the unit tests with the same gradlew command above and they should all pass.
