### PR TITLE
fix: Promises in Tree subscriptions should reject if aborted

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -370,7 +370,7 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
             viewRequest.setResultViewId(ticket);
             keyTable.then(t -> {
                 if (controller.signal.aborted) {
-                    return Promise.resolve(controller.signal.reason);
+                    return Promise.reject(controller.signal.reason);
                 }
                 if (keyTableData[0].length > 0) {
                     HierarchicalTableViewKeyTableDescriptor expansions = new HierarchicalTableViewKeyTableDescriptor();
@@ -382,7 +382,7 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
                         connection.hierarchicalTableServiceClient().view(viewRequest, connection.metadata(), c::apply);
                 controller.signal.addEventListener("abort", e -> viewCreationCall.cancel());
                 return null;
-            }, error -> {
+            }).catch_(error -> {
                 c.apply(error, null);
                 return null;
             });


### PR DESCRIPTION
Noticed this bug when backporting the original fix. This fix rejects (instead of resolves) the initial view call when aborted, and correctly passes the failure off to the callback to drive the next outer promise.

Follow-up #6591