### PR TITLE
feat: DH-18493: Add Table.is_failed property

### DIFF
--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -584,6 +584,11 @@ class Table(JObjectWrapper):
         """Whether this table is a blink table."""
         return _JBlinkTableTools.isBlink(self.j_table)
 
+    @property
+    def is_failed(self) -> bool:
+        """Whether this table is in a failure state and is no longer usable."""
+        return self.j_table.isFailed()
+
     @cached_property
     def update_graph(self) -> UpdateGraph:
         """The update graph of the table."""

--- a/py/server/tests/test_barrage.py
+++ b/py/server/tests/test_barrage.py
@@ -93,7 +93,7 @@ class BarrageTestCase(BaseTestCase):
             # TODO this test is flaky because of https://github.com/deephaven/deephaven-core/issues/5416, re-enable it
             #  when the issue is fixed.
             # for _ in range(10):
-            #     if t.j_table.isFailed():
+            #     if t.is_failed():
             #         break
             #     time.sleep(1)
             # else:

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -593,12 +593,12 @@ class TableTestCase(BaseTestCase):
         t = time_table("PT0.1S").update("X = i % 2 == 0 ? i : i - 1").sort("X").tail(10)
         with update_graph.shared_lock(t):
             snapshot_hist = self.test_table.snapshot_when(t, history=True)
-            self.assertFalse(snapshot_hist.j_table.isFailed())
+            self.assertFalse(snapshot_hist.is_failed)
         self.wait_ticking_table_update(t, row_count=10, timeout=2)
         # we have not waited for a whole cycle yet, wait for the shared lock to guarantee cycle is over
         # to ensure snapshot_hist has had the opportunity to process the update we just saw
         with update_graph.shared_lock(t):
-            self.assertTrue(snapshot_hist.j_table.isFailed())
+            self.assertTrue(snapshot_hist.is_failed)
 
     def test_agg_all_by(self):
         test_table = empty_table(10)

--- a/py/server/tests/test_table_data_service.py
+++ b/py/server/tests/test_table_data_service.py
@@ -348,7 +348,7 @@ class TableDataServiceTestCase(BaseTestCase):
         with self.assertRaises(Exception) as cm:
             # failure_cb will be called in the background thread after 2 PUG cycles, 3 seconds timeout should be enough
             self.wait_ticking_table_update(table, 600, 3)
-        self.assertTrue(table.j_table.isFailed())
+        self.assertTrue(table.is_failed)
 
     def test_partition_size_sub_failure(self):
         pc_schema = pa.schema(
@@ -361,7 +361,7 @@ class TableDataServiceTestCase(BaseTestCase):
             # failure_cb will be called in the background thread after 2 PUG cycles, 3 seconds timeout should be enough
             self.wait_ticking_table_update(table, 600, 3)
 
-        self.assertTrue(table.j_table.isFailed())
+        self.assertTrue(table.is_failed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes DH-18493

This is a new property on Table. It wraps the Java Table.isFailed() method to let you check if the Table object is in a failure state and is no longer usable.