### PR TITLE
fix!: DH-18471 `update_by` min/max functions to return original-typed output columns

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
@@ -856,6 +856,8 @@ public class UpdateByOperatorFactory {
 
             if (csType == byte.class || csType == Byte.class) {
                 return new ByteCumMinMaxOperator(pair, isMax, NULL_BYTE);
+            } else if (csType == char.class || csType == Character.class) {
+                return new CharCumMinMaxOperator(pair, isMax);
             } else if (csType == short.class || csType == Short.class) {
                 return new ShortCumMinMaxOperator(pair, isMax);
             } else if (csType == int.class || csType == Integer.class) {
@@ -1033,7 +1035,7 @@ public class UpdateByOperatorFactory {
 
             return new RollingGroupOperator(pairs, affectingColumns,
                     rg.revWindowScale().timestampCol(),
-                    prevWindowScaleUnits, fwdWindowScaleUnits, tableDef);
+                    prevWindowScaleUnits, fwdWindowScaleUnits);
         }
 
         private UpdateByOperator makeRollingAvgOperator(@NotNull final MatchPair pair,
@@ -1132,7 +1134,7 @@ public class UpdateByOperatorFactory {
             } else if (csType == long.class || csType == Long.class || isTimeType(csType)) {
                 return new LongRollingMinMaxOperator(pair, affectingColumns,
                         rmm.revWindowScale().timestampCol(),
-                        prevWindowScaleUnits, fwdWindowScaleUnits, rmm.isMax());
+                        prevWindowScaleUnits, fwdWindowScaleUnits, rmm.isMax(), csType);
             } else if (csType == float.class || csType == Float.class) {
                 return new FloatRollingMinMaxOperator(pair, affectingColumns,
                         rmm.revWindowScale().timestampCol(),

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/ByteCumMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/ByteCumMinMaxOperator.java
@@ -2,7 +2,7 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 // ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY
-// ****** Edit ShortCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
+// ****** Edit CharCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
 //
 // @formatter:off
 package io.deephaven.engine.table.impl.updateby.minmax;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/CharCumMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/CharCumMinMaxOperator.java
@@ -1,31 +1,27 @@
 //
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
-// ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY
-// ****** Edit CharCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
-//
-// @formatter:off
 package io.deephaven.engine.table.impl.updateby.minmax;
 
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.Chunk;
-import io.deephaven.chunk.ShortChunk;
+import io.deephaven.chunk.CharChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.impl.MatchPair;
 import io.deephaven.engine.table.impl.updateby.UpdateByOperator;
-import io.deephaven.engine.table.impl.updateby.internal.BaseShortUpdateByOperator;
+import io.deephaven.engine.table.impl.updateby.internal.BaseCharUpdateByOperator;
 import org.jetbrains.annotations.NotNull;
 
 import static io.deephaven.util.QueryConstants.*;
 
-public class ShortCumMinMaxOperator extends BaseShortUpdateByOperator {
+public class CharCumMinMaxOperator extends BaseCharUpdateByOperator {
     private final boolean isMax;
 
     // region extra-fields
     // endregion extra-fields
 
-    protected class Context extends BaseShortUpdateByOperator.Context {
-        public ShortChunk<? extends Values> shortValueChunk;
+    protected class Context extends BaseCharUpdateByOperator.Context {
+        public CharChunk<? extends Values> charValueChunk;
 
         protected Context(final int chunkSize) {
             super(chunkSize);
@@ -33,18 +29,18 @@ public class ShortCumMinMaxOperator extends BaseShortUpdateByOperator {
 
         @Override
         public void setValueChunks(@NotNull final Chunk<? extends Values>[] valueChunks) {
-            shortValueChunk = valueChunks[0].asShortChunk();
+            charValueChunk = valueChunks[0].asCharChunk();
         }
 
         @Override
         public void push(int pos, int count) {
             Assert.eq(count, "push count", 1);
 
-            final short val = shortValueChunk.get(pos);
+            final char val = charValueChunk.get(pos);
 
-            if (curVal == NULL_SHORT) {
+            if (curVal == NULL_CHAR) {
                 curVal = val;
-            } else if (val != NULL_SHORT) {
+            } else if (val != NULL_CHAR) {
                 if ((isMax && val > curVal) ||
                         (!isMax && val < curVal)) {
                     curVal = val;
@@ -53,7 +49,7 @@ public class ShortCumMinMaxOperator extends BaseShortUpdateByOperator {
         }
     }
 
-    public ShortCumMinMaxOperator(
+    public CharCumMinMaxOperator(
             @NotNull final MatchPair pair,
             final boolean isMax
     // region extra-constructor-args
@@ -67,7 +63,7 @@ public class ShortCumMinMaxOperator extends BaseShortUpdateByOperator {
 
     @Override
     public UpdateByOperator copy() {
-        return new ShortCumMinMaxOperator(
+        return new CharCumMinMaxOperator(
                 pair,
                 isMax
         // region extra-copy-args

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/DoubleCumMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/DoubleCumMinMaxOperator.java
@@ -2,7 +2,7 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 // ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY
-// ****** Edit ShortCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
+// ****** Edit CharCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
 //
 // @formatter:off
 package io.deephaven.engine.table.impl.updateby.minmax;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/FloatCumMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/FloatCumMinMaxOperator.java
@@ -2,7 +2,7 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 // ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY
-// ****** Edit ShortCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
+// ****** Edit CharCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
 //
 // @formatter:off
 package io.deephaven.engine.table.impl.updateby.minmax;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/IntCumMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/IntCumMinMaxOperator.java
@@ -2,7 +2,7 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 // ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY
-// ****** Edit ShortCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
+// ****** Edit CharCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
 //
 // @formatter:off
 package io.deephaven.engine.table.impl.updateby.minmax;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/LongCumMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/LongCumMinMaxOperator.java
@@ -2,7 +2,7 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 // ****** AUTO-GENERATED CLASS - DO NOT EDIT MANUALLY
-// ****** Edit ShortCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
+// ****** Edit CharCumMinMaxOperator and run "./gradlew replicateUpdateBy" to regenerate
 //
 // @formatter:off
 package io.deephaven.engine.table.impl.updateby.minmax;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollinggroup/RollingGroupOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollinggroup/RollingGroupOperator.java
@@ -234,8 +234,7 @@ public class RollingGroupOperator extends UpdateByOperator {
             @NotNull final String[] affectingColumns,
             @Nullable final String timestampColumnName,
             final long reverseWindowScaleUnits,
-            final long forwardWindowScaleUnits,
-            @NotNull final TableDefinition tableDef) {
+            final long forwardWindowScaleUnits) {
         super(pairs[0], affectingColumns, timestampColumnName, reverseWindowScaleUnits, forwardWindowScaleUnits, true);
 
         this.pairs = pairs;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/ByteRollingMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/ByteRollingMinMaxOperator.java
@@ -168,4 +168,7 @@ public class ByteRollingMinMaxOperator extends BaseByteUpdateByOperator {
         // endregion extra-copy-args
         );
     }
+
+    // region extra-methods
+    // endregion extra-methods
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/CharRollingMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/CharRollingMinMaxOperator.java
@@ -164,4 +164,7 @@ public class CharRollingMinMaxOperator extends BaseCharUpdateByOperator {
         // endregion extra-copy-args
         );
     }
+
+    // region extra-methods
+    // endregion extra-methods
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/DoubleRollingMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/DoubleRollingMinMaxOperator.java
@@ -168,4 +168,7 @@ public class DoubleRollingMinMaxOperator extends BaseDoubleUpdateByOperator {
         // endregion extra-copy-args
         );
     }
+
+    // region extra-methods
+    // endregion extra-methods
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/FloatRollingMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/FloatRollingMinMaxOperator.java
@@ -168,4 +168,7 @@ public class FloatRollingMinMaxOperator extends BaseFloatUpdateByOperator {
         // endregion extra-copy-args
         );
     }
+
+    // region extra-methods
+    // endregion extra-methods
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/IntRollingMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/IntRollingMinMaxOperator.java
@@ -168,4 +168,7 @@ public class IntRollingMinMaxOperator extends BaseIntUpdateByOperator {
         // endregion extra-copy-args
         );
     }
+
+    // region extra-methods
+    // endregion extra-methods
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/ShortRollingMinMaxOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/rollingminmax/ShortRollingMinMaxOperator.java
@@ -168,4 +168,7 @@ public class ShortRollingMinMaxOperator extends BaseShortUpdateByOperator {
         // endregion extra-copy-args
         );
     }
+
+    // region extra-methods
+    // endregion extra-methods
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
@@ -253,7 +253,7 @@ public class TestCumMinMax extends BaseUpdateByTest {
                 "zdtCol=baseZDT.plusSeconds(i)",
         };
 
-        // NOTE: boolean is not supported by RollingMinMaxSpec.applicableTo()
+        // NOTE: boolean is not supported by CumMinMaxSpec.applicableTo()
         final Table source = TableTools.emptyTable(20).update(updateStrings);
 
         // Verify all the source columns are the expected types.

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestCumMinMax.java
@@ -5,44 +5,78 @@ package io.deephaven.engine.table.impl.updateby;
 
 import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.context.QueryScope;
+import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.PartitionedTable;
 import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.vectors.ColumnVectors;
 import io.deephaven.engine.testutil.ControlledUpdateGraph;
 import io.deephaven.engine.testutil.EvalNugget;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.testutil.TstUtils;
+import io.deephaven.engine.testutil.generator.CharGenerator;
 import io.deephaven.engine.testutil.generator.TestDataGenerator;
+import io.deephaven.engine.util.TableTools;
 import io.deephaven.function.Numeric;
 import io.deephaven.test.types.OutOfBandTest;
-import io.deephaven.util.type.ArrayTypeUtils;
+import io.deephaven.time.DateTimeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
 import static io.deephaven.engine.testutil.GenerateTableUpdates.generateAppends;
 import static io.deephaven.engine.testutil.testcase.RefreshingTableTestCase.simulateShiftAwareStep;
+import static io.deephaven.util.QueryConstants.NULL_CHAR;
 import static org.junit.Assert.assertArrayEquals;
 
 @Category(OutOfBandTest.class)
 public class TestCumMinMax extends BaseUpdateByTest {
+    private final int STATIC_TABLE_SIZE = 10000;
+
+    private final String[] cumMin = new String[] {
+            "byteColMin=byteCol",
+            "charColMin=charCol",
+            "shortColMin=shortCol",
+            "intColMin=intCol",
+            "longColMin=longCol",
+            "floatColMin=floatCol",
+            "doubleColMin=doubleCol",
+            "bigIntColMin=bigIntCol",
+            "bigDecimalColMin=bigDecimalCol"
+    };
+
+    private final String[] cumMax = new String[] {
+            "byteColMax=byteCol",
+            "charColMax=charCol",
+            "shortColMax=shortCol",
+            "intColMax=intCol",
+            "longColMax=longCol",
+            "floatColMax=floatCol",
+            "doubleColMax=doubleCol",
+            "bigIntColMax=bigIntCol",
+            "bigDecimalColMax=bigDecimalCol"
+    };
+
     // region Zero Key Tests
 
     @Test
     public void testStaticZeroKey() {
-        final QueryTable t = createTestTable(100000, false, false, false, 0x2134BCFA).t;
+        final QueryTable t = createTestTable(STATIC_TABLE_SIZE, false, false, false, 0x2134BCFA,
+                new String[] {"charCol"},
+                new TestDataGenerator[] {new CharGenerator('A', 'z', 0.1)}).t;
 
         final Table result = t.updateBy(List.of(
-                UpdateByOperation.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
-                        "longColMin=longCol", "floatColMin=floatCol", "doubleColMin=doubleCol",
-                        "bigIntColMin=bigIntCol", "bigDecimalColMin=bigDecimalCol"),
-                UpdateByOperation.CumMax("byteColMax=byteCol", "shortColMax=shortCol", "intColMax=intCol",
-                        "longColMax=longCol", "floatColMax=floatCol", "doubleColMax=doubleCol",
-                        "bigIntColMax=bigIntCol", "bigDecimalColMax=bigDecimalCol")));
+                UpdateByOperation.CumMin(cumMin),
+                UpdateByOperation.CumMax(cumMax)));
         for (String col : t.getDefinition().getColumnNamesArray()) {
             if ("boolCol".equals(col)) {
                 continue;
@@ -54,16 +88,13 @@ public class TestCumMinMax extends BaseUpdateByTest {
 
     @Test
     public void testStaticZeroKeyAllNulls() {
-        final QueryTable t = createTestTableAllNull(100000, false, false, false, 0x31313131,
-                ArrayTypeUtils.EMPTY_STRING_ARRAY, new TestDataGenerator[0]).t;
+        final QueryTable t = createTestTable(STATIC_TABLE_SIZE, false, false, false, 0x2134BCFA,
+                new String[] {"charCol"},
+                new TestDataGenerator[] {new CharGenerator('A', 'z', 0.1)}).t;
 
         final Table result = t.updateBy(List.of(
-                UpdateByOperation.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
-                        "longColMin=longCol", "floatColMin=floatCol", "doubleColMin=doubleCol",
-                        "bigIntColMin=bigIntCol", "bigDecimalColMin=bigDecimalCol"),
-                UpdateByOperation.CumMax("byteColMax=byteCol", "shortColMax=shortCol", "intColMax=intCol",
-                        "longColMax=longCol", "floatColMax=floatCol", "doubleColMax=doubleCol",
-                        "bigIntColMax=bigIntCol", "bigDecimalColMax=bigDecimalCol")));
+                UpdateByOperation.CumMin(cumMin),
+                UpdateByOperation.CumMax(cumMax)));
         for (String col : t.getDefinition().getColumnNamesArray()) {
             if ("boolCol".equals(col)) {
                 continue;
@@ -92,15 +123,13 @@ public class TestCumMinMax extends BaseUpdateByTest {
     }
 
     private void doTestStaticBucketed(boolean grouped) {
-        final QueryTable t = createTestTable(100000, true, grouped, false, 0xACDB4321).t;
+        final QueryTable t = createTestTable(STATIC_TABLE_SIZE, true, grouped, false, 0xACDB4321,
+                new String[] {"charCol"},
+                new TestDataGenerator[] {new CharGenerator('A', 'z', 0.1)}).t;
 
         final Table result = t.updateBy(List.of(
-                UpdateByOperation.CumMin("byteColMin=byteCol", "shortColMin=shortCol", "intColMin=intCol",
-                        "longColMin=longCol", "floatColMin=floatCol", "doubleColMin=doubleCol",
-                        "bigIntColMin=bigIntCol", "bigDecimalColMin=bigDecimalCol"),
-                UpdateByOperation.CumMax("byteColMax=byteCol", "shortColMax=shortCol", "intColMax=intCol",
-                        "longColMax=longCol", "floatColMax=floatCol", "doubleColMax=doubleCol",
-                        "bigIntColMax=bigIntCol", "bigDecimalColMax=bigDecimalCol")),
+                UpdateByOperation.CumMin(cumMin),
+                UpdateByOperation.CumMax(cumMax)),
                 "Sym");
 
         final PartitionedTable preOp = t.partitionBy("Sym");
@@ -147,7 +176,9 @@ public class TestCumMinMax extends BaseUpdateByTest {
     }
 
     private void doTestTicking(boolean bucketed, boolean appendOnly) {
-        final CreateResult result = createTestTable(10000, bucketed, false, true, 0x31313131);
+        final CreateResult result = createTestTable(10000, bucketed, false, true, 0x31313131,
+                new String[] {"charCol"},
+                new TestDataGenerator[] {new CharGenerator('A', 'z', 0.1)});
         final QueryTable t = result.t;
 
         if (appendOnly) {
@@ -183,6 +214,129 @@ public class TestCumMinMax extends BaseUpdateByTest {
         }
     }
     // endregion
+
+    @Test
+    public void testResultDataTypes() {
+        final Instant baseInstant = DateTimeUtils.parseInstant("2023-01-01T00:00:00 NY");
+        final ZoneId zone = ZoneId.of("America/Los_Angeles");
+
+        QueryScope.addParam("baseInstant", baseInstant);
+        QueryScope.addParam("baseLDT", LocalDateTime.ofInstant(baseInstant, zone));
+        QueryScope.addParam("baseZDT", baseInstant.atZone(zone));
+
+        final TableDefinition expectedDefinition = TableDefinition.of(
+                ColumnDefinition.ofByte("byteCol"),
+                ColumnDefinition.ofChar("charCol"),
+                ColumnDefinition.ofShort("shortCol"),
+                ColumnDefinition.ofInt("intCol"),
+                ColumnDefinition.ofLong("longCol"),
+                ColumnDefinition.ofFloat("floatCol"),
+                ColumnDefinition.ofDouble("doubleCol"),
+                ColumnDefinition.ofString("stringCol"),
+                ColumnDefinition.fromGenericType("instantCol", Instant.class),
+                ColumnDefinition.fromGenericType("ldtCol", LocalDateTime.class),
+                ColumnDefinition.fromGenericType("zdtCol", ZonedDateTime.class));
+
+        final String[] columnNames = expectedDefinition.getColumnNamesArray();
+
+        final String[] updateStrings = new String[] {
+                "byteCol=(byte)i",
+                "charCol=(char)(i + 64)",
+                "shortCol=(short)i",
+                "intCol=i",
+                "longCol=ii",
+                "floatCol=(float)ii",
+                "doubleCol=(double)ii",
+                "stringCol=String.valueOf(i)",
+                "instantCol=baseInstant.plusSeconds(i)",
+                "ldtCol=baseLDT.plusSeconds(i)",
+                "zdtCol=baseZDT.plusSeconds(i)",
+        };
+
+        // NOTE: boolean is not supported by RollingMinMaxSpec.applicableTo()
+        final Table source = TableTools.emptyTable(20).update(updateStrings);
+
+        // Verify all the source columns are the expected types.
+        source.getDefinition().checkCompatibility(expectedDefinition);
+
+        final Table expected = source.updateBy(UpdateByOperation.CumMin(columnNames));
+
+        // Verify all the result columns are the expected types.
+        expected.getDefinition().checkCompatibility(expectedDefinition);
+    }
+
+    @Test
+    public void testProxy() {
+        final QueryTable t = createTestTable(STATIC_TABLE_SIZE, true, false, false, 0x31313131,
+                new String[] {"charCol"},
+                new TestDataGenerator[] {new CharGenerator('A', 'z', 0.1)}).t;
+
+        Table actual;
+        Table expected;
+
+        PartitionedTable pt = t.partitionBy("Sym");
+        actual = pt.proxy()
+                .updateBy(UpdateByOperation.CumMin())
+                .target().merge().sort("Sym");
+        expected = t.sort("Sym").updateBy(UpdateByOperation.CumMin(), "Sym");
+        TstUtils.assertTableEquals(expected, actual);
+
+        actual = pt.proxy()
+                .updateBy(UpdateByOperation.CumMax())
+                .target().merge().sort("Sym");
+        expected = t.sort("Sym").updateBy(UpdateByOperation.CumMax(), "Sym");
+        TstUtils.assertTableEquals(expected, actual);
+    }
+
+    public static char[] cumMin(char... values) {
+        if (values == null) {
+            return null;
+        }
+
+        if (values.length == 0) {
+            return new char[0];
+        }
+
+        char[] result = new char[values.length];
+        result[0] = values[0];
+
+        for (int i = 1; i < values.length; i++) {
+            if (result[i - 1] == NULL_CHAR) {
+                result[i] = values[i];
+            } else if (values[i] == NULL_CHAR) {
+                result[i] = result[i - 1];
+            } else {
+                result[i] = values[i] < result[i - 1] ? values[i] : result[i - 1];
+            }
+        }
+
+        return result;
+    }
+
+    public static char[] cumMax(char... values) {
+        if (values == null) {
+            return null;
+        }
+
+        if (values.length == 0) {
+            return new char[0];
+        }
+
+        char[] result = new char[values.length];
+        result[0] = values[0];
+
+        for (int i = 1; i < values.length; i++) {
+            if (result[i - 1] == NULL_CHAR) {
+                result[i] = values[i];
+            } else if (values[i] == NULL_CHAR) {
+                result[i] = result[i - 1];
+            } else {
+                result[i] = values[i] > result[i - 1] ? values[i] : result[i - 1];
+            }
+        }
+
+        return result;
+    }
 
     public static Object[] cumMin(Object... values) {
         if (values == null) {
@@ -237,6 +391,8 @@ public class TestCumMinMax extends BaseUpdateByTest {
     final void assertWithCumMin(@NotNull final Object expected, @NotNull final Object actual) {
         if (expected instanceof byte[]) {
             assertArrayEquals(Numeric.cummin((byte[]) expected), (byte[]) actual);
+        } else if (expected instanceof char[]) {
+            assertArrayEquals(cumMin((char[]) expected), (char[]) actual);
         } else if (expected instanceof short[]) {
             assertArrayEquals(Numeric.cummin((short[]) expected), (short[]) actual);
         } else if (expected instanceof int[]) {
@@ -255,6 +411,8 @@ public class TestCumMinMax extends BaseUpdateByTest {
     final void assertWithCumMax(@NotNull final Object expected, @NotNull final Object actual) {
         if (expected instanceof byte[]) {
             assertArrayEquals(Numeric.cummax((byte[]) expected), (byte[]) actual);
+        } else if (expected instanceof char[]) {
+            assertArrayEquals(cumMax((char[]) expected), (char[]) actual);
         } else if (expected instanceof short[]) {
             assertArrayEquals(Numeric.cummax((short[]) expected), (short[]) actual);
         } else if (expected instanceof int[]) {

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateUpdateBy.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateUpdateBy.java
@@ -87,9 +87,10 @@ public class ReplicateUpdateBy {
         ReplicatePrimitiveCode.floatToAllFloatingPoints(TASK,
                 "engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/sum/FloatCumSumOperator.java");
 
-        files = ReplicatePrimitiveCode.shortToAllNumericals(TASK,
-                "engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/ShortCumMinMaxOperator.java",
-                null);
+
+        files = ReplicatePrimitiveCode.charToAllButBoolean(TASK,
+                "engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/minmax/CharCumMinMaxOperator.java",
+                exemptions);
         for (final String f : files) {
             if (f.contains("Integer")) {
                 fixupInteger(f);
@@ -141,6 +142,9 @@ public class ReplicateUpdateBy {
                 fixupInteger(f);
             } else if (f.contains("Float") || f.contains("Double")) {
                 fixupFloatDoubleMinMax(f);
+            }
+            if (f.contains("Long")) {
+                augmentLongWithReinterps(f);
             }
         }
 

--- a/table-api/src/main/java/io/deephaven/api/updateby/spec/CumMinMaxSpec.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/spec/CumMinMaxSpec.java
@@ -25,7 +25,7 @@ public abstract class CumMinMaxSpec extends UpdateBySpecBase {
         return
         // is primitive or boxed numeric?
         applicableToNumeric(inputType)
-
+                || inputType == char.class || inputType == Character.class
                 // is comparable?
                 || (Comparable.class.isAssignableFrom(inputType) && inputType != Boolean.class);
     }


### PR DESCRIPTION
Add'l work performed:

- Added `char` support to `CumMin`/`CumMax` and expanded tests
- Added PartionedTable proxy tests