### PR TITLE
fix: DH-18472 correct the ordering of result columns in `update_by`

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -1392,13 +1392,24 @@ public abstract class UpdateBy {
 
         final Map<String, ColumnSource<?>> resultSources = new LinkedHashMap<>(source.getColumnSourceMap());
 
-        // We have the source table and the row redirection; we can initialize the operators and add the output
-        // columns to the result sources
+        final Map<String, ColumnSource<?>> unorderedResultSources = new HashMap<>();
+        // We have the source table and the row redirection; we can initialize the operators and collect the output
+        // columns.
         for (UpdateByWindow win : operatorCollection.windowArr) {
             for (UpdateByOperator op : win.operators) {
                 op.initializeSources(source, rowRedirection);
-                resultSources.putAll(op.getOutputColumns());
+                unorderedResultSources.putAll(op.getOutputColumns());
             }
+        }
+
+        // Add the output result sources to the table column map in the order specified by the updateBy call.
+        for (String outputColumnName : operatorCollection.outputColumnNames) {
+            final ColumnSource<?> cs = unorderedResultSources.get(outputColumnName);
+            if (cs == null) {
+                throw new IllegalStateException(
+                        "Requested output column '" + outputColumnName + "' was not found in operator output");
+            }
+            resultSources.put(outputColumnName, cs);
         }
 
         if (operatorCollection.byColumnNames.length == 0) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
@@ -212,6 +212,20 @@ public class UpdateByOperatorFactory {
         @Override
         public Void visit(@NotNull final ColumnUpdateOperation clause) {
             final UpdateBySpec spec = clause.spec();
+            // Need to handle some specs uniquely
+            if (spec instanceof CumCountWhereSpec) {
+                outputColumns.add(((CumCountWhereSpec) spec).column().name());
+                return null;
+            }
+            if (spec instanceof RollingCountWhereSpec) {
+                outputColumns.add(((RollingCountWhereSpec) spec).column().name());
+                return null;
+            }
+            if (spec instanceof RollingFormulaSpec && ((RollingFormulaSpec) spec).paramToken().isEmpty()) {
+                // The presence of the paramToken indicates that this is a multi-column formula and we have a single
+                // output column in #selectable()
+                outputColumns.add(((RollingFormulaSpec) spec).selectable().newColumn().name());
+            }
             final MatchPair[] pairs =
                     createColumnsToAddIfMissing(tableDef, parseMatchPairs(clause.columns()), spec, groupByColumns);
             for (MatchPair pair : pairs) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByOperatorFactory.java
@@ -225,6 +225,7 @@ public class UpdateByOperatorFactory {
                 // The presence of the paramToken indicates that this is a multi-column formula and we have a single
                 // output column in #selectable()
                 outputColumns.add(((RollingFormulaSpec) spec).selectable().newColumn().name());
+                return null;
             }
             final MatchPair[] pairs =
                     createColumnsToAddIfMissing(tableDef, parseMatchPairs(clause.columns()), spec, groupByColumns);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
@@ -8,11 +8,11 @@ import io.deephaven.api.updateby.BadDataBehavior;
 import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.context.ExecutionContext;
-import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.UpdateErrorReporter;
 import io.deephaven.engine.table.impl.util.AsyncClientErrorNotifier;
+import io.deephaven.engine.table.impl.util.ColumnHolder;
 import io.deephaven.engine.testutil.ControlledUpdateGraph;
 import io.deephaven.engine.testutil.EvalNugget;
 import io.deephaven.engine.table.impl.TableDefaults;
@@ -38,8 +38,7 @@ import org.junit.experimental.categories.Category;
 import java.time.Duration;
 import java.util.*;
 
-import static io.deephaven.api.updateby.UpdateByOperation.CumMax;
-import static io.deephaven.api.updateby.UpdateByOperation.RollingMax;
+import static io.deephaven.api.updateby.UpdateByOperation.*;
 import static io.deephaven.engine.testutil.GenerateTableUpdates.generateAppends;
 import static io.deephaven.engine.testutil.TstUtils.*;
 import static io.deephaven.engine.testutil.testcase.RefreshingTableTestCase.simulateShiftAwareStep;
@@ -157,7 +156,7 @@ public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateError
                                 UpdateByOperation.Ema(skipControl, "ts", 10 * MINUTE,
                                         makeOpColNames(columnNamesArray, "_ema", "Sym", "ts", "boolCol")),
                                 UpdateByOperation.CumSum(makeOpColNames(columnNamesArray, "_sum", "Sym", "ts")),
-                                UpdateByOperation.CumMin(makeOpColNames(columnNamesArray, "_min", "boolCol")),
+                                CumMin(makeOpColNames(columnNamesArray, "_min", "boolCol")),
                                 CumMax(makeOpColNames(columnNamesArray, "_max", "boolCol")),
                                 UpdateByOperation
                                         .CumProd(makeOpColNames(columnNamesArray, "_prod", "Sym", "ts", "boolCol")));
@@ -275,24 +274,24 @@ public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateError
         final Collection<? extends UpdateByOperation> clauses = List.of(
                 UpdateByOperation.Fill(),
 
-                UpdateByOperation.RollingGroup(50, 50,
+                RollingGroup(50, 50,
                         makeOpColNames(columnNamesArray, "_rollgroupfwdrev", "Sym", "ts")),
-                UpdateByOperation.RollingGroup("ts", Duration.ofMinutes(5), Duration.ofMinutes(5),
+                RollingGroup("ts", Duration.ofMinutes(5), Duration.ofMinutes(5),
                         makeOpColNames(columnNamesArray, "_rollgrouptimefwdrev", "Sym", "ts")),
 
-                UpdateByOperation.RollingSum(100, 0,
+                RollingSum(100, 0,
                         makeOpColNames(columnNamesArray, "_rollsumticksrev", "Sym", "ts", "boolCol")),
-                UpdateByOperation.RollingSum("ts", Duration.ofMinutes(15), Duration.ofMinutes(0),
+                RollingSum("ts", Duration.ofMinutes(15), Duration.ofMinutes(0),
                         makeOpColNames(columnNamesArray, "_rollsumtimerev", "Sym", "ts", "boolCol")),
 
-                UpdateByOperation.RollingAvg(100, 0,
+                RollingAvg(100, 0,
                         makeOpColNames(columnNamesArray, "_rollavgticksrev", "Sym", "ts", "boolCol")),
-                UpdateByOperation.RollingAvg("ts", Duration.ofMinutes(15), Duration.ofMinutes(0),
+                RollingAvg("ts", Duration.ofMinutes(15), Duration.ofMinutes(0),
                         makeOpColNames(columnNamesArray, "_rollavgtimerev", "Sym", "ts", "boolCol")),
 
-                UpdateByOperation.RollingMin(100, 0,
+                RollingMin(100, 0,
                         makeOpColNames(columnNamesArray, "_rollminticksrev", "Sym", "ts", "boolCol")),
-                UpdateByOperation.RollingMin("ts", Duration.ofMinutes(5), Duration.ofMinutes(0),
+                RollingMin("ts", Duration.ofMinutes(5), Duration.ofMinutes(0),
                         makeOpColNames(columnNamesArray, "_rollmintimerev", "Sym", "ts", "boolCol")),
 
                 RollingMax(100, 0,
@@ -300,13 +299,11 @@ public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateError
                 RollingMax("ts", Duration.ofMinutes(5), Duration.ofMinutes(0),
                         makeOpColNames(columnNamesArray, "_rollmaxtimerev", "Sym", "ts", "boolCol")),
 
-                UpdateByOperation.Ema(skipControl, "ts", 10 * MINUTE,
-                        makeOpColNames(columnNamesArray, "_ema", "Sym", "ts", "boolCol")),
-                UpdateByOperation.CumSum(makeOpColNames(columnNamesArray, "_sum", "Sym", "ts")),
-                UpdateByOperation.CumMin(makeOpColNames(columnNamesArray, "_min", "boolCol")),
+                Ema(skipControl, "ts", 10 * MINUTE, makeOpColNames(columnNamesArray, "_ema", "Sym", "ts", "boolCol")),
+                CumSum(makeOpColNames(columnNamesArray, "_sum", "Sym", "ts")),
+                CumMin(makeOpColNames(columnNamesArray, "_min", "boolCol")),
                 CumMax(makeOpColNames(columnNamesArray, "_max", "boolCol")),
-                UpdateByOperation
-                        .CumProd(makeOpColNames(columnNamesArray, "_prod", "Sym", "ts", "boolCol")));
+                CumProd(makeOpColNames(columnNamesArray, "_prod", "Sym", "ts", "boolCol")));
         final UpdateByControl control = UpdateByControl.builder().useRedirection(false).build();
 
         final Table table = result.t.updateBy(control, clauses, ColumnName.from("Sym"));
@@ -328,19 +325,73 @@ public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateError
 
     @Test
     public void testResultColumnOrdering() {
-        QueryScope.addParam("baseTime", DateTimeUtils.parseInstant("2022-03-09T09:00:00.000 NY"));
-        final Table source = emptyTable(10).update("Timestamp = baseTime + i * SECOND", "X = ii % 10");
+        final Table source = emptyTable(5).update("X=ii");
+
+        final ColumnHolder<?> x = longCol("X", 0, 1, 2, 3, 4);
+        final ColumnHolder<?> cumMin = longCol("cumMin", 0, 0, 0, 0, 0);
+        final ColumnHolder<?> cumMax = longCol("cumMax", 0, 1, 2, 3, 4);
+        final ColumnHolder<?> rollingMin = longCol("rollingMin", 0, 0, 1, 2, 3);
+        final ColumnHolder<?> rollingMax = longCol("rollingMax", 0, 1, 2, 3, 4);
 
         final Table result_1 = source.updateBy(List.of(
-                CumMax("cumMaxTime=Timestamp"),
-                RollingMax(20, "rollingMaxTime=Timestamp")), "X");
-        Assert.assertArrayEquals(result_1.getDefinition().getColumnNamesArray(),
-                new String[] {"Timestamp", "X", "cumMaxTime", "rollingMaxTime"});
+                CumMin("cumMin=X"),
+                CumMax("cumMax=X"),
+                RollingMin(2, "rollingMin=X"),
+                RollingMax(2, "rollingMax=X")));
+        final Table expected_1 = TableTools.newTable(x, cumMin, cumMax, rollingMin, rollingMax);
+        Assert.assertEquals("", diff(result_1, expected_1, 10));
 
         final Table result_2 = source.updateBy(List.of(
-                RollingMax(20, "rollingMaxTime=Timestamp"),
-                CumMax("cumMaxTime=Timestamp")), "X");
-        Assert.assertArrayEquals(result_2.getDefinition().getColumnNamesArray(),
-                new String[] {"Timestamp", "X", "rollingMaxTime", "cumMaxTime"});
+                CumMax("cumMax=X"),
+                CumMin("cumMin=X"),
+                RollingMax(2, "rollingMax=X"),
+                RollingMin(2, "rollingMin=X")));
+        final Table expected_2 = TableTools.newTable(x, cumMax, cumMin, rollingMax, rollingMin);
+        Assert.assertEquals("", diff(result_2, expected_2, 10));
+
+        final Table result_3 = source.updateBy(List.of(
+                RollingMin(2, "rollingMin=X"),
+                RollingMax(2, "rollingMax=X"),
+                CumMin("cumMin=X"),
+                CumMax("cumMax=X")));
+        final Table expected_3 = TableTools.newTable(x, rollingMin, rollingMax, cumMin, cumMax);
+        Assert.assertEquals("", diff(result_3, expected_3, 10));
+
+        final Table result_4 = source.updateBy(List.of(
+                RollingMax(2, "rollingMax=X"),
+                RollingMin(2, "rollingMin=X"),
+                CumMax("cumMax=X"),
+                CumMin("cumMin=X")));
+        final Table expected_4 = TableTools.newTable(x, rollingMax, rollingMin, cumMax, cumMin);
+        Assert.assertEquals("", diff(result_4, expected_4, 10));
+
+        final Table result_5 = source.updateBy(List.of(
+                CumMin("cumMin=X"),
+                RollingMin(2, "rollingMin=X"),
+                CumMax("cumMax=X"),
+                RollingMax(2, "rollingMax=X")));
+        final Table expected_5 = TableTools.newTable(x, cumMin, rollingMin, cumMax, rollingMax);
+        Assert.assertEquals("", diff(result_5, expected_5, 10));
+
+        // Trickiest one, since we internally combine groupBy operations.
+        final Table source_2 = source.update("Y=ii % 2");
+        final Table result_6 = source_2.updateBy(List.of(
+                CumMin("cumMin=X"),
+                RollingGroup(2, "rollingGroupY=Y"),
+                RollingMin(2, "rollingMin=X"),
+                CumMax("cumMax=X"),
+                RollingGroup(2, "rollingGroupX=X"),
+                RollingMax(2, "rollingMax=X")));
+
+        Assert.assertArrayEquals(result_6.getDefinition().getColumnNamesArray(),
+                new String[] {
+                        "X",
+                        "Y",
+                        "cumMin",
+                        "rollingGroupY",
+                        "rollingMin",
+                        "cumMax",
+                        "rollingGroupX",
+                        "rollingMax"});
     }
 }

--- a/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpecBase.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpecBase.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 public abstract class UpdateBySpecBase implements UpdateBySpec {
 
+
     @Override
     public final ColumnUpdateOperation clause(String pair) {
         return clause(Pair.parse(pair));

--- a/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpecBase.java
+++ b/table-api/src/main/java/io/deephaven/api/updateby/spec/UpdateBySpecBase.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 public abstract class UpdateBySpecBase implements UpdateBySpec {
 
-
     @Override
     public final ColumnUpdateOperation clause(String pair) {
         return clause(Pair.parse(pair));


### PR DESCRIPTION
Previously:

![image](https://github.com/user-attachments/assets/1a3b21d3-5d2c-4a5b-9d21-2d2972c23dd9)

After the change:

<img width="1817" alt="image" src="https://github.com/user-attachments/assets/8456e9a6-f0d9-4854-a0e6-6ed71f64a37b" />

