### PR TITLE
build: Code Coverage for Nightly Build Workflows

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -7,20 +7,22 @@ on:
     # 2AM EST == 6AM UTC
     - cron:  '0 6 * * *'
   push:
-    branches: [ 'nightly/**', 'release/v*', 'dependabot/**' ]
+    branches: [ 'nightly/**', 'release/v*', 'dependabot/**', 'coverage/**']
 
 jobs:
   nightly:
     strategy:
       fail-fast: false
       matrix:
-        gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
+        gradle-task: ['check', 'testSerial']
         test-jvm-version: ['11', '17', '21', '23']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
     concurrency:
       group: ${{ matrix.gradle-task }}-${{ matrix.test-jvm-version }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      do-coverage: ${{ github.event_name == 'schedule' || startsWith(github.ref_name, 'coverage/') && matrix.test-jvm-version == '21' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,7 +69,20 @@ jobs:
           cat gradle.properties
 
       - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}
+        if: ${{ ! env.do-coverage }}
         run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
+
+      - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}
+        if: ${{ env.do-coverage }}
+        run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }} -Pcoverage.enabled=true
+        
+      - name: Upload Coverage Results
+        if: ${{ env.do-coverage }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.gradle-task }}-results
+          path: |
+            **/build/jacoco/*.exec
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
@@ -111,3 +126,56 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
+          
+  combined-coverage-report:
+    needs: nightly
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Download Coverage Results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*-results
+          merge-multiple: true
+
+      - name: Setup JDK 17
+        id: setup-java-17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup JDK 11
+        id: setup-java-11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set JAVA_HOME
+        run: echo "JAVA_HOME=${{ steps.setup-java-11.outputs.path }}" >> $GITHUB_ENV
+
+      - name: Setup gradle properties
+        run: |
+          .github/scripts/gradle-properties.sh >> gradle.properties
+          cat gradle.properties
+          
+      - name: Run gradle ${{ matrix.gradle-task }}
+        run: |
+          ./gradlew --scan --continue -Pcoverage.enabled=true jacocoTestReport
+          ./gradlew --scan --continue -Pcoverage.enabled=true coverage-merge
+          
+      - name: Upload Combined Coverage Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined-coverage-results
+          path: |
+            coverage/build/reports/jacoco/**
+            coverage/build/reports/coverage/**

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -22,7 +22,7 @@ jobs:
       group: ${{ matrix.gradle-task }}-${{ matrix.test-jvm-version }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     env:
-      iscoverage: ${{ (github.event_name == 'schedule' || startsWith(github.ref_name, 'coverage/')) && matrix.test-jvm-version == '21' }}
+      COVER: ${{ (github.event_name == 'schedule' || startsWith(github.ref_name, 'coverage/')) && matrix.test-jvm-version == '21' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,16 +68,11 @@ jobs:
           .github/scripts/gradle-properties.sh >> gradle.properties
           cat gradle.properties
 
-      - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}
-        if: ${{ ! env.iscoverage }}
-        run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
-
-      - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }} with coverage
-        if: ${{ env.iscoverage }}
-        run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }} -Pcoverage.enabled=true
+      - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }} with coverage=${{ env.COVER }}
+        run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }} -Pcoverage.enabled=$COVER
         
       - name: Upload Coverage Results
-        if: ${{ env.iscoverage }}
+        if: ${{ env.COVER == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.gradle-task }}-results

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Run gradle ${{ matrix.gradle-task }}
         run: |
           ./gradlew -Pcoverage.enabled=true jacocoTestReport
-          ./gradlew -Pcoverage.enabled=true coverage-merge
+          ./gradlew -Pcoverage.enabled=true coverage:coverage-merge
           
       - name: Upload Combined Coverage Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle-task: ['check', 'testSerial']
+        gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
         test-jvm-version: ['11', '17', '21', '23']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
@@ -67,10 +67,6 @@ jobs:
         run: |
           .github/scripts/gradle-properties.sh >> gradle.properties
           cat gradle.properties
-          
-      - name: Fail On JVM 17 Check
-        if: ${{ matrix.test-jvm-version == '17' &&  matrix.gradle-task == 'check' }}
-        run: boguscommand
 
       - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }} with coverage=${{ env.COVER }}
         run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }} -Pcoverage.enabled=$COVER

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
+        gradle-task: ['check', 'testSerial']
         test-jvm-version: ['11', '17', '21', '23']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
@@ -67,6 +67,10 @@ jobs:
         run: |
           .github/scripts/gradle-properties.sh >> gradle.properties
           cat gradle.properties
+          
+      - name: Fail On JVM 17 Check
+        if: ${{ matrix.test-jvm-version == '17' &&  matrix.gradle-task == 'check' }}
+        run: boguscommand
 
       - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }} with coverage=${{ env.COVER }}
         run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }} -Pcoverage.enabled=$COVER
@@ -165,8 +169,8 @@ jobs:
           
       - name: Run gradle ${{ matrix.gradle-task }}
         run: |
-          ./gradlew --scan --continue -Pcoverage.enabled=true jacocoTestReport
-          ./gradlew --scan --continue -Pcoverage.enabled=true coverage-merge
+          ./gradlew -Pcoverage.enabled=true jacocoTestReport
+          ./gradlew -Pcoverage.enabled=true coverage-merge
           
       - name: Upload Combined Coverage Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle-task: ['check', 'testSerial']
+        gradle-task: ['check', 'testSerial', 'testParallel', 'testOutOfBand']
         test-jvm-version: ['11', '17', '21', '23']
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -22,7 +22,7 @@ jobs:
       group: ${{ matrix.gradle-task }}-${{ matrix.test-jvm-version }}-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     env:
-      do-coverage: ${{ github.event_name == 'schedule' || startsWith(github.ref_name, 'coverage/') && matrix.test-jvm-version == '21' }}
+      iscoverage: ${{ (github.event_name == 'schedule' || startsWith(github.ref_name, 'coverage/')) && matrix.test-jvm-version == '21' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,15 +69,15 @@ jobs:
           cat gradle.properties
 
       - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}
-        if: ${{ ! env.do-coverage }}
+        if: ${{ ! env.iscoverage }}
         run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }}
 
-      - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }}
-        if: ${{ env.do-coverage }}
+      - name: Run gradle ${{ matrix.gradle-task }} on java ${{ matrix.test-jvm-version }} with coverage
+        if: ${{ env.iscoverage }}
         run: ./gradlew --scan --continue --rerun-tasks ${{ matrix.gradle-task }} -PtestRuntimeVersion=${{ matrix.test-jvm-version }} -Pcoverage.enabled=true
         
       - name: Upload Coverage Results
-        if: ${{ env.do-coverage }}
+        if: ${{ env.iscoverage }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.gradle-task }}-results

--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -123,6 +123,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_FAILURE }}
           
   combined-coverage-report:
+    if: ${{ github.event_name == 'schedule' || startsWith(github.ref_name, 'coverage/') }}
     needs: nightly
     runs-on: ubuntu-24.04
     steps:
@@ -137,12 +138,12 @@ jobs:
           pattern: coverage-*-results
           merge-multiple: true
 
-      - name: Setup JDK 17
-        id: setup-java-17
+      - name: Setup JDK 21
+        id: setup-java-21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Setup JDK 11
         id: setup-java-11

--- a/coverage/gather-coverage.py
+++ b/coverage/gather-coverage.py
@@ -19,16 +19,17 @@ if os.path.exists(coverage_dir):
 os.makedirs(coverage_dir)
 
 # Aggregate and normalize coverage for java projects
+print("Aggregating Java Coverage")
 input_glob = proj_root_dir + '/build/reports/jacoco/jacoco-merge/jacoco-merge.csv'
 with open(f'{coverage_dir}/java-coverage.csv', 'w', newline='') as outfile:
     csv_writer = csv.writer(outfile)
-    csv_writer.writerow(['Language','Project','Package','Class','Missed','Covered'])
+    csv_writer.writerow(['Language','Package','Class','Missed','Covered'])
     for filename in glob.glob(input_glob, recursive = True):
         with open(filename, 'r') as csv_in:
             csv_reader = csv.reader(csv_in)
             next(csv_reader, None)
             for row in csv_reader:
-                new_row = ['java',row[0],row[1],row[2],row[3],row[4]]
+                new_row = ['java',row[1],row[2],row[3],row[4]]
                 csv_writer.writerow(new_row)
 
 # Load packages to be excluded from the aggregated coverage CSV
@@ -39,8 +40,10 @@ with open(exclude_path) as f:
 with open(coverage_output_path, 'w', newline='') as outfile:
     csv_writer = csv.writer(outfile)
     for csv_file in glob.glob(coverage_input_glob):
+        if os.path.basename(csv_file) == "all-coverage.csv": continue
+        print('Merging', os.path.basename(csv_file))
         with open(csv_file, 'r') as csv_in:
             for row in csv.reader(csv_in):
-                if row[2] in excludes: continue
-                new_row = [row[0],row[1],row[2],row[3],row[4],row[5]]
+                if row[1] in excludes: continue
+                new_row = [row[0],row[1],row[2],row[3],row[4]]
                 csv_writer.writerow(new_row)


### PR DESCRIPTION
Added java coverage to the Nightly Check CI according to the following contract:
- Coverage only runs on JVM 21
- Coverage runs on a schedule for any main repo branch
- Coverage runs On Push on any branch (including forks) that starts with "coverage/"
- Coverage is collected from separate jobs into a combined report uploaded as an Github artifact
