### PR TITLE
test: Restore old behavior of timeout per script line

### DIFF
--- a/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
@@ -33,8 +33,8 @@ public class ChartDataTestGwt extends AbstractAsyncGwtTestCase {
                     "my_col_defs = {\"ID\": dht.int32, \"Value\": dht.string, \"Deleted\": dht.bool_}",
                     "ug = jpy.get_type('io.deephaven.engine.updategraph.impl.EventDrivenUpdateGraph').newBuilder('test').existingOrBuild()",
                     "exec_ctx = ExecutionContext(get_exec_ctx().j_object.withUpdateGraph(ug))",
-                    "with exec_ctx:",
-                    "    input = input_table(col_defs=my_col_defs, key_cols=\"ID\")",
+                    "with exec_ctx:\n" +
+                    "    input = input_table(col_defs=my_col_defs, key_cols=\"ID\")\n" +
                     "    result = input.without_attributes('InputTable').where(\"!Deleted\").sort(\"ID\")");
 
     @Override

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/ChartDataTestGwt.java
@@ -34,8 +34,8 @@ public class ChartDataTestGwt extends AbstractAsyncGwtTestCase {
                     "ug = jpy.get_type('io.deephaven.engine.updategraph.impl.EventDrivenUpdateGraph').newBuilder('test').existingOrBuild()",
                     "exec_ctx = ExecutionContext(get_exec_ctx().j_object.withUpdateGraph(ug))",
                     "with exec_ctx:\n" +
-                    "    input = input_table(col_defs=my_col_defs, key_cols=\"ID\")\n" +
-                    "    result = input.without_attributes('InputTable').where(\"!Deleted\").sort(\"ID\")");
+                            "    input = input_table(col_defs=my_col_defs, key_cols=\"ID\")\n" +
+                            "    result = input.without_attributes('InputTable').where(\"!Deleted\").sort(\"ID\")");
 
     @Override
     public String getModuleName() {


### PR DESCRIPTION
Effectively increases the timeout for each command run - multiline commands must be explicitly declared as such.

Follow-up DH-18632