### PR TITLE
fix: DH-18803: Add qst Type find support for componentType

### DIFF
--- a/engine/sql/src/main/java/io/deephaven/engine/sql/Sql.java
+++ b/engine/sql/src/main/java/io/deephaven/engine/sql/Sql.java
@@ -109,7 +109,7 @@ public final class Sql {
     }
 
     private static ColumnHeader<?> adapt(ColumnDefinition<?> columnDef) {
-        return ColumnHeader.of(columnDef.getName(), Type.find(columnDef.getDataType()));
+        return ColumnHeader.of(columnDef.getName(), Type.find(columnDef.getDataType(), columnDef.getComponentType()));
     }
 
     private enum ToGraphvizDot implements ObjFormatter<TableSpec> {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/util/PartitionParser.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/util/PartitionParser.java
@@ -195,9 +195,11 @@ public enum PartitionParser {
     @Nullable
     public static PartitionParser lookup(@NotNull final Class<?> dataType, @Nullable final Class<?> componentType) {
         if (componentType != null) {
+            // This is a short-circuit since we know that Resolver does not support ArrayType.
             return null;
         }
-        return lookup(Type.find(dataType));
+        // noinspection ConstantValue
+        return lookup(Type.find(dataType, componentType));
     }
 
     /**
@@ -289,6 +291,8 @@ public enum PartitionParser {
 
         @Override
         public PartitionParser visit(@NotNull final ArrayType<?, ?> arrayType) {
+            // If the partition parser ever supports ArrayTypes, make sure the short-circuit in
+            // PartitionParser.lookup(java.lang.Class<?>, java.lang.Class<?>) is removed.
             return null;
         }
 

--- a/engine/table/src/test/java/io/deephaven/qst/type/GenericVectorTest.java
+++ b/engine/table/src/test/java/io/deephaven/qst/type/GenericVectorTest.java
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.qst.type;
+
+import io.deephaven.vector.ObjectVector;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericVectorTest {
+
+    @Test
+    public void stringType() throws ClassNotFoundException {
+        testConstruction(GenericVectorType.of(ObjectVector.class, Type.stringType()));
+    }
+
+    @Test
+    public void instantType() throws ClassNotFoundException {
+        testConstruction(GenericVectorType.of(ObjectVector.class, Type.instantType()));
+    }
+
+    private static <ComponentType> void testConstruction(GenericVectorType<?, ComponentType> vectorType)
+            throws ClassNotFoundException {
+        assertThat(Type.find(vectorType.clazz(), vectorType.componentType().clazz())).isEqualTo(vectorType);
+        assertThat(GenericVectorType.of(vectorType.clazz(), vectorType.componentType())).isEqualTo(vectorType);
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/qst/type/PrimitiveVectorTest.java
+++ b/engine/table/src/test/java/io/deephaven/qst/type/PrimitiveVectorTest.java
@@ -3,13 +3,20 @@
 //
 package io.deephaven.qst.type;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.deephaven.vector.*;
+import io.deephaven.vector.ByteVector;
+import io.deephaven.vector.CharVector;
+import io.deephaven.vector.DoubleVector;
+import io.deephaven.vector.FloatVector;
+import io.deephaven.vector.IntVector;
+import io.deephaven.vector.LongVector;
+import io.deephaven.vector.ShortVector;
+import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.stream.Collectors;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class PrimitiveVectorTest {
 
@@ -24,5 +31,78 @@ public class PrimitiveVectorTest {
                 LongVector.type(),
                 FloatVector.type(),
                 DoubleVector.type());
+    }
+
+    @Test
+    public void byteVector() throws ClassNotFoundException {
+        testConstruction(ByteVector.type());
+    }
+
+    @Test
+    public void charVector() throws ClassNotFoundException {
+        testConstruction(CharVector.type());
+    }
+
+    @Test
+    public void shortVector() throws ClassNotFoundException {
+        testConstruction(ShortVector.type());
+    }
+
+    @Test
+    public void intVector() throws ClassNotFoundException {
+        testConstruction(IntVector.type());
+    }
+
+    @Test
+    public void longVector() throws ClassNotFoundException {
+        testConstruction(LongVector.type());
+    }
+
+    @Test
+    public void floatVector() throws ClassNotFoundException {
+        testConstruction(FloatVector.type());
+    }
+
+    @Test
+    public void doubleVector() throws ClassNotFoundException {
+        testConstruction(DoubleVector.type());
+    }
+
+    private static <T, ComponentType> void testConstruction(PrimitiveVectorType<T, ComponentType> vectorType)
+            throws ClassNotFoundException {
+        assertThat(Type.find(vectorType.clazz())).isEqualTo(vectorType);
+        assertThat(Type.find(vectorType.clazz(), vectorType.componentType().clazz())).isEqualTo(vectorType);
+        assertThat(PrimitiveVectorType.of(vectorType.clazz(), vectorType.componentType())).isEqualTo(vectorType);
+        // fail if component type is bad
+        for (PrimitiveType<?> badComponent : PrimitiveType.instances().collect(Collectors.toList())) {
+            if (badComponent.equals(vectorType.componentType())) {
+                continue;
+            }
+            fail(vectorType.clazz(), badComponent);
+        }
+        // fail if data type is bad
+        fail(Object.class, vectorType.componentType());
+        for (PrimitiveVectorType<?, ?> primitiveVectorType : TypeHelper.primitiveVectorTypes()
+                .collect(Collectors.toList())) {
+            if (primitiveVectorType.equals(vectorType)) {
+                continue;
+            }
+            fail(primitiveVectorType.clazz(), vectorType.componentType());
+        }
+    }
+
+    public static void fail(Class<?> clazz, PrimitiveType<?> ct) {
+        try {
+            Type.find(clazz, ct.clazz());
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessageContaining("Invalid PrimitiveVectorType");
+        }
+        try {
+            PrimitiveVectorType.of(clazz, ct);
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessageContaining("Invalid PrimitiveVectorType");
+        }
     }
 }

--- a/extensions/flight-sql/src/test/java/io/deephaven/server/flightsql/FlightSqlTest.java
+++ b/extensions/flight-sql/src/test/java/io/deephaven/server/flightsql/FlightSqlTest.java
@@ -17,10 +17,20 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.proto.backplane.grpc.WrappedAuthenticationRequest;
+import io.deephaven.qst.type.GenericVectorType;
+import io.deephaven.qst.type.Type;
 import io.deephaven.server.auth.AuthorizationProvider;
 import io.deephaven.server.config.ServerConfig;
 import io.deephaven.server.runner.DeephavenApiServerTestBase;
 import io.deephaven.server.runner.DeephavenApiServerTestBase.TestComponent.Builder;
+import io.deephaven.vector.ByteVector;
+import io.deephaven.vector.CharVector;
+import io.deephaven.vector.DoubleVector;
+import io.deephaven.vector.FloatVector;
+import io.deephaven.vector.IntVector;
+import io.deephaven.vector.LongVector;
+import io.deephaven.vector.ObjectVector;
+import io.deephaven.vector.ShortVector;
 import io.grpc.ManagedChannel;
 import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.ActionType;
@@ -585,6 +595,31 @@ public class FlightSqlTest extends DeephavenApiServerTestBase {
     @Test
     public void badSqlQuery() {
         queryError("this is not SQL", FlightStatusCode.INVALID_ARGUMENT, "Flight SQL: query can't be parsed");
+    }
+
+    @Test
+    public void testDh18803() throws Exception {
+        // https://deephaven.atlassian.net/browse/DH-18803: Sql fails to adapt Vector types
+        final TableDefinition td = TableDefinition.of(
+                ColumnDefinition.ofVector("ByteVector", ByteVector.class),
+                ColumnDefinition.ofVector("CharVector", CharVector.class),
+                ColumnDefinition.ofVector("ShortVector", ShortVector.class),
+                ColumnDefinition.ofVector("IntVector", IntVector.class),
+                ColumnDefinition.ofVector("LongVector", LongVector.class),
+                ColumnDefinition.ofVector("FloatVector", FloatVector.class),
+                ColumnDefinition.ofVector("DoubleVector", DoubleVector.class),
+                ColumnDefinition.of("StringVector", GenericVectorType.of(ObjectVector.class, Type.stringType())));
+        final Table emptyTable = TableTools.newTable(td);
+        ExecutionContext.getContext().getQueryScope().putParam("MyTable", emptyTable);
+        {
+            final SchemaResult schema = flightSqlClient.getExecuteSchema("SELECT * FROM MyTable");
+            assertThat(schema.getSchema().getFields()).hasSize(8);
+        }
+        {
+            final FlightInfo info = flightSqlClient.execute("SELECT * FROM MyTable");
+            assertThat(info.getSchema().getFields()).hasSize(8);
+            consume(info, 0, 0, false);
+        }
     }
 
     @Test

--- a/extensions/kafka/src/main/java/io/deephaven/kafka/SimpleImpl.java
+++ b/extensions/kafka/src/main/java/io/deephaven/kafka/SimpleImpl.java
@@ -233,13 +233,14 @@ class SimpleImpl {
 
         @Override
         Serializer<?> getSerializer(SchemaRegistryClient schemaRegistryClient, TableDefinition definition) {
-            final Class<?> dataType = definition.getColumn(columnName).getDataType();
-            final Serializer<?> serializer = serializer(Type.find(dataType)).orElse(null);
+            final ColumnDefinition<?> cd = definition.getColumn(columnName);
+            final Type<?> type = Type.find(cd.getDataType(), cd.getComponentType());
+            final Serializer<?> serializer = serializer(type).orElse(null);
             if (serializer != null) {
                 return serializer;
             }
             throw new UncheckedDeephavenException(
-                    String.format("Serializer not found for column %s, type %s", columnName, dataType.getName()));
+                    String.format("Serializer not found for column %s, type %s", columnName, type));
         }
 
         @Override

--- a/qst/type/build.gradle
+++ b/qst/type/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     compileOnly project(':util-immutables')
     annotationProcessor libs.immutables.value
 
+    compileOnly libs.jetbrains.annotations
+
     testImplementation libs.assertj
     testImplementation platform(libs.junit.bom)
     testImplementation libs.junit.jupiter

--- a/qst/type/src/main/java/io/deephaven/qst/type/GenericVectorType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/GenericVectorType.java
@@ -4,12 +4,15 @@
 package io.deephaven.qst.type;
 
 import io.deephaven.annotations.SimpleStyle;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 
 @Immutable
 @SimpleStyle
 public abstract class GenericVectorType<T, ComponentType> extends ArrayTypeBase<T, ComponentType> {
+
+    private static final String OBJECT_VECTOR = "io.deephaven.vector.ObjectVector";
 
     public static <T, ComponentType> GenericVectorType<T, ComponentType> of(
             Class<T> clazz,
@@ -26,5 +29,13 @@ public abstract class GenericVectorType<T, ComponentType> extends ArrayTypeBase<
     @Override
     public final <R> R walk(ArrayType.Visitor<R> visitor) {
         return visitor.visit(this);
+    }
+
+    @Check
+    final void checkClazz() {
+        if (!OBJECT_VECTOR.equals(clazz().getName())) {
+            throw new IllegalArgumentException(String.format("Invalid GenericVectorType. clazz=%s, componentType=%s",
+                    clazz().getName(), componentType()));
+        }
     }
 }

--- a/qst/type/src/main/java/io/deephaven/qst/type/PrimitiveVectorType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/PrimitiveVectorType.java
@@ -73,10 +73,55 @@ public abstract class PrimitiveVectorType<T, ComponentType>
     }
 
     @Check
-    final void checkClazz() {
-        if (!VALID_CLASSES.contains(clazz().getName())) {
-            throw new IllegalArgumentException(String.format("Class '%s' is not a valid '%s'",
-                    clazz(), PrimitiveVectorType.class));
+    final void checkPairing() {
+        final String vectorClassNameFromComponent = componentType().walk(VectorClassName.INSTANCE);
+        if (!clazz().getName().equals(vectorClassNameFromComponent)) {
+            throw new IllegalArgumentException(String.format("Invalid PrimitiveVectorType. clazz=%s, componentType=%s",
+                    clazz().getName(), componentType()));
+        }
+    }
+
+    private enum VectorClassName implements PrimitiveType.Visitor<String> {
+        INSTANCE;
+
+        @Override
+        public String visit(BooleanType booleanType) {
+            return null;
+        }
+
+        @Override
+        public String visit(ByteType byteType) {
+            return BYTE_VECTOR;
+        }
+
+        @Override
+        public String visit(CharType charType) {
+            return CHAR_VECTOR;
+        }
+
+        @Override
+        public String visit(ShortType shortType) {
+            return SHORT_VECTOR;
+        }
+
+        @Override
+        public String visit(IntType intType) {
+            return INT_VECTOR;
+        }
+
+        @Override
+        public String visit(LongType longType) {
+            return LONG_VECTOR;
+        }
+
+        @Override
+        public String visit(FloatType floatType) {
+            return FLOAT_VECTOR;
+        }
+
+        @Override
+        public String visit(DoubleType doubleType) {
+            return DOUBLE_VECTOR;
         }
     }
 }

--- a/qst/type/src/test/java/io/deephaven/qst/type/TypeTest.java
+++ b/qst/type/src/test/java/io/deephaven/qst/type/TypeTest.java
@@ -42,7 +42,6 @@ public class TypeTest {
         assertThat(BoxedType.instances().distinct()).hasSize(8);
     }
 
-
     @Test
     void findBooleans() {
         check(boolean.class, Boolean.class, booleanType(), BoxedBooleanType.of());
@@ -87,99 +86,139 @@ public class TypeTest {
     void findString() {
         assertThat(find(String.class)).isEqualTo(stringType());
         assertThat(find(String[].class)).isEqualTo(stringType().arrayType());
+        assertThat(find(String[].class, String.class)).isEqualTo(stringType().arrayType());
     }
 
     @Test
     void findInstant() {
         assertThat(find(Instant.class)).isEqualTo(instantType());
         assertThat(find(Instant[].class)).isEqualTo(instantType().arrayType());
+        assertThat(find(Instant[].class, Instant.class)).isEqualTo(instantType().arrayType());
     }
 
     @Test
     void findCustom() {
         assertThat(find(Custom.class)).isEqualTo(ofCustom(Custom.class));
         assertThat(find(Custom[].class)).isEqualTo(ofCustom(Custom.class).arrayType());
+        assertThat(find(Custom[].class, Custom.class)).isEqualTo(ofCustom(Custom.class).arrayType());
     }
 
     @Test
     void booleanArrayType() {
         assertThat(find(boolean[].class)).isEqualTo(booleanType().arrayType());
+        assertThat(find(boolean[].class, boolean.class)).isEqualTo(booleanType().arrayType());
+
         assertThat(find(Boolean[].class)).isEqualTo(BoxedBooleanType.of().arrayType());
+        assertThat(find(Boolean[].class, Boolean.class)).isEqualTo(BoxedBooleanType.of().arrayType());
     }
 
     @Test
     void byteArrayType() {
         assertThat(find(byte[].class)).isEqualTo(byteType().arrayType());
+        assertThat(find(byte[].class, byte.class)).isEqualTo(byteType().arrayType());
+
         assertThat(find(Byte[].class)).isEqualTo(BoxedByteType.of().arrayType());
+        assertThat(find(Byte[].class, Byte.class)).isEqualTo(BoxedByteType.of().arrayType());
     }
 
     @Test
     void charArrayType() {
         assertThat(find(char[].class)).isEqualTo(charType().arrayType());
+        assertThat(find(char[].class, char.class)).isEqualTo(charType().arrayType());
+
         assertThat(find(Character[].class)).isEqualTo(BoxedCharType.of().arrayType());
+        assertThat(find(Character[].class, Character.class)).isEqualTo(BoxedCharType.of().arrayType());
     }
 
     @Test
     void shortArrayType() {
         assertThat(find(short[].class)).isEqualTo(shortType().arrayType());
+        assertThat(find(short[].class, short.class)).isEqualTo(shortType().arrayType());
+
         assertThat(find(Short[].class)).isEqualTo(BoxedShortType.of().arrayType());
+        assertThat(find(Short[].class, Short.class)).isEqualTo(BoxedShortType.of().arrayType());
     }
 
     @Test
     void intArrayType() {
         assertThat(find(int[].class)).isEqualTo(intType().arrayType());
+        assertThat(find(int[].class, int.class)).isEqualTo(intType().arrayType());
+
         assertThat(find(Integer[].class)).isEqualTo(BoxedIntType.of().arrayType());
+        assertThat(find(Integer[].class, Integer.class)).isEqualTo(BoxedIntType.of().arrayType());
     }
 
     @Test
     void longArrayType() {
         assertThat(find(long[].class)).isEqualTo(longType().arrayType());
+        assertThat(find(long[].class, long.class)).isEqualTo(longType().arrayType());
+
         assertThat(find(Long[].class)).isEqualTo(BoxedLongType.of().arrayType());
+        assertThat(find(Long[].class, Long.class)).isEqualTo(BoxedLongType.of().arrayType());
     }
 
     @Test
     void floatArrayType() {
         assertThat(find(float[].class)).isEqualTo(floatType().arrayType());
+        assertThat(find(float[].class, float.class)).isEqualTo(floatType().arrayType());
+
         assertThat(find(Float[].class)).isEqualTo(BoxedFloatType.of().arrayType());
+        assertThat(find(Float[].class, Float.class)).isEqualTo(BoxedFloatType.of().arrayType());
     }
 
     @Test
     void doubleArrayType() {
         assertThat(find(double[].class)).isEqualTo(doubleType().arrayType());
-        assertThat(find(Double[].class)).isEqualTo(BoxedDoubleType.of().arrayType());
+        assertThat(find(double[].class, double.class)).isEqualTo(doubleType().arrayType());
 
+        assertThat(find(Double[].class)).isEqualTo(BoxedDoubleType.of().arrayType());
+        assertThat(find(Double[].class, Double.class)).isEqualTo(BoxedDoubleType.of().arrayType());
     }
 
     @Test
     void nestedPrimitive2x() {
         assertThat(find(int[][].class)).isEqualTo(intType().arrayType().arrayType());
+        assertThat(find(int[][].class, int[].class)).isEqualTo(intType().arrayType().arrayType());
+
         assertThat(find(Integer[][].class)).isEqualTo(BoxedIntType.of().arrayType().arrayType());
+        assertThat(find(Integer[][].class, Integer[].class)).isEqualTo(BoxedIntType.of().arrayType().arrayType());
     }
 
     @Test
     void nestedPrimitive3x() {
         assertThat(find(int[][][].class)).isEqualTo(intType().arrayType().arrayType().arrayType());
+        assertThat(find(int[][][].class, int[][].class)).isEqualTo(intType().arrayType().arrayType().arrayType());
+
         assertThat(find(Integer[][][].class)).isEqualTo(BoxedIntType.of().arrayType().arrayType().arrayType());
+        assertThat(find(Integer[][][].class, Integer[][].class))
+                .isEqualTo(BoxedIntType.of().arrayType().arrayType().arrayType());
     }
 
     @Test
     void nestedStatic2x() {
         assertThat(find(String[][].class)).isEqualTo(stringType().arrayType().arrayType());
+        assertThat(find(String[][].class, String[].class)).isEqualTo(stringType().arrayType().arrayType());
     }
 
     @Test
     void nestedStatic3x() {
         assertThat(find(String[][][].class)).isEqualTo(stringType().arrayType().arrayType().arrayType());
+        assertThat(find(String[][][].class, String[][].class))
+                .isEqualTo(stringType().arrayType().arrayType().arrayType());
     }
 
     @Test
     void nestedCustom2x() {
         assertThat(find(Custom[][].class)).isEqualTo(CustomType.of(Custom.class).arrayType().arrayType());
+        assertThat(find(Custom[][].class, Custom[].class))
+                .isEqualTo(CustomType.of(Custom.class).arrayType().arrayType());
     }
 
     @Test
     void nestedCustom3x() {
         assertThat(find(Custom[][][].class)).isEqualTo(CustomType.of(Custom.class).arrayType().arrayType().arrayType());
+        assertThat(find(Custom[][][].class, Custom[][].class))
+                .isEqualTo(CustomType.of(Custom.class).arrayType().arrayType().arrayType());
     }
 
     @Test
@@ -217,12 +256,14 @@ public class TypeTest {
             PrimitiveType<T> expectedPrimitive,
             BoxedType<T> expectedBoxed) {
         assertThat(find(primitive)).isEqualTo(expectedPrimitive);
+        assertThat(find(primitive, null)).isEqualTo(expectedPrimitive);
         assertThat(expectedPrimitive.clazz()).isEqualTo(primitive);
         assertThat(expectedPrimitive.boxedType()).isEqualTo(expectedBoxed);
         assertThat(expectedPrimitive.arrayType().componentType()).isEqualTo(expectedPrimitive);
         assertThat(expectedPrimitive.arrayType().clazz()).isEqualTo(Array.newInstance(primitive, 0).getClass());
 
         assertThat(find(boxed)).isEqualTo(expectedBoxed);
+        assertThat(find(boxed, null)).isEqualTo(expectedBoxed);
         assertThat(expectedBoxed.clazz()).isEqualTo(boxed);
         assertThat(expectedBoxed.primitiveType()).isEqualTo(expectedPrimitive);
         assertThat(expectedBoxed.arrayType().componentType()).isEqualTo(expectedBoxed);


### PR DESCRIPTION
This adds the needed, centralized logic for adapting to qst Type when componentType is not null. This allows downstream callers, such as the Sql adapter layer, to correctly construct the appropriate Types.