### PR TITLE
chore: Remove unnecessary dependency, add missing direct dependencies

### DIFF
--- a/Integrations/build.gradle
+++ b/Integrations/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation project(':log-factory')
     implementation project(":util-thread")
     implementation libs.commons.lang3
+    implementation libs.google.findbugs.jsr305
 
     testImplementation project(':engine-test-utils')
     testImplementation project(path: ':Base', configuration: 'tests')

--- a/authentication/build.gradle
+++ b/authentication/build.gradle
@@ -6,7 +6,6 @@ plugins {
 description 'authentication: Deephaven authentication and identity'
 
 dependencies {
-    api project(':proto:proto-backplane-grpc')
     implementation project(':log-factory')
     implementation project(':Configuration')
 

--- a/authentication/example-providers/mtls/build.gradle
+++ b/authentication/example-providers/mtls/build.gradle
@@ -5,4 +5,6 @@ plugins {
 
 dependencies {
     shadow project(':grpc-java:grpc-mtls')
+    shadow platform(libs.grpc.bom)
+    shadow libs.grpc.api
 }

--- a/authorization-codegen/build.gradle
+++ b/authorization-codegen/build.gradle
@@ -14,4 +14,6 @@ dependencies {
     implementation libs.grpc.services
 
     implementation libs.squareup.javapoet
+
+    implementation libs.protobuf.java
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
@@ -34,12 +34,18 @@ PublishingTools.setupPublications(project) { publication ->
       def dependenciesNode = root.appendNode('dependencies')
 
       project.configurations.shadow.allDependencies.each {
-        if ((it instanceof ProjectDependency) || ! (it instanceof SelfResolvingDependency)) {
+        if ((it instanceof ProjectDependency)) {
           def dependencyNode = dependenciesNode.appendNode('dependency')
           dependencyNode.appendNode('groupId', it.group)
           BasePluginConvention base = it.dependencyProject.convention.getPlugin(BasePluginConvention)
 
           dependencyNode.appendNode('artifactId', base.archivesBaseName)
+          dependencyNode.appendNode('version', it.version)
+          dependencyNode.appendNode('scope', 'runtime')
+        } else if (! (it instanceof SelfResolvingDependency)) {
+          def dependencyNode = dependenciesNode.appendNode('dependency')
+          dependencyNode.appendNode('groupId', it.group)
+          dependencyNode.appendNode('artifactId', it.name)
           dependencyNode.appendNode('version', it.version)
           dependencyNode.appendNode('scope', 'runtime')
         }

--- a/extensions/iceberg/s3/build.gradle
+++ b/extensions/iceberg/s3/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     // actually calls it?), but we need to be able to compile against it to implement AwsClientFactory
     compileOnly libs.awssdk.kms
 
+    implementation libs.guava
+
     compileOnly libs.autoservice
     annotationProcessor libs.autoservice.compiler
 

--- a/extensions/parquet/table/build.gradle
+++ b/extensions/parquet/table/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation libs.jackson.dataformat.yaml
     implementation libs.jackson.datatype.jdk8
 
+    implementation libs.guava
+
     compileOnly project(':util-immutables')
     annotationProcessor libs.immutables.value
 

--- a/extensions/performance/build.gradle
+++ b/extensions/performance/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(':DHProcess')
     implementation project(':engine-table')
     implementation project(':Plot')
+    implementation libs.guava
     compileOnly libs.autoservice
     annotationProcessor libs.autoservice.compiler
     implementation libs.groovy

--- a/web/client-api/client-api.gradle
+++ b/web/client-api/client-api.gradle
@@ -44,6 +44,8 @@ dependencies {
 
     js project(path: ':proto:raw-js-openapi', configuration: 'js')
 
+    implementation libs.guava
+
     testImplementation libs.junit4
     testImplementation libs.selenium.remote.driver
 


### PR DESCRIPTION
Authentication unnecessarily depends on our generated proto/grpc types, which means all manner of other projects must wait for our proto project to build, and pick up all sorts of transitive dependencies. This patch removes that build dependency (improving build parallelization slightly), and also identified various direct dependencies that should have previously been declared.

This mostly comes from grpc-api - for reasons that I don't yet understand, even though grpc-api declares guava to be an `implementation` dependency, when grpc-api itself is an `api` dependency this causes Gradle to pick up transitive guava as an implementation dependency, so all downstream projects end up getting it on their classpath for free. The jsr305 dependency at least is explicitly declared as `api` in grpc-api, so that one makes sense.