### PR TITLE
docs: Create venv in the user dir instead of /tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ A Python virtual environment is highly recommended for building Deephaven from s
 ```sh
 git clone https://github.com/deephaven/deephaven-core.git
 cd deephaven-core
-python3 -m venv /tmp/my-dh-venv
-source /tmp/my-dh-venv/bin/activate
+python3 -m venv ~/my-dh-venv
+source ~/my-dh-venv/bin/activate
 ./gradlew py-server:assemble
 pip install "py/server/build/wheel/deephaven_core-<version>-py3-non-any.whl[autocomplete]
 ./gradlew server-jetty-app:run


### PR DESCRIPTION
macOS does periodic cleanup of the /tmp directory, so the build starts failing on its own a few days after creating the venv. 