### PR TITLE
chore: Update more modules to Java 11 now that this is the baseline for flight

### DIFF
--- a/Base/gradle.properties
+++ b/Base/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/Configuration/gradle.properties
+++ b/Configuration/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/IO/gradle.properties
+++ b/IO/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/SevenZip/gradle.properties
+++ b/SevenZip/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_EXTERNAL
-languageLevel=8

--- a/Util/immutables/gradle.properties
+++ b/Util/immutables/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_LOCAL
-languageLevel=8

--- a/Util/pool/gradle.properties
+++ b/Util/pool/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/Util/processenvironment/gradle.properties
+++ b/Util/processenvironment/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/Util/thread/gradle.properties
+++ b/Util/thread/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -16,13 +16,13 @@ def testRuntimeVersion = Integer.parseInt((String)project.findProperty('testRunt
 def testRuntimeVendor = project.hasProperty('testRuntimeVendor') ?  JvmVendorSpec.matching((String)project.property('testRuntimeVendor')): null
 
 if (languageLevel > compilerVersion) {
-  throw new IllegalArgumentException("languageLevel must be less than or equal to compileVersion")
+  throw new IllegalArgumentException("languageLevel must be less than or equal to compilerVersion")
 }
-if (languageLevel < 8) {
-  throw new IllegalArgumentException("languageLevel must be greater than or equal to 8")
+if (languageLevel < 11) {
+  throw new IllegalArgumentException("languageLevel must be greater than or equal to 11")
 }
-if (testLanguageLevel < 8) {
-  throw new IllegalArgumentException("testLanguageLevel must be greater than or equal to 8")
+if (testLanguageLevel < 11) {
+  throw new IllegalArgumentException("testLanguageLevel must be greater than or equal to 11")
 }
 if (runtimeVersion < languageLevel) {
   throw new IllegalArgumentException("runtimeVersion must be greater than or equal to languageLevel")

--- a/clock/gradle.properties
+++ b/clock/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/codec/api/gradle.properties
+++ b/codec/api/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/engine/query-constants/gradle.properties
+++ b/engine/query-constants/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/java-client/uri/gradle.properties
+++ b/java-client/uri/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/log-factory/gradle.properties
+++ b/log-factory/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/py/jpy-config/gradle.properties
+++ b/py/jpy-config/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/py/jpy-ext/gradle.properties
+++ b/py/jpy-ext/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/qst/gradle.properties
+++ b/qst/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/qst/type/gradle.properties
+++ b/qst/type/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/sql/gradle.properties
+++ b/sql/gradle.properties
@@ -1,5 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-
-# Note: it would take a little bit of work, but we _could_ make this project Java 8 compatible. This would benefit
-# external java-client users who need Java 8 compatibility.
-# languageLevel=8

--- a/ssl/config/gradle.properties
+++ b/ssl/config/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/ssl/kickstart/gradle.properties
+++ b/ssl/kickstart/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8

--- a/table-api/gradle.properties
+++ b/table-api/gradle.properties
@@ -1,2 +1,1 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
-languageLevel=8


### PR DESCRIPTION
We no longer support Java 8 for flight clients, so we don't have any other modules that must have this level of language support either.

Follow-up #6417