### PR TITLE
fix: If using python, any thread that calls python must have a python frame

### DIFF
--- a/Base/src/main/java/io/deephaven/base/system/StandardStreamState.java
+++ b/Base/src/main/java/io/deephaven/base/system/StandardStreamState.java
@@ -5,7 +5,7 @@ package io.deephaven.base.system;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -23,7 +23,7 @@ public class StandardStreamState {
         this.initialized = new AtomicBoolean(false);
     }
 
-    public void setupRedirection() throws UnsupportedEncodingException {
+    public void setupRedirection() {
         if (!initialized.compareAndSet(false, true)) {
             throw new IllegalStateException("May only call StandardStreamState#setupRedirection once");
         }
@@ -59,16 +59,16 @@ public class StandardStreamState {
         }
     }
 
-    private static PrintStream adapt(List<OutputStream> outputStreams) throws UnsupportedEncodingException {
+    private static PrintStream adapt(List<OutputStream> outputStreams) {
         // TODO (core#88): Figure out appropriate stdout / LogBuffer encoding
         if (outputStreams.size() == 1) {
             OutputStream out = outputStreams.get(0);
             if (out instanceof PrintStream) {
                 return (PrintStream) out;
             }
-            return new PrintStream(out, true, "ISO-8859-1");
+            return new PrintStream(out, true, StandardCharsets.ISO_8859_1);
         }
-        return new PrintStream(MultipleOutputStreams.of(outputStreams), true, "ISO-8859-1");
+        return new PrintStream(MultipleOutputStreams.of(outputStreams), true, StandardCharsets.ISO_8859_1);
     }
 }
 

--- a/server/src/main/java/io/deephaven/server/console/python/PythonConsoleSessionModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonConsoleSessionModule.java
@@ -21,7 +21,7 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-@Module
+@Module(includes = PythonDebuggingModule.class)
 public class PythonConsoleSessionModule {
     @Provides
     @IntoMap

--- a/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeCopyModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeCopyModule.java
@@ -6,6 +6,7 @@ package io.deephaven.server.console.python;
 import dagger.Module;
 import dagger.Provides;
 import io.deephaven.engine.util.PythonEvaluatorJpy;
+import io.deephaven.server.log.LogInit;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -14,8 +15,10 @@ import java.util.concurrent.TimeoutException;
 public interface PythonGlobalScopeCopyModule {
 
     @Provides
-    static PythonEvaluatorJpy providePythonEvaluatorJpy() {
+    static PythonEvaluatorJpy providePythonEvaluatorJpy(LogInit logInit) {
         try {
+            // Before we can initialize python and set up our logging redirect from sys.out/err, we ensure that Java's
+            // System fields are reassigned.
             PythonEvaluatorJpy jpy = PythonEvaluatorJpy.withGlobalCopy();
             PythonImportInitializer.init();
             return jpy;

--- a/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeCopyModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeCopyModule.java
@@ -15,10 +15,10 @@ import java.util.concurrent.TimeoutException;
 public interface PythonGlobalScopeCopyModule {
 
     @Provides
-    static PythonEvaluatorJpy providePythonEvaluatorJpy(LogInit logInit) {
+    static PythonEvaluatorJpy providePythonEvaluatorJpy(LogInit ignoredLogInit) {
+        // Before we can initialize python and set up our logging redirect from sys.out/err, we ensure that Java's
+        // System fields are reassigned.
         try {
-            // Before we can initialize python and set up our logging redirect from sys.out/err, we ensure that Java's
-            // System fields are reassigned.
             PythonEvaluatorJpy jpy = PythonEvaluatorJpy.withGlobalCopy();
             PythonImportInitializer.init();
             return jpy;

--- a/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeModule.java
+++ b/server/src/main/java/io/deephaven/server/console/python/PythonGlobalScopeModule.java
@@ -6,6 +6,7 @@ package io.deephaven.server.console.python;
 import dagger.Module;
 import dagger.Provides;
 import io.deephaven.engine.util.PythonEvaluatorJpy;
+import io.deephaven.server.log.LogInit;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -14,7 +15,9 @@ import java.util.concurrent.TimeoutException;
 public interface PythonGlobalScopeModule {
 
     @Provides
-    static PythonEvaluatorJpy providePythonEvaluatorJpy() {
+    static PythonEvaluatorJpy providePythonEvaluatorJpy(LogInit ignoredLogInit) {
+        // Before we can initialize python and set up our logging redirect from sys.out/err, we ensure that Java's
+        // System fields are reassigned.
         try {
             PythonEvaluatorJpy jpy = PythonEvaluatorJpy.withGlobals();
             PythonImportInitializer.init();

--- a/server/src/main/java/io/deephaven/server/log/LogInit.java
+++ b/server/src/main/java/io/deephaven/server/log/LogInit.java
@@ -12,9 +12,11 @@ import io.deephaven.io.logger.LogBuffer;
 import io.deephaven.io.logger.Logger;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.UnsupportedEncodingException;
 import java.util.Set;
 
+@Singleton
 public class LogInit {
 
     private static final Logger log = LoggerFactory.getLogger(LogInit.class);
@@ -33,7 +35,8 @@ public class LogInit {
         this.sinkInits = sinkInits;
     }
 
-    public void run() throws UnsupportedEncodingException {
+    @Inject
+    public void run() {
         checkLogSinkIsSingleton();
         standardStreamState.setupRedirection();
         configureLoggerSink();

--- a/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
+++ b/server/src/main/java/io/deephaven/server/runner/DeephavenApiServer.java
@@ -88,7 +88,7 @@ public class DeephavenApiServer {
 
     private final GrpcServer server;
     private final UpdateGraph ug;
-    private final LogInit logInit;
+    private final Provider<LogInit> logInit;
     private final Provider<Set<BusinessCalendar>> calendars;
     private final Scheduler scheduler;
     private final Provider<ScriptSession> scriptSessionProvider;
@@ -105,7 +105,7 @@ public class DeephavenApiServer {
     public DeephavenApiServer(
             final GrpcServer server,
             @Named(PeriodicUpdateGraph.DEFAULT_UPDATE_GRAPH_NAME) final UpdateGraph ug,
-            final LogInit logInit,
+            final Provider<LogInit> logInit,
             final Provider<Set<BusinessCalendar>> calendars,
             final Scheduler scheduler,
             final Provider<ScriptSession> scriptSessionProvider,
@@ -173,8 +173,9 @@ public class DeephavenApiServer {
             }
         });
 
+        // Ensure that our logging is configured no later than this point
         log.info().append("Configuring logging...").endl();
-        logInit.run();
+        logInit.get();
 
         for (BusinessCalendar calendar : calendars.get()) {
             Calendars.addCalendar(calendar);


### PR DESCRIPTION
Adds explicit DI breadcrumbs to ensure that logging is initialized before python is started, and ensures python is initialized before any threads are created that could call back into python.

Fixes DH-18074