### PR TITLE
fix: DH-18968: Close ManifestReader in IcebergBaseLayout.findKeys

### DIFF
--- a/extensions/iceberg/s3/src/test/java/io/deephaven/iceberg/util/S3WarehouseSqliteCatalogBase.java
+++ b/extensions/iceberg/s3/src/test/java/io/deephaven/iceberg/util/S3WarehouseSqliteCatalogBase.java
@@ -6,7 +6,7 @@ package io.deephaven.iceberg.util;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.extensions.s3.S3Instructions;
-import io.deephaven.iceberg.base.IcebergUtils;
+import io.deephaven.iceberg.base.IcebergTestUtils;
 import io.deephaven.iceberg.junit5.SqliteCatalogBase;
 import io.deephaven.iceberg.sqlite.SqliteHelper;
 import org.apache.iceberg.CatalogProperties;
@@ -133,7 +133,7 @@ abstract class S3WarehouseSqliteCatalogBase extends SqliteCatalogBase {
                 .build());
 
         // Verify all data files have the right scheme
-        final List<DataFile> dataFiles = IcebergUtils.allDataFiles(icebergTable, icebergTable.currentSnapshot())
+        final List<DataFile> dataFiles = IcebergTestUtils.allDataFiles(icebergTable, icebergTable.currentSnapshot())
                 .collect(Collectors.toList());
         assertThat(dataFiles).hasSize(2);
         assertThat(dataFiles).allMatch(dataFile -> dataFileUri(icebergTable, dataFile).getScheme().equals(scheme));
@@ -159,7 +159,7 @@ abstract class S3WarehouseSqliteCatalogBase extends SqliteCatalogBase {
         icebergTable.newAppend().appendFile(newDataFile).commit();
 
         // Verify the new data file has the right scheme
-        final List<DataFile> newDataFiles = IcebergUtils.allDataFiles(icebergTable, icebergTable.currentSnapshot())
+        final List<DataFile> newDataFiles = IcebergTestUtils.allDataFiles(icebergTable, icebergTable.currentSnapshot())
                 .collect(Collectors.toList());
         int s3DataFiles = 0;
         int nonS3DataFiles = 0;

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergBaseLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergBaseLayout.java
@@ -6,7 +6,6 @@ package io.deephaven.iceberg.layout;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.impl.TableLocationKeyFinder;
-import io.deephaven.iceberg.base.IcebergUtils;
 import io.deephaven.iceberg.location.IcebergTableLocationKey;
 import io.deephaven.iceberg.location.IcebergTableParquetLocationKey;
 import io.deephaven.iceberg.util.IcebergReadInstructions;
@@ -21,15 +20,14 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
-import static io.deephaven.iceberg.base.IcebergUtils.allManifestFiles;
 import static io.deephaven.iceberg.base.IcebergUtils.dataFileUri;
 
 public abstract class IcebergBaseLayout implements TableLocationKeyFinder<IcebergTableLocationKey> {
@@ -188,24 +186,44 @@ public abstract class IcebergBaseLayout implements TableLocationKeyFinder<Iceber
             URI fileUri,
             SeekableChannelsProvider channelsProvider);
 
+    private IcebergTableLocationKey key(
+            final Table table,
+            final ManifestFile manifestFile,
+            final ManifestReader<?> ignoredManifestReader,
+            final DataFile dataFile) {
+        // Note: ManifestReader explicitly modelled in this path, as it can contain relevant information.
+        // ie, ManifestReader.spec(), ManifestReader.spec().schema()
+        // See https://lists.apache.org/thread/88md2fdk17k26cl4gj3sz6sdbtwcgbk5
+        final URI fileUri = dataFileUri(table, dataFile);
+        return keyFromDataFile(manifestFile, dataFile, fileUri, getChannelsProvider(fileUri.getScheme()));
+    }
+
+    private static void checkIsDataManifest(ManifestFile manifestFile) {
+        if (manifestFile.content() != ManifestContent.DATA) {
+            throw new UnsupportedOperationException(String.format(
+                    "only DATA manifest files are currently supported, encountered %s", manifestFile.content()));
+        }
+    }
+
     @Override
     public synchronized void findKeys(@NotNull final Consumer<IcebergTableLocationKey> locationKeyObserver) {
         if (snapshot == null) {
             return;
         }
         final Table table = tableAdapter.icebergTable();
-        try (final Stream<ManifestFile> manifestFiles = allManifestFiles(table, snapshot)) {
-            manifestFiles.forEach(manifestFile -> {
-                final ManifestReader<DataFile> reader = ManifestFiles.read(manifestFile, table.io());
-                IcebergUtils.toStream(reader)
-                        .map(dataFile -> {
-                            final URI fileUri = dataFileUri(table, dataFile);
-                            return keyFromDataFile(manifestFile, dataFile, fileUri,
-                                    getChannelsProvider(fileUri.getScheme()));
-                        })
-                        .forEach(locationKeyObserver);
-            });
-        } catch (final RuntimeException e) {
+        try {
+            final List<ManifestFile> manifestFiles = snapshot.allManifests(table.io());
+            for (final ManifestFile manifestFile : manifestFiles) {
+                checkIsDataManifest(manifestFile);
+            }
+            for (final ManifestFile manifestFile : manifestFiles) {
+                try (final ManifestReader<DataFile> manifestReader = ManifestFiles.read(manifestFile, table.io())) {
+                    for (final DataFile dataFile : manifestReader) {
+                        locationKeyObserver.accept(key(table, manifestFile, manifestReader, dataFile));
+                    }
+                }
+            }
+        } catch (RuntimeException | IOException e) {
             throw new TableDataException(
                     String.format("%s:%d - error finding Iceberg locations", tableAdapter, snapshot.snapshotId()), e);
         }

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergBaseLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergBaseLayout.java
@@ -17,6 +17,7 @@ import io.deephaven.util.channel.SeekableChannelsProviderLoader;
 import org.apache.iceberg.*;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.FileIO;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -212,12 +213,13 @@ public abstract class IcebergBaseLayout implements TableLocationKeyFinder<Iceber
         }
         final Table table = tableAdapter.icebergTable();
         try {
-            final List<ManifestFile> manifestFiles = snapshot.allManifests(table.io());
+            final FileIO io = table.io();
+            final List<ManifestFile> manifestFiles = snapshot.allManifests(io);
             for (final ManifestFile manifestFile : manifestFiles) {
                 checkIsDataManifest(manifestFile);
             }
             for (final ManifestFile manifestFile : manifestFiles) {
-                try (final ManifestReader<DataFile> manifestReader = ManifestFiles.read(manifestFile, table.io())) {
+                try (final ManifestReader<DataFile> manifestReader = ManifestFiles.read(manifestFile, io)) {
                     for (final DataFile dataFile : manifestReader) {
                         locationKeyObserver.accept(key(table, manifestFile, manifestReader, dataFile));
                     }

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/base/IcebergTestUtils.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/base/IcebergTestUtils.java
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.iceberg.base;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class IcebergTestUtils {
+    /**
+     * Get a stream of all {@link DataFile} objects from the given {@link Table} and {@link Snapshot}.
+     *
+     * @param table The {@link Table} to retrieve data files for.
+     * @param snapshot The {@link Snapshot} to retrieve data files from.
+     *
+     * @return A stream of {@link DataFile} objects.
+     */
+    public static Stream<DataFile> allDataFiles(@NotNull final Table table, @NotNull final Snapshot snapshot) {
+        return snapshot.allManifests(table.io())
+                .stream()
+                .map(x -> ManifestFiles.read(x, table.io()))
+                .flatMap(IcebergTestUtils::toStream);
+    }
+
+    /**
+     * Convert a {@link org.apache.iceberg.io.CloseableIterable} to a {@link Stream} that will close the iterable when
+     * the stream is closed.
+     */
+    private static <T> Stream<T> toStream(final org.apache.iceberg.io.CloseableIterable<T> iterable) {
+        return StreamSupport.stream(iterable.spliterator(), false).onClose(() -> {
+            try {
+                iterable.close();
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+}

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
@@ -14,7 +14,7 @@ import io.deephaven.engine.table.impl.PartitionAwareSourceTable;
 import io.deephaven.engine.table.impl.select.FormulaEvaluationException;
 import io.deephaven.engine.testutil.ControlledUpdateGraph;
 import io.deephaven.engine.util.TableTools;
-import io.deephaven.iceberg.base.IcebergUtils;
+import io.deephaven.iceberg.base.IcebergTestUtils;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.iceberg.sqlite.SqliteHelper;
 import io.deephaven.iceberg.util.IcebergCatalogAdapter;
@@ -32,7 +32,6 @@ import io.deephaven.parquet.table.location.ParquetTableLocationKey;
 import io.deephaven.qst.type.Type;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -570,7 +569,7 @@ public abstract class SqliteCatalogBase {
             final TableIdentifier tableIdentifier,
             final List<Table> dhTables) {
         final org.apache.iceberg.Table table = catalogAdapter.catalog().loadTable(tableIdentifier);
-        final List<DataFile> dataFileList = IcebergUtils.allDataFiles(table, table.currentSnapshot())
+        final List<DataFile> dataFileList = IcebergTestUtils.allDataFiles(table, table.currentSnapshot())
                 .collect(Collectors.toList());
         assertThat(dataFileList).hasSize(dhTables.size());
 
@@ -591,7 +590,7 @@ public abstract class SqliteCatalogBase {
      */
     private List<String> getAllParquetFilesFromDataFiles(final TableIdentifier tableIdentifier) {
         final org.apache.iceberg.Table table = catalogAdapter.catalog().loadTable(tableIdentifier);
-        return IcebergUtils.allDataFiles(table, table.currentSnapshot())
+        return IcebergTestUtils.allDataFiles(table, table.currentSnapshot())
                 .map(dataFile -> dataFile.path().toString())
                 .collect(Collectors.toList());
     }
@@ -1064,7 +1063,7 @@ public abstract class SqliteCatalogBase {
             @NotNull final ParquetInstructions readInstructions) {
         final org.apache.iceberg.Table icebergTable = tableAdapter.icebergTable();
         final List<List<SortColumn>> actualSortOrders = new ArrayList<>();
-        IcebergUtils.allDataFiles(icebergTable, icebergTable.currentSnapshot())
+        IcebergTestUtils.allDataFiles(icebergTable, icebergTable.currentSnapshot())
                 .forEach(dataFile -> actualSortOrders
                         .add(computeSortedColumns(icebergTable, dataFile, readInstructions)));
         assertThat(actualSortOrders).isEqualTo(expectedSortOrders);


### PR DESCRIPTION
This fixes a `ManifestReader` leak in `IcebergBaseLayout`, which was not being closed. Additionally, this refactors the `findKeys` implementation to use `Iterable` patterns instead of `Stream` patterns, making the code less lamba / wrap heavy. A couple of unused `IcebergUtils` methods were removed, and one was moved to test sources since none of the actual Iceberg implementation code depends on it anymore.