### PR TITLE
fix: DH-19003: ensure ATLP.getTLIfPresent returns a managed TableLocation

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocationProvider.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocationProvider.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.locations.impl;
 import io.deephaven.base.Pair;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.liveness.LiveSupplier;
+import io.deephaven.engine.liveness.LivenessReferent;
 import io.deephaven.engine.liveness.ReferenceCountedLivenessNode;
 import io.deephaven.engine.liveness.StandaloneLivenessManager;
 import io.deephaven.engine.table.Table;
@@ -100,7 +101,8 @@ public abstract class AbstractTableLocationProvider
         }
 
         /**
-         * Create the {@link TableLocation} for this key, if it has not already been created, and return it.
+         * Create the {@link TableLocation} for this key and {@link #manage(LivenessReferent)} it if it has not already
+         * been created, and return it.
          */
         private TableLocation getTableLocation() {
             TableLocation localTableLocation;
@@ -109,8 +111,9 @@ public abstract class AbstractTableLocationProvider
                     if ((localTableLocation = tableLocation) == null) {
                         // Make a new location, have the tracked key manage it, then store the location in the tracked
                         // key.
-                        tableLocation = localTableLocation = makeTableLocation(key);
+                        localTableLocation = makeTableLocation(key);
                         manage(localTableLocation);
+                        tableLocation = localTableLocation;
                     }
                 }
             }


### PR DESCRIPTION
This fixes a theoretical race between two threads:

* Thread 1 vol read null
* Thread 1 synchronized
* Thread 1 vol read null
* Thread 1 TL = makeTableLocation
* Thread 1 vol write TL
* Thread 2 vol read TL
* (Thread 2 could theoretically retainReference, dropReference causing TL to become unlive)
* Thread 1 ATLP.manage(TL)

While it is unlikely to happen in practice, we should prefer technical correctness for double checked patterns like this (volatile write is last operation inside the creation block).