### PR TITLE
fix: PythonTableDataService use __eq__ instead of PyObject#equals

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
@@ -557,7 +557,7 @@ public class PythonTableDataService extends AbstractTableDataService {
                 return false;
             }
             final TableKeyImpl otherTableKey = (TableKeyImpl) other;
-            return this.key.call("__eq__", otherTableKey.key).getBooleanValue();
+            return this.key.eq(otherTableKey.key);
         }
 
         @Override
@@ -711,8 +711,7 @@ public class PythonTableDataService extends AbstractTableDataService {
                 return false;
             }
             final TableLocationKeyImpl otherTyped = (TableLocationKeyImpl) other;
-            return partitions.equals(otherTyped.partitions)
-                    && locationKey.call("__eq__", otherTyped.locationKey).getBooleanValue();
+            return partitions.equals(otherTyped.partitions) && locationKey.eq(otherTyped.locationKey);
         }
 
         @Override

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
@@ -563,7 +563,7 @@ public class PythonTableDataService extends AbstractTableDataService {
         @Override
         public int hashCode() {
             if (cachedHashCode == 0) {
-                final int computedHashCode = (int) key.hash();
+                final int computedHashCode = Long.hashCode(key.hash());
                 // Don't use 0; that's used by StandaloneTableKey, and also our sentinel for the need to compute
                 if (computedHashCode == 0) {
                     final int fallbackHashCode = TableKeyImpl.class.hashCode();
@@ -717,7 +717,7 @@ public class PythonTableDataService extends AbstractTableDataService {
         @Override
         public int hashCode() {
             if (cachedHashCode == 0) {
-                final int computedHashCode = 31 * partitions.hashCode() + (int) locationKey.hash();
+                final int computedHashCode = 31 * partitions.hashCode() + Long.hashCode(locationKey.hash());
                 // Don't use 0; that's used by StandaloneTableLocationKey, and also our sentinel for the need to compute
                 if (computedHashCode == 0) {
                     final int fallbackHashCode = TableLocationKeyImpl.class.hashCode();

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
@@ -563,7 +563,7 @@ public class PythonTableDataService extends AbstractTableDataService {
         @Override
         public int hashCode() {
             if (cachedHashCode == 0) {
-                final int computedHashCode = Long.hashCode(key.call("__hash__").getLongValue());
+                final int computedHashCode = (int) key.hash();
                 // Don't use 0; that's used by StandaloneTableKey, and also our sentinel for the need to compute
                 if (computedHashCode == 0) {
                     final int fallbackHashCode = TableKeyImpl.class.hashCode();
@@ -717,8 +717,7 @@ public class PythonTableDataService extends AbstractTableDataService {
         @Override
         public int hashCode() {
             if (cachedHashCode == 0) {
-                final int computedHashCode =
-                        31 * partitions.hashCode() + Long.hashCode(locationKey.call("__hash__").getLongValue());
+                final int computedHashCode = 31 * partitions.hashCode() + (int) locationKey.hash();
                 // Don't use 0; that's used by StandaloneTableLocationKey, and also our sentinel for the need to compute
                 if (computedHashCode == 0) {
                     final int fallbackHashCode = TableLocationKeyImpl.class.hashCode();

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/PythonTableDataService.java
@@ -557,7 +557,7 @@ public class PythonTableDataService extends AbstractTableDataService {
                 return false;
             }
             final TableKeyImpl otherTableKey = (TableKeyImpl) other;
-            return this.key.equals(otherTableKey.key);
+            return this.key.call("__eq__", otherTableKey.key).getBooleanValue();
         }
 
         @Override
@@ -711,7 +711,8 @@ public class PythonTableDataService extends AbstractTableDataService {
                 return false;
             }
             final TableLocationKeyImpl otherTyped = (TableLocationKeyImpl) other;
-            return partitions.equals((otherTyped).partitions) && locationKey.equals(otherTyped.locationKey);
+            return partitions.equals(otherTyped.partitions)
+                    && locationKey.call("__eq__", otherTyped.locationKey).getBooleanValue();
         }
 
         @Override

--- a/py/server/deephaven/experimental/table_data_service.py
+++ b/py/server/deephaven/experimental/table_data_service.py
@@ -24,26 +24,32 @@ _JTableLocationKeyImpl = jpy.get_type("io.deephaven.extensions.barrage.util.Pyth
 
 class TableKey(ABC):
     """A key that identifies a table. The key should be unique for each table. The key can be any Python object and
-    should include sufficient information to uniquely identify the table for the backend service. The __hash__ method
-    must be implemented to ensure that the key is hashable.
+    should include sufficient information to uniquely identify the table for the backend service. The __hash__ and
+    __eq__ methods must be implemented consistently to ensure that the key is hashable.
     """
 
     @abstractmethod
     def __hash__(self):
         pass
 
+    @abstractmethod
+    def __eq__(self, other):
+        pass
 
 class TableLocationKey(ABC):
     """A key that identifies a specific location of a table. The key should be unique for each table location of the
     table. The key can be any Python object and should include sufficient information to uniquely identify the location
-    for the backend service to fetch the data values and data size. The __hash__ method must be implemented to ensure
-    that the key is hashable.
+    for the backend service to fetch the data values and data size. The __hash__ and __eq__ methods must be implemented
+    consistently to ensure that the key is hashable.
     """
 
     @abstractmethod
     def __hash__(self):
         pass
 
+    @abstractmethod
+    def __eq__(self, other):
+        pass
 
 class TableDataServiceBackend(ABC):
     """An interface for a backend service that provides access to table data."""

--- a/py/server/deephaven/experimental/table_data_service.py
+++ b/py/server/deephaven/experimental/table_data_service.py
@@ -25,7 +25,8 @@ _JTableLocationKeyImpl = jpy.get_type("io.deephaven.extensions.barrage.util.Pyth
 class TableKey(ABC):
     """A key that identifies a table. The key should be unique for each table. The key can be any Python object and
     should include sufficient information to uniquely identify the table for the backend service. The __hash__ and
-    __eq__ methods must be implemented consistently to ensure that the key is hashable.
+    __eq__ methods must be implemented consistently to ensure that the key is hashable and behaves correctly for
+    the equality check.
     """
 
     @abstractmethod
@@ -40,7 +41,7 @@ class TableLocationKey(ABC):
     """A key that identifies a specific location of a table. The key should be unique for each table location of the
     table. The key can be any Python object and should include sufficient information to uniquely identify the location
     for the backend service to fetch the data values and data size. The __hash__ and __eq__ methods must be implemented
-    consistently to ensure that the key is hashable.
+    consistently to ensure that the key is hashable and behaves correctly for the equality check.
     """
 
     @abstractmethod

--- a/py/server/tests/test_table_data_service.py
+++ b/py/server/tests/test_table_data_service.py
@@ -30,6 +30,11 @@ class TableKeyImpl(TableKey):
     def __hash__(self):
         return hash(self.key)
 
+    def __eq__(self, other):
+        if not isinstance(other, TableKeyImpl):
+            return False
+        return self.key == other.key
+
 
 class TableLocationKeyImpl(TableLocationKey):
     def __init__(self, key: str):
@@ -37,6 +42,11 @@ class TableLocationKeyImpl(TableLocationKey):
 
     def __hash__(self):
         return hash(self.key)
+
+    def __eq__(self, other):
+        if not isinstance(other, TableLocationKeyImpl):
+            return False
+        return self.key == other.key
 
 
 class TestBackend(TableDataServiceBackend):
@@ -53,6 +63,8 @@ class TestBackend(TableDataServiceBackend):
         self.partitions_size_subscriptions: Dict[TableLocationKey, bool] = {}
         self.existing_partitions_called: int = 0
         self.partition_size_called: int = 0
+        self.num_table_location_subs: int = 0
+        self.location_cb: Optional[Callable[[TableLocationKeyImpl, Optional[pa.Table]], None]] = None
 
     def table_schema(self, table_key: TableKeyImpl,
                      schema_cb: Callable[[pa.Schema, Optional[pa.Schema]], None],
@@ -124,6 +136,8 @@ class TestBackend(TableDataServiceBackend):
     def subscribe_to_table_locations(self, table_key: TableKeyImpl,
                                     location_cb: Callable[[TableLocationKeyImpl, Optional[pa.Table]], None],
                                     success_cb: Callable[[], None], failure_cb: Callable[[str], None]) -> Callable[[], None]:
+        self.num_table_location_subs += 1
+        self.location_cb = location_cb
         if table_key.key != "test":
             return lambda: None
 
@@ -144,6 +158,7 @@ class TestBackend(TableDataServiceBackend):
 
         def _cancellation_callback():
             self.sub_new_partition_cancelled = True
+            self.location_cb = None
 
         success_cb()
         return _cancellation_callback
@@ -176,9 +191,15 @@ class TestBackend(TableDataServiceBackend):
                                          success_cb: Callable[[], None], failure_cb: Callable[[str], None]
                                          ) -> Callable[[], None]:
         if table_key.key != "test":
+            failure_cb("tlk not for test table")
             return lambda: None
 
         if table_location_key not in self.partitions:
+            failure_cb("tlk not in partitions")
+            return lambda: None
+
+        if table_location_key in self.partitions_size_subscriptions and self.partitions_size_subscriptions[table_location_key]:
+            failure_cb("already subscribed")
             return lambda: None
 
         # need to initial size
@@ -281,6 +302,41 @@ class TableDataServiceTestCase(BaseTestCase):
         self.assertGreaterEqual(table.size, 20)
         self.assertEqual(backend.existing_partitions_called, 0)
         self.assertEqual(backend.partition_size_called, 0)
+
+    def test_live_table_subscribes_tlk_only_once(self):
+        pc_schema = pa.schema(
+            [pa.field(name="Ticker", type=pa.string()), pa.field(name="Exchange", type=pa.string())])
+        backend = TestBackend(self.gen_pa_table(), pt_schema=self.pa_table.schema, pc_schema=pc_schema)
+        data_service = TableDataService(backend)
+        table = data_service.make_table(TableKeyImpl("test"), refreshing=True).coalesce()
+        partitioned_table = data_service.make_partitioned_table(TableKeyImpl("test"), refreshing=True).merge().coalesce()
+        self.assertIsNotNone(table)
+        self.assertIsNotNone(partitioned_table)
+
+        self.wait_ticking_table_update(table, 20, 5)
+
+        self.assertFalse(table.is_failed)
+        self.assertFalse(partitioned_table.is_failed)
+        self.assertEqual(backend.num_table_location_subs, 1)
+
+    def test_live_table_subscribes_size_changes_only_once(self):
+        pc_schema = pa.schema(
+            [pa.field(name="Ticker", type=pa.string()), pa.field(name="Exchange", type=pa.string())])
+        backend = TestBackend(self.gen_pa_table(), pt_schema=self.pa_table.schema, pc_schema=pc_schema)
+        data_service = TableDataService(backend)
+        table = data_service.make_table(TableKeyImpl("test"), refreshing=True).coalesce()
+        self.assertIsNotNone(table)
+
+        # note there is an assert in the backend that checks that the subscription is only made once; so just pretend
+        # there is a new partition describing an existing partition
+        partitioning_columns = next(self.gen_pa_table()) \
+            .filter(pc.field("Ticker") == "AAPL") \
+            .select(["Ticker", "Exchange"]) \
+            .slice(0, 1)
+        backend.location_cb(TableLocationKeyImpl("AAPL/NYSE"), partitioning_columns)
+
+        self.wait_ticking_table_update(table, 20, 5)
+        self.assertFalse(table.is_failed)
 
     def test_make_live_partitioned_table_with_partition_schema(self):
         pc_schema = pa.schema(


### PR DESCRIPTION
Requires TableKey and TableLocationKey to implement `__eq__` so that we can guarantee subscribe-once semantics. Includes tests one for each kind of double subscribe.