### PR TITLE
chore: Bump to 0.39.0-SNAPSHOT

### DIFF
--- a/R/rdeephaven/DESCRIPTION
+++ b/R/rdeephaven/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rdeephaven
 Type: Package
 Title: R Client for Deephaven Core
-Version: 0.38.0
+Version: 0.39.0
 Date: 2023-05-12
 Author: Deephaven Data Labs
 Maintainer: Alex Peters <alexpeters@deephaven.io>

--- a/cpp-client/deephaven/CMakeLists.txt
+++ b/cpp-client/deephaven/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 project(deephaven)
 
-set(deephaven_VERSION 0.38.0)
+set(deephaven_VERSION 0.39.0)
 set(CMAKE_CXX_STANDARD 17)
 
 # for CMAKE_INSTALL_{dir}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 # Re-builders who want to inherit the base version, but have their own qualifier can set -PdeephavenBaseQualifier="customQualifier": "X.Y.Z-customQualifier".
 #
 # Re-builders who want a fully custom version can set -PdeephavenBaseVersion="customVersion" -PdeephavenBaseQualifier="": "customVersion".
-deephavenBaseVersion=0.38.0
+deephavenBaseVersion=0.39.0
 deephavenBaseQualifier=SNAPSHOT
 
 #org.gradle.debug


### PR DESCRIPTION
Bump the version number after the 0.38.0 release.