### PR TITLE
build: Fix two gRPC build quirks

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -178,7 +178,7 @@ grpc-core = { module = "io.grpc:grpc-core" }
 grpc-netty = { module = "io.grpc:grpc-netty" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf" }
 grpc-services = { module = "io.grpc:grpc-services" }
-grpc-stub = { module = "io.grpc:grpc-services" }
+grpc-stub = { module = "io.grpc:grpc-stub" }
 grpc-testing = { module = "io.grpc:grpc-testing" }
 grpc-inprocess = { module = "io.grpc:grpc-inprocess" }
 grpc-util = { module = "io.grpc:grpc-util" }

--- a/proto/proto-backplane-grpc/Dockerfile
+++ b/proto/proto-backplane-grpc/Dockerfile
@@ -69,13 +69,10 @@ RUN set -eux; \
   /opt/protoc/bin/protoc \
     --plugin=protoc-gen-go=/opt/go/bin/protoc-gen-go \
     --plugin=protoc-gen-go-grpc=/opt/go/bin/protoc-gen-go-grpc \
-    --plugin=protoc-gen-cpp_grpc=/opt/deephaven/bin/grpc_cpp_plugin \
     --go_out=/generated/go \
     --go-grpc_out=/generated/go \
     --go_opt=module=github.com/deephaven/deephaven-core/go \
     --go-grpc_opt=module=github.com/deephaven/deephaven-core/go \
-    --cpp_out=generated/cpp \
-    --cpp_grpc_out=generated/cpp \
     -I/includes \
     /includes/deephaven_core/proto/ticket.proto \
     /includes/deephaven_core/proto/console.proto \

--- a/proto/proto-backplane-grpc/Dockerfile
+++ b/proto/proto-backplane-grpc/Dockerfile
@@ -6,7 +6,6 @@ COPY dependencies /dependencies
 
 RUN set -eux; \
   mkdir -p /generated/java; \
-  mkdir -p /generated/grpc; \
   mkdir -p /generated/js; \
   mkdir -p /generated/go; \
   mkdir -p /generated/python; \
@@ -18,7 +17,7 @@ RUN set -eux; \
   /opt/protoc/bin/protoc \
     --plugin=protoc-gen-grpc=/opt/java/bin/protoc-gen-grpc-java \
     --java_out=/generated/java \
-    --grpc_out=/generated/grpc \
+    --grpc_out=/generated/java \
     -I/dependencies \
     -I/includes \
     /dependencies/BrowserFlight.proto \

--- a/proto/proto-backplane-grpc/build.gradle
+++ b/proto/proto-backplane-grpc/build.gradle
@@ -47,8 +47,7 @@ dependencies {
   testImplementation libs.junit4
 }
 
-def protoOutputDir =  layout.buildDirectory.dir('generated/source/proto/main')
-
+def protoOutputDir = layout.buildDirectory.dir('protoc-output');
 TaskProvider<Task> generateProtobuf = Docker.registerDockerTask(project, 'generateProtobuf') {
   copyIn {
     from(project.projectDir) {
@@ -74,6 +73,14 @@ TaskProvider<Task> generateProtobuf = Docker.registerDockerTask(project, 'genera
   }
 }
 
+tasks.register('syncProtocJava', Sync) {
+  dependsOn(generateProtobuf)
+  from(protoOutputDir.get().dir('java')) {
+    from 'java'
+  }
+  into layout.buildDirectory.dir('generated/sources/protoc/java/main')
+}
+
 // Provide js, go, python output as distinct artifacts - the java output will be consumed in this project by
 // declaring it as a new sourceset, see below. This could definitely be more precisely stated, but given that
 // all are generated in the same docker image creation step, we don't need to get too clever here.
@@ -92,12 +99,10 @@ artifacts {
   }
 }
 
-compileJava.dependsOn generateProtobuf
-
 sourceSets {
   main {
     java {
-      srcDir(protoOutputDir.get().dir('java')).include("**/*.java")
+        srcDir(syncProtocJava)
     }
     resources {
       srcDir 'src/main/proto'

--- a/proto/proto-backplane-grpc/build.gradle
+++ b/proto/proto-backplane-grpc/build.gradle
@@ -47,6 +47,8 @@ dependencies {
   testImplementation libs.junit4
 }
 
+def protoOutputDir =  layout.buildDirectory.dir('generated/source/proto/main')
+
 TaskProvider<Task> generateProtobuf = Docker.registerDockerTask(project, 'generateProtobuf') {
   copyIn {
     from(project.projectDir) {
@@ -68,7 +70,7 @@ TaskProvider<Task> generateProtobuf = Docker.registerDockerTask(project, 'genera
   containerOutPath = '/generated'
   imageName = Docker.localImageName('proto-backplane-grpc')
   copyOut {
-    into('build/generated/source/proto/main')
+    into(protoOutputDir)
   }
 }
 
@@ -90,13 +92,12 @@ artifacts {
   }
 }
 
-
 compileJava.dependsOn generateProtobuf
 
 sourceSets {
   main {
     java {
-      srcDir(generateProtobuf).include("**/*.java")
+      srcDir(protoOutputDir.get().dir('java')).include("**/*.java")
     }
     resources {
       srcDir 'src/main/proto'

--- a/proto/proto-backplane-grpc/build.gradle
+++ b/proto/proto-backplane-grpc/build.gradle
@@ -73,11 +73,9 @@ TaskProvider<Task> generateProtobuf = Docker.registerDockerTask(project, 'genera
   }
 }
 
-tasks.register('syncProtocJava', Sync) {
+def syncProtocJava = tasks.register('syncProtocJava', Sync) {
   dependsOn(generateProtobuf)
-  from(protoOutputDir.get().dir('java')) {
-    from 'java'
-  }
+  from(protoOutputDir.get().dir('java'))
   into layout.buildDirectory.dir('generated/sources/protoc/java/main')
 }
 
@@ -85,16 +83,16 @@ tasks.register('syncProtocJava', Sync) {
 // declaring it as a new sourceset, see below. This could definitely be more precisely stated, but given that
 // all are generated in the same docker image creation step, we don't need to get too clever here.
 artifacts {
-  js(layout.buildDirectory.dir('generated/source/proto/main/js')) {
+  js(protoOutputDir.get().dir('js')) {
     builtBy generateProtobuf
   }
-  python(layout.buildDirectory.dir('generated/source/proto/main/python')) {
+  python(protoOutputDir.get().dir('python')) {
     builtBy generateProtobuf
   }
-  go(layout.buildDirectory.dir('generated/source/proto/main/go')) {
+  go(protoOutputDir.get().dir('go')) {
     builtBy generateProtobuf
   }
-  protoDocs(layout.buildDirectory.dir('generated/source/proto/main/proto-doc')) {
+  protoDocs(protoOutputDir.get().dir('proto-doc')) {
     builtBy generateProtobuf
   }
 }


### PR DESCRIPTION
First, libs.grpc.stub accidentally was referencing grpc-services, a bigger classpath than was needed/desired.

Second, our gRPC project was specifying the parent directory of the sources, and needlessly splitting proto vs grpc outputs. The extra parent meant that classes were technically not in a directory to match their package - IDEs sometimes complain about this, but javac rarely does.