### PR TITLE
refactor: Update Iceberg key finders

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergBaseLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergBaseLayout.java
@@ -67,7 +67,7 @@ public abstract class IcebergBaseLayout implements TableLocationKeyFinder<Iceber
      * The {@link TableDefinition} that will be used for life of this table. Although Iceberg table schema may change,
      * schema changes are not supported in Deephaven.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     final TableDefinition tableDef;
 
     /**

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergFlatLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergFlatLayout.java
@@ -4,7 +4,9 @@
 package io.deephaven.iceberg.layout;
 
 import io.deephaven.engine.table.impl.locations.impl.TableLocationKeyFinder;
+import io.deephaven.iceberg.internal.DataInstructionsProviderLoader;
 import io.deephaven.iceberg.location.IcebergTableLocationKey;
+import io.deephaven.iceberg.util.IcebergReadInstructions;
 import io.deephaven.iceberg.util.IcebergTableAdapter;
 import io.deephaven.parquet.table.ParquetInstructions;
 import io.deephaven.util.annotations.InternalUseOnly;
@@ -21,6 +23,20 @@ import java.net.URI;
  */
 @InternalUseOnly
 public final class IcebergFlatLayout extends IcebergBaseLayout {
+
+    /**
+     * @param tableAdapter The {@link IcebergTableAdapter} that will be used to access the table.
+     * @param instructions The instructions for customizations while reading.
+     * @param dataInstructionsProvider The provider for special instructions, to be used if special instructions not
+     *        provided in the {@code instructions}.
+     */
+    @Deprecated
+    public IcebergFlatLayout(
+            @NotNull final IcebergTableAdapter tableAdapter,
+            @NotNull final IcebergReadInstructions instructions,
+            @NotNull final DataInstructionsProviderLoader dataInstructionsProvider) {
+        super(tableAdapter, instructions, dataInstructionsProvider);
+    }
 
     public IcebergFlatLayout(
             @NotNull IcebergTableAdapter tableAdapter,

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergFlatLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergFlatLayout.java
@@ -5,12 +5,13 @@ package io.deephaven.iceberg.layout;
 
 import io.deephaven.engine.table.impl.locations.impl.TableLocationKeyFinder;
 import io.deephaven.iceberg.location.IcebergTableLocationKey;
-import io.deephaven.iceberg.util.IcebergReadInstructions;
-import io.deephaven.iceberg.internal.DataInstructionsProviderLoader;
 import io.deephaven.iceberg.util.IcebergTableAdapter;
+import io.deephaven.parquet.table.ParquetInstructions;
+import io.deephaven.util.annotations.InternalUseOnly;
 import io.deephaven.util.channel.SeekableChannelsProvider;
 import org.apache.iceberg.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 
@@ -18,18 +19,15 @@ import java.net.URI;
  * Iceberg {@link TableLocationKeyFinder location finder} for tables without partitions that will discover data files
  * from a {@link Snapshot}
  */
+@InternalUseOnly
 public final class IcebergFlatLayout extends IcebergBaseLayout {
-    /**
-     * @param tableAdapter The {@link IcebergTableAdapter} that will be used to access the table.
-     * @param instructions The instructions for customizations while reading.
-     * @param dataInstructionsProvider The provider for special instructions, to be used if special instructions not
-     *        provided in the {@code instructions}.
-     */
+
     public IcebergFlatLayout(
-            @NotNull final IcebergTableAdapter tableAdapter,
-            @NotNull final IcebergReadInstructions instructions,
-            @NotNull final DataInstructionsProviderLoader dataInstructionsProvider) {
-        super(tableAdapter, instructions, dataInstructionsProvider);
+            @NotNull IcebergTableAdapter tableAdapter,
+            @NotNull ParquetInstructions parquetInstructions,
+            @NotNull SeekableChannelsProvider seekableChannelsProvider,
+            @Nullable Snapshot snapshot) {
+        super(tableAdapter, parquetInstructions, seekableChannelsProvider, snapshot);
     }
 
     @Override

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergFlatLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergFlatLayout.java
@@ -30,7 +30,8 @@ public final class IcebergFlatLayout extends IcebergBaseLayout {
      * @param dataInstructionsProvider The provider for special instructions, to be used if special instructions not
      *        provided in the {@code instructions}.
      */
-    @Deprecated
+    // TODO(DH-19072): Refactor Iceberg TLKFs to reduce visibility
+    @Deprecated(forRemoval = true)
     public IcebergFlatLayout(
             @NotNull final IcebergTableAdapter tableAdapter,
             @NotNull final IcebergReadInstructions instructions,

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergKeyValuePartitionedLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergKeyValuePartitionedLayout.java
@@ -3,18 +3,17 @@
 //
 package io.deephaven.iceberg.layout;
 
-import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.impl.TableLocationKeyFinder;
 import io.deephaven.iceberg.location.IcebergTableLocationKey;
-import io.deephaven.iceberg.util.IcebergReadInstructions;
 import io.deephaven.iceberg.util.IcebergTableAdapter;
-import io.deephaven.iceberg.internal.DataInstructionsProviderLoader;
+import io.deephaven.parquet.table.ParquetInstructions;
+import io.deephaven.util.annotations.InternalUseOnly;
 import io.deephaven.util.channel.SeekableChannelsProvider;
-import io.deephaven.util.type.TypeUtils;
 import org.apache.iceberg.*;
 import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 import java.util.*;
@@ -23,13 +22,16 @@ import java.util.*;
  * Iceberg {@link TableLocationKeyFinder location finder} for tables with partitions that will discover data files from
  * a {@link Snapshot}
  */
+@InternalUseOnly
 public final class IcebergKeyValuePartitionedLayout extends IcebergBaseLayout {
-    private static class IdentityPartitioningColData {
+
+    @InternalUseOnly
+    public static class IdentityPartitioningColData {
         final String name;
         final Class<?> type;
         final int index; // position in the partition spec
 
-        private IdentityPartitioningColData(String name, Class<?> type, int index) {
+        public IdentityPartitioningColData(String name, Class<?> type, int index) {
             this.name = name;
             this.type = type;
             this.index = index;
@@ -38,42 +40,14 @@ public final class IcebergKeyValuePartitionedLayout extends IcebergBaseLayout {
 
     private final List<IdentityPartitioningColData> identityPartitioningColumns;
 
-    /**
-     * @param tableAdapter The {@link IcebergTableAdapter} that will be used to access the table.
-     * @param partitionSpec The Iceberg {@link PartitionSpec partition spec} for the table.
-     * @param instructions The instructions for customizations while reading.
-     * @param dataInstructionsProvider The provider for special instructions, to be used if special instructions not
-     *        provided in the {@code instructions}.
-     */
     public IcebergKeyValuePartitionedLayout(
-            @NotNull final IcebergTableAdapter tableAdapter,
-            @NotNull final PartitionSpec partitionSpec,
-            @NotNull final IcebergReadInstructions instructions,
-            @NotNull final DataInstructionsProviderLoader dataInstructionsProvider) {
-        super(tableAdapter, instructions, dataInstructionsProvider);
-
-        // We can assume due to upstream validation that there are no duplicate names (after renaming) that are included
-        // in the output definition, so we can ignore duplicates.
-        final List<PartitionField> partitionFields = partitionSpec.fields();
-        final int numPartitionFields = partitionFields.size();
-        identityPartitioningColumns = new ArrayList<>(numPartitionFields);
-        for (int fieldId = 0; fieldId < numPartitionFields; ++fieldId) {
-            final PartitionField partitionField = partitionFields.get(fieldId);
-            if (!partitionField.transform().isIdentity()) {
-                // TODO (DH-18160): Improve support for handling non-identity transforms
-                continue;
-            }
-            final String icebergColName = partitionField.name();
-            final String dhColName = instructions.columnRenames().getOrDefault(icebergColName, icebergColName);
-            final ColumnDefinition<?> columnDef = tableDef.getColumn(dhColName);
-            if (columnDef == null) {
-                // Table definition provided by the user doesn't have this column, so skip.
-                continue;
-            }
-            identityPartitioningColumns.add(new IdentityPartitioningColData(dhColName,
-                    TypeUtils.getBoxedType(columnDef.getDataType()), fieldId));
-
-        }
+            @NotNull IcebergTableAdapter tableAdapter,
+            @NotNull ParquetInstructions parquetInstructions,
+            @NotNull SeekableChannelsProvider seekableChannelsProvider,
+            @Nullable Snapshot snapshot,
+            @NotNull List<IdentityPartitioningColData> identityPartitioningColumns) {
+        super(tableAdapter, parquetInstructions, seekableChannelsProvider, snapshot);
+        this.identityPartitioningColumns = Objects.requireNonNull(identityPartitioningColumns);
     }
 
     @Override

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergKeyValuePartitionedLayout.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/layout/IcebergKeyValuePartitionedLayout.java
@@ -51,7 +51,8 @@ public final class IcebergKeyValuePartitionedLayout extends IcebergBaseLayout {
      * @param dataInstructionsProvider The provider for special instructions, to be used if special instructions not
      *        provided in the {@code instructions}.
      */
-    @Deprecated
+    // TODO(DH-19072): Refactor Iceberg TLKFs to reduce visibility
+    @Deprecated(forRemoval = true)
     public IcebergKeyValuePartitionedLayout(
             @NotNull final IcebergTableAdapter tableAdapter,
             @NotNull final PartitionSpec partitionSpec,


### PR DESCRIPTION
This refactors the constructors for the Iceberg key finders, such that the `ParquetInstructions`, `SeekableChannelsProvider`, `Snapshot`, and `identityPartitioningColumns` logic is now contained in the `IcebergTableAdapter` layer. The existing constructors are annotated as `@Deprecated`, but left as-is for now until Core+ can migrate away from them. This does introduce a bit of intentional duplication of logic, but ultimately will be cleaned up once the deprecated methods are removed. These classes are now annotated as `@InternalUseOnly` to more clearly reflect their intended visibility.

In support of DH-18365