### PR TITLE
fix: DH-19077: Remove ModifiedColumnSet empty check from validateUpdateIndices.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -68,7 +68,8 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
             Configuration.getInstance().getBooleanWithDefault("BaseTable.validateUpdateIndices", false);
     public static final boolean VALIDATE_UPDATE_OVERLAPS =
             Configuration.getInstance().getBooleanWithDefault("BaseTable.validateUpdateOverlaps", true);
-    private static final boolean VALIDATE_UPDATE_MCSEMPTY = Configuration.getInstance().getBooleanWithDefault("BaseTable.validateUpdateModifiedColumnSets", false);
+    private static final boolean VALIDATE_UPDATE_MCSEMPTY =
+            Configuration.getInstance().getBooleanWithDefault("BaseTable.validateUpdateModifiedColumnSets", false);
     public static final boolean PRINT_SERIALIZED_UPDATE_OVERLAPS =
             Configuration.getInstance().getBooleanWithDefault("BaseTable.printSerializedUpdateOverlaps", false);
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BaseTable.java
@@ -68,6 +68,7 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
             Configuration.getInstance().getBooleanWithDefault("BaseTable.validateUpdateIndices", false);
     public static final boolean VALIDATE_UPDATE_OVERLAPS =
             Configuration.getInstance().getBooleanWithDefault("BaseTable.validateUpdateOverlaps", true);
+    private static final boolean VALIDATE_UPDATE_MCSEMPTY = Configuration.getInstance().getBooleanWithDefault("BaseTable.validateUpdateModifiedColumnSets", false);
     public static final boolean PRINT_SERIALIZED_UPDATE_OVERLAPS =
             Configuration.getInstance().getBooleanWithDefault("BaseTable.printSerializedUpdateOverlaps", false);
 
@@ -729,6 +730,9 @@ public abstract class BaseTable<IMPL_TYPE extends BaseTable<IMPL_TYPE>> extends 
             update.removed().validate();
             update.modified().validate();
             update.shifted().validate();
+        }
+
+        if (VALIDATE_UPDATE_MCSEMPTY) {
             Assert.eq(update.modified().isEmpty(), "update.modified.empty()", update.modifiedColumnSet().empty(),
                     "update.modifiedColumnSet.empty()");
         }

--- a/props/test-configs/src/main/resources/dh-tests.prop
+++ b/props/test-configs/src/main/resources/dh-tests.prop
@@ -105,3 +105,5 @@ client.version.list=
 authentication.anonymous.warn=false
 
 deephaven.console.type=none
+
+BaseTable.validateUpdateIndices=true


### PR DESCRIPTION
Unit tests are now also run with validateUpdateIndices, no nightlies resulted in failure with the additional validation.