### PR TITLE
fix: ListFields should always return up-to-date snapshot

### DIFF
--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
@@ -132,11 +132,16 @@ public class ApplicationServiceGrpcImpl extends ApplicationServiceGrpc.Applicati
         final SessionState session = sessionService.getCurrentSession();
         final Subscription subscription = new Subscription(session, responseObserver);
 
+        // Before building the initial state, ensure it is up to date.
+        propagateUpdates();
+
         final FieldsChangeUpdate.Builder responseBuilder = FieldsChangeUpdate.newBuilder();
         for (FieldInfo fieldInfo : known.values()) {
             responseBuilder.addCreated(fieldInfo);
         }
+
         if (subscription.send(responseBuilder.build())) {
+            // Now that the new client has received their initial state, add them to the list of subscriptions
             subscriptions.add(subscription);
         } else {
             subscription.onCancel();

--- a/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
+++ b/server/src/main/java/io/deephaven/server/appmode/ApplicationServiceGrpcImpl.java
@@ -194,7 +194,7 @@ public class ApplicationServiceGrpcImpl extends ApplicationServiceGrpc.Applicati
             isScheduled = true;
             final long now = scheduler.currentTimeMillis();
             final long nextMin = lastScheduledMillis + UPDATE_INTERVAL_MS;
-            if (lastScheduledMillis > 0 && now >= nextMin) {
+            if (now >= nextMin) {
                 lastScheduledMillis = now;
                 scheduler.runImmediately(this);
             } else {

--- a/server/src/test/java/io/deephaven/server/appmode/ApplicationServiceGrpcImplTest.java
+++ b/server/src/test/java/io/deephaven/server/appmode/ApplicationServiceGrpcImplTest.java
@@ -25,9 +25,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ApplicationServiceGrpcImplTest {
 
@@ -67,8 +70,7 @@ public class ApplicationServiceGrpcImplTest {
         AtomicBoolean faultyObserverShouldStillWork = new AtomicBoolean(true);
 
         // start two subscriptions to the app fields, spoofing auth as different connections - the first will behave,
-        // the
-        // second will not
+        // the second will not
         Context.current().withValue(SessionServiceGrpcImpl.SESSION_CONTEXT_KEY, sessionService.newSession(AUTH_CONTEXT))
                 .wrap(() -> {
                     applicationServiceGrpcImpl.listFields(ListFieldsRequest.getDefaultInstance(),
@@ -99,6 +101,54 @@ public class ApplicationServiceGrpcImplTest {
 
         // verify the second subscriber got its call
         assertEquals(2, workingObserver.messageCount);
+    }
+
+    /**
+     * Confirm that an existing ListFields subscription won't prevent a new one from getting an accurate initial
+     * snapshot
+     */
+    @Test
+    public void onListFieldsSubscribeNewObserver() {
+        // start two subscriptions to the app fields, spoofing auth as different connections - the first will behave,
+        // the second will not
+        Context.current().withValue(SessionServiceGrpcImpl.SESSION_CONTEXT_KEY, sessionService.newSession(AUTH_CONTEXT))
+                .run(() -> {
+                    // Open a subscription, leave it running for the duration of the test
+                    applicationServiceGrpcImpl.listFields(ListFieldsRequest.getDefaultInstance(),
+                            new CountingObserver<>());
+
+                    // Trigger a change, don't ask the test scheduler to pick this up
+                    ScriptSession scriptSession = new NoLanguageDeephavenSession(
+                            ExecutionContext.getContext().getUpdateGraph(),
+                            ExecutionContext.getContext().getOperationInitializer());
+                    scriptSession.getQueryScope().putParam("key", "hello world");
+                    ScriptSession.Changes changes = new ScriptSession.Changes();
+                    changes.created.put("key", "Object");
+                    applicationServiceGrpcImpl.onScopeChanges(scriptSession, changes);
+
+                    // Open a second subscription, ensure it has the new object
+                    CountDownLatch latch = new CountDownLatch(1);
+                    applicationServiceGrpcImpl.listFields(ListFieldsRequest.getDefaultInstance(), new StreamObserver<>() {
+                        @Override
+                        public void onNext(FieldsChangeUpdate fieldsChangeUpdate) {
+                            assertEquals(1, fieldsChangeUpdate.getCreatedCount());
+                            assertEquals("key", fieldsChangeUpdate.getCreated(0).getFieldName());
+                            latch.countDown();
+                        }
+
+                        @Override
+                        public void onError(Throwable throwable) {}
+
+                        @Override
+                        public void onCompleted() {}
+                    });
+
+                    try {
+                        assertTrue(latch.await(1, TimeUnit.SECONDS));
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 
     private static class CountingObserver<T> implements StreamObserver<T> {

--- a/server/src/test/java/io/deephaven/server/appmode/ApplicationServiceGrpcImplTest.java
+++ b/server/src/test/java/io/deephaven/server/appmode/ApplicationServiceGrpcImplTest.java
@@ -128,20 +128,21 @@ public class ApplicationServiceGrpcImplTest {
 
                     // Open a second subscription, ensure it has the new object
                     CountDownLatch latch = new CountDownLatch(1);
-                    applicationServiceGrpcImpl.listFields(ListFieldsRequest.getDefaultInstance(), new StreamObserver<>() {
-                        @Override
-                        public void onNext(FieldsChangeUpdate fieldsChangeUpdate) {
-                            assertEquals(1, fieldsChangeUpdate.getCreatedCount());
-                            assertEquals("key", fieldsChangeUpdate.getCreated(0).getFieldName());
-                            latch.countDown();
-                        }
+                    applicationServiceGrpcImpl.listFields(ListFieldsRequest.getDefaultInstance(),
+                            new StreamObserver<>() {
+                                @Override
+                                public void onNext(FieldsChangeUpdate fieldsChangeUpdate) {
+                                    assertEquals(1, fieldsChangeUpdate.getCreatedCount());
+                                    assertEquals("key", fieldsChangeUpdate.getCreated(0).getFieldName());
+                                    latch.countDown();
+                                }
 
-                        @Override
-                        public void onError(Throwable throwable) {}
+                                @Override
+                                public void onError(Throwable throwable) {}
 
-                        @Override
-                        public void onCompleted() {}
-                    });
+                                @Override
+                                public void onCompleted() {}
+                            });
 
                     try {
                         assertTrue(latch.await(1, TimeUnit.SECONDS));


### PR DESCRIPTION
Also removes an extra check performed in markUpdates() that would defer the very first scheduled check, instead of running right away.

Fixes DH-19078