### PR TITLE
fix: Don't size chunks incorrectly/unnecessarily

### DIFF
--- a/engine/base/src/main/java/io/deephaven/engine/table/impl/ContextWithChunk.java
+++ b/engine/base/src/main/java/io/deephaven/engine/table/impl/ContextWithChunk.java
@@ -7,7 +7,6 @@ import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.engine.table.Context;
-import io.deephaven.util.SafeCloseable;
 import org.jetbrains.annotations.NotNull;
 
 public class ContextWithChunk<ATTR extends Any, CONTEXT extends Context> implements Context {
@@ -66,20 +65,6 @@ public class ContextWithChunk<ATTR extends Any, CONTEXT extends Context> impleme
     public static <CONTEXT extends Context> CONTEXT getContext(@NotNull Context context) {
         // noinspection unchecked,rawtypes
         return (CONTEXT) ((ContextWithChunk) context).context;
-    }
-
-    /**
-     * Makes sure that the internal array (and hence the writableChunk) is at least the specified size.
-     */
-    public void ensureSize(final int length) {
-        if (writableChunk.size() < length) {
-            if (writableChunk.capacity() < length) {
-                final SafeCloseable oldWritableChunk = writableChunk;
-                writableChunk = writableChunk.getChunkType().makeWritableChunk(length);
-                oldWritableChunk.close();
-            }
-            writableChunk.setSize(length);
-        }
     }
 
     /**

--- a/engine/base/src/main/java/io/deephaven/engine/table/impl/ContextWithChunk.java
+++ b/engine/base/src/main/java/io/deephaven/engine/table/impl/ContextWithChunk.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.engine.table.impl;
 
+import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.engine.table.Context;
@@ -18,7 +19,7 @@ public class ContextWithChunk<ATTR extends Any, CONTEXT extends Context> impleme
     ContextWithChunk(CONTEXT context, ChunkType chunkType, int chunkCapacity) {
         this.context = context;
         writableChunk = chunkType.makeWritableChunk(chunkCapacity);
-        writableChunk.setSize(chunkCapacity);
+        Assert.eq(chunkCapacity, "chunkCapacity", writableChunk.size(), "writableChunk.size()");
         resettableWritableChunk = chunkType.makeResettableWritableChunk();
     }
 

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkReader.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.extensions.barrage.chunk;
 
+import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.chunk.WritableChunk;
@@ -32,7 +33,7 @@ public abstract class BaseChunkReader<READ_CHUNK_TYPE extends WritableChunk<Valu
             return castFunction.apply(outChunk);
         }
         final T newChunk = chunkFactory.apply(numRows);
-        newChunk.setSize(numRows);
+        Assert.eq(numRows, "numRows", newChunk.size(), "chunk.size()");
         return newChunk;
     }
 

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BooleanChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BooleanChunkReader.java
@@ -80,14 +80,11 @@ public class BooleanChunkReader extends BaseChunkReader<WritableByteChunk<Values
         final long validityBuffer = bufferInfoIter.nextLong();
         final long payloadBuffer = bufferInfoIter.nextLong();
 
-        final WritableByteChunk<Values> chunk;
-        if (outChunk != null) {
-            chunk = outChunk.asWritableByteChunk();
-        } else {
-            final int numRows = Math.max(totalRows, nodeInfo.numElements);
-            chunk = WritableByteChunk.makeWritableChunk(numRows);
-            chunk.setSize(numRows);
-        }
+        final WritableByteChunk<Values> chunk = castOrCreateChunk(
+                outChunk,
+                Math.max(totalRows, nodeInfo.numElements),
+                WritableByteChunk::makeWritableChunk,
+                WritableChunk::asWritableByteChunk);
 
         if (nodeInfo.numElements == 0) {
             return chunk;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/TransformingChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/TransformingChunkReader.java
@@ -57,7 +57,6 @@ public class TransformingChunkReader<INPUT_CHUNK_TYPE extends WritableChunk<Valu
                 Assert.eqZero(outOffset, "outOffset");
             }
             transformer.transform(wireValues, chunk, outOffset);
-            chunk.setSize(outOffset + wireValues.size());
             return chunk;
         }
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageMessageReader.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageMessageReader.java
@@ -8,8 +8,6 @@ import io.deephaven.barrage.flatbuf.BarrageMessageType;
 import io.deephaven.barrage.flatbuf.BarrageMessageWrapper;
 import io.deephaven.barrage.flatbuf.BarrageModColumnMetadata;
 import io.deephaven.barrage.flatbuf.BarrageUpdateMetadata;
-import io.deephaven.chunk.ChunkType;
-import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;


### PR DESCRIPTION
In addition to fixing a case where TransformingChunkReader was resizing something it shouldn't alter, this patch also removes a few unnecessary Chunk.setSize calls.

Fixes DH-18515

This version of the patch replaces unnecessary (but not wrong) setSize calls with asserts to make sure we don't have any missing cases to worry about, and arguably should be removed.