### PR TITLE
fix: DH-18659: Make Barrage ChunkFactorys' #register Public

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
@@ -35,7 +35,6 @@ import io.deephaven.vector.ByteVector;
 import io.deephaven.vector.ByteVectorDirect;
 import io.deephaven.vector.Vector;
 import org.apache.arrow.vector.PeriodDuration;
-import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -87,9 +86,12 @@ public class DefaultChunkReaderFactory implements ChunkReader.Factory {
             ArrowType.ArrowTypeID.Null);
 
     public static final Logger log = LoggerFactory.getLogger(DefaultChunkReaderFactory.class);
-    public static final ChunkReader.Factory INSTANCE = new DefaultChunkReaderFactory();
+    public static final DefaultChunkReaderFactory INSTANCE = new DefaultChunkReaderFactory();
 
-    protected interface ChunkReaderFactory {
+    /**
+     * Factory method to create a new {@link ChunkReader} for the given type and options.
+     */
+    public interface ChunkReaderFactory {
         ChunkReader<? extends WritableChunk<Values>> make(
                 final ArrowType arrowType,
                 final BarrageTypeInfo<Field> typeInfo,
@@ -347,7 +349,7 @@ public class DefaultChunkReaderFactory implements ChunkReader.Factory {
     }
 
     @SuppressWarnings("unchecked")
-    protected void register(
+    public void register(
             final ArrowType.ArrowTypeID arrowType,
             final Class<?> deephavenType,
             final ChunkReaderFactory chunkReaderFactory) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkWriterFactory.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkWriterFactory.java
@@ -43,7 +43,6 @@ import io.deephaven.util.type.TypeUtils;
 import io.deephaven.vector.ByteVector;
 import io.deephaven.vector.Vector;
 import org.apache.arrow.vector.PeriodDuration;
-import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -55,7 +54,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -82,13 +80,13 @@ import static io.deephaven.extensions.barrage.chunk.FactoryHelper.maskIfOverflow
  */
 public class DefaultChunkWriterFactory implements ChunkWriter.Factory {
     public static final Logger log = LoggerFactory.getLogger(DefaultChunkWriterFactory.class);
-    public static final ChunkWriter.Factory INSTANCE = new DefaultChunkWriterFactory();
+    public static final DefaultChunkWriterFactory INSTANCE = new DefaultChunkWriterFactory();
 
     /**
      * This supplier interface simplifies the cost to operate off of the ArrowType directly since the Arrow POJO is not
      * yet supported over GWT.
      */
-    protected interface ArrowTypeChunkWriterSupplier {
+    public interface ArrowTypeChunkWriterSupplier {
         ChunkWriter<? extends Chunk<Values>> make(
                 final BarrageTypeInfo<Field> typeInfo);
     }
@@ -349,7 +347,7 @@ public class DefaultChunkWriterFactory implements ChunkWriter.Factory {
     }
 
     @SuppressWarnings("unchecked")
-    protected void register(
+    public void register(
             final ArrowType.ArrowTypeID arrowType,
             final Class<?> deephavenType,
             final ArrowTypeChunkWriterSupplier chunkWriterFactory) {

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -53,7 +53,6 @@ import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
 import io.deephaven.proto.flight.util.MessageHelper;
 import io.deephaven.proto.flight.util.SchemaHelper;
 import io.deephaven.proto.util.Exceptions;
-import io.deephaven.util.annotations.VisibleForTesting;
 import io.deephaven.util.type.TypeUtils;
 import io.deephaven.vector.ObjectVector;
 import io.deephaven.vector.Vector;


### PR DESCRIPTION
We need these exposed to support registering custom encodings over barrage/arrow-flight.