### PR TITLE
fix: DH-18659: ApplyPreviewColumns Should Strip Custom Barrage Schema From Table Attributes

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/preview/ColumnPreviewManager.java
@@ -131,6 +131,9 @@ public class ColumnPreviewManager {
             }
 
             result.setAttribute(Table.COLUMN_DESCRIPTIONS_ATTRIBUTE, columnDescriptions);
+            if (table.hasAttribute(Table.BARRAGE_SCHEMA_ATTRIBUTE)) {
+                result = (BaseTable<?>) result.withoutAttributes(List.of(Table.BARRAGE_SCHEMA_ATTRIBUTE));
+            }
         }
 
         return result;


### PR DESCRIPTION
jsapi does not support any barrage type coercion, so we should remove custom serialization instructions whenever applying preview columns to ensure payloads can be read by the web-ui.