### PR TITLE
feat: Enforce stricter web security rules

### DIFF
--- a/extensions/flight-sql/src/adbcTest/java/io/deephaven/server/flightsql/JettyTestComponent.java
+++ b/extensions/flight-sql/src/adbcTest/java/io/deephaven/server/flightsql/JettyTestComponent.java
@@ -15,6 +15,7 @@ import io.deephaven.server.runner.ExecutionContextUnitTestModule;
 import javax.inject.Singleton;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Set;
 
 @Singleton
 @Component(modules = {
@@ -32,6 +33,7 @@ public interface JettyTestComponent extends TestComponent {
             return JettyConfig.builder()
                     .port(0)
                     .tokenExpire(Duration.of(5, ChronoUnit.MINUTES))
+                    .allowedHttpMethods(Set.of("POST"))
                     .build();
         }
     }

--- a/extensions/flight-sql/src/jdbcTest/java/io/deephaven/server/flightsql/JettyTestComponent.java
+++ b/extensions/flight-sql/src/jdbcTest/java/io/deephaven/server/flightsql/JettyTestComponent.java
@@ -15,6 +15,7 @@ import io.deephaven.server.runner.ExecutionContextUnitTestModule;
 import javax.inject.Singleton;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Set;
 
 @Singleton
 @Component(modules = {
@@ -32,6 +33,7 @@ public interface JettyTestComponent extends TestComponent {
             return JettyConfig.builder()
                     .port(0)
                     .tokenExpire(Duration.of(5, ChronoUnit.MINUTES))
+                    .allowedHttpMethods(Set.of("POST"))
                     .build();
         }
     }

--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -71,3 +71,47 @@ client.configuration.list=java.version,deephaven.version,barrage.version,groovy.
 # jar, and a class that is found in that jar. Any such keys will be made available to the client.configuration.list
 # as <key>.version.
 client.version.list=deephaven=io.deephaven.engine.table.Table,barrage=io.deephaven.barrage.flatbuf.BarrageMessageWrapper,groovy=groovy.lang.GroovyShell
+
+# Disabled by default, applications should enable this after their TLS certificates are
+# deployed and confirmed to work, as disabling this after the fact can result in clients
+# remembering the old value for a long time.
+http.add.header.Strict-Transport-Security.enabled = false
+http.add.header.Strict-Transport-Security.value = max-age=31536000; includeSubDomains
+
+# Disable by default, but can be enabled if iframe widgets will not be used from other origins.
+# This can optionally be fine tuned to allow specific origins or same origin loading.
+http.add.header.X-Frame-Options.enabled = false
+http.add.header.X-Frame-Options.value = DENY
+
+# Disabled by default, this CSP policy prevents embedding pages in an iframe. This is a more
+# modern equivalent to the X-Frame-Options header above, and also can be fine tuned to allow
+# specific remote origins or same origin.
+http.add.header.Content-Security-Policy.enabled = false
+http.add.header.Content-Security-Policy.value = frame-ancestors 'none';
+
+# Enabled by default as the risk should be low for breaking other pages. We advise against
+# fine tuning this, but instead if it is breaking a specific use case, outright disable it.
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection
+# for more information.
+http.add.header.X-XSS-Protection.enabled = true
+http.add.header.X-XSS-Protection.value = 1; mode=block
+
+# Enabled by default, the server should be able to set all of its own content-type headers
+# correctly. It is possible that third-party plugins could cause issues with this, so it can
+# be disabled if desired.
+http.add.header.X-Content-Type-Options.enabled = true
+http.add.header.X-Content-Type-Options.value = nosniff
+
+# Enabled by default, the server doesn't make use of any referrer information. Can be enabled
+# as desired to handle other use cases.
+http.add.header.Referrer-Policy.enabled = true
+http.add.header.Referrer-Policy.value = no-referrer
+
+# Enabled by default, these settings restrict documents loaded from Deephaven-core to block
+# no-cors calls and permit running the page in a secure context.
+http.add.header.Cross-Origin-Resource-Policy.enabled = true
+http.add.header.Cross-Origin-Resource-Policy.value = same-origin
+http.add.header.Cross-Origin-Embedder-Policy.enabled = true
+http.add.header.Cross-Origin-Embedder-Policy.value = require-corp
+http.add.header.Cross-Origin-Opener-Policy.enabled = true
+http.add.header.Cross-Origin-Opener-Policy.value = same-origin

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/AllowedHttpMethodsCustomizer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/AllowedHttpMethodsCustomizer.java
@@ -28,6 +28,7 @@ public class AllowedHttpMethodsCustomizer implements HttpConfiguration.Customize
 
     /**
      * Creates a new instance of the customizer, allowing only the specified HTTP methods.
+     *
      * @param allowedMethods the HTTP methods to allow
      */
     public AllowedHttpMethodsCustomizer(final Set<String> allowedMethods) {

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/AllowedHttpMethodsCustomizer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/AllowedHttpMethodsCustomizer.java
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.jetty11;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+
+import java.util.Set;
+
+/**
+ * Limits the allowed HTTP methods to those specified in the configuration. When set on the http configuration itself,
+ * this is applied for all calls made to the server, regardless of context.
+ * <p>
+ * For the deephaven-core server, we need to allow only one HTTP method, with two other optional ones, depending on how
+ * the server is to be used.
+ * <ul>
+ * <li>POST - required for the server to be useful at all, used for all gRPC endpoints that deephaven-core
+ * supports.</li>
+ * <li>GET - optional, likely only needed for browser clients at this time.</li>
+ * <li>OPTIONS - optional, necessary for CORS requests.</li>
+ * </ul>
+ */
+public class AllowedHttpMethodsCustomizer implements HttpConfiguration.Customizer {
+    private final Set<String> allowedMethods;
+
+    public AllowedHttpMethodsCustomizer(Set<String> allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
+    @Override
+    public void customize(Connector connector, HttpConfiguration httpConfiguration, Request request) {
+        if (!allowedMethods.contains(request.getMethod())) {
+            request.setHandled(true);
+            request.getResponse().setStatus(HttpStatus.METHOD_NOT_ALLOWED_405);
+        }
+    }
+}

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/AllowedHttpMethodsCustomizer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/AllowedHttpMethodsCustomizer.java
@@ -26,12 +26,16 @@ import java.util.Set;
 public class AllowedHttpMethodsCustomizer implements HttpConfiguration.Customizer {
     private final Set<String> allowedMethods;
 
-    public AllowedHttpMethodsCustomizer(Set<String> allowedMethods) {
+    /**
+     * Creates a new instance of the customizer, allowing only the specified HTTP methods.
+     * @param allowedMethods the HTTP methods to allow
+     */
+    public AllowedHttpMethodsCustomizer(final Set<String> allowedMethods) {
         this.allowedMethods = allowedMethods;
     }
 
     @Override
-    public void customize(Connector connector, HttpConfiguration httpConfiguration, Request request) {
+    public void customize(final Connector connector, final HttpConfiguration httpConfiguration, final Request request) {
         if (!allowedMethods.contains(request.getMethod())) {
             request.setHandled(true);
             request.getResponse().setStatus(HttpStatus.METHOD_NOT_ALLOWED_405);

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/ConfiguredHeadersCustomizer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/ConfiguredHeadersCustomizer.java
@@ -18,6 +18,7 @@ public class ConfiguredHeadersCustomizer implements HttpConfiguration.Customizer
 
     /**
      * Creates a new instance of the customizer, applying the given headers to every outgoing response.
+     *
      * @param configuredHeaders the headers to add to every response
      */
     public ConfiguredHeadersCustomizer(final Map<String, String> configuredHeaders) {

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/ConfiguredHeadersCustomizer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/ConfiguredHeadersCustomizer.java
@@ -1,11 +1,12 @@
 //
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
-package io.deephaven.server.jetty;
+package io.deephaven.server.jetty11;
 
-import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 
 import java.util.Map;
 
@@ -20,10 +21,10 @@ public class ConfiguredHeadersCustomizer implements HttpConfiguration.Customizer
     }
 
     @Override
-    public Request customize(Request request, HttpFields.Mutable responseHeaders) {
+    public void customize(Connector connector, HttpConfiguration channelConfig, Request request) {
+        Response response = request.getResponse();
         for (Map.Entry<String, String> header : configuredHeaders.entrySet()) {
-            responseHeaders.add(header.getKey(), header.getValue());
+            response.setHeader(header.getKey(), header.getValue());
         }
-        return request;
     }
 }

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/ConfiguredHeadersCustomizer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/ConfiguredHeadersCustomizer.java
@@ -16,14 +16,18 @@ import java.util.Map;
 public class ConfiguredHeadersCustomizer implements HttpConfiguration.Customizer {
     private final Map<String, String> configuredHeaders;
 
-    public ConfiguredHeadersCustomizer(Map<String, String> configuredHeaders) {
+    /**
+     * Creates a new instance of the customizer, applying the given headers to every outgoing response.
+     * @param configuredHeaders the headers to add to every response
+     */
+    public ConfiguredHeadersCustomizer(final Map<String, String> configuredHeaders) {
         this.configuredHeaders = configuredHeaders;
     }
 
     @Override
-    public void customize(Connector connector, HttpConfiguration channelConfig, Request request) {
-        Response response = request.getResponse();
-        for (Map.Entry<String, String> header : configuredHeaders.entrySet()) {
+    public void customize(final Connector connector, final HttpConfiguration channelConfig, final Request request) {
+        final Response response = request.getResponse();
+        for (final Map.Entry<String, String> header : configuredHeaders.entrySet()) {
             response.setHeader(header.getKey(), header.getValue());
         }
     }

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
@@ -349,6 +349,9 @@ public class JettyBackedGrpcServer implements GrpcServer {
         final HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
+        if (!config.extraHeaders().isEmpty()) {
+            httpConfig.addCustomizer(new ConfiguredHeadersCustomizer(config.extraHeaders()));
+        }
         final HttpConnectionFactory http11 = config.http1OrDefault() ? new HttpConnectionFactory(httpConfig) : null;
         final ServerConnector serverConnector;
         if (config.ssl().isPresent()) {

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
@@ -348,6 +348,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
         // https://www.eclipse.org/jetty/documentation/jetty-11/programming-guide/index.html#pg-server-http-connector-protocol-http2-tls
         final HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
         final HttpConnectionFactory http11 = config.http1OrDefault() ? new HttpConnectionFactory(httpConfig) : null;
         final ServerConnector serverConnector;
         if (config.ssl().isPresent()) {

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyConfig.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyConfig.java
@@ -11,6 +11,10 @@ import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -35,6 +39,7 @@ public abstract class JettyConfig implements ServerConfig {
     public static final String MAX_HEADER_REQUEST_SIZE = "http.maxHeaderRequestSize";
     public static final String ALLOWED_HTTP_METHODS = "http.allowedMethods";
     public static final Set<String> DEFAULT_ALLOWED_METHODS = Set.of("GET", "POST", "OPTIONS");
+    public static final String EXTRA_HEADERS = "http.add.header.";
 
     /**
      * Values to indicate what kind of websocket support should be offered.
@@ -103,6 +108,7 @@ public abstract class JettyConfig implements ServerConfig {
         String maxHeaderRequestSize = config.getStringWithDefault(MAX_HEADER_REQUEST_SIZE, null);
         Set<String> allowedHttpMethods = config.getStringSetFromPropertyWithDefault(ALLOWED_HTTP_METHODS,
                 DEFAULT_ALLOWED_METHODS);
+        Map<String, String> extraHeaders = readExtraHeaders(config);
 
         if (httpWebsockets != null) {
             switch (httpWebsockets.toLowerCase()) {
@@ -140,7 +146,28 @@ public abstract class JettyConfig implements ServerConfig {
             builder.maxHeaderRequestSize(Integer.parseInt(maxHeaderRequestSize));
         }
         builder.allowedHttpMethods(allowedHttpMethods);
+        builder.extraHeaders(extraHeaders);
         return builder;
+    }
+
+    private static Map<String, String> readExtraHeaders(Configuration config) {
+        Map<String, String> extraHeaders = new HashMap<>();
+        final List<String> headerKeys = new ArrayList<>();
+
+        config.getProperties(EXTRA_HEADERS).forEach((suffixArg, valueArg) -> {
+            final String suffix = (String) suffixArg;
+            if (suffix != null && suffix.endsWith(".enabled") && valueArg != null
+                    && Boolean.parseBoolean(valueArg.toString())) {
+                headerKeys.add(suffix.substring(0, suffix.length() - ".enabled".length()));
+            }
+        });
+        for (String headerKey : headerKeys) {
+            final String headerValue = config.getStringWithDefault(EXTRA_HEADERS + headerKey + ".value", null);
+            if (headerValue != null) {
+                extraHeaders.put(headerKey, headerValue);
+            }
+        }
+        return extraHeaders;
     }
 
     /**
@@ -246,6 +273,11 @@ public abstract class JettyConfig implements ServerConfig {
      */
     public abstract Set<String> allowedHttpMethods();
 
+    /**
+     * Extra headers to return in every response from this server.
+     */
+    public abstract Map<String, String> extraHeaders();
+
     public interface Builder extends ServerConfig.Builder<JettyConfig, Builder> {
 
         Builder websockets(WebsocketsSupport websockets);
@@ -263,5 +295,7 @@ public abstract class JettyConfig implements ServerConfig {
         Builder maxConcurrentStreams(int maxConcurrentStreams);
 
         Builder allowedHttpMethods(Iterable<String> allowedHttpMethods);
+
+        Builder extraHeaders(Map<String, ? extends String> extraHeaders);
     }
 }

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyConfig.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyConfig.java
@@ -11,9 +11,9 @@ import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Style;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 
 /**
  * The jetty server configuration.
@@ -33,6 +33,8 @@ public abstract class JettyConfig implements ServerConfig {
     public static final String SNI_HOST_CHECK = "https.sniHostCheck";
     public static final String MAX_CONCURRENT_STREAMS = "http2.maxConcurrentStreams";
     public static final String MAX_HEADER_REQUEST_SIZE = "http.maxHeaderRequestSize";
+    public static final String ALLOWED_HTTP_METHODS = "http.allowedMethods";
+    public static final Set<String> DEFAULT_ALLOWED_METHODS = Set.of("GET", "POST", "OPTIONS");
 
     /**
      * Values to indicate what kind of websocket support should be offered.
@@ -99,6 +101,9 @@ public abstract class JettyConfig implements ServerConfig {
         String h2StreamIdleTimeout = config.getStringWithDefault(HTTP_STREAM_TIMEOUT, null);
         String h2MaxConcurrentStreams = config.getStringWithDefault(MAX_CONCURRENT_STREAMS, null);
         String maxHeaderRequestSize = config.getStringWithDefault(MAX_HEADER_REQUEST_SIZE, null);
+        Set<String> allowedHttpMethods = config.getStringSetFromPropertyWithDefault(ALLOWED_HTTP_METHODS,
+                DEFAULT_ALLOWED_METHODS);
+
         if (httpWebsockets != null) {
             switch (httpWebsockets.toLowerCase()) {
                 case "true":// backwards compatible
@@ -134,6 +139,7 @@ public abstract class JettyConfig implements ServerConfig {
         if (maxHeaderRequestSize != null) {
             builder.maxHeaderRequestSize(Integer.parseInt(maxHeaderRequestSize));
         }
+        builder.allowedHttpMethods(allowedHttpMethods);
         return builder;
     }
 
@@ -234,6 +240,12 @@ public abstract class JettyConfig implements ServerConfig {
      */
     public abstract OptionalInt maxConcurrentStreams();
 
+    /**
+     * If unset, defaults to permitting "GET", "POST", and "OPTIONS" methods, ensuring that gRPC calls and requests to
+     * load the web client are permitted.
+     */
+    public abstract Set<String> allowedHttpMethods();
+
     public interface Builder extends ServerConfig.Builder<JettyConfig, Builder> {
 
         Builder websockets(WebsocketsSupport websockets);
@@ -249,5 +261,7 @@ public abstract class JettyConfig implements ServerConfig {
         Builder maxHeaderRequestSize(int maxHeaderRequestSize);
 
         Builder maxConcurrentStreams(int maxConcurrentStreams);
+
+        Builder allowedHttpMethods(Iterable<String> allowedHttpMethods);
     }
 }

--- a/server/jetty-11/src/test/java/io/deephaven/server/jetty11/JettyFlightRoundTripTest.java
+++ b/server/jetty-11/src/test/java/io/deephaven/server/jetty11/JettyFlightRoundTripTest.java
@@ -23,6 +23,7 @@ import javax.inject.Singleton;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -37,6 +38,7 @@ public class JettyFlightRoundTripTest extends FlightMessageRoundTripTest {
             return JettyConfig.builder()
                     .port(0)
                     .tokenExpire(Duration.of(5, ChronoUnit.MINUTES))
+                    .allowedHttpMethods(Set.of("GET", "POST"))
                     .build();
         }
     }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/AllowedHttpMethodsCustomizer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/AllowedHttpMethodsCustomizer.java
@@ -27,12 +27,16 @@ import java.util.Set;
 public class AllowedHttpMethodsCustomizer implements HttpConfiguration.Customizer {
     private final Set<String> allowedMethods;
 
-    public AllowedHttpMethodsCustomizer(Set<String> allowedMethods) {
+    /**
+     * Creates a new instance of the customizer, allowing only the specified HTTP methods.
+     * @param allowedMethods the HTTP methods to allow
+     */
+    public AllowedHttpMethodsCustomizer(final Set<String> allowedMethods) {
         this.allowedMethods = allowedMethods;
     }
 
     @Override
-    public Request customize(Request request, HttpFields.Mutable mutable) {
+    public Request customize(final Request request, final HttpFields.Mutable mutable) {
         if (!allowedMethods.contains(request.getMethod())) {
             throw new HttpException.RuntimeException(HttpStatus.METHOD_NOT_ALLOWED_405, "Method not allowed");
         }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/AllowedHttpMethodsCustomizer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/AllowedHttpMethodsCustomizer.java
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.jetty;
+
+import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+
+import java.util.Set;
+
+/**
+ * Limits the allowed HTTP methods to those specified in the configuration. When set on the http configuration itself,
+ * this is applied for all calls made to the server, regardless of context.
+ * <p>
+ * For the deephaven-core server, we need to allow only one HTTP method, with two other optional ones, depending on how
+ * the server is to be used.
+ * <ul>
+ * <li>POST - required for the server to be useful at all, used for all gRPC endpoints that deephaven-core
+ * supports.</li>
+ * <li>GET - optional, likely only needed for browser clients at this time.</li>
+ * <li>OPTIONS - optional, necessary for CORS requests.</li>
+ * </ul>
+ */
+public class AllowedHttpMethodsCustomizer implements HttpConfiguration.Customizer {
+    private final Set<String> allowedMethods;
+
+    public AllowedHttpMethodsCustomizer(Set<String> allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
+    @Override
+    public Request customize(Request request, HttpFields.Mutable mutable) {
+        if (!allowedMethods.contains(request.getMethod())) {
+            throw new HttpException.RuntimeException(HttpStatus.METHOD_NOT_ALLOWED_405, "Method not allowed");
+        }
+        return request;
+    }
+}

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/AllowedHttpMethodsCustomizer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/AllowedHttpMethodsCustomizer.java
@@ -29,6 +29,7 @@ public class AllowedHttpMethodsCustomizer implements HttpConfiguration.Customize
 
     /**
      * Creates a new instance of the customizer, allowing only the specified HTTP methods.
+     *
      * @param allowedMethods the HTTP methods to allow
      */
     public AllowedHttpMethodsCustomizer(final Set<String> allowedMethods) {

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/ConfiguredHeadersCustomizer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/ConfiguredHeadersCustomizer.java
@@ -1,0 +1,4 @@
+package io.deephaven.server.jetty;
+
+public class ConfiguredHeadersCustomizer {
+}

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/ConfiguredHeadersCustomizer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/ConfiguredHeadersCustomizer.java
@@ -17,6 +17,7 @@ public class ConfiguredHeadersCustomizer implements HttpConfiguration.Customizer
 
     /**
      * Creates a new instance of the customizer, applying the given headers to every outgoing response.
+     *
      * @param configuredHeaders the headers to add to every response
      */
     public ConfiguredHeadersCustomizer(final Map<String, String> configuredHeaders) {

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/ConfiguredHeadersCustomizer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/ConfiguredHeadersCustomizer.java
@@ -15,12 +15,16 @@ import java.util.Map;
 public class ConfiguredHeadersCustomizer implements HttpConfiguration.Customizer {
     private final Map<String, String> configuredHeaders;
 
-    public ConfiguredHeadersCustomizer(Map<String, String> configuredHeaders) {
+    /**
+     * Creates a new instance of the customizer, applying the given headers to every outgoing response.
+     * @param configuredHeaders the headers to add to every response
+     */
+    public ConfiguredHeadersCustomizer(final Map<String, String> configuredHeaders) {
         this.configuredHeaders = configuredHeaders;
     }
 
     @Override
-    public Request customize(Request request, HttpFields.Mutable responseHeaders) {
+    public Request customize(final Request request, final HttpFields.Mutable responseHeaders) {
         for (Map.Entry<String, String> header : configuredHeaders.entrySet()) {
             responseHeaders.add(header.getKey(), header.getValue());
         }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -334,6 +334,9 @@ public class JettyBackedGrpcServer implements GrpcServer {
         final HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
+        if (!config.extraHeaders().isEmpty()) {
+            httpConfig.addCustomizer(new ConfiguredHeadersCustomizer(config.extraHeaders()));
+        }
         final HttpConnectionFactory http11 = config.http1OrDefault() ? new HttpConnectionFactory(httpConfig) : null;
         final ServerConnector serverConnector;
         if (config.ssl().isPresent()) {

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -333,6 +333,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
         // https://www.eclipse.org/jetty/documentation/jetty-11/programming-guide/index.html#pg-server-http-connector-protocol-http2-tls
         final HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
         final HttpConnectionFactory http11 = config.http1OrDefault() ? new HttpConnectionFactory(httpConfig) : null;
         final ServerConnector serverConnector;
         if (config.ssl().isPresent()) {

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyConfig.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyConfig.java
@@ -13,6 +13,7 @@ import org.immutables.value.Value.Style;
 import javax.annotation.Nullable;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 
 /**
  * The jetty server configuration.
@@ -32,6 +33,8 @@ public abstract class JettyConfig implements ServerConfig {
     public static final String SNI_HOST_CHECK = "https.sniHostCheck";
     public static final String MAX_CONCURRENT_STREAMS = "http2.maxConcurrentStreams";
     public static final String MAX_HEADER_REQUEST_SIZE = "http.maxHeaderRequestSize";
+    public static final String ALLOWED_HTTP_METHODS = "http.allowedMethods";
+    public static final Set<String> DEFAULT_ALLOWED_METHODS = Set.of("GET", "POST", "DELETE");
 
     /**
      * Values to indicate what kind of websocket support should be offered.
@@ -98,6 +101,8 @@ public abstract class JettyConfig implements ServerConfig {
         String h2StreamIdleTimeout = config.getStringWithDefault(HTTP_STREAM_TIMEOUT, null);
         String h2MaxConcurrentStreams = config.getStringWithDefault(MAX_CONCURRENT_STREAMS, null);
         String maxHeaderRequestSize = config.getStringWithDefault(MAX_HEADER_REQUEST_SIZE, null);
+        Set<String> allowedHttpMethods = config.getStringSetFromPropertyWithDefault(ALLOWED_HTTP_METHODS,
+                DEFAULT_ALLOWED_METHODS);
 
         if (httpWebsockets != null) {
             switch (httpWebsockets.toLowerCase()) {
@@ -134,6 +139,7 @@ public abstract class JettyConfig implements ServerConfig {
         if (maxHeaderRequestSize != null) {
             builder.maxHeaderRequestSize(Integer.parseInt(maxHeaderRequestSize));
         }
+        builder.allowedHttpMethods(allowedHttpMethods);
         return builder;
     }
 
@@ -234,6 +240,12 @@ public abstract class JettyConfig implements ServerConfig {
      */
     public abstract OptionalInt maxConcurrentStreams();
 
+    /**
+     * If unset, defaults to permitting "GET", "POST", and "OPTIONS" methods, ensuring that gRPC calls and requests to
+     * load the web client are permitted.
+     */
+    public abstract Set<String> allowedHttpMethods();
+
     public interface Builder extends ServerConfig.Builder<JettyConfig, Builder> {
 
         Builder websockets(WebsocketsSupport websockets);
@@ -249,5 +261,7 @@ public abstract class JettyConfig implements ServerConfig {
         Builder maxHeaderRequestSize(int maxHeaderRequestSize);
 
         Builder maxConcurrentStreams(int maxConcurrentStreams);
+
+        Builder allowedHttpMethods(Iterable<String> allowedHttpMethods);
     }
 }

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/BarrageChunkFactoryTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/BarrageChunkFactoryTest.java
@@ -190,6 +190,7 @@ public class BarrageChunkFactoryTest {
             return JettyConfig.builder()
                     .port(0)
                     .tokenExpire(Duration.of(5, ChronoUnit.MINUTES))
+                    .allowedHttpMethods(Set.of("POST"))
                     .build();
         }
     }

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
@@ -23,6 +23,7 @@ import javax.inject.Singleton;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -37,6 +38,7 @@ public class JettyFlightRoundTripTest extends FlightMessageRoundTripTest {
             return JettyConfig.builder()
                     .port(0)
                     .tokenExpire(Duration.of(5, ChronoUnit.MINUTES))
+                    .allowedHttpMethods(Set.of("GET", "POST"))
                     .build();
         }
     }


### PR DESCRIPTION
HTTP methods are now limited through configuration to a specific allow list, denying other verbs: POST is required for all gRPC/gRPC-web calls, and GET/OPTIONS are enabled as well to support loading the web UI, connecting to websockets, and allowing cross-origin calls.

Extra HTTP headers are added to every response, to ensure every page load defaults to a reasonably safe configuration. Several suggested headers are configured, with most enabled by default - the rest can easily be enabled as desired.

Fixes DH-17509
Fixes DH-18646