### PR TITLE
feat(cpp-client): Eliminate the member variable time_nano_scale_factor_ [part 1/8 of groupby]

### DIFF
--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_column_source.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_column_source.cc
@@ -2,86 +2,27 @@
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/client/arrowutil/arrow_column_source.h"
-#include "deephaven/client/utility/arrow_util.h"
 
-using deephaven::client::utility::OkOrThrow;
+#include <cstddef>
+#include <stdexcept>
+#include <arrow/type.h>
+
+#include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/core.h"
 
 namespace deephaven::client::arrowutil {
 namespace internal {
-
-namespace {
-struct NanoScaleFactorVisitor final : public arrow::TypeVisitor {
-  size_t result_ = 1;
-
-  arrow::Status Visit(const arrow::Int8Type  &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::FloatType &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::StringType &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::TimestampType &type) final {
-    result_ = ScaleFromUnit(type.unit());
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Date64Type &/*type*/) final {
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Visit(const arrow::Time64Type &type) final {
-    result_ = ScaleFromUnit(type.unit());
-    return arrow::Status::OK();
-  }
-
-  static size_t ScaleFromUnit(arrow::TimeUnit::type unit) {
-    switch (unit) {
-      case arrow::TimeUnit::SECOND: return 1'000'000'000;
-      case arrow::TimeUnit::MILLI: return 1'000'000;
-      case arrow::TimeUnit::MICRO: return 1'000;
-      case arrow::TimeUnit::NANO: return 1;
-      default: {
-        auto message = fmt::format("Unhandled arrow::TimeUnit {}", static_cast<size_t>(unit));
-        throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
-      }
+size_t ScaleFromUnit(arrow::TimeUnit::type unit) {
+  switch (unit) {
+    case arrow::TimeUnit::SECOND: return 1'000'000'000;
+    case arrow::TimeUnit::MILLI: return 1'000'000;
+    case arrow::TimeUnit::MICRO: return 1'000;
+    case arrow::TimeUnit::NANO: return 1;
+    default: {
+      auto message = fmt::format("Unhandled arrow::TimeUnit {}", static_cast<size_t>(unit));
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }
   }
-};
-}  // namespace
-
-size_t CalcTimeNanoScaleFactor(const arrow::Array &array) {
-  NanoScaleFactorVisitor visitor;
-  OkOrThrow(DEEPHAVEN_LOCATION_EXPR(array.type()->Accept(&visitor)));
-  return visitor.result_;
 }
 }  // namespace internal
 }  // namespace deephaven::client::arrowutil


### PR DESCRIPTION
The previous version of this code calculated the needed "scale factor" at construction time and cached it in a member variable.
This is not necessary because the column source knows its underlying Arrow type and can calculate the needed scale factor on demand.
This change removes that member variable.
There is no user-visible behavioral change.
