### PR TITLE
feat(cpp-client): redo TableMaker/Comparer, and the tests that use them [part 3/8 of groupby]

### DIFF
--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -73,8 +73,10 @@ set(ALL_FILES
     include/private/deephaven/client/impl/update_by_operation_impl.h
     include/private/deephaven/client/impl/util.h
 
+    src/arrowutil/arrow_array_converter.cc
     src/arrowutil/arrow_client_table.cc
     src/arrowutil/arrow_column_source.cc
+    include/private/deephaven/client/arrowutil/arrow_array_converter.h
     include/private/deephaven/client/arrowutil/arrow_client_table.h
     include/private/deephaven/client/arrowutil/arrow_column_source.h
     include/private/deephaven/client/arrowutil/arrow_value_converter.h

--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_array_converter.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_array_converter.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+ */
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <arrow/type.h>
+#include "deephaven/dhcore/column/column_source.h"
+
+namespace deephaven::client::arrowutil {
+class ArrowArrayConverter {
+  /**
+   * Convenience using.
+   */
+  using ColumnSource = deephaven::dhcore::column::ColumnSource;
+public:
+  static std::shared_ptr<ColumnSource> ArrayToColumnSource(
+      std::shared_ptr<arrow::Array> array);
+
+  static std::shared_ptr<ColumnSource> ChunkedArrayToColumnSource(
+      std::shared_ptr<arrow::ChunkedArray> chunked_array);
+
+  static std::shared_ptr<arrow::Array> ColumnSourceToArray(const ColumnSource &column_source,
+      size_t num_rows);
+};
+}  // namespace deephaven::client::arrowutil

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/client.h
@@ -3,8 +3,11 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <string_view>
+#include <vector>
 #include "deephaven/client/client_options.h"
 #include "deephaven/client/utility/misc_types.h"
 #include "deephaven/dhcore/clienttable/client_table.h"

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
@@ -3,20 +3,22 @@
  */
 #pragma once
 
-#include <iostream>
 #include <memory>
+#include <optional>
 #include <string>
-#include <vector>
 #include <arrow/type.h>
 #include <arrow/flight/types.h>
 
 #include "deephaven/dhcore/clienttable/client_table.h"
+#include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 
 namespace deephaven::client::utility {
 class ArrowUtil {
   using ElementTypeId = deephaven::dhcore::ElementTypeId;
+  using ClientTable = deephaven::dhcore::clienttable::ClientTable;
+  using ColumnSource = deephaven::dhcore::column::ColumnSource;
   using FlightDescriptor = arrow::flight::FlightDescriptor;
   using Schema = deephaven::dhcore::clienttable::Schema;
 
@@ -40,13 +42,21 @@ public:
       bool must_succeed);
 
   /**
+   * Converts an ElementType to an Arrow DataType.
+   */
+  static std::shared_ptr<arrow::DataType> GetArrowType(ElementTypeId::Enum element_type_id);
+
+  /**
    * Convert an Arrow Schema into a Deephaven Schema
    * @param schema The arrow Schema
    * @return a Deephaven Schema
    */
   static std::shared_ptr<Schema> MakeDeephavenSchema(const arrow::Schema &schema);
-};
 
+  static std::shared_ptr<arrow::Table> MakeArrowTable(const ClientTable &client_table);
+  static std::shared_ptr<arrow::Schema> MakeArrowSchema(
+      const deephaven::dhcore::clienttable::Schema &dh_schema);
+  };
 
 /**
  * If status is OK, do nothing. Otherwise throw a runtime error with an informative message.

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
@@ -3,7 +3,13 @@
  */
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <arrow/array.h>
 #include <arrow/record_batch.h>
@@ -14,6 +20,7 @@
 #include <arrow/flight/types.h>
 #include <arrow/array/array_primitive.h>
 #include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_nested.h>
 #include <arrow/array/builder_primitive.h>
 #include <arrow/util/key_value_metadata.h>
 
@@ -27,58 +34,255 @@
 
 namespace deephaven::client::utility {
 namespace internal {
-class TypeConverter {
+template<typename T>
+struct ColumnBuilder {
+  // The below assert fires when this class is instantiated; i.e. when none of the specializations
+  // match. It needs to be written this way (with "is_same<T,T>") because for technical reasons it
+  // needs to be dependent on T, even if degenerately so.
+  static_assert(!std::is_same_v<T, T>, "ColumnBuilder doesn't know how to work with this type");
+};
+
+template<typename TArrowBuilder, const char *kDeephavenTypeName>
+class BuilderBase {
 public:
-  template<typename T>
-  [[nodiscard]]
-  static TypeConverter CreateNew(const std::vector<T> &values);
+  explicit BuilderBase(std::shared_ptr<TArrowBuilder> builder) : builder_(std::move(builder)) {}
 
-  template<typename T, typename GetValue, typename IsNull>
-  [[nodiscard]]
-  static TypeConverter CreateNew(const GetValue &get_value, const IsNull &is_null,
-      size_t size);
-
-  TypeConverter(std::shared_ptr<arrow::DataType> data_type, std::string deephaven_type,
-      std::shared_ptr<arrow::Array> column);
-  ~TypeConverter();
-
-  [[nodiscard]]
-  const std::shared_ptr<arrow::DataType> &DataType() const { return dataType_; }
-  [[nodiscard]]
-  std::shared_ptr<arrow::DataType> &DataType() { return dataType_; }
+  void AppendNull() {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->AppendNull()));
+  }
+  std::shared_ptr<arrow::Array> Finish() {
+    return ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Finish()));
+  }
+  const char *GetDeephavenServerTypeName() {
+    return kDeephavenTypeName;
+  }
 
   [[nodiscard]]
-  const std::string &DeephavenType() const { return deephavenType_; }
-  [[nodiscard]]
-  std::string &DeephavenType() { return deephavenType_; }
+  const std::shared_ptr<TArrowBuilder> &GetBuilder() const {
+    return builder_;
+  }
 
-  [[nodiscard]]
-  const std::shared_ptr<arrow::Array> &Column() const { return column_; }
-  [[nodiscard]]
-  std::shared_ptr<arrow::Array> &Column() { return column_; }
+protected:
+  std::shared_ptr<TArrowBuilder> builder_;
+};
+
+template<typename T, typename TArrowBuilder, const char *kDeephavenTypeName>
+class TypicalBuilderBase : public BuilderBase<TArrowBuilder, kDeephavenTypeName> {
+  /**
+   * Convenience using.
+   */
+  using base = BuilderBase<TArrowBuilder, kDeephavenTypeName>;
+
+public:
+  TypicalBuilderBase() : BuilderBase<TArrowBuilder, kDeephavenTypeName>(
+      std::make_shared<TArrowBuilder>()) {
+  }
+
+  void Append(const T &value) {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(base::builder_->Append(value)));
+  }
+};
+
+struct DeephavenServerConstants {
+  static const char kBool[];
+  static const char kChar16[];
+  static const char kInt8[];
+  static const char kInt16[];
+  static const char kInt32[];
+  static const char kInt64[];
+  static const char kFloat[];
+  static const char kDouble[];
+  static const char kString[];
+  static const char kDateTime[];
+  static const char kLocalDate[];
+  static const char kLocalTime[];
+  static const char kList[];
+};
+
+template<>
+class ColumnBuilder<bool> : public TypicalBuilderBase<bool,
+    arrow::BooleanBuilder,
+    DeephavenServerConstants::kBool> {
+};
+
+template<>
+class ColumnBuilder<char16_t> : public TypicalBuilderBase<char16_t, arrow::UInt16Builder,
+    DeephavenServerConstants::kChar16> {
+};
+
+template<>
+class ColumnBuilder<int8_t> : public TypicalBuilderBase<int8_t, arrow::Int8Builder,
+    DeephavenServerConstants::kInt8> {
+};
+
+template<>
+class ColumnBuilder<int16_t> : public TypicalBuilderBase<int16_t, arrow::Int16Builder,
+    DeephavenServerConstants::kInt16> {
+};
+
+template<>
+class ColumnBuilder<int32_t> : public TypicalBuilderBase<int32_t, arrow::Int32Builder,
+    DeephavenServerConstants::kInt32> {
+};
+
+template<>
+class ColumnBuilder<int64_t> : public TypicalBuilderBase<int64_t, arrow::Int64Builder,
+    DeephavenServerConstants::kInt64> {
+};
+
+template<>
+class ColumnBuilder<float> : public TypicalBuilderBase<float, arrow::FloatBuilder,
+    DeephavenServerConstants::kFloat> {
+};
+
+template<>
+class ColumnBuilder<double> : public TypicalBuilderBase<double, arrow::DoubleBuilder,
+    DeephavenServerConstants::kDouble> {
+};
+
+template<>
+class ColumnBuilder<std::string> : public TypicalBuilderBase<std::string, arrow::StringBuilder,
+    DeephavenServerConstants::kString> {
+};
+
+template<>
+class ColumnBuilder<deephaven::dhcore::DateTime> : public BuilderBase<arrow::TimestampBuilder,
+    DeephavenServerConstants::kDateTime> {
+public:
+  // constructor with data type nanos
+  ColumnBuilder() : BuilderBase<arrow::TimestampBuilder, DeephavenServerConstants::kDateTime>(
+      std::make_shared<arrow::TimestampBuilder>(arrow::timestamp(arrow::TimeUnit::NANO, "UTC"),
+          arrow::default_memory_pool())) {
+  }
+
+  void Append(const deephaven::dhcore::DateTime &value) {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Append(value.Nanos())));
+  }
+};
+
+template<>
+class ColumnBuilder<deephaven::dhcore::LocalDate> : public BuilderBase<arrow::Date64Builder,
+    DeephavenServerConstants::kLocalDate> {
+public:
+  // constructor with data type nanos
+  ColumnBuilder() : BuilderBase<arrow::Date64Builder, DeephavenServerConstants::kLocalDate>(
+      std::make_shared<arrow::Date64Builder>()) {
+  }
+
+  void Append(const deephaven::dhcore::LocalDate &value) {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Append(value.Millis())));
+  }
+};
+
+template<>
+class ColumnBuilder<deephaven::dhcore::LocalTime> : public BuilderBase<arrow::Time64Builder,
+    DeephavenServerConstants::kLocalTime> {
+public:
+  ColumnBuilder() : BuilderBase<arrow::Time64Builder, DeephavenServerConstants::kLocalTime>(
+      std::make_shared<arrow::Time64Builder>(arrow::time64(arrow::TimeUnit::NANO),
+  arrow::default_memory_pool())) {
+
+  }
+
+  void Append(const deephaven::dhcore::LocalTime &value) {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Append(value.Nanos())));
+  }
+};
+
+template<arrow::TimeUnit::type UNIT>
+class ColumnBuilder<InternalDateTime<UNIT>> : public BuilderBase<arrow::TimestampBuilder,
+    DeephavenServerConstants::kDateTime> {
+public:
+  ColumnBuilder() : BuilderBase<arrow::TimestampBuilder, DeephavenServerConstants::kDateTime>(
+      std::make_shared<arrow::TimestampBuilder>(arrow::timestamp(UNIT, "UTC"),
+          arrow::default_memory_pool())) {
+  }
+
+  void Append(const InternalDateTime<UNIT> &value) {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Append(value.value_)));
+  }
+};
+
+template<arrow::TimeUnit::type UNIT>
+class ColumnBuilder<InternalLocalTime<UNIT>> : public BuilderBase<arrow::Time64Builder,
+    DeephavenServerConstants::kLocalTime> {
+public:
+  ColumnBuilder() : BuilderBase<arrow::Time64Builder, DeephavenServerConstants::kLocalTime>(
+      std::make_shared<arrow::Time64Builder>(arrow::time64(UNIT),
+          arrow::default_memory_pool())) {
+  }
+
+  void Append(const InternalLocalTime<UNIT> &value) {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Append(value.value_)));
+  }
+};
+
+template<typename T>
+class ColumnBuilder<std::optional<T>> {
+public:
+  void Append(const std::optional<T> &value) {
+    if (!value.has_value()) {
+      wrapped_column_builder_.AppendNull();
+    } else {
+      wrapped_column_builder_.Append(*value);
+    }
+  }
+
+  void AppendNull() {
+    wrapped_column_builder_.AppendNull();
+  }
+
+  std::shared_ptr<arrow::Array> Finish() {
+    return wrapped_column_builder_.Finish();
+  }
+
+  const char *GetDeephavenServerTypeName() {
+    return wrapped_column_builder_.GetDeephavenServerTypeName();
+  }
+
+  const auto &GetBuilder() const {
+    return wrapped_column_builder_.GetBuilder();
+  }
 
 private:
-  template<typename T>
-  [[nodiscard]]
-  static const T *TryGetContainedValue(const T *value, bool *valid) {
-    *valid = true;
-    return value;
+  ColumnBuilder<T> wrapped_column_builder_;
+};
+
+template<typename T>
+class ColumnBuilder<std::vector<T>> {
+public:
+  ColumnBuilder() :
+      builder_(std::make_shared<arrow::ListBuilder>(arrow::default_memory_pool(),
+          nested_column_builder_.GetBuilder())) {
   }
 
-  template<typename T>
-  [[nodiscard]]
-  static const T *TryGetContainedValue(const std::optional<T> *value, bool *valid) {
-    if (!value->has_value()) {
-      *valid = false;
-      return nullptr;
+  void Append(const std::vector<T> &entry) {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Append()));
+    for (const auto &element : entry) {
+      nested_column_builder_.Append(element);
     }
-    *valid = true;
-    return &**value;
   }
 
-  std::shared_ptr<arrow::DataType> dataType_;
-  std::string deephavenType_;
-  std::shared_ptr<arrow::Array> column_;
+  void AppendNull() {
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->AppendNull()));
+  }
+
+  std::shared_ptr<arrow::Array> Finish() {
+    return ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->Finish()));
+  }
+
+  const char *GetDeephavenServerTypeName() {
+    return DeephavenServerConstants::kList;
+  }
+  
+  [[nodiscard]]
+  const std::shared_ptr<arrow::ListBuilder> &GetBuilder() const {
+    return builder_;
+  }
+
+private:
+  ColumnBuilder<T> nested_column_builder_;
+  std::shared_ptr<arrow::ListBuilder> builder_;
 };
 }  // namespace internal
 
@@ -91,7 +295,8 @@ private:
  * std::vector<T2> data2 = { ... };
  * tm.AddColumn("col1", data1);
  * tm.AddColumn("col2", data2);
- * auto tableHandle = tm.MakeTable();
+ * auto arrow_table = tm.MakeArrowTable();
+ * auto table_handle = tm.MakeDeephavenTable(const TableHandleManager &manager);
  * @endcode
  */
 class TableMaker {
@@ -108,367 +313,70 @@ public:
   ~TableMaker();
 
   /**
-   * Creates a column whose server type most closely matches type T, having the given
-   * name and values. Each call to this method adds a column. When there are multiple calls
-   * to this method, the sizes of the `values` arrays must be consistent.
+   * Creates a column whose server type most closely matches type T, having the given name and
+   * values. Each call to this method adds a column. When there are multiple calls to this method,
+   * the sizes of the `values` arrays must be consistent across those calls. That is, when the
+   * table has multiple columns, they all have to have the same number of rows.
    */
   template<typename T>
-  void AddColumn(std::string name, const std::vector<T> &values);
-
-  template<typename T>
-  void AddColumn(std::string name, const std::vector<std::optional<T>> &values);
+  void AddColumn(std::string name, const std::vector<T> &values) {
+    internal::ColumnBuilder<T> cb;
+    for (const auto &element : values) {
+      cb.Append(element);
+    }
+    auto array = cb.Finish();
+    const char *dh_type = cb.GetDeephavenServerTypeName();
+    FinishAddColumn(std::move(name), std::move(array), dh_type);
+  }
 
   template<typename T, typename GetValue, typename IsNull>
   void AddColumn(std::string name, const GetValue &get_value, const IsNull &is_null,
-      size_t size);
+      size_t size) {
+    internal::ColumnBuilder<T> cb;
+    for (size_t i = 0; i != size; ++i) {
+      if (!is_null(i)) {
+        const auto &value = get_value(i);
+        cb.Append(value);
+      } else {
+        cb.AppendNull();
+      }
+    }
+    auto array = cb.Finish();
+    const char *dh_type = cb.GetDeephavenServerTypeName();
+    FinishAddColumn(std::move(name), std::move(array), dh_type);
+  }
 
   /**
-   * Make the table. Call this after all your calls to AddColumn().
+   * Make a table on the Deephaven server based on all the AddColumn calls you have made so far.
    * @param manager The TableHandleManager
    * @return The TableHandle referencing the newly-created table.
    */
   [[nodiscard]]
-  TableHandle MakeTable(const TableHandleManager &manager);
+  TableHandle MakeTable(const TableHandleManager &manager) const;
+
+  [[nodiscard]]
+  std::shared_ptr<arrow::Table> MakeArrowTable() const;
 
 private:
-  void FinishAddColumn(std::string name, internal::TypeConverter info);
+  void FinishAddColumn(std::string name, std::shared_ptr<arrow::Array> data,
+      std::string deephaven_server_type_name);
+  [[nodiscard]]
+  std::shared_ptr<arrow::Schema> MakeSchema() const;
+  [[nodiscard]]
+  std::vector<std::shared_ptr<arrow::Array>> GetColumnsNotEmpty() const;
 
-  arrow::SchemaBuilder schemaBuilder_;
-  int64_t numRows_ = 0;
-  std::vector<std::shared_ptr<arrow::Array>> columns_;
+  struct ColumnInfo {
+    ColumnInfo(std::string name, std::shared_ptr<arrow::DataType> arrow_type,
+        std::string deepaven_server_type_name, std::shared_ptr<arrow::Array> data);
+    ColumnInfo(ColumnInfo &&other) noexcept;
+    ~ColumnInfo();
+
+    std::string name_;
+    std::shared_ptr<arrow::DataType> arrow_type_;
+    std::string deepaven_server_type_name_;
+    std::shared_ptr<arrow::Array> data_;
+  };
+
+  std::vector<ColumnInfo> column_infos_;
 };
-
-namespace internal {
-template<typename T>
-struct TypeConverterTraits {
-  // The below assert fires when this class is instantiated; i.e. when none of the specializations
-  // match. It needs to be written this way (with "is_same<T,T>") because for technical reasons it
-  // needs to be dependent on T, even if degenerately so.
-  static_assert(!std::is_same_v<T, T>, "TableMaker doesn't know how to work with this type");
-};
-
-// Implementation note: GetDeephavenTypeName() is better as a function rather than a constant,
-// because it helps us avoid the dllimport problem for using constants across libraries in Windows.
-
-template<>
-struct TypeConverterTraits<char16_t> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::UInt16Type>();
-  }
-  static arrow::UInt16Builder GetBuilder() {
-    return arrow::UInt16Builder();
-  }
-  static char16_t Reinterpret(char16_t o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "char";
-  }
-};
-
-template<>
-struct TypeConverterTraits<bool> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::BooleanType>();
-  }
-  static arrow::BooleanBuilder GetBuilder() {
-    return arrow::BooleanBuilder();
-  }
-  static bool Reinterpret(bool o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "java.lang.Boolean";
-  }
-};
-
-template<>
-struct TypeConverterTraits<int8_t> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::Int8Type>();
-  }
-  static arrow::Int8Builder GetBuilder() {
-    return arrow::Int8Builder();
-  }
-  static int8_t Reinterpret(int8_t o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "byte";
-  }
-};
-
-template<>
-struct TypeConverterTraits<int16_t> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::Int16Type>();
-  }
-  static arrow::Int16Builder GetBuilder() {
-    return arrow::Int16Builder();
-  }
-  static int16_t Reinterpret(int16_t o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "short";
-  }
-};
-
-template<>
-struct TypeConverterTraits<int32_t> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::Int32Type>();
-  }
-  static arrow::Int32Builder GetBuilder() {
-    return arrow::Int32Builder();
-  }
-  static int32_t Reinterpret(int32_t o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "int";
-  }
-};
-
-template<>
-struct TypeConverterTraits<int64_t> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::Int64Type>();
-  }
-  static arrow::Int64Builder GetBuilder() {
-    return arrow::Int64Builder();
-  }
-  static int64_t Reinterpret(int64_t o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "long";
-  }
-};
-
-template<>
-struct TypeConverterTraits<float> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::FloatType>();
-  }
-  static arrow::FloatBuilder GetBuilder() {
-    return arrow::FloatBuilder();
-  }
-  static float Reinterpret(float o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "float";
-  }
-};
-
-template<>
-struct TypeConverterTraits<double> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::DoubleType>();
-  }
-  static arrow::DoubleBuilder GetBuilder() {
-    return arrow::DoubleBuilder();
-  }
-  static double Reinterpret(double o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "double";
-  }
-};
-
-template<>
-struct TypeConverterTraits<std::string> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return std::make_shared<arrow::StringType>();
-  }
-  static arrow::StringBuilder GetBuilder() {
-    return arrow::StringBuilder();
-  }
-  static const std::string &Reinterpret(const std::string &o) {
-    return o;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "java.lang.String";
-  }
-};
-
-template<>
-struct TypeConverterTraits<deephaven::dhcore::DateTime> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
-  }
-  static arrow::TimestampBuilder GetBuilder() {
-    return arrow::TimestampBuilder(GetDataType(), arrow::default_memory_pool());
-  }
-  static int64_t Reinterpret(const deephaven::dhcore::DateTime &dt) {
-    return dt.Nanos();
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "java.time.ZonedDateTime";
-  }
-};
-
-template<>
-struct TypeConverterTraits<deephaven::dhcore::LocalDate> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return arrow::date64();
-  }
-  static arrow::Date64Builder GetBuilder() {
-    return arrow::Date64Builder();
-  }
-  static int64_t Reinterpret(const deephaven::dhcore::LocalDate &o) {
-    return o.Millis();
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "java.time.LocalDate";
-  }
-};
-
-template<>
-struct TypeConverterTraits<deephaven::dhcore::LocalTime> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return arrow::time64(arrow::TimeUnit::NANO);
-  }
-  static arrow::Time64Builder GetBuilder() {
-    return arrow::Time64Builder(GetDataType(), arrow::default_memory_pool());
-  }
-  static int64_t Reinterpret(const deephaven::dhcore::LocalTime &o) {
-    return o.Nanos();
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "java.time.LocalTime";
-  }
-};
-
-template<typename T>
-struct TypeConverterTraits<std::optional<T>> {
-  using inner_t = TypeConverterTraits<T>;
-  static auto GetDataType() {
-    return inner_t::GetDataType();
-  }
-  static auto GetBuilder() {
-    return inner_t::GetBuilder();
-  }
-  static auto Reinterpret(const T &o) {
-    return inner_t::Reinterpret(o);
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return TypeConverterTraits<T>::GetDeephavenTypeName();
-  }
-};
-
-template<arrow::TimeUnit::type UNIT>
-struct TypeConverterTraits<deephaven::client::utility::internal::InternalDateTime<UNIT>> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return arrow::timestamp(UNIT, "UTC");
-  }
-  static arrow::TimestampBuilder GetBuilder() {
-    return arrow::TimestampBuilder(GetDataType(), arrow::default_memory_pool());
-  }
-  static int64_t Reinterpret(const deephaven::client::utility::internal::InternalDateTime<UNIT> &o) {
-    return o.value_;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "java.time.ZonedDateTime";
-  }
-};
-
-template<arrow::TimeUnit::type UNIT>
-struct TypeConverterTraits<deephaven::client::utility::internal::InternalLocalTime<UNIT>> {
-  static std::shared_ptr<arrow::DataType> GetDataType() {
-    return arrow::time64(UNIT);
-  }
-  static arrow::Time64Builder GetBuilder() {
-    return arrow::Time64Builder(GetDataType(), arrow::default_memory_pool());
-  }
-  static int64_t Reinterpret(const deephaven::client::utility::internal::InternalLocalTime<UNIT> &o) {
-    return o.value_;
-  }
-  static std::string_view GetDeephavenTypeName() {
-    return "java.time.LocalTime";
-  }
-};
-
-template<typename T>
-TypeConverter TypeConverter::CreateNew(const std::vector<T> &values) {
-  using deephaven::client::utility::OkOrThrow;
-
-  typedef TypeConverterTraits<T> traits_t;
-
-  auto data_type = traits_t::GetDataType();
-  auto builder = traits_t::GetBuilder();
-
-  for (const auto &value : values) {
-    bool valid;
-    const auto *contained_value = TryGetContainedValue(&value, &valid);
-    if (valid) {
-      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.Append(traits_t::Reinterpret(*contained_value))));
-    } else {
-      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.AppendNull()));
-    }
-  }
-  auto builder_res = builder.Finish();
-  if (!builder_res.ok()) {
-    auto message = fmt::format("Error building array of type {}: {}",
-        traits_t::GetDeephavenTypeName(), builder_res.status().ToString());
-  }
-  auto array = builder_res.ValueUnsafe();
-  return TypeConverter(std::move(data_type), std::string(traits_t::GetDeephavenTypeName()),
-      std::move(array));
-}
-
-template<typename T, typename GetValue, typename IsNull>
-TypeConverter TypeConverter::CreateNew(const GetValue &get_value, const IsNull &is_null,
-    size_t size) {
-  using deephaven::client::utility::OkOrThrow;
-
-  typedef TypeConverterTraits<T> traits_t;
-
-  auto data_type = traits_t::GetDataType();
-  auto builder = traits_t::GetBuilder();
-
-  for (size_t i = 0; i != size; ++i) {
-    if (!is_null(i)) {
-       OkOrThrow(DEEPHAVEN_LOCATION_EXPR(
-           builder.Append(traits_t::Reinterpret(get_value(i)))));
-    } else {
-      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.AppendNull()));
-    }
-  }
-  auto builder_res = builder.Finish();
-  if (!builder_res.ok()) {
-    auto message = fmt::format("Error building array of type {}: {}",
-        traits_t::GetDeephavenTypeName(), builder_res.status().ToString());
-  }
-  auto array = builder_res.ValueUnsafe();
-  return TypeConverter(std::move(data_type), std::string(traits_t::GetDeephavenTypeName()),
-      std::move(array));
-}
-}  // namespace internal
-
-template<typename T>
-void TableMaker::AddColumn(std::string name, const std::vector<T> &values) {
-  // Specifying the return type here in this way (rather than const T &)
-  // allows us to deal with std::vector<bool>, which is very special, and would
-  // otherwise cause a compiler error, because of the way it is specialized.
-  auto get_value = [&](size_t index) -> typename std::vector<T>::const_reference { return values[index]; };
-  auto is_null = [](size_t /*index*/) { return false; };
-  return AddColumn<T>(std::move(name), get_value, is_null, values.size());
-}
-
-template<typename T>
-void TableMaker::AddColumn(std::string name, const std::vector<std::optional<T>> &values) {
-  auto get_value = [&](size_t index) -> const T& { return *values[index]; };
-  auto is_null = [&](size_t index) { return !values[index].has_value(); };
-  return AddColumn<T>(std::move(name), get_value, is_null, values.size());
-}
-
-template<typename T, typename GetValue, typename IsNull>
-void TableMaker::AddColumn(std::string name, const GetValue &get_value, const IsNull &is_null,
-    size_t size) {
-  auto info = internal::TypeConverter::CreateNew<T>(get_value, is_null, size);
-  FinishAddColumn(std::move(name), std::move(info));
-}
 }  // namespace deephaven::client::utility

--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/client/arrowutil/arrow_array_converter.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include <arrow/visitor.h>
+#include <arrow/array/array_base.h>
+#include <arrow/array/array_primitive.h>
+#include <arrow/scalar.h>
+#include <arrow/builder.h>
+#include "deephaven/client/arrowutil/arrow_column_source.h"
+#include "deephaven/client/utility/arrow_util.h"
+#include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/column/array_column_source.h"
+#include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/container/row_sequence.h"
+#include "deephaven/dhcore/types.h"
+#include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/core.h"
+
+namespace deephaven::client::arrowutil {
+using deephaven::client::utility::OkOrThrow;
+using deephaven::client::utility::ValueOrThrow;
+using deephaven::dhcore::DateTime;
+using deephaven::dhcore::ElementTypeId;
+using deephaven::dhcore::LocalDate;
+using deephaven::dhcore::LocalTime;
+using deephaven::dhcore::chunk::BooleanChunk;
+using deephaven::dhcore::chunk::Chunk;
+using deephaven::dhcore::chunk::CharChunk;
+using deephaven::dhcore::chunk::DateTimeChunk;
+using deephaven::dhcore::chunk::FloatChunk;
+using deephaven::dhcore::chunk::DoubleChunk;
+using deephaven::dhcore::chunk::Int8Chunk;
+using deephaven::dhcore::chunk::Int16Chunk;
+using deephaven::dhcore::chunk::Int32Chunk;
+using deephaven::dhcore::chunk::Int64Chunk;
+using deephaven::dhcore::chunk::LocalDateChunk;
+using deephaven::dhcore::chunk::LocalTimeChunk;
+using deephaven::dhcore::chunk::StringChunk;
+using deephaven::dhcore::chunk::UInt64Chunk;
+using deephaven::dhcore::column::BooleanColumnSource;
+using deephaven::dhcore::column::CharColumnSource;
+using deephaven::dhcore::column::ColumnSource;
+using deephaven::dhcore::column::DoubleColumnSource;
+using deephaven::dhcore::column::FloatColumnSource;
+using deephaven::dhcore::column::Int8ColumnSource;
+using deephaven::dhcore::column::Int16ColumnSource;
+using deephaven::dhcore::column::Int32ColumnSource;
+using deephaven::dhcore::column::Int64ColumnSource;
+using deephaven::dhcore::column::ColumnSourceVisitor;
+using deephaven::dhcore::column::StringColumnSource;
+using deephaven::dhcore::container::RowSequence;
+using deephaven::dhcore::utility::demangle;
+using deephaven::dhcore::utility::MakeReservedVector;
+
+namespace {
+template<typename TArrowArray>
+std::vector<std::shared_ptr<TArrowArray>> DowncastChunks(const arrow::ChunkedArray &chunked_array) {
+  auto downcasted = MakeReservedVector<std::shared_ptr<TArrowArray>>(chunked_array.num_chunks());
+  for (const auto &vec : chunked_array.chunks()) {
+    auto dest = std::dynamic_pointer_cast<TArrowArray>(vec);
+    if (dest == nullptr) {
+      const auto &deref_vec = *vec;
+      auto message = fmt::format("can't cast {} to {}",
+          demangle(typeid(deref_vec).name()),
+          demangle(typeid(TArrowArray).name()));
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
+    downcasted.push_back(std::move(dest));
+  }
+  return downcasted;
+}
+
+struct ChunkedArrayToColumnSourceVisitor final : public arrow::TypeVisitor {
+  explicit ChunkedArrayToColumnSourceVisitor(std::shared_ptr<arrow::ChunkedArray> chunked_array) :
+    chunked_array_(std::move(chunked_array)) {}
+
+  arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::UInt16Array>(*chunked_array_);
+    result_ = CharArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int8Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int8Array>(*chunked_array_);
+    result_ = Int8ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int16Array>(*chunked_array_);
+    result_ = Int16ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int32Array>(*chunked_array_);
+    result_ = Int32ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Int64Array>(*chunked_array_);
+    result_ = Int64ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::FloatType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::FloatArray>(*chunked_array_);
+    result_ = FloatArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::DoubleArray>(*chunked_array_);
+    result_ = DoubleArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::BooleanArray>(*chunked_array_);
+    result_ = BooleanArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::StringType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::StringArray>(*chunked_array_);
+    result_ = StringArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::TimestampType &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::TimestampArray>(*chunked_array_);
+    result_ = DateTimeArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Date64Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Date64Array>(*chunked_array_);
+    result_ = LocalDateArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Visit(const arrow::Time64Type &/*type*/) final {
+    auto arrays = DowncastChunks<arrow::Time64Array>(*chunked_array_);
+    result_ = LocalTimeArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<arrow::ChunkedArray> chunked_array_;
+  std::shared_ptr<ColumnSource> result_;
+};
+}  // namespace
+
+
+
+std::shared_ptr<ColumnSource> ArrowArrayConverter::ArrayToColumnSource(
+    std::shared_ptr<arrow::Array> array) {
+  auto chunked_array = std::make_shared<arrow::ChunkedArray>(std::move(array));
+  return ChunkedArrayToColumnSource(std::move(chunked_array));
+}
+
+std::shared_ptr<ColumnSource> ArrowArrayConverter::ChunkedArrayToColumnSource(
+    std::shared_ptr<arrow::ChunkedArray> chunked_array) {
+  ChunkedArrayToColumnSourceVisitor v(std::move(chunked_array));
+  OkOrThrow(DEEPHAVEN_LOCATION_EXPR(v.chunked_array_->type()->Accept(&v)));
+  return std::move(v.result_);
+}
+
+
+//-------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------
+
+namespace {
+struct ColumnSourceToArrayVisitor final : ColumnSourceVisitor {
+  explicit ColumnSourceToArrayVisitor(size_t num_rows) : num_rows_(num_rows),
+      row_sequence_(RowSequence::CreateSequential(0, num_rows)),
+      null_flags_(BooleanChunk::Create(num_rows)) {
+  }
+
+  void Visit(const dhcore::column::CharColumnSource &source) final {
+    SimpleCopyValues<CharChunk, arrow::UInt16Builder>(source);
+  }
+
+  void Visit(const dhcore::column::Int8ColumnSource &source) final {
+    SimpleCopyValues<Int8Chunk, arrow::Int8Builder>(source);
+  }
+
+  void Visit(const dhcore::column::Int16ColumnSource &source) final {
+    SimpleCopyValues<Int16Chunk, arrow::Int16Builder>(source);
+  }
+
+  void Visit(const dhcore::column::Int32ColumnSource &source) final {
+    SimpleCopyValues<Int32Chunk, arrow::Int32Builder>(source);
+  }
+
+  void Visit(const dhcore::column::Int64ColumnSource &source) final {
+    SimpleCopyValues<Int64Chunk, arrow::Int64Builder>(source);
+  }
+
+  void Visit(const dhcore::column::FloatColumnSource &source) final {
+    SimpleCopyValues<FloatChunk, arrow::FloatBuilder>(source);
+  }
+
+  void Visit(const dhcore::column::DoubleColumnSource &source) final {
+    SimpleCopyValues<DoubleChunk, arrow::DoubleBuilder>(source);
+  }
+
+  void Visit(const dhcore::column::BooleanColumnSource &source) final {
+    SimpleCopyValues<BooleanChunk, arrow::BooleanBuilder>(source);
+  }
+
+  void Visit(const dhcore::column::StringColumnSource &source) final {
+    SimpleCopyValues<StringChunk, arrow::StringBuilder>(source);
+  }
+
+  void Visit(const dhcore::column::DateTimeColumnSource &source) final {
+    auto src_chunk = PopulateChunk<DateTimeChunk>(source);
+    auto dest_chunk = Int64Chunk::Create(num_rows_);
+    for (size_t i = 0; i != num_rows_; ++i) {
+      dest_chunk[i] = src_chunk[i].Nanos();
+    }
+    arrow::TimestampBuilder builder(arrow::timestamp(arrow::TimeUnit::NANO, "UTC"),
+        arrow::default_memory_pool());
+    PopulateAndFinishBuilder(dest_chunk, &builder);
+  }
+
+  void Visit(const dhcore::column::LocalDateColumnSource &source) final {
+    auto src_chunk = PopulateChunk<LocalDateChunk>(source);
+    auto dest_chunk = Int64Chunk::Create(num_rows_);
+    for (size_t i = 0; i != num_rows_; ++i) {
+      dest_chunk[i] = src_chunk[i].Millis();
+    }
+    arrow::Date64Builder builder;
+    PopulateAndFinishBuilder(dest_chunk, &builder);
+  }
+
+  void Visit(const dhcore::column::LocalTimeColumnSource &source) final {
+    auto src_chunk = PopulateChunk<LocalTimeChunk>(source);
+    auto dest_chunk = Int64Chunk::Create(num_rows_);
+    for (size_t i = 0; i != num_rows_; ++i) {
+      dest_chunk[i] = src_chunk[i].Nanos();
+    }
+    arrow::Time64Builder builder(arrow::time64(arrow::TimeUnit::NANO), arrow::default_memory_pool());
+    PopulateAndFinishBuilder(dest_chunk, &builder);
+  }
+
+  template<typename TChunk, typename TBuilder, typename TColumnSource>
+  void SimpleCopyValues(const TColumnSource &source) {
+    auto chunk = PopulateChunk<TChunk>(source);
+    TBuilder builder;
+    PopulateAndFinishBuilder(chunk, &builder);
+  }
+
+  template<typename TChunk, typename TColumnSource>
+  TChunk PopulateChunk(const TColumnSource &source) {
+    auto chunk = TChunk::Create(num_rows_);
+    source.FillChunk(*row_sequence_, &chunk, &null_flags_);
+    return chunk;
+  }
+
+  template<typename TChunk, typename TBuilder>
+  void PopulateAndFinishBuilder(const TChunk &chunk, TBuilder *builder) {
+    for (size_t i = 0; i != num_rows_; ++i) {
+      if (!null_flags_[i]) {
+        OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder->Append(chunk.data()[i])));
+      } else {
+        OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder->AppendNull()));
+      }
+    }
+    result_ = ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(builder->Finish()));
+  }
+
+  size_t num_rows_;
+  std::shared_ptr<RowSequence> row_sequence_;
+  BooleanChunk null_flags_;
+  std::shared_ptr<arrow::Array> result_;
+};
+}  // namespace
+
+std::shared_ptr<arrow::Array> ArrowArrayConverter::ColumnSourceToArray(
+    const ColumnSource &column_source, size_t num_rows) {
+  ColumnSourceToArrayVisitor visitor(num_rows);
+  column_source.AcceptVisitor(&visitor);
+  return std::move(visitor.result_);
+}
+}  // namespace deephaven::client::arrowutil

--- a/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
@@ -1,15 +1,24 @@
 /*
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
-#include "deephaven/client/flight.h"
 #include "deephaven/client/utility/table_maker.h"
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "deephaven/client/flight.h"
 #include "deephaven/client/utility/arrow_util.h"
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/format.h"
 
+#include "arrow/array/array_base.h"
+#include "arrow/array/builder_nested.h"
+
+using deephaven::dhcore::utility::MakeReservedVector;
 using deephaven::client::TableHandle;
-using deephaven::client::utility::OkOrThrow;
-using deephaven::client::utility::ValueOrThrow;
 
 #include <memory>
 
@@ -17,27 +26,24 @@ namespace deephaven::client::utility {
 TableMaker::TableMaker() = default;
 TableMaker::~TableMaker() = default;
 
-void TableMaker::FinishAddColumn(std::string name, internal::TypeConverter info) {
-  auto kv_metadata = std::make_shared<arrow::KeyValueMetadata>();
-  OkOrThrow(DEEPHAVEN_LOCATION_EXPR(kv_metadata->Set("deephaven:type", info.DeephavenType())));
-
-  auto field = std::make_shared<arrow::Field>(std::move(name), std::move(info.DataType()), true,
-      std::move(kv_metadata));
-  OkOrThrow(DEEPHAVEN_LOCATION_EXPR(schemaBuilder_.AddField(field)));
-
-  if (columns_.empty()) {
-    numRows_ = info.Column()->length();
-  } else if (numRows_ != info.Column()->length()) {
-    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(
-        fmt::format("Column sizes not consistent: expected {}, have {}", numRows_,
-            info.Column()->length())));
+void TableMaker::FinishAddColumn(std::string name, std::shared_ptr<arrow::Array> data,
+    std::string deephaven_server_type_name) {
+  if (!column_infos_.empty()) {
+    auto num_rows = column_infos_.back().data_->length();
+    if (data->length() != num_rows) {
+      auto message = fmt::format("Column sizes not consistent: expected {}, have {}", num_rows,
+          data->length());
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
   }
 
-  columns_.push_back(std::move(info.Column()));
+  const auto &arrow_type = data->type();
+  column_infos_.emplace_back(std::move(name), arrow_type, std::move(deephaven_server_type_name),
+      std::move(data));
 }
 
-TableHandle TableMaker::MakeTable(const TableHandleManager &manager) {
-  auto schema = ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(schemaBuilder_.Finish()));
+TableHandle TableMaker::MakeTable(const TableHandleManager &manager) const {
+  auto schema = MakeSchema();
 
   auto wrapper = manager.CreateFlightWrapper();
   auto ticket = manager.NewTicket();
@@ -48,7 +54,9 @@ TableHandle TableMaker::MakeTable(const TableHandleManager &manager) {
 
   auto res = wrapper.FlightClient()->DoPut(options, flight_descriptor, schema);
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(res));
-  auto batch = arrow::RecordBatch::Make(schema, numRows_, std::move(columns_));
+  auto data = GetColumnsNotEmpty();
+  auto num_rows = data.back()->length();
+  auto batch = arrow::RecordBatch::Make(schema, num_rows, std::move(data));
 
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(res->writer->WriteRecordBatch(*batch)));
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(res->writer->DoneWriting()));
@@ -59,11 +67,64 @@ TableHandle TableMaker::MakeTable(const TableHandleManager &manager) {
   return manager.MakeTableHandleFromTicket(std::move(ticket));
 }
 
+std::shared_ptr<arrow::Table> TableMaker::MakeArrowTable() const {
+  auto schema = MakeSchema();
+
+  // Extract the data_vec column.
+  auto data_vec = MakeReservedVector<std::shared_ptr<arrow::Array>>(column_infos_.size());
+  for (const auto &info : column_infos_) {
+    data_vec.push_back(info.data_);
+  }
+  auto data = GetColumnsNotEmpty();
+  return arrow::Table::Make(std::move(schema), std::move(data));
+}
+
+std::vector<std::shared_ptr<arrow::Array>> TableMaker::GetColumnsNotEmpty() const {
+  std::vector<std::shared_ptr<arrow::Array>> result;
+  for (const auto &info : column_infos_) {
+    result.emplace_back(info.data_);
+  }
+  if (result.empty()) {
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR("Can't make table with no columns"));
+  }
+  return result;
+}
+
+std::shared_ptr<arrow::Schema> TableMaker::MakeSchema() const {
+  arrow::SchemaBuilder sb;
+  for (const auto &info : column_infos_) {
+    auto kv_metadata = std::make_shared<arrow::KeyValueMetadata>();
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(kv_metadata->Set("deephaven:type",
+        info.deepaven_server_type_name_)));
+
+    auto field = std::make_shared<arrow::Field>(info.name_, info.arrow_type_, true,
+        std::move(kv_metadata));
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(sb.AddField(field)));
+  }
+
+  return ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(sb.Finish()));
+}
+
+TableMaker::ColumnInfo::ColumnInfo(std::string name, std::shared_ptr<arrow::DataType> arrow_type,
+    std::string deepaven_server_type_name, std::shared_ptr<arrow::Array> data) :
+    name_(std::move(name)), arrow_type_(std::move(arrow_type)),
+    deepaven_server_type_name_(std::move(deepaven_server_type_name)), data_(std::move(data)) {}
+TableMaker::ColumnInfo::ColumnInfo(ColumnInfo &&other) noexcept = default;
+TableMaker::ColumnInfo::~ColumnInfo() = default;
+
 namespace internal {
-TypeConverter::TypeConverter(std::shared_ptr<arrow::DataType> data_type,
-    std::string deephaven_type, std::shared_ptr<arrow::Array> column) :
-    dataType_(std::move(data_type)), deephavenType_(std::move(deephaven_type)),
-    column_(std::move(column)) {}
-    TypeConverter::~TypeConverter() = default;
+const char DeephavenServerConstants::kBool[] = "java.lang.Boolean";
+const char DeephavenServerConstants::kChar16[] = "char";
+const char DeephavenServerConstants::kInt8[] = "byte";
+const char DeephavenServerConstants::kInt16[] = "short";
+const char DeephavenServerConstants::kInt32[] = "int";
+const char DeephavenServerConstants::kInt64[] = "long";
+const char DeephavenServerConstants::kFloat[] = "float";
+const char DeephavenServerConstants::kDouble[] = "double";
+const char DeephavenServerConstants::kString[] = "java.lang.String";
+const char DeephavenServerConstants::kDateTime[] = "java.time.ZonedDateTime";
+const char DeephavenServerConstants::kLocalDate[] = "java.time.LocalDate";
+const char DeephavenServerConstants::kLocalTime[] = "java.time.LocalTime";
+const char DeephavenServerConstants::kList[] = "what.goes.here";
 }  // namespace internal
 }  // namespace deephaven::client::utility

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -7,7 +7,10 @@
 #include <cmath>
 #include <cstdint>
 #include <ostream>
-#include "deephaven/dhcore/utility/utility.h"
+#include <stdexcept>
+#include <string_view>
+#include <type_traits>
+#include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/ostream.h"
 
 namespace deephaven::dhcore {

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
@@ -253,3 +253,6 @@ ObjectId(const std::string &class_short_name, void* this_ptr);
 
 // Add the specialization for the DebugInfo formatter
 template<> struct fmt::formatter<deephaven::dhcore::utility::DebugInfo> : fmt::ostream_formatter {};
+
+template<typename Iterator, typename Callback>
+struct fmt::formatter<deephaven::dhcore::utility::internal::SeparatedListAdaptor<Iterator, Callback>> : fmt::ostream_formatter {};

--- a/cpp-client/deephaven/dhcore/src/types.cc
+++ b/cpp-client/deephaven/dhcore/src/types.cc
@@ -3,13 +3,20 @@
  */
 #include "deephaven/dhcore/types.h"
 
+#include <cstdint>
+#include <chrono>
+#include <cmath>
+#include <iostream>
 #include <limits>
 #include <sstream>
+#include <string>
+#include <string_view>
 
 #include "date/date.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/third_party/fmt/chrono.h"
 #include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/ostream.h"
 
 static_assert(FMT_VERSION >= 100000);

--- a/cpp-client/deephaven/examples/create_table_with_arrow_flight/main.cc
+++ b/cpp-client/deephaven/examples/create_table_with_arrow_flight/main.cc
@@ -1,11 +1,24 @@
 /*
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
 #include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 #include "deephaven/client/client.h"
 #include "deephaven/client/flight.h"
 #include "deephaven/client/utility/table_maker.h"
 #include "deephaven/dhcore/utility/utility.h"
+
+#include <arrow/flight/client.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
 
 using deephaven::client::Client;
 using deephaven::client::TableHandle;
@@ -122,7 +135,8 @@ void Doit(const TableHandleManager &manager) {
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(res));
 
   // 13. Make a RecordBatch containing both the schema and the data
-  auto batch = arrow::RecordBatch::Make(schema, static_cast<std::int64_t>(num_rows), std::move(columns));
+  auto batch = arrow::RecordBatch::Make(schema,
+      static_cast<std::int64_t>(num_rows), std::move(columns));
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(res->writer->WriteRecordBatch(*batch)));
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(res->writer->DoneWriting()));
 

--- a/cpp-client/deephaven/tests/include/private/deephaven/tests/test_util.h
+++ b/cpp-client/deephaven/tests/include/private/deephaven/tests/test_util.h
@@ -21,6 +21,7 @@
 #include "deephaven/client/client.h"
 #include "deephaven/client/utility/table_maker.h"
 #include "deephaven/dhcore/chunk/chunk_traits.h"
+#include "deephaven/dhcore/clienttable/client_table.h"
 #include "deephaven/dhcore/utility/utility.h"
 
 namespace deephaven::client::tests {
@@ -142,85 +143,15 @@ private:
   ColumnDataForTests columnData_;
 };
 
-namespace internal {
-void CompareTableHelper(int depth, const std::shared_ptr<arrow::Table> &table,
-    const std::string &column_name, const std::shared_ptr<arrow::Array> &data);
+class TableComparerForTests {
+  using TableMaker = deephaven::client::utility::TableMaker;
+  using ClientTable = deephaven::dhcore::clienttable::ClientTable;
 
-// base case
-inline void CompareTableRecurse(int /*depth*/, const std::shared_ptr<arrow::Table> &/*table*/) {
-}
-
-template<typename T, typename... Args>
-void CompareTableRecurse(int depth, const std::shared_ptr<arrow::Table> &table,
-    const std::string &column_name, const std::vector<T> &data, Args &&... rest) {
-  auto tc = deephaven::client::utility::internal::TypeConverter::CreateNew(data);
-  const auto &data_as_arrow = tc.Column();
-  CompareTableHelper(depth, table, column_name, data_as_arrow);
-  CompareTableRecurse(depth + 1, table, std::forward<Args>(rest)...);
-}
-
-[[nodiscard]]
-std::shared_ptr<arrow::Table> BasicValidate(const deephaven::client::TableHandle &table,
-    int expected_columns);
-}  // namespace internal
-
-template<typename... Args>
-void CompareTable(const deephaven::client::TableHandle &table, Args &&... args) {
-  auto arrow_table = internal::BasicValidate(table, sizeof...(Args) / 2);
-  internal::CompareTableRecurse(0, arrow_table, std::forward<Args>(args)...);
-}
-
-template<typename T>
-struct OptionalAdapter {
-  explicit OptionalAdapter(const std::optional<T> &value) : value_(value) {}
-
-  const std::optional<T> &value_;
-
-  friend std::ostream &operator<<(std::ostream &s, const OptionalAdapter &o) {
-    if (!o.value_.has_value()) {
-      return s << "(null)";
-    }
-    return s << *o.value_;
-  }
+public:
+  static void Compare(const TableMaker &expected, const TableHandle &actual);
+  static void Compare(const TableMaker &expected, const ClientTable &actual);
+  static void Compare(const TableMaker &expected, const arrow::Table &actual);
+  static void Compare(const arrow::Table &expected, const arrow::Table &actual);
 };
 
-template<typename T>
-void CompareColumn(const deephaven::dhcore::clienttable::ClientTable &table,
-    std::string_view column_name, const std::vector<std::optional<T>> &expected) {
-
-  using deephaven::dhcore::chunk::BooleanChunk;
-  using deephaven::dhcore::container::RowSequence;
-
-  auto num_rows = table.NumRows();
-  if (expected.size() != num_rows) {
-    auto message = fmt::format("Expected 'expected' to have size {}, have {}",
-        num_rows, expected.size());
-    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
-  }
-  auto cs = table.GetColumn(column_name, true);
-  auto rs = RowSequence::CreateSequential(0, num_rows);
-  using chunkType_t = typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t;
-  auto chunk = chunkType_t::Create(num_rows);
-  auto nulls = BooleanChunk::Create(num_rows);
-  cs->FillChunk(*rs, &chunk, &nulls);
-
-  for (size_t row_num = 0; row_num != num_rows; ++row_num) {
-    const auto &expected_elt = expected[row_num];
-
-    // expected_elt is optional<T>. Convert actual_elt to the optional<T> convention.
-    std::optional<T> actual_elt;  // Assume null
-    if (!nulls.data()[row_num]) {
-      actual_elt = chunk.data()[row_num];
-    }
-
-    if (expected_elt != actual_elt) {
-      auto message = fmt::format(R"(In column "{}", row {}, expected={}, actual={})",
-          column_name, row_num, OptionalAdapter<T>(expected_elt), OptionalAdapter<T>(actual_elt));
-      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
-    }
-  }
-}
 }  // namespace deephaven::client::tests
-
-template<typename T>
-struct fmt::formatter<deephaven::client::tests::OptionalAdapter<T>> : ostream_formatter {};

--- a/cpp-client/deephaven/tests/src/add_drop_test.cc
+++ b/cpp-client/deephaven/tests/src/add_drop_test.cc
@@ -4,6 +4,8 @@
 #include "deephaven/third_party/catch.hpp"
 #include "deephaven/tests/test_util.h"
 
+using deephaven::client::utility::TableMaker;
+
 namespace deephaven::client::tests {
 
 TEST_CASE("Drop some columns", "[adddrop]") {
@@ -14,13 +16,10 @@ TEST_CASE("Drop some columns", "[adddrop]") {
   auto t2 = t.DropColumns(cn.ImportDate(), cn.Ticker(), cn.Open(), cn.Close());
   std::cout << t2.Stream(true) << '\n';
 
-  std::vector<int64_t> vol_data = {100000, 250000, 19000};
-  std::vector<int64_t> ii_data = {5, 6, 7};
+  TableMaker expected;
+  expected.AddColumn<int64_t>("Volume", {100000, 250000, 19000});
+  expected.AddColumn<int64_t>("II", {5, 6, 7});
 
-  CompareTable(
-      t2,
-      "Volume", vol_data,
-      "II", ii_data
-  );
+  TableComparerForTests::Compare(expected, t2);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/aggregates_test.cc
+++ b/cpp-client/deephaven/tests/src/aggregates_test.cc
@@ -5,18 +5,7 @@
 #include "deephaven/tests/test_util.h"
 #include "deephaven/dhcore/utility/utility.h"
 
-using deephaven::client::AggAvg;
-using deephaven::client::aggSum;
-using deephaven::client::aggMin;
-using deephaven::client::aggMax;
-using deephaven::client::aggCount;
-using deephaven::client::aggCombo;
-using deephaven::client::Aggregate;
-using deephaven::client::AggregateCombo;
-using deephaven::client::TableHandleManager;
-using deephaven::client::TableHandle;
-using deephaven::client::SortPair;
-using deephaven::dhcore::DeephavenConstants;
+using deephaven::client::utility::TableMaker;
 
 namespace deephaven::client::tests {
 TEST_CASE("Various Aggregates", "[aggregates]") {
@@ -34,20 +23,13 @@ TEST_CASE("Various Aggregates", "[aggregates]") {
           Aggregate::Max("MaxClose=Close"),
           Aggregate::Count("Count")}));
 
-  std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL"};
-  std::vector<double> avg_close_data = {541.55};
-  std::vector<double> sum_close_data = {1083.1};
-  std::vector<double> min_close_data = {538.2};
-  std::vector<double> max_close_data = {544.9};
-  std::vector<int64_t> count_data = {2};
+  TableMaker expected;
+  expected.AddColumn<double>("AvgClose", {541.55});
+  expected.AddColumn<double>("SumClose", {1083.1});
+  expected.AddColumn<double>("MinClose", {538.2});
+  expected.AddColumn<double>("MaxClose", {544.9});
+  expected.AddColumn<int64_t>("Count", {2});
 
-  CompareTable(
-      agg_table,
-      "AvgClose", avg_close_data,
-      "SumClose", sum_close_data,
-      "MinClose", min_close_data,
-      "MaxClose", max_close_data,
-      "Count", count_data
-  );
+  TableComparerForTests::Compare(expected, agg_table);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/filter_test.cc
+++ b/cpp-client/deephaven/tests/src/filter_test.cc
@@ -6,7 +6,7 @@
 #include "deephaven/tests/test_util.h"
 #include "deephaven/client/client.h"
 
-using deephaven::client::TableHandle;
+using deephaven::client::utility::TableMaker;
 
 namespace deephaven::client::tests {
 TEST_CASE("Filter a Table", "[filter]") {
@@ -17,19 +17,13 @@ TEST_CASE("Filter a Table", "[filter]") {
       "ImportDate == `2017-11-01` && Ticker == `AAPL` && (Close <= 120.0 || isNull(Close))");
   std::cout << t1.Stream(true) << '\n';
 
-  std::vector<std::string> import_date_data = {"2017-11-01", "2017-11-01", "2017-11-01"};
-  std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL"};
-  std::vector<double> open_data = {22.1, 26.8, 31.5};
-  std::vector<double> close_data = {23.5, 24.2, 26.7};
-  std::vector<int64_t> vol_data = {100000, 250000, 19000};
+  TableMaker expected;
+  expected.AddColumn<std::string>("ImportDate", {"2017-11-01", "2017-11-01", "2017-11-01"});
+  expected.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "AAPL"});
+  expected.AddColumn<double>("Open", {22.1, 26.8, 31.5});
+  expected.AddColumn<double>("Close", {23.5, 24.2, 26.7});
+  expected.AddColumn<int64_t>("Volume", {100000, 250000, 19000});
 
-  CompareTable(
-      t1,
-      "ImportDate", import_date_data,
-      "Ticker", ticker_data,
-      "Open", open_data,
-      "Close", close_data,
-      "Volume", vol_data
-  );
+  TableComparerForTests::Compare(expected, t1);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/head_and_tail_test.cc
+++ b/cpp-client/deephaven/tests/src/head_and_tail_test.cc
@@ -4,8 +4,7 @@
 #include "deephaven/third_party/catch.hpp"
 #include "deephaven/tests/test_util.h"
 
-using deephaven::client::TableHandleManager;
-using deephaven::client::TableHandle;
+using deephaven::client::utility::TableMaker;
 
 namespace deephaven::client::tests {
 TEST_CASE("Head and Tail", "[headtail]") {
@@ -21,22 +20,14 @@ TEST_CASE("Head and Tail", "[headtail]") {
 //  std::cout << th.Stream(true) << '\n';
 //  std::cout << tt.Stream(true) << '\n';
 
-  std::vector<std::string> head_ticker_data = {"XRX", "XRX"};
-  std::vector<std::int64_t> head_volume_data = {345000, 87000};
+  TableMaker expected_head;
+  expected_head.AddColumn<std::string>("Ticker", {"XRX", "XRX"});
+  expected_head.AddColumn<std::int64_t>("Volume", {345000, 87000});
+  TableComparerForTests::Compare(expected_head, th);
 
-  std::vector<std::string> tail_ticker_data = {"ZNGA", "ZNGA"};
-  std::vector<std::int64_t> tail_volume_data = {46123, 48300};
-
-  CompareTable(
-      th,
-      "Ticker", head_ticker_data,
-      "Volume", head_volume_data
-  );
-
-  CompareTable(
-      tt,
-      "Ticker", tail_ticker_data,
-      "Volume", tail_volume_data
-  );
+  TableMaker expected_tail;
+  expected_tail.AddColumn<std::string>("Ticker", {"ZNGA", "ZNGA"});
+  expected_tail.AddColumn<std::int64_t>("Volume", {46123, 48300});
+  TableComparerForTests::Compare(expected_tail, tt);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/input_table_test.cc
+++ b/cpp-client/deephaven/tests/src/input_table_test.cc
@@ -17,11 +17,10 @@ TEST_CASE("Input Table: append", "[input_table]") {
 
   // expect input_table to be {0, 100}, {1, 101}, {2, 102}
   {
-    std::vector<int64_t> a_data = {0, 1, 2};
-    std::vector<int64_t> b_data = {100, 101, 102};
-    CompareTable(input_table,
-        "A", a_data,
-        "B", b_data);
+    TableMaker expected;
+    expected.AddColumn<int64_t>("A", {0, 1, 2});
+    expected.AddColumn<int64_t>("B", {100, 101, 102});
+    TableComparerForTests::Compare(expected, input_table);
   }
 
   auto table_to_add = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
@@ -29,11 +28,10 @@ TEST_CASE("Input Table: append", "[input_table]") {
 
   // Because of append, expect input_table to be {0, 100}, {1, 101}, {2, 102}, {0, 200}, {1, 201}
   {
-    std::vector<int64_t> a_data = {0, 1, 2, 0, 1};
-    std::vector<int64_t> b_data = {100, 101, 102, 200, 201};
-    CompareTable(input_table,
-        "A", a_data,
-        "B", b_data);
+    TableMaker expected;
+    expected.AddColumn<int64_t>("A", {0, 1, 2, 0, 1});
+    expected.AddColumn<int64_t>("B", {100, 101, 102, 200, 201});
+    TableComparerForTests::Compare(expected, input_table);
   }
 }
 
@@ -46,11 +44,10 @@ TEST_CASE("Input Table: keyed", "[input_table]") {
 
   // expect input_table to be {0, 100}, {1, 101}, {2, 102}
   {
-    std::vector<int64_t> a_data = {0, 1, 2};
-    std::vector<int64_t> b_data = {100, 101, 102};
-    CompareTable(input_table,
-        "A", a_data,
-        "B", b_data);
+    TableMaker expected;
+    expected.AddColumn<int64_t>("A", {0, 1, 2});
+    expected.AddColumn<int64_t>("B", {100, 101, 102});
+    TableComparerForTests::Compare(expected, input_table);
   }
 
   auto table_to_add = tm.EmptyTable(2).Update({"A = ii", "B = ii + 200"});
@@ -58,11 +55,10 @@ TEST_CASE("Input Table: keyed", "[input_table]") {
 
   // Because key is "A", expect input_table to be {0, 200}, {1, 201}, {2, 102}
   {
-    std::vector<int64_t> a_data = {0, 1, 2};
-    std::vector<int64_t> b_data = {200, 201, 102};
-    CompareTable(input_table,
-        "A", a_data,
-        "B", b_data);
+    TableMaker expected;
+    expected.AddColumn<int64_t>("A", {0, 1, 2});
+    expected.AddColumn<int64_t>("B", {200, 201, 102});
+    TableComparerForTests::Compare(expected, input_table);
   }
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/join_test.cc
+++ b/cpp-client/deephaven/tests/src/join_test.cc
@@ -25,64 +25,48 @@ TEST_CASE("Join", "[join]") {
 
   auto filtered = joined.Select("Ticker", "Close", "ADV");
 
-  std::vector<std::string> ticker_data = {"XRX", "XYZZY", "IBM", "GME", "AAPL", "ZNGA"};
-  std::vector<double> close_data = {53.8, 88.5, 38.7, 453, 26.7, 544.9};
-  std::vector<double> adv_data = {216000, 6060842, 138000, 138000000, 123000, 47211.50};
-
-  CompareTable(
-      filtered,
-      "Ticker", ticker_data,
-      "Close", close_data,
-      "ADV", adv_data
-  );
+  TableMaker expected;
+  expected.AddColumn<std::string>("Ticker", {"XRX", "XYZZY", "IBM", "GME", "AAPL", "ZNGA"});
+  expected.AddColumn<double>("Close", {53.8, 88.5, 38.7, 453, 26.7, 544.9});
+  expected.AddColumn<double>("ADV", {216000, 6060842, 138000, 138000000, 123000, 47211.50});
+  TableComparerForTests::Compare(expected, filtered);
 }
 
 TEST_CASE("Aj", "[join]") {
   auto tm = TableMakerForTests::Create();
-  auto q = arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
 
   TableHandle trades;
   {
-    std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL", "IBM", "IBM"};
-    std::vector<DateTime> instant_data = {
+    TableMaker table_maker;
+    table_maker.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "AAPL", "IBM", "IBM"});
+    table_maker.AddColumn<DateTime>("Timestamp", {
         DateTime::Parse("2021-04-05T09:10:00-0500"),
         DateTime::Parse("2021-04-05T09:31:00-0500"),
         DateTime::Parse("2021-04-05T16:00:00-0500"),
         DateTime::Parse("2021-04-05T16:00:00-0500"),
         DateTime::Parse("2021-04-05T16:30:00-0500")
-    };
-    std::vector<double> price_data = {2.5, 3.7, 3.0, 100.50, 110};
-    std::vector<int32_t> size_data = {52, 14, 73, 11, 6};
-    TableMaker table_maker;
-    table_maker.AddColumn("Ticker", ticker_data);
-    table_maker.AddColumn("Timestamp", instant_data);
-    table_maker.AddColumn("Price", price_data);
-    table_maker.AddColumn("Size", size_data);
+    });
+    table_maker.AddColumn<double>("Price", {2.5, 3.7, 3.0, 100.50, 110});
+    table_maker.AddColumn<int32_t>("Size", {52, 14, 73, 11, 6});
     trades = table_maker.MakeTable(tm.Client().GetManager());
     // std::cout << trades.Stream(true) << '\n';
   }
 
   TableHandle quotes;
   {
-    std::vector<std::string> ticker_data = {"AAPL", "AAPL", "IBM", "IBM", "IBM"};
-    std::vector<DateTime> timestamp_data = {
+    TableMaker table_maker;
+    table_maker.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "IBM", "IBM", "IBM"});
+    table_maker.AddColumn<DateTime>("Timestamp", {
         DateTime::Parse("2021-04-05T09:11:00-0500"),
         DateTime::Parse("2021-04-05T09:30:00-0500"),
         DateTime::Parse("2021-04-05T16:00:00-0500"),
         DateTime::Parse("2021-04-05T16:30:00-0500"),
         DateTime::Parse("2021-04-05T17:00:00-0500")
-    };
-    std::vector<double> bid_data = {2.5, 3.4, 97, 102, 108};
-    std::vector<int32_t> bid_size_data = {10, 20, 5, 13, 23};
-    std::vector<double> ask_data = {2.5, 3.4, 105, 110, 111};
-    std::vector<int32_t> ask_size_data = {83, 33, 47, 15, 5};
-    TableMaker table_maker;
-    table_maker.AddColumn("Ticker", ticker_data);
-    table_maker.AddColumn("Timestamp", timestamp_data);
-    table_maker.AddColumn("Bid", bid_data);
-    table_maker.AddColumn("BidSize", bid_size_data);
-    table_maker.AddColumn("Ask", ask_data);
-    table_maker.AddColumn("AskSize", ask_size_data);
+    });
+    table_maker.AddColumn<double>("Bid", {2.5, 3.4, 97, 102, 108});
+    table_maker.AddColumn<int32_t>("BidSize", {10, 20, 5, 13, 23});
+    table_maker.AddColumn<double>("Ask", {2.5, 3.4, 105, 110, 111});
+    table_maker.AddColumn<int32_t>("AskSize", {83, 33, 47, 15, 5});
     quotes = table_maker.MakeTable(tm.Client().GetManager());
     // std::cout << quotes.Stream(true) << '\n';
   }
@@ -90,47 +74,22 @@ TEST_CASE("Aj", "[join]") {
   auto result = trades.Aj(quotes, {"Ticker", "Timestamp"});
   // std::cout << result.Stream(true) << '\n';
 
-  // Expected data
-  {
-    std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL", "IBM", "IBM"};
-    std::vector<DateTime> timestamp_data = {
-        DateTime::Parse("2021-04-05T09:10:00-0500"),
-        DateTime::Parse("2021-04-05T09:31:00-0500"),
-        DateTime::Parse("2021-04-05T16:00:00-0500"),
-        DateTime::Parse("2021-04-05T16:00:00-0500"),
-        DateTime::Parse("2021-04-05T16:30:00-0500")
-    };
-    for (const auto &ts : timestamp_data) {
-      fmt::print(std::cout, "{} - {}\n", ts, ts.Nanos());
+  TableMaker expected;
+  expected.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "AAPL", "IBM", "IBM"});
+  expected.AddColumn<DateTime>("Timestamp", {
+      DateTime::Parse("2021-04-05T09:10:00-0500"),
+      DateTime::Parse("2021-04-05T09:31:00-0500"),
+      DateTime::Parse("2021-04-05T16:00:00-0500"),
+      DateTime::Parse("2021-04-05T16:00:00-0500"),
+      DateTime::Parse("2021-04-05T16:30:00-0500")});
+  expected.AddColumn<double>("Price", {2.5, 3.7, 3.0, 100.50, 110});
+  expected.AddColumn<int32_t>("Size", {52, 14, 73, 11, 6});
+  expected.AddColumn<std::optional<double>>("Bid", {{}, 3.4, 3.4, 97, 102});
+  expected.AddColumn<std::optional<int32_t>>("BidSize", {{}, 20, 20, 5, 13});
+  expected.AddColumn<std::optional<double>>("Ask", {{}, 3.4, 3.4, 105, 110});
+  expected.AddColumn<std::optional<int32_t>>("AskSize", {{}, 33, 33, 47, 15});
 
-    }
-    std::vector<double> price_data = {2.5, 3.7, 3.0, 100.50, 110};
-    std::vector<int32_t> size_data = {52, 14, 73, 11, 6};
-    std::vector<std::optional<double>> bid_data = {{}, 3.4, 3.4, 97, 102};
-    std::vector<std::optional<int32_t>> bid_size_data = {{}, 20, 20, 5, 13};
-    std::vector<std::optional<double>> ask_data = {{}, 3.4, 3.4, 105, 110};
-    std::vector<std::optional<int32_t>> ask_size_data = {{}, 33, 33, 47, 15};
-    TableMaker table_maker;
-    table_maker.AddColumn("Ticker", ticker_data);
-    table_maker.AddColumn("Timestamp", timestamp_data);
-    table_maker.AddColumn("Price", price_data);
-    table_maker.AddColumn("Size", size_data);
-    table_maker.AddColumn("Bid", bid_data);
-    table_maker.AddColumn("BidSize", bid_size_data);
-    table_maker.AddColumn("Ask", ask_data);
-    table_maker.AddColumn("AskSize", ask_size_data);
-
-    CompareTable(
-        result,
-        "Ticker", ticker_data,
-        "Timestamp", timestamp_data,
-        "Price", price_data,
-        "Size", size_data,
-        "Bid", bid_data,
-        "BidSize", bid_size_data,
-        "Ask", ask_data,
-        "AskSize", ask_size_data);
-  }
+  TableComparerForTests::Compare(expected, result);
 }
 
 TEST_CASE("Raj", "[join]") {
@@ -148,35 +107,35 @@ TEST_CASE("Raj", "[join]") {
     std::vector<double> price_data = {2.5, 3.7, 3.0, 100.50, 110};
     std::vector<int32_t> size_data = {52, 14, 73, 11, 6};
     TableMaker table_maker;
-    table_maker.AddColumn("Ticker", ticker_data);
-    table_maker.AddColumn("Timestamp", instant_data);
-    table_maker.AddColumn("Price", price_data);
-    table_maker.AddColumn("Size", size_data);
+    table_maker.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "AAPL", "IBM", "IBM"});
+    table_maker.AddColumn<DateTime>("Timestamp", {
+        DateTime::Parse("2021-04-05T09:10:00-0500"),
+        DateTime::Parse("2021-04-05T09:31:00-0500"),
+        DateTime::Parse("2021-04-05T16:00:00-0500"),
+        DateTime::Parse("2021-04-05T16:00:00-0500"),
+        DateTime::Parse("2021-04-05T16:30:00-0500")
+    });
+    table_maker.AddColumn<double>("Price", {2.5, 3.7, 3.0, 100.50, 110});
+    table_maker.AddColumn<int32_t>("Size", {52, 14, 73, 11, 6});
     trades = table_maker.MakeTable(tm.Client().GetManager());
     // std::cout << trades.Stream(true) << '\n';
   }
 
   TableHandle quotes;
   {
-    std::vector<std::string> ticker_data = {"AAPL", "AAPL", "IBM", "IBM", "IBM"};
-    std::vector<DateTime> timestamp_data = {
+    TableMaker table_maker;
+    table_maker.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "IBM", "IBM", "IBM"});
+    table_maker.AddColumn<DateTime>("Timestamp",  {
         DateTime::Parse("2021-04-05T09:11:00-0500"),
         DateTime::Parse("2021-04-05T09:30:00-0500"),
         DateTime::Parse("2021-04-05T16:00:00-0500"),
         DateTime::Parse("2021-04-05T16:30:00-0500"),
         DateTime::Parse("2021-04-05T17:00:00-0500")
-    };
-    std::vector<double> bid_data = {2.5, 3.4, 97, 102, 108};
-    std::vector<int32_t> bid_size_data = {10, 20, 5, 13, 23};
-    std::vector<double> ask_data = {2.5, 3.4, 105, 110, 111};
-    std::vector<int32_t> ask_size_data = {83, 33, 47, 15, 5};
-    TableMaker table_maker;
-    table_maker.AddColumn("Ticker", ticker_data);
-    table_maker.AddColumn("Timestamp", timestamp_data);
-    table_maker.AddColumn("Bid", bid_data);
-    table_maker.AddColumn("BidSize", bid_size_data);
-    table_maker.AddColumn("Ask", ask_data);
-    table_maker.AddColumn("AskSize", ask_size_data);
+    });
+    table_maker.AddColumn<double>("Bid", {2.5, 3.4, 97, 102, 108});
+    table_maker.AddColumn<int32_t>("BidSize", {10, 20, 5, 13, 23});
+    table_maker.AddColumn<double>("Ask", {2.5, 3.4, 105, 110, 111});
+    table_maker.AddColumn<int32_t>("AskSize", {83, 33, 47, 15, 5});
     quotes = table_maker.MakeTable(tm.Client().GetManager());
     // std::cout << quotes.Stream(true) << '\n';
   }
@@ -186,35 +145,23 @@ TEST_CASE("Raj", "[join]") {
 
   // Expected data
   {
-    std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL", "IBM", "IBM"};
-    std::vector<DateTime> timestamp_data = {
+    TableMaker expected;
+    expected.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "AAPL", "IBM", "IBM"});
+    expected.AddColumn<DateTime>("Timestamp", {
         DateTime::Parse("2021-04-05T09:10:00-0500"),
         DateTime::Parse("2021-04-05T09:31:00-0500"),
         DateTime::Parse("2021-04-05T16:00:00-0500"),
         DateTime::Parse("2021-04-05T16:00:00-0500"),
         DateTime::Parse("2021-04-05T16:30:00-0500")
-    };
-    for (const auto &ts : timestamp_data) {
-      fmt::print(std::cout, "{} - {}\n", ts, ts.Nanos());
+    });
+    expected.AddColumn<double>("Price", {2.5, 3.7, 3.0, 100.50, 110});
+    expected.AddColumn<int32_t>("Size", {52, 14, 73, 11, 6});
+    expected.AddColumn<std::optional<double>>("Bid", {2.5, {}, {}, 97, 102});
+    expected.AddColumn<std::optional<int32_t>>("BidSize", {10, {}, {}, 5, 13});
+    expected.AddColumn<std::optional<double>>("Ask", {2.5, {}, {}, 105, 110});
+    expected.AddColumn<std::optional<int32_t>>("AskSize", {83, {}, {}, 47, 15});
 
-    }
-    std::vector<double> price_data = {2.5, 3.7, 3.0, 100.50, 110};
-    std::vector<int32_t> size_data = {52, 14, 73, 11, 6};
-    std::vector<std::optional<double>> bid_data = {2.5, {}, {}, 97, 102};
-    std::vector<std::optional<int32_t>> bid_size_data = {10, {}, {}, 5, 13};
-    std::vector<std::optional<double>> ask_data = {2.5, {}, {}, 105, 110};
-    std::vector<std::optional<int32_t>> ask_size_data = {83, {}, {}, 47, 15};
-
-    CompareTable(
-        result,
-        "Ticker", ticker_data,
-        "Timestamp", timestamp_data,
-        "Price", price_data,
-        "Size", size_data,
-        "Bid", bid_data,
-        "BidSize", bid_size_data,
-        "Ask", ask_data,
-        "AskSize", ask_size_data);
+    TableComparerForTests::Compare(expected, result);
   }
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/lastby_test.cc
+++ b/cpp-client/deephaven/tests/src/lastby_test.cc
@@ -4,8 +4,7 @@
 #include "deephaven/third_party/catch.hpp"
 #include "deephaven/tests/test_util.h"
 
-using deephaven::client::TableHandleManager;
-using deephaven::client::TableHandle;
+using deephaven::client::utility::TableMaker;
 
 namespace deephaven::client::tests {
 TEST_CASE("Last By", "[lastby]") {
@@ -21,11 +20,12 @@ TEST_CASE("Last By", "[lastby]") {
   std::vector<double> close_data = {53.8, 88.5, 38.7, 453, 26.7, 544.9};
 
   INFO(lb.Stream(true));
-  CompareTable(
-      lb,
-      "Ticker", ticker_data,
-      "Open", open_data,
-      "Close", close_data
-  );
+
+  TableMaker expected;
+  expected.AddColumn<std::string>("Ticker", {"XRX", "XYZZY", "IBM", "GME", "AAPL", "ZNGA"});
+  expected.AddColumn<double>("Open", {50.5, 92.3, 40.1, 681.43, 31.5, 685.3});
+  expected.AddColumn<double>("Close", {53.8, 88.5, 38.7, 453, 26.7, 544.9});
+  TableComparerForTests::Compare(expected, lb);
+
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/merge_tables_test.cc
+++ b/cpp-client/deephaven/tests/src/merge_tables_test.cc
@@ -4,6 +4,8 @@
 #include "deephaven/third_party/catch.hpp"
 #include "deephaven/tests/test_util.h"
 
+using deephaven::client::utility::TableMaker;
+
 namespace deephaven::client::tests {
 TEST_CASE("Merge Tables", "[Merge]") {
   auto tm = TableMakerForTests::Create();
@@ -18,20 +20,14 @@ TEST_CASE("Merge Tables", "[Merge]") {
   auto merged = aapl_table.Merge({znga_table});
   std::cout << merged.Stream(true) << '\n';
 
-  std::vector<std::string> import_date_data = {"2017-11-01", "2017-11-01", "2017-11-01",
-      "2017-11-01", "2017-11-01"};
-  std::vector<std::string> ticker_data = {"AAPL", "AAPL", "AAPL", "ZNGA", "ZNGA"};
-  std::vector<double> open_data = {22.1, 26.8, 31.5, 541.2, 685.3};
-  std::vector<double> close_data = {23.5, 24.2, 26.7, 538.2, 544.9};
-  std::vector<int64_t> vol_data = {100000, 250000, 19000, 46123, 48300};
+  TableMaker expected;
+  expected.AddColumn<std::string>("ImportDate", {"2017-11-01", "2017-11-01", "2017-11-01",
+      "2017-11-01", "2017-11-01"});
+  expected.AddColumn<std::string>("Ticker", {"AAPL", "AAPL", "AAPL", "ZNGA", "ZNGA"});
+  expected.AddColumn<double>("Open", {22.1, 26.8, 31.5, 541.2, 685.3});
+  expected.AddColumn<double>("Close", {23.5, 24.2, 26.7, 538.2, 544.9});
+  expected.AddColumn<int64_t>("Volume", {100000, 250000, 19000, 46123, 48300});
 
-  CompareTable(
-      merged,
-      "ImportDate", import_date_data,
-      "Ticker", ticker_data,
-      "Open", open_data,
-      "Close", close_data,
-      "Volume", vol_data
-  );
+  TableComparerForTests::Compare(expected, merged);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/new_table_test.cc
+++ b/cpp-client/deephaven/tests/src/new_table_test.cc
@@ -7,9 +7,6 @@
 #include "deephaven/tests/test_util.h"
 #include "deephaven/dhcore/utility/utility.h"
 
-using deephaven::client::TableHandleManager;
-using deephaven::client::TableHandle;
-using deephaven::client::SortPair;
 using deephaven::client::utility::TableMaker;
 using deephaven::dhcore::DeephavenConstants;
 
@@ -17,24 +14,24 @@ namespace deephaven::client::tests {
 TEST_CASE("New Table", "[newtable]") {
   auto tm = TableMakerForTests::Create();
 
-  // std::vector<std::optional<bool>> boolData = { {}, false, true, false, false, true };
-  std::vector<std::optional<int8_t>> byte_data = { {}, 0, 1, -1, DeephavenConstants::kMinByte, DeephavenConstants::kMaxByte };
-  std::vector<std::optional<int16_t>> short_data = { {}, 0, 1, -1, DeephavenConstants::kMinShort, DeephavenConstants::kMaxShort };
-  std::vector<std::optional<int32_t>> int_data = { {}, 0, 1, -1, DeephavenConstants::kMinInt, DeephavenConstants::kMaxInt };
-  std::vector<std::optional<int64_t>> long_data = { {}, 0L, 1L, -1L, DeephavenConstants::kMinLong, DeephavenConstants::kMaxLong };
-  std::vector<std::optional<float>> float_data = { {}, 0.0F, 1.0F, -1.0F, -3.4e+38F, std::numeric_limits<float>::max() };
-  std::vector<std::optional<double>> double_data = { {}, 0.0, 1.0, -1.0, -1.79e+308, std::numeric_limits<double>::max() };
-  std::vector<std::optional<std::string>> string_data = { {}, "", "A string", "Also a string", "AAAAAA", "ZZZZZZ" };
-
   TableMaker maker;
-  // maker.addColumn("BoolValue", boolData);
-  maker.AddColumn("ByteValue", byte_data);
-  maker.AddColumn("ShortValue", short_data);
-  maker.AddColumn("IntValue", int_data);
-  maker.AddColumn("LongValue", long_data);
-  maker.AddColumn("FloatValue", float_data);
-  maker.AddColumn("DoubleValue", double_data);
-  maker.AddColumn("StringValue", string_data);
+  maker.AddColumn<std::optional<bool>>("BoolValue",
+      { {}, false, true, false, false, true });
+  maker.AddColumn<std::optional<int8_t>>("ByteValue",
+      { {}, 0, 1, -1, DeephavenConstants::kMinByte, DeephavenConstants::kMaxByte });
+  maker.AddColumn<std::optional<int16_t>>("ShortValue",
+      { {}, 0, 1, -1, DeephavenConstants::kMinShort, DeephavenConstants::kMaxShort });
+  maker.AddColumn<std::optional<int32_t>>("IntValue",
+      { {}, 0, 1, -1, DeephavenConstants::kMinInt, DeephavenConstants::kMaxInt });
+  maker.AddColumn<std::optional<int64_t>>("LongValue",
+      { {}, 0L, 1L, -1L, DeephavenConstants::kMinLong, DeephavenConstants::kMaxLong });
+  maker.AddColumn<std::optional<float>>("FloatValue",
+      { {}, 0.0F, 1.0F, -1.0F, -3.4e+38F, std::numeric_limits<float>::max() });
+  maker.AddColumn<std::optional<double>>("DoubleValue",
+      { {}, 0.0, 1.0, -1.0, -1.79e+308, std::numeric_limits<double>::max() });
+  maker.AddColumn<std::optional<std::string>>("StringValue",
+      { {}, "", "A string", "Also a string", "AAAAAA", "ZZZZZZ" });
+
   auto temp = maker.MakeTable(tm.Client().GetManager());
   std::cout << temp.Stream(true) << '\n';
 }

--- a/cpp-client/deephaven/tests/src/new_table_test.cc
+++ b/cpp-client/deephaven/tests/src/new_table_test.cc
@@ -1,38 +1,147 @@
 /*
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
+#include <cstdint>
+#include <iostream>
+#include <limits>
 #include <optional>
+#include <vector>
 
+#include "deephaven/client/client.h"
+#include "deephaven/client/utility/table_maker.h"
+#include "deephaven/dhcore/types.h"
 #include "deephaven/third_party/catch.hpp"
 #include "deephaven/tests/test_util.h"
-#include "deephaven/dhcore/utility/utility.h"
 
+using Catch::Matchers::StartsWith;
 using deephaven::client::utility::TableMaker;
 using deephaven::dhcore::DeephavenConstants;
+using deephaven::dhcore::DateTime;
+using deephaven::dhcore::LocalDate;
+using deephaven::dhcore::LocalTime;
 
 namespace deephaven::client::tests {
-TEST_CASE("New Table", "[newtable]") {
+
+// Test schema validation
+TEST_CASE("Schema validation", "[newtable]") {
+  TableMaker maker;
+  maker.AddColumn<bool>("Bools", { false, true, false, false, true });
+  // Inconsistent number of rows
+  maker.AddColumn<int32_t>("Ints", { 0, 1, 2, 3 });
+
+  REQUIRE_THROWS_WITH(maker.MakeArrowTable(), StartsWith("Column sizes not consistent"));
+}
+
+// Make tables out of scalar types and see if they successfully round-trip.
+TEST_CASE("Scalar Types", "[newtable]") {
   auto tm = TableMakerForTests::Create();
 
   TableMaker maker;
-  maker.AddColumn<std::optional<bool>>("BoolValue",
+  maker.AddColumn<std::optional<bool>>("Bools",
       { {}, false, true, false, false, true });
-  maker.AddColumn<std::optional<int8_t>>("ByteValue",
+  maker.AddColumn<std::optional<char16_t>>("Chars",
+      { {}, 0, 'a', u'ᐾ', DeephavenConstants::kMinChar, DeephavenConstants::kMaxChar });
+  maker.AddColumn<std::optional<int8_t>>("Bytes",
       { {}, 0, 1, -1, DeephavenConstants::kMinByte, DeephavenConstants::kMaxByte });
-  maker.AddColumn<std::optional<int16_t>>("ShortValue",
+  maker.AddColumn<std::optional<int16_t>>("Shorts",
       { {}, 0, 1, -1, DeephavenConstants::kMinShort, DeephavenConstants::kMaxShort });
-  maker.AddColumn<std::optional<int32_t>>("IntValue",
+  maker.AddColumn<std::optional<int32_t>>("Ints",
       { {}, 0, 1, -1, DeephavenConstants::kMinInt, DeephavenConstants::kMaxInt });
-  maker.AddColumn<std::optional<int64_t>>("LongValue",
+  maker.AddColumn<std::optional<int64_t>>("Longs",
       { {}, 0L, 1L, -1L, DeephavenConstants::kMinLong, DeephavenConstants::kMaxLong });
-  maker.AddColumn<std::optional<float>>("FloatValue",
+  maker.AddColumn<std::optional<float>>("Floats",
       { {}, 0.0F, 1.0F, -1.0F, -3.4e+38F, std::numeric_limits<float>::max() });
-  maker.AddColumn<std::optional<double>>("DoubleValue",
+  maker.AddColumn<std::optional<double>>("Doubles",
       { {}, 0.0, 1.0, -1.0, -1.79e+308, std::numeric_limits<double>::max() });
-  maker.AddColumn<std::optional<std::string>>("StringValue",
+  maker.AddColumn<std::optional<std::string>>("Strings",
       { {}, "", "A string", "Also a string", "AAAAAA", "ZZZZZZ" });
+  maker.AddColumn<std::optional<DateTime>>("DateTimes",
+      { {}, DateTime(), DateTime::FromNanos(-1), DateTime::FromNanos(1),
+          DateTime::Parse("2020-03-01T12:34:56Z"), DateTime::Parse("1900-05-05T11:22:33Z") });
+  maker.AddColumn<std::optional<LocalDate>>("LocalDates",
+      { {}, LocalDate(), LocalDate::FromMillis(-86'400'000), LocalDate::FromMillis(86'400'000),
+          LocalDate::Of(2020, 3, 1), LocalDate::Of(1900, 5, 5) });
+  maker.AddColumn<std::optional<LocalTime>>("LocalTimes",
+      { {}, LocalTime(), LocalTime::FromNanos(1), LocalTime::FromNanos(10'000'000'000),
+          LocalTime::Of(12, 34, 56), LocalTime::Of(11, 22, 33) });
 
-  auto temp = maker.MakeTable(tm.Client().GetManager());
-  std::cout << temp.Stream(true) << '\n';
+  auto dh_table = maker.MakeTable(tm.Client().GetManager());
+
+  std::cout << dh_table.Stream(true) << '\n';
+
+  TableComparerForTests::Compare(maker, dh_table);
+}
+
+// Make tables out of list types and see if they successfully round-trip.
+TEST_CASE("List Types", "[newtable]") {
+  auto tm = TableMakerForTests::Create();
+
+  TableMaker maker;
+  maker.AddColumn<std::optional<std::vector<std::optional<bool>>>>("Bools", {
+      {}, // a null list
+      { { false, true } }, // a non-null list
+      { { false, true, {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<char16_t>>>>("Chars", {
+      {}, // a null list
+      { { 'a', u'ᐾ' } }, // a non-null list
+      { { 'a', u'ᐾ', {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<int8_t>>>>("Bytes", {
+      {}, // a null list
+      { { 0, 35 } }, // a non-null list
+      { { 0, 35, {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<int16_t>>>>("Shorts", {
+      {}, // a null list
+      { { 0, 1111 } }, // a non-null list
+      { { 0, 1111, {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<int32_t>>>>("Ints", {
+      {}, // a null list
+      { { 0, 91919 } }, // a non-null list
+      { { 0, 91919, {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<int64_t>>>>("Longs", {
+      {}, // a null list
+      { { 0, 987654321 } }, // a non-null list
+      { { 0, 987654321, {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<float>>>>("Floats", {
+      {}, // a null list
+      { { 0, 123.456 } }, // a non-null list
+      { { 0, 123.456, {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<double>>>>("Doubles", {
+      {}, // a null list
+      { { 0, 123.456 } }, // a non-null list
+      { { 0, 123.456, {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<std::string>>>>("Strings", {
+      {}, // a null list
+      { { "", "hello" } }, // a non-null list
+      { { "", "hello", {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<DateTime>>>>("DateTimes", {
+      {}, // a null list
+      { { DateTime(), DateTime::Parse("2020-03-01T12:34:56Z") } }, // a non-null list
+      { { DateTime(), DateTime::Parse("2020-03-01T12:34:56Z"), {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<LocalDate>>>>("LocalDates", {
+      {}, // a null list
+      { { LocalDate(), LocalDate::Of(2020, 3, 1) } }, // a non-null list
+      { { LocalDate(), LocalDate::Of(2020, 3, 1), {} } } // a non-null list with a null entry
+  });
+  maker.AddColumn<std::optional<std::vector<std::optional<LocalTime>>>>("LocalTimes", {
+      {}, // a null list
+      { { LocalTime(), LocalTime::Of(11, 22, 33) } }, // a non-null list
+      { { LocalTime(), LocalTime::Of(11, 22, 33), {} } } // a non-null list with a null entry
+  });
+
+  auto dh_table = maker.MakeTable(tm.Client().GetManager());
+
+  std::cout << dh_table.Stream(true) << '\n';
+
+  TableComparerForTests::Compare(maker, dh_table);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/script_test.cc
+++ b/cpp-client/deephaven/tests/src/script_test.cc
@@ -6,6 +6,8 @@
 #include "deephaven/tests/test_util.h"
 #include "deephaven/dhcore/utility/utility.h"
 
+using deephaven::client::utility::TableMaker;
+
 namespace deephaven::client::tests {
 TEST_CASE("Script session error", "[script]") {
   auto client = TableMakerForTests::CreateClient(ClientOptions().SetSessionType(""));
@@ -16,16 +18,6 @@ TEST_CASE("Script session error", "[script]") {
 }
 
 TEST_CASE("Script execution", "[script]") {
-  std::vector<int32_t> int_data;
-  std::vector<int64_t> long_data;
-
-  const int start_value = -8;
-  const int end_value = 8;
-  for (auto i = start_value; i != end_value; ++i) {
-    int_data.push_back(i);
-    long_data.push_back(i * 100);
-  }
-
   auto client = TableMakerForTests::CreateClient();
   auto thm = client.GetManager();
 
@@ -39,10 +31,19 @@ mytable = empty_table(16).update(["intData = (int)(ii - 8)", "longData = (long)(
 
   std::cout << t.Stream(true) << '\n';
 
-  CompareTable(
-      t,
-      "intData", int_data,
-      "longData", long_data
-  );
+  std::vector<int32_t> int_data;
+  std::vector<int64_t> long_data;
+
+  const int start_value = -8;
+  const int end_value = 8;
+  for (auto i = start_value; i != end_value; ++i) {
+    int_data.push_back(i);
+    long_data.push_back(i * 100);
+  }
+
+  TableMaker expected;
+  expected.AddColumn("intData", int_data);
+  expected.AddColumn("longData", long_data);
+  TableComparerForTests::Compare(expected, t);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/sort_test.cc
+++ b/cpp-client/deephaven/tests/src/sort_test.cc
@@ -6,9 +6,6 @@
 
 #include "deephaven/dhcore/utility/utility.h"
 
-using deephaven::client::TableHandleManager;
-using deephaven::client::TableHandle;
-using deephaven::client::SortPair;
 using deephaven::client::utility::TableMaker;
 
 namespace deephaven::client::tests {
@@ -24,47 +21,31 @@ TEST_CASE("Sort demo Table", "[sort]") {
 
   auto table1 = filtered.Sort(SortPair::Descending("Ticker"), SortPair::Ascending("Volume"));
 
-  std::vector<std::string> ticker_data = {"ZNGA", "ZNGA", "XYZZY", "XRX", "XRX"};
-  std::vector<double> open_data = {541.2, 685.3, 92.3, 50.5, 83.1};
-  std::vector<int64_t> vol_data = {46123, 48300, 6060842, 87000, 345000};
-
-  CompareTable(
-      table1,
-      "Ticker", ticker_data,
-      "Open", open_data,
-      "Volume", vol_data
-  );
+  TableMaker expected;
+  expected.AddColumn<std::string>("Ticker", {"ZNGA", "ZNGA", "XYZZY", "XRX", "XRX"});
+  expected.AddColumn<double>("Open", {541.2, 685.3, 92.3, 50.5, 83.1});
+  expected.AddColumn<int64_t>("Volume", {46123, 48300, 6060842, 87000, 345000});
+  TableComparerForTests::Compare(expected, table1);
 }
 
 TEST_CASE("Sort temp Table", "[sort]") {
   auto tm = TableMakerForTests::Create();
 
-  std::vector<int32_t> int_data0{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-  std::vector<int32_t> int_data1{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
-  std::vector<int32_t> int_data2{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
-  std::vector<int32_t> int_data3{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1};
-
   TableMaker maker;
-  maker.AddColumn("IntValue0", int_data0);
-  maker.AddColumn("IntValue1", int_data1);
-  maker.AddColumn("IntValue2", int_data2);
-  maker.AddColumn("IntValue3", int_data3);
+  maker.AddColumn<int32_t>("IntValue0", {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+  maker.AddColumn<int32_t>("IntValue1", {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7});
+  maker.AddColumn<int32_t>("IntValue2", {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3});
+  maker.AddColumn<int32_t>("IntValue3", {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1});
 
   auto temp_table = maker.MakeTable(tm.Client().GetManager());
 
   auto sorted = temp_table.Sort(SortPair::Descending("IntValue3"), SortPair::Ascending("IntValue2"));
 
-  std::vector<int32_t> sid0{8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7};
-  std::vector<int32_t> sid1{4, 4, 5, 5, 6, 6, 7, 7, 0, 0, 1, 1, 2, 2, 3, 3};
-  std::vector<int32_t> sid2{2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1};
-  std::vector<int32_t> sid3{1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0};
-
-  CompareTable(
-      sorted,
-      "IntValue0", sid0,
-      "IntValue1", sid1,
-      "IntValue2", sid2,
-      "IntValue3", sid3
-  );
+  TableMaker expected;
+  expected.AddColumn<int32_t>("IntValue0", {8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7});
+  expected.AddColumn<int32_t>("IntValue1", {4, 4, 5, 5, 6, 6, 7, 7, 0, 0, 1, 1, 2, 2, 3, 3});
+  expected.AddColumn<int32_t>("IntValue2", {2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1});
+  expected.AddColumn<int32_t>("IntValue3", {1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0});
+  TableComparerForTests::Compare(expected, sorted);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/string_filter_test.cc
+++ b/cpp-client/deephaven/tests/src/string_filter_test.cc
@@ -5,6 +5,8 @@
 #include "deephaven/tests/test_util.h"
 
 using deephaven::client::TableHandle;
+using deephaven::client::utility::TableMaker;
+
 namespace deephaven::client::tests {
 namespace {
 void TestFilter(const char *description, const TableHandle &filtered_table,
@@ -53,11 +55,10 @@ void TestFilter(const char *description, const TableHandle &filtered_table,
     const std::vector<double> &close_data) {
   INFO(description);
   INFO(filtered_table.Stream(true));
-  CompareTable(
-      filtered_table,
-      "Ticker", ticker_data,
-      "Close", close_data
-  );
+  TableMaker expected;
+  expected.AddColumn("Ticker", ticker_data);
+  expected.AddColumn("Close", close_data);
+  TableComparerForTests::Compare(expected, filtered_table);
 }
 }  // namespace
 }  // namespace deephaven::client::tests {

--- a/cpp-client/deephaven/tests/src/table_test.cc
+++ b/cpp-client/deephaven/tests/src/table_test.cc
@@ -46,8 +46,7 @@ TEST_CASE("Fetch the entire table (small)", "[client_table]") {
       });
   std::cout << th.Stream(true) << '\n';
 
-  auto ct = th.ToClientTable();
-  auto schema = ct->Schema();
+  auto arrow_table = th.ToArrowTable();
 
   auto chars = MakeReservedVector<std::optional<char16_t>>(target);
   auto int8s = MakeReservedVector<std::optional<int8_t>>(target);
@@ -95,17 +94,19 @@ TEST_CASE("Fetch the entire table (small)", "[client_table]") {
   local_dates[t2] = {};
   local_times[t2] = {};
 
-  CompareColumn(*ct, "Chars", chars);
-  CompareColumn(*ct, "Bytes", int8s);
-  CompareColumn(*ct, "Shorts", int16s);
-  CompareColumn(*ct, "Ints", int32s);
-  CompareColumn(*ct, "Longs", int64s);
-  CompareColumn(*ct, "Floats", floats);
-  CompareColumn(*ct, "Doubles", doubles);
-  CompareColumn(*ct, "Bools", bools);
-  CompareColumn(*ct, "Strings", strings);
-  CompareColumn(*ct, "DateTimes", date_times);
-  CompareColumn(*ct, "LocalDates", local_dates);
-  CompareColumn(*ct, "LocalTimes", local_times);
+  TableMaker expected;
+  expected.AddColumn("Chars", chars);
+  expected.AddColumn("Bytes", int8s);
+  expected.AddColumn("Shorts", int16s);
+  expected.AddColumn("Ints", int32s);
+  expected.AddColumn("Longs", int64s);
+  expected.AddColumn("Floats", floats);
+  expected.AddColumn("Doubles", doubles);
+  expected.AddColumn("Bools", bools);
+  expected.AddColumn("Strings", strings);
+  expected.AddColumn("DateTimes", date_times);
+  expected.AddColumn("LocalDates", local_dates);
+  expected.AddColumn("LocalTimes", local_times);
+  TableComparerForTests::Compare(expected, *arrow_table);
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/time_unit_test.cc
+++ b/cpp-client/deephaven/tests/src/time_unit_test.cc
@@ -4,8 +4,9 @@
 #include <iostream>
 #include "deephaven/third_party/catch.hpp"
 #include "deephaven/tests/test_util.h"
+#include "deephaven/client/client.h"
 #include "deephaven/client/utility/internal_types.h"
-#include "deephaven/client/utility/misc_types.h"
+#include "deephaven/client/utility/table_maker.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/types.h"
 

--- a/cpp-client/deephaven/tests/src/update_by_test.cc
+++ b/cpp-client/deephaven/tests/src/update_by_test.cc
@@ -70,7 +70,10 @@ TEST_CASE("UpdateBy: SimpleCumSum", "[update_by]") {
   auto source = tm.EmptyTable(10).Update("Letter = (i % 2 == 0) ? `A` : `B`", "X = i");
   auto result = source.UpdateBy({cumSum({"SumX = X"})}, {"Letter"});
   auto filtered = result.Select("SumX");
-  CompareTable(filtered, "SumX", std::vector<int64_t>{0, 1, 2, 4, 6, 9, 12, 16, 20, 25});
+
+  TableMaker expected;
+  expected.AddColumn<int64_t>("SumX", {0, 1, 2, 4, 6, 9, 12, 16, 20, 25});
+  TableComparerForTests::Compare(expected, filtered);
 }
 
 TEST_CASE("UpdateBy: SimpleOps", "[update_by]") {

--- a/cpp-client/deephaven/tests/src/validation_test.cc
+++ b/cpp-client/deephaven/tests/src/validation_test.cc
@@ -1,17 +1,21 @@
 /*
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
-#include "deephaven/third_party/catch.hpp"
-#include "deephaven/tests/test_util.h"
-#include "deephaven/dhcore/utility/utility.h"
-#include "deephaven/third_party/fmt/format.h"
-#include "deephaven/third_party/fmt/ostream.h"
-#include "deephaven/third_party/fmt/ranges.h"
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
 
-using deephaven::client::TableHandleManager;
+#include "deephaven/client/client.h"
+#include "deephaven/tests/test_util.h"
+#include "deephaven/third_party/catch.hpp"
+#include "deephaven/third_party/fmt/core.h"
+#include "deephaven/third_party/fmt/ranges.h"
+#include "deephaven/third_party/fmt/ostream.h"
+
 using deephaven::client::TableHandle;
-using deephaven::dhcore::utility::SimpleOstringstream;
-using deephaven::dhcore::utility::separatedList;
 
 namespace deephaven::client::tests {
 namespace {

--- a/cpp-client/deephaven/tests/src/view_test.cc
+++ b/cpp-client/deephaven/tests/src/view_test.cc
@@ -5,8 +5,7 @@
 #include "deephaven/tests/test_util.h"
 #include "deephaven/dhcore/utility/utility.h"
 
-using deephaven::client::TableHandleManager;
-using deephaven::client::TableHandle;
+using deephaven::client::utility::TableMaker;
 
 namespace deephaven::client::tests {
 TEST_CASE("View", "[View]") {
@@ -16,15 +15,10 @@ TEST_CASE("View", "[View]") {
   // literal strings
   auto t1 = table.LastBy("Ticker").View("Ticker", "Close", "Volume");
 
-  std::vector<std::string> ticker_data = {"XRX", "XYZZY", "IBM", "GME", "AAPL", "ZNGA", "T"};
-  std::vector<double> close_data = {53.8, 88.5, 38.7, 453, 26.7, 544.9, 13.4};
-  std::vector<int64_t> vol_data = {87000, 6060842, 138000, 138000000, 19000, 48300, 1500};
-
-  CompareTable(
-      t1,
-      "Ticker", ticker_data,
-      "Close", close_data,
-      "Volume", vol_data
-  );
+  TableMaker expected;
+  expected.AddColumn<std::string>("Ticker", {"XRX", "XYZZY", "IBM", "GME", "AAPL", "ZNGA", "T"});
+  expected.AddColumn<double>("Close", {53.8, 88.5, 38.7, 453, 26.7, 544.9, 13.4});
+  expected.AddColumn<int64_t>("Volume", {87000, 6060842, 138000, 138000000, 19000, 48300, 1500});
+  TableComparerForTests::Compare(expected, t1);
 }
 }  // namespace deephaven::client::tests


### PR DESCRIPTION
This PR depends on https://github.com/deephaven/deephaven-core/pull/6788 being merged first.

This PR unifies and simplifies the `TableMaker` and `TableComparer` classes, which are generally useful in unit tests but can also be used from client code.

The motivations for this change were
1. To have a more straightforward API
2. To clean up the code (away from a confusing nest of template metaprogramming)
3. To be ready for creating and comparing tables that have nested containers, such as those created by groupby

The most fundamental change is the way `TableComparer` works. Now, the two tables it compares (expected and actual) are always Arrow tables. To create "expected" tables, `TableMaker` is now able to make Arrow tables in memory.