### PR TITLE
feat(cpp-client): Upgrade ElementTypeId to the richer ElementType representation [part 7/8 of groupby]

### DIFF
--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_column_source.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_column_source.h
@@ -2,13 +2,19 @@
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
 #pragma once
-#include <string>
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <vector>
 #include <arrow/array.h>
-#include "deephaven/dhcore/chunk/chunk_traits.h"
+#include <arrow/type.h>
+#include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/column/column_source.h"
-#include "deephaven/dhcore/column/column_source_utils.h"
+#include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/types.h"
+#include "deephaven/dhcore/utility/utility.h"
 
 namespace deephaven::client::arrowutil {
 namespace internal {
@@ -44,25 +50,22 @@ class GenericArrowColumnSource final : public TColumnSourceBase {
   using Chunk = deephaven::dhcore::chunk::Chunk;
   using ColumnSourceVisitor = deephaven::dhcore::column::ColumnSourceVisitor;
   using DateTime = deephaven::dhcore::DateTime;
+  using ElementType = deephaven::dhcore::ElementType;
   using LocalDate = deephaven::dhcore::LocalDate;
   using LocalTime = deephaven::dhcore::LocalTime;
   using RowSequence = deephaven::dhcore::container::RowSequence;
   using UInt64Chunk = deephaven::dhcore::chunk::UInt64Chunk;
 
 public:
-  static std::shared_ptr<GenericArrowColumnSource>
-  OfArrowArray(std::shared_ptr<TArrowArray> array) {
-    std::vector<std::shared_ptr<TArrowArray>> arrays{std::move(array)};
-    return OfArrowArrayVec(std::move(arrays));
-  }
-
   static std::shared_ptr<GenericArrowColumnSource> OfArrowArrayVec(
+      const ElementType &element_type,
       std::vector<std::shared_ptr<TArrowArray>> arrays) {
-    return std::make_shared<GenericArrowColumnSource>(std::move(arrays));
+    return std::make_shared<GenericArrowColumnSource>(element_type, std::move(arrays));
   }
 
-  explicit GenericArrowColumnSource(std::vector<std::shared_ptr<TArrowArray>> arrays) :
-      arrays_(std::move(arrays)) {
+  GenericArrowColumnSource(const ElementType &element_type,
+      std::vector<std::shared_ptr<TArrowArray>> arrays) :
+      element_type_(element_type), arrays_(std::move(arrays)) {
   }
 
   ~GenericArrowColumnSource() final = default;
@@ -224,7 +227,13 @@ public:
     visitor->Visit(*this);
   }
 
+  [[nodiscard]]
+  const ElementType &GetElementType() const final {
+    return element_type_;
+  }
+
 private:
+  ElementType element_type_;
   std::vector<std::shared_ptr<TArrowArray>> arrays_;
 };
 }  // namespace internal

--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/arrow_util.h
@@ -16,9 +16,9 @@
 
 namespace deephaven::client::utility {
 class ArrowUtil {
-  using ElementTypeId = deephaven::dhcore::ElementTypeId;
   using ClientTable = deephaven::dhcore::clienttable::ClientTable;
   using ColumnSource = deephaven::dhcore::column::ColumnSource;
+  using ElementType = deephaven::dhcore::ElementType;
   using FlightDescriptor = arrow::flight::FlightDescriptor;
   using Schema = deephaven::dhcore::clienttable::Schema;
 
@@ -38,13 +38,13 @@ public:
    *   and must_succeed is true, throws an exception. Otherwise (if the conversion failed
    *   and must_succeed is false), returns an unset optional.
    */
-  static std::optional<ElementTypeId::Enum> GetElementTypeId(const arrow::DataType &data_type,
+  static std::optional<ElementType> GetElementType(const arrow::DataType &data_type,
       bool must_succeed);
 
   /**
    * Converts an ElementType to an Arrow DataType.
    */
-  static std::shared_ptr<arrow::DataType> GetArrowType(ElementTypeId::Enum element_type_id);
+  static std::shared_ptr<arrow::DataType> GetArrowType(const ElementType &element_type);
 
   /**
    * Convert an Arrow Schema into a Deephaven Schema

--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
@@ -29,6 +29,7 @@ namespace deephaven::client::arrowutil {
 using deephaven::client::utility::OkOrThrow;
 using deephaven::client::utility::ValueOrThrow;
 using deephaven::dhcore::DateTime;
+using deephaven::dhcore::ElementType;
 using deephaven::dhcore::ElementTypeId;
 using deephaven::dhcore::LocalDate;
 using deephaven::dhcore::LocalTime;
@@ -85,73 +86,85 @@ struct ChunkedArrayToColumnSourceVisitor final : public arrow::TypeVisitor {
 
   arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
     auto arrays = DowncastChunks<arrow::UInt16Array>(*chunked_array_);
-    result_ = CharArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = CharArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kChar),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::Int8Type &/*type*/) final {
     auto arrays = DowncastChunks<arrow::Int8Array>(*chunked_array_);
-    result_ = Int8ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = Int8ArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kInt8),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
     auto arrays = DowncastChunks<arrow::Int16Array>(*chunked_array_);
-    result_ = Int16ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = Int16ArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kInt16),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
     auto arrays = DowncastChunks<arrow::Int32Array>(*chunked_array_);
-    result_ = Int32ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = Int32ArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kInt32),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
     auto arrays = DowncastChunks<arrow::Int64Array>(*chunked_array_);
-    result_ = Int64ArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = Int64ArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kInt64),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::FloatType &/*type*/) final {
     auto arrays = DowncastChunks<arrow::FloatArray>(*chunked_array_);
-    result_ = FloatArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = FloatArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kFloat),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
     auto arrays = DowncastChunks<arrow::DoubleArray>(*chunked_array_);
-    result_ = DoubleArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = DoubleArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kDouble),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
     auto arrays = DowncastChunks<arrow::BooleanArray>(*chunked_array_);
-    result_ = BooleanArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = BooleanArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kBool),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::StringType &/*type*/) final {
     auto arrays = DowncastChunks<arrow::StringArray>(*chunked_array_);
-    result_ = StringArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = StringArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kString),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::TimestampType &/*type*/) final {
     auto arrays = DowncastChunks<arrow::TimestampArray>(*chunked_array_);
-    result_ = DateTimeArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = DateTimeArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kTimestamp),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::Date64Type &/*type*/) final {
     auto arrays = DowncastChunks<arrow::Date64Array>(*chunked_array_);
-    result_ = LocalDateArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = LocalDateArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kLocalDate),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 
   arrow::Status Visit(const arrow::Time64Type &/*type*/) final {
     auto arrays = DowncastChunks<arrow::Time64Array>(*chunked_array_);
-    result_ = LocalTimeArrowColumnSource::OfArrowArrayVec(std::move(arrays));
+    result_ = LocalTimeArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kLocalTime),
+        std::move(arrays));
     return arrow::Status::OK();
   }
 

--- a/cpp-client/deephaven/dhclient/src/interop/client_interop.cc
+++ b/cpp-client/deephaven/dhclient/src/interop/client_interop.cc
@@ -237,7 +237,7 @@ void deephaven_client_TableHandle_GetSchema(
     StringPoolBuilder builder;
     for (int32_t i = 0; i != num_columns; ++i) {
       column_handles[i] = builder.Add(schema->Names()[i]);
-      column_types[i] = static_cast<int32_t>(schema->Types()[i]);
+      column_types[i] = static_cast<int32_t>(schema->Types()[i].Id());
     }
     *string_pool_handle = builder.Build();
   });
@@ -794,7 +794,7 @@ void deephaven_client_ArrowTable_GetSchema(
     for (int32_t i = 0; i != num_columns; ++i) {
       const auto &field = schema->fields()[i];
       column_handles[i] = builder.Add(field->name());
-      auto element_type_id = *ArrowUtil::GetElementTypeId(*field->type(), true);
+      auto element_type_id = ArrowUtil::GetElementType(*field->type(), true)->Id();
       column_types[i] = static_cast<int32_t>(element_type_id);
     }
     *string_pool_handle = builder.Build();
@@ -838,7 +838,7 @@ void deephaven_client_ClientTable_Schema(NativePtr<ClientTableSpWrapper> self,
     StringPoolBuilder builder;
     for (int32_t i = 0; i != num_columns; ++i) {
       column_handles[i] = builder.Add(schema->Names()[i]);
-      column_types[i] = static_cast<int32_t>(schema->Types()[i]);
+      column_types[i] = static_cast<int32_t>(schema->Types()[i].Id());
     }
     *string_pool_handle = builder.Build();
   });

--- a/cpp-client/deephaven/dhclient/src/interop/client_interop.cc
+++ b/cpp-client/deephaven/dhclient/src/interop/client_interop.cc
@@ -3,18 +3,27 @@
  */
 #include "deephaven/client/interop/client_interop.h"
 
-#include <codecvt>
-#include <locale>
-#include <arrow/table.h>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "deephaven/client/client.h"
 #include "deephaven/client/client_options.h"
 #include "deephaven/client/subscription/subscription_handle.h"
 #include "deephaven/client/update_by.h"
 #include "deephaven/client/utility/arrow_util.h"
+#include "deephaven/client/utility/misc_types.h"
 #include "deephaven/client/utility/table_maker.h"
+#include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/interop/interop_util.h"
+#include "deephaven/dhcore/ticking/ticking.h"
+#include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
-#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/core.h"
 
 using deephaven::client::Aggregate;
 using deephaven::client::AggregateCombo;
@@ -237,7 +246,7 @@ void deephaven_client_TableHandle_GetSchema(
     StringPoolBuilder builder;
     for (int32_t i = 0; i != num_columns; ++i) {
       column_handles[i] = builder.Add(schema->Names()[i]);
-      column_types[i] = static_cast<int32_t>(schema->Types()[i].Id());
+      column_types[i] = static_cast<int32_t>(schema->ElementTypes()[i].Id());
     }
     *string_pool_handle = builder.Build();
   });
@@ -838,7 +847,7 @@ void deephaven_client_ClientTable_Schema(NativePtr<ClientTableSpWrapper> self,
     StringPoolBuilder builder;
     for (int32_t i = 0; i != num_columns; ++i) {
       column_handles[i] = builder.Add(schema->Names()[i]);
-      column_types[i] = static_cast<int32_t>(schema->Types()[i].Id());
+      column_types[i] = static_cast<int32_t>(schema->ElementTypes()[i].Id());
     }
     *string_pool_handle = builder.Build();
   });

--- a/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/arrow_util.cc
@@ -230,7 +230,7 @@ std::shared_ptr<arrow::Schema> ArrowUtil::MakeArrowSchema(
   arrow::SchemaBuilder builder;
   for (int32_t i = 0; i != dh_schema.NumCols(); ++i) {
     const auto &name = dh_schema.Names()[i];
-    auto element_type = dh_schema.Types()[i];
+    auto element_type = dh_schema.ElementTypes()[i];
     auto arrow_type = GetArrowType(element_type);
     auto field = std::make_shared<arrow::Field>(name, std::move(arrow_type));
     OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder.AddField(field)));

--- a/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/private/deephaven/dhcore/immerutil/immer_column_source.h
@@ -2,11 +2,15 @@
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
 #pragma once
+
+#include <memory>
+#include <utility>
 #include <immer/algorithm.hpp>
 #include <immer/flex_vector.hpp>
 #include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/chunk/chunk_traits.h"
 #include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 
@@ -35,7 +39,7 @@ struct ImmerColumnSourceImpls {
     using deephaven::dhcore::chunk::TypeToChunk;
     using deephaven::dhcore::utility::TrueOrThrow;
     using deephaven::dhcore::utility::VerboseCast;
-    typedef typename TypeToChunk<T>::type_t chunkType_t;
+    using chunkType_t = typename TypeToChunk<T>::type_t;
     auto *typed_dest = VerboseCast<chunkType_t *>(DEEPHAVEN_LOCATION_EXPR(dest_data));
 
     constexpr bool kTypeIsNumeric = deephaven::dhcore::DeephavenTraits<T>::kIsNumeric;
@@ -162,6 +166,15 @@ struct ImmerColumnSourceImpls {
 }  // namespace internal
 
 class ImmerColumnSource : public virtual deephaven::dhcore::column::ColumnSource {
+public:
+  explicit ImmerColumnSource(const ElementType &elementType) : element_type_(elementType) {}
+
+  const ElementType &GetElementType() const final {
+    return element_type_;
+  }
+
+protected:
+  ElementType element_type_;
 };
 
 template<typename T>
@@ -176,11 +189,13 @@ class NumericImmerColumnSource final : public ImmerColumnSource,
   using RowSequence = deephaven::dhcore::container::RowSequence;
 
 public:
-  static std::shared_ptr<NumericImmerColumnSource> Create(immer::flex_vector<T> data) {
-    return std::make_shared<NumericImmerColumnSource>(Private(), std::move(data));
+  static std::shared_ptr<NumericImmerColumnSource> Create(const ElementType &element_type,
+      immer::flex_vector<T> data) {
+    return std::make_shared<NumericImmerColumnSource>(Private(), element_type, std::move(data));
   }
 
-  explicit NumericImmerColumnSource(Private, immer::flex_vector<T> data) : data_(std::move(data)) {}
+  explicit NumericImmerColumnSource(Private, const ElementType &element_type,
+      immer::flex_vector<T> data) : ImmerColumnSource(element_type), data_(std::move(data)) {}
 
   ~NumericImmerColumnSource() final = default;
 
@@ -210,13 +225,15 @@ class GenericImmerColumnSource final : public ImmerColumnSource,
   struct Private {};
   using ColumnSourceVisitor = deephaven::dhcore::column::ColumnSourceVisitor;
 public:
-  static std::shared_ptr<GenericImmerColumnSource> Create(immer::flex_vector<T> data,
-      immer::flex_vector<bool> null_flags) {
-    return std::make_shared<GenericImmerColumnSource>(Private(), std::move(data), std::move(null_flags));
+  static std::shared_ptr<GenericImmerColumnSource> Create(const ElementType &element_type,
+      immer::flex_vector<T> data, immer::flex_vector<bool> null_flags) {
+    return std::make_shared<GenericImmerColumnSource>(Private(), element_type, std::move(data),
+        std::move(null_flags));
   }
 
-  GenericImmerColumnSource(Private, immer::flex_vector<T> &&data, immer::flex_vector<bool> &&null_flags) :
-      data_(std::move(data)), null_flags_(std::move(null_flags)) {}
+  GenericImmerColumnSource(Private, const ElementType &element_type,
+      immer::flex_vector<T> &&data, immer::flex_vector<bool> &&null_flags) :
+      ImmerColumnSource(element_type), data_(std::move(data)), null_flags_(std::move(null_flags)) {}
   ~GenericImmerColumnSource() final = default;
 
   void FillChunk(const RowSequence &rows, Chunk *dest, BooleanChunk *optional_dest_null_flags) const final {

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
@@ -3,13 +3,16 @@
  */
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 #include "deephaven/dhcore/types.h"
-#include "deephaven/dhcore/column/column_source.h"
-#include "deephaven/dhcore/container/row_sequence.h"
 
 namespace deephaven::dhcore::clienttable {
 /**
@@ -18,7 +21,7 @@ namespace deephaven::dhcore::clienttable {
  */
 class Schema {
   struct Private {};
-  using ElementTypeId = deephaven::dhcore::ElementTypeId;
+  using ElementType = deephaven::dhcore::ElementType;
 
 public:
   /**
@@ -26,11 +29,11 @@ public:
    */
   [[nodiscard]]
   static std::shared_ptr<Schema> Create(std::vector<std::string> names,
-      std::vector<ElementTypeId::Enum> types);
+      std::vector<ElementType> types);
   /**
    * Constructor.
    */
-  Schema(Private, std::vector<std::string> names, std::vector<ElementTypeId::Enum> types,
+  Schema(Private, std::vector<std::string> names, std::vector<ElementType> types,
       std::map<std::string_view, size_t, std::less<>> index);
   /**
    * Destructor.
@@ -46,7 +49,7 @@ public:
   }
 
   [[nodiscard]]
-  const std::vector<ElementTypeId::Enum> &Types() const {
+  const std::vector<ElementType> &Types() const {
     return types_;
   }
 
@@ -57,7 +60,7 @@ public:
 
 private:
   std::vector<std::string> names_;
-  std::vector<ElementTypeId::Enum> types_;
+  std::vector<ElementType> types_;
   std::map<std::string_view, size_t, std::less<>> index_;
 };
 }  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
@@ -25,6 +25,14 @@ class Schema {
 
 public:
   /**
+   * Factory method. This exists for backward compatibility and will be removed
+   * when we update our Cython code.
+   */
+  [[nodiscard]]
+  static std::shared_ptr<Schema> Create(std::vector<std::string> names,
+      std::vector<ElementTypeId::Enum> type_ids);
+
+  /**
    * Factory method
    */
   [[nodiscard]]
@@ -34,7 +42,8 @@ public:
    * Constructor.
    */
   Schema(Private, std::vector<std::string> names, std::vector<ElementType> types,
-      std::map<std::string_view, size_t, std::less<>> index);
+      std::vector<ElementTypeId::Enum> type_ids, std::map<std::string_view,
+      size_t, std::less<>> index);
   /**
    * Destructor.
    */
@@ -49,8 +58,17 @@ public:
   }
 
   [[nodiscard]]
-  const std::vector<ElementType> &Types() const {
+  const std::vector<ElementType> &ElementTypes() const {
     return types_;
+  }
+
+  /**
+   * Accessor. This exists for backward compatibility and will be removed
+   * when we update our Cython code.
+   */
+  [[nodiscard]]
+  const std::vector<ElementTypeId::Enum> &Types() const {
+    return type_ids_;
   }
 
   [[nodiscard]]
@@ -61,6 +79,7 @@ public:
 private:
   std::vector<std::string> names_;
   std::vector<ElementType> types_;
+  std::vector<ElementTypeId::Enum> type_ids_;
   std::map<std::string_view, size_t, std::less<>> index_;
 };
 }  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
@@ -201,12 +201,6 @@ class GenericArrayColumnSource final : public deephaven::dhcore::column::Mutable
   using RowSequence = deephaven::dhcore::container::RowSequence;
 
 public:
-//  static std::shared_ptr<GenericArrayColumnSource> Create() {
-//    auto elements = std::make_unique<T[]>(0);
-//    auto nulls = std::make_unique<T[]>(0);
-//    return CreateFromArrays(std::move(elements), std::move(nulls), 0);
-//  }
-
   static std::shared_ptr<GenericArrayColumnSource> CreateFromArrays(const ElementType &element_type,
       std::unique_ptr<T[]> elements, std::unique_ptr<bool[]> nulls, size_t size) {
     return std::make_shared<GenericArrayColumnSource>(Private(), element_type, std::move(elements),

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
@@ -3,6 +3,11 @@
  */
 #pragma once
 
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/chunk/chunk_traits.h"
 #include "deephaven/dhcore/column/column_source.h"
@@ -196,44 +201,50 @@ class GenericArrayColumnSource final : public deephaven::dhcore::column::Mutable
   using RowSequence = deephaven::dhcore::container::RowSequence;
 
 public:
-  static std::shared_ptr<GenericArrayColumnSource> Create() {
-    auto elements = std::make_unique<T[]>(0);
-    auto nulls = std::make_unique<T[]>(0);
-    return CreateFromArrays(std::move(elements), std::move(nulls), 0);
+//  static std::shared_ptr<GenericArrayColumnSource> Create() {
+//    auto elements = std::make_unique<T[]>(0);
+//    auto nulls = std::make_unique<T[]>(0);
+//    return CreateFromArrays(std::move(elements), std::move(nulls), 0);
+//  }
+
+  static std::shared_ptr<GenericArrayColumnSource> CreateFromArrays(const ElementType &element_type,
+      std::unique_ptr<T[]> elements, std::unique_ptr<bool[]> nulls, size_t size) {
+    return std::make_shared<GenericArrayColumnSource>(Private(), element_type, std::move(elements),
+        std::move(nulls), size);
   }
 
-  static std::shared_ptr<GenericArrayColumnSource> CreateFromArrays(std::unique_ptr<T[]> elements,
-      std::unique_ptr<bool[]> nulls, size_t size) {
-    return std::make_shared<GenericArrayColumnSource>(Private(), std::move(elements), std::move(nulls),
-        size);
-  }
-
-  explicit GenericArrayColumnSource(Private, std::unique_ptr<T[]> elements,
-      std::unique_ptr<bool[]> nulls, size_t size) : data_(std::move(elements), std::move(nulls), size) {}
+  explicit GenericArrayColumnSource(Private, const ElementType &element_type,
+      std::unique_ptr<T[]> elements, std::unique_ptr<bool[]> nulls, size_t size) :
+      element_type_(element_type), data_(std::move(elements), std::move(nulls), size) {}
   ~GenericArrayColumnSource() final = default;
 
   void FillChunk(const RowSequence &rows, Chunk *dest, BooleanChunk *optional_dest_null_flags) const final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t chunkType_t;
+    using chunkType_t = typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t;
     ColumnSourceImpls::FillChunk<chunkType_t>(rows, dest, optional_dest_null_flags, data_);
   }
 
   void FillChunkUnordered(const UInt64Chunk &row_keys, Chunk *dest,
       BooleanChunk *optional_dest_null_flags) const final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t chunkType_t;
+    using chunkType_t = typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t;
     ColumnSourceImpls::FillChunkUnordered<chunkType_t>(row_keys, dest, optional_dest_null_flags, data_);
   }
 
   void FillFromChunk(const Chunk &src, const BooleanChunk *optional_src_null_flags,
       const RowSequence &rows) final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t chunkType_t;
+    using chunkType_t = typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t;
     ColumnSourceImpls::FillFromChunk<chunkType_t>(src, optional_src_null_flags, rows, &data_);
   }
 
   void FillFromChunkUnordered(const Chunk &src, const BooleanChunk *optional_src_null_flags,
       const UInt64Chunk &row_keys) final {
-    typedef typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t chunkType_t;
+    using chunkType_t = typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t;
     ColumnSourceImpls::FillFromChunkUnordered<chunkType_t>(src, optional_src_null_flags, row_keys,
         &data_);
+  }
+
+  [[nodiscard]]
+  const ElementType &GetElementType() const final {
+    return element_type_;
   }
 
   void AcceptVisitor(ColumnSourceVisitor *visitor) const final {
@@ -241,6 +252,7 @@ public:
   }
 
 private:
+  ElementType element_type_;
   internal::GenericBackingStore<T> data_;
 };
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
@@ -72,6 +72,12 @@ public:
       BooleanChunk *optional_dest_null_flags) const = 0;
 
   /**
+   * Get the ElementType of the ColumnSource
+   * @return The ElementType of this ColumnSource
+   */
+  [[nodiscard]]
+  virtual const ElementType &GetElementType() const = 0;
+  /**
    * Implement the Visitor pattern.
    */
   virtual void AcceptVisitor(ColumnSourceVisitor *visitor) const = 0;

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -29,67 +29,38 @@ struct ElementTypeId {
   };
 };
 
+class ElementType {
+public:
+  static ElementType Of(ElementTypeId::Enum element_type_id) {
+    return {0, element_type_id};
+  }
+
+  ElementType() = default;
+
+  ElementType(uint32_t list_depth, ElementTypeId::Enum element_type_id) :
+    list_depth_(list_depth), element_type_id_(element_type_id) {}
+
+  [[nodiscard]]
+  uint32_t ListDepth() const { return list_depth_; }
+  [[nodiscard]]
+  ElementTypeId::Enum Id() const { return element_type_id_; }
+
+  [[nodiscard]]
+  ElementType WrapList() const {
+    return {list_depth_ + 1, element_type_id_};
+  }
+
+  [[nodiscard]]
+  ElementType UnwrapList() const;
+
+private:
+  uint32_t list_depth_ = 0;
+  ElementTypeId::Enum element_type_id_ = ElementTypeId::kInt8;
+};
+
 class DateTime;
 class LocalDate;
 class LocalTime;
-
-template<typename T>
-void VisitElementTypeId(ElementTypeId::Enum type_id, T *visitor) {
-  switch (type_id) {
-    case ElementTypeId::kChar: {
-      visitor->template operator()<char16_t>();
-      break;
-    }
-    case ElementTypeId::kInt8: {
-      visitor->template operator()<int8_t>();
-      break;
-    }
-    case ElementTypeId::kInt16: {
-      visitor->template operator()<int16_t>();
-      break;
-    }
-    case ElementTypeId::kInt32: {
-      visitor->template operator()<int32_t>();
-      break;
-    }
-    case ElementTypeId::kInt64: {
-      visitor->template operator()<int64_t>();
-      break;
-    }
-    case ElementTypeId::kFloat: {
-      visitor->template operator()<float>();
-      break;
-    }
-    case ElementTypeId::kDouble: {
-      visitor->template operator()<double>();
-      break;
-    }
-    case ElementTypeId::kBool: {
-      visitor->template operator()<bool>();
-      break;
-    }
-    case ElementTypeId::kString: {
-      visitor->template operator()<std::string>();
-      break;
-    }
-    case ElementTypeId::kTimestamp: {
-      visitor->template operator()<deephaven::dhcore::DateTime>();
-      break;
-    }
-    case ElementTypeId::kLocalDate: {
-      visitor->template operator()<deephaven::dhcore::LocalDate>();
-      break;
-    }
-    case ElementTypeId::kLocalTime: {
-      visitor->template operator()<deephaven::dhcore::LocalTime>();
-      break;
-    }
-    default: {
-      auto message = fmt::format("Unrecognized ElementTypeId {}", static_cast<int>(type_id));
-      throw std::runtime_error(message);
-    }
-  }
-}
 
 class DeephavenConstants {
 public:

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
@@ -3,10 +3,11 @@
  */
 #pragma once
 
-#include <string>
-#include <vector>
+#include <cstdint>
+#include <cstddef>
+#include <memory>
 #include "deephaven/dhcore/types.h"
-#include "deephaven/dhcore/column/buffer_column_source.h"
+#include "deephaven/dhcore/column/column_source.h"
 
 namespace deephaven::dhcore::utility {
 class CythonSupport {
@@ -25,6 +26,9 @@ public:
   static std::shared_ptr<ColumnSource> CreateLocalTimeColumnSource(const int64_t *data_begin, const int64_t *data_end,
       const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements);
 
+  /**
+   * For backwards compatibility. Will be removed when Cython is updated.
+   */
   static ElementTypeId::Enum GetElementTypeId(const ColumnSource &column_source);
 };
 }  // namespace deephaven::dhcore::utility

--- a/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
@@ -2,11 +2,16 @@
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/clienttable/schema.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include "deephaven/dhcore/utility/utility.h"
-#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/core.h"
 
 namespace deephaven::dhcore::clienttable {
-std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names, std::vector<ElementTypeId::Enum> types) {
+std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names, std::vector<ElementType> types) {
   if (names.size() != types.size()) {
     auto message = fmt::format("Sizes differ: {} vs {}", names.size(), types.size());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
@@ -23,9 +28,9 @@ std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names, std::vect
   return std::make_shared<Schema>(Private(), std::move(names), std::move(types), std::move(index));
 }
 
-Schema::Schema(Private, std::vector<std::string> names, std::vector<ElementTypeId::Enum> types,
-     std::map<std::string_view, size_t, std::less<>> index) : names_(std::move(names)), types_(std::move(types)),
-     index_(std::move(index)) {}
+Schema::Schema(Private, std::vector<std::string> names, std::vector<ElementType> types,
+     std::map<std::string_view, size_t, std::less<>> index) : names_(std::move(names)),
+     types_(std::move(types)), index_(std::move(index)) {}
 Schema::~Schema() = default;
 
 std::optional<int32_t> Schema::GetColumnIndex(std::string_view name, bool strict) const {

--- a/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
@@ -3,19 +3,35 @@
  */
 #include "deephaven/dhcore/clienttable/schema.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
 #include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/third_party/fmt/core.h"
 
+using deephaven::dhcore::utility::MakeReservedVector;
+
 namespace deephaven::dhcore::clienttable {
-std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names, std::vector<ElementType> types) {
-  if (names.size() != types.size()) {
-    auto message = fmt::format("Sizes differ: {} vs {}", names.size(), types.size());
+namespace {
+std::map<std::string_view, size_t, std::less<>> ValidateAndMakeIndex(
+    const std::vector<std::string> &names, const std::vector<ElementType> &types,
+    const std::vector<ElementTypeId::Enum> &type_ids) {
+  if (names.size() != types.size() || names.size() != type_ids.size()) {
+    auto message = fmt::format("Sizes differ: {} vs {} vs {}", names.size(), types.size(),
+        type_ids.size());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
+
   std::map<std::string_view, size_t, std::less<>> index;
   for (size_t i = 0; i != names.size(); ++i) {
     std::string_view sv_name = names[i];
@@ -25,12 +41,40 @@ std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names, std::vect
       throw std::runtime_error(message);
     }
   }
-  return std::make_shared<Schema>(Private(), std::move(names), std::move(types), std::move(index));
+  return index;
+}
+}  // namespace
+
+std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names,
+    std::vector<ElementType> types) {
+  auto type_ids = MakeReservedVector<ElementTypeId::Enum>(types.size());
+  for (const auto &type : types) {
+    type_ids.push_back(type.Id());
+  }
+  auto index = ValidateAndMakeIndex(names, types, type_ids);
+
+  return std::make_shared<Schema>(Private(), std::move(names), std::move(types),
+      std::move(type_ids), std::move(index));
+}
+
+std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names,
+    std::vector<ElementTypeId::Enum> type_ids) {
+  auto types = MakeReservedVector<ElementType>(type_ids.size());
+  for (auto type_id : type_ids) {
+    types.push_back(ElementType::Of(type_id));
+  }
+  auto index = ValidateAndMakeIndex(names, types, type_ids);
+
+  return std::make_shared<Schema>(Private(), std::move(names), std::move(types),
+      std::move(type_ids), std::move(index));
 }
 
 Schema::Schema(Private, std::vector<std::string> names, std::vector<ElementType> types,
-     std::map<std::string_view, size_t, std::less<>> index) : names_(std::move(names)),
-     types_(std::move(types)), index_(std::move(index)) {}
+     std::vector<ElementTypeId::Enum> type_ids, std::map<std::string_view,
+     size_t, std::less<>> index) : names_(std::move(names)),
+     types_(std::move(types)), type_ids_(std::move(type_ids)), index_(std::move(index)) {
+}
+
 Schema::~Schema() = default;
 
 std::optional<int32_t> Schema::GetColumnIndex(std::string_view name, bool strict) const {

--- a/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
@@ -275,7 +275,7 @@ std::unique_ptr<AbstractFlexVectorBase> MakeFlexVectorFromType(const ElementType
     }
 
     default: {
-      auto message = fmt::format("Programming error: elementTypeId {} not supported here",
+      auto message = fmt::format("Internal error: elementTypeId {} not supported here",
           static_cast<int>(element_type.Id()));
       throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
     }

--- a/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
@@ -3,7 +3,11 @@
  */
 #include "deephaven/dhcore/ticking/immer_table_state.h"
 
-#include <optional>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "deephaven/dhcore/chunk/chunk.h"
@@ -14,10 +18,9 @@
 #include "deephaven/dhcore/ticking/shift_processor.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
-#include "deephaven/third_party/fmt/format.h"
+#include "deephaven/third_party/fmt/core.h"
 
 using deephaven::dhcore::ElementTypeId;
-using deephaven::dhcore::VisitElementTypeId;
 using deephaven::dhcore::chunk::AnyChunk;
 using deephaven::dhcore::chunk::Chunk;
 using deephaven::dhcore::chunk::ChunkVisitor;
@@ -216,77 +219,138 @@ std::shared_ptr<RowSequence> MyTable::GetRowSequence() const {
   return rb.Build();
 }
 
-struct FlexVectorFromTypeMaker final {
-  template<typename T>
-  void operator()() {
-    if constexpr(DeephavenTraits<T>::kIsNumeric) {
-      result_ = std::make_unique<NumericAbstractFlexVector<T>>();
-    } else {
-      result_ = std::make_unique<GenericAbstractFlexVector<T>>();
-    }
+std::unique_ptr<AbstractFlexVectorBase> MakeFlexVectorFromType(const ElementType &element_type) {
+  if (element_type.ListDepth() != 0) {
+    const char *message = "Don't know how to make flex vectors with element types that are lists";
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 
-  std::unique_ptr<AbstractFlexVectorBase> result_;
-};
+  switch (element_type.Id()) {
+    case ElementTypeId::kChar: {
+      return std::make_unique<NumericAbstractFlexVector<char16_t>>(element_type);
+    }
+
+    case ElementTypeId::kInt8: {
+      return std::make_unique<NumericAbstractFlexVector<int8_t>>(element_type);
+    }
+
+    case ElementTypeId::kInt16: {
+      return std::make_unique<NumericAbstractFlexVector<int16_t>>(element_type);
+    }
+
+    case ElementTypeId::kInt32: {
+      return std::make_unique<NumericAbstractFlexVector<int32_t>>(element_type);
+    }
+
+    case ElementTypeId::kInt64: {
+      return std::make_unique<NumericAbstractFlexVector<int64_t>>(element_type);
+    }
+
+    case ElementTypeId::kFloat: {
+      return std::make_unique<NumericAbstractFlexVector<float>>(element_type);
+    }
+
+    case ElementTypeId::kDouble: {
+      return std::make_unique<NumericAbstractFlexVector<double>>(element_type);
+    }
+
+    case ElementTypeId::kBool: {
+      return std::make_unique<GenericAbstractFlexVector<bool>>(element_type);
+    }
+
+    case ElementTypeId::kString: {
+      return std::make_unique<GenericAbstractFlexVector<std::string>>(element_type);
+    }
+
+    case ElementTypeId::kTimestamp: {
+      return std::make_unique<GenericAbstractFlexVector<DateTime>>(element_type);
+    }
+
+    case ElementTypeId::kLocalDate: {
+      return std::make_unique<GenericAbstractFlexVector<LocalDate>>(element_type);
+    }
+
+    case ElementTypeId::kLocalTime: {
+      return std::make_unique<GenericAbstractFlexVector<LocalTime>>(element_type);
+    }
+
+    default: {
+      auto message = fmt::format("Programming error: elementTypeId {} not supported here",
+          static_cast<int>(element_type.Id()));
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
+  }
+}
 
 std::vector<std::unique_ptr<AbstractFlexVectorBase>> MakeEmptyFlexVectorsFromSchema(const Schema &schema) {
   auto ncols = schema.NumCols();
   auto result = MakeReservedVector<std::unique_ptr<AbstractFlexVectorBase>>(ncols);
-  for (auto type_id : schema.Types()) {
-    FlexVectorFromTypeMaker fvm;
-    VisitElementTypeId(type_id, &fvm);
-    result.push_back(std::move(fvm.result_));
+  for (const auto &type_id : schema.Types()) {
+    auto fv = MakeFlexVectorFromType(type_id);
+    result.push_back(std::move(fv));
   }
   return result;
 }
 
 struct FlexVectorFromSourceMaker final : public ColumnSourceVisitor {
   void Visit(const column::CharColumnSource &/*source*/) final {
-    result_ = std::make_unique<NumericAbstractFlexVector<char16_t>>();
+    result_ = std::make_unique<NumericAbstractFlexVector<char16_t>>(
+        ElementType::Of(ElementTypeId::kChar));
   }
 
   void Visit(const column::Int8ColumnSource &/*source*/) final {
-    result_ = std::make_unique<NumericAbstractFlexVector<int8_t>>();
+    result_ = std::make_unique<NumericAbstractFlexVector<int8_t>>(
+        ElementType::Of(ElementTypeId::kInt8));
   }
 
   void Visit(const column::Int16ColumnSource &/*source*/) final {
-    result_ = std::make_unique<NumericAbstractFlexVector<int16_t>>();
+    result_ = std::make_unique<NumericAbstractFlexVector<int16_t>>(
+        ElementType::Of(ElementTypeId::kInt16));
   }
 
   void Visit(const column::Int32ColumnSource &/*source*/) final {
-    result_ = std::make_unique<NumericAbstractFlexVector<int32_t>>();
+    result_ = std::make_unique<NumericAbstractFlexVector<int32_t>>(
+        ElementType::Of(ElementTypeId::kInt32));
   }
 
   void Visit(const column::Int64ColumnSource &/*source*/) final {
-    result_ = std::make_unique<NumericAbstractFlexVector<int64_t>>();
+    result_ = std::make_unique<NumericAbstractFlexVector<int64_t>>(
+        ElementType::Of(ElementTypeId::kInt64));
   }
 
   void Visit(const column::FloatColumnSource &/*source*/) final {
-    result_ = std::make_unique<NumericAbstractFlexVector<float>>();
+    result_ = std::make_unique<NumericAbstractFlexVector<float>>(
+        ElementType::Of(ElementTypeId::kFloat));
   }
 
   void Visit(const column::DoubleColumnSource &/*source*/) final {
-    result_ = std::make_unique<NumericAbstractFlexVector<double>>();
+    result_ = std::make_unique<NumericAbstractFlexVector<double>>(
+        ElementType::Of(ElementTypeId::kDouble));
   }
 
   void Visit(const column::BooleanColumnSource &/*source*/) final {
-    result_ = std::make_unique<GenericAbstractFlexVector<bool>>();
+    result_ = std::make_unique<GenericAbstractFlexVector<bool>>(
+        ElementType::Of(ElementTypeId::kBool));
   }
 
   void Visit(const column::StringColumnSource &/*source*/) final {
-    result_ = std::make_unique<GenericAbstractFlexVector<std::string>>();
+    result_ = std::make_unique<GenericAbstractFlexVector<std::string>>(
+        ElementType::Of(ElementTypeId::kString));
   }
 
   void Visit(const column::DateTimeColumnSource &/*source*/) final {
-    result_ = std::make_unique<GenericAbstractFlexVector<DateTime>>();
+    result_ = std::make_unique<GenericAbstractFlexVector<DateTime>>(
+        ElementType::Of(ElementTypeId::kTimestamp));
   }
 
   void Visit(const column::LocalDateColumnSource &/*source*/) final {
-    result_ = std::make_unique<GenericAbstractFlexVector<LocalDate>>();
+    result_ = std::make_unique<GenericAbstractFlexVector<LocalDate>>(
+        ElementType::Of(ElementTypeId::kLocalDate));
   }
 
   void Visit(const column::LocalTimeColumnSource &/*source*/) final {
-    result_ = std::make_unique<GenericAbstractFlexVector<LocalTime>>();
+    result_ = std::make_unique<GenericAbstractFlexVector<LocalTime>>(
+        ElementType::Of(ElementTypeId::kLocalTime));
   }
 
   std::unique_ptr<AbstractFlexVectorBase> result_;

--- a/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
+++ b/cpp-client/deephaven/dhcore/src/ticking/immer_table_state.cc
@@ -285,7 +285,7 @@ std::unique_ptr<AbstractFlexVectorBase> MakeFlexVectorFromType(const ElementType
 std::vector<std::unique_ptr<AbstractFlexVectorBase>> MakeEmptyFlexVectorsFromSchema(const Schema &schema) {
   auto ncols = schema.NumCols();
   auto result = MakeReservedVector<std::unique_ptr<AbstractFlexVectorBase>>(ncols);
-  for (const auto &type_id : schema.Types()) {
+  for (const auto &type_id : schema.ElementTypes()) {
     auto fv = MakeFlexVectorFromType(type_id);
     result.push_back(std::move(fv));
   }

--- a/cpp-client/deephaven/dhcore/src/types.cc
+++ b/cpp-client/deephaven/dhcore/src/types.cc
@@ -3,11 +3,12 @@
  */
 #include "deephaven/dhcore/types.h"
 
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <stdexcept>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -15,6 +16,7 @@
 #include "date/date.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/third_party/fmt/chrono.h"
+#include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/format.h"
 #include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/ostream.h"
@@ -61,6 +63,15 @@ constexpr const int32_t DeephavenConstants::kMaxInt;
 constexpr const int64_t DeephavenConstants::kNullLong;
 constexpr const int64_t DeephavenConstants::kMinLong;
 constexpr const int64_t DeephavenConstants::kMaxLong;
+
+ElementType ElementType::UnwrapList() const {
+  if (list_depth_ == 0) {
+    const char *message = "Can't unwrap list of depth 0";
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+  }
+
+  return {list_depth_ - 1, element_type_id_};
+}
 
 DateTime DateTime::Parse(std::string_view iso_8601_timestamp) {
   // Special handling for "Z" timezone

--- a/cpp-client/deephaven/tests/src/buffer_column_source_test.cc
+++ b/cpp-client/deephaven/tests/src/buffer_column_source_test.cc
@@ -1,11 +1,16 @@
 /*
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
+#include <cstdint>
+#include <vector>
 #include "deephaven/third_party/catch.hpp"
 #include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/column/buffer_column_source.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 
+using deephaven::dhcore::ElementType;
+using deephaven::dhcore::ElementTypeId;
 using deephaven::dhcore::chunk::Int64Chunk;
 using deephaven::dhcore::column::NumericBufferColumnSource;
 using deephaven::dhcore::container::RowSequence;
@@ -14,7 +19,8 @@ namespace deephaven::client::tests {
 TEST_CASE("Simple BufferColumnSource", "[columnsource]") {
   std::vector<int64_t> chunk{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-  auto cs = NumericBufferColumnSource<int64_t>::Create(chunk.data(), chunk.size());
+  auto cs = NumericBufferColumnSource<int64_t>::Create(
+      ElementType::Of(ElementTypeId::kInt64), chunk.data(), chunk.size());
 
   auto rs = RowSequence::CreateSequential(5, 9);
   auto data = Int64Chunk::Create(4);


### PR DESCRIPTION
This PR depends on https://github.com/deephaven/deephaven-core/pull/6792 being merged first.

This PR does two things:
1. Introduce the notion of `ElementType`, a *slightly* richer representation of our types than the enum defined in `ElementTypeId`
2. Add a field to all of our column sources so they know their element type.

Rationale:

It is useful for ColumnSources to know their element types. Prior to groupby support, it sufficed to have a simple enum representing the set of known types. However in principle there are infinitely many types: `int32`, `list<int32>`, `list<list<int32>>` etc.

Arrow has a rich, recursive type system that can represent a rich family of types. We have decided to not go all the way there and just support the types we need.

It turns out that for our purposes, our supported set of types are:
1. all the scalar types
2. 0 or more applications of `list` to a Deephaven type.

For example, we need `int32`, `int64`, `string`. But also `list<int32>`, `list<int64>`, and `list<string>`. And (not implemented yet), `list<list<int32>>`, `list<list<int64>>`, `list<list<string>>`.

Importantly, `list` is the only type combinator we have. e.g. we don't support `list<map<x,y>>` or `list<union<x,y>>` etc.

So for our purposes it suffices to have type descriptor that contains:
1. The scalar type at the leaf
2. The number of applications of `list` to that scalar type (could be 0)

This PR adds that type descriptor (called `ElementType`) and also adds it as a field to all the ColumnSources so they know their element type.