### PR TITLE
feat(cpp-client): Add nested containers in order to support groupby [part 8/8 of groupby]

### DIFF
--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
@@ -20,6 +20,7 @@
 #include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/column/array_column_source.h"
 #include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/container/container.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
@@ -36,6 +37,7 @@ using deephaven::dhcore::LocalTime;
 using deephaven::dhcore::chunk::BooleanChunk;
 using deephaven::dhcore::chunk::Chunk;
 using deephaven::dhcore::chunk::CharChunk;
+using deephaven::dhcore::chunk::ContainerBaseChunk;
 using deephaven::dhcore::chunk::DateTimeChunk;
 using deephaven::dhcore::chunk::FloatChunk;
 using deephaven::dhcore::chunk::DoubleChunk;
@@ -50,6 +52,7 @@ using deephaven::dhcore::chunk::UInt64Chunk;
 using deephaven::dhcore::column::BooleanColumnSource;
 using deephaven::dhcore::column::CharColumnSource;
 using deephaven::dhcore::column::ColumnSource;
+using deephaven::dhcore::column::ContainerArrayColumnSource;
 using deephaven::dhcore::column::DoubleColumnSource;
 using deephaven::dhcore::column::FloatColumnSource;
 using deephaven::dhcore::column::Int8ColumnSource;
@@ -58,6 +61,9 @@ using deephaven::dhcore::column::Int32ColumnSource;
 using deephaven::dhcore::column::Int64ColumnSource;
 using deephaven::dhcore::column::ColumnSourceVisitor;
 using deephaven::dhcore::column::StringColumnSource;
+using deephaven::dhcore::container::Container;
+using deephaven::dhcore::container::ContainerBase;
+using deephaven::dhcore::container::ContainerVisitor;
 using deephaven::dhcore::container::RowSequence;
 using deephaven::dhcore::utility::demangle;
 using deephaven::dhcore::utility::MakeReservedVector;
@@ -79,6 +85,115 @@ std::vector<std::shared_ptr<TArrowArray>> DowncastChunks(const arrow::ChunkedArr
   }
   return downcasted;
 }
+
+struct Reconstituter final : public arrow::TypeVisitor {
+  Reconstituter(std::shared_ptr<ColumnSource> flattened_elements,
+      std::unique_ptr<size_t[]> slice_lengths,
+      std::unique_ptr<bool[]> slice_nulls,
+      size_t num_slices,
+      size_t flattened_size) :
+      flattened_elements_(std::move(flattened_elements)),
+      slice_lengths_(std::move(slice_lengths)),
+      slice_nulls_(std::move(slice_nulls)),
+      num_slices_(num_slices),
+      flattened_size_(flattened_size),
+      flattened_nulls_(new bool[flattened_size_]),
+      flattened_nulls_chunk_(BooleanChunk::CreateView(flattened_nulls_.get(), flattened_size_)),
+      rowSequence_(RowSequence::CreateSequential(0, flattened_size_)),
+      slices_(std::make_unique<std::shared_ptr<ContainerBase>[]>(num_slices_)) {
+  }
+
+  ~Reconstituter() final = default;
+
+  arrow::Status Visit(const arrow::UInt16Type &/*type*/) final {
+    return VisitHelper<char16_t, CharChunk>(ElementTypeId::kChar);
+  }
+
+  arrow::Status Visit(const arrow::Int8Type &/*type*/) final {
+    return VisitHelper<int8_t, Int8Chunk>(ElementTypeId::kInt8);
+  }
+
+  arrow::Status Visit(const arrow::Int16Type &/*type*/) final {
+    return VisitHelper<int16_t, Int16Chunk>(ElementTypeId::kInt16);
+  }
+
+  arrow::Status Visit(const arrow::Int32Type &/*type*/) final {
+    return VisitHelper<int32_t, Int32Chunk>(ElementTypeId::kInt32);
+  }
+
+  arrow::Status Visit(const arrow::Int64Type &/*type*/) final {
+    return VisitHelper<int64_t, Int64Chunk>(ElementTypeId::kInt64);
+  }
+
+  arrow::Status Visit(const arrow::FloatType &/*type*/) final {
+    return VisitHelper<float, FloatChunk>(ElementTypeId::kFloat);
+  }
+
+  arrow::Status Visit(const arrow::DoubleType &/*type*/) final {
+    return VisitHelper<double, DoubleChunk>(ElementTypeId::kDouble);
+  }
+
+  arrow::Status Visit(const arrow::BooleanType &/*type*/) final {
+    return VisitHelper<bool, BooleanChunk>(ElementTypeId::kBool);
+  }
+
+  arrow::Status Visit(const arrow::StringType &/*type*/) final {
+    return VisitHelper<std::string, StringChunk>(ElementTypeId::kString);
+  }
+
+  arrow::Status Visit(const arrow::TimestampType &/*type*/) final {
+    return VisitHelper<DateTime, DateTimeChunk>(ElementTypeId::kTimestamp);
+  }
+
+  arrow::Status Visit(const arrow::Date64Type &/*type*/) final {
+    return VisitHelper<LocalDate, LocalDateChunk>(ElementTypeId::kLocalDate);
+  }
+
+  arrow::Status Visit(const arrow::Time64Type &/*type*/) final {
+    return VisitHelper<LocalTime, LocalTimeChunk>(ElementTypeId::kLocalTime);
+  }
+
+  template<typename TElement, typename TChunk>
+  arrow::Status VisitHelper(ElementTypeId::Enum element_type_id) {
+    std::shared_ptr<TElement[]> flattened_data(new TElement[flattened_size_]);
+    auto flattened_data_chunk = TChunk::CreateView(flattened_data.get(), flattened_size_);
+    flattened_elements_->FillChunk(*rowSequence_, &flattened_data_chunk, &flattened_nulls_chunk_);
+
+    size_t slice_offset = 0;
+    for (size_t i = 0; i != num_slices_; ++i) {
+      auto *slice_data_start = flattened_data.get() + slice_offset;
+      auto *slice_null_start = flattened_nulls_.get() + slice_offset;
+
+      // Make shared pointers from these slice pointers that share the lifetime of the
+      // original shared pointers
+      std::shared_ptr<TElement[]> slice_data_start_sp(flattened_data, slice_data_start);
+      std::shared_ptr<bool[]> slice_null_start_sp(flattened_nulls_, slice_null_start);
+
+      auto slice_size = slice_lengths_[i];
+      auto slice = Container<TElement>::Create(std::move(slice_data_start_sp),
+          std::move(slice_null_start_sp), slice_size);
+      slices_[i] = std::move(slice);
+      slice_offset += slice_size;
+    }
+
+    auto element_type = ElementType::Of(element_type_id).WrapList();
+
+    result_ = ContainerArrayColumnSource::CreateFromArrays(element_type,
+        std::move(slices_), std::move(slice_nulls_), num_slices_);
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<ColumnSource> flattened_elements_;
+  std::unique_ptr<size_t[]> slice_lengths_;
+  std::unique_ptr<bool[]> slice_nulls_;
+  size_t num_slices_ = 0;
+  size_t flattened_size_ = 0;
+  std::shared_ptr<bool[]> flattened_nulls_;
+  BooleanChunk flattened_nulls_chunk_;
+  std::shared_ptr<RowSequence> rowSequence_;
+  std::unique_ptr<std::shared_ptr<ContainerBase>[]> slices_;
+  std::shared_ptr<ContainerArrayColumnSource> result_;
+};
 
 struct ChunkedArrayToColumnSourceVisitor final : public arrow::TypeVisitor {
   explicit ChunkedArrayToColumnSourceVisitor(std::shared_ptr<arrow::ChunkedArray> chunked_array) :
@@ -165,6 +280,128 @@ struct ChunkedArrayToColumnSourceVisitor final : public arrow::TypeVisitor {
     auto arrays = DowncastChunks<arrow::Time64Array>(*chunked_array_);
     result_ = LocalTimeArrowColumnSource::OfArrowArrayVec(ElementType::Of(ElementTypeId::kLocalTime),
         std::move(arrays));
+    return arrow::Status::OK();
+  }
+
+  /**
+   * When the element is a list, we use recursion to extract the flattened elements of the list into
+   * a single column source. Then we extract the data out of that column source into a single pair
+   * of arrays (one for the flattened data, and one for the flattened null flags), and then we
+   * reconstitute the 2D list structure as a ColumnSource<shared_ptr<ContainerBase>>, where the
+   * shared_ptr<ContainerBase> has the appropriate dynamic type.
+   *
+   * Example
+   * Input is ListArray:
+   *   [a, b, c]
+   *   null
+   *   []
+   *   [d, e, f, null, g]
+   *
+   * It has 4 slices.
+   * When it is flattened, it looks like [a, b, c, d, e, f, null, g]. There are 8 elements in the
+   * flattened data. Note: that throughout this discussion it will be important to recognize the
+   * difference between a slice that is null (the second slice, above), a slice that is empty
+   * (the third slice above), and a slice that is not null but contains a null element (the fourth
+   * element of the fourth slice above). Empty slices and null slices don't take up any space in the
+   * flattened column source, but null leaf elements do.
+   *
+   * We use recursion to create the flattened data [a, b, c, d, e, f, null, g] as a ColumnSource
+   * (of the appropriate dynamic type). This ColumnSource is only a very temporary holding area,
+   * because we immediately copy all the data back out of it. We do this as a convenience mainly
+   * because the ColumnSource has knowledge about data type conversions and Deephaven null
+   * conventions. In an alternate implementation we might be able to copy data directly from Arrow
+   * to the two target arrays, but that would require some refactoring of our code.
+   *
+   * Anyway, next we make an array of slice lengths and slice null flags. These will be inputs to
+   * the Reconstituter. In our example these arrays are of size 4 and contain:
+   *   lengths: [3, 0, 0, 5]  [bookmark #1]
+   *   null flags: [false, true, false, false]   [bookmark #2]
+   *
+   *  The first 0 in lengths is a "dontcare" because the element itself is null.
+   *  The second 0 is an actual zero in the sense that it represents a list of length 0 (not a null
+   *  entry)
+   *
+   * We then pass these arrays to the Reconstituter to finish the job of reconstituting a
+   * ColumnSource<shared_ptr<ContainerBase>> from these arrays.
+   *
+   * Inside the Reconstituter, we make two arrays for the flattened data and the flattened null
+   * flags. We use ColumnSource::FillChunk to populate these arrays. In our example these arrays
+   * are of size 8 and contain:
+   *   data: [a, b, c, d, e, f, null, g]
+   *   nulls: [false, false, false, false, false, false, true, false]
+   *
+   * These arrays are owned by shared pointers because, when we are done, there will be multiple
+   * Container<T> objects that point to (the interior) of these arrays and share their lifetime.
+   *
+   * Then the Reconstituter goes to work at recovering the original shape of the ListArray slices.
+   * To do this, it uses the flattened data we just obtained, combined with the original slice
+   * lengths (bookmark #1) and slice null flags (bookmark #2) that were passed in.
+   *
+   *   con0: size=3, data = [a, b, c], nulls=[false, false, false].
+   *         It points into the above data and nulls arrays at offset 0.
+   *   con1: size = 0, data = [], nulls = [].  This entry is null and so it doesn't matter where its
+   *         data points to
+   *   con2: size = 0, data = [], nulls = [].  This entry is of length zero, so for different
+   *         reasons it also doesn't matter where its data points to
+   *   con3: size = 5, data = [d, e, f, null, g], nulls = [false, false, false, true, false]
+   *         It points into the above data and nulls arrays at offset 3.
+   *
+   * We arrange these container objects into an array of size 4 of shared_ptr<ContainerBase>
+   *
+   * The Reconstituter also needs a null flags array of size 4 to work in tandem with this
+   * shared_ptr array. But the Reconstituter already have this null array; it was passed in as an
+   * input to the Reconstituter (see bookmark #2). In this example it is:
+   * [false, true, false, false]
+   *
+   * We provide these two arrays to ContainerArrayColumnSource::CreateFromArrays() and we are
+   * done.
+   *
+   * TODO(kosak): This code probably does not work correctly for nested lists, i.e. a grouped
+   * table that is grouped again
+   */
+  arrow::Status Visit(const arrow::ListType &type) final {
+    auto chunked_listarrays = DowncastChunks<arrow::ListArray>(*chunked_array_);
+
+    // 1. extract offsets
+    // 2. use recursion to create a column set of values
+    // 3. use rowset operations to extract an array from that column source (hacky)
+    // 4. return a ContainerColumnSource of that array
+    auto flattened_chunks = MakeReservedVector<std::shared_ptr<arrow::Array>>(
+        chunked_listarrays.size());
+    size_t num_slices = 0;
+    size_t flattened_size = 0;
+    for (const auto &la: chunked_listarrays) {
+      flattened_chunks.push_back(la->values());
+      num_slices += la->length();
+      flattened_size += la->values()->length();
+    }
+    auto flattened_chunked_array = ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(
+        arrow::ChunkedArray::Make(std::move(flattened_chunks), type.value_type())));
+    auto flattened_elements =
+        ArrowArrayConverter::ChunkedArrayToColumnSource(std::move(flattened_chunked_array));
+
+    // We have a single column source with all the flattened data in it. Now we have to
+    // recover the offset, length, and nullness of each slice. This is unusually annoying because
+    // our input was a ChunkedArray, not just an array.
+
+    auto slice_lengths = std::make_unique<size_t[]>(num_slices);
+    auto slice_nulls = std::make_unique<bool[]>(num_slices);
+    size_t next_index = 0;
+    for (const auto &la : chunked_listarrays) {
+      for (int64_t i = 0; i != la->length(); ++i, ++next_index) {
+        slice_lengths[next_index] = la->value_length(i);
+        slice_nulls[next_index] = la->IsNull(i);
+      }
+    }
+    if (next_index != num_slices) {
+      auto message = fmt::format("Programming error: {} != {}", next_index, num_slices);
+      throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+    }
+
+    Reconstituter reconstituter(std::move(flattened_elements), std::move(slice_lengths),
+        std::move(slice_nulls), num_slices, flattened_size);
+    OkOrThrow(DEEPHAVEN_LOCATION_EXPR(type.value_type()->Accept(&reconstituter)));
+    result_ = std::move(reconstituter.result_);
     return arrow::Status::OK();
   }
 
@@ -257,6 +494,183 @@ struct ColumnSourceToArrayVisitor final : ColumnSourceVisitor {
   void Visit(const dhcore::column::LocalTimeColumnSource &source) final {
     arrow::Time64Builder builder(arrow::time64(arrow::TimeUnit::NANO), arrow::default_memory_pool());
     CopyValues<LocalTimeChunk>(source, &builder, [](const LocalTime &o) { return o.Nanos(); });
+  }
+
+  struct InnerBuilderMaker {
+    explicit InnerBuilderMaker(const ElementType &element_type) {
+      if (element_type.ListDepth() != 1) {
+        auto message = fmt::format("Expected list_depth 1, got {}", element_type.ListDepth());
+        throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+      }
+
+      switch (element_type.Id()) {
+        case ElementTypeId::kChar: {
+          array_builder_ = std::make_shared<arrow::UInt16Builder>();
+          return;
+        }
+
+        case ElementTypeId::kInt8: {
+          array_builder_ = std::make_shared<arrow::Int8Builder>();
+          return;
+        }
+
+        case ElementTypeId::kInt16: {
+          array_builder_ = std::make_shared<arrow::Int16Builder>();
+          return;
+        }
+
+        case ElementTypeId::kInt32: {
+          array_builder_ = std::make_shared<arrow::Int32Builder>();
+          return;
+        }
+
+        case ElementTypeId::kInt64: {
+          array_builder_ = std::make_shared<arrow::Int64Builder>();
+          return;
+        }
+
+        case ElementTypeId::kFloat: {
+          array_builder_ = std::make_shared<arrow::FloatBuilder>();
+          return;
+        }
+
+        case ElementTypeId::kDouble: {
+          array_builder_ = std::make_shared<arrow::DoubleBuilder>();
+          return;
+        }
+
+        case ElementTypeId::kBool: {
+          array_builder_ = std::make_shared<arrow::BooleanBuilder>();
+          return;
+        }
+
+        case ElementTypeId::kString: {
+          array_builder_ = std::make_shared<arrow::StringBuilder>();
+          return;
+        }
+
+        case ElementTypeId::kTimestamp: {
+          // TODO(kosak): will we pass through non-nano units?
+          array_builder_ = std::make_shared<arrow::TimestampBuilder>(
+              arrow::timestamp(arrow::TimeUnit::NANO, "UTC"),
+              arrow::default_memory_pool());
+          return;
+        }
+
+        case ElementTypeId::kLocalDate: {
+          array_builder_ = std::make_shared<arrow::Date64Builder>();
+          return;
+        }
+
+        case ElementTypeId::kLocalTime: {
+          array_builder_ = std::make_shared<arrow::Time64Builder>(
+              arrow::time64(arrow::TimeUnit::NANO), arrow::default_memory_pool());
+          return;
+        }
+
+        default: {
+          auto message = fmt::format("Programming error: elementTypeId {} not supported here",
+              static_cast<int>(element_type.Id()));
+          throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+        }
+      }
+    }
+
+    std::shared_ptr<arrow::ArrayBuilder> array_builder_;
+  };
+
+  struct ChunkAppender final : public ContainerVisitor {
+    explicit ChunkAppender(std::shared_ptr<arrow::ArrayBuilder> array_builder) :
+      array_builder_(std::move(array_builder)) {}
+
+    void Visit(const Container<char16_t> *container) final {
+      VisitHelper<arrow::UInt16Builder>(container, [](char16_t x) { return x; });
+    }
+
+    void Visit(const Container<int8_t> *container) final {
+      VisitHelper<arrow::Int8Builder>(container, [](int8_t x) { return x; });
+    }
+
+    void Visit(const Container<int16_t> *container) final {
+      VisitHelper<arrow::Int16Builder>(container, [](int16_t x) { return x; });
+    }
+
+    void Visit(const Container<int32_t> *container) final {
+      VisitHelper<arrow::Int32Builder>(container, [](int32_t x) { return x; });
+    }
+
+    void Visit(const Container<int64_t> *container) final {
+      VisitHelper<arrow::Int64Builder>(container, [](int64_t x) { return x; });
+    }
+
+    void Visit(const Container<float> *container) final {
+      VisitHelper<arrow::FloatBuilder>(container, [](float x) { return x; });
+    }
+
+    void Visit(const Container<double> *container) final {
+      VisitHelper<arrow::DoubleBuilder>(container, [](double x) { return x; });
+    }
+
+    void Visit(const Container<bool> *container) final {
+      VisitHelper<arrow::BooleanBuilder>(container, [](bool x) { return x; });
+    }
+
+    void Visit(const Container<std::string> *container) final {
+      VisitHelper<arrow::StringBuilder>(container,
+          [](const std::string &x) -> const std::string & { return x; });
+    }
+
+    void Visit(const Container<DateTime> *container) final {
+      VisitHelper<arrow::TimestampBuilder>(container, [](const DateTime &x) { return x.Nanos(); });
+    }
+
+    void Visit(const Container<LocalDate> *container) final {
+      VisitHelper<arrow::Date64Builder>(container, [](const LocalDate &x) { return x.Millis(); });
+    }
+
+    void Visit(const Container<LocalTime> *container) final {
+      VisitHelper<arrow::Time64Builder>(container, [](const LocalTime &x) { return x.Nanos(); });
+    }
+
+    template<typename TBuilder, typename TElement, typename TConverter>
+    void VisitHelper(const Container<TElement> *container, const TConverter &converter) {
+      auto *typed_builder = deephaven::dhcore::utility::VerboseCast<TBuilder*>(
+          DEEPHAVEN_LOCATION_EXPR(array_builder_.get()));
+      auto size = container->size();
+      for (size_t i = 0; i != size; ++i) {
+        if (container->IsNull(i)) {
+          OkOrThrow(DEEPHAVEN_LOCATION_EXPR(typed_builder->AppendNull()));
+        } else {
+          OkOrThrow(DEEPHAVEN_LOCATION_EXPR(typed_builder->Append(converter((*container)[i]))));
+        }
+      }
+    }
+
+    std::shared_ptr<arrow::ArrayBuilder> array_builder_;
+  };
+
+  void Visit(const dhcore::column::ContainerBaseColumnSource &source) final {
+    InnerBuilderMaker ibm(source.GetElementType());
+
+    auto row_sequence = RowSequence::CreateSequential(0, num_rows_);
+    auto src_chunk = ContainerBaseChunk::Create(num_rows_);
+    source.FillChunk(*row_sequence, &src_chunk, nullptr);
+
+    arrow::ListBuilder lb(arrow::default_memory_pool(), ibm.array_builder_);
+
+    ChunkAppender ca(ibm.array_builder_);
+
+    for (const auto &container_base : src_chunk) {
+      if (container_base == nullptr) {
+        OkOrThrow(DEEPHAVEN_LOCATION_EXPR(lb.AppendNull()));
+        continue;
+      }
+
+      OkOrThrow(DEEPHAVEN_LOCATION_EXPR(lb.Append()));
+      container_base->AcceptVisitor(&ca);
+    }
+
+    result_ = ValueOrThrow(DEEPHAVEN_LOCATION_EXPR(lb.Finish()));
   }
 
   template<typename TChunk, typename TColumnSource, typename TBuilder, typename TConverter>

--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
@@ -316,8 +316,8 @@ struct ChunkedArrayToColumnSourceVisitor final : public arrow::TypeVisitor {
    */
   arrow::Status Visit(const arrow::ListType &type) final {
     // This code can be confusing because there are multiple levels of aggregation here.
-    // 1. The incoming data is a column whose element type is list; each list represents an array of
-    //    T.
+    // 1. The incoming data is a column whose element type is list; each list represents
+    //    an array of T.
     // 2. The lists are represented as an arrow::ListArray. ListArray stores data which logically
     //    looks like a list<T[]> but for efficiency the data itself is stored as a flattened T[]
     //    along with enough offset information to recover the nested structure.

--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_array_converter.cc
@@ -361,9 +361,8 @@ struct ChunkedArrayToColumnSourceVisitor final : public arrow::TypeVisitor {
     // num_slices = 4 (represented as slice_lengths.size())
 
     // The next step is a deaggregation step. We make a vector which has one element for each chunk.
-    // Inside each such element are is are the flattened version of the ListArray above. Again, in
-    // practice there is typically only one chunk, so our result array will typically have only one
-    // element.
+    // Inside each such element is the flattened version of the ListArray above. Again, in practice
+    // there is typically only one chunk, so our result array will typically have only one element.
     auto flattened_chunks = MakeReservedVector<std::shared_ptr<arrow::Array>>(
         chunked_listarrays.size());
     for (const auto &la: chunked_listarrays) {

--- a/cpp-client/deephaven/dhclient/src/arrowutil/arrow_client_table.cc
+++ b/cpp-client/deephaven/dhclient/src/arrowutil/arrow_client_table.cc
@@ -13,6 +13,7 @@
 #include "deephaven/client/arrowutil/arrow_column_source.h"
 #include "deephaven/client/utility/arrow_util.h"
 #include "deephaven/dhcore/column/array_column_source.h"
+#include "deephaven/dhcore/container/container.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/third_party/fmt/core.h"
@@ -33,6 +34,9 @@ using deephaven::client::utility::OkOrThrow;
 using deephaven::client::utility::ValueOrThrow;
 using deephaven::dhcore::clienttable::ClientTable;
 using deephaven::dhcore::column::ColumnSource;
+using deephaven::dhcore::column::ContainerArrayColumnSource;
+using deephaven::dhcore::container::Container;
+using deephaven::dhcore::container::ContainerBase;
 using deephaven::dhcore::DateTime;
 using deephaven::dhcore::DeephavenTraits;
 using deephaven::dhcore::utility::MakeReservedVector;

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -18,6 +18,7 @@ set(ALL_FILES
     src/column/column_source.cc
     src/column/column_source_helpers.cc
     src/column/column_source_utils.cc
+    src/container/container.cc
     src/container/row_sequence.cc
     src/immerutil/abstract_flex_vector.cc
     src/immerutil/immer_column_source.cc
@@ -50,6 +51,7 @@ set(ALL_FILES
     include/public/deephaven/dhcore/column/column_source.h
     include/public/deephaven/dhcore/column/column_source_helpers.h
     include/public/deephaven/dhcore/column/column_source_utils.h
+    include/public/deephaven/dhcore/container/container.h
     include/public/deephaven/dhcore/container/row_sequence.h
     include/public/deephaven/dhcore/interop/testapi/basic_interop_interactions.h
     include/public/deephaven/dhcore/interop/interop_util.h

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk.h
@@ -10,6 +10,13 @@
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 
+namespace deephaven::dhcore::container {
+/**
+ * Forward declaration
+ */
+class ContainerBase;
+}  // namespace deephaven::dhcore::container
+
 namespace deephaven::dhcore::chunk {
 
 class ChunkVisitor;
@@ -223,6 +230,10 @@ using LocalDateChunk = GenericChunk<deephaven::dhcore::LocalDate>;
  * Convenience using.
  */
 using LocalTimeChunk = GenericChunk<deephaven::dhcore::LocalTime>;
+/**
+ * Convenience using.
+ */
+using ContainerBaseChunk = GenericChunk<std::shared_ptr<deephaven::dhcore::container::ContainerBase>>;
 
 
 /**
@@ -253,7 +264,15 @@ public:
   /**
    * Implements the visitor pattern.
    */
+  virtual void Visit(const UInt8Chunk &) = 0;
+  /**
+   * Implements the visitor pattern.
+   */
   virtual void Visit(const UInt16Chunk &) = 0;
+  /**
+   * Implements the visitor pattern.
+   */
+  virtual void Visit(const UInt32Chunk &) = 0;
   /**
    * Implements the visitor pattern.
    */
@@ -286,6 +305,10 @@ public:
    * Implements the visitor pattern.
    */
   virtual void Visit(const LocalTimeChunk &) = 0;
+  /**
+   * Implements the visitor pattern.
+   */
+  virtual void Visit(const ContainerBaseChunk &) = 0;
 };
 
 template<typename T>
@@ -301,7 +324,7 @@ void GenericChunk<T>::AcceptVisitor(ChunkVisitor *visitor) const {
 class AnyChunk {
   using variant_t = std::variant<CharChunk, Int8Chunk, Int16Chunk, Int32Chunk, Int64Chunk,
      UInt64Chunk, FloatChunk, DoubleChunk, BooleanChunk, StringChunk, DateTimeChunk,
-     LocalDateChunk, LocalTimeChunk>;
+     LocalDateChunk, LocalTimeChunk, ContainerBaseChunk>;
 
 public:
   /**

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk_traits.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk_traits.h
@@ -6,6 +6,13 @@
 #include <cstdint>
 #include "deephaven/dhcore/chunk/chunk.h"
 
+namespace deephaven::dhcore::container {
+/**
+ * Forward declaration
+ */
+class ContainerBase;
+}  // namespace deephaven::dhcore::container
+
 namespace deephaven::dhcore::chunk {
 template<typename T>
 struct TypeToChunk {};
@@ -73,5 +80,10 @@ struct TypeToChunk<deephaven::dhcore::LocalDate> {
 template<>
 struct TypeToChunk<deephaven::dhcore::LocalTime> {
   using type_t = deephaven::dhcore::chunk::LocalTimeChunk;
+};
+
+template<>
+struct TypeToChunk<std::shared_ptr<deephaven::dhcore::container::ContainerBase>> {
+  using type_t = deephaven::dhcore::chunk::ContainerBaseChunk;
 };
 }  // namespace deephaven::client::chunk

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/array_column_source.h
@@ -12,6 +12,7 @@
 #include "deephaven/dhcore/chunk/chunk_traits.h"
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/column/column_source_utils.h"
+#include "deephaven/dhcore/container/container.h"
 #include "deephaven/dhcore/types.h"
 
 namespace deephaven::dhcore::column {
@@ -255,4 +256,6 @@ using StringArrayColumnSource = GenericArrayColumnSource<std::string>;
 using DateTimeArrayColumnSource = GenericArrayColumnSource<DateTime>;
 using LocalDateArrayColumnSource = GenericArrayColumnSource<LocalDate>;
 using LocalTimeArrayColumnSource = GenericArrayColumnSource<LocalTime>;
+using ContainerArrayColumnSource =
+    GenericArrayColumnSource<std::shared_ptr<deephaven::dhcore::container::ContainerBase>>;
 }  // namespace deephaven::dhcore::column

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
@@ -3,11 +3,12 @@
  */
 #pragma once
 
-#include <any>
+#include <cstdint>
+#include <memory>
 #include <string>
-#include <vector>
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/container/container.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/utility/utility.h"
 
@@ -77,6 +78,7 @@ public:
    */
   [[nodiscard]]
   virtual const ElementType &GetElementType() const = 0;
+
   /**
    * Implement the Visitor pattern.
    */
@@ -188,6 +190,10 @@ using LocalDateColumnSource = GenericColumnSource<deephaven::dhcore::LocalDate>;
  * Convenience using.
  */
 using LocalTimeColumnSource = GenericColumnSource<deephaven::dhcore::LocalTime>;
+/**
+ * Convenience using.
+ */
+using ContainerBaseColumnSource = GenericColumnSource<std::shared_ptr<deephaven::dhcore::container::ContainerBase>>;
 
 // the mutable per-type interfaces
 template<typename T>
@@ -251,5 +257,9 @@ public:
    * Implements the visitor pattern.
    */
   virtual void Visit(const LocalTimeColumnSource &) = 0;
+  /**
+   * Implements the visitor pattern.
+   */
+  virtual void Visit(const ContainerBaseColumnSource &) = 0;
 };
 }  // namespace deephaven::dhcore::column

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_helpers.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_helpers.h
@@ -23,6 +23,7 @@ public:
   static const char kDateTimeName[];
   static const char kLocalDateName[];
   static const char kLocalTimeName[];
+  static const char kContainerBaseName[];
 };
 
 struct ElementTypeVisitor : public ColumnSourceVisitor {
@@ -72,6 +73,10 @@ struct ElementTypeVisitor : public ColumnSourceVisitor {
 
   void Visit(const LocalTimeColumnSource & /*source*/) final {
     value_ = HumanReadableTypeNames::kLocalTimeName;
+  }
+
+  void Visit(const ContainerBaseColumnSource & /*source*/) final {
+    value_ = HumanReadableTypeNames::kContainerBaseName;
   }
 
   const char *value_ = nullptr;
@@ -150,4 +155,8 @@ struct HumanReadableStaticTypeName<deephaven::dhcore::LocalTime> {
   static const char *GetName() { return internal::HumanReadableTypeNames::kLocalTimeName; }
 };
 
+template<>
+struct HumanReadableStaticTypeName<std::shared_ptr<deephaven::dhcore::container::ContainerBase>> {
+  static const char *GetName() { return internal::HumanReadableTypeNames::kContainerBaseName; }
+};
 }  // namespace deephaven::client::column

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <iostream>
+#include <string>
+#include <utility>
+#include "deephaven/dhcore/types.h"
+#include "deephaven/dhcore/utility/utility.h"
+
+namespace deephaven::dhcore::container {
+/**
+ * Forward declaration
+ * @tparam T
+ */
+template<typename T>
+class Container;
+
+class ContainerVisitor {
+protected:
+  using DateTime = deephaven::dhcore::DateTime;
+  using LocalDate = deephaven::dhcore::LocalDate;
+  using LocalTime = deephaven::dhcore::LocalTime;
+
+public:
+  virtual ~ContainerVisitor() = default;
+  virtual void Visit(const Container<char16_t> *) = 0;
+  virtual void Visit(const Container<int8_t> *) = 0;
+  virtual void Visit(const Container<int16_t> *) = 0;
+  virtual void Visit(const Container<int32_t> *) = 0;
+  virtual void Visit(const Container<int64_t> *) = 0;
+  virtual void Visit(const Container<float> *) = 0;
+  virtual void Visit(const Container<double> *) = 0;
+  virtual void Visit(const Container<bool> *) = 0;
+  virtual void Visit(const Container<std::string> *) = 0;
+  virtual void Visit(const Container<DateTime> *) = 0;
+  virtual void Visit(const Container<LocalDate> *) = 0;
+  virtual void Visit(const Container<LocalTime> *) = 0;
+};
+
+class ContainerBase : public std::enable_shared_from_this<ContainerBase> {
+public:
+  explicit ContainerBase(size_t size) : size_(size) {}
+  virtual ~ContainerBase();
+
+  size_t size() const {
+    return size_;
+  }
+
+  template<class T>
+  std::shared_ptr<const Container<T>> AsContainerPtr() const {
+    auto self = shared_from_this();
+    return std::dynamic_pointer_cast<const Container<T>>(self);
+  }
+
+  template<class T>
+  const Container<T> &AsContainer() const {
+    return *deephaven::dhcore::utility::VerboseCast<const Container<T>*>(DEEPHAVEN_LOCATION_EXPR(this));
+  }
+
+  virtual void AcceptVisitor(ContainerVisitor *visitor) const = 0;
+
+protected:
+  virtual std::ostream &StreamTo(std::ostream &s) const = 0;
+
+  size_t size_ = 0;
+
+  friend std::ostream &operator<<(std::ostream &s, const ContainerBase &o) {
+    return o.StreamTo(s);
+  }
+};
+
+template<typename T>
+class Container final : public ContainerBase {
+  using ElementRenderer = deephaven::dhcore::utility::ElementRenderer;
+  struct Private{};
+public:
+  static std::shared_ptr<Container<T>> Create(std::shared_ptr<T[]> data,
+      std::shared_ptr<bool[]> nulls, size_t size) {
+    return std::make_shared<Container<T>>(Private(), std::move(data), std::move(nulls),
+        size);
+  }
+
+  Container(Private, std::shared_ptr<T[]> &&data, std::shared_ptr<bool[]> &&nulls, size_t size) :
+      ContainerBase(size), data_(std::move(data)), nulls_(std::move(nulls)) {}
+
+  void AcceptVisitor(ContainerVisitor *visitor) const final {
+    visitor->Visit(this);
+  }
+
+  const T &operator[](size_t index) const {
+    return data_[index];
+  }
+
+  bool IsNull(size_t index) const {
+    return nulls_[index];
+  }
+
+  const T *begin() const {
+    return data_.get();
+  }
+
+  const T *end() const {
+    return begin() + size();
+  }
+
+private:
+  std::ostream &StreamTo(std::ostream &s) const final {
+    ElementRenderer renderer;
+    s << '[';
+    const char *sep = "";
+    const auto sz = size();
+    for (size_t i = 0; i != sz; ++i) {
+      s << sep;
+      sep = ",";
+      if (nulls_[i]) {
+        s << "null";
+      } else {
+        renderer.Render(s, data_[i]);
+      }
+    }
+    return s << ']';
+  }
+
+  std::shared_ptr<T[]> data_;
+  std::shared_ptr<bool[]> nulls_;
+};
+}  // namespace deephaven::dhcore::container

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container.h
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
-
 #pragma once
 
 #include <cstddef>
@@ -48,17 +47,20 @@ public:
   explicit ContainerBase(size_t size) : size_(size) {}
   virtual ~ContainerBase();
 
+  [[nodiscard]]
   size_t size() const {
     return size_;
   }
 
   template<class T>
+  [[nodiscard]]
   std::shared_ptr<const Container<T>> AsContainerPtr() const {
     auto self = shared_from_this();
     return std::dynamic_pointer_cast<const Container<T>>(self);
   }
 
   template<class T>
+  [[nodiscard]]
   const Container<T> &AsContainer() const {
     return *deephaven::dhcore::utility::VerboseCast<const Container<T>*>(DEEPHAVEN_LOCATION_EXPR(this));
   }

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -28,8 +28,6 @@ struct ElementTypeId {
     kInt8, kInt16, kInt32, kInt64,
     kFloat, kDouble,
     kBool, kString, kTimestamp,
-    // TODO(kosak): remove this when we update Cython
-    kList_UNUSED,
     kLocalDate, kLocalTime
   };
 };

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/types.h
@@ -6,25 +6,30 @@
 #include <limits>
 #include <cmath>
 #include <cstdint>
+#include <memory>
 #include <ostream>
-#include <stdexcept>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/ostream.h"
+
+namespace deephaven::dhcore::container {
+class ContainerBase;
+}  // namespace deephaven::dhcore::container
 
 namespace deephaven::dhcore {
 struct ElementTypeId {
   ElementTypeId() = delete;
 
   // We don't use "enum class" here because we can't figure out how to get it to work right with Cython.
-  // TODO(kosak): we are going to have to expand LIST to be a true nested type.
   enum Enum {
     kChar,
     kInt8, kInt16, kInt32, kInt64,
     kFloat, kDouble,
     kBool, kString, kTimestamp,
-    kList,
+    // TODO(kosak): remove this when we update Cython
+    kList_UNUSED,
     kLocalDate, kLocalTime
   };
 };
@@ -307,6 +312,11 @@ struct DeephavenTraits<LocalDate> {
 
 template<>
 struct DeephavenTraits<LocalTime> {
+  static constexpr bool kIsNumeric = false;
+};
+
+template<>
+struct DeephavenTraits<std::shared_ptr<deephaven::dhcore::container::ContainerBase>> {
   static constexpr bool kIsNumeric = false;
 };
 

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/utility.h
@@ -20,6 +20,11 @@
 #include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/ostream.h"
 
+// Forward declaration
+namespace deephaven::dhcore::container {
+class ContainerBase;
+} // namespace deephaven::dhcore::container
+
 namespace deephaven::dhcore::utility {
 template<typename Dest, typename Src>
 inline Dest Bit_cast(const Src &item) {
@@ -260,6 +265,9 @@ public:
   void Render(std::ostream &s, const T &item) const {
     s << item;
   }
+
+  void Render(std::ostream &s,
+      const std::shared_ptr<deephaven::dhcore::container::ContainerBase> &item) const;
 
   void Render(std::ostream &s, const bool &item) const {
     s << (item ? "true" : "false");

--- a/cpp-client/deephaven/dhcore/src/chunk/chunk_maker.cc
+++ b/cpp-client/deephaven/dhcore/src/chunk/chunk_maker.cc
@@ -7,6 +7,7 @@
 #include "deephaven/dhcore/column/column_source.h"
 
 using deephaven::dhcore::column::CharColumnSource;
+using deephaven::dhcore::column::ContainerBaseColumnSource;
 using deephaven::dhcore::column::ColumnSourceVisitor;
 using deephaven::dhcore::column::DateTimeColumnSource;
 using deephaven::dhcore::column::DoubleColumnSource;
@@ -70,6 +71,10 @@ struct Visitor final : ColumnSourceVisitor {
 
   void Visit(const LocalTimeColumnSource &/*source*/) final {
     result_ = LocalTimeChunk::Create(chunk_size_);
+  }
+
+  void Visit(const ContainerBaseColumnSource &/*source*/) final {
+    result_ = ContainerBaseChunk::Create(chunk_size_);
   }
 
   size_t chunk_size_;

--- a/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/client_table.cc
@@ -17,6 +17,7 @@
 #include "deephaven/dhcore/chunk/chunk_maker.h"
 #include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/clienttable/schema.h"
+#include "deephaven/dhcore/container/container.h"
 #include "deephaven/dhcore/container/row_sequence.h"
 #include "deephaven/dhcore/utility/utility.h"
 
@@ -24,6 +25,7 @@ using deephaven::dhcore::chunk::AnyChunk;
 using deephaven::dhcore::chunk::BooleanChunk;
 using deephaven::dhcore::chunk::ChunkMaker;
 using deephaven::dhcore::column::ColumnSource;
+using deephaven::dhcore::container::ContainerBase;
 using deephaven::dhcore::container::RowSequence;
 using deephaven::dhcore::container::RowSequenceIterator;
 using deephaven::dhcore::utility::ElementRenderer;

--- a/cpp-client/deephaven/dhcore/src/container/container.cc
+++ b/cpp-client/deephaven/dhcore/src/container/container.cc
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+ */
+#include "deephaven/dhcore/container/container.h"
+
+namespace deephaven::dhcore::container {
+ContainerBase::~ContainerBase() = default;
+}  // namespace deephaven::dhcore::container

--- a/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
@@ -24,8 +24,8 @@ using deephaven::dhcore::column::StringArrayColumnSource;
 
 namespace deephaven::dhcore::utility {
 namespace {
-void populateArrayFromPackedData(const uint8_t *src, bool *dest, size_t num_elements, bool invert);
-void populateNullsFromDeephavenConvention(const int64_t *data_begin, bool *dest, size_t num_elements);
+void PopulateArrayFromPackedData(const uint8_t *src, bool *dest, size_t num_elements, bool invert);
+void PopulateNullsFromDeephavenConvention(const int64_t *data_begin, bool *dest, size_t num_elements);
 }  // namespace
 
 std::shared_ptr<ColumnSource>
@@ -34,8 +34,8 @@ CythonSupport::CreateBooleanColumnSource(const uint8_t *data_begin, const uint8_
   auto elements = std::make_unique<bool[]>(num_elements);
   auto nulls = std::make_unique<bool[]>(num_elements);
 
-  populateArrayFromPackedData(data_begin, elements.get(), num_elements, false);
-  populateArrayFromPackedData(validity_begin, nulls.get(), num_elements, true);
+  PopulateArrayFromPackedData(data_begin, elements.get(), num_elements, false);
+  PopulateArrayFromPackedData(validity_begin, nulls.get(), num_elements, true);
   return BooleanArrayColumnSource::CreateFromArrays(ElementType::Of(ElementTypeId::kBool),
       std::move(elements), std::move(nulls), num_elements);
 }
@@ -53,7 +53,7 @@ CythonSupport::CreateStringColumnSource(const char *text_begin, const char *text
     elements[i] = std::string(current, current + element_size);
     current += element_size;
   }
-  populateArrayFromPackedData(validity_begin, nulls.get(), num_elements, true);
+  PopulateArrayFromPackedData(validity_begin, nulls.get(), num_elements, true);
   return StringArrayColumnSource::CreateFromArrays(ElementType::Of(ElementTypeId::kString),
       std::move(elements), std::move(nulls), num_elements);
 }
@@ -67,7 +67,7 @@ CythonSupport::CreateDateTimeColumnSource(const int64_t *data_begin, const int64
   for (size_t i = 0; i != num_elements; ++i) {
     elements[i] = DateTime::FromNanos(data_begin[i]);
   }
-  populateNullsFromDeephavenConvention(data_begin, nulls.get(), num_elements);
+  PopulateNullsFromDeephavenConvention(data_begin, nulls.get(), num_elements);
   return DateTimeArrayColumnSource::CreateFromArrays(ElementType::Of(ElementTypeId::kTimestamp),
       std::move(elements), std::move(nulls), num_elements);
 }
@@ -81,7 +81,7 @@ CythonSupport::CreateLocalDateColumnSource(const int64_t *data_begin, const int6
   for (size_t i = 0; i != num_elements; ++i) {
     elements[i] = LocalDate::FromMillis(data_begin[i]);
   }
-  populateNullsFromDeephavenConvention(data_begin, nulls.get(), num_elements);
+  PopulateNullsFromDeephavenConvention(data_begin, nulls.get(), num_elements);
   return LocalDateArrayColumnSource::CreateFromArrays(ElementType::Of(ElementTypeId::kLocalDate),
       std::move(elements), std::move(nulls), num_elements);
 }
@@ -95,7 +95,7 @@ CythonSupport::CreateLocalTimeColumnSource(const int64_t *data_begin, const int6
   for (size_t i = 0; i != num_elements; ++i) {
     elements[i] = LocalTime::FromNanos(data_begin[i]);
   }
-  populateNullsFromDeephavenConvention(data_begin, nulls.get(), num_elements);
+  PopulateNullsFromDeephavenConvention(data_begin, nulls.get(), num_elements);
   return LocalTimeArrayColumnSource::CreateFromArrays(ElementType::Of(ElementTypeId::kLocalTime),
       std::move(elements), std::move(nulls), num_elements);
 }
@@ -110,7 +110,7 @@ ElementTypeId::Enum CythonSupport::GetElementTypeId(const ColumnSource &column_s
 }
 
 namespace {
-void populateArrayFromPackedData(const uint8_t *src, bool *dest, size_t num_elements, bool invert) {
+void PopulateArrayFromPackedData(const uint8_t *src, bool *dest, size_t num_elements, bool invert) {
   if (src == nullptr) {
     std::fill(dest, dest + num_elements, false);
     return;
@@ -128,7 +128,7 @@ void populateArrayFromPackedData(const uint8_t *src, bool *dest, size_t num_elem
   }
 }
 
-void populateNullsFromDeephavenConvention(const int64_t *data_begin, bool *dest, size_t num_elements) {
+void PopulateNullsFromDeephavenConvention(const int64_t *data_begin, bool *dest, size_t num_elements) {
   for (size_t i = 0; i != num_elements; ++i) {
     dest[i] = data_begin[i] == DeephavenConstants::kNullLong;
   }

--- a/cpp-client/deephaven/dhcore/src/utility/utility.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/utility.cc
@@ -3,14 +3,15 @@
  */
 #include "deephaven/dhcore/utility/utility.h"
 
+#include <chrono>
 #include <filesystem>
 #include <ostream>
 #include <string>
-#include <vector>
 
 #include "deephaven/third_party/fmt/chrono.h"
 #include "deephaven/third_party/fmt/core.h"
 #include "deephaven/third_party/fmt/ostream.h"
+#include "deephaven/dhcore/container/container.h"
 
 #ifdef __GNUG__
 #include <cstdlib>
@@ -19,6 +20,8 @@
 #endif
 
 static_assert(FMT_VERSION >= 100000);
+
+using deephaven::dhcore::container::ContainerBase;
 
 namespace deephaven::dhcore::utility {
 
@@ -177,4 +180,7 @@ std::string ReadPasswordFromStdinNoEcho() {
   return password;
 }
 
+void ElementRenderer::Render(std::ostream &s, const std::shared_ptr<ContainerBase> &item) const {
+  s << *item;
+}
 }  // namespace deephaven::dhcore::utility

--- a/cpp-client/deephaven/tests/CMakeLists.txt
+++ b/cpp-client/deephaven/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(dhclient_tests
         src/cython_support_test.cc
         src/date_time_test.cc
         src/filter_test.cc
+        src/group_test.cc
         src/head_and_tail_test.cc
         src/input_table_test.cc
         src/join_test.cc

--- a/cpp-client/deephaven/tests/src/group_test.cc
+++ b/cpp-client/deephaven/tests/src/group_test.cc
@@ -3,6 +3,7 @@
  */
 #include <cstdint>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -10,9 +11,9 @@
 #include "deephaven/tests/test_util.h"
 #include "deephaven/client/client.h"
 #include "deephaven/client/utility/table_maker.h"
-#include "deephaven/dhcore/container/row_sequence.h"
 
 using deephaven::client::utility::TableMaker;
+using Catch::Matchers::StartsWith;
 
 namespace deephaven::client::tests {
 TEST_CASE("Group a Table", "[group]") {
@@ -54,5 +55,34 @@ TEST_CASE("Group a Table", "[group]") {
       {53, 48}, {51, 61}, {46, 57}
   });
   TableComparerForTests::Compare(expected, grouped);
+}
+
+TEST_CASE("Nested lists not supported", "[group]") {
+  auto tm = TableMakerForTests::Create();
+
+  TableMaker maker;
+  maker.AddColumn<std::vector<std::vector<int32_t>>>("Value", {
+      { { 1, 2, 3 } },  // [[1, 2, 3]]
+      { { 4, 5 } },  // [[4, 5]]
+  });
+  auto t = maker.MakeTable(tm.Client().GetManager());
+  CHECK_THROWS_WITH(t.ToClientTable(), StartsWith("Nested lists are not currently supported"));
+}
+
+TEST_CASE("Test case for group example", "[group]") {
+  // This is not really a "test" per se. Instead, it provides the source data that matches the
+  // examples we have documented in arrow_array_converter.cc. It was used to single-step through
+  // that code and provide the documentation for various steps in that code.
+  auto tm = TableMakerForTests::Create();
+
+  TableMaker maker;
+  maker.AddColumn<std::optional<std::vector<std::optional<std::string>>>>("Value", {
+      { {"a", "b", "c"} },  // [a, b, c]
+      {}, // null
+      {{}}, // []
+      {{"d", "e", "f", {}, "g"}}  // [d, e, f, null, g]
+  });
+  auto t = maker.MakeTable(tm.Client().GetManager());
+  auto ct = t.ToClientTable();
 }
 }  // namespace deephaven::client::tests

--- a/cpp-client/deephaven/tests/src/group_test.cc
+++ b/cpp-client/deephaven/tests/src/group_test.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+ */
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "deephaven/third_party/catch.hpp"
+#include "deephaven/tests/test_util.h"
+#include "deephaven/client/client.h"
+#include "deephaven/client/utility/table_maker.h"
+#include "deephaven/dhcore/container/row_sequence.h"
+
+using deephaven::client::utility::TableMaker;
+
+namespace deephaven::client::tests {
+TEST_CASE("Group a Table", "[group]") {
+  auto tm = TableMakerForTests::Create();
+
+  TableMaker maker;
+  maker.AddColumn<std::string>("Type", {
+      "Granny Smith",
+      "Granny Smith",
+      "Gala",
+      "Gala",
+      "Golden Delicious",
+      "Golden Delicious"
+  });
+  maker.AddColumn<std::string>("Color", {
+      "Green", "Green", "Red-Green", "Orange-Green", "Yellow", "Yellow"
+  });
+  maker.AddColumn<int32_t>("Weight", {
+      102, 85, 79, 92, 78, 99
+  });
+  maker.AddColumn<int32_t>("Calories", {
+      53, 48, 51, 61, 46, 57
+  });
+  auto t1 = maker.MakeTable(tm.Client().GetManager());
+
+  auto grouped = t1.By("Type");
+
+  std::cout << grouped.Stream(true) << '\n';
+
+  TableMaker expected;
+  expected.AddColumn<std::string>("Type", {"Granny Smith", "Gala", "Golden Delicious"});
+  expected.AddColumn<std::vector<std::string>>("Color", {
+      {"Green", "Green"}, {"Red-Green", "Orange-Green"}, {"Yellow", "Yellow"}
+  });
+  expected.AddColumn<std::vector<int32_t>>("Weight", {
+      {102, 85}, {79, 92}, {78, 99}
+  });
+  expected.AddColumn<std::vector<int32_t>>("Calories", {
+      {53, 48}, {51, 61}, {46, 57}
+  });
+  TableComparerForTests::Compare(expected, grouped);
+}
+}  // namespace deephaven::client::tests


### PR DESCRIPTION
This PR depends on https://github.com/deephaven/deephaven-core/pull/6793 being merged first.

This PR introduces a new data structure to the C++ client, a "Container", which is similar in feeling to a ColumnSource in that it's specialized to its element type, but also it:
1. is dense and linear
2. knows its size

For these new Containers, this PR adds:
1. Chunk support
2. Column Source support
3. MakeTable and CompareTable support for testing
4. Unit tests for running the Deephaven operation groupby and checking the result
