### PR TITLE
fix: DH-19238: Barrage Must use VectorChunkAdapter to Copy Virtual Vectors on PUG

### DIFF
--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -20,6 +20,7 @@ import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.TableUpdateValidator;
 import io.deephaven.engine.table.impl.util.BarrageMessage;
+import io.deephaven.engine.table.vectors.IntVectorColumnWrapper;
 import io.deephaven.engine.testutil.*;
 import io.deephaven.engine.testutil.generator.*;
 import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
@@ -40,6 +41,7 @@ import io.deephaven.test.types.OutOfBandTest;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.annotations.ReferentialIntegrity;
 import io.deephaven.util.mutable.MutableInt;
+import io.deephaven.vector.IntVector;
 import io.grpc.stub.StreamObserver;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -1412,6 +1414,78 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
                         helper.random, helper.sourceTable, helper.columnInfo));
             });
         }
+    }
+
+    public void testVectorConcurrentModification() {
+        // this is a regression test for DH-19238; Barrage was not creating a static copy of ColumnWrapped vectors
+        final BitSet allColumns = new BitSet(2);
+        allColumns.set(0, 2);
+
+        final QueryTable queryTable = TstUtils.testRefreshingTable(RowSetFactory.flat(4).toTracking(),
+                col("Sym", "ZVZZT", "ZVZZT", "ZVZZT", "ZVZZT"),
+                col("Val", 1, 1, 1, 1));
+        final RemoteNugget remoteNugget = new RemoteNugget(() -> queryTable.groupBy("Sym"));
+
+        final RemoteClient remoteClient = remoteNugget.newClient(null, allColumns, "client");
+
+        // Obtain snapshot of original table.
+        flushProducerTable();
+        remoteNugget.flushClientEvents();
+        final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+        updateGraph.runWithinUnitTestCycle(updateSourceCombiner::run);
+        remoteNugget.validate("original viewport");
+
+        // Let's assert that our column source is virtual (important that the test is capable of failing).
+        Assert.eq(remoteNugget.originalTable.getColumnSource("Val").get(0).getClass(),
+                "remoteNugget.originalTable.getColumnSource(\"Val\").get(0).getClass()",
+                IntVectorColumnWrapper.class);
+
+        // Queue up a change to make Val == 2
+        updateGraph.runWithinUnitTestCycle(() -> {
+            TstUtils.addToTable(queryTable, queryTable.getRowSet(),
+                    col("Sym", "ZVZZT", "ZVZZT", "ZVZZT", "ZVZZT"),
+                    col("Val", 2, 2, 2, 2));
+
+            queryTable.notifyListeners(new TableUpdateImpl(
+                    RowSetFactory.empty(),
+                    RowSetFactory.empty(),
+                    queryTable.getRowSet().copy(),
+                    RowSetShiftData.EMPTY, ModifiedColumnSet.ALL));
+        });
+
+        // Queue up another change, but flush BMP before the table ticks. Client should receive 2's not 3's.
+        updateGraph.runWithinUnitTestCycle(() -> {
+            TstUtils.addToTable(queryTable, queryTable.getRowSet(),
+                    col("Sym", "ZVZZT", "ZVZZT", "ZVZZT", "ZVZZT"),
+                    col("Val", 3, 3, 3, 3));
+
+            flushProducerTable();
+
+            queryTable.notifyListeners(new TableUpdateImpl(
+                    RowSetFactory.empty(),
+                    RowSetFactory.empty(),
+                    queryTable.getRowSet().copy(),
+                    RowSetShiftData.EMPTY, ModifiedColumnSet.ALL));
+        });
+
+        // we're expecting a single update in the queue, flush and propagate to BarrageTable
+        Assert.equals(remoteClient.commandQueue.size(), "remoteClient.getValue().commandQueue.size()", 1);
+        remoteNugget.flushClientEvents();
+        updateGraph.runWithinUnitTestCycle(updateSourceCombiner::run);
+
+        IntVector destVal = (IntVector) remoteClient.barrageTable.getColumnSource("Val").get(0);
+        Assert.neqNull(destVal, "destVal");
+        Assert.eq(destVal.size(), "destVal.size()", queryTable.size(), "queryTable.size()");
+        for (int ii = 0; ii < destVal.size(); ++ii) {
+            Assert.eq(destVal.get(ii), "destVal.get(ii)", 2);
+        }
+
+        // flush bmp and client one last time so we properly cleanup the test's chunks
+        flushProducerTable();
+        Assert.equals(remoteClient.commandQueue.size(), "remoteClient.getValue().commandQueue.size()", 1);
+        remoteNugget.flushClientEvents();
+        updateGraph.runWithinUnitTestCycle(updateSourceCombiner::run);
+        remoteNugget.validate("end-of-test tables should match");
     }
 
     public static class DummyObserver implements StreamObserver<BarrageMessageWriter.MessageView> {


### PR DESCRIPTION
Targeted unit test included that fails on main (and it fails where it expects a 2 but finds a 3).

Nightlies: https://github.com/nbauernfeind/deephaven-core/actions/runs/14526240901/