### PR TITLE
build: Fix two oversights in our published jars

### DIFF
--- a/Util/immutables/gradle.properties
+++ b/Util/immutables/gradle.properties
@@ -1,1 +1,1 @@
-io.deephaven.project.ProjectType=JAVA_LOCAL
+io.deephaven.project.ProjectType=JAVA_PUBLIC

--- a/buildSrc/src/main/groovy/io.deephaven.java-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-publishing-conventions.gradle
@@ -16,10 +16,8 @@ java {
 // See https://github.com/gradle/gradle/issues/33287
 sourceSets.configureEach { sourceSet ->
   if (tasks.names.contains(sourceSet.getSourcesJarTaskName())) {
-    def compile = tasks.named(sourceSet.getCompileTaskName('java'))
     tasks.named(sourceSet.getSourcesJarTaskName(), Jar) {
-      dependsOn(compile)
-      from compile.map { it.options.generatedSourceOutputDirectory }
+      from sourceSet.output.generatedSourcesDirs
     }
   }
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-publishing-conventions.gradle
@@ -12,6 +12,18 @@ java {
   withSourcesJar()
 }
 
+// Any published source jar should contain apt-generated sources
+// See https://github.com/gradle/gradle/issues/33287
+sourceSets.configureEach { sourceSet ->
+  if (tasks.names.contains(sourceSet.getSourcesJarTaskName())) {
+    def compile = tasks.named(sourceSet.getCompileTaskName('java'))
+    tasks.named(sourceSet.getSourcesJarTaskName(), Jar) {
+      dependsOn(compile)
+      from compile.map { it.options.generatedSourceOutputDirectory }
+    }
+  }
+}
+
 tasks.withType(Javadoc) {
   // https://github.com/gradle/gradle/issues/19869
   options.addStringOption('sourcepath', sourceSets.main.allJava.getSourceDirectories().getAsPath())


### PR DESCRIPTION
First, we leave bytecode in published code that references util-immutables annotations, but we don't make those annotations available. This fixes that - but does not make the annotations a requirement for downstream projects. Any project which wants to depend on the annotations themselves can do so.

Second, Gradle does not include apt-generated sources in its published source jars. This patch adds those generated types to the source jar. See https://github.com/gradle/gradle/issues/33287 for more information.