### PR TITLE
fix: Ensure that Iceberg metadata tables fail on loadTable

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergCatalogAdapter.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergCatalogAdapter.java
@@ -14,6 +14,7 @@ import io.deephaven.iceberg.internal.DataInstructionsProviderLoader;
 import io.deephaven.iceberg.internal.DataInstructionsProviderPlugin;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.annotations.VisibleForTesting;
+import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
@@ -275,6 +276,10 @@ public class IcebergCatalogAdapter {
         final org.apache.iceberg.Table table = catalog.loadTable(options.id());
         if (table == null) {
             throw new IllegalArgumentException("Table not found: " + options.id());
+        }
+        if (table instanceof BaseMetadataTable) {
+            // TODO(DH-19314): Add support for reading Iceberg metadata tables
+            throw new IllegalArgumentException("Metadata tables are not currently supported");
         }
         final Resolver resolver;
         try {

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -1995,6 +1996,20 @@ public abstract class SqliteCatalogBase {
             assertThat(e).hasMessageContaining("Unable to map Deephaven column stringCol");
             assertThat(e.getCause()).hasMessageContaining("No PartitionField with source field id " +
                     stringColFieldId + " exists in PartitionSpec");
+        }
+    }
+
+    @Test
+    void metadataTables() {
+        final String id = "MyNamespace.MetadataTables";
+        catalogAdapter.createTable(id, TableDefinition.of(ColumnDefinition.ofInt("Foo")));
+        for (final MetadataTableType type : MetadataTableType.values()) {
+            try {
+                catalogAdapter.loadTable(id + "." + type.name());
+                failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+            } catch (IllegalArgumentException e) {
+                assertThat(e).hasMessageContaining("Metadata tables are not currently supported");
+            }
         }
     }
 }


### PR DESCRIPTION
Deephaven does not currently support reading Iceberg metadata tables, as it doesn't make sense based on our current implementation. Instead of failing during the `IcebergTableAdapter.table` read, we should fail upfront when a user tries to do the `IcebergCatalogAdapter.loadTable`.

DH-19314 has been filed for implementing Iceberg metadata table support