### PR TITLE
fix(cpp-client): virtual dtors for visitors, IWYU, small cleanups

### DIFF
--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_visitors.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/arrowutil/arrow_visitors.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <arrow/type.h>
+#include <arrow/visitor.h>
+#include <string>
 #include "deephaven/dhcore/types.h"
 
 namespace deephaven::client::arrowutil {
@@ -13,6 +15,7 @@ class ArrowTypeVisitor final : public arrow::TypeVisitor {
 public:
   ArrowTypeVisitor() = default;
   explicit ArrowTypeVisitor(InnerType inner) : inner_(std::move(inner)) {}
+  ~ArrowTypeVisitor() final = default;
 
   arrow::Status Visit(const arrow::Int8Type &) final {
     inner_.template operator()<int8_t>();
@@ -67,10 +70,11 @@ private:
 };
 
 template<typename InnerType>
-class ArrowArrayTypeVisitor : public arrow::ArrayVisitor {
+class ArrowArrayTypeVisitor final : public arrow::ArrayVisitor {
 public:
   ArrowArrayTypeVisitor() = default;
   explicit ArrowArrayTypeVisitor(InnerType inner) : inner_(std::move(inner)) {}
+  ~ArrowArrayTypeVisitor() final = default;
 
   arrow::Status Visit(const arrow::Int8Array &) final {
     inner_.template operator()<int8_t>();

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/chunk/chunk.h
@@ -3,6 +3,7 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <string_view>
@@ -241,6 +242,7 @@ using ContainerBaseChunk = GenericChunk<std::shared_ptr<deephaven::dhcore::conta
  */
 class ChunkVisitor {
 public:
+  virtual ~ChunkVisitor() = default;
   /**
    * Implements the visitor pattern.
    */

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/client_table.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include "deephaven/dhcore/column/column_source.h"

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source.h
@@ -209,6 +209,7 @@ class MutableGenericColumnSource : public GenericColumnSource<T>, public Mutable
  */
 class ColumnSourceVisitor {
 public:
+  virtual ~ColumnSourceVisitor() = default;
   /**
    * Implements the visitor pattern.
    */

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_helpers.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/column_source_helpers.h
@@ -3,9 +3,11 @@
  */
 #pragma once
 
-#include <type_traits>
-
+#include <cstdint>
+#include <memory>
+#include <string>
 #include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/types.h"
 
 namespace deephaven::dhcore::column {
 namespace internal {

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container.h
@@ -28,18 +28,18 @@ protected:
 
 public:
   virtual ~ContainerVisitor() = default;
-  virtual void Visit(const Container<char16_t> *) = 0;
-  virtual void Visit(const Container<int8_t> *) = 0;
-  virtual void Visit(const Container<int16_t> *) = 0;
-  virtual void Visit(const Container<int32_t> *) = 0;
-  virtual void Visit(const Container<int64_t> *) = 0;
-  virtual void Visit(const Container<float> *) = 0;
-  virtual void Visit(const Container<double> *) = 0;
-  virtual void Visit(const Container<bool> *) = 0;
-  virtual void Visit(const Container<std::string> *) = 0;
-  virtual void Visit(const Container<DateTime> *) = 0;
-  virtual void Visit(const Container<LocalDate> *) = 0;
-  virtual void Visit(const Container<LocalTime> *) = 0;
+  virtual void Visit(const Container<char16_t> *container) = 0;
+  virtual void Visit(const Container<int8_t> *container) = 0;
+  virtual void Visit(const Container<int16_t> *container) = 0;
+  virtual void Visit(const Container<int32_t> *container) = 0;
+  virtual void Visit(const Container<int64_t> *container) = 0;
+  virtual void Visit(const Container<float> *container) = 0;
+  virtual void Visit(const Container<double> *container) = 0;
+  virtual void Visit(const Container<bool> *container) = 0;
+  virtual void Visit(const Container<std::string> *container) = 0;
+  virtual void Visit(const Container<DateTime> *container) = 0;
+  virtual void Visit(const Container<LocalDate> *container) = 0;
+  virtual void Visit(const Container<LocalTime> *container) = 0;
 };
 
 class ContainerBase : public std::enable_shared_from_this<ContainerBase> {
@@ -103,12 +103,16 @@ public:
     return nulls_[index];
   }
 
-  const T *begin() const {
+  const T *data() const {
     return data_.get();
   }
 
+  const T *begin() const {
+    return data();
+  }
+
   const T *end() const {
-    return begin() + size();
+    return data() + size();
   }
 
 private:

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/row_sequence.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/row_sequence.h
@@ -3,6 +3,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <map>

--- a/cpp-client/deephaven/dhcore/src/chunk/chunk.cc
+++ b/cpp-client/deephaven/dhcore/src/chunk/chunk.cc
@@ -2,7 +2,11 @@
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
 #include "deephaven/dhcore/chunk/chunk.h"
+
+#include <cstddef>
+#include <string_view>
 #include "deephaven/dhcore/utility/utility.h"
+#include "deephaven/third_party/fmt/core.h"
 
 using deephaven::dhcore::chunk::Chunk;
 


### PR DESCRIPTION
This PR contains a set of small cleanups. The only behavioral change is making sure that a couple of Visitor classes have virtual destructors. There was no existing code that depended on the presence of virtual destructors, so this is not a behavioral change.