### PR TITLE
feat(cpp-client): Add more support in CythonSupport for nested lists [pyticking 5/7]

### DIFF
--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -51,6 +51,7 @@ set(ALL_FILES
     include/public/deephaven/dhcore/column/column_source.h
     include/public/deephaven/dhcore/column/column_source_helpers.h
     include/public/deephaven/dhcore/column/column_source_utils.h
+    include/public/deephaven/dhcore/column/container_column_source.h
     include/public/deephaven/dhcore/container/container.h
     include/public/deephaven/dhcore/container/container_util.h
     include/public/deephaven/dhcore/container/row_sequence.h

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -52,6 +52,7 @@ set(ALL_FILES
     include/public/deephaven/dhcore/column/column_source_helpers.h
     include/public/deephaven/dhcore/column/column_source_utils.h
     include/public/deephaven/dhcore/container/container.h
+    include/public/deephaven/dhcore/container/container_util.h
     include/public/deephaven/dhcore/container/row_sequence.h
     include/public/deephaven/dhcore/interop/testapi/basic_interop_interactions.h
     include/public/deephaven/dhcore/interop/interop_util.h

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/container_column_source.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/column/container_column_source.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/chunk/chunk_traits.h"
+#include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/column/column_source_utils.h"
+#include "deephaven/dhcore/container/container.h"
+#include "deephaven/dhcore/container/row_sequence.h"
+#include "deephaven/dhcore/types.h"
+
+namespace deephaven::dhcore::column {
+template<typename T>
+class ContainerColumnSource final : public GenericColumnSource<T>,
+  public std::enable_shared_from_this<ContainerColumnSource<T>> {
+  struct Private {
+  };
+  using BooleanChunk = deephaven::dhcore::chunk::BooleanChunk;
+  using Chunk = deephaven::dhcore::chunk::Chunk;
+  using UInt64Chunk = deephaven::dhcore::chunk::UInt64Chunk;
+  using ColumnSourceImpls = deephaven::dhcore::column::ColumnSourceImpls;
+  using ColumnSourceVisitor = deephaven::dhcore::column::ColumnSourceVisitor;
+  using ContainerBase = deephaven::dhcore::container::ContainerBase;
+  using RowSequence = deephaven::dhcore::container::RowSequence;
+
+  template<typename U>
+  using Container = deephaven::dhcore::container::Container<U>;
+
+public:
+  static std::shared_ptr<ContainerColumnSource> Create(const ElementType &element_type,
+    std::shared_ptr<Container<T>> container) {
+    return std::make_shared<ContainerColumnSource>(Private(), element_type, std::move(container));
+  }
+
+  explicit ContainerColumnSource(Private, const ElementType &element_type,
+    std::shared_ptr<Container<T>> container) : element_type_(element_type),
+    container_(std::move(container)) {}
+  ~ContainerColumnSource() final = default;
+
+  void FillChunk(const RowSequence &rows, Chunk *dest, BooleanChunk *optional_dest_null_flags) const final {
+    using chunkType_t = typename deephaven::dhcore::chunk::TypeToChunk<T>::type_t;
+    using deephaven::dhcore::utility::VerboseCast;
+    size_t dest_index = 0;
+    const auto *data = container_->data();
+    auto *typed_dest = VerboseCast<chunkType_t*>(DEEPHAVEN_LOCATION_EXPR(dest));
+    rows.ForEachInterval([&](uint64_t begin_key, uint64_t end_key) {
+      for (auto current = begin_key; current != end_key; ++current) {
+        auto is_null = container_->IsNull(current);
+        if (!is_null) {
+          (*typed_dest)[dest_index] = data[current];
+        }
+        if (optional_dest_null_flags != nullptr) {
+          (*optional_dest_null_flags)[dest_index] = is_null;
+        }
+        ++dest_index;
+      }
+    });
+  }
+
+  void FillChunkUnordered(const UInt64Chunk &row_keys, Chunk *dest,
+      BooleanChunk *optional_dest_null_flags) const final {
+    const char *message = "FillChunkUnordered is not implemented yet";
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+  }
+
+  [[nodiscard]]
+  const ElementType &GetElementType() const final {
+    return element_type_;
+  }
+
+  void AcceptVisitor(ColumnSourceVisitor *visitor) const final {
+    visitor->Visit(*this);
+  }
+
+private:
+  ElementType element_type_;
+  std::shared_ptr<Container<T>> container_;
+};
+
+using CharContainerColumnSource = ContainerColumnSource<char16_t>;
+using Int8ContainerColumnSource = ContainerColumnSource<int8_t>;
+using Int16ContainerColumnSource = ContainerColumnSource<int16_t>;
+using Int32ContainerColumnSource = ContainerColumnSource<int32_t>;
+using Int64ContainerColumnSource = ContainerColumnSource<int64_t>;
+using FloatContainerColumnSource = ContainerColumnSource<float>;
+using DoubleContainerColumnSource = ContainerColumnSource<double>;
+
+using BooleanContainerColumnSource = ContainerColumnSource<bool>;
+using StringContainerColumnSource = ContainerColumnSource<std::string>;
+using DateTimeContainerColumnSource = ContainerColumnSource<DateTime>;
+using LocalDateContainerColumnSource = ContainerColumnSource<LocalDate>;
+using LocalTimeContainerColumnSource = ContainerColumnSource<LocalTime>;
+}  // namespace deephaven::dhcore::column

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container_util.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/container/container_util.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+ */
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "deephaven/dhcore/types.h"
+#include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/column/array_column_source.h"
+#include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/container/container.h"
+#include "deephaven/dhcore/container/row_sequence.h"
+
+namespace deephaven::dhcore::container {
+class ContainerUtil {
+  using ColumnSource = deephaven::dhcore::column::ColumnSource;
+  using ContainerArrayColumnSource = deephaven::dhcore::column::ContainerArrayColumnSource;
+public:
+  template<typename TElement, typename TChunk>
+  static std::shared_ptr<ContainerArrayColumnSource> Inflate(const ElementType &element_type,
+      const ColumnSource &flattened_elements, size_t flattened_size,
+      const std::vector<std::optional<size_t>> &slice_lengths) {
+    using deephaven::dhcore::chunk::BooleanChunk;
+    using deephaven::dhcore::container::Container;
+    using deephaven::dhcore::ElementType;
+
+    // Continuing the example data we used in ChunkedArrayToColumnSourceVisitor, assume we have:
+    // flattened_elements = [a, b, c, d, e, f, null, g]
+    // flattened_size = 8
+    // slice_lengths = [3, {}, 0, 5]
+
+    // Copy the data in flattened_elements out of the ColumnSource into a shared_ptr<TElement[]>.
+    // Likewise, copy the null flags into a shared_ptr<bool[]>.
+    std::shared_ptr<TElement[]> flattened_data(new TElement[flattened_size]);
+    std::shared_ptr<bool[]> flattened_nulls(new bool[flattened_size]);
+
+    auto flattened_data_chunk = TChunk::CreateView(flattened_data.get(), flattened_size);
+    auto flattened_nulls_chunk = BooleanChunk::CreateView(flattened_nulls.get(), flattened_size);
+
+    auto row_sequence = RowSequence::CreateSequential(0, flattened_size);
+    flattened_elements.FillChunk(*row_sequence, &flattened_data_chunk, &flattened_nulls_chunk);
+
+    // Now take slices of the above data and null flags arrays. We use shared_ptr operations so that
+    // the slices share their refcount with the original shared_ptr they were derived from.
+
+    auto num_slices = slice_lengths.size();
+    // Slices of the original data array.
+    auto slice_data = std::make_unique<std::shared_ptr<ContainerBase>[]>(num_slices);
+    // Whether each slice is null.
+    auto slice_nulls = std::make_unique<bool[]>(num_slices);
+
+    size_t slice_offset = 0;
+    for (size_t i = 0; i != num_slices; ++i) {
+      auto *slice_data_start = flattened_data.get() + slice_offset;
+      auto *slice_null_start = flattened_nulls.get() + slice_offset;
+
+      const auto &slice_length = slice_lengths[i];
+      if (slice_length.has_value()) {
+        // Pointer to the start of the data for the slice.
+        std::shared_ptr < TElement[] > slice_data_start_sp(flattened_data, slice_data_start);
+        // The nulls array for the contents of this slice. In other words, this is a non-null slice
+        // that might contain a mixture of null and non-null elements.
+        std::shared_ptr<bool[]> slice_null_start_sp(flattened_nulls, slice_null_start);
+
+        auto slice_container = Container<TElement>::Create(std::move(slice_data_start_sp),
+            std::move(slice_null_start_sp), *slice_length);
+        slice_data[i] = std::move(slice_container);
+        slice_nulls[i] = false;
+        slice_offset += *slice_length;
+      } else {
+        slice_data[i] = nullptr;
+        slice_nulls[i] = true;
+      }
+    }
+
+    auto list_element_type = element_type.WrapList();
+
+    return ContainerArrayColumnSource::CreateFromArrays(list_element_type,
+        std::move(slice_data), std::move(slice_nulls), num_slices);
+  }
+};
+}  // namespace deephaven::dhcore::container

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
@@ -6,12 +6,14 @@
 #include <cstdint>
 #include <cstddef>
 #include <memory>
-#include "deephaven/dhcore/types.h"
+#include <string>
 #include "deephaven/dhcore/column/column_source.h"
+#include "deephaven/dhcore/container/container.h"
 
 namespace deephaven::dhcore::utility {
 class CythonSupport {
   using ColumnSource = deephaven::dhcore::column::ColumnSource;
+  using ContainerBase = deephaven::dhcore::container::ContainerBase;
 public:
   static std::shared_ptr<ColumnSource> CreateBooleanColumnSource(const uint8_t *data_begin,
       const uint8_t *data_end, const uint8_t *validity_begin, const uint8_t *validity_end,
@@ -30,5 +32,13 @@ public:
    * For backwards compatibility. Will be removed when Cython is updated.
    */
   static ElementTypeId::Enum GetElementTypeId(const ColumnSource &column_source);
+
+  static std::shared_ptr<ColumnSource> SlicesToColumnSource(
+      const ColumnSource &data, size_t data_size,
+      const ColumnSource &lengths, size_t lengths_size);
+
+  static std::shared_ptr<ColumnSource> ContainerToColumnSource(std::shared_ptr<ContainerBase> data);
+
+  static std::string ColumnSourceToString(const ColumnSource &cs, size_t size);
 };
 }  // namespace deephaven::dhcore::utility

--- a/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
@@ -7,20 +7,75 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <stdexcept>
+#include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
+#include "deephaven/dhcore/chunk/chunk.h"
 #include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/column/array_column_source.h"
+#include "deephaven/dhcore/column/container_column_source.h"
+#include "deephaven/dhcore/container/container.h"
+#include "deephaven/dhcore/container/container_util.h"
+#include "deephaven/dhcore/container/row_sequence.h"
 
+using deephaven::dhcore::chunk::BooleanChunk;
+using deephaven::dhcore::chunk::CharChunk;
+using deephaven::dhcore::chunk::DateTimeChunk;
+using deephaven::dhcore::chunk::DoubleChunk;
+using deephaven::dhcore::chunk::FloatChunk;
+using deephaven::dhcore::chunk::Int8Chunk;
+using deephaven::dhcore::chunk::Int16Chunk;
+using deephaven::dhcore::chunk::Int32Chunk;
+using deephaven::dhcore::chunk::Int64Chunk;
+using deephaven::dhcore::chunk::GenericChunk;
+using deephaven::dhcore::chunk::LocalDateChunk;
+using deephaven::dhcore::chunk::LocalTimeChunk;
+using deephaven::dhcore::chunk::StringChunk;
 using deephaven::dhcore::column::BooleanArrayColumnSource;
+using deephaven::dhcore::column::CharContainerColumnSource;
 using deephaven::dhcore::column::ColumnSource;
+using deephaven::dhcore::column::ColumnSourceVisitor;
+using deephaven::dhcore::column::ContainerArrayColumnSource;
+using deephaven::dhcore::column::ContainerColumnSource;
+using deephaven::dhcore::column::CharColumnSource;
+using deephaven::dhcore::column::Int8ColumnSource;
+using deephaven::dhcore::column::Int16ColumnSource;
+using deephaven::dhcore::column::Int64ColumnSource;
+using deephaven::dhcore::column::FloatColumnSource;
+using deephaven::dhcore::column::DoubleColumnSource;
+using deephaven::dhcore::column::BooleanColumnSource;
+using deephaven::dhcore::column::GenericColumnSource;
+using deephaven::dhcore::column::StringColumnSource;
+using deephaven::dhcore::column::DateTimeColumnSource;
+using deephaven::dhcore::column::LocalDateColumnSource;
+using deephaven::dhcore::column::LocalTimeColumnSource;
+using deephaven::dhcore::column::ContainerBaseColumnSource;
 using deephaven::dhcore::column::DateTimeArrayColumnSource;
+using deephaven::dhcore::column::BooleanContainerColumnSource;
+using deephaven::dhcore::column::DoubleContainerColumnSource;
+using deephaven::dhcore::column::FloatContainerColumnSource;
+using deephaven::dhcore::column::Int8ContainerColumnSource;
+using deephaven::dhcore::column::Int16ContainerColumnSource;
+using deephaven::dhcore::column::Int32ContainerColumnSource;
+using deephaven::dhcore::column::Int64ContainerColumnSource;
+using deephaven::dhcore::column::Int32ColumnSource;
 using deephaven::dhcore::column::LocalDateArrayColumnSource;
 using deephaven::dhcore::column::LocalTimeArrayColumnSource;
 using deephaven::dhcore::column::StringArrayColumnSource;
+using deephaven::dhcore::column::DateTimeContainerColumnSource;
+using deephaven::dhcore::column::LocalDateContainerColumnSource;
+using deephaven::dhcore::column::LocalTimeContainerColumnSource;
+using deephaven::dhcore::column::StringContainerColumnSource;
+using deephaven::dhcore::container::Container;
+using deephaven::dhcore::container::ContainerBase;
+using deephaven::dhcore::container::ContainerUtil;
+using deephaven::dhcore::container::ContainerVisitor;
+using deephaven::dhcore::container::RowSequence;
 
 namespace deephaven::dhcore::utility {
 namespace {
@@ -86,6 +141,15 @@ CythonSupport::CreateLocalDateColumnSource(const int64_t *data_begin, const int6
       std::move(elements), std::move(nulls), num_elements);
 }
 
+ElementTypeId::Enum CythonSupport::GetElementTypeId(const ColumnSource &column_source) {
+  const auto &element_type = column_source.GetElementType();
+  if (element_type.ListDepth() != 0) {
+    const char *message = "GetElementTypeId does not support non-zero list depth";
+    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
+  }
+  return element_type.Id();
+}
+
 std::shared_ptr<ColumnSource>
 CythonSupport::CreateLocalTimeColumnSource(const int64_t *data_begin, const int64_t *data_end,
     const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements) {
@@ -100,13 +164,351 @@ CythonSupport::CreateLocalTimeColumnSource(const int64_t *data_begin, const int6
       std::move(elements), std::move(nulls), num_elements);
 }
 
-ElementTypeId::Enum CythonSupport::GetElementTypeId(const ColumnSource &column_source) {
-  const auto &element_type = column_source.GetElementType();
-  if (element_type.ListDepth() != 0) {
-    const char *message = "GetElementTypeId does not support non-zero list depth";
+namespace {
+struct CreateContainerVisitor final : ColumnSourceVisitor {
+  CreateContainerVisitor(const ColumnSource *data, size_t data_size,
+    std::vector<std::optional<size_t>> slice_lengths) : data_(data),
+    data_size_(data_size), slice_lengths_(std::move(slice_lengths)) {}
+  ~CreateContainerVisitor() final = default;
+
+  void Visit(const column::CharColumnSource &/*source*/) final {
+    VisitHelper<char16_t, CharChunk>(ElementTypeId::kChar);
+  }
+
+  void Visit(const column::Int8ColumnSource &/*source*/) final {
+    VisitHelper<int8_t, Int8Chunk>(ElementTypeId::kInt8);
+  }
+
+  void Visit(const column::Int16ColumnSource &/*source*/) final {
+    VisitHelper<int16_t, Int16Chunk>(ElementTypeId::kInt16);
+  }
+
+  void Visit(const column::Int32ColumnSource &/*source*/) final {
+    VisitHelper<int32_t, Int32Chunk>(ElementTypeId::kInt32);
+  }
+
+  void Visit(const column::Int64ColumnSource &/*source*/) final {
+    VisitHelper<int64_t, Int64Chunk>(ElementTypeId::kInt64);
+  }
+
+  void Visit(const column::FloatColumnSource &/*source*/) final {
+    VisitHelper<float, FloatChunk>(ElementTypeId::kFloat);
+  }
+
+  void Visit(const column::DoubleColumnSource &/*source*/) final {
+    VisitHelper<double, DoubleChunk>(ElementTypeId::kDouble);
+  }
+
+  void Visit(const column::BooleanColumnSource &/*source*/) final {
+    VisitHelper<bool, BooleanChunk>(ElementTypeId::kBool);
+  }
+
+  void Visit(const column::StringColumnSource &/*source*/) final {
+    VisitHelper<std::string, StringChunk>(ElementTypeId::kString);
+  }
+
+  void Visit(const column::DateTimeColumnSource &/*source*/) final {
+    VisitHelper<DateTime, DateTimeChunk>(ElementTypeId::kTimestamp);
+  }
+
+  void Visit(const column::LocalDateColumnSource &/*source*/) final {
+    VisitHelper<LocalDate, LocalDateChunk>(ElementTypeId::kLocalDate);
+  }
+
+  void Visit(const column::LocalTimeColumnSource &/*source*/) final {
+    VisitHelper<LocalTime, LocalTimeChunk>(ElementTypeId::kLocalTime);
+  }
+
+  void Visit(const column::ContainerBaseColumnSource &/*source*/) final {
+    const char *message = "Nested containers are not supported";
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
-  return element_type.Id();
+
+  template<typename TElement, typename TChunk>
+  void VisitHelper(ElementTypeId::Enum element_type_id) {
+    result_ = ContainerUtil::Inflate<TElement, TChunk>(ElementType::Of(element_type_id),
+        *data_, data_size_, slice_lengths_);
+  }
+
+  const ColumnSource *data_ = nullptr;
+  size_t data_size_ = 0;
+  std::vector<std::optional<size_t>> slice_lengths_;
+  std::shared_ptr<ContainerArrayColumnSource> result_;
+};
+}  // namespace
+
+std::shared_ptr<ColumnSource>
+CythonSupport::SlicesToColumnSource(const ColumnSource &data, size_t data_size,
+    const ColumnSource &lengths, size_t lengths_size) {
+
+  // Change the representation of the 'lengths' ColumnSource into vector<optional<int32_t>>. This is slightly laborious
+  const auto *typed_lengths = VerboseCast<const Int32ColumnSource*>(DEEPHAVEN_LOCATION_EXPR(&lengths));
+  auto row_sequence = RowSequence::CreateSequential(0, lengths_size);
+  auto lengths_data = Int32Chunk::Create(lengths_size);
+  auto lengths_nulls = BooleanChunk::Create(lengths_size);
+  typed_lengths->FillChunk(*row_sequence, &lengths_data, &lengths_nulls);
+
+  auto lengths_vec = MakeReservedVector<std::optional<std::size_t>>(lengths_size);
+  for (size_t i = 0; i != lengths_size; ++i) {
+    if (lengths_nulls[i]) {
+      lengths_vec.emplace_back();
+    } else {
+      lengths_vec.emplace_back(lengths_data[i]);
+    }
+  }
+
+  CreateContainerVisitor visitor(&data, data_size, std::move(lengths_vec));
+  visitor.data_->AcceptVisitor(&visitor);
+  return std::move(visitor.result_);
+}
+
+namespace {
+struct ContainerToColumnSourceVisitor final : public ContainerVisitor {
+  explicit ContainerToColumnSourceVisitor(std::shared_ptr<ContainerBase> container_base) :
+      container_base_(std::move(container_base)) {}
+
+  void Visit(const Container<char16_t> *) final {
+    VisitHelper<char16_t, CharContainerColumnSource>(ElementTypeId::kChar);
+  }
+
+  void Visit(const container::Container<int8_t> *) final {
+    VisitHelper<int8_t, Int8ContainerColumnSource>(ElementTypeId::kInt8);
+  }
+
+  void Visit(const container::Container<int16_t> *) final {
+    VisitHelper<int16_t, Int16ContainerColumnSource>(ElementTypeId::kInt16);
+  }
+
+  void Visit(const container::Container<int32_t> *) final {
+    VisitHelper<int32_t, Int32ContainerColumnSource>(ElementTypeId::kInt32);
+  }
+
+  void Visit(const container::Container<int64_t> *) final {
+    VisitHelper<int64_t, Int64ContainerColumnSource>(ElementTypeId::kInt64);
+  }
+
+  void Visit(const container::Container<float> *) final {
+    VisitHelper<float, FloatContainerColumnSource>(ElementTypeId::kFloat);
+  }
+
+  void Visit(const container::Container<double> *) final {
+    VisitHelper<double, DoubleContainerColumnSource>(ElementTypeId::kDouble);
+  }
+
+  void Visit(const container::Container<bool> *) final {
+    VisitHelper<bool, BooleanContainerColumnSource>(ElementTypeId::kBool);
+  }
+
+  void Visit(const container::Container<std::string> *) final {
+    VisitHelper<std::string, StringContainerColumnSource>(ElementTypeId::kString);
+  }
+
+  void Visit(const container::Container<DateTime> *) final {
+    VisitHelper<DateTime, DateTimeContainerColumnSource>(ElementTypeId::kTimestamp);
+  }
+
+  void Visit(const container::Container<LocalDate> *) final {
+    VisitHelper<LocalDate, LocalDateContainerColumnSource>(ElementTypeId::kLocalDate);
+  }
+
+  void Visit(const container::Container<LocalTime> *) final {
+    VisitHelper<LocalTime, LocalTimeContainerColumnSource>(ElementTypeId::kLocalTime);
+  }
+
+  template<typename TElement, typename TColumnSource>
+  void VisitHelper(ElementTypeId::Enum element_type_id) {
+    auto typed_container_base = VerboseSharedPtrCast<Container<TElement>>(DEEPHAVEN_LOCATION_EXPR(container_base_));
+
+    result_ = TColumnSource::Create(ElementType::Of(element_type_id),
+      std::move(typed_container_base));
+  }
+
+  std::shared_ptr<ContainerBase> container_base_;
+  std::shared_ptr<ColumnSource> result_;
+};
+}  // namespace
+
+
+std::shared_ptr<ColumnSource>
+CythonSupport::ContainerToColumnSource(std::shared_ptr<ContainerBase> data) {
+  ContainerToColumnSourceVisitor visitor(std::move(data));
+  visitor.container_base_->AcceptVisitor(&visitor);
+  return std::move(visitor.result_);
+}
+
+namespace {
+struct ContainerPrinter final : public ContainerVisitor {
+  explicit ContainerPrinter(std::ostream *output) : output_(output) {}
+
+  void Visit(const Container<char16_t> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<int8_t> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<int16_t> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<int32_t> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<int64_t> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<float> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<double> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<bool> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<std::string> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<DateTime> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<LocalDate> *container) final {
+    VisitHelper(container);
+  }
+
+  void Visit(const Container<LocalTime> *container) final {
+    VisitHelper(container);
+  }
+
+  template<typename T>
+  void VisitHelper(const Container<T> *container) {
+    *output_ << '[';
+    for (size_t i = 0; i != container->size(); ++i) {
+      if (i != 0) {
+        *output_ << ',';
+      }
+      if (container->IsNull(i)) {
+        *output_ << "null";
+      } else {
+        *output_ << (*container)[i];
+      }
+    }
+    *output_ << ']';
+  }
+
+  std::ostream *output_ = nullptr;
+};
+
+struct ColumnSourcePrinter final : public ColumnSourceVisitor {
+  explicit ColumnSourcePrinter(size_t size, std::ostream *output) : size_(size),
+    output_(output) {}
+
+  void Visit(const CharColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const Int8ColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const Int16ColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const Int32ColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const Int64ColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const FloatColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const DoubleColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const BooleanColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const StringColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const DateTimeColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const LocalDateColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const LocalTimeColumnSource &cs) final {
+    VisitHelper(cs);
+  }
+
+  void Visit(const ContainerBaseColumnSource &cs) final {
+    auto rs = RowSequence::CreateSequential(0, size_);
+    auto data = GenericChunk<std::shared_ptr<ContainerBase>>::Create(size_);
+    auto nulls = BooleanChunk::Create(size_);
+    cs.FillChunk(*rs, &data, &nulls);
+    *output_ << '[';
+    for (size_t i = 0; i != size_; ++i) {
+      if (i != 0) {
+        *output_ << ',';
+      }
+      if (nulls[i]) {
+        *output_ << "null";
+      } else {
+        const auto &cb = data[i];
+        ContainerPrinter container_printer(output_);
+        cb->AcceptVisitor(&container_printer);
+      }
+    }
+    *output_ << ']';
+  }
+
+  template<typename TElement>
+  void VisitHelper(const GenericColumnSource<TElement> &cs) {
+    auto rs = RowSequence::CreateSequential(0, size_);
+    auto data = GenericChunk<TElement>::Create(size_);
+    auto nulls = BooleanChunk::Create(size_);
+    cs.FillChunk(*rs, &data, &nulls);
+
+    for (size_t i = 0; i != size_; ++i) {
+      if (i != 0) {
+        *output_ << '\n';
+      }
+      if (nulls[i]) {
+        *output_ << "(null)";
+      } else {
+        *output_ << data[i];
+      }
+    }
+  }
+
+  size_t size_ = 0;
+  std::ostream *output_ = nullptr;
+};
+}
+
+std::string CythonSupport::ColumnSourceToString(const ColumnSource &cs, size_t size) {
+  SimpleOstringstream output;
+  ColumnSourcePrinter visitor(size, &output);
+  cs.AcceptVisitor(&visitor);
+  return std::move(output.str());
 }
 
 namespace {

--- a/cpp-client/deephaven/tests/src/cython_support_test.cc
+++ b/cpp-client/deephaven/tests/src/cython_support_test.cc
@@ -2,21 +2,45 @@
  * Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
  */
 #include <array>
-#include <type_traits>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+#include "deephaven/client/utility/table_maker.h"
 #include "deephaven/dhcore/chunk/chunk.h"
+#include "deephaven/dhcore/column/column_source.h"
 #include "deephaven/dhcore/column/array_column_source.h"
+#include "deephaven/dhcore/container/container.h"
 #include "deephaven/dhcore/container/row_sequence.h"
+#include "deephaven/dhcore/types.h"
 #include "deephaven/dhcore/utility/cython_support.h"
+#include "deephaven/dhcore/utility/utility.h"
 #include "deephaven/third_party/catch.hpp"
+#include "deephaven/third_party/fmt/ostream.h"
+#include "deephaven/third_party/fmt/ranges.h"
 
+using deephaven::dhcore::chunk::BooleanChunk;
+using deephaven::dhcore::chunk::ContainerBaseChunk;
+using deephaven::dhcore::chunk::GenericChunk;
 using deephaven::dhcore::chunk::Int64Chunk;
+using deephaven::dhcore::column::ColumnSource;
+using deephaven::dhcore::column::Int32ArrayColumnSource;
 using deephaven::dhcore::column::StringArrayColumnSource;
+using deephaven::dhcore::container::Container;
+using deephaven::dhcore::container::ContainerBase;
 using deephaven::dhcore::container::RowSequence;
+using deephaven::dhcore::ElementType;
+using deephaven::dhcore::ElementTypeId;
 using deephaven::dhcore::utility::CythonSupport;
+using deephaven::dhcore::utility::MakeReservedVector;
+using deephaven::dhcore::utility::VerboseCast;
 using deephaven::dhcore::chunk::StringChunk;
 
 namespace deephaven::client::tests {
-TEST_CASE("CreateStringColumnsSource", "[cython]") {
+TEST_CASE("CreateStringColumnSource", "[cython]") {
   // hello, NULL, Deephaven, abc
   // We do these as constexpr so our test won't even compile unless we get the basics right
   constexpr const char *kText = "helloDeephavenabc";
@@ -46,5 +70,199 @@ TEST_CASE("CreateStringColumnsSource", "[cython]") {
 
   CHECK(expected_data == actual_data);
   CHECK(expected_nulls == actual_nulls);
+}
+
+namespace {
+template<typename TElement>
+std::pair<std::unique_ptr<TElement[]>, std::unique_ptr<bool[]>> VectorToArrays(
+  std::vector<std::optional<TElement>> vec) {
+  auto elements = std::make_unique<TElement[]>(vec.size());
+  auto null_flags = std::make_unique<bool[]>(vec.size());
+
+  for (size_t i = 0; i != vec.size(); ++i) {
+    auto &elt = vec[i];
+    if (elt.has_value()) {
+      elements[i] = std::move(elt.value());
+      null_flags[i] = false;
+    } else {
+      elements[i] = TElement();
+      null_flags[i] = true;
+    }
+  }
+
+  return std::make_pair(std::move(elements), std::move(null_flags));
+}
+
+template<typename TArrayColumnSource, typename TElement>
+std::shared_ptr<ColumnSource> VectorToColumnSource(const ElementType &element_type,
+  std::vector<std::optional<TElement>> vec) {
+  auto vec_size = vec.size();
+  auto [elements, null_flags] = VectorToArrays(std::move(vec));
+
+  return TArrayColumnSource::CreateFromArrays(element_type, std::move(elements),
+    std::move(null_flags), vec_size);
+}
+
+template<typename TElement>
+std::vector<std::optional<TElement>> ColumnSourceToVector(const ColumnSource &column_source, size_t size) {
+  auto rs = RowSequence::CreateSequential(0, size);
+  auto data = GenericChunk<TElement>::Create(size);
+  auto null_flags = dhcore::chunk::BooleanChunk::Create(size);
+  column_source.FillChunk(*rs, &data, &null_flags);
+
+  auto result = MakeReservedVector<std::optional<TElement>>(size);
+  for (size_t i = 0; i != size; ++i) {
+    if (null_flags[i]) {
+      result.emplace_back();
+    } else {
+      result.emplace_back(std::move(data[i]));
+    }
+  }
+  return result;
+}
+
+template<typename TElement>
+std::vector<std::optional<TElement>> ContainerBaseToVector(const ContainerBase *container_base) {
+  auto result = dhcore::utility::MakeReservedVector<std::optional<TElement>>(container_base->size());
+
+  const auto *typed_container = VerboseCast<const Container<TElement>*>(DEEPHAVEN_LOCATION_EXPR(container_base));
+
+  for (size_t i = 0; i != typed_container->size(); ++i) {
+    if (!typed_container->IsNull(i)) {
+      result.emplace_back((*typed_container)[i]);
+    } else {
+      result.emplace_back();
+    }
+  }
+
+  return result;
+}
+
+template<typename TElement>
+std::vector<std::optional<std::vector<std::optional<TElement>>>>
+ContainerColumnSourceToVector(const ColumnSource &cs, size_t num_slices) {
+  auto chunk_data = ContainerBaseChunk::Create(num_slices);
+  auto chunk_nulls = BooleanChunk::Create(num_slices);
+  auto row_sequence = RowSequence::CreateSequential(0, num_slices);
+  cs.FillChunk(*row_sequence, &chunk_data, &chunk_nulls);
+
+  auto result = dhcore::utility::MakeReservedVector<std::optional<std::vector<std::optional<TElement>>>>(num_slices);
+  for (size_t i = 0; i != num_slices; ++i) {
+    if (chunk_nulls[i]) {
+      result.emplace_back();
+    } else {
+      result.emplace_back(ContainerBaseToVector<TElement>(chunk_data[i].get()));
+    }
+  }
+  return result;
+}
+
+template<typename T>
+void zambonidump(const std::vector<std::optional<T>> &vec) {
+  std::cout << "HATE\n";
+  for (const auto &elt : vec) {
+    if (elt.has_value()) {
+      std::cout << *elt << '\n';
+    } else {
+      std::cout << "NONE\n";
+    }
+  }
+}
+}  // namespace
+
+// Testing the entry point CythonSupport::SlicesToColumnSource
+TEST_CASE("SlicesToColumnSource", "[cython]") {
+  // Input: [a, b, c, d, e, f, null, g]
+  // Lengths: 3, null, 0, 4
+  // Expected output:
+  //   [a, b, c]
+  //   null  # null list
+  //   [] # empty list
+  //   [d, e, null, g]
+
+  std::vector<std::optional<std::string>> elements = {
+    "a", "b", "c", "d", "e", "f", {}, "g"
+  };
+
+  std::vector<std::optional<int32_t>> slice_lengths = {
+    3, {}, 0, 5
+  };
+
+  auto elements_size = elements.size();
+  auto slice_lengths_size = slice_lengths.size();
+
+  auto elements_cs = VectorToColumnSource<StringArrayColumnSource>(
+    ElementType::Of(ElementTypeId::kString), std::move(elements));
+  auto slice_lengths_cs = VectorToColumnSource<Int32ArrayColumnSource>(
+    ElementType::Of(ElementTypeId::kInt32), std::move(slice_lengths));
+
+  auto actual = CythonSupport::SlicesToColumnSource(*elements_cs, elements_size,
+    *slice_lengths_cs, slice_lengths_size);
+
+  auto actual_vector = ContainerColumnSourceToVector<std::string>(*actual, slice_lengths_size);
+
+  std::vector<std::optional<std::vector<std::optional<std::string>>>> expected_vector = {
+    { { "a", "b", "c"} },
+    {},
+    { {} },
+    { {"d", "e", "f", {}, "g" }},
+  };
+
+  CHECK(expected_vector == actual_vector);
+}
+
+// Testing the entry point CythonSupport::ContainerToColumnSource
+TEST_CASE("ContainerToColumnSource", "[cython]") {
+  // Input: [d, e, f, null, g]
+  std::vector<std::optional<std::string>> expected_vector = {
+    "d", "e", "f", {}, "g"
+  };
+
+  auto [data, nulls] = VectorToArrays(expected_vector);
+
+  auto container = Container<std::string>::Create(std::move(data), std::move(nulls),
+    expected_vector.size());
+  auto cs = CythonSupport::ContainerToColumnSource(std::move(container));
+
+  auto actual_vector = ColumnSourceToVector<std::string>(*cs, expected_vector.size());
+
+  CHECK(expected_vector == actual_vector);
+  zambonidump(expected_vector);
+  zambonidump(actual_vector);
+}
+
+// Testing the entry point CythonSupport::ColumnSourceToString
+TEST_CASE("ColumnSourceToString", "[cython]") {
+  // Input: [a, b, c, d, e, f, null, g]
+  // Lengths: 3, null, 0, 4
+  // Expected output:
+  //   [a, b, c]
+  //   null  # null list
+  //   [] # empty list
+  //   [d, e, null, g]
+
+  std::vector<std::optional<std::string>> elements = {
+    "a", "b", "c", "d", "e", "f", {}, "g"
+  };
+
+  std::vector<std::optional<int32_t>> slice_lengths = {
+    3, {}, 0, 5
+  };
+
+  auto elements_size = elements.size();
+  auto slice_lengths_size = slice_lengths.size();
+
+  auto elements_cs = VectorToColumnSource<StringArrayColumnSource>(
+    ElementType::Of(ElementTypeId::kString), std::move(elements));
+  auto slice_lengths_cs = VectorToColumnSource<Int32ArrayColumnSource>(
+    ElementType::Of(ElementTypeId::kInt32), std::move(slice_lengths));
+
+  auto actual_cs = CythonSupport::SlicesToColumnSource(*elements_cs, elements_size,
+    *slice_lengths_cs, slice_lengths_size);
+
+  auto actual_string = CythonSupport::ColumnSourceToString(*actual_cs, slice_lengths_size);
+
+  const char *expected = "[[a,b,c],null,[],[d,e,f,null,g]]";
+  CHECK(expected == actual_string);
 }
 }  // namespace deephaven::client::tests


### PR DESCRIPTION
This PR is dependent on https://github.com/deephaven/deephaven-core/pull/6829 and should not be reviewed until that PR is merged

This PR allows C++ to do some of the "heavy lifting" for working with Arrow nested lists.

Because, broadly speaking, the interface between Python and the `dhcore` library is over `ColumnSource`, this PR adds more methods to `CythonSupport` to work with nested lists.

One of the methods, `SlicesToColumnSource`, takes leaf data like `[a,b,c,d,e,f,null,g]` and length data like `[3,null,0,4]`, both passed in as `ColumnSources`, and creates a new `ColumnSource<ContainerBase>` containing `[[a,b,c],null,[],[e,f,null,g]]`

Another method, `ContainerToColumnSource`, takes a `ContainerBase<T>` and wraps it as a `ColumnSource<T>`. This is useful because the Cython code already knows how to convert ColumnSources into python arrays, so it's useful to have a `ColumnSource` representation of a `Container` so we don't have to write a bunch more Python code.