### PR TITLE
feat(cpp-client): Remove redundant ElementTypeId support from Schema [pyticking 7/7]

### DIFF
--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/clienttable/schema.h
@@ -25,14 +25,6 @@ class Schema {
 
 public:
   /**
-   * Factory method. This exists for backward compatibility and will be removed
-   * when we update our Cython code.
-   */
-  [[nodiscard]]
-  static std::shared_ptr<Schema> Create(std::vector<std::string> names,
-      std::vector<ElementTypeId::Enum> type_ids);
-
-  /**
    * Factory method
    */
   [[nodiscard]]
@@ -42,8 +34,23 @@ public:
    * Constructor.
    */
   Schema(Private, std::vector<std::string> names, std::vector<ElementType> types,
-      std::vector<ElementTypeId::Enum> type_ids, std::map<std::string_view,
-      size_t, std::less<>> index);
+      std::map<std::string_view, size_t, std::less<>> index);
+  /**
+   * Copy constructor (disabled).
+   */
+  Schema(const Schema &other) = delete;
+  /**
+   * Copy assignment operator (disabled).
+   */
+  Schema &operator=(const Schema &other) = delete;
+  /**
+   * Move constructor (disabled).
+   */
+  Schema(Schema &&other) noexcept = delete;
+  /**
+   * Move assignment operator (disabled).
+   */
+  Schema &operator=(Schema &&other) noexcept = delete;
   /**
    * Destructor.
    */
@@ -62,15 +69,6 @@ public:
     return types_;
   }
 
-  /**
-   * Accessor. This exists for backward compatibility and will be removed
-   * when we update our Cython code.
-   */
-  [[nodiscard]]
-  const std::vector<ElementTypeId::Enum> &Types() const {
-    return type_ids_;
-  }
-
   [[nodiscard]]
   int32_t NumCols() const {
     return static_cast<int32_t>(names_.size());
@@ -79,7 +77,6 @@ public:
 private:
   std::vector<std::string> names_;
   std::vector<ElementType> types_;
-  std::vector<ElementTypeId::Enum> type_ids_;
   std::map<std::string_view, size_t, std::less<>> index_;
 };
 }  // namespace deephaven::dhcore::clienttable

--- a/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
+++ b/cpp-client/deephaven/dhcore/include/public/deephaven/dhcore/utility/cython_support.h
@@ -28,11 +28,6 @@ public:
   static std::shared_ptr<ColumnSource> CreateLocalTimeColumnSource(const int64_t *data_begin, const int64_t *data_end,
       const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements);
 
-  /**
-   * For backwards compatibility. Will be removed when Cython is updated.
-   */
-  static ElementTypeId::Enum GetElementTypeId(const ColumnSource &column_source);
-
   static std::shared_ptr<ColumnSource> SlicesToColumnSource(
       const ColumnSource &data, size_t data_size,
       const ColumnSource &lengths, size_t lengths_size);

--- a/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
+++ b/cpp-client/deephaven/dhcore/src/clienttable/schema.cc
@@ -24,11 +24,9 @@ using deephaven::dhcore::utility::MakeReservedVector;
 namespace deephaven::dhcore::clienttable {
 namespace {
 std::map<std::string_view, size_t, std::less<>> ValidateAndMakeIndex(
-    const std::vector<std::string> &names, const std::vector<ElementType> &types,
-    const std::vector<ElementTypeId::Enum> &type_ids) {
-  if (names.size() != types.size() || names.size() != type_ids.size()) {
-    auto message = fmt::format("Sizes differ: {} vs {} vs {}", names.size(), types.size(),
-        type_ids.size());
+    const std::vector<std::string> &names, const std::vector<ElementType> &types) {
+  if (names.size() != types.size()) {
+    auto message = fmt::format("Sizes differ: {} vs {}", names.size(), types.size());
     throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
   }
 
@@ -51,28 +49,15 @@ std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names,
   for (const auto &type : types) {
     type_ids.push_back(type.Id());
   }
-  auto index = ValidateAndMakeIndex(names, types, type_ids);
+  auto index = ValidateAndMakeIndex(names, types);
 
   return std::make_shared<Schema>(Private(), std::move(names), std::move(types),
-      std::move(type_ids), std::move(index));
-}
-
-std::shared_ptr<Schema> Schema::Create(std::vector<std::string> names,
-    std::vector<ElementTypeId::Enum> type_ids) {
-  auto types = MakeReservedVector<ElementType>(type_ids.size());
-  for (auto type_id : type_ids) {
-    types.push_back(ElementType::Of(type_id));
-  }
-  auto index = ValidateAndMakeIndex(names, types, type_ids);
-
-  return std::make_shared<Schema>(Private(), std::move(names), std::move(types),
-      std::move(type_ids), std::move(index));
+    std::move(index));
 }
 
 Schema::Schema(Private, std::vector<std::string> names, std::vector<ElementType> types,
-     std::vector<ElementTypeId::Enum> type_ids, std::map<std::string_view,
-     size_t, std::less<>> index) : names_(std::move(names)),
-     types_(std::move(types)), type_ids_(std::move(type_ids)), index_(std::move(index)) {
+     std::map<std::string_view, size_t, std::less<>> index) : names_(std::move(names)),
+     types_(std::move(types)), index_(std::move(index)) {
 }
 
 Schema::~Schema() = default;

--- a/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
+++ b/cpp-client/deephaven/dhcore/src/utility/cython_support.cc
@@ -141,15 +141,6 @@ CythonSupport::CreateLocalDateColumnSource(const int64_t *data_begin, const int6
       std::move(elements), std::move(nulls), num_elements);
 }
 
-ElementTypeId::Enum CythonSupport::GetElementTypeId(const ColumnSource &column_source) {
-  const auto &element_type = column_source.GetElementType();
-  if (element_type.ListDepth() != 0) {
-    const char *message = "GetElementTypeId does not support non-zero list depth";
-    throw std::runtime_error(DEEPHAVEN_LOCATION_STR(message));
-  }
-  return element_type.Id();
-}
-
 std::shared_ptr<ColumnSource>
 CythonSupport::CreateLocalTimeColumnSource(const int64_t *data_begin, const int64_t *data_end,
     const uint8_t *validity_begin, const uint8_t *validity_end, size_t num_elements) {


### PR DESCRIPTION
This PR is dependent on https://github.com/deephaven/deephaven-core/pull/6831 and should not be reviewed until that PR is merged

This PR removes a backward-compatible accessor in our `Schema` class that is no longer needed now that the Cython code has been updated.

Also I happened to notice that `Schema` had its copy constructors and assignment operators enabled. They should be disabled (a) on general principles and (b) copies won't even work because of the `string_view` trick I'm doing.
