### PR TITLE
feat: Allow downstream applications to contribute, control web resources

### DIFF
--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
@@ -3,7 +3,10 @@
 //
 package io.deephaven.server.jetty11;
 
+import io.deephaven.base.verify.Require;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.server.browserstreaming.BrowserStreamInterceptor;
+import io.deephaven.server.resources.ServerResources;
 import io.deephaven.server.runner.GrpcServer;
 import io.deephaven.ssl.config.CiphersIntermediate;
 import io.deephaven.ssl.config.ProtocolsIntermediate;
@@ -53,6 +56,8 @@ import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.eclipse.jetty.util.MultiException;
 import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceCollection;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.jakarta.common.SessionTracker;
 import org.eclipse.jetty.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
@@ -76,6 +81,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static io.grpc.servlet.web.websocket.MultiplexedWebSocketServerStream.GRPC_WEBSOCKETS_MULTIPLEX_PROTOCOL;
 import static io.grpc.servlet.web.websocket.WebSocketServerStream.GRPC_WEBSOCKETS_PROTOCOL;
@@ -102,12 +108,14 @@ public class JettyBackedGrpcServer implements GrpcServer {
         final ServletContextHandler context =
                 new ServletContextHandler(null, "/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
         try {
-            // Build a URL to a known file on the classpath, so Jetty can load resources from that jar to serve as
-            // static content
-            String knownFile = "/ide/index.html";
-            URL ide = JettyBackedGrpcServer.class.getResource(knownFile);
-            Resource jarContents = Resource.newResource(ide.toExternalForm().replace("!" + knownFile, "!/"));
-            context.setBaseResource(ControlledCacheResource.wrap(jarContents));
+            List<String> urls = ServerResources.resourcesFromServiceLoader(Configuration.getInstance());
+            List<Resource> resources = new ArrayList<>();
+            for (String s : urls) {
+                Resource resource = Resource.newResource(s);
+                Require.neqNull(resource, "newResource(" + s + ")");
+                resources.add(resource);
+            }
+            context.setBaseResource(ControlledCacheResource.wrap(new ResourceCollection(resources)));
         } catch (IOException ioException) {
             throw new UncheckedIOException(ioException);
         }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -3,7 +3,10 @@
 //
 package io.deephaven.server.jetty;
 
+import io.deephaven.base.verify.Require;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.server.browserstreaming.BrowserStreamInterceptor;
+import io.deephaven.server.resources.ServerResources;
 import io.deephaven.server.runner.GrpcServer;
 import io.deephaven.ssl.config.CiphersIntermediate;
 import io.deephaven.ssl.config.ProtocolsIntermediate;
@@ -55,7 +58,9 @@ import org.eclipse.jetty.server.handler.CrossOriginHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.component.Graceful;
+import org.eclipse.jetty.util.resource.CombinedResource;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import javax.inject.Inject;
@@ -100,11 +105,14 @@ public class JettyBackedGrpcServer implements GrpcServer {
 
         final WebAppContext context =
                 new WebAppContext("/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
-        String knownFile = "/ide/index.html";
-        URL ide = JettyBackedGrpcServer.class.getResource(knownFile);
-        Resource jarContents =
-                context.getResourceFactory().newResource(ide.toExternalForm().replace("!" + knownFile, "!/"));
-        context.setBaseResource(ControlledCacheResource.wrap(jarContents));
+
+        List<String> urls = ServerResources.resourcesFromServiceLoader(Configuration.getInstance());
+        Resource resources = ResourceFactory.combine(urls.stream().map(url -> {
+            Resource resource = context.getResourceFactory().newResource(url);
+            Require.neqNull(resource, "newResource(" + url + ")");
+            return resource;
+        }).toList());
+        context.setBaseResource(ControlledCacheResource.wrap(resources));
         context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");
 
         // Cache all of the appropriate assets folders

--- a/server/src/main/java/io/deephaven/server/resources/ServerResource.java
+++ b/server/src/main/java/io/deephaven/server/resources/ServerResource.java
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.resources;
+
+import java.net.URL;
+
+/**
+ * Represents a set of resources that can be provided by the HTTP server. Priority will be controlled by configuration.
+ */
+public abstract class ServerResource {
+
+    /**
+     * Returns the name of the resource to use in configuration.
+     *
+     * @return the name of the resource
+     */
+    public abstract String getName();
+
+    /**
+     * A URL that can be provided to Jetty to serve the resources.
+     *
+     * @return the URL to the resources
+     */
+    public String getResourceBaseUrl() {
+        // Default implementation assumes that the current class is in the same jar as the resources,
+        // and that there exists a META-INF/resources directory in the jar containing the resources.
+        return getResourceFromClasspath("/META-INF/resources", getClass());
+    }
+
+    protected static String getResourceFromClasspath(String resourceName, Class<?> clazz) {
+        URL resource = clazz.getResource(clazz.getSimpleName() + ".class");
+        return resource.toExternalForm().replaceAll("!.*\\.class$", "!" + resourceName);
+    }
+}

--- a/server/src/main/java/io/deephaven/server/resources/ServerResources.java
+++ b/server/src/main/java/io/deephaven/server/resources/ServerResources.java
@@ -16,11 +16,10 @@ import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
 /**
- * Helper to load resources based on configuration. Any resource specified in configuration be give a boolean "enabled"
- * with true to allow the resources to be served and false to have them be excluded, with a default of true. Resources
- * may also specify a positive integer "priority" to determine the order in which they are served, lowest first,
- * allowing higher priority resources to override those with lower priority. Default priority is
- * {@value Integer#MAX_VALUE}.
+ * Helper to load resources based on configuration. Any resource specified in configuration may be give a boolean
+ * "enabled" with true to allow the resources to be served and false to have them be excluded, with a default of true.
+ * Resources may also specify a positive integer "priority" to determine the order in which they are served, lowest
+ * first, allowing more important resources to override others. Default priority is {@value Integer#MAX_VALUE}.
  */
 public class ServerResources {
     private static final Logger log = LoggerFactory.getLogger(ServerResources.class);

--- a/server/src/main/java/io/deephaven/server/resources/ServerResources.java
+++ b/server/src/main/java/io/deephaven/server/resources/ServerResources.java
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.resources;
+
+import io.deephaven.configuration.Configuration;
+import io.deephaven.internal.log.LoggerFactory;
+import io.deephaven.io.logger.Logger;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+/**
+ * Helper to load resources based on configuration. Any resource specified in configuration be give a boolean "enabled"
+ * with true to allow the resources to be served and false to have them be excluded, with a default of true. Resources
+ * may also specify a positive integer "priority" to determine the order in which they are served, lowest first,
+ * allowing higher priority resources to override those with lower priority. Default priority is
+ * {@value Integer#MAX_VALUE}.
+ */
+public class ServerResources {
+    private static final Logger log = LoggerFactory.getLogger(ServerResources.class);
+    private static final String CONFIG_PREFIX = "http.resources.";
+
+    public static List<String> resourcesFromServiceLoader(Configuration configuration) {
+        Properties properties = configuration.getProperties(CONFIG_PREFIX);
+
+        List<ServerResource> resources = ServiceLoader.load(ServerResource.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .collect(Collectors.toList());
+
+        Map<String, Integer> priorities = new HashMap<>();
+        for (ServerResource resource : resources) {
+            Object enabled = properties.get(resource.getName() + ".enabled");
+            if (enabled == null || Boolean.parseBoolean(enabled.toString())) {
+                Object priority = properties.get(resource.getName() + ".priority");
+                if (priority == null) {
+                    priorities.put(resource.getName(), Integer.MAX_VALUE);
+                } else {
+                    priorities.put(resource.getName(), Integer.parseInt(priority.toString()));
+                }
+            }
+        }
+
+        return resources.stream()
+                .filter(res -> priorities.containsKey(res.getName()))
+                .sorted(Comparator.comparing(res -> priorities.get(res.getName())))
+                .peek(resource -> {
+                    log.debug().append("Loading resource: ").append(resource.getName()).append(" with priority: ")
+                            .append(priorities.get(resource.getName())).endl();
+                })
+                .map(ServerResource::getResourceBaseUrl)
+                .collect(Collectors.toList());
+    }
+}

--- a/web/src/main/java/io/deephaven/web/WebResources.java
+++ b/web/src/main/java/io/deephaven/web/WebResources.java
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.web;
+
+import com.google.auto.service.AutoService;
+import io.deephaven.server.resources.ServerResource;
+
+/**
+ * Default resources for the Deephaven web server. Includes the JS API, the web UI, and JS example pages.
+ */
+@AutoService(ServerResource.class)
+public class WebResources extends ServerResource {
+    @Override
+    public String getName() {
+        return "deephaven-core-web";
+    }
+}

--- a/web/web.gradle
+++ b/web/web.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'io.deephaven.project.register'
+    id 'java-library'
 }
 
 configurations {
@@ -9,13 +10,19 @@ configurations {
 dependencies {
     js project(path: ':web-client-ui', configuration: 'js')
     js project(path: ':web-client-api', configuration: 'js')
+
+    api project(':server')
+    compileOnly libs.autoservice
+    annotationProcessor libs.autoservice.compiler
 }
 
 /**
  * Attach the static js/html/css to the main jar so that can be served from jetty
  */
 tasks.named(JavaPlugin.JAR_TASK_NAME, Jar, { jar ->
-    jar.from(configurations.js)
+    jar.from(configurations.js) {
+        into 'META-INF/resources'
+    }
 })
 
 artifacts {


### PR DESCRIPTION
Through configuration, applications can order priority of jars containing web resources, and can disable resources they don't need.

In a future version, we may remove the deephaven-web resource, allowing the JS API and web UI to be independently controlled in this way, and split JS examples into their own artifact as well.

Partial #18996