### PR TITLE
docs: Conventional release notes instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -103,7 +103,7 @@ $ git fetch upstream
 $ git checkout upstream/main
 $ ./gradlew printVersion -PdeephavenBaseQualifier= -q
 $ git checkout -b release/vX.Y.Z
-$ git commit --allow-empty -m "Cut for X.Y.Z"
+$ git commit --allow-empty -m "chore: Cut for X.Y.Z"
 ```
 
 #### Procedure for patch releases
@@ -127,7 +127,7 @@ $ git cherry-pick <...>
 #
 # See https://github.com/deephaven/deephaven-core/issues/3466 for future improvements to this process.
 $ ...
-$ git commit -m "Bump to X.Y.1"
+$ git commit -m "chore: Bump to X.Y.1"
 $ git --no-pager log --oneline vX.Y.0..release/vX.Y.1
 #
 # Compare output to expected PR list for missing or extraneous PRs
@@ -234,6 +234,12 @@ $ git push upstream vX.Y.Z
 Create a new [GitHub release](https://github.com/deephaven/deephaven-core/releases/new) and use the `vX.Y.Z` tag as reference.
 
 The convention is to have the Release title of the form `vX.Y.Z` and to autogenerate the release notes in comparison to the previous release tag. Question: should we always generate release notes based off of the previous minor release, instead of patch? Our git release workflow suggests we may want to do it always minor to minor.
+
+Do not use Github's "Generate release notes" button. Use Cocogitto to generate the release notes and copy the result into the text box.
+
+```shell
+cog changelog vX.Y.0..vX.Y.1
+```
 
 Upload the Deephaven server application, deephaven-core wheel, pydeephaven wheel, pydeephaven-ticking wheels, @deephaven/jsapi-types tarball, and SBOM artifacts. Also, upload the C++, Java, Python, R and TypeScript docs artifacts.
 (These are the artifacts downloaded in Step #5)

--- a/deephaven-changelog
+++ b/deephaven-changelog
@@ -16,9 +16,12 @@
 {% endif %}
 
 {# Now group the rest of the commits and display them -#}
-{% for type, typed_commits in commits | sort(attribute="type")| group_by(attribute="type") -%}
+{% set typed_commit_map = commits | group_by(attribute="type") -%}
+{% set type_order = ["Features", "Bug Fixes", "Performance Improvements", "Miscellaneous Chores", "Documentation", "Refactoring", "Build system", "Style"] -%}
+{% for type in type_order -%}
+{% if typed_commit_map[type] -%}
 #### {{ type | upper_first }}
-{% for scope, scoped_commits in typed_commits | group_by(attribute="scope") -%}
+{% for scope, scoped_commits in typed_commit_map[type] | group_by(attribute="scope") -%}
 
 {% for commit in scoped_commits | sort(attribute="scope") -%}
     {% if commit.author and repository_url -%}
@@ -35,7 +38,7 @@
 
 {% endfor -%}
 
-{% for commit in typed_commits | unscoped -%}
+{% for commit in typed_commit_map[type] | unscoped -%}
     {% if commit.author and repository_url -%}
         {% set author = "@" ~ commit.author -%}
         {% set author_link = platform ~ "/" ~ commit.author -%}
@@ -47,5 +50,5 @@
     {% set shorthand = commit.id | truncate(length=7, end="") -%}
     - {{ commit.summary }} - ([{{shorthand}}]({{ commit_link }})) - {{ author }}
 {% endfor -%}
-
+{% endif %}
 {% endfor -%}


### PR DESCRIPTION
- Added section on generating conventional release notes
- Updated the doc's commits to use conventional prefixes
- Updated `deephaven-changelog` to make Core more like Plugin (e.g. Features just under Breaking Changes)

Jira: https://deephaven.atlassian.net/browse/DH-19361