### PR TITLE
fix: remove anon classes from NameMappingProvider, ResolverProvider

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/NameMappingProvider.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/NameMappingProvider.java
@@ -9,8 +9,6 @@ import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
-
 public interface NameMappingProvider {
 
     /**
@@ -21,12 +19,7 @@ public interface NameMappingProvider {
      * @see <a href="https://iceberg.apache.org/spec/#column-projection">schema.name-mapping.default</a>
      */
     static NameMappingProvider fromTable() {
-        return new NameMappingProviderImpl() {
-            @Override
-            NameMapping create(Table table) {
-                return NameMappingUtil.readNameMappingDefault(table).orElse(NameMapping.empty());
-            }
-        };
+        return NameMappingProviderImpl.FromTable.FROM_TABLE;
     }
 
     /**
@@ -37,13 +30,7 @@ public interface NameMappingProvider {
      * @see MappingUtil
      */
     static NameMappingProvider of(@NotNull final NameMapping nameMapping) {
-        Objects.requireNonNull(nameMapping);
-        return new NameMappingProviderImpl() {
-            @Override
-            NameMapping create(Table table) {
-                return nameMapping;
-            }
-        };
+        return new NameMappingProviderImpl.Explicit(nameMapping);
     }
 
     /**
@@ -55,6 +42,6 @@ public interface NameMappingProvider {
      * @return the empty name mapping
      */
     static NameMappingProvider empty() {
-        return of(NameMapping.empty());
+        return NameMappingProviderImpl.Empty.EMPTY;
     }
 }

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/NameMappingProviderImpl.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/NameMappingProviderImpl.java
@@ -6,7 +6,40 @@ package io.deephaven.iceberg.util;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.mapping.NameMapping;
 
-abstract class NameMappingProviderImpl implements NameMappingProvider {
+import java.util.Objects;
 
-    abstract NameMapping create(Table table);
+interface NameMappingProviderImpl extends NameMappingProvider {
+
+    NameMapping create(Table table);
+
+    enum Empty implements NameMappingProviderImpl {
+        EMPTY;
+
+        @Override
+        public NameMapping create(Table table) {
+            return NameMapping.empty();
+        }
+    }
+
+    enum FromTable implements NameMappingProviderImpl {
+        FROM_TABLE;
+
+        @Override
+        public NameMapping create(Table table) {
+            return NameMappingUtil.readNameMappingDefault(table).orElse(NameMapping.empty());
+        }
+    }
+
+    final class Explicit implements NameMappingProviderImpl {
+        private final NameMapping impl;
+
+        public Explicit(NameMapping impl) {
+            this.impl = Objects.requireNonNull(impl);
+        }
+
+        @Override
+        public NameMapping create(Table table) {
+            return impl;
+        }
+    }
 }

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/ResolverProvider.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/ResolverProvider.java
@@ -3,8 +3,6 @@
 //
 package io.deephaven.iceberg.util;
 
-import org.apache.iceberg.Table;
-
 public interface ResolverProvider {
     /**
      * An explicit resolver provider.
@@ -13,12 +11,7 @@ public interface ResolverProvider {
      * @return the provider for {@code resolver}
      */
     static ResolverProvider of(Resolver resolver) {
-        return new ResolverProviderImpl() {
-            @Override
-            Resolver resolver(Table table) {
-                return resolver;
-            }
-        };
+        return new ResolverProviderImpl.Explicit(resolver);
     }
 
     /**

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/ResolverProviderImpl.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/ResolverProviderImpl.java
@@ -5,7 +5,22 @@ package io.deephaven.iceberg.util;
 
 import org.apache.iceberg.Table;
 
+import java.util.Objects;
+
 abstract class ResolverProviderImpl implements ResolverProvider {
 
     abstract Resolver resolver(Table table) throws TypeInference.UnsupportedType;
+
+    static final class Explicit extends ResolverProviderImpl {
+        private final Resolver resolver;
+
+        public Explicit(Resolver resolver) {
+            this.resolver = Objects.requireNonNull(resolver);
+        }
+
+        @Override
+        Resolver resolver(Table table) throws TypeInference.UnsupportedType {
+            return resolver;
+        }
+    }
 }


### PR DESCRIPTION
This is necessary so that Enterprise can get access to the internal implementations to serialize / deserialize them for the upcoming Iceberg schema extended format.