### PR TITLE
feat: expose IcebergTableAdapter.nameMapping

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTableAdapter.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTableAdapter.java
@@ -110,6 +110,13 @@ public final class IcebergTableAdapter {
     }
 
     /**
+     * The name mapping.
+     */
+    public NameMapping nameMapping() {
+        return nameMapping;
+    }
+
+    /**
      * Get the current {@link Snapshot snapshot} of a given Iceberg table or {@code null} if there are no snapshots.
      *
      * @return The current snapshot of the table or {@code null} if there are no snapshots.

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
@@ -1726,6 +1727,7 @@ public abstract class SqliteCatalogBase {
         final TableIdentifier tableIdentifier = TableIdentifier.parse("MyNamespace.NameMappingTest");
 
         final IcebergTableAdapter tableAdapter = catalogAdapter.createTable(tableIdentifier, definition);
+        assertThat(tableAdapter.nameMapping().asMappedFields()).isEqualTo(MappedFields.of());
 
         // This is emulating a write outside of DH where the field ids are _not_ written
         {
@@ -1777,6 +1779,7 @@ public abstract class SqliteCatalogBase {
                     .resolver(tableAdapter.resolver())
                     .nameMapping(nameMapping)
                     .build());
+            assertThat(ta.nameMapping()).isSameAs(nameMapping);
             assertTableEquals(source, ta.table());
         }
 
@@ -1790,6 +1793,7 @@ public abstract class SqliteCatalogBase {
                     .id(tableIdentifier)
                     .resolver(tableAdapter.resolver())
                     .build());
+            assertThat(ta.nameMapping().asMappedFields()).isEqualTo(nameMapping.asMappedFields());
             assertTableEquals(source, ta.table());
         }
 
@@ -1800,6 +1804,7 @@ public abstract class SqliteCatalogBase {
                     .resolver(tableAdapter.resolver())
                     .nameMapping(NameMappingProvider.empty())
                     .build());
+            assertThat(ta.nameMapping().asMappedFields()).isEqualTo(MappedFields.of());
             try {
                 ta.table().select();
                 failBecauseExceptionWasNotThrown(TableInitializationException.class);
@@ -1818,6 +1823,7 @@ public abstract class SqliteCatalogBase {
                     .resolver(tableAdapter.resolver())
                     .nameMapping(NameMappingProvider.empty())
                     .build());
+            assertThat(ta.nameMapping().asMappedFields()).isEqualTo(MappedFields.of());
             assertTableEquals(empty, ta.table(IGNORE_ERRORS));
         }
     }


### PR DESCRIPTION
This is necessary so that Enterprise can get access to the name mapping results after a IcebergCatalogAdapter loadTable call.