### PR TITLE
feat: Add Iceberg BuildCatalogOptions

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/BuildCatalogOptions.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/BuildCatalogOptions.java
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.iceberg.util;
+
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.immutables.value.Value;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The options to use with {@link IcebergTools#createAdapter(BuildCatalogOptions)}.
+ */
+@Value.Immutable
+public abstract class BuildCatalogOptions {
+
+    public static Builder builder() {
+        return ImmutableBuildCatalogOptions.builder();
+    }
+
+    /**
+     * The catalog name.
+     */
+    public abstract Optional<String> name();
+
+    /**
+     * The catalog properties.
+     */
+    public abstract Map<String, String> properties();
+
+    /**
+     * The Hadoop configuration properties.
+     */
+    public abstract Map<String, String> hadoopConfig();
+
+    public interface Builder {
+
+        Builder name(String name);
+
+        Builder putProperties(String key, String value);
+
+        Builder putAllProperties(Map<String, ? extends String> entries);
+
+        Builder putHadoopConfig(String key, String value);
+
+        Builder putAllHadoopConfig(Map<String, ? extends String> entries);
+
+        BuildCatalogOptions build();
+    }
+
+    @Value.Check
+    final void checkProperties() {
+        // Validate the minimum required properties are set
+        if (!properties().containsKey(CatalogProperties.CATALOG_IMPL)
+                && !properties().containsKey(CatalogUtil.ICEBERG_CATALOG_TYPE)) {
+            throw new IllegalArgumentException(
+                    String.format("Catalog type '%s' or implementation class '%s' is required",
+                            CatalogUtil.ICEBERG_CATALOG_TYPE, CatalogProperties.CATALOG_IMPL));
+        }
+    }
+}

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTools.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTools.java
@@ -93,7 +93,7 @@ public final class IcebergTools {
      * <li>{@code "s3.endpoint"} - the S3 endpoint to connect to.</li>
      * </ul>
      * <p>
-     * Additional properties for the specific catalog should also be included, such as as S3-specific properties for
+     * Additional properties for the specific catalog should also be included, such as S3-specific properties for
      * authentication or endpoint overriding.
      * </p>
      *
@@ -107,27 +107,63 @@ public final class IcebergTools {
             @Nullable final String name,
             @NotNull final Map<String, String> properties,
             @NotNull final Map<String, String> hadoopConfig) {
-        // Validate the minimum required properties are set
-        if (!properties.containsKey(CatalogProperties.CATALOG_IMPL)
-                && !properties.containsKey(CatalogUtil.ICEBERG_CATALOG_TYPE)) {
-            throw new IllegalArgumentException(
-                    String.format("Catalog type '%s' or implementation class '%s' is required",
-                            CatalogUtil.ICEBERG_CATALOG_TYPE, CatalogProperties.CATALOG_IMPL));
+        final BuildCatalogOptions.Builder builder = BuildCatalogOptions.builder()
+                .putAllProperties(properties)
+                .putAllHadoopConfig(hadoopConfig);
+        if (name != null) {
+            builder.name(name);
         }
+        return createAdapter(builder.build());
+    }
 
-        final String catalogUri = properties.get(CatalogProperties.URI);
-        final String catalogName = name != null
-                ? name
+    /**
+     * <p>
+     * Create an Iceberg catalog adapter for an Iceberg catalog created from configuration properties. These properties
+     * map to the Iceberg catalog Java API properties and are used to create the catalog and file IO implementations.
+     * </p>
+     * <p>
+     * The minimal set of properties required to create an Iceberg catalog are:
+     * <ul>
+     * <li>{@value CatalogProperties#CATALOG_IMPL} or {@value CatalogUtil#ICEBERG_CATALOG_TYPE} - the Java catalog
+     * implementation to use. When providing {@value CatalogProperties#CATALOG_IMPL}, the implementing Java class should
+     * be provided (e.g. {@code "org.apache.iceberg.rest.RESTCatalog"} or
+     * {@code "org.apache.iceberg.aws.glue.GlueCatalog")}. Choices for {@value CatalogUtil#ICEBERG_CATALOG_TYPE} include
+     * {@value CatalogUtil#ICEBERG_CATALOG_TYPE_HIVE}, {@value CatalogUtil#ICEBERG_CATALOG_TYPE_HADOOP},
+     * {@value CatalogUtil#ICEBERG_CATALOG_TYPE_REST}, {@value CatalogUtil#ICEBERG_CATALOG_TYPE_GLUE},
+     * {@value CatalogUtil#ICEBERG_CATALOG_TYPE_NESSIE}, {@value CatalogUtil#ICEBERG_CATALOG_TYPE_JDBC}.</li>
+     * </ul>
+     * <p>
+     * Other common properties include:
+     * </p>
+     * <ul>
+     * <li>{@value CatalogProperties#URI} - the URI of the catalog.</li>
+     * <li>{@value CatalogProperties#WAREHOUSE_LOCATION} - the location of the data warehouse.</li>
+     * <li>{@code "client.region"} - the region of the AWS client.</li>
+     * <li>{@code "s3.access-key-id"} - the S3 access key for reading files.</li>
+     * <li>{@code "s3.secret-access-key"} - the S3 secret access key for reading files.</li>
+     * <li>{@code "s3.endpoint"} - the S3 endpoint to connect to.</li>
+     * </ul>
+     * <p>
+     * Additional properties for the specific catalog should also be included, such as S3-specific properties for
+     * authentication or endpoint overriding.
+     * </p>
+     *
+     * @param options the options
+     * @return the Iceberg catalog adapter
+     */
+    public static IcebergCatalogAdapter createAdapter(@NotNull final BuildCatalogOptions options) {
+        final String catalogUri = options.properties().get(CatalogProperties.URI);
+        final String catalogName = options.name().isPresent()
+                ? options.name().get()
                 : "IcebergCatalog" + (catalogUri == null ? "" : "-" + catalogUri);
 
         // Load the Hadoop configuration with the provided properties
         final Configuration hadoopConf = new Configuration();
-        hadoopConfig.forEach(hadoopConf::set);
+        options.hadoopConfig().forEach(hadoopConf::set);
 
         // Create the Iceberg catalog from the properties
-        final Catalog catalog = CatalogUtil.buildIcebergCatalog(catalogName, properties, hadoopConf);
+        final Catalog catalog = CatalogUtil.buildIcebergCatalog(catalogName, options.properties(), hadoopConf);
 
-        return IcebergCatalogAdapter.of(catalog, properties);
+        return IcebergCatalogAdapter.of(catalog, options.properties());
     }
-
 }

--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/InferenceInstructions.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/InferenceInstructions.java
@@ -151,6 +151,19 @@ public abstract class InferenceInstructions {
             return new FieldNameNamer();
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof FieldNameNamerFactory))
+                return false;
+            FieldNameNamerFactory that = (FieldNameNamerFactory) o;
+            return delimiter.equals(that.delimiter);
+        }
+
+        @Override
+        public int hashCode() {
+            return delimiter.hashCode();
+        }
+
         private final class FieldNameNamer implements Namer {
 
             private final Set<String> usedNames = new HashSet<>();

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/util/BuildCatalogOptionsTest.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/util/BuildCatalogOptionsTest.java
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.iceberg.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+class BuildCatalogOptionsTest {
+
+    public static final Map<String, String> MINIMAL_PROPS = Map.of("type", "minimal");
+
+    @Test
+    void minimalOptions() {
+        final BuildCatalogOptions options = BuildCatalogOptions.builder()
+                .putAllProperties(MINIMAL_PROPS)
+                .build();
+        assertThat(options.name()).isEmpty();
+        assertThat(options.properties()).isEqualTo(MINIMAL_PROPS);
+        assertThat(options.hadoopConfig()).isEmpty();
+    }
+
+    @Test
+    void named() {
+        final BuildCatalogOptions options = BuildCatalogOptions.builder()
+                .name("Test")
+                .putAllProperties(MINIMAL_PROPS)
+                .build();
+        assertThat(options.name()).hasValue("Test");
+        assertThat(options.properties()).isEqualTo(MINIMAL_PROPS);
+        assertThat(options.hadoopConfig()).isEmpty();
+    }
+
+    @Test
+    void hadoopConfig() {
+        final BuildCatalogOptions options = BuildCatalogOptions.builder()
+                .putAllProperties(MINIMAL_PROPS)
+                .putHadoopConfig("Foo", "Bar")
+                .build();
+        assertThat(options.name()).isEmpty();
+        assertThat(options.properties()).isEqualTo(MINIMAL_PROPS);
+        assertThat(options.hadoopConfig()).isEqualTo(Map.of("Foo", "Bar"));
+    }
+
+    @Test
+    void missingType() {
+        try {
+            BuildCatalogOptions.builder().build();
+            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+        } catch (IllegalArgumentException e) {
+            assertThat(e)
+                    .hasMessageContaining("Catalog type 'type' or implementation class 'catalog-impl' is required");
+        }
+    }
+}

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/util/LoadTableOptionsTest.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/util/LoadTableOptionsTest.java
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.iceberg.util;
+
+import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.TableDefinition;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoadTableOptionsTest {
+
+    private static final TableIdentifier FOO_BAR = TableIdentifier.of("Foo", "Bar");
+
+    @Test
+    void basic() {
+        final LoadTableOptions options = LoadTableOptions.builder().id(FOO_BAR).build();
+        assertThat(options.id()).isEqualTo(FOO_BAR);
+        assertThat(options.resolver()).isEqualTo(ResolverProvider.infer());
+        assertThat(options.nameMapping()).isEqualTo(NameMappingProvider.fromTable());
+    }
+
+    @Test
+    void custom() {
+        final UnboundResolver resolver = UnboundResolver.builder()
+                .definition(TableDefinition.of(ColumnDefinition.ofInt("Foo")))
+                .build();
+        final LoadTableOptions options = LoadTableOptions.builder()
+                .id(FOO_BAR)
+                .resolver(resolver)
+                .nameMapping(NameMappingProvider.empty())
+                .build();
+        assertThat(options.id()).isEqualTo(FOO_BAR);
+        assertThat(options.resolver()).isEqualTo(resolver);
+        assertThat(options.nameMapping()).isEqualTo(NameMappingProvider.empty());
+    }
+
+    @Test
+    void idString() {
+        assertThat(LoadTableOptions.builder().id("Foo.Bar").build())
+                .isEqualTo(LoadTableOptions.builder().id(FOO_BAR).build());
+    }
+}


### PR DESCRIPTION
This is to a convenience so Enterprise can depend on a Core object for building a catalog, in much the same way that it can currently depend on LoadTableOptions.