### PR TITLE
chore: bump guava to 33.4.8

### DIFF
--- a/Util/channel/build.gradle
+++ b/Util/channel/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     // For CountingInputStream
     implementation libs.guava
 
+    compileOnly libs.google.findbugs.jsr305
+
     compileOnly libs.jetbrains.annotations
 
     testImplementation libs.assertj

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ColumnDescriptorUtil.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ColumnDescriptorUtil.java
@@ -5,8 +5,7 @@ package io.deephaven.parquet.impl;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public final class ColumnDescriptorUtil {
     /**

--- a/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DecompressorHolder.java
+++ b/extensions/parquet/compression/src/main/java/io/deephaven/parquet/compress/DecompressorHolder.java
@@ -8,8 +8,7 @@ import org.apache.hadoop.io.compress.CodecPool;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class DecompressorHolder implements SafeCloseable {
     private CompressionCodecName codecName;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ graalvm = "24.2.1"
 groovy = "3.0.24"
 # Only bump this in concert with boringssl
 grpc = "1.65.1"
-guava = "33.4.0-jre"
+guava = "33.4.8-jre"
 gwt = "2.12.2"
 # used by GwtTools
 gwtJetty = "9.4.44.v20210927"


### PR DESCRIPTION
Guava is migrating to https://jspecify.dev/ for their nullness annotations. As part of this, they have removed their dependency on JSR-305. There are a couple of places where we have incorrectly depended on it. These have been fixed up with the proper jetbrains annotations.

https://github.com/google/guava/releases/tag/v33.4.3
> removes our dependency on JSR-305

There is at least one annotation that JSR-305 provides (`javax.annotation.OverridingMethodsMustInvokeSuper`) that we use that jetbrains doesn't, and so I've added that as an explicit dependency.