### PR TITLE
fix: DH-19523: Respect Future API by Respecting thenApply May Run on Another Thread

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractFormulaColumn.java
@@ -258,8 +258,10 @@ public abstract class AbstractFormulaColumn implements FormulaColumn {
             QueryScopeParam<?>... params) {
         final FormulaFactory formulaFactory;
         try {
-            // the future must already be completed or else it is an error
-            formulaFactory = formulaFactoryFuture.get(0, TimeUnit.SECONDS);
+            // The future's root-parent is definitely complete via the QueryCompilerRequestProcessor. However, we
+            // might need to wait for follow on thenApply mappers to complete. We expect this to be very fast, so we
+            // use a 1-minute timeout to avoid blocking indefinitely.
+            formulaFactory = formulaFactoryFuture.get(1, TimeUnit.MINUTES);
         } catch (InterruptedException | TimeoutException e) {
             throw new IllegalStateException("Formula factory not already compiled!", e);
         } catch (ExecutionException e) {


### PR DESCRIPTION
We were seeing in CI some rare cases where these `thenApply` futures were not already complete. It was possible to increase the probability invoking an agg_by on a partition table with many partitions. I could have likely reproduced with a transform that invoked select/update/view/updateView; but not the top level select/update/view/updateView (since we compile them once for all partitions).

The query compiler's `#compile` has a final stage that resolves the compilation task futures for this thread by any futures that were cached or compiled simultaneously on another thread. This is `resolvers[ii].complete(allFutures[ii].get());`. We discovered that the `Future#get` might invoke the `postComplete` code path and perform `thenApply` subtasks on a thread that was waiting on the cached but not-yet-finished compilation task future.

The fix is to respect that `thenApply` may run on another thread and may indeed not actually be completed yet.