### PR TITLE
feat: DH-19475 predicate pushdown - parquet dictionary support

### DIFF
--- a/Util/src/main/java/io/deephaven/util/type/ArrayTypeUtils.java
+++ b/Util/src/main/java/io/deephaven/util/type/ArrayTypeUtils.java
@@ -97,6 +97,12 @@ public class ArrayTypeUtils {
         return result;
     }
 
+    public static Object[] objectNullArray(int size) {
+        Object[] result = new Object[size];
+        Arrays.fill(result, null);
+        return result;
+    }
+
     public static Character[] getBoxedArray(char[] referenceData) {
         Character[] result = new Character[referenceData.length];
         for (int i = 0; i < result.length; i++) {

--- a/engine/chunk/src/main/java/io/deephaven/chunk/BooleanChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/BooleanChunk.java
@@ -30,10 +30,16 @@ public class BooleanChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final BooleanChunk EMPTY = new BooleanChunk<>(ArrayTypeUtils.EMPTY_BOOLEAN_ARRAY, 0, 0);
 
+    // region NULL_definition
+    // endregion NULL_definition
+
     public static <ATTR extends Any> BooleanChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final BooleanChunk[] EMPTY_BOOLEAN_CHUNK_ARRAY = new BooleanChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ByteChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ByteChunk.java
@@ -34,10 +34,22 @@ public class ByteChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final ByteChunk EMPTY = new ByteChunk<>(ArrayTypeUtils.EMPTY_BYTE_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final ByteChunk NULL = new ByteChunk<>(ArrayTypeUtils.byteNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <ATTR extends Any> ByteChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <ATTR extends Any> ByteChunk<ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final ByteChunk[] EMPTY_BYTE_CHUNK_ARRAY = new ByteChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/CharChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/CharChunk.java
@@ -29,10 +29,22 @@ public class CharChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final CharChunk EMPTY = new CharChunk<>(ArrayTypeUtils.EMPTY_CHAR_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final CharChunk NULL = new CharChunk<>(ArrayTypeUtils.charNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <ATTR extends Any> CharChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <ATTR extends Any> CharChunk<ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final CharChunk[] EMPTY_CHAR_CHUNK_ARRAY = new CharChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ChunkType.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ChunkType.java
@@ -61,6 +61,12 @@ public enum ChunkType implements ChunkFactory {
 
     @NotNull
     @Override
+    public <ATTR extends Any> Chunk<ATTR> getNullChunk() {
+        return factory.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public <ATTR extends Any> ChunkChunk<ATTR> getEmptyChunkChunk() {
         return factory.getEmptyChunkChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/DoubleChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/DoubleChunk.java
@@ -33,10 +33,22 @@ public class DoubleChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final DoubleChunk EMPTY = new DoubleChunk<>(ArrayTypeUtils.EMPTY_DOUBLE_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final DoubleChunk NULL = new DoubleChunk<>(ArrayTypeUtils.doubleNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <ATTR extends Any> DoubleChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <ATTR extends Any> DoubleChunk<ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final DoubleChunk[] EMPTY_DOUBLE_CHUNK_ARRAY = new DoubleChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/FloatChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/FloatChunk.java
@@ -33,10 +33,22 @@ public class FloatChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final FloatChunk EMPTY = new FloatChunk<>(ArrayTypeUtils.EMPTY_FLOAT_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final FloatChunk NULL = new FloatChunk<>(ArrayTypeUtils.floatNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <ATTR extends Any> FloatChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <ATTR extends Any> FloatChunk<ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final FloatChunk[] EMPTY_FLOAT_CHUNK_ARRAY = new FloatChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/IntChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/IntChunk.java
@@ -33,10 +33,22 @@ public class IntChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final IntChunk EMPTY = new IntChunk<>(ArrayTypeUtils.EMPTY_INT_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final IntChunk NULL = new IntChunk<>(ArrayTypeUtils.intNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <ATTR extends Any> IntChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <ATTR extends Any> IntChunk<ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final IntChunk[] EMPTY_INT_CHUNK_ARRAY = new IntChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/LongChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/LongChunk.java
@@ -33,10 +33,22 @@ public class LongChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final LongChunk EMPTY = new LongChunk<>(ArrayTypeUtils.EMPTY_LONG_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final LongChunk NULL = new LongChunk<>(ArrayTypeUtils.longNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <ATTR extends Any> LongChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <ATTR extends Any> LongChunk<ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final LongChunk[] EMPTY_LONG_CHUNK_ARRAY = new LongChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ObjectChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ObjectChunk.java
@@ -31,10 +31,22 @@ public class ObjectChunk<T, ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final ObjectChunk EMPTY = new ObjectChunk<>(ArrayTypeUtils.EMPTY_OBJECT_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final ObjectChunk NULL = new ObjectChunk<>(ArrayTypeUtils.objectNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <T, ATTR extends Any> ObjectChunk<T, ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <T, ATTR extends Any> ObjectChunk<T, ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final ObjectChunk[] EMPTY_OBJECT_CHUNK_ARRAY = new ObjectChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/ShortChunk.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/ShortChunk.java
@@ -33,10 +33,22 @@ public class ShortChunk<ATTR extends Any> extends ChunkBase<ATTR> {
     @SuppressWarnings("rawtypes")
     private static final ShortChunk EMPTY = new ShortChunk<>(ArrayTypeUtils.EMPTY_SHORT_ARRAY, 0, 0);
 
+    // region NULL_definition
+    @SuppressWarnings("rawtypes")
+    private static final ShortChunk NULL = new ShortChunk<>(ArrayTypeUtils.shortNullArray(1), 0, 1);
+    // endregion NULL_definition
+
     public static <ATTR extends Any> ShortChunk<ATTR> getEmptyChunk() {
         // noinspection unchecked
         return EMPTY;
     }
+
+    // region getNullChunk
+    public static <ATTR extends Any> ShortChunk<ATTR> getNullChunk() {
+        // noinspection unchecked
+        return NULL;
+    }
+    // endregion getNullChunk
 
     @SuppressWarnings("rawtypes")
     private static final ShortChunk[] EMPTY_SHORT_CHUNK_ARRAY = new ShortChunk[0];

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/BooleanChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/BooleanChunkFactory.java
@@ -34,6 +34,12 @@ public class BooleanChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> BooleanChunk<ATTR> getNullChunk() {
+        throw new UnsupportedOperationException("BooleanChunk does not support null values");
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> BooleanChunkChunk<ATTR> getEmptyChunkChunk() {
         return BooleanChunkChunk.getEmptyChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ByteChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ByteChunkFactory.java
@@ -34,6 +34,12 @@ public class ByteChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> ByteChunk<ATTR> getNullChunk() {
+        return ByteChunk.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> ByteChunkChunk<ATTR> getEmptyChunkChunk() {
         return ByteChunkChunk.getEmptyChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/CharChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/CharChunkFactory.java
@@ -30,6 +30,12 @@ public class CharChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> CharChunk<ATTR> getNullChunk() {
+        return CharChunk.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> CharChunkChunk<ATTR> getEmptyChunkChunk() {
         return CharChunkChunk.getEmptyChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ChunkFactory.java
@@ -20,6 +20,9 @@ public interface ChunkFactory {
     <ATTR extends Any> Chunk<ATTR> getEmptyChunk();
 
     @NotNull
+    <ATTR extends Any> Chunk<ATTR> getNullChunk();
+
+    @NotNull
     <ATTR extends Any> ChunkChunk<ATTR> getEmptyChunkChunk();
 
     @NotNull

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/DoubleChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/DoubleChunkFactory.java
@@ -34,6 +34,12 @@ public class DoubleChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> DoubleChunk<ATTR> getNullChunk() {
+        return DoubleChunk.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> DoubleChunkChunk<ATTR> getEmptyChunkChunk() {
         return DoubleChunkChunk.getEmptyChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/FloatChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/FloatChunkFactory.java
@@ -34,6 +34,12 @@ public class FloatChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> FloatChunk<ATTR> getNullChunk() {
+        return FloatChunk.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> FloatChunkChunk<ATTR> getEmptyChunkChunk() {
         return FloatChunkChunk.getEmptyChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/IntChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/IntChunkFactory.java
@@ -34,6 +34,12 @@ public class IntChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> IntChunk<ATTR> getNullChunk() {
+        return IntChunk.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> IntChunkChunk<ATTR> getEmptyChunkChunk() {
         return IntChunkChunk.getEmptyChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/LongChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/LongChunkFactory.java
@@ -34,6 +34,12 @@ public class LongChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> LongChunk<ATTR> getNullChunk() {
+        return LongChunk.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> LongChunkChunk<ATTR> getEmptyChunkChunk() {
         return LongChunkChunk.getEmptyChunk();
     }

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ObjectChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ObjectChunkFactory.java
@@ -6,6 +6,7 @@ package io.deephaven.chunk.util.factories;
 import io.deephaven.chunk.*;
 import io.deephaven.chunk.attributes.Any;
 
+import io.deephaven.util.type.ArrayTypeUtils;
 import org.jetbrains.annotations.NotNull;
 import java.util.function.IntFunction;
 
@@ -26,6 +27,13 @@ public final class ObjectChunkFactory<T> implements ChunkFactory {
     @Override
     public final <ATTR extends Any> ObjectChunk<T, ATTR> getEmptyChunk() {
         return ObjectChunk.getEmptyChunk();
+    }
+
+    @NotNull
+    @Override
+    public final <ATTR extends Any> ObjectChunk<T, ATTR> getNullChunk() {
+        // noinspection unchecked
+        return (ObjectChunk<T, ATTR>) ObjectChunk.chunkWrap(ArrayTypeUtils.objectNullArray(1), 0, 1);
     }
 
     @NotNull

--- a/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ShortChunkFactory.java
+++ b/engine/chunk/src/main/java/io/deephaven/chunk/util/factories/ShortChunkFactory.java
@@ -34,6 +34,12 @@ public class ShortChunkFactory implements ChunkFactory {
 
     @NotNull
     @Override
+    public final <ATTR extends Any> ShortChunk<ATTR> getNullChunk() {
+        return ShortChunk.getNullChunk();
+    }
+
+    @NotNull
+    @Override
     public final <ATTR extends Any> ShortChunkChunk<ATTR> getEmptyChunkChunk() {
         return ShortChunkChunk.getEmptyChunk();
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
@@ -43,7 +43,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 import java.util.function.Consumer;
 
 public abstract class AbstractColumnSource<T> implements
@@ -365,7 +365,6 @@ public abstract class AbstractColumnSource<T> implements
     @Override
     public void pushdownFilter(
             final WhereFilter filter,
-            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,
@@ -379,13 +378,9 @@ public abstract class AbstractColumnSource<T> implements
     }
 
     @Override
-    public Map<String, String> renameMap(final WhereFilter filter, final ColumnSource<?>[] filterSources) {
-        // Default to returning an empty map
-        return Map.of();
-    }
-
-    @Override
-    public PushdownFilterContext makePushdownFilterContext() {
+    public PushdownFilterContext makePushdownFilterContext(
+            final WhereFilter filter,
+            final List<ColumnSource<?>> filterSources) {
         return PushdownFilterContext.NO_PUSHDOWN_CONTEXT;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
@@ -414,6 +414,10 @@ abstract class AbstractFilterExecution {
 
         final RowSet input = localInput.getValue();
         if (sf.pushdownMatcher != null && sf.pushdownFilterCost < Long.MAX_VALUE) {
+            // TODO: we could take advantage of previous pushdown operations on this filter to restrict the input
+            // to the rows that were not matched by the previous pushdown operations. Just like we do with the final
+            // filter. This would allow better chaining of successive pushdown operations on the same filter.
+
             // Execute the pushdown filter and return.
             sf.pushdownMatcher.pushdownFilter(sf.filter, input, sourceTable.getRowSet(), usePrev, sf.context,
                     costCeiling, jobScheduler(), onPushdownComplete, filterNec);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -211,10 +210,6 @@ abstract class AbstractFilterExecution {
          */
         public final WhereFilter filter;
         /**
-         * Map of filter column names to underlying column names.
-         */
-        public final Map<String, String> renameMap;
-        /**
          * The executor to use for pushdown filtering, or null if pushdown is not supported.
          */
         public final PushdownFilterMatcher pushdownMatcher;
@@ -234,14 +229,12 @@ abstract class AbstractFilterExecution {
         public StatelessFilter(
                 final int filterIdx,
                 final WhereFilter filter,
-                final Map<String, String> renameMap,
                 final PushdownFilterMatcher pushdownMatcher,
                 final PushdownFilterContext context) {
             Require.eqTrue((pushdownMatcher == null) == (context == null),
                     "pushdownExecutor and context must be both null or both non-null");
             this.filterIdx = filterIdx;
             this.filter = filter;
-            this.renameMap = renameMap;
             this.pushdownMatcher = pushdownMatcher;
             this.context = context;
         }
@@ -422,8 +415,8 @@ abstract class AbstractFilterExecution {
         final RowSet input = localInput.getValue();
         if (sf.pushdownMatcher != null && sf.pushdownFilterCost < Long.MAX_VALUE) {
             // Execute the pushdown filter and return.
-            sf.pushdownMatcher.pushdownFilter(sf.filter, sf.renameMap, input, sourceTable.getRowSet(), usePrev,
-                    sf.context, costCeiling, jobScheduler(), onPushdownComplete, filterNec);
+            sf.pushdownMatcher.pushdownFilter(sf.filter, input, sourceTable.getRowSet(), usePrev, sf.context,
+                    costCeiling, jobScheduler(), onPushdownComplete, filterNec);
             return;
         }
 
@@ -475,15 +468,13 @@ abstract class AbstractFilterExecution {
             } else {
                 executor = null;
             }
-            // Create a rename map.
-            final ColumnSource<?>[] filterSources = filter.getColumns().stream()
+            final List<ColumnSource<?>> filterSources = filter.getColumns().stream()
                     .map(sourceTable::getColumnSource)
-                    .toArray(ColumnSource[]::new);
-            final Map<String, String> renameMap =
-                    executor != null ? executor.renameMap(filter, filterSources) : Map.of();
-
-            statelessFilters[ii] = new StatelessFilter(ii, filter, renameMap, executor,
-                    executor != null ? executor.makePushdownFilterContext() : null);
+                    .collect(Collectors.toList());
+            final PushdownFilterContext context = executor != null
+                    ? executor.makePushdownFilterContext(filter, filterSources)
+                    : null;
+            statelessFilters[ii] = new StatelessFilter(ii, filter, executor, context);
         }
 
         // Sort the filters by cost, with the lowest cost first.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BasePushdownFilterContext.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BasePushdownFilterContext.java
@@ -3,14 +3,197 @@
 //
 package io.deephaven.engine.table.impl;
 
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.LongChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.impl.chunkfilter.ChunkFilter;
+import io.deephaven.engine.table.impl.select.*;
+import io.deephaven.engine.table.impl.sources.NullValueColumnSource;
+import io.deephaven.util.SafeCloseable;
+import io.deephaven.util.SafeCloseableList;
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
+
+import java.util.List;
+import java.util.Map;
+
 /**
  * Base class for {@link PushdownFilterContext} to help with execution cost tracking.
  */
 public class BasePushdownFilterContext implements PushdownFilterContext {
-    protected long executedFilterCost;
+    private final WhereFilter filter;
+    private final List<ColumnSource<?>> columnSources;
 
-    public BasePushdownFilterContext() {
+    private final boolean isRangeFilter;
+    private final boolean isMatchFilter;
+    private final boolean supportsChunkFilter;
+    private final Boolean filterIncludesNulls;
+
+    protected final SafeCloseableList closeList = new SafeCloseableList();
+
+    private long executedFilterCost;
+
+    private volatile QueryTable dummyTable = null;
+
+    /**
+     * Interface for a unified chunk filter that can be used to apply a filter to a chunk of data, whether the
+     * underlying filter is a {@link ExposesChunkFilter} or a {@link ConditionFilter}.
+     */
+    public interface UnifiedChunkFilter extends SafeCloseable {
+        LongChunk<OrderedRowKeys> filter(Chunk<? extends Values> values, LongChunk<OrderedRowKeys> keys);
+    }
+
+    public BasePushdownFilterContext(final WhereFilter filter, final List<ColumnSource<?>> columnSources) {
+        this.filter = filter;
+        this.columnSources = columnSources;
+
         executedFilterCost = 0;
+
+        // Compute useful properties of the filter
+        isRangeFilter = filter instanceof RangeFilter
+                && ((RangeFilter) filter).getRealFilter() instanceof AbstractRangeFilter;
+        isMatchFilter = filter instanceof MatchFilter;
+        if (columnSources.size() == 1) {
+            supportsChunkFilter =
+                    (filter instanceof ExposesChunkFilter && ((ExposesChunkFilter) filter).chunkFilter().isPresent())
+                            || filter instanceof ConditionFilter;
+            if (supportsChunkFilter) {
+                // Run the filter over a chunk containing only null values and check if nulls pass the filter.
+                final ChunkType chunkType = columnSources.get(0).getChunkType();
+                if (chunkType == ChunkType.Boolean) {
+                    // BooleanChunk does not support nulls, so we can skip this check.
+                    filterIncludesNulls = false;
+                } else {
+                    final Chunk<? extends Values> nullChunk = chunkType.getNullChunk();
+                    try (final UnifiedChunkFilter unifiedChunkFilter = createChunkFilter(1);
+                            final WritableLongChunk<OrderedRowKeys> nullChunkKeys =
+                                    WritableLongChunk.makeWritableChunk(1)) {
+                        nullChunkKeys.set(0, 0);
+                        final LongChunk<OrderedRowKeys> matchingKeys =
+                                unifiedChunkFilter.filter(nullChunk, nullChunkKeys);
+                        filterIncludesNulls = matchingKeys.size() > 0;
+                    }
+                }
+            } else {
+                // If we don't support chunk filtering, we can't easily determine if filter includes nulls.
+                filterIncludesNulls = null;
+            }
+        } else {
+            supportsChunkFilter = false;
+            filterIncludesNulls = null; // Unknown for multi-column filters
+        }
+    }
+
+    /**
+     * Get the column sources this filter will use.
+     */
+    public List<ColumnSource<?>> columnSources() {
+        return columnSources;
+    }
+
+    /**
+     * Whether this is a simple range filter, not implemented by a ConditionFilter.
+     */
+    public boolean isRangeFilter() {
+        return isRangeFilter;
+    }
+
+    /**
+     * Whether this is a MatchFilter.
+     */
+    public boolean isMatchFilter() {
+        return isMatchFilter;
+    }
+
+    /**
+     * Whether this filter supports direct chunk filtering, i.e. it can be applied to a chunk of data rather than a
+     * table. This includes any filter that implements {#@link ExposesChunkFilter} or
+     * {@link io.deephaven.engine.table.impl.select.ConditionFilter} with exactly one column.
+     */
+    public boolean supportsChunkFilter() {
+        return supportsChunkFilter;
+    }
+
+    /**
+     * Whether this filter includes nulls in its results. Using boxed Boolean to allow tri-state where {@code null}
+     * implies "unknown".
+     */
+    public Boolean filterIncludesNulls() {
+        return filterIncludesNulls;
+    }
+
+    /**
+     * Create a {@link UnifiedChunkFilter} for this filter that efficiently filters chunks of data. Every thread that
+     * uses this filter should create its own instance of the filter and must close it after use.
+     *
+     * @param maxChunkSize the maximum size of the chunk that will be filtered
+     * @return the initialized {@link UnifiedChunkFilter}
+     */
+    public final UnifiedChunkFilter createChunkFilter(int maxChunkSize) {
+        if (!supportsChunkFilter) {
+            return null;
+        }
+        final UnifiedChunkFilter unifiedChunkFilter;
+        if (filter instanceof ExposesChunkFilter) {
+            final WritableLongChunk<OrderedRowKeys> resultChunk = WritableLongChunk.makeWritableChunk(maxChunkSize);
+            final ChunkFilter chunkFilter = ((ExposesChunkFilter) filter).chunkFilter()
+                    .orElseThrow(() -> new IllegalStateException("ExposesChunkFilter#chunkFilter() returned null."));
+            unifiedChunkFilter = new UnifiedChunkFilter() {
+                @Override
+                public LongChunk<OrderedRowKeys> filter(Chunk<? extends Values> values,
+                        LongChunk<OrderedRowKeys> keys) {
+                    chunkFilter.filter(values, keys, resultChunk);
+                    return resultChunk;
+                }
+
+                @Override
+                public void close() {
+                    resultChunk.close();
+                }
+            };
+        } else {
+            // Create and store a dummy table to use for initializing the ConditionFilter.
+            if (dummyTable == null) {
+                synchronized (this) {
+                    if (dummyTable == null) {
+                        final Map<String, ColumnSource<?>> columnSourceMap = Map.of(filter.getColumns().get(0),
+                                NullValueColumnSource.getInstance(
+                                        columnSources.get(0).getType(),
+                                        columnSources.get(0).getComponentType()));
+                        dummyTable = new QueryTable(RowSetFactory.empty().toTracking(), columnSourceMap);
+                    }
+                }
+            }
+            try {
+                final ConditionFilter conditionFilter = (ConditionFilter) filter;
+                final AbstractConditionFilter.Filter acfFilter =
+                        conditionFilter.getFilter(dummyTable, dummyTable.getRowSet());
+                final ConditionFilter.FilterKernel.Context conditionFilterContext = acfFilter.getContext(maxChunkSize);
+
+                unifiedChunkFilter = new UnifiedChunkFilter() {
+                    @Override
+                    public LongChunk<OrderedRowKeys> filter(Chunk<? extends Values> values,
+                            LongChunk<OrderedRowKeys> keys) {
+                        // noinspection unchecked
+                        return (LongChunk<OrderedRowKeys>) acfFilter.filter(conditionFilterContext, keys,
+                                new Chunk[] {values});
+                    }
+
+                    @Override
+                    public void close() {
+                        conditionFilterContext.close();
+                    }
+                };
+
+            } catch (final Exception e) {
+                throw new IllegalArgumentException("Error creating condition filter in BasePushdownFilterContext", e);
+            }
+        }
+        return unifiedChunkFilter;
     }
 
     @Override
@@ -23,8 +206,10 @@ public class BasePushdownFilterContext implements PushdownFilterContext {
         this.executedFilterCost = executedFilterCost;
     }
 
+    @MustBeInvokedByOverriders
     @Override
     public void close() {
-        // No-op
+        closeList.close();
+        dummyTable = null;
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownFilterMatcher.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownFilterMatcher.java
@@ -9,7 +9,7 @@ import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.impl.select.WhereFilter;
 import io.deephaven.engine.table.impl.util.JobScheduler;
 
-import java.util.Map;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -49,7 +49,6 @@ public interface PushdownFilterMatcher {
      * less than or equal to {@code costCeiling}.
      *
      * @param filter The {@link Filter filter} to apply.
-     * @param renameMap Map of filter column names to underlying column names.
      * @param selection The set of rows to test.
      * @param fullSet The full set of rows
      * @param usePrev Whether to use the previous result
@@ -61,7 +60,6 @@ public interface PushdownFilterMatcher {
      */
     void pushdownFilter(
             final WhereFilter filter,
-            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,
@@ -72,18 +70,14 @@ public interface PushdownFilterMatcher {
             final Consumer<Exception> onError);
 
     /**
-     * Create a map of filter column names to underlying column names using the provided filter and filter sources.
-     *
-     * @param filter the filter to use for the rename map
-     * @param filterSources the column sources that match the filter column names
-     * @return a map of filter column names to underlying column names
-     */
-    Map<String, String> renameMap(final WhereFilter filter, final ColumnSource<?>[] filterSources);
-
-    /**
      * Create a pushdown filter context for this entity.
+     *
+     * @param filter the filter to use while making the context
+     * @param filterSources the column sources that match the filter column names
      *
      * @return the created filter context
      */
-    PushdownFilterContext makePushdownFilterContext();
+    PushdownFilterContext makePushdownFilterContext(
+            final WhereFilter filter,
+            final List<ColumnSource<?>> filterSources);
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownResult.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownResult.java
@@ -16,6 +16,7 @@ public class PushdownResult implements SafeCloseable {
     public static long METADATA_STATS_COST = 10_000L;
     public static long BLOOM_FILTER_COST = 20_000L;
     public static long IN_MEMORY_DATA_INDEX_COST = 30_000L;
+    public static long DICTIONARY_DATA_COST = 35_000L;
     public static long SORTED_DATA_COST = 40_000L;
     public static long DEFERRED_DATA_INDEX_COST = 50_000L;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -270,6 +270,13 @@ public class QueryTable extends BaseTable<QueryTable> {
             Configuration.getInstance().getBooleanWithDefault("QueryTable.disableWherePushdownDataIndex", false);
 
     /**
+     * Disable the usage of parquet row group dictionaries during push-down filtering.
+     */
+    public static boolean DISABLE_WHERE_PUSHDOWN_PARQUET_DICTIONARY =
+            Configuration.getInstance().getBooleanWithDefault("QueryTable.disableWherePushdownParquetDictionary",
+                    false);
+
+    /**
      * You can choose to enable or disable the column parallel select and update.
      */
     static boolean ENABLE_PARALLEL_SELECT_AND_UPDATE =

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocation.java
@@ -4,18 +4,20 @@
 package io.deephaven.engine.table.impl.locations.impl;
 
 import io.deephaven.base.verify.Require;
-import io.deephaven.engine.liveness.*;
+import io.deephaven.engine.liveness.DelegatingLivenessReferent;
+import io.deephaven.engine.liveness.LivenessReferent;
+import io.deephaven.engine.liveness.ReferenceCountedLivenessReferent;
+import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.BasicDataIndex;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.impl.PushdownFilterContext;
 import io.deephaven.engine.table.impl.PushdownResult;
+import io.deephaven.engine.table.impl.locations.*;
 import io.deephaven.engine.table.impl.select.WhereFilter;
 import io.deephaven.engine.table.impl.util.FieldUtils;
 import io.deephaven.engine.table.impl.util.JobScheduler;
 import io.deephaven.engine.util.string.StringUtils;
-import io.deephaven.engine.table.impl.locations.*;
-import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.hash.KeyedObjectHashMap;
 import io.deephaven.hash.KeyedObjectKey;
 import io.deephaven.util.annotations.InternalUseOnly;
@@ -27,7 +29,6 @@ import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Consumer;
 
@@ -310,7 +311,6 @@ public abstract class AbstractTableLocation
     @Override
     public void pushdownFilter(
             final WhereFilter filter,
-            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,
@@ -324,13 +324,9 @@ public abstract class AbstractTableLocation
     }
 
     @Override
-    public Map<String, String> renameMap(final WhereFilter filter, final ColumnSource<?>[] filterSources) {
-        // Default to returning an empty map
-        return Map.of();
-    }
-
-    @Override
-    public PushdownFilterContext makePushdownFilterContext() {
+    public PushdownFilterContext makePushdownFilterContext(
+            final WhereFilter filter,
+            final List<ColumnSource<?>> filterSources) {
         throw new UnsupportedOperationException(
                 "makePushdownFilterContext() not supported for AbstractTableLocation");
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractRangeFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/AbstractRangeFilter.java
@@ -125,8 +125,8 @@ public abstract class AbstractRangeFilter extends WhereFilterImpl implements Exp
      * @return {@code true} if the range filter overlaps with the given range, {@code false} otherwise
      */
     public abstract boolean overlaps(
-            @NotNull final Object lower,
-            @NotNull final Object upper,
+            final Object lower,
+            final Object upper,
             final boolean lowerInclusive,
             final boolean upperInclusive);
 
@@ -139,7 +139,7 @@ public abstract class AbstractRangeFilter extends WhereFilterImpl implements Exp
      * @param max the maximum value in the given range
      * @return {@code true} if the range filter overlaps with the given range, {@code false} otherwise
      */
-    public boolean overlaps(@NotNull final Object min, @NotNull final Object max) {
+    public boolean overlaps(final Object min, final Object max) {
         return overlaps(min, max, true, true);
     }
 
@@ -150,5 +150,15 @@ public abstract class AbstractRangeFilter extends WhereFilterImpl implements Exp
      * @param value the value to check
      * @return {@code true} if the range filter matches the given value, {@code false} otherwise
      */
-    public abstract boolean contains(@NotNull final Object value);
+    public abstract boolean contains(final Object value);
+
+    /**
+     * Returns true if {@code null} is within the range filter. This function is intended to be accurate rather than
+     * fast and is not recommended for performance-critical value comparison.
+     *
+     * @return {@code true} if the range filter includes {@code null}, {@code false} otherwise
+     */
+    public boolean containsNull() {
+        return contains(null);
+    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ComparableRangeFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/ComparableRangeFilter.java
@@ -218,8 +218,8 @@ public class ComparableRangeFilter extends AbstractRangeFilter {
 
     @Override
     public boolean overlaps(
-            @NotNull final Object lower,
-            @NotNull final Object upper,
+            final Object lower,
+            final Object upper,
             final boolean lowerInclusive,
             final boolean upperInclusive) {
 
@@ -238,7 +238,7 @@ public class ComparableRangeFilter extends AbstractRangeFilter {
     }
 
     @Override
-    public boolean contains(@NotNull final Object value) {
+    public boolean contains(final Object value) {
         final int c1 = CompareUtils.compare(this.lower, value);
         if (c1 > 0) {
             return false; // this.lower > value, no overlap possible.

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/CompareUtils.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/CompareUtils.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.engine.table.impl.select;
 
+import io.deephaven.function.Basic;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.compare.ObjectComparisons;
 import io.deephaven.util.type.NumericTypeUtils;
@@ -10,6 +11,7 @@ import io.deephaven.util.type.NumericTypeUtils;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.Objects;
 
 class CompareUtils {
     /**
@@ -21,6 +23,14 @@ class CompareUtils {
      * @return a < b returns negative value, a > b returns positive value, a == b returns 0
      */
     static int compare(Object a, Object b) {
+        // Convert deephaven nulls to Java nulls.
+        if (Objects.nonNull(a) && Objects.equals(a, Basic.nullValueFor(a.getClass()))) {
+            a = null;
+        }
+        if (Objects.nonNull(b) && Objects.equals(b, Basic.nullValueFor(b.getClass()))) {
+            b = null;
+        }
+
         // Enforce NULL < non-null (Deephaven convention)
         if (a == null && b == null) {
             return 0;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
@@ -343,14 +343,18 @@ public class MatchFilter extends WhereFilterImpl implements DependencyStreamProv
      * @return {@code true} if the range filter overlaps with the given range, {@code false} otherwise
      */
     public boolean overlaps(
-            @NotNull final Object lower,
-            @NotNull final Object upper,
+            final Object lower,
+            final Object upper,
             final boolean lowerInclusive,
             final boolean upperInclusive) {
 
         // Converting to upper case lowers (or maintains) ordering, lower case raises (or maintains) it.
-        final Object oLower = caseInsensitive ? ((String) lower).toUpperCase() : lower;
-        final Object oUpper = caseInsensitive ? ((String) upper).toLowerCase() : upper;
+        final Object oLower = caseInsensitive
+                ? lower == null ? null : ((String) lower).toUpperCase()
+                : lower;
+        final Object oUpper = caseInsensitive
+                ? upper == null ? null : ((String) upper).toLowerCase()
+                : upper;
 
         // Use the strValues if values is null (for String comparisons, e.g.)
         final Object[] valuesToTest = values == null ? strValues : values;
@@ -380,8 +384,18 @@ public class MatchFilter extends WhereFilterImpl implements DependencyStreamProv
      * @param max the maximum value in the given range
      * @return {@code true} if the match filter overlaps with the given range, {@code false} otherwise
      */
-    public boolean overlaps(@NotNull final Object min, @NotNull final Object max) {
+    public boolean overlaps(final Object min, final Object max) {
         return overlaps(min, max, true, true);
+    }
+
+    /**
+     * Returns true if {@code null} is within the match filter. This function is intended to be accurate rather than
+     * fast and is not recommended for performance-critical value comparison.
+     *
+     * @return {@code true} if the match filter includes {@code null}, {@code false} otherwise
+     */
+    public boolean containsNull() {
+        return overlaps(null, null, true, true);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
@@ -1001,6 +1001,7 @@ public class MatchFilter extends WhereFilterImpl implements DependencyStreamProv
         if (initialized) {
             copy.initialized = true;
             copy.values = values;
+            copy.columnType = columnType;
         }
         return copy;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MatchFilter.java
@@ -378,7 +378,7 @@ public class MatchFilter extends WhereFilterImpl implements DependencyStreamProv
      *
      * @param min the minimum value in the given range
      * @param max the maximum value in the given range
-     * @return {@code true} if the range filter overlaps with the given range, {@code false} otherwise
+     * @return {@code true} if the match filter overlaps with the given range, {@code false} otherwise
      */
     public boolean overlaps(@NotNull final Object min, @NotNull final Object max) {
         return overlaps(min, max, true, true);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SingleSidedComparableRangeFilter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/SingleSidedComparableRangeFilter.java
@@ -173,7 +173,7 @@ public class SingleSidedComparableRangeFilter extends AbstractRangeFilter {
     }
 
     @Override
-    public boolean contains(@NotNull final Object value) {
+    public boolean contains(final Object value) {
         final int c = CompareUtils.compare(pivot, value);
         if (isGreaterThan) {
             return c < 0 || (c == 0 && this.lowerInclusive);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceBase.java
@@ -16,7 +16,7 @@ import io.deephaven.util.annotations.TestUseOnly;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -118,7 +118,6 @@ abstract class RegionedColumnSourceBase<DATA_TYPE, ATTR extends Values, REGION_T
     @Override
     public void pushdownFilter(
             final WhereFilter filter,
-            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,
@@ -128,19 +127,15 @@ abstract class RegionedColumnSourceBase<DATA_TYPE, ATTR extends Values, REGION_T
             final Consumer<PushdownResult> onComplete,
             final Consumer<Exception> onError) {
         // Delegate to the manager.
-        manager.pushdownFilter(filter, renameMap, selection, fullSet, usePrev, context, costCeiling, jobScheduler,
+        manager.pushdownFilter(filter, selection, fullSet, usePrev, context, costCeiling, jobScheduler,
                 onComplete, onError);
     }
 
     @Override
-    public Map<String, String> renameMap(final WhereFilter filter, final ColumnSource<?>[] filterSources) {
+    public PushdownFilterContext makePushdownFilterContext(
+            final WhereFilter filter,
+            final List<ColumnSource<?>> filterSources) {
         // Delegate to the manager.
-        return manager.renameMap(filter, filterSources);
-    }
-
-    @Override
-    public PushdownFilterContext makePushdownFilterContext() {
-        // Delegate to the manager.
-        return manager.makePushdownFilterContext();
+        return manager.makePushdownFilterContext(filter, filterSources);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -4,6 +4,7 @@
 package io.deephaven.engine.table.impl.sources.regioned;
 
 import io.deephaven.base.verify.Assert;
+import io.deephaven.base.verify.Require;
 import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.*;
@@ -70,9 +71,19 @@ public class RegionedColumnSourceManager
     private final List<ColumnDefinition<?>> columnDefinitions;
 
     /**
+     * The column definitions of this table as a map from column name.
+     */
+    private Map<String, ColumnDefinition<?>> columnNameToDefinition;
+
+    /**
      * The column sources that make up this table.
      */
     private final Map<String, RegionedColumnSource<?>> columnSources = new LinkedHashMap<>();
+
+    /**
+     * The column sources of this table as a map from column source to column name.
+     */
+    private Map<ColumnSource<?>, String> columnSourceToName;
 
     /**
      * An unmodifiable view of columnSources.
@@ -807,7 +818,6 @@ public class RegionedColumnSourceManager
     @Override
     public void pushdownFilter(
             final WhereFilter filter,
-            final Map<String, String> renameMap,
             final RowSet input,
             final RowSet fullSet,
             final boolean usePrev,
@@ -856,8 +866,8 @@ public class RegionedColumnSourceManager
                                 }
                             }
                         };
-                        entry.location.pushdownFilter(filter, renameMap, locationInput, fullSet, usePrev, context,
-                                costCeiling, jobScheduler, resultConsumer, onError);
+                        entry.location.pushdownFilter(filter, locationInput, fullSet, usePrev, context, costCeiling,
+                                jobScheduler, resultConsumer, onError);
                     }
                     locationResume.run();
                 }, () -> onComplete.accept(PushdownResult.of(matchBuilder.build(),
@@ -865,32 +875,68 @@ public class RegionedColumnSourceManager
                 onError);
     }
 
-    @Override
-    public Map<String, String> renameMap(final WhereFilter filter, final ColumnSource<?>[] filterSources) {
-        final Map<? extends ColumnSource<?>, String> lookupMap = getColumnSources().entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    public static class RegionedColumnSourcePushdownFilterContext extends BasePushdownFilterContext {
+        public final List<ColumnSource<?>> columnSources;
+        public final List<ColumnDefinition<?>> columnDefinitions;
+        public final Map<String, String> renameMap;
 
-        final List<String> filterColumns = filter.getColumns();
+        public RegionedColumnSourcePushdownFilterContext(
+                final RegionedColumnSourceManager manager,
+                final WhereFilter filter,
+                final List<ColumnSource<?>> columnSources) {
+            this.columnSources = columnSources;
 
-        final Map<String, String> renameMap = new HashMap<>();
-        for (int ii = 0; ii < filterColumns.size(); ii++) {
-            final String filterColumnName = filterColumns.get(ii);
-            final ColumnSource<?> filterSource = filterSources[ii];
-            final String localColumnName = lookupMap.get(filterSource);
-            if (localColumnName == null) {
-                throw new IllegalArgumentException(
-                        "No associated source for '" + filterColumnName + "' found in column sources");
+            final List<String> filterColumns = filter.getColumns();
+            Require.eq(filterColumns.size(), "filterColumns.size()",
+                    columnSources.size(), "columnSources.size()");
+
+            // We knw the column sources are in the same order as the filter columns, build a rename map and collect
+            // column definitions for the filter sources
+            columnDefinitions = new ArrayList<>(columnSources.size());
+
+            // Maybe populate some useful lookup maps
+            if (manager.columnSourceToName == null) {
+                manager.columnSourceToName = manager.columnSources.entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
             }
-            if (localColumnName.equals(filterColumnName)) {
-                continue;
+            if (manager.columnNameToDefinition == null) {
+                manager.columnNameToDefinition = manager.columnDefinitions.stream()
+                        .collect(Collectors.toMap(ColumnDefinition::getName, cd -> cd));
             }
-            renameMap.put(filterColumnName, localColumnName);
+
+            renameMap = new HashMap<>();
+            for (int ii = 0; ii < filterColumns.size(); ii++) {
+                final String filterColumnName = filterColumns.get(ii);
+                final ColumnSource<?> filterSource = columnSources.get(ii);
+                final String localColumnName = manager.columnSourceToName.get(filterSource);
+                if (localColumnName == null) {
+                    throw new IllegalArgumentException(
+                            "No associated source for '" + filterColumnName + "' found in column sources");
+                }
+                // Add the definition.
+                columnDefinitions.add(manager.columnNameToDefinition.get(localColumnName));
+
+                // Add the rename (if needed)
+                if (localColumnName.equals(filterColumnName)) {
+                    continue;
+                }
+                renameMap.put(filterColumnName, localColumnName);
+            }
         }
-        return renameMap;
+
+        @Override
+        public void close() {
+            columnSources.clear();
+            columnDefinitions.clear();
+            renameMap.clear();
+            super.close();
+        }
     }
 
     @Override
-    public PushdownFilterContext makePushdownFilterContext() {
-        return new BasePushdownFilterContext();
+    public PushdownFilterContext makePushdownFilterContext(
+            final WhereFilter filter,
+            final List<ColumnSource<?>> filterSources) {
+        return new RegionedColumnSourcePushdownFilterContext(this, filter, filterSources);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -889,7 +889,7 @@ public class RegionedColumnSourceManager
             Require.eq(filterColumns.size(), "filterColumns.size()",
                     columnSources.size(), "columnSources.size()");
 
-            // We knw the column sources are in the same order as the filter columns, build a rename map and collect
+            // We know the column sources are in the same order as the filter columns, build a rename map and collect
             // column definitions for the filter sources
             columnDefinitions = new ArrayList<>(columnSources.size());
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -876,7 +876,6 @@ public class RegionedColumnSourceManager
     }
 
     public static class RegionedColumnSourcePushdownFilterContext extends BasePushdownFilterContext {
-        public final List<ColumnSource<?>> columnSources;
         public final List<ColumnDefinition<?>> columnDefinitions;
         public final Map<String, String> renameMap;
 
@@ -884,7 +883,7 @@ public class RegionedColumnSourceManager
                 final RegionedColumnSourceManager manager,
                 final WhereFilter filter,
                 final List<ColumnSource<?>> columnSources) {
-            this.columnSources = columnSources;
+            super(filter, columnSources);
 
             final List<String> filterColumns = filter.getColumns();
             Require.eq(filterColumns.size(), "filterColumns.size()",
@@ -926,9 +925,9 @@ public class RegionedColumnSourceManager
 
         @Override
         public void close() {
-            columnSources.clear();
             columnDefinitions.clear();
             renameMap.clear();
+            closeList.close();
             super.close();
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
@@ -55,6 +55,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -1895,9 +1896,15 @@ public abstract class QueryTableWhereTest {
         }
 
         @Override
-        public void pushdownFilter(final WhereFilter filter, final Map<String, String> renameMap, final RowSet input,
-                final RowSet fullSet, final boolean usePrev, final PushdownFilterContext context,
-                final long costCeiling, final JobScheduler jobScheduler, final Consumer<PushdownResult> onComplete,
+        public void pushdownFilter(
+                final WhereFilter filter,
+                final RowSet input,
+                final RowSet fullSet,
+                final boolean usePrev,
+                final PushdownFilterContext context,
+                final long costCeiling,
+                final JobScheduler jobScheduler,
+                final Consumer<PushdownResult> onComplete,
                 final Consumer<Exception> onError) {
             encounterOrder = counter.getAndIncrement();
             PushdownColumnSourceHeler.pushdownFilter(filter, input, fullSet, usePrev, this, maybePercentage,
@@ -2080,7 +2087,6 @@ public abstract class QueryTableWhereTest {
         @Override
         public void pushdownFilter(
                 final WhereFilter filter,
-                final Map<String, String> renameMap,
                 final RowSet selection,
                 final RowSet fullSet,
                 final boolean usePrev,
@@ -2105,12 +2111,9 @@ public abstract class QueryTableWhereTest {
         }
 
         @Override
-        public Map<String, String> renameMap(WhereFilter filter, ColumnSource<?>[] filterSources) {
-            return Map.of();
-        }
-
-        @Override
-        public PushdownFilterContext makePushdownFilterContext() {
+        public PushdownFilterContext makePushdownFilterContext(
+                final WhereFilter filter,
+                final List<ColumnSource<?>> filterSources) {
             return PushdownFilterContext.NO_PUSHDOWN_CONTEXT;
         }
     }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
@@ -287,7 +287,7 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
      * @return The page stores
      */
     @NotNull
-    private ColumnChunkPageStore<ATTR>[] getPageStores(
+    ColumnChunkPageStore<ATTR>[] getPageStores(
             @NotNull final ColumnDefinition<?> columnDefinition) {
         initializePages(columnDefinition);
         return pageStores;
@@ -299,7 +299,7 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
      * @param columnDefinition The {@link ColumnDefinition} used to lookup type information
      * @return The dictionary values chunk suppliers, or null if none exist
      */
-    private Supplier<Chunk<ATTR>>[] getDictionaryChunkSuppliers(
+    Supplier<Chunk<ATTR>>[] getDictionaryChunkSuppliers(
             @NotNull final ColumnDefinition<?> columnDefinition) {
         initializePages(columnDefinition);
         return dictionaryChunkSuppliers;
@@ -312,7 +312,7 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
      * @param columnDefinition The {@link ColumnDefinition} used to lookup type information
      * @return The page stores
      */
-    private ColumnChunkPageStore<DictionaryKeys>[] getDictionaryKeysPageStores(
+    ColumnChunkPageStore<DictionaryKeys>[] getDictionaryKeysPageStores(
             @NotNull final ColumnDefinition<?> columnDefinition) {
         initializePages(columnDefinition);
         return dictionaryKeysPageStores;

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -631,7 +631,8 @@ public class ParquetTableLocation extends AbstractTableLocation {
     private void iterateRowGroupsAndRowSet(final RowSet input, final RowGroupAndRowSetConsumer consumer) {
         // TODO: should we parallelize this? I think so, is parallelStream good enough or should we re-use the
         // jobscheduler? I think we should change the name to parallelIterateRowGroupsAndRowSet() or something equally
-        // obvious to the user that they need to use RandomBuilder (or even better, the planned PushdownResult
+        // obvious to the user that they need to use RandomBuilder (or even better, the planned
+        // `PushdownResult#buildSequentialFast()` function.
 
         try (final RowSequence.Iterator rsIt = input.getRowSequenceIterator()) {
             final RowGroupReader[] rgReaders = getRowGroupReaders();

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
@@ -94,7 +94,7 @@ public final class ParquetTableFilterTest {
     private void verifyResults(Table filteredDiskTable, Table filteredMemTable) {
         Assert.assertFalse("filteredMemTable.isEmpty()", filteredMemTable.isEmpty());
         Assert.assertFalse("filteredDiskTable.isEmpty()", filteredDiskTable.isEmpty());
-        assertTableEquals(filteredDiskTable, filteredMemTable);
+        assertTableEquals(filteredMemTable, filteredDiskTable);
     }
 
     private void filterAndVerifyResults(Table diskTable, Table memTable, String... filters) {
@@ -768,6 +768,9 @@ public final class ParquetTableFilterTest {
 
         // NOTE: first file has 10k rows and `id` column is sequential, so id 0-9999 are in a file without
         // row group stats.
+
+        filterAndVerifyResults(diskTable, memTable, "random_string = `xgsah`");
+        filterAndVerifyResults(diskTable, memTable, "random_string < `zzzzz`", "random_string = `fiaai`");
 
         // int range and match filters
         filterAndVerifyResults(diskTable, memTable, "id <= 3000"); // entirely inside file with no metadata

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
@@ -110,7 +110,7 @@ public final class ParquetTableFilterTest {
         QueryScope.addParam("baseTime", baseTime);
 
         final Table largeTable = TableTools.emptyTable(tableSize).update(
-                "sequential_val = i",
+                "sequential_val = i % 117 == 0 ? null : i", // with nulls
                 "price = randomInt(0,100000) * 0.01f");
         final int partitionCount = 5;
 
@@ -222,7 +222,10 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "symbol.startsWith(`002`)", "exchange % 10 == 0");
 
         // mixed type with complex filters
-        final Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
+        Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`"));
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
     }
 
@@ -236,8 +239,8 @@ public final class ParquetTableFilterTest {
 
         final Table largeTable = TableTools.emptyTable(tableSize).update(
                 "Timestamp = baseTime + i * 1_000_000_000L",
-                "sequential_val = ii",
-                "symbol = String.format(`%04d`, randomInt(0,10_000))",
+                "sequential_val = ii % 117 == 0 ? null : ii", // with nulls
+                "symbol = ii % 119 == 0 ? null : String.format(`%04d`, randomInt(0,10_000))",
                 "sequential_bd = java.math.BigDecimal.valueOf(ii * 0.1)",
                 "sequential_bi = java.math.BigInteger.valueOf(ii)");
         final int partitionCount = 11;
@@ -251,6 +254,9 @@ public final class ParquetTableFilterTest {
         assertTableEquals(diskTable, memTable);
 
         // string range and match filters
+        filterAndVerifyResults(diskTable, memTable, "symbol = null");
+        filterAndVerifyResults(diskTable, memTable, "symbol != null");
+        filterAndVerifyResults(diskTable, memTable, "symbol = `1000`");
         filterAndVerifyResults(diskTable, memTable, "symbol < `1000`");
         filterAndVerifyResults(diskTable, memTable, "symbol = `5000`");
 
@@ -282,13 +288,20 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "sequential_bi = 500");
 
         // long range and match filters
+        filterAndVerifyResults(diskTable, memTable, "sequential_val = null");
+        filterAndVerifyResults(diskTable, memTable, "sequential_val != null");
         filterAndVerifyResults(diskTable, memTable, "sequential_val <= 500");
         filterAndVerifyResults(diskTable, memTable, "sequential_val <= 5000", "sequential_val > 3000");
         filterAndVerifyResults(diskTable, memTable, "sequential_val = 500");
 
         // mixed type with complex filters
-        final Filter complexFilter =
+        Filter complexFilter =
                 Filter.or(Filter.from("sequential_val <= 500", "sequential_val = 555", "symbol > `1000`"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("sequential_val <= 500", "sequential_val = 555"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
     }
 
@@ -302,8 +315,8 @@ public final class ParquetTableFilterTest {
 
         final Table largeTable = TableTools.emptyTable(tableSize).update(
                 "Timestamp = baseTime + i * 1_000_000_000L",
-                "sequential_val = ii",
-                "symbol = String.format(`s_%04d`, randomInt(0,300))",
+                "sequential_val = ii % 117 == 0 ? null : ii", // with nulls
+                "symbol = ii % 119 == 0 ? null : String.format(`s%04d`, randomInt(0,10_000))",
                 "sequential_bd = java.math.BigDecimal.valueOf(ii * 0.1)",
                 "sequential_bi = java.math.BigInteger.valueOf(ii)");
 
@@ -316,8 +329,11 @@ public final class ParquetTableFilterTest {
         assertTableEquals(diskTable, memTable);
 
         // string range and match filters
-        filterAndVerifyResults(diskTable, memTable, "symbol < `s_0100`");
-        filterAndVerifyResults(diskTable, memTable, "symbol = `s_0050`");
+        filterAndVerifyResults(diskTable, memTable, "symbol = null");
+        filterAndVerifyResults(diskTable, memTable, "symbol != null");
+        filterAndVerifyResults(diskTable, memTable, "symbol = `s1000`");
+        filterAndVerifyResults(diskTable, memTable, "symbol < `s1000`");
+        filterAndVerifyResults(diskTable, memTable, "symbol = `s5000`");
 
         // Timestamp range and match filters
         filterAndVerifyResults(diskTable, memTable, "Timestamp < '2023-01-02T00:00:00 NY'");
@@ -346,13 +362,18 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "sequential_bi = 500");
 
         // long range and match filters
+        filterAndVerifyResults(diskTable, memTable, "sequential_val = null");
+        filterAndVerifyResults(diskTable, memTable, "sequential_val != null");
         filterAndVerifyResults(diskTable, memTable, "sequential_val <= 500");
         filterAndVerifyResults(diskTable, memTable, "sequential_val <= 5000", "sequential_val > 3000");
         filterAndVerifyResults(diskTable, memTable, "sequential_val = 500");
 
         // mixed type with complex filters
-        final Filter complexFilter =
+        Filter complexFilter =
                 Filter.or(Filter.from("sequential_val <= 500", "sequential_val = 555", "symbol > `1000`"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("sequential_val <= 500", "sequential_val = 555"));
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
     }
 
@@ -366,8 +387,8 @@ public final class ParquetTableFilterTest {
 
         final Table largeTable = TableTools.emptyTable(tableSize).update(
                 "Timestamp = baseTime + i * 1_000_000_000L",
-                "sequential_val = ii",
-                "symbol = String.format(`%04d`, randomInt(0,10_000))",
+                "sequential_val = ii % 117 == 0 ? null : ii", // with nulls
+                "symbol = ii % 119 == 0 ? null : String.format(`%04d`, randomInt(0,10_000))",
                 "sequential_bd = java.math.BigDecimal.valueOf(ii * 0.1)",
                 "sequential_bi = java.math.BigInteger.valueOf(ii)");
         final int partitionCount = 11;
@@ -387,6 +408,9 @@ public final class ParquetTableFilterTest {
         assertTableEquals(diskTable, memTable);
 
         // string range and match filters
+        filterAndVerifyResults(diskTable, memTable, "symbol_renamed = null");
+        filterAndVerifyResults(diskTable, memTable, "symbol_renamed != null");
+        filterAndVerifyResults(diskTable, memTable, "symbol_renamed = `1000`");
         filterAndVerifyResults(diskTable, memTable, "symbol_renamed < `1000`");
         filterAndVerifyResults(diskTable, memTable, "symbol_renamed = `5000`");
 
@@ -420,15 +444,20 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "sequential_bi_renamed = 500");
 
         // long range and match filters
+        filterAndVerifyResults(diskTable, memTable, "sequential_val_renamed = null");
+        filterAndVerifyResults(diskTable, memTable, "sequential_val_renamed != null");
         filterAndVerifyResults(diskTable, memTable, "sequential_val_renamed <= 500");
         filterAndVerifyResults(diskTable, memTable, "sequential_val_renamed <= 5000", "sequential_val_renamed > 3000");
         filterAndVerifyResults(diskTable, memTable, "sequential_val_renamed = 500");
 
         // mixed type with complex filters
-        final Filter complexFilter =
-                Filter.or(Filter.from("sequential_val_renamed <= 500", "sequential_val_renamed = 555",
-                        "symbol_renamed > `1000`"));
+        Filter complexFilter = Filter.or(Filter.from("sequential_val_renamed <= 500", "sequential_val_renamed = 555",
+                "symbol_renamed > `1000`"));
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("sequential_val_renamed <= 500", "sequential_val_renamed = 555"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
 
         // Rename again and do some more tests.
         final Table renamedDiskTable = diskTable.renameColumns(
@@ -456,8 +485,8 @@ public final class ParquetTableFilterTest {
 
         final Table largeTable = TableTools.emptyTable(tableSize).update(
                 "Timestamp = baseTime + i * 1_000_000_000L",
-                "sequential_val = ii",
-                "symbol = String.format(`%04d`, randomInt(0,10_000))",
+                "sequential_val = ii % 117 == 0 ? null : ii", // with nulls
+                "symbol = ii % 119 == 0 ? null : String.format(`%04d`, randomInt(0,10_000))",
                 "sequential_bd = java.math.BigDecimal.valueOf(ii * 0.1)",
                 "sequential_bi = java.math.BigInteger.valueOf(ii)");
         final int partitionCount = 11;
@@ -518,9 +547,11 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "sequential_val_renamed = 500");
 
         // mixed type with complex filters
-        final Filter complexFilter =
-                Filter.or(Filter.from("sequential_val_renamed <= 500", "sequential_val_renamed = 555",
-                        "symbol_renamed > `1000`"));
+        Filter complexFilter = Filter.or(Filter.from("sequential_val_renamed <= 500", "sequential_val_renamed = 555",
+                "symbol_renamed > `1000`"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("sequential_val_renamed <= 500", "sequential_val_renamed = 555"));
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
 
         // Rename again and do some more tests.
@@ -548,7 +579,7 @@ public final class ParquetTableFilterTest {
         QueryScope.addParam("baseTime", baseTime);
 
         final Table largeTable = TableTools.emptyTable(tableSize).update(
-                "symbol = String.format(`%04d`, randomInt(0,10000))",
+                "symbol = ii % 119 == 0 ? null : String.format(`%04d`, randomInt(0,10_000))",
                 "exchange = randomInt(0,100)",
                 "price = randomInt(0,10000) * 0.01");
         final int partitionCount = 11;
@@ -568,10 +599,12 @@ public final class ParquetTableFilterTest {
         assertTableEquals(diskTable, memTable);
 
         // string range and match filters
+        filterAndVerifyResults(diskTable, memTable, "symbol = null");
+        filterAndVerifyResults(diskTable, memTable, "symbol != null");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "symbol >= `0049`");
         filterAndVerifyResults(diskTable, memTable, "symbol = `0050`");
-        filterAndVerifyResults(diskTable, memTable, "symbol.startsWith(`002`)");
+        filterAndVerifyResults(diskTable, memTable, "symbol != null && symbol.startsWith(`002`)");
 
         // int range and match filters
         filterAndVerifyResults(diskTable, memTable, "exchange <= 10");
@@ -583,10 +616,13 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "exchange <= 10");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "exchange <= 10", "exchange >= 9");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "exchange = 10");
-        filterAndVerifyResults(diskTable, memTable, "symbol.startsWith(`002`)", "exchange % 10 == 0");
+        filterAndVerifyResults(diskTable, memTable, "symbol != null && symbol.startsWith(`002`)", "exchange % 10 == 0");
 
         // mixed type with complex filters
-        final Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
+        Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`"));
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
     }
 
@@ -600,7 +636,8 @@ public final class ParquetTableFilterTest {
 
         // large consecutive blocks of sequential data
         final Table largeTable = TableTools.emptyTable(tableSize).update(
-                "symbol = String.format(`%04d`, (long)(ii / 1000))", // produces 0000 to 0999 given 1M rows
+                "symbol = ii % 119 == 0 ? null : String.format(`%04d`, (long)(ii / 1000))", // produces 0000 to 0999
+                                                                                            // given 1M rows
                 "exchange = (int)(i / 100)", // produces 0 to 9999 given 1M rows
                 "price = randomInt(0,10000) * 0.01");
 
@@ -620,10 +657,11 @@ public final class ParquetTableFilterTest {
         assertTableEquals(diskTable, memTable);
 
         // string range and match filters
+        filterAndVerifyResults(diskTable, memTable, "symbol = null");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "symbol >= `0049`");
         filterAndVerifyResults(diskTable, memTable, "symbol = `0050`");
-        filterAndVerifyResults(diskTable, memTable, "symbol.startsWith(`002`)");
+        filterAndVerifyResults(diskTable, memTable, "symbol != null && symbol.startsWith(`002`)");
 
         // int range and match filters
         filterAndVerifyResults(diskTable, memTable, "exchange <= 10");
@@ -635,11 +673,15 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "exchange <= 10");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "exchange <= 10", "exchange >= 9");
         filterAndVerifyResults(diskTable, memTable, "symbol < `0050`", "exchange = 10");
-        filterAndVerifyResults(diskTable, memTable, "symbol.startsWith(`002`)", "exchange % 10 == 0");
+        filterAndVerifyResults(diskTable, memTable, "symbol != null && symbol.startsWith(`002`)", "exchange % 10 == 0");
 
         // mixed type with complex filters
-        final Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
+        Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
 
         // Rename columns and do some more tests.
         final Table renamedDiskTable = diskTable.renameColumns(
@@ -653,7 +695,8 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(renamedDiskTable, renamedMemTable, "symbol_renamed < `0050`",
                 "symbol_renamed >= `0049`");
         filterAndVerifyResults(renamedDiskTable, renamedMemTable, "symbol_renamed = `0050`");
-        filterAndVerifyResults(renamedDiskTable, renamedMemTable, "symbol_renamed.startsWith(`002`)");
+        filterAndVerifyResults(renamedDiskTable, renamedMemTable,
+                "symbol_renamed != null && symbol_renamed.startsWith(`002`)");
 
         // int range and match filters
         filterAndVerifyResults(renamedDiskTable, renamedMemTable, "exchange_renamed <= 10");
@@ -666,7 +709,8 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(renamedDiskTable, renamedMemTable, "symbol_renamed < `0050`", "exchange_renamed <= 10",
                 "exchange_renamed >= 9");
         filterAndVerifyResults(renamedDiskTable, renamedMemTable, "symbol_renamed < `0050`", "exchange_renamed = 10");
-        filterAndVerifyResults(renamedDiskTable, renamedMemTable, "symbol_renamed.startsWith(`002`)",
+        filterAndVerifyResults(renamedDiskTable, renamedMemTable,
+                "symbol_renamed != null && symbol_renamed.startsWith(`002`)",
                 "exchange_renamed % 10 == 0");
 
     }
@@ -722,7 +766,10 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "symbol.startsWith(`002`)", "exchange % 10 == 0");
 
         // mixed type with complex filters
-        final Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
+        Filter complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`", "exchange = 10"));
+        verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
+
+        complexFilter = Filter.or(Filter.from("symbol < `1000`", "symbol > `0900`"));
         verifyResults(diskTable.where(complexFilter), memTable.where(complexFilter));
 
         // Rename columns and do some more tests.

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
@@ -147,6 +147,14 @@ public final class ParquetTableFilterTest {
                 largeTable.where("price = 500.0").size());
     }
 
+    /**
+     * This test fails because of the mismatch between the data index and the upcast parquet column types. This test
+     * will continue to fail until the data index is also upcast to match the parquet column types (DH-19443).
+     * <p>
+     * When the data index is fixed, this test should be re-enabled.
+     *
+     */
+    @Ignore
     @Test
     public void filterDatatypeMismatchDataIndexTest() {
         final String destPath = Path.of(rootFile.getPath(), "ParquetTest_flatPartitionsTest").toString();

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSourcesAndChunks.java
@@ -597,6 +597,8 @@ public class ReplicateSourcesAndChunks {
         classLines = ReplicationUtils.removeRegion(classLines, "CopyToBuffer");
         classLines = ReplicationUtils.removeRegion(classLines, "BinarySearchImports");
         classLines = ReplicationUtils.removeRegion(classLines, "BinarySearch");
+        classLines = ReplicationUtils.removeRegion(classLines, "NULL_definition");
+        classLines = ReplicationUtils.removeRegion(classLines, "getNullChunk");
         classLines = ReplicationUtils.replaceRegion(classLines, "isNull", Arrays.asList(
                 "    public final boolean isNull(int index) {",
                 "        return false;",
@@ -617,7 +619,8 @@ public class ReplicateSourcesAndChunks {
                 "ObjectChunk<[?] ", "ObjectChunk<T, ? ",
                 "ObjectChunk<Any> EMPTY", "ObjectChunk<Object, Any> EMPTY",
                 "static T\\[\\] makeArray", "static <T> T[] makeArray",
-                "QueryConstants.NULL_OBJECT", "null");
+                "QueryConstants.NULL_OBJECT", "null",
+                "ArrayTypeUtils.ObjectNullArray", "ArrayTypeUtils.objectNullArray");
 
         lines = replaceRegion(lines, "makeArray", Arrays.asList(
                 "    public static <T> T[] makeArray(int capacity) {",
@@ -871,6 +874,9 @@ public class ReplicateSourcesAndChunks {
                 "engine/chunk/src/main/java/io/deephaven/chunk/util/factories/CharChunkFactory.java");
         final File classFile = new File(className);
         List<String> classLines = FileUtils.readLines(classFile, Charset.defaultCharset());
+        classLines = globalReplacements(classLines,
+                "return BooleanChunk.getNullChunk\\(\\)",
+                "throw new UnsupportedOperationException(\"BooleanChunk does not support null values\")");
         FileUtils.writeLines(classFile, classLines);
     }
 


### PR DESCRIPTION
Adds full support for dictionary filtering including resolving dictionary matches and returning the specific rows that are included.  It is expected that long comparison will be faster than object comparison and that this will result in improved performance vs. object comparison and filtering.