### PR TITLE
fix: Enable partial testing of py-client-ticking

### DIFF
--- a/py/client-ticking/build.gradle
+++ b/py/client-ticking/build.gradle
@@ -139,7 +139,7 @@ def testCPythonClientTicking = { String pythonVersion, String image -> Docker.re
     network = deephavenDocker.networkName.get()
     parentContainers = [ cpythonWheelTask, Docker.registryTask(project, image.toString()) ]
     copyOut {
-        into layout.buildDirectory.dir("testCPythonClientTicking/${image}/${pythonVersion}")
+        into layout.buildDirectory.dir("test-results/testCPythonClientTicking/${image}/${pythonVersion}")
     }
     entrypoint = ['/entrypoint.sh']
 }}


### PR DESCRIPTION
This is a middle ground instead of waiting for the full solution in #5899. This also ensures that the py-client-ticking test results are placed under the build directory 'test-results' folder so they get picked up as a testing CI artifact.