### PR TITLE
docs: Remove requirements from Python readme

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -2,7 +2,7 @@
 
 This folder contains Deephaven Community Core's Python source code, tests, and more. Source code can be found in `server/deephaven` and unit tests can be found in `server/tests`. Other content includes `jpy`, the Python client, wheels, and more.
 
-Our documentation on building and running the Python server is available [here](https://deephaven.io/core/docs/getting-started/launch-build/).
+Our documentation on building and running the Python server, which include software and version requirements, is available [here](https://deephaven.io/core/docs/getting-started/launch-build/).
 
 ## Virtual environments
 


### PR DESCRIPTION
The requirements section is duplicative of our core docs. It makes no sense to document in two places, because that will make it more difficult to keep up with.

There is still useful information in this page, so we shouldn't remove it altogether. This just links to the core docs for requirements.