### PR TITLE
fix: DH-19570: UnionSourceManager Should Not Inspect Stale Slot Location Entries

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionRedirection.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionRedirection.java
@@ -197,7 +197,7 @@ public class UnionRedirection {
 
     private static int slotForRowKey(final long rowKey, int firstSlot,
             @NotNull final long[] firstRowKeyForSlot, final int numSlots) {
-        if (rowKey >= firstRowKeyForSlot[firstSlot]) {
+        if (firstSlot < numSlots && rowKey >= firstRowKeyForSlot[firstSlot]) {
             if (rowKey < firstRowKeyForSlot[firstSlot + 1]) {
                 return firstSlot;
             }

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestTableTools.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestTableTools.java
@@ -4,15 +4,19 @@
 package io.deephaven.engine.util;
 
 import io.deephaven.chunk.IntChunk;
+import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.context.*;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetBuilderSequential;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.rowset.RowSetShiftData;
+import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.InstrumentedTableUpdateListener;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
+import io.deephaven.engine.table.impl.partitioned.PartitionedTableCreatorImpl;
 import io.deephaven.engine.table.impl.sources.UnionRedirection;
 import io.deephaven.engine.table.impl.util.ColumnHolder;
 import io.deephaven.engine.table.vectors.ColumnVectors;
@@ -36,6 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import javax.management.Query;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -1061,5 +1066,73 @@ public class TestTableTools {
         final int line3Idx = lines[2].indexOf("|");
         assertEquals(line1Idx, line2Idx);
         assertEquals(line1Idx, line3Idx);
+    }
+
+    @Test
+    public void testMergeWithRemovedPartitions_DH_19570() {
+        final long origSize = 65536L;
+        final String CONSTITUENT_NAME = PartitionedTableCreatorImpl.CONSTITUENT.name();
+        final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+
+        final QueryTable[] pSources = new QueryTable[] {
+                testRefreshingTable(RowSetFactory.flat(origSize).toTracking()),
+                testRefreshingTable(RowSetFactory.flat(origSize).toTracking()),
+                testRefreshingTable(RowSetFactory.flat(origSize).toTracking()),
+                testRefreshingTable(RowSetFactory.flat(origSize).toTracking())
+        };
+        final Table[] pTables = new Table[] {
+                pSources[0].update("Partition = 0", "Value = `A_` + ii"),
+                pSources[1].update("Partition = 1", "Value = `B_` + ii"),
+                pSources[2].update("Partition = 2", "Value = `C_` + ii"),
+                pSources[3].update("Partition = 3", "Value = `D_` + ii")
+        };
+
+        final QueryTable manualPT = testRefreshingTable(RowSetFactory.flat(4).toTracking(),
+                col("Partition", 0, 1, 2, 3),
+                col(CONSTITUENT_NAME, pTables));
+
+        final PartitionedTable pt = PartitionedTableCreatorImpl.INSTANCE.of(
+                manualPT, Set.of("Partition"), false, CONSTITUENT_NAME,
+                pTables[0].getDefinition(), true);
+
+        final Table resultTable = pt.merge();
+        final ColumnSource<Object> unionedSource = resultTable.getColumnSource("Value");
+
+        updateGraph.runWithinUnitTestCycle(() -> {
+            removeRows(manualPT, i(2, 3));
+            manualPT.notifyListeners(i(), i(2, 3), i());
+
+            // double all partitions, so that the slot lookup looks valid past the end of the array
+            for (final QueryTable table : pSources) {
+                final WritableRowSet toAdd = RowSetFactory.fromRange(origSize, 2 * origSize - 1);
+                addToTable(table, toAdd);
+                table.notifyListeners(toAdd, i(), i());
+            }
+
+            updateGraph.markSourcesRefreshedForUnitTests();
+            updateGraph.flushAllNormalNotificationsForUnitTests();
+
+            try (final WritableObjectChunk<String, Values> chk =
+                    WritableObjectChunk.makeWritableChunk(resultTable.getRowSet().intSizePrev());
+                    final ChunkSource.FillContext ctxt = unionedSource.makeFillContext(chk.size());
+                    final WritableRowSet fetchRows = resultTable.getRowSet().subSetByPositionRange(
+                            3 * origSize, 4 * origSize - 1)) {
+
+                // we need to target a slot that will be past the end of the partition-size array
+                unionedSource.fillPrevChunk(ctxt, chk, fetchRows);
+                Assert.assertEquals(chk.size(), fetchRows.size());
+                for (int ii = 0; ii < chk.size(); ++ii) {
+                    Assert.assertEquals("D_" + ii, chk.get(ii));
+                }
+
+                // swap from prev to curr so that we poke into the slot-binary-searched array, but we need to stay
+                // tricky by sending a row key that is in the prev slot
+                unionedSource.fillChunk(ctxt, chk, fetchRows);
+                Assert.assertEquals(chk.size(), fetchRows.intSize());
+                for (int ii = 0; ii < chk.size(); ++ii) {
+                    Assert.assertEquals("B_" + (origSize + ii), chk.get(ii));
+                }
+            }
+        }, false);
     }
 }


### PR DESCRIPTION
We were not bounds checking the initial array lookup. When losing partitions we don't zero out or change any values in the slot-lookup-array that are beyond the total number of slots. However the number of valid slots may decrease from prev to curr (or vice versa) and a lookup past the end of an array could appear as if the slot mapping was right/valid, but really it's just looking at stale values and making bad choices.

The fix is to bounds check. The unit test is targeted and failed before the fix.