### PR TITLE
feat: expose IcebergTableAdapter.nameMapping (#6873)

### DIFF
--- a/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTableAdapter.java
+++ b/extensions/iceberg/src/main/java/io/deephaven/iceberg/util/IcebergTableAdapter.java
@@ -109,6 +109,13 @@ public final class IcebergTableAdapter {
     }
 
     /**
+     * The name mapping.
+     */
+    public NameMapping nameMapping() {
+        return nameMapping;
+    }
+
+    /**
      * Get the current {@link Snapshot snapshot} of a given Iceberg table or {@code null} if there are no snapshots.
      *
      * @return The current snapshot of the table or {@code null} if there are no snapshots.

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
@@ -71,6 +71,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
@@ -2795,6 +2796,7 @@ public abstract class SqliteCatalogBase {
         final TableIdentifier tableIdentifier = TableIdentifier.parse("MyNamespace.NameMappingTest");
 
         final IcebergTableAdapter tableAdapter = catalogAdapter.createTable(tableIdentifier, definition);
+        assertThat(tableAdapter.nameMapping().asMappedFields()).isEqualTo(MappedFields.of());
 
         // This is emulating a write outside of DH where the field ids are _not_ written
         {
@@ -2846,6 +2848,7 @@ public abstract class SqliteCatalogBase {
                     .resolver(tableAdapter.resolver())
                     .nameMapping(nameMapping)
                     .build());
+            assertThat(ta.nameMapping()).isSameAs(nameMapping);
             assertTableEquals(source, ta.table());
         }
 
@@ -2859,6 +2862,7 @@ public abstract class SqliteCatalogBase {
                     .id(tableIdentifier)
                     .resolver(tableAdapter.resolver())
                     .build());
+            assertThat(ta.nameMapping().asMappedFields()).isEqualTo(nameMapping.asMappedFields());
             assertTableEquals(source, ta.table());
         }
 
@@ -2869,6 +2873,7 @@ public abstract class SqliteCatalogBase {
                     .resolver(tableAdapter.resolver())
                     .nameMapping(NameMappingProvider.empty())
                     .build());
+            assertThat(ta.nameMapping().asMappedFields()).isEqualTo(MappedFields.of());
             try {
                 ta.table().select();
                 failBecauseExceptionWasNotThrown(TableInitializationException.class);
@@ -2887,6 +2892,7 @@ public abstract class SqliteCatalogBase {
                     .resolver(tableAdapter.resolver())
                     .nameMapping(NameMappingProvider.empty())
                     .build());
+            assertThat(ta.nameMapping().asMappedFields()).isEqualTo(MappedFields.of());
             assertTableEquals(empty, ta.table(IGNORE_ERRORS));
         }
     }


### PR DESCRIPTION
This is necessary so that Enterprise can get access to the name mapping results after a IcebergCatalogAdapter loadTable call.

Cherry-pick for https://github.com/deephaven/deephaven-core/pull/6873