### PR TITLE
feat: add AWS SessionCredentials to S3 module

### DIFF
--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/Credentials.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/Credentials.java
@@ -47,8 +47,8 @@ public interface Credentials {
     }
 
     /**
-     * Session credentials with the specified access key id, secret access key, and session token.
-     * This is useful when using temporary credentials from AWS STS or similar services.
+     * Session credentials with the specified access key id, secret access key, and session token. This is useful when
+     * using temporary credentials from AWS STS or similar services.
      *
      * @param accessKeyId the access key id, used to identify the user
      * @param secretAccessKey the secret access key, used to authenticate the user

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/Credentials.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/Credentials.java
@@ -47,6 +47,18 @@ public interface Credentials {
     }
 
     /**
+     * Session credentials with the specified access key id, secret access key, and session token.
+     * This is useful when using temporary credentials from AWS STS or similar services.
+     *
+     * @param accessKeyId the access key id, used to identify the user
+     * @param secretAccessKey the secret access key, used to authenticate the user
+     * @param sessionToken the session token, used for temporary credentials
+     */
+    static Credentials session(final String accessKeyId, final String secretAccessKey, final String sessionToken) {
+        return SessionCredentials.of(accessKeyId, secretAccessKey, sessionToken);
+    }
+
+    /**
      * Anonymous credentials. This is useful when the S3 policy has been set to allow anonymous access.
      */
     static Credentials anonymous() {

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/SessionCredentials.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/SessionCredentials.java
@@ -19,8 +19,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 abstract class SessionCredentials implements AwsSdkV2Credentials {
 
     static SessionCredentials of(
-        final String accessKeyId, final String secretAccessKey, final String sessionToken
-    ) {
+            final String accessKeyId, final String secretAccessKey, final String sessionToken) {
         return ImmutableSessionCredentials.of(accessKeyId, secretAccessKey, sessionToken);
     }
 
@@ -38,7 +37,6 @@ abstract class SessionCredentials implements AwsSdkV2Credentials {
     @Override
     public final AwsCredentialsProvider awsV2CredentialsProvider(@NotNull final S3Instructions instructions) {
         return StaticCredentialsProvider.create(AwsSessionCredentials.create(
-            accessKeyId(), secretAccessKey(), sessionToken()
-        ));
+                accessKeyId(), secretAccessKey(), sessionToken()));
     }
 }

--- a/extensions/s3/src/main/java/io/deephaven/extensions/s3/SessionCredentials.java
+++ b/extensions/s3/src/main/java/io/deephaven/extensions/s3/SessionCredentials.java
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.extensions.s3;
+
+import io.deephaven.annotations.SimpleStyle;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+import org.jetbrains.annotations.NotNull;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+/**
+ * Basic credentials that uses access key id and secret access key provided at construction.
+ */
+@Immutable
+@SimpleStyle
+abstract class SessionCredentials implements AwsSdkV2Credentials {
+
+    static SessionCredentials of(
+        final String accessKeyId, final String secretAccessKey, final String sessionToken
+    ) {
+        return ImmutableSessionCredentials.of(accessKeyId, secretAccessKey, sessionToken);
+    }
+
+    @Value.Parameter
+    abstract String accessKeyId();
+
+    @Value.Redacted
+    @Value.Parameter
+    abstract String secretAccessKey();
+
+    @Value.Redacted
+    @Value.Parameter
+    abstract String sessionToken();
+
+    @Override
+    public final AwsCredentialsProvider awsV2CredentialsProvider(@NotNull final S3Instructions instructions) {
+        return StaticCredentialsProvider.create(AwsSessionCredentials.create(
+            accessKeyId(), secretAccessKey(), sessionToken()
+        ));
+    }
+}

--- a/extensions/s3/src/test/java/io/deephaven/extensions/s3/CredentialsTest.java
+++ b/extensions/s3/src/test/java/io/deephaven/extensions/s3/CredentialsTest.java
@@ -20,6 +20,11 @@ class CredentialsTest {
     }
 
     @Test
+    void session() {
+        isCredentials(Credentials.session("accessKeyId", "secretAccessKey", "sessionToken"));
+    }
+
+    @Test
     void anonymous() {
         isCredentials(Credentials.anonymous());
     }

--- a/py/server/deephaven/experimental/s3.py
+++ b/py/server/deephaven/experimental/s3.py
@@ -92,6 +92,22 @@ class Credentials(JObjectWrapper):
         return cls(_JCredentials.basic(access_key_id, secret_access_key))
 
     @classmethod
+    def session(cls, access_key_id: str, secret_access_key: str, session_token: str) -> 'Credentials':
+        """
+        Session credentials provider with the specified access key id, secret access key, and session token.
+        This is useful when using temporary credentials from AWS STS or similar services.
+
+        Args:
+            access_key_id (str): the access key id, used to identify the user.
+            secret_access_key (str): the secret access key, used to authenticate the user.
+            session_token (str): the session token, used for temporary credentials.
+
+        Returns:
+            Credentials: the credentials object.
+        """
+        return cls(_JCredentials.session(access_key_id, secret_access_key, session_token))
+
+    @classmethod
     def anonymous(cls) -> 'Credentials':
         """
        Anonymous credentials provider, which can only be used to read data with S3 policy set to allow anonymous access.


### PR DESCRIPTION
The current version of the Deephaven S3 module does not support temporary AWS credentials via [SessionCredentials](https://docs.aws.amazon.com/AmazonS3/latest/API/API_SessionCredentials.html). The Amazon SDK supports this, so this PR adds the necessary wrapping in the Java and Python DH layers to expose SessionCredentials to the user. I did not write any tests for the Python layer as it appears that the "basic" credentials, which also requires specific creds, is untested. I assume this means it is not trivial to write such tests without real credentials of some kind.