### PR TITLE
fix: DH-19549: Bug fixes for pushdown predicate

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractColumnSource.java
@@ -354,6 +354,7 @@ public abstract class AbstractColumnSource<T> implements
     @Override
     public long estimatePushdownFilterCost(
             final WhereFilter filter,
+            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
@@ -254,8 +254,8 @@ abstract class AbstractFilterExecution {
                 final PushdownFilterContext context) {
             pushdownFilterCost = pushdownMatcher == null
                     ? Long.MAX_VALUE
-                    : pushdownMatcher.estimatePushdownFilterCost(filter, selection, sourceTable.getRowSet(), usePrev,
-                            context);
+                    : pushdownMatcher.estimatePushdownFilterCost(filter, renameMap, selection, sourceTable.getRowSet(),
+                            usePrev, context);
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownFilterMatcher.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownFilterMatcher.java
@@ -30,6 +30,7 @@ public interface PushdownFilterMatcher {
      * implemented pushdown operations.
      *
      * @param filter The {@link Filter filter} to test.
+     * @param renameMap Map of filter column names to underlying column names.
      * @param selection The set of rows to tests.
      * @param fullSet The full set of rows
      * @param usePrev Whether to use the previous result
@@ -38,6 +39,7 @@ public interface PushdownFilterMatcher {
      */
     long estimatePushdownFilterCost(
             final WhereFilter filter,
+            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocation.java
@@ -299,6 +299,7 @@ public abstract class AbstractTableLocation
     @Override
     public long estimatePushdownFilterCost(
             final WhereFilter filter,
+            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSource.java
@@ -98,6 +98,16 @@ public interface RegionedColumnSource<DATA_TYPE>
     }
 
     /**
+     * Get the region index for a row key.
+     *
+     * @param rowKey The row key to get the region index for
+     * @return The region index for the row key
+     */
+    static int getRegionIndex(final long rowKey) {
+        return Math.toIntExact(rowKey >> SUB_REGION_ROW_INDEX_ADDRESS_BITS);
+    }
+
+    /**
      * <p>
      * Add a region to this regioned column source.
      *

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceBase.java
@@ -107,12 +107,13 @@ abstract class RegionedColumnSourceBase<DATA_TYPE, ATTR extends Values, REGION_T
     @Override
     public long estimatePushdownFilterCost(
             final WhereFilter filter,
+            final Map<String, String> renameMap,
             final RowSet selection,
             final RowSet fullSet,
             final boolean usePrev,
             final PushdownFilterContext context) {
         // Delegate to the manager.
-        return manager.estimatePushdownFilterCost(filter, selection, fullSet, usePrev, context);
+        return manager.estimatePushdownFilterCost(filter, renameMap, selection, fullSet, usePrev, context);
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -831,8 +831,8 @@ public class RegionedColumnSourceManager
                             "locations: " + tableLocationEntries.size() + " for input row set: " + inputRowSet);
                 }
                 final IncludedTableLocationEntry entry = tableLocationEntries.get(regionIndex);
-                // Based on the cost of computing overlapping row sets, we can push overlap computation into the
-                // parallel region-processing jobs.
+                // Note: Based on the cost of computing overlapping row sets, we can push overlap computation into the
+                // parallel region-processing jobs in the future. For now, we can compute it serially here.
                 try (final WritableRowSet overlappingShiftedRowSet = entry.getOverlappingShiftedRowSet(inputRowSet)) {
                     if (overlappingShiftedRowSet.isEmpty()) {
                         throw new IllegalStateException(

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -858,10 +858,9 @@ public class RegionedColumnSourceManager
         final List<IncludedTableLocationEntry> tableLocationEntries = includedLocationEntries();
         for (final IncludedTableLocationEntry entry : tableLocationEntries) {
             try (final WritableRowSet overlappingRowSet = entry.getOverlappingRowSet(inputRowSet)) {
-                if (overlappingRowSet.isEmpty()) {
-                    continue; // No overlap, skip this entry
+                if (!overlappingRowSet.isEmpty()) {
+                    includedRegions.add(new RegionInfoHolder(entry, overlappingRowSet.copy()));
                 }
-                includedRegions.add(new RegionInfoHolder(entry, overlappingRowSet.copy()));
             }
         }
         return includedRegions;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -795,8 +795,8 @@ public class RegionedColumnSourceManager
     }
 
     /**
-     * A simple holder for information about a region and its row set. Closing this object will close the row set. This
-     * is used to manage row sets for regions that overlap with a given input row set during filter pushdown.
+     * Lightweight wrapper that couples an {@link IncludedTableLocationEntry} with the {@link WritableRowSet}
+     * representing the subset of rows from that region that participate in a filter-pushdown operation.
      */
     private static class RegionInfoHolder implements AutoCloseable {
         private final IncludedTableLocationEntry tle;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -33,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -747,7 +746,7 @@ public class RegionedColumnSourceManager
          * @param inputRows The input row set
          * @return A writable row set for the location
          */
-        private WritableRowSet getOverlappingRowSet(final RowSet inputRows) {
+        private WritableRowSet getOverlappingShiftedRowSet(final RowSet inputRows) {
             final long locationStartKey = getFirstRowKey(regionIndex);
             final long locationEndKey = getLastRowKey(regionIndex);
 
@@ -832,13 +831,13 @@ public class RegionedColumnSourceManager
                             "locations: " + tableLocationEntries.size() + " for input row set: " + inputRowSet);
                 }
                 final IncludedTableLocationEntry entry = tableLocationEntries.get(regionIndex);
-                try (final WritableRowSet overlappingRowSet = entry.getOverlappingRowSet(inputRowSet)) {
-                    if (overlappingRowSet.isEmpty()) {
+                try (final WritableRowSet overlappingShiftedRowSet = entry.getOverlappingShiftedRowSet(inputRowSet)) {
+                    if (overlappingShiftedRowSet.isEmpty()) {
                         throw new IllegalStateException(
                                 "Overlapping row set is empty for region index " + regionIndex + " and input row set: "
                                         + inputRowSet);
                     }
-                    includedRegions.add(new RegionInfoHolder(entry, overlappingRowSet.copy()));
+                    includedRegions.add(new RegionInfoHolder(entry, overlappingShiftedRowSet.copy()));
                     // Move to the next region, skipping the current one
                     final long regionEndKey = getLastRowKey(regionIndex);
                     startSearchFrom = regionEndKey + 1;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
@@ -1902,8 +1902,8 @@ public abstract class QueryTableWhereTest {
         }
 
         @Override
-        public long estimatePushdownFilterCost(WhereFilter filter, RowSet selection, RowSet fullSet, boolean usePrev,
-                final PushdownFilterContext context) {
+        public long estimatePushdownFilterCost(WhereFilter filter, Map<String, String> renameMap, RowSet selection,
+                RowSet fullSet, boolean usePrev, final PushdownFilterContext context) {
             return pushdownCost;
         }
 
@@ -2083,6 +2083,7 @@ public abstract class QueryTableWhereTest {
         @Override
         public long estimatePushdownFilterCost(
                 final WhereFilter filter,
+                final Map<String, String> renameMap,
                 final RowSet selection,
                 final RowSet fullSet,
                 final boolean usePrev,

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
@@ -67,7 +67,7 @@ public final class ParquetSchemaUtil {
     }
 
     /**
-     * This method returns a map from the path to the field ID, where the path is represented as a dot-separated string.
+     * This method returns a map from the path to the field ID, where the path is represented as a list of string.
      */
     public static Map<List<String>, Integer> getPathToFieldId(final MessageType schema) {
         final List<String[]> paths = ParquetSchemaUtil.paths(schema);

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
@@ -4,7 +4,6 @@
 package io.deephaven.parquet.impl;
 
 import io.deephaven.base.verify.Assert;
-import io.deephaven.util.mutable.MutableInt;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
@@ -14,6 +13,7 @@ import org.apache.parquet.schema.Type.Repetition;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -66,6 +66,18 @@ public final class ParquetSchemaUtil {
         return out;
     }
 
+    /**
+     * This method returns a map from the path to the field ID, where the path is represented as a dot-separated string.
+     */
+    public static Map<List<String>, Integer> getPathToFieldId(final MessageType schema) {
+        final List<String[]> paths = ParquetSchemaUtil.paths(schema);
+        final int size = paths.size();
+        final Map<List<String>, Integer> pathToFieldId = new HashMap<>(size);
+        for (int fieldId = 0; fieldId < size; fieldId++) {
+            pathToFieldId.put(Arrays.asList(paths.get(fieldId)), fieldId);
+        }
+        return pathToFieldId;
+    }
 
     /**
      * An alternative interface for traversing the column descriptors of a Parquet {@code schema}.

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
@@ -13,17 +13,13 @@ import org.apache.parquet.schema.Type.Repetition;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Various improved ways of traversing {@link MessageType}.
@@ -64,19 +60,6 @@ public final class ParquetSchemaUtil {
         final List<String[]> out = new ArrayList<>();
         walk(schema, (typePath, primitiveType) -> out.add(makePath(typePath)));
         return out;
-    }
-
-    /**
-     * This method returns a map from the path to the field ID, where the path is represented as a list of string.
-     */
-    public static Map<List<String>, Integer> getPathToFieldId(final MessageType schema) {
-        final List<String[]> paths = ParquetSchemaUtil.paths(schema);
-        final int size = paths.size();
-        final Map<List<String>, Integer> pathToFieldId = new HashMap<>(size);
-        for (int fieldId = 0; fieldId < size; fieldId++) {
-            pathToFieldId.put(Arrays.asList(paths.get(fieldId)), fieldId);
-        }
-        return pathToFieldId;
     }
 
     /**
@@ -165,10 +148,6 @@ public final class ParquetSchemaUtil {
 
     private static String[] makePath(Collection<Type> typePath) {
         return typePath.stream().map(Type::getName).toArray(String[]::new);
-    }
-
-    private static String makePathString(Collection<Type> typePath) {
-        return typePath.stream().map(Type::getName).collect(Collectors.joining("."));
     }
 
     private static void walk(Type type, Visitor visitor, Deque<Type> stack) {

--- a/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
+++ b/extensions/parquet/base/src/main/java/io/deephaven/parquet/impl/ParquetSchemaUtil.java
@@ -68,21 +68,6 @@ public final class ParquetSchemaUtil {
 
 
     /**
-     * This method returns a map from the path to the field ID, where the path is represented as a dot-separated string.
-     * For example, if the schema has a field at path ["foo", "bar"] with field ID 42, the map will contain an entry
-     * "foo.bar" -> 42.
-     */
-    public static Map<String, Integer> getPathToFieldId(final MessageType schema) {
-        final Map<String, Integer> out = new HashMap<>();
-        final MutableInt fieldId = new MutableInt(0);
-        walk(schema, (typePath, primitiveType) -> {
-            final String path = makePathString(typePath);
-            out.put(path, fieldId.getAndIncrement());
-        });
-        return out;
-    }
-
-    /**
      * An alternative interface for traversing the column descriptors of a Parquet {@code schema}.
      */
     public static void walkColumnDescriptors(MessageType schema, Consumer<ColumnDescriptor> consumer) {

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -439,13 +439,13 @@ public class ParquetTableLocation extends AbstractTableLocation {
             final PushdownFilterContext context) {
         if (selection.isEmpty()) {
             // If the selection is empty, we can skip all pushdown filtering.
-            log.error().append("Estimate pushdown filter cost called with empty selection for table ")
+            log.warn().append("Estimate pushdown filter cost called with empty selection for table ")
                     .append(getTableKey()).endl();
             return Long.MAX_VALUE;
         }
         final long executedFilterCost = context.executedFilterCost();
 
-        // Some range filter host a condition filter as the internal filter and we can't push that down.
+        // Some range filters host a condition filter as the internal filter, and we can't push that down.
         final boolean isRangeFilter =
                 filter instanceof RangeFilter && ((RangeFilter) filter).getRealFilter() instanceof AbstractRangeFilter;
         final boolean isMatchFilter = filter instanceof MatchFilter;
@@ -529,7 +529,7 @@ public class ParquetTableLocation extends AbstractTableLocation {
             final Consumer<PushdownResult> onComplete,
             final Consumer<Exception> onError) {
         if (selection.isEmpty()) {
-            log.error().append("Pushdown filter called with empty selection for table ").append(getTableKey()).endl();
+            log.warn().append("Pushdown filter called with empty selection for table ").append(getTableKey()).endl();
             onComplete.accept(PushdownResult.of(RowSetFactory.empty(), RowSetFactory.empty()));
             return;
         }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -500,19 +500,14 @@ public class ParquetTableLocation extends AbstractTableLocation {
             final MessageType schema,
             final Collection<List<String>> parquetColumnPaths) {
         // Get the list of paths from the schema, and then find the indices of the column's path in that list.
-        final int numColumns = parquetColumnPaths.size();
-        final Map<List<String>, Integer> indexByPath = new HashMap<>(numColumns);
-        final List<String[]> pathsFromSchema = ParquetSchemaUtil.paths(schema);
-        for (int fieldId = 0; fieldId < pathsFromSchema.size(); fieldId++) {
-            indexByPath.put(Arrays.asList(pathsFromSchema.get(fieldId)), fieldId);
-        }
-        final List<Integer> indices = new ArrayList<>(numColumns);
+        final Map<List<String>, Integer> pathToFieldId = ParquetSchemaUtil.getPathToFieldId(schema);
+        final List<Integer> indices = new ArrayList<>(parquetColumnPaths.size());
         for (final List<String> columnPath : parquetColumnPaths) {
             if (columnPath.isEmpty()) {
                 throw new IllegalArgumentException(
                         "Parquet paths must contain at least one element, found " + columnPath);
             }
-            final Integer idx = indexByPath.get(columnPath);
+            final Integer idx = pathToFieldId.get(columnPath);
             if (idx == null) {
                 throw new IllegalArgumentException(String.format(
                         "Parquet schema does not contain column '%s' for table %s",

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -448,6 +448,9 @@ public class ParquetTableLocation extends AbstractTableLocation {
                     .append(getTableKey()).endl();
             return Long.MAX_VALUE;
         }
+
+        initialize();
+
         final long executedFilterCost = context.executedFilterCost();
 
         // Some range filters host a condition filter as the internal filter, and we can't push that down.
@@ -594,6 +597,8 @@ public class ParquetTableLocation extends AbstractTableLocation {
             onComplete.accept(PushdownResult.of(RowSetFactory.empty(), RowSetFactory.empty()));
             return;
         }
+
+        initialize();
 
         // Initialize the pushdown result with the selection rowset as "maybe" rows
         PushdownResult result = PushdownResult.of(RowSetFactory.empty(), selection.copy());

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.*;
 
 import static io.deephaven.engine.testutil.TstUtils.assertTableEquals;
+import static io.deephaven.parquet.table.ParquetTools.writeTable;
 import static io.deephaven.time.DateTimeUtils.parseInstant;
 
 @Category(OutOfBandTest.class)
@@ -94,11 +95,19 @@ public final class ParquetTableFilterTest {
     private void verifyResults(Table filteredDiskTable, Table filteredMemTable) {
         Assert.assertFalse("filteredMemTable.isEmpty()", filteredMemTable.isEmpty());
         Assert.assertFalse("filteredDiskTable.isEmpty()", filteredDiskTable.isEmpty());
-        assertTableEquals(filteredDiskTable, filteredMemTable);
+        verifyResultsAllowEmpty(filteredDiskTable, filteredMemTable);
     }
 
     private void filterAndVerifyResults(Table diskTable, Table memTable, String... filters) {
         verifyResults(diskTable.where(filters).coalesce(), memTable.where(filters).coalesce());
+    }
+
+    private void filterAndVerifyResultsAllowEmpty(Table diskTable, Table memTable, String... filters) {
+        verifyResultsAllowEmpty(diskTable.where(filters).coalesce(), memTable.where(filters).coalesce());
+    }
+
+    private void verifyResultsAllowEmpty(Table filteredDiskTable, Table filteredMemTable) {
+        assertTableEquals(filteredDiskTable, filteredMemTable);
     }
 
     @Test
@@ -759,7 +768,7 @@ public final class ParquetTableFilterTest {
         // This dataset has two files, 0000 and 0005 that have missing row group metadata. Make sure to do some
         // tests which include row groups from these files.
 
-        final String dirPath = ParquetTableReadWriteTest.class.getResource("/parquet_no_stat").getFile();
+        final String dirPath = ParquetTableFilterTest.class.getResource("/parquet_no_stat").getFile();
 
         final Table diskTable = ParquetTools.readTable(dirPath);
         final Table memTable = diskTable.select();
@@ -782,5 +791,77 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, "random_int < 50", "id <= 100000", "id >= 1900");
         filterAndVerifyResults(diskTable, memTable, "random_int < 900", "id = 3000");
         filterAndVerifyResults(diskTable, memTable, "random_int < 900", "id = 50000");
+    }
+
+    @Test
+    public void filterArrayColumnsTest() {
+        final String destPath = Path.of(rootFile.getPath(), "ParquetTest_filterArrayColumnsTest.parquet").toString();
+        final int tableSize = 1_000_000;
+
+        final Table largeTable = TableTools.emptyTable(tableSize).update(
+                "array_col = ii%2 == 0 ? null : new long[] {ii + 1}");
+
+        writeTable(largeTable, destPath);
+
+        final Table diskTable = ParquetTools.readTable(destPath);
+        final Table memTable = diskTable.select();
+
+        assertTableEquals(diskTable, memTable);
+
+        filterAndVerifyResults(diskTable, memTable, "array_col == null");
+        filterAndVerifyResults(diskTable, memTable, "array_col != null");
+        filterAndVerifyResults(diskTable, memTable, "array_col != null && array_col[0] > 1");
+        filterAndVerifyResultsAllowEmpty(diskTable, memTable, "array_col != null && array_col[0] < 1");
+    }
+
+    /**
+     * <pre>
+     * import pyarrow as pa
+     * import pyarrow.parquet as pq
+     *
+     * schema = pa.schema([
+     *     pa.field("Foo",
+     *              pa.struct([pa.field("Field1", pa.int32(), nullable=False),
+     *                         pa.field("Field2", pa.int32(), nullable=False)])),
+     *     pa.field("Bar",
+     *              pa.struct([pa.field("Field1", pa.int32(), nullable=False),
+     *                         pa.field("Field2", pa.int32(), nullable=False)])),
+     *     pa.field("Baz",   pa.int32()),
+     *     pa.field("Longs", pa.list_(pa.int64()))
+     * ])
+     *
+     * N = 10
+     * table = pa.Table.from_pydict(
+     *     {
+     *         "Foo":   [{"Field1": i,      "Field2": -i}      for i in range(N)],
+     *         "Bar":   [{"Field1": i * 10, "Field2": -i * 10} for i in range(N)],
+     *         "Baz":   list(range(N)),
+     *         "Longs": [[i * 1_000 + j for j in range(3)]     for i in range(N)],
+     *     },
+     *     schema=schema,
+     * )
+     *
+     * pq.write_table(table, "NestedStruct3.parquet")
+     * </pre>
+     */
+    @Test
+    public void nestedStructsFilterTest() {
+        final String path = ParquetTableFilterTest.class.getResource("/NestedStruct3.parquet").getFile();
+        final TableDefinition definition = TableDefinition.of(
+                ColumnDefinition.ofInt("Baz"),
+                ColumnDefinition.fromGenericType("Longs", long[].class, long.class));
+
+        // If we use an explicit definition, we can skip over struct columns and just read the Baz column.
+        final Table diskTable = ParquetTools.readTable(path, ParquetInstructions.EMPTY.withTableDefinition(definition));
+        final Table memTable = diskTable.select();
+
+        assertTableEquals(diskTable, memTable);
+
+        filterAndVerifyResults(diskTable, memTable, "Baz != null");
+        filterAndVerifyResults(diskTable, memTable, "Baz < 5");
+        filterAndVerifyResultsAllowEmpty(diskTable, memTable, "Baz == null");
+
+        filterAndVerifyResults(diskTable, memTable, "Longs != null");
+        filterAndVerifyResultsAllowEmpty(diskTable, memTable, "Longs == null");
     }
 }

--- a/extensions/parquet/table/src/test/resources/NestedStruct3.parquet
+++ b/extensions/parquet/table/src/test/resources/NestedStruct3.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:140fb75353be13af950cbaf3a10dd8b133d075f648aa9f205ee2061edc543126
+size 2390

--- a/extensions/parquet/table/src/test/resources/NestedStruct3.parquet
+++ b/extensions/parquet/table/src/test/resources/NestedStruct3.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ccfe854c5afa287798741087e1e9d6ad91f5cd4e6b363446bf2fa646f64f5ea6
-size 1811
+oid sha256:140fb75353be13af950cbaf3a10dd8b133d075f648aa9f205ee2061edc543126
+size 2390


### PR DESCRIPTION
Related to https://deephaven.atlassian.net/browse/DH-19549

This PR includes fixes for:
- Only check table locations which overlap with the input row set at the time of pushdown.
- If a parquet table location does not know about a column being filtered, mark all rows as maybe matching.
- Proper mapping of column names from the filter to the column names from the schema.
- Disable pushdown predicate for list columns in parquet.