### PR TITLE
fix: DH-19656: Fix Windows build of Deephaven Core

### DIFF
--- a/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
+++ b/cpp-client/deephaven/dhclient/include/public/deephaven/client/utility/table_maker.h
@@ -31,7 +31,7 @@
 namespace deephaven::client::utility {
 namespace internal {
 template<typename T>
-struct ColumnBuilder {
+class ColumnBuilder {
   // The legitimate usages of ColumnBuilder<T> are all template specializations, which are defined
   // later in this same file. The definition provided here is the "fallback" definition in case none
   // of the specializations match. For ColumnBuilder, it is always a programming error to
@@ -50,10 +50,12 @@ struct ColumnBuilder {
   static_assert(!std::is_same_v<T, T>, "ColumnBuilder doesn't know how to work with this type");
 };
 
-template<typename TArrowBuilder, const char *kDeephavenTypeName>
+template<typename TArrowBuilder>
 class BuilderBase {
 public:
-  explicit BuilderBase(std::shared_ptr<TArrowBuilder> builder) : builder_(std::move(builder)) {}
+  explicit BuilderBase(std::shared_ptr<TArrowBuilder> builder,
+    const char *deephaven_type_name) : builder_(std::move(builder)),
+    deephaven_type_name_(deephaven_type_name) {}
 
   void AppendNull() {
     OkOrThrow(DEEPHAVEN_LOCATION_EXPR(builder_->AppendNull()));
@@ -63,7 +65,7 @@ public:
   }
 
   std::tuple<std::string, std::optional<std::string>> GetDeephavenMetadata() {
-    return { kDeephavenTypeName, {}};
+    return { deephaven_type_name_, {}};
   }
 
   [[nodiscard]]
@@ -73,18 +75,19 @@ public:
 
 protected:
   std::shared_ptr<TArrowBuilder> builder_;
+  const char *deephaven_type_name_ = nullptr;
 };
 
-template<typename T, typename TArrowBuilder, const char *kDeephavenTypeName>
-class TypicalBuilderBase : public BuilderBase<TArrowBuilder, kDeephavenTypeName> {
+template<typename T, typename TArrowBuilder>
+class TypicalBuilderBase : public BuilderBase<TArrowBuilder> {
   /**
    * Convenience using.
    */
-  using base = BuilderBase<TArrowBuilder, kDeephavenTypeName>;
+  using base = BuilderBase<TArrowBuilder>;
 
 public:
-  TypicalBuilderBase() : BuilderBase<TArrowBuilder, kDeephavenTypeName>(
-      std::make_shared<TArrowBuilder>()) {
+  explicit TypicalBuilderBase(const char *deephaven_type_name) : BuilderBase<TArrowBuilder>(
+      std::make_shared<TArrowBuilder>(), deephaven_type_name) {
   }
 
   void Append(const T &value) {
@@ -94,80 +97,87 @@ public:
 
 struct DeephavenMetadataConstants {
   struct Keys {
-    static const char kType[];
-    static const char kComponentType[];
+    static const char *Type();
+    static const char *ComponentType();
   };
 
   struct Types {
-    static const char kBool[];
-    static const char kChar16[];
-    static const char kInt8[];
-    static const char kInt16[];
-    static const char kInt32[];
-    static const char kInt64[];
-    static const char kFloat[];
-    static const char kDouble[];
-    static const char kString[];
-    static const char kDateTime[];
-    static const char kLocalDate[];
-    static const char kLocalTime[];
+    static const char *Bool();
+    static const char *Char16();
+    static const char *Int8();
+    static const char *Int16();
+    static const char *Int32();
+    static const char *Int64();
+    static const char *Float();
+    static const char *Double();
+    static const char *String();
+    static const char *DateTime();
+    static const char *LocalDate();
+    static const char *LocalTime();
   };
 };
 
 template<>
-class ColumnBuilder<bool> : public TypicalBuilderBase<bool,
-    arrow::BooleanBuilder,
-    DeephavenMetadataConstants::Types::kBool> {
+class ColumnBuilder<bool> : public TypicalBuilderBase<bool, arrow::BooleanBuilder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Bool()) {}
 };
 
 template<>
-class ColumnBuilder<char16_t> : public TypicalBuilderBase<char16_t, arrow::UInt16Builder,
-    DeephavenMetadataConstants::Types::kChar16> {
+class ColumnBuilder<char16_t> : public TypicalBuilderBase<char16_t, arrow::UInt16Builder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Char16()) {}
 };
 
 template<>
-class ColumnBuilder<int8_t> : public TypicalBuilderBase<int8_t, arrow::Int8Builder,
-    DeephavenMetadataConstants::Types::kInt8> {
+class ColumnBuilder<int8_t> : public TypicalBuilderBase<int8_t, arrow::Int8Builder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Int8()) {}
 };
 
 template<>
-class ColumnBuilder<int16_t> : public TypicalBuilderBase<int16_t, arrow::Int16Builder,
-    DeephavenMetadataConstants::Types::kInt16> {
+class ColumnBuilder<int16_t> : public TypicalBuilderBase<int16_t, arrow::Int16Builder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Int16()) {}
 };
 
 template<>
-class ColumnBuilder<int32_t> : public TypicalBuilderBase<int32_t, arrow::Int32Builder,
-    DeephavenMetadataConstants::Types::kInt32> {
+class ColumnBuilder<int32_t> : public TypicalBuilderBase<int32_t, arrow::Int32Builder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Int32()) {}
 };
 
 template<>
-class ColumnBuilder<int64_t> : public TypicalBuilderBase<int64_t, arrow::Int64Builder,
-    DeephavenMetadataConstants::Types::kInt64> {
+class ColumnBuilder<int64_t> : public TypicalBuilderBase<int64_t, arrow::Int64Builder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Int64()) {}
 };
 
 template<>
-class ColumnBuilder<float> : public TypicalBuilderBase<float, arrow::FloatBuilder,
-    DeephavenMetadataConstants::Types::kFloat> {
+class ColumnBuilder<float> : public TypicalBuilderBase<float, arrow::FloatBuilder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Float()) {}
 };
 
 template<>
-class ColumnBuilder<double> : public TypicalBuilderBase<double, arrow::DoubleBuilder,
-    DeephavenMetadataConstants::Types::kDouble> {
+class ColumnBuilder<double> : public TypicalBuilderBase<double, arrow::DoubleBuilder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::Double()) {}
 };
 
 template<>
-class ColumnBuilder<std::string> : public TypicalBuilderBase<std::string, arrow::StringBuilder,
-    DeephavenMetadataConstants::Types::kString> {
+class ColumnBuilder<std::string> : public TypicalBuilderBase<std::string, arrow::StringBuilder> {
+public:
+  ColumnBuilder() : TypicalBuilderBase(DeephavenMetadataConstants::Types::String()) {}
 };
 
 template<>
-class ColumnBuilder<deephaven::dhcore::DateTime> : public BuilderBase<arrow::TimestampBuilder,
-    DeephavenMetadataConstants::Types::kDateTime> {
+class ColumnBuilder<deephaven::dhcore::DateTime> : public BuilderBase<arrow::TimestampBuilder> {
 public:
   // constructor with data type nanos
   ColumnBuilder() : BuilderBase(
       std::make_shared<arrow::TimestampBuilder>(arrow::timestamp(arrow::TimeUnit::NANO, "UTC"),
-          arrow::default_memory_pool())) {
+          arrow::default_memory_pool()), DeephavenMetadataConstants::Types::DateTime()) {
   }
 
   void Append(const deephaven::dhcore::DateTime &value) {
@@ -176,11 +186,11 @@ public:
 };
 
 template<>
-class ColumnBuilder<deephaven::dhcore::LocalDate> : public BuilderBase<arrow::Date64Builder,
-    DeephavenMetadataConstants::Types::kLocalDate> {
+class ColumnBuilder<deephaven::dhcore::LocalDate> : public BuilderBase<arrow::Date64Builder> {
 public:
   // constructor with data type nanos
-  ColumnBuilder() : BuilderBase(std::make_shared<arrow::Date64Builder>()) {
+  ColumnBuilder() : BuilderBase(std::make_shared<arrow::Date64Builder>(),
+    DeephavenMetadataConstants::Types::LocalDate()) {
   }
 
   void Append(const deephaven::dhcore::LocalDate &value) {
@@ -189,11 +199,10 @@ public:
 };
 
 template<>
-class ColumnBuilder<deephaven::dhcore::LocalTime> : public BuilderBase<arrow::Time64Builder,
-    DeephavenMetadataConstants::Types::kLocalTime> {
+class ColumnBuilder<deephaven::dhcore::LocalTime> : public BuilderBase<arrow::Time64Builder> {
 public:
   ColumnBuilder() : BuilderBase(std::make_shared<arrow::Time64Builder>(arrow::time64(arrow::TimeUnit::NANO),
-      arrow::default_memory_pool())) {
+      arrow::default_memory_pool()), DeephavenMetadataConstants::Types::LocalTime()) {
   }
 
   void Append(const deephaven::dhcore::LocalTime &value) {
@@ -202,11 +211,10 @@ public:
 };
 
 template<arrow::TimeUnit::type UNIT>
-class ColumnBuilder<InternalDateTime<UNIT>> : public BuilderBase<arrow::TimestampBuilder,
-    DeephavenMetadataConstants::Types::kDateTime> {
+class ColumnBuilder<InternalDateTime<UNIT>> : public BuilderBase<arrow::TimestampBuilder> {
 public:
   ColumnBuilder() : BuilderBase(std::make_shared<arrow::TimestampBuilder>(arrow::timestamp(UNIT, "UTC"),
-          arrow::default_memory_pool())) {
+          arrow::default_memory_pool()), DeephavenMetadataConstants::Types::DateTime()) {
   }
 
   void Append(const InternalDateTime<UNIT> &value) {
@@ -215,11 +223,10 @@ public:
 };
 
 template<arrow::TimeUnit::type UNIT>
-class ColumnBuilder<InternalLocalTime<UNIT>> : public BuilderBase<arrow::Time64Builder,
-    DeephavenMetadataConstants::Types::kLocalTime> {
+class ColumnBuilder<InternalLocalTime<UNIT>> : public BuilderBase<arrow::Time64Builder> {
 public:
   ColumnBuilder() : BuilderBase(std::make_shared<arrow::Time64Builder>(arrow::time64(UNIT),
-          arrow::default_memory_pool())) {
+          arrow::default_memory_pool()), DeephavenMetadataConstants::Types::LocalTime()) {
   }
 
   void Append(const InternalLocalTime<UNIT> &value) {

--- a/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
+++ b/cpp-client/deephaven/dhclient/src/utility/table_maker.cc
@@ -39,10 +39,10 @@ void TableMaker::FinishAddColumn(std::string name, std::shared_ptr<arrow::Array>
     std::optional<std::string> deephaven_metadata_component_type_name) {
   auto kv_metadata = std::make_shared<arrow::KeyValueMetadata>();
   OkOrThrow(DEEPHAVEN_LOCATION_EXPR(
-    kv_metadata->Set(DeephavenMetadataConstants::Keys::kType, std::move(deephaven_metadata_type_name))));
+    kv_metadata->Set(DeephavenMetadataConstants::Keys::Type(), std::move(deephaven_metadata_type_name))));
   if (deephaven_metadata_component_type_name.has_value()) {
     OkOrThrow(DEEPHAVEN_LOCATION_EXPR(
-        kv_metadata->Set(DeephavenMetadataConstants::Keys::kComponentType,
+        kv_metadata->Set(DeephavenMetadataConstants::Keys::ComponentType(),
             std::move(*deephaven_metadata_component_type_name))));
   }
 
@@ -135,20 +135,19 @@ TableMaker::ColumnInfo::ColumnInfo(ColumnInfo &&other) noexcept = default;
 TableMaker::ColumnInfo::~ColumnInfo() = default;
 
 namespace internal {
-const char DeephavenMetadataConstants::Keys::kType[] = "deephaven:type";
-const char DeephavenMetadataConstants::Keys::kComponentType[] = "deephaven:componentType";
-
-const char DeephavenMetadataConstants::Types::kBool[] = "java.lang.Boolean";
-const char DeephavenMetadataConstants::Types::kChar16[] = "char";
-const char DeephavenMetadataConstants::Types::kInt8[] = "byte";
-const char DeephavenMetadataConstants::Types::kInt16[] = "short";
-const char DeephavenMetadataConstants::Types::kInt32[] = "int";
-const char DeephavenMetadataConstants::Types::kInt64[] = "long";
-const char DeephavenMetadataConstants::Types::kFloat[] = "float";
-const char DeephavenMetadataConstants::Types::kDouble[] = "double";
-const char DeephavenMetadataConstants::Types::kString[] = "java.lang.String";
-const char DeephavenMetadataConstants::Types::kDateTime[] = "java.time.ZonedDateTime";
-const char DeephavenMetadataConstants::Types::kLocalDate[] = "java.time.LocalDate";
-const char DeephavenMetadataConstants::Types::kLocalTime[] = "java.time.LocalTime";
+const char *DeephavenMetadataConstants::Keys::Type() { return "deephaven:type"; }
+const char *DeephavenMetadataConstants::Keys::ComponentType() {  return "deephaven:componentType";}
+const char *DeephavenMetadataConstants::Types::Bool() { return "java.lang.Boolean"; }
+const char *DeephavenMetadataConstants::Types::Char16() { return "char"; }
+const char *DeephavenMetadataConstants::Types::Int8() { return "byte"; }
+const char *DeephavenMetadataConstants::Types::Int16() { return "short"; }
+const char *DeephavenMetadataConstants::Types::Int32() { return "int"; }
+const char *DeephavenMetadataConstants::Types::Int64() { return "long"; }
+const char *DeephavenMetadataConstants::Types::Float() { return "float"; }
+const char *DeephavenMetadataConstants::Types::Double() { return "double"; }
+const char *DeephavenMetadataConstants::Types::String() { return "java.lang.String"; }
+const char *DeephavenMetadataConstants::Types::DateTime() { return "java.time.ZonedDateTime"; }
+const char *DeephavenMetadataConstants::Types::LocalDate() { return "java.time.LocalDate"; }
+const char *DeephavenMetadataConstants::Types::LocalTime() { return "java.time.LocalTime"; }
 }  // namespace internal
 }  // namespace deephaven::client::utility

--- a/cpp-client/deephaven/examples/demos/feedtimes.cc
+++ b/cpp-client/deephaven/examples/demos/feedtimes.cc
@@ -246,11 +246,11 @@ public:
 
       if (!min_.has_value() || lmin < min_->Nanos()) {
         min_ = DateTime::FromNanos(lmin);
-        min_delay_ = recv_ts - ToTimePoint(*min_);
+        min_delay_ = recv_ts - ToTimePoint<my_clock, my_duration>(*min_);
       }
       if (!max_.has_value() || lmax > max_->Nanos()) {
         max_ = DateTime::FromNanos(lmax);
-        max_delay_ = recv_ts - ToTimePoint(*max_);
+        max_delay_ = recv_ts - ToTimePoint<my_clock, my_duration>(*max_);
       }
     }
   }

--- a/cpp-client/deephaven/tests/src/cython_support_test.cc
+++ b/cpp-client/deephaven/tests/src/cython_support_test.cc
@@ -156,18 +156,6 @@ ContainerColumnSourceToVector(const ColumnSource &cs, size_t num_slices) {
   }
   return result;
 }
-
-template<typename T>
-void zambonidump(const std::vector<std::optional<T>> &vec) {
-  std::cout << "HATE\n";
-  for (const auto &elt : vec) {
-    if (elt.has_value()) {
-      std::cout << *elt << '\n';
-    } else {
-      std::cout << "NONE\n";
-    }
-  }
-}
 }  // namespace
 
 // Testing the entry point CythonSupport::SlicesToColumnSource
@@ -227,8 +215,6 @@ TEST_CASE("ContainerToColumnSource", "[cython]") {
   auto actual_vector = ColumnSourceToVector<std::string>(*cs, expected_vector.size());
 
   CHECK(expected_vector == actual_vector);
-  zambonidump(expected_vector);
-  zambonidump(actual_vector);
 }
 
 // Testing the entry point CythonSupport::ColumnSourceToString

--- a/cpp-client/deephaven/tests/src/new_table_test.cc
+++ b/cpp-client/deephaven/tests/src/new_table_test.cc
@@ -40,7 +40,7 @@ TEST_CASE("Scalar Types", "[newtable]") {
   maker.AddColumn<std::optional<bool>>("Bools",
       { {}, false, true, false, false, true });
   maker.AddColumn<std::optional<char16_t>>("Chars",
-      { {}, 0, 'a', u'ᐾ', DeephavenConstants::kMinChar, DeephavenConstants::kMaxChar });
+      { {}, 0, 'a', u'\u143E', DeephavenConstants::kMinChar, DeephavenConstants::kMaxChar });
   maker.AddColumn<std::optional<int8_t>>("Bytes",
       { {}, 0, 1, -1, DeephavenConstants::kMinByte, DeephavenConstants::kMaxByte });
   maker.AddColumn<std::optional<int16_t>>("Shorts",
@@ -84,8 +84,8 @@ TEST_CASE("List Types", "[newtable]") {
   });
   maker.AddColumn<std::optional<std::vector<std::optional<char16_t>>>>("Chars", {
       {}, // a null list
-      { { 'a', u'ᐾ' } }, // a non-null list
-      { { 'a', u'ᐾ', {} } } // a non-null list with a null entry
+      { { 'a', u'\u143E' } }, // a non-null list
+      { { 'a', u'\u143E', {} } } // a non-null list with a null entry
   });
   maker.AddColumn<std::optional<std::vector<std::optional<int8_t>>>>("Bytes", {
       {}, // a null list


### PR DESCRIPTION
This PR fixes three problems that were preventing Community Core from building successfully on Windows. Additionally, it removes some debugging code that had some silly messages.

Briefly,
1. The way we do Windows builds, we rely on cmake to do the necessary dllexport/dllimport stuff for shared libraries. However that support is limited to functions; it does not work for global variables. The workaround we use is that when we have a global variable that we want to provide from one library and reference in another, we represent that global variable as a simple accessor function. In a previous PR I forgot about this limitation and introduced a bunch of global variables.
2. There were a few instances of Unicode character literals that Visual Studio wasn't parsing correctly, probably because it was assuming the source file had an iso-latin-1 encoding rather than UTF-8. This was fixed by using \uxxxx escape codes.
3. There was an expression in feedtimes.cc that calculated the difference between two time_points. The Windows compiler couldn't find a suitable `operator-`. It's possible this is because `std::chrono::high_resolution_clock` has a different type on Windows and Linux. By specifying types to `ToTimePoint` explicitly we are able to make this work.
4. Removed the infelicitous method `zambonidump` from cython_support_test.cc