### PR TITLE
fix: NPE in UnionSourceManager When Constituent Fails

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/UnionSourceManager.java
@@ -584,10 +584,11 @@ public class UnionSourceManager {
 
                 // Make sure we propagate any actual error on to the listeners, and advance the listener so we can
                 // continue to process the rest of the tables
-                if (nextListener.error != null) {
+                final Throwable listenerError = nextListener.error;
+                if (listenerError != null) {
                     final String referentDescription = nextListener.getParent().getDescription();
                     advanceListener();
-                    throw new ConstituentTableException(referentDescription, nextListener.error);
+                    throw new ConstituentTableException(referentDescription, listenerError);
                 }
 
                 changes = nextListener.getUpdate();

--- a/engine/table/src/test/java/io/deephaven/engine/util/TestTableTools.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/TestTableTools.java
@@ -1166,6 +1166,7 @@ public class TestTableTools {
 
         Assert.assertTrue(res.isFailed());
         Assert.assertTrue(errRef.get() instanceof ConstituentTableException);
+        Assert.assertEquals(err, errRef.get().getCause());
     }
 
     @Test
@@ -1197,5 +1198,6 @@ public class TestTableTools {
 
         Assert.assertTrue(res.isFailed());
         Assert.assertTrue(errRef.get() instanceof ConstituentTableException);
+        Assert.assertEquals(err, errRef.get().getCause());
     }
 }


### PR DESCRIPTION
A community user ran into this when trying to merge several barrage-subscribed tables. They were all failing, causing an NPE as the iterator advanced past the end of the list and then attempts to dereference a null instead of capturing the error locally before advancing the iterator.