### PR TITLE
feat: DH-18316: throw error if FileHandle key changes

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/util/file/TrackedFileHandleFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/util/file/TrackedFileHandleFactory.java
@@ -142,10 +142,8 @@ public class TrackedFileHandleFactory implements FileHandleFactory {
             // Synchronous cleanup at full capacity.
             cleanup();
         }
-        final FileChannel fileChannel = FileChannel.open(file.toPath(), openOptions);
-        final CloseRecorder closeRecorder = new CloseRecorder();
-        final FileHandle handle = new FileHandle(fileChannel, closeRecorder);
-        handleReferences.add(new HandleReference(handle, fileChannel, closeRecorder));
+        final FileHandle handle = FileHandle.open(file.toPath(), new CloseRecorder(), openOptions);
+        handleReferences.add(new HandleReference(handle));
         return handle;
     }
 
@@ -207,16 +205,15 @@ public class TrackedFileHandleFactory implements FileHandleFactory {
         }
     }
 
-    private class HandleReference extends WeakReference<FileHandle> {
+    private static class HandleReference extends WeakReference<FileHandle> {
 
         private final FileChannel fileChannel;
-        private final CloseRecorder closeRecorder;
+        private final Runnable closeRecorder;
 
-        private HandleReference(@NotNull final FileHandle referent, @NotNull final FileChannel fileChannel,
-                @NotNull final CloseRecorder closeRecorder) {
+        private HandleReference(@NotNull final FileHandle referent) {
             super(referent);
-            this.fileChannel = fileChannel;
-            this.closeRecorder = closeRecorder;
+            this.fileChannel = referent.fileChannel();
+            this.closeRecorder = referent.postCloseProcedure();
         }
 
         private void reclaim() {

--- a/engine/table/src/test/java/io/deephaven/engine/util/file/TestFileHandle.java
+++ b/engine/table/src/test/java/io/deephaven/engine/util/file/TestFileHandle.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 
 /**
@@ -27,11 +26,9 @@ public class TestFileHandle {
     @Before
     public void setup() throws IOException {
         file = File.createTempFile("TestFileHandle-", ".dat");
-        FHUT = new FileHandle(FileChannel.open(file.toPath(),
-                StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING,
-                StandardOpenOption.CREATE),
-                () -> {
-                });
+        FHUT = FileHandle.open(file.toPath(), () -> {
+        }, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.CREATE);
     }
 
     @After


### PR DESCRIPTION
This adds upfront safety checks whenever a FileHandle gets refreshed to ensure it represents the same physical file as it did before. When this is not the case, it can lead to very hard to debug downstream issues, taking days of time to track down.