### PR TITLE
fix: DH-19690: migrate to Central Portal publishing

### DIFF
--- a/.github/workflows/nightly-publish-ci.yml
+++ b/.github/workflows/nightly-publish-ci.yml
@@ -43,13 +43,15 @@ jobs:
           .github/scripts/gradle-properties.sh >> gradle.properties
           cat gradle.properties
 
-      - name: Publish to OSSRH snapshots repository
+      - name: Publish to Central Portal snapshots repository
         # We are not worried here about using --no-parallel (as we are with release publishing), since publishing
         # snapshots does not even create staging repositories.
-        run: ./gradlew publish
+        # Note: --no-configuration-cache is documented as necessary due https://github.com/gradle/gradle/issues/22779
+        # from https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-automatic-publishing
+        run: ./gradlew --no-configuration-cache publishToMavenCentral
         env:
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CI_AT_DEEPHAVEN_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingRequired: true

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -56,13 +56,16 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/heads/release/v') }}
         run: ./gradlew server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publishToMavenLocal
 
-      - name: Build all artifacts, publish to Sonatype for staging to Maven Central
+      - name: Build all artifacts, publish to Sonatype for staging to Maven Central Portal
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         # We need to be explicit here about no parallelism to ensure we don't create disjointed staging repositories.
-        run: ./gradlew --no-parallel server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publish
+        # Edit: unclear if above note is still possible with the new portal API / plugin implementation.
+        # Note: --no-configuration-cache is documented as necessary due https://github.com/gradle/gradle/issues/22779
+        # from https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-automatic-publishing
+        run: ./gradlew --no-parallel --no-configuration-cache server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publishToMavenCentral
         env:
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CI_AT_DEEPHAVEN_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingRequired: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -152,7 +152,7 @@ Note: release branches are _not_ typically merged back into `main`.
 The release will proceed with [GitHub Actions](https://github.com/deephaven/deephaven-core/actions/workflows/publish-ci.yml).
 The specific action can be found based off of the name of the release branch: [?query=branch%3Arelease%2FvX.Y.Z](https://github.com/deephaven/deephaven-core/actions/workflows/publish-ci.yml?query=branch%3Arelease%2FvX.Y.Z).
 
-The "Publish" step creates the artifacts and publishes the jars to a [Maven Central staging repository](https://s01.oss.sonatype.org).
+The "Publish" step creates the artifacts and publishes the jars to a [Maven Central Portal staging repository](https://central.sonatype.com/).
 
 The "Upload Artifacts" step uploads the Deephaven server application, the deephaven-core wheel, and the deephaven-server wheel as *temporary* GitHub action artifacts.
 
@@ -203,7 +203,7 @@ Please post the difference to the Deephaven team to ensure there are no unexpect
 
 ### 7. Maven Central jars
 
-The jars are put into a [Maven Central Repository Manager](https://s01.oss.sonatype.org) staging repository.
+The jars are put into a [Maven Central Portal](https://central.sonatype.com/) staging repository.
 You'll need your own username and password to sign in (to ensure auditability).
 
 Arguably, the Maven Central jars are the most important artifacts - once they are officially released from the staging repository, they are released "forever".

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -35,4 +35,8 @@ dependencies {
     }
 
     implementation "com.gradleup.shadow:shadow-gradle-plugin:8.3.8"
+
+    implementation('com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.33.0') {
+        because('needed by plugin java-publishing-conventions')
+    }
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-publishing-conventions.gradle
@@ -3,7 +3,9 @@ import io.deephaven.project.util.PublishingTools
 plugins {
   id 'java'
   id 'signing'
-  id 'maven-publish'
+  // Note: applying `com.vanniktech.maven.publish.base` instead of `com.vanniktech.maven.publish` which gives us more
+  // control over (otherwise `com.vanniktech.maven.publish.JavaLibrary` would be applied by default).
+  id 'com.vanniktech.maven.publish.base'
   id 'io.deephaven.javadoc-conventions'
 }
 
@@ -22,15 +24,18 @@ sourceSets.configureEach { sourceSet ->
   }
 }
 
-tasks.withType(Javadoc) {
+tasks.withType(Javadoc).configureEach {
   // https://github.com/gradle/gradle/issues/19869
   options.addStringOption('sourcepath', sourceSets.main.allJava.getSourceDirectories().getAsPath())
 }
 
-PublishingTools.setupPublications(project) {
-  from components.java
-}
+project
+    .extensions
+    .getByType(PublishingExtension)
+    .publications
+    .create('mavenJava', MavenPublication) {
+      // "java" is the component name created by the java plugin (does not provide a constant)
+      from(project.components.named('java').get())
+    }
 
-PublishingTools.setupRepositories(project)
-PublishingTools.setupMavenPublication(project, publishing.publications.mavenJava)
-PublishingTools.setupSigning(project, publishing.publications.mavenJava)
+PublishingTools.setupPublishing(project)

--- a/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
@@ -7,7 +7,13 @@ import org.gradle.jvm.tasks.Jar
 plugins {
   id 'java'
   id 'signing'
-  id 'maven-publish'
+  // Note: applying `com.vanniktech.maven.publish.base` instead of `com.vanniktech.maven.publish` since we need more
+  // fine-grained configuration wrt shadowing. Specifically, when `com.vanniktech.maven.publish.JavaLibrary` is applied
+  // by `com.vanniktech.maven.publish`, it automatically creates a "maven" publication based on the "java" component,
+  // and that conflicts with our desires for the "shadow" publication, and would result in the error:
+  // Multiple publications with coordinates '...' are published to repository 'mavenLocal'. The publications 'maven' in
+  // project '...' and 'shadow' in project '...' will overwrite each other!
+  id 'com.vanniktech.maven.publish.base'
   id 'com.gradleup.shadow'
   id 'io.deephaven.javadoc-conventions'
 }
@@ -22,15 +28,15 @@ tasks.withType(Javadoc).configureEach {
   options.addStringOption('sourcepath', sourceSets.main.allJava.getSourceDirectories().getAsPath())
 }
 
-def shadowPublication = project
-        .extensions
-        .getByType(PublishingExtension)
-        .publications
-        .create(PublishingTools.SHADOW_PUBLICATION_NAME, MavenPublication) {
-          from(project.components.named(ShadowBasePlugin.COMPONENT_NAME).get())
-          artifact(project.tasks.named('sourcesJar'))
-          artifact(project.tasks.named('javadocJar'))
-        }
+project
+    .extensions
+    .getByType(PublishingExtension)
+    .publications
+    .create(PublishingTools.SHADOW_PUBLICATION_NAME, MavenPublication) {
+      from(project.components.named(ShadowBasePlugin.COMPONENT_NAME).get())
+      artifact(project.tasks.named('sourcesJar'))
+      artifact(project.tasks.named('javadocJar'))
+    }
 
 def shadowJar = project.tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME, ShadowJar) {
   // We want the shadow jar to be the "default" jar, so we don't want it to have a classifier
@@ -48,8 +54,5 @@ project.tasks.named('assemble') {
   it.dependsOn(shadowJar)
 }
 
-PublishingTools.setupRepositories(project)
-PublishingTools.setupLicense(project, shadowPublication)
-PublishingTools.setupMavenPublication(project, shadowPublication)
-PublishingTools.setupSigning(project, shadowPublication)
+PublishingTools.setupPublishing(project)
 // Projects will need to call PublishingTools.setupShadowName to setup appropriate shadow names

--- a/buildSrc/src/main/groovy/io.deephaven.project.bom-public.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.project.bom-public.gradle
@@ -1,32 +1,34 @@
 import io.deephaven.project.util.JavaDependencies
 import io.deephaven.project.util.PublishingTools
+import io.deephaven.tools.License
 
 plugins {
     id 'io.deephaven.common-conventions'
     id 'java-platform'
-    id 'maven-publish'
+    // Note: applying `com.vanniktech.maven.publish.base` instead of `com.vanniktech.maven.publish` which gives us more
+    // control over (otherwise `com.vanniktech.maven.publish.JavaPlatform` would be applied by default).
+    id 'com.vanniktech.maven.publish.base'
     id 'signing'
 }
 
-publishing {
-    publications {
-        myPlatform(MavenPublication) {
-            from components.javaPlatform
+project
+        .extensions
+        .getByType(PublishingExtension)
+        .publications
+        .create('myPublication', MavenPublication) {
+            // "javaPlatform" is the component name created by the java-platform plugin (does not provide a constant)
+            from(project.components.named('javaPlatform').get())
             pom {
                 licenses {
                     license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        name = License.APACHE_LICENSE_NAME
+                        url = License.APACHE_LICENSE_URL
                     }
                 }
             }
         }
-    }
-}
 
-PublishingTools.setupRepositories(project)
-PublishingTools.setupMavenPublication(project, publishing.publications.myPlatform)
-PublishingTools.setupSigning(project, publishing.publications.myPlatform)
+PublishingTools.setupBomPublishing(project)
 
 project.tasks
         .getByName('quick')

--- a/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
@@ -2,17 +2,16 @@ package io.deephaven.project.util
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import groovy.transform.CompileStatic
 import io.deephaven.tools.License
-import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.plugins.BasePluginExtension
-import org.gradle.api.publish.Publication
 import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.plugins.signing.SigningExtension
 
@@ -33,113 +32,96 @@ class PublishingTools {
     static final String SCM_CONNECTION = 'scm:git:git://github.com/deephaven/deephaven-core.git'
     static final String SCM_DEV_CONNECTION = 'scm:git:ssh://github.com/deephaven/deephaven-core.git'
 
-    static final String REPO_NAME = 'ossrh'
-    static final String SNAPSHOT_REPO = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-    static final String RELEASE_REPO = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-
     static final String SHADOW_PUBLICATION_NAME = 'shadow'
-
-    static void setupPublications(Project project, Closure closure) {
-        setupPublications(project, new Action<MavenPublication>() {
-            @Override
-            void execute(MavenPublication mavenPublication) {
-                project.configure(mavenPublication, closure)
-            }
-        })
-    }
-
-    static void setupPublications(Project project, Action<MavenPublication> action) {
-        project.extensions
-                .getByType(PublishingExtension)
-                .publications
-                .create('mavenJava', MavenPublication) { publication ->
-                    action.execute(publication)
-                    setupLicense(project, publication)
-                }
-    }
-
-    static void setupLicense(Project project, MavenPublication publication) {
-        def projectLicense = project.extensions.extraProperties.get('license') as License
-        publication.pom {pom ->
-            pom.licenses { licenses ->
-                licenses.license { license ->
-                    license.name.set projectLicense.name
-                    license.url.set projectLicense.url
-                }
-            }
-        }
-    }
 
     static boolean isSnapshot(Project project) {
         return ((String)project.version).endsWith('-SNAPSHOT')
     }
 
-    static void setupRepositories(Project project) {
-        PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)
-        publishingExtension.repositories { repoHandler ->
-            repoHandler.maven { MavenArtifactRepository repo ->
-                repo.name = REPO_NAME
-                repo.url = isSnapshot(project) ? SNAPSHOT_REPO : RELEASE_REPO
-                // ossrhUsername, ossrhPassword
-                repo.credentials(PasswordCredentials)
+    static void setupPublishing(Project project) {
+        setupPublishingImpl project, false
+        setupSigning project
+    }
+
+    static void setupBomPublishing(Project project) {
+        // Note: setting up bom as separate entrypoint than setupPublishing because we can't use
+        // io.deephaven.java-license-conventions to provide License since a the bom ('java-platform') can't use 'java'
+        // nor 'java-library' plugin
+        setupPublishingImpl project, true
+        setupSigning project
+    }
+
+    private static void setupPublishingImpl(Project project, boolean isBom) {
+        MavenPublishBaseExtension mpb = project.extensions.getByType(MavenPublishBaseExtension)
+        BasePluginExtension base = project.extensions.getByType(BasePluginExtension)
+        mpb.publishToMavenCentral()
+        mpb.signAllPublications()
+        mpb.pom { pom ->
+            setPomConstants pom
+            if (!isBom) {
+                // Bom sets the license at the top level
+                setPomLicense project, pom
+            }
+        }
+        project.afterEvaluate {
+            mpb.coordinates(null, base.archivesName.get(), null)
+            mpb.pom { pom ->
+                pom.name.set base.archivesName.get()
+                pom.description.set project.description
+            }
+        }
+        def assertIsRelease = assertIsReleaseTask(project)
+        // Note: this is the same way that com.vanniktech.maven.publish.MavenPublishBaseExtension hooks into the
+        // lower-level publish tasks to establish its own dependencies on the maven-publish tasks.
+        // It uses `repo.name = "mavenCentral"` and the pattern as documented
+        // https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:tasks,
+        // publish[PubName]PublicationTo[RepoName]Repository
+        project.tasks.withType(PublishToMavenRepository).configureEach { publishTask ->
+            if (publishTask.name.endsWith("ToMavenCentralRepository")) {
+                publishTask.dependsOn assertIsRelease
             }
         }
     }
 
-    static void setupMavenPublication(Project project, MavenPublication mavenPublication) {
-        mavenPublication.pom {pom ->
-            pom.url.set PROJECT_URL
-            pom.organization {org ->
-                org.name.set ORG_NAME
-                org.url.set ORG_URL
-            }
-            pom.scm { scm ->
-                scm.url.set SCM_URL
-                scm.connection.set SCM_CONNECTION
-                scm.developerConnection.set SCM_DEV_CONNECTION
-            }
-            pom.issueManagement { im ->
-                im.system.set ISSUES_SYSTEM
-                im.url.set ISSUES_URL
-            }
-            pom.developers { devs ->
-                devs.developer { dev ->
-                    dev.id.set DEVELOPER_ID
-                    dev.name.set DEVELOPER_NAME
-                    dev.email.set DEVELOPER_EMAIL
-                    dev.organization.set ORG_NAME
-                    dev.organizationUrl.set ORG_URL
-                }
-            }
-        }
-
-        def publishToOssrhTask = project.tasks.getByName("publish${mavenPublication.getName().capitalize()}PublicationToOssrhRepository")
-
-        publishToOssrhTask.dependsOn assertIsReleaseTask(project)
-
-        project.afterEvaluate { Project p ->
-            // https://central.sonatype.org/publish/requirements/
-            if (p.description == null) {
-                throw new IllegalStateException("Project '${project.name}' is missing a description, which is required for publishing to maven central")
-            }
-            BasePluginExtension base = p.extensions.findByType(BasePluginExtension)
-            // The common-conventions plugin should take care of this, but we'll double-check here
-            String archivesName = base.archivesName.get()
-            if (!archivesName.contains('deephaven')) {
-                throw new IllegalStateException("Project '${project.name}' archiveBaseName '${archivesName}' does not contain 'deephaven'")
-            }
-            mavenPublication.artifactId = archivesName
-            mavenPublication.pom { pom ->
-                pom.name.set archivesName
-                pom.description.set p.description
+    private static void setPomLicense(Project project, MavenPom pom) {
+        License theLicense = project.extensions.extraProperties.get('license') as License
+        pom.licenses { licenses ->
+            licenses.license { license ->
+                license.name.set theLicense.name
+                license.url.set theLicense.url
             }
         }
     }
 
-    static void setupSigning(Project project, Publication publication) {
+    private static void setPomConstants(MavenPom pom) {
+        pom.url.set PROJECT_URL
+        pom.organization { org ->
+            org.name.set ORG_NAME
+            org.url.set ORG_URL
+        }
+        pom.scm { scm ->
+            scm.url.set SCM_URL
+            scm.connection.set SCM_CONNECTION
+            scm.developerConnection.set SCM_DEV_CONNECTION
+        }
+        pom.issueManagement { im ->
+            im.system.set ISSUES_SYSTEM
+            im.url.set ISSUES_URL
+        }
+        pom.developers { devs ->
+            devs.developer { dev ->
+                dev.id.set DEVELOPER_ID
+                dev.name.set DEVELOPER_NAME
+                dev.email.set DEVELOPER_EMAIL
+                dev.organization.set ORG_NAME
+                dev.organizationUrl.set ORG_URL
+            }
+        }
+    }
+
+    static void setupSigning(Project project) {
         SigningExtension signingExtension = project.extensions.getByType(SigningExtension)
         signingExtension.required = "true" == project.findProperty('signingRequired')
-        signingExtension.sign(publication)
         String signingKey = project.findProperty('signingKey')
         String signingPassword = project.findProperty('signingPassword')
         if (signingKey != null && signingPassword != null) {

--- a/buildSrc/src/main/groovy/io/deephaven/tools/License.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/tools/License.groovy
@@ -20,8 +20,8 @@ class License {
     private static final String LICENSE_SOURCE_SET_NAME = 'license'
 
     private static final String APACHE_LICENSE_SHA256 = 'cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30'
-    private static final String APACHE_LICENSE_NAME = 'The Apache License, Version 2.0'
-    private static final String APACHE_LICENSE_URL = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    static final String APACHE_LICENSE_NAME = 'The Apache License, Version 2.0'
+    static final String APACHE_LICENSE_URL = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 
     static License deephavenCommunityLicense(Project project) {
         return new License(


### PR DESCRIPTION
This is a migration to Central Portal publishing via the [gradle-maven-publish-plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/).

As best as I can tell, the resulting pom and module files for our java libraries, shadow libraries, and the bom are identical.