### PR TITLE
fix: DH-19830: lastBy on Blink Tables Reports Incorrect Previous Values for Vectors.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/BaseBlinkFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/BaseBlinkFirstOrLastChunkedOperator.java
@@ -9,6 +9,7 @@ import io.deephaven.chunk.attributes.ChunkPositions;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.MatchPair;
+import io.deephaven.engine.table.impl.snapshot.SnapshotUtils;
 import io.deephaven.engine.table.impl.sources.*;
 import io.deephaven.chunk.*;
 import io.deephaven.engine.rowset.chunkattributes.RowKeys;
@@ -44,7 +45,7 @@ public abstract class BaseBlinkFirstOrLastChunkedOperator
      * <p>
      * These are the source columns from the upstream table, reinterpreted to primitives where applicable.
      */
-    protected final ColumnSource<?>[] inputColumns;
+    protected final ChunkSource.WithPrev<?>[] inputColumns;
     /**
      * <p>
      * Output columns, parallel to {@link #inputColumns} and {@link #resultColumns}.
@@ -66,7 +67,7 @@ public abstract class BaseBlinkFirstOrLastChunkedOperator
             @NotNull final MatchPair[] resultPairs,
             @NotNull final Table blinkTable) {
         numResultColumns = resultPairs.length;
-        inputColumns = new ColumnSource[numResultColumns];
+        inputColumns = new ChunkSource.WithPrev[numResultColumns];
         outputColumns = new WritableColumnSource[numResultColumns];
         final Map<String, WritableColumnSource<?>> resultColumnsMutable = new LinkedHashMap<>(numResultColumns);
         for (int ci = 0; ci < numResultColumns; ++ci) {
@@ -75,7 +76,7 @@ public abstract class BaseBlinkFirstOrLastChunkedOperator
             final WritableColumnSource<?> resultSource = ArrayBackedColumnSource.getMemoryColumnSource(0,
                     streamSource.getType(), streamSource.getComponentType());
             resultColumnsMutable.put(resultPair.leftColumn(), resultSource);
-            inputColumns[ci] = ReinterpretUtils.maybeConvertToPrimitive(streamSource);
+            inputColumns[ci] = SnapshotUtils.maybeWrapVector(ReinterpretUtils.maybeConvertToPrimitive(streamSource));
             // Note that ArrayBackedColumnSources implementations reinterpret very efficiently where applicable.
             outputColumns[ci] = (WritableColumnSource<?>) ReinterpretUtils.maybeConvertToPrimitive(resultSource);
             Assert.eq(inputColumns[ci].getChunkType(), "inputColumns[ci].getChunkType()",

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/BlinkFirstChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/BlinkFirstChunkedOperator.java
@@ -216,7 +216,7 @@ public class BlinkFirstChunkedOperator extends BaseBlinkFirstOrLastChunkedOperat
 
                 try (final RowSequence sliceSources = RowSequenceFactory.wrapRowKeysChunkAsRowSequence(sourceIndices)) {
                     for (int ci = 0; ci < numResultColumns; ++ci) {
-                        final Chunk<? extends Values> inputChunk =
+                        final Chunk inputChunk =
                                 inputColumns[ci].getChunk(inputContexts[ci], sliceSources);
                         outputColumns[ci].fillFromChunk(outputContexts[ci], inputChunk, sliceDestinations);
                     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/CopyingPermutedBlinkFirstOrLastChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/CopyingPermutedBlinkFirstOrLastChunkedOperator.java
@@ -106,7 +106,7 @@ public abstract class CopyingPermutedBlinkFirstOrLastChunkedOperator extends Bas
                 try (final RowSequence sliceSources =
                         RowSequenceFactory.wrapRowKeysChunkAsRowSequence(WritableLongChunk.downcast(sourceIndices))) {
                     for (int ci = 0; ci < numResultColumns; ++ci) {
-                        final Chunk<? extends Values> inputChunk =
+                        final Chunk inputChunk =
                                 inputColumns[ci].getChunk(inputContexts[ci], sliceSources);
                         permuteKernels[ci].permute(inputChunk, sourceIndicesOrder, outputChunks[ci]);
                         outputColumns[ci].fillFromChunk(outputContexts[ci], outputChunks[ci], sliceDestinations);


### PR DESCRIPTION
Cherry-pick of https://github.com/deephaven/deephaven-core/pull/6987