### PR TITLE
fix: DH-18563, DH-19804: Migrate shadow plugin to com.gradleup.shadow

### DIFF
--- a/authentication/example-providers/build.gradle
+++ b/authentication/example-providers/build.gradle
@@ -1,3 +1,5 @@
+import io.deephaven.project.util.PublishingTools
+
 plugins {
     id 'io.deephaven.project.register'
 }
@@ -13,9 +15,6 @@ project.subprojects { Project p ->
         shadow project(':log-factory')
     }
 
-    // ensure we build the shadow jar as part of simple builds
-    p.tasks.findByName('assemble').dependsOn(p.tasks.named('shadowJar'))
-
-    // Let projects be named consistently
-    p.base.archivesName = "deephaven-${p.name}-authentication-provider"
+    // We know all of the subprojects have io.deephaven.project.ProjectType=JAVA_PUBLIC_SHADOW
+    PublishingTools.setupShadowName(p, "deephaven-${p.name}-authentication-provider")
 }

--- a/authorization-codegen/build.gradle
+++ b/authorization-codegen/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.deephaven.project.register'
 
     // TODO (deephaven-core#3133): invoke protoc during the build via docker; maybe convert to a replicate task
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
 }
 
 description 'Deephaven Authorization Code Generator'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -34,5 +34,5 @@ dependencies {
         because('needed by plugin java-coding-conventions')
     }
 
-    implementation "com.github.johnrengelman:shadow:8.1.1"
+    implementation "com.gradleup.shadow:shadow-gradle-plugin:8.3.8"
 }

--- a/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-shadow-publishing-conventions.gradle
@@ -1,10 +1,14 @@
 import io.deephaven.project.util.PublishingTools
+import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin
+import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.jvm.tasks.Jar
 
 plugins {
   id 'java'
   id 'signing'
   id 'maven-publish'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
   id 'io.deephaven.javadoc-conventions'
 }
 
@@ -13,47 +17,39 @@ java {
   withSourcesJar()
 }
 
-tasks.withType(Javadoc) {
+tasks.withType(Javadoc).configureEach {
   // https://github.com/gradle/gradle/issues/19869
   options.addStringOption('sourcepath', sourceSets.main.allJava.getSourceDirectories().getAsPath())
 }
 
-PublishingTools.setupPublications(project) { publication ->
-  // This assumes that the shadow plugin is enabled, rather than using the vanilla java component.
-
-  // Inlines the shadow.component call, which doesn't actually use components, and doesn't generate
-  // the pom late enough to pick up gradle's own artifactId wiring from our archivesBaseName changes.
-  // Also un-sets the classifier for the shadow jar, since we want this to be the default artifact
-//  project.shadow.component(publication)
-  publication.artifact(source: project.tasks.named('shadowJar'), classifier: '')
-  publication.artifact(source: project.tasks.named('sourcesJar'))
-  publication.artifact(source: project.tasks.named('javadocJar'))
-  publication.pom {
-    withXml {
-      def root = asNode()
-      def dependenciesNode = root.appendNode('dependencies')
-
-      project.configurations.shadow.allDependencies.each {
-        if ((it instanceof ProjectDependency)) {
-          def dependencyNode = dependenciesNode.appendNode('dependency')
-          dependencyNode.appendNode('groupId', it.group)
-          BasePluginConvention base = it.dependencyProject.convention.getPlugin(BasePluginConvention)
-
-          dependencyNode.appendNode('artifactId', base.archivesBaseName)
-          dependencyNode.appendNode('version', it.version)
-          dependencyNode.appendNode('scope', 'runtime')
-        } else if (! (it instanceof SelfResolvingDependency)) {
-          def dependencyNode = dependenciesNode.appendNode('dependency')
-          dependencyNode.appendNode('groupId', it.group)
-          dependencyNode.appendNode('artifactId', it.name)
-          dependencyNode.appendNode('version', it.version)
-          dependencyNode.appendNode('scope', 'runtime')
+def shadowPublication = project
+        .extensions
+        .getByType(PublishingExtension)
+        .publications
+        .create(PublishingTools.SHADOW_PUBLICATION_NAME, MavenPublication) {
+          from(project.components.named(ShadowBasePlugin.COMPONENT_NAME).get())
+          artifact(project.tasks.named('sourcesJar'))
+          artifact(project.tasks.named('javadocJar'))
         }
-      }
-    }
-  }
+
+def shadowJar = project.tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME, ShadowJar) {
+  // We want the shadow jar to be the "default" jar, so we don't want it to have a classifier
+  archiveClassifier = ''
+}
+
+project.tasks.named('jar', Jar) {
+  // Note: this is forcing the output name of the plain jar task to be _different_ than the shadow jar, otherwise you
+  // can end up with gradle thinking that the jar output is an implicit, unstated dependency of some shadow tasks, and
+  // causes failures. (In addition to potential issues w/ tasks stomping on other tasks.)
+  archiveClassifier = 'orig'
+}
+
+project.tasks.named('assemble') {
+  it.dependsOn(shadowJar)
 }
 
 PublishingTools.setupRepositories(project)
-PublishingTools.setupMavenPublication(project, publishing.publications.mavenJava)
-PublishingTools.setupSigning(project, publishing.publications.mavenJava)
+PublishingTools.setupLicense(project, shadowPublication)
+PublishingTools.setupMavenPublication(project, shadowPublication)
+PublishingTools.setupSigning(project, shadowPublication)
+// Projects will need to call PublishingTools.setupShadowName to setup appropriate shadow names

--- a/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
+++ b/buildSrc/src/main/groovy/io/deephaven/project/util/PublishingTools.groovy
@@ -1,5 +1,7 @@
 package io.deephaven.project.util
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import groovy.transform.CompileStatic
 import io.deephaven.tools.License
 import org.gradle.api.Action
@@ -35,6 +37,8 @@ class PublishingTools {
     static final String SNAPSHOT_REPO = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
     static final String RELEASE_REPO = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
 
+    static final String SHADOW_PUBLICATION_NAME = 'shadow'
+
     static void setupPublications(Project project, Closure closure) {
         setupPublications(project, new Action<MavenPublication>() {
             @Override
@@ -45,19 +49,22 @@ class PublishingTools {
     }
 
     static void setupPublications(Project project, Action<MavenPublication> action) {
+        project.extensions
+                .getByType(PublishingExtension)
+                .publications
+                .create('mavenJava', MavenPublication) { publication ->
+                    action.execute(publication)
+                    setupLicense(project, publication)
+                }
+    }
+
+    static void setupLicense(Project project, MavenPublication publication) {
         def projectLicense = project.extensions.extraProperties.get('license') as License
-
-        project.extensions.findByType(PublishingExtension).publications { container ->
-            container.create('mavenJava', MavenPublication) { publication ->
-                action.execute(publication)
-                publication.pom {pom ->
-                    pom.licenses { licenses ->
-                        licenses.license { license ->
-                            license.name.set projectLicense.name
-                            license.url.set projectLicense.url
-                        }
-                    }
-
+        publication.pom {pom ->
+            pom.licenses { licenses ->
+                licenses.license { license ->
+                    license.name.set projectLicense.name
+                    license.url.set projectLicense.url
                 }
             }
         }
@@ -157,5 +164,15 @@ class PublishingTools {
                 }
             }
         }
+    }
+
+    static void setupShadowName(Project project, String name) {
+        project.tasks.named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME, ShadowJar) {
+            it.archiveBaseName.set(name)
+        }
+        project.extensions.getByType(PublishingExtension).publications.named(SHADOW_PUBLICATION_NAME, MavenPublication) {
+            it.artifactId = name
+        }
+        project.extensions.getByType(BasePluginExtension).archivesName.set(name)
     }
 }


### PR DESCRIPTION
The johnrengelman shadow plugin has been migrated to the GradleUp organization (see https://github.com/GradleUp/shadow/issues/908).

In addition, the custom POM xml building has been replaced with setting a custom artifact name (as documented
https://gradleup.com/shadow/publishing/#publish-the-shadowed-jar-with-custom-artifact-name).

This is a separation of some work that would otherwise make DH-19690 more complicated.

This also fixes DH-19804 by ensuring the grpc-bom is correctly referred to in the `deephaven-mtls-authentication-provider` pom (in the `dependencyManagement` section).

Cherry-pick of #6980