### PR TITLE
fix: DH-19338: Ensure we have an ExecutionContext while handling HierarchicalTableViewSubscription snapshots.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/FunctionGeneratedTableFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/FunctionGeneratedTableFactory.java
@@ -15,6 +15,7 @@ import io.deephaven.engine.updategraph.UpdateGraph;
 import io.deephaven.util.SafeCloseable;
 import io.deephaven.util.annotations.ReferentialIntegrity;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import java.util.*;
@@ -44,6 +45,7 @@ public class FunctionGeneratedTableFactory {
     private final Map<String, WritableColumnSource<?>> writableSources = new LinkedHashMap<>();
     private final Map<String, ColumnSource<?>> columns = new LinkedHashMap<>();
     private final TrackingWritableRowSet rowSet;
+    private final ExecutionContext executionContextForUpdates;
 
     private long nextRefresh;
 
@@ -129,9 +131,13 @@ public class FunctionGeneratedTableFactory {
     private FunctionGeneratedTableFactory(@NotNull final Supplier<Table> tableGenerator, final int refreshIntervalMs) {
         this.tableGenerator = tableGenerator;
         this.refreshIntervalMs = refreshIntervalMs;
+        this.executionContextForUpdates = makeExecutionContextForUpdates();
         nextRefresh = System.currentTimeMillis() + this.refreshIntervalMs;
 
-        Table initialTable = tableGenerator.get();
+        final Table initialTable;
+        try (final SafeCloseable ignored = executionContextForUpdates.open()) {
+            initialTable = tableGenerator.get();
+        }
         if (initialTable.isRefreshing()) {
             if (ExecutionContext.getContext().getUpdateGraph() != initialTable.getUpdateGraph()) {
                 throw new IllegalStateException(
@@ -156,12 +162,30 @@ public class FunctionGeneratedTableFactory {
         rowSet = RowSetFactory.flat(initialTable.size()).toTracking();
     }
 
+    /**
+     * If we have a systemic context we need to capture the authentication context. If we have a user-supplied context
+     * we should keep that so that any query scope, query library, etc. is available to produce the table.
+     *
+     * @return the execution context to use for updates
+     */
+    private static @NotNull ExecutionContext makeExecutionContextForUpdates() {
+        final ExecutionContext contextToRecord = ExecutionContext.getContextToRecord();
+        if (contextToRecord != null) {
+            return contextToRecord;
+        } else {
+            return ExecutionContext.newBuilder().build();
+        }
+    }
+
     private FunctionBackedTable getTable() {
         return new FunctionBackedTable(rowSet, columns);
     }
 
     private long updateTable() {
-        Table newTable = tableGenerator.get();
+        final Table newTable;
+        try (final SafeCloseable ignored = executionContextForUpdates.open()) {
+            newTable = tableGenerator.get();
+        }
         if (newTable.isRefreshing()) {
             if (ExecutionContext.getContext().getUpdateGraph() != newTable.getUpdateGraph()) {
                 throw new IllegalStateException(

--- a/extensions/performance/src/test/java/io/deephaven/engine/table/impl/util/TestUpdateAncestorViz.java
+++ b/extensions/performance/src/test/java/io/deephaven/engine/table/impl/util/TestUpdateAncestorViz.java
@@ -6,6 +6,7 @@ package io.deephaven.engine.table.impl.util;
 import guru.nidi.graphviz.engine.Format;
 import guru.nidi.graphviz.engine.Graphviz;
 import guru.nidi.graphviz.model.*;
+import io.deephaven.auth.AuthContext;
 import io.deephaven.base.FileUtils;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.context.QueryCompilerImpl;
@@ -58,7 +59,7 @@ public class TestUpdateAncestorViz {
                 .setQueryCompiler(QueryCompilerImpl.create(
                         cacheDir, TestUpdateAncestorViz.class.getClassLoader()))
                 .setOperationInitializer(ForkJoinPoolOperationInitializer.fromCommonPool())
-                .setUpdateGraph(defaultUpdateGraph).build();
+                .setUpdateGraph(defaultUpdateGraph).build().withAuthContext(new AuthContext.Anonymous());
     }
 
     @AfterEach
@@ -100,6 +101,15 @@ public class TestUpdateAncestorViz {
     @Test
     public void testDynamicMerge() {
         final StandaloneLivenessManager manager = new StandaloneLivenessManager(false);
+
+        // because we have two separate calls to testGraphGen we should make sure to keep these around for the duration
+        final Table upl, ua;
+        try (final SafeCloseable ignored = executionContext.open()) {
+            upl = TableLoggers.updatePerformanceLog();
+            ua = TableLoggers.updatePerformanceAncestorsLog();
+        }
+        manager.manage(upl);
+        manager.manage(ua);
 
         final MutableObject<KeyedArrayBackedInputTable> source = new MutableObject<>();
         final MutableObject<Table> result = new MutableObject<>();
@@ -144,11 +154,11 @@ public class TestUpdateAncestorViz {
     private void testGraphGen(final String terminalOperation,
             final Map<String, Integer> expectedNodes,
             final ThrowingSupplier<Table, RuntimeException> testSnippet) {
-        final Table upl = TableLoggers.updatePerformanceLog();
-        final Table ua = TableLoggers.updatePerformanceAncestorsLog();
-
         try (final SafeCloseable ignored = executionContext.open();
                 final SafeCloseable ignored2 = LivenessScopeStack.open()) {
+            final Table upl = TableLoggers.updatePerformanceLog();
+            final Table ua = TableLoggers.updatePerformanceAncestorsLog();
+
             // noinspection unused, referential integrity
             final Table result = defaultUpdateGraph.sharedLock().computeLocked(testSnippet);
 

--- a/props/test-configs/src/main/resources/dh-tests.prop
+++ b/props/test-configs/src/main/resources/dh-tests.prop
@@ -108,3 +108,5 @@ authentication.anonymous.warn=false
 deephaven.console.type=none
 
 BaseTable.validateUpdateIndices=true
+
+PerformanceEntry.requireAuthContext=true

--- a/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableViewSubscription.java
+++ b/server/src/main/java/io/deephaven/server/hierarchicaltable/HierarchicalTableViewSubscription.java
@@ -5,9 +5,11 @@ package io.deephaven.server.hierarchicaltable;
 
 import com.google.rpc.Code;
 import io.deephaven.base.verify.Assert;
+import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.liveness.LivenessArtifact;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
@@ -69,6 +71,12 @@ public class HierarchicalTableViewSubscription extends LivenessArtifact {
     private final BarrageSubscriptionOptions subscriptionOptions;
     private final long intervalDurationNanos;
 
+    /**
+     * We must capture the ExecutionContext when the subscription is created, because during processing we initiate
+     * operations and should include the correct context for those subsequent operations as part of the propagation job.
+     */
+    private final ExecutionContext executionContext;
+
     private final Stats stats;
 
     private final TableUpdateListener keyTableListener;
@@ -115,6 +123,7 @@ public class HierarchicalTableViewSubscription extends LivenessArtifact {
         this.listener = listener;
         this.subscriptionOptions = subscriptionOptions;
         this.intervalDurationNanos = NANOSECONDS.convert(intervalDurationMillis, MILLISECONDS);
+        this.executionContext = ExecutionContext.newBuilder().build();
 
         final String statsKey = BarragePerformanceLog.getKeyFor(
                 view.getHierarchicalTable(), view.getHierarchicalTable()::getDescription);
@@ -282,7 +291,7 @@ public class HierarchicalTableViewSubscription extends LivenessArtifact {
                 GrpcUtil.safelyError(listener, errorTransformer.transform(upstreamFailure));
                 return;
             }
-            try {
+            try (final SafeCloseable ignored = executionContext == null ? null : executionContext.open()) {
                 buildAndSendSnapshot(streamGeneratorFactory, listener, subscriptionOptions, view,
                         this::recordSnapshotNanos, this::recordWriteMetrics, columns, rows, prevKeyspaceViewportRows);
             } catch (Exception e) {


### PR DESCRIPTION
Cherry-pick of https://github.com/deephaven/deephaven-core/pull/6984

This consists of three actual changes:
1. The HierarchicalTableView subscriptions would call snapshot, etc. from their update propagation job. This resulted in sorts that had no context. In the Core+ case, this meant we could not correctly log performance in the face of sorted rollups. This is the root of this entire PR.
2. The FunctionGeneratedTableFactory had a similar problem when refreshing a table.
3. I added a flag to PerformanceEntry that will fail when the auth context is not set. It defaults to false, to avoid breaking Core users unnecessarily. In Enterprise, we are breaking already; so this is an appropriate setting. I also added it to the tests, to find other cases where we were broken (like the FunctionGeneratedTableFactory).

The rest of this is just changing the tests to include a context.

I think #1 and #2 are a point release candidate, but not the rest of the fixes/changes.

---------