### PR TITLE
feat: DH-18998, DH-18999: Enable etags (#6892)

### DIFF
--- a/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheHttpContent.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheHttpContent.java
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.jetty;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+
+import com.google.common.hash.Funnels;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import com.google.common.io.ByteStreams;
+import org.eclipse.jetty.http.DateGenerator;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.content.HttpContent;
+
+/**
+ * A custom {@link HttpContent} implementation for finer control over caching behavior.
+ * <p>
+ * <ul>
+ * <li>Calculates a strong ETag based on the content's SHA-256 hash.</li>
+ * <li>Overrides all last modified related methods to signal that the content does not have a last modified time. This
+ * is needed since we don't use last modified timestamps inside of our .jar files.</li>
+ * </ul>
+ */
+public class ControlledCacheHttpContent extends HttpContent.Wrapper {
+
+    public ControlledCacheHttpContent(HttpContent content) throws IOException {
+        super(content);
+        this.eTag = computeStrongETag(content);
+    }
+
+    private final String eTag;
+
+    private String computeStrongETag(HttpContent content) throws IOException {
+        try (InputStream input = content.getResource().newInputStream()) {
+            Hasher hasher = Hashing.sha256().newHasher();
+            ByteStreams.copy(input, Funnels.asOutputStream(hasher));
+            return "\"" + hasher.hash() + "\"";
+        }
+    }
+
+    @Override
+    public String getETagValue() {
+        return eTag;
+    }
+
+    @Override
+    public HttpField getLastModified() {
+        // We don't have a last modified time, so return null so that no Last-Modified header is sent.
+        return null;
+    }
+
+    @Override
+    public Instant getLastModifiedInstant() {
+        // Always return -1, so that we don't get the build system timestamp.
+        return Instant.ofEpochMilli(-1);
+    }
+
+    @Override
+    public String getLastModifiedValue() {
+        Instant lm = getLastModifiedInstant();
+        return DateGenerator.formatDate(lm);
+    }
+}

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheHttpContentFactory.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/ControlledCacheHttpContentFactory.java
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.jetty;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.http.content.FileMappingHttpContentFactory;
+import org.eclipse.jetty.http.content.HttpContent;
+import org.eclipse.jetty.http.content.PreCompressedHttpContentFactory;
+import org.eclipse.jetty.http.content.ResourceHttpContentFactory;
+import org.eclipse.jetty.http.content.ValidatingCachingHttpContentFactory;
+import org.eclipse.jetty.io.ByteBufferPool;
+import org.eclipse.jetty.util.resource.Resource;
+
+/**
+ * A custom {@link HttpContent.Factory} that creates {@link ControlledCacheHttpContent} instances.
+ */
+public class ControlledCacheHttpContentFactory extends ResourceHttpContentFactory {
+    /**
+     * Creates a {@link HttpContent.Factory} using a similar methodology used in
+     * {@link org.eclipse.jetty.server.handler.ResourceHandler#newHttpContentFactory()} except that we use
+     * {@link ControlledCacheHttpContentFactory} instead of {@link ResourceHttpContentFactory} as the innermost factory,
+     * and we don't include the {@link org.eclipse.jetty.http.content.VirtualHttpContentFactory}.
+     *
+     * @param baseResource the base Resource
+     * @param byteBufferPool the ByteBufferPool for {@link ValidatingCachingHttpContentFactory}
+     * @param mimeTypes the MimeTypes
+     * @return the wrapped {@link HttpContent.Factory}
+     */
+    public static HttpContent.Factory create(
+            Resource baseResource,
+            ByteBufferPool byteBufferPool,
+            MimeTypes mimeTypes) {
+        // Use ControlledCacheHttpContentFactory instead of ResourceHttpContentFactory
+        HttpContent.Factory contentFactory = new ControlledCacheHttpContentFactory(baseResource, mimeTypes);
+        contentFactory = new FileMappingHttpContentFactory(contentFactory);
+        contentFactory = new PreCompressedHttpContentFactory(contentFactory, new ArrayList<>());
+        contentFactory = new ValidatingCachingHttpContentFactory(contentFactory, Duration.ofSeconds(1).toMillis(),
+                byteBufferPool);
+
+        return contentFactory;
+    }
+
+    private ControlledCacheHttpContentFactory(Resource baseResource, MimeTypes mimeTypes) {
+        super(baseResource, mimeTypes);
+    }
+
+    @Override
+    public HttpContent getContent(String pathInContext) throws IOException {
+        HttpContent content = super.getContent(pathInContext);
+
+        if (content == null) {
+            return null;
+        }
+
+        if (content.getResource().isDirectory()) {
+            return content;
+        }
+
+        return new ControlledCacheHttpContent(content);
+    }
+}

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/EmptyResource.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/EmptyResource.java
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.jetty;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+import org.eclipse.jetty.util.resource.Resource;
+
+/**
+ * An empty {@link Resource} that always indicates non-existence. This is mostly needed to get around a bug in
+ * {@link org.eclipse.jetty.util.resource.CombinedResource} where it does not handle null resources correctly.
+ */
+public class EmptyResource extends Resource {
+    @Override
+    public boolean exists() {
+        return false;
+    }
+
+    @Override
+    public Path getPath() {
+        return null;
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return false;
+    }
+
+    @Override
+    public boolean isReadable() {
+        return false;
+    }
+
+    @Override
+    public URI getURI() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return "";
+    }
+
+    @Override
+    public String getFileName() {
+        return "";
+    }
+
+    @Override
+    public Resource resolve(String subUriPath) {
+        return null;
+    }
+}

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -30,8 +30,6 @@ import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.ee10.servlet.DefaultServlet;
 import org.eclipse.jetty.ee10.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
-import org.eclipse.jetty.ee10.servlet.ResourceServlet;
-import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.ee10.websocket.jakarta.common.SessionTracker;
@@ -39,6 +37,7 @@ import org.eclipse.jetty.ee10.websocket.jakarta.server.JakartaWebSocketServerCon
 import org.eclipse.jetty.ee10.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.content.HttpContent;
 import org.eclipse.jetty.http2.HTTP2Connection;
 import org.eclipse.jetty.http2.HTTP2Session;
 import org.eclipse.jetty.http2.RateControl;
@@ -46,36 +45,21 @@ import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.http2.server.internal.HTTP2ServerConnection;
 import org.eclipse.jetty.io.Connection;
-import org.eclipse.jetty.server.ForwardedRequestCustomizer;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.SecureRequestCustomizer;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.CrossOriginHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.component.Graceful;
-import org.eclipse.jetty.util.resource.CombinedResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -89,7 +73,9 @@ import static org.eclipse.jetty.ee10.servlet.ServletContextHandler.NO_SESSIONS;
 public class JettyBackedGrpcServer implements GrpcServer {
     private static final String JS_PLUGINS_PATH_SPEC = "/" + JsPlugins.JS_PLUGINS + "/*";
 
+    private final WebAppContext context;
     private final Server jetty;
+    private final JsPlugins jsPlugins;
     private final ScheduledExecutorService executorService;
     private final boolean websocketsEnabled;
 
@@ -99,21 +85,14 @@ public class JettyBackedGrpcServer implements GrpcServer {
             final GrpcFilter filter,
             final JsPlugins jsPlugins,
             @Named("grpc.server") final ScheduledExecutorService executorService) {
+        this.jsPlugins = jsPlugins;
         jetty = new Server();
         jetty.addConnector(createConnector(jetty, config));
         this.executorService = executorService;
 
-        final WebAppContext context =
-                new WebAppContext("/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
-
-        List<String> urls = ServerResources.resourcesFromServiceLoader(Configuration.getInstance());
-        Resource resources = ResourceFactory.combine(urls.stream().map(url -> {
-            Resource resource = context.getResourceFactory().newResource(url);
-            Require.neqNull(resource, "newResource(" + url + ")");
-            return resource;
-        }).toList());
-        context.setBaseResource(ControlledCacheResource.wrap(resources));
+        context = new WebAppContext("/", null, null, null, new ErrorPageErrorHandler(), NO_SESSIONS);
         context.setInitParameter(DefaultServlet.CONTEXT_INIT + "dirAllowed", "false");
+        context.setInitParameter(DefaultServlet.CONTEXT_INIT + "etags", "true");
 
         // Cache all of the appropriate assets folders
         for (String appRoot : List.of("/ide/", "/iframe/table/", "/iframe/chart/", "/iframe/widget/")) {
@@ -122,6 +101,8 @@ public class JettyBackedGrpcServer implements GrpcServer {
         }
         context.addFilter(NoCacheFilter.class, "/jsapi/*", EnumSet.noneOf(DispatcherType.class));
         context.addFilter(DropIfModifiedSinceHeader.class, "/*", EnumSet.noneOf(DispatcherType.class));
+        // TODO(deephaven-core#4620): Add js-plugins version-aware caching
+        context.addFilter(NoCacheFilter.class, JS_PLUGINS_PATH_SPEC, EnumSet.noneOf(DispatcherType.class));
 
         context.setSecurityHandler(new ConstraintSecurityHandler());
 
@@ -133,11 +114,6 @@ public class JettyBackedGrpcServer implements GrpcServer {
 
         // Wire up the provided grpc filter
         context.addFilter(new FilterHolder(filter), "/*", EnumSet.noneOf(DispatcherType.class));
-
-        // Wire up /js-plugins/*
-        // TODO(deephaven-core#4620): Add js-plugins version-aware caching
-        context.addFilter(NoCacheFilter.class, JS_PLUGINS_PATH_SPEC, EnumSet.noneOf(DispatcherType.class));
-        context.addServlet(servletHolder("js-plugins", jsPlugins.filesystem()), JS_PLUGINS_PATH_SPEC);
 
         // Set up websockets for grpc-web - depending on configuration, we can register both in case we encounter a
         // client using "vanilla"
@@ -174,76 +150,58 @@ public class JettyBackedGrpcServer implements GrpcServer {
             this.websocketsEnabled = false;
         }
 
-        // If requested, permit CORS requests
-        CrossOriginHandler corsHandler = new CrossOriginHandler();
-        // Permit all origins
-        corsHandler.setAllowedOriginPatterns(Set.of("*"));
-
-        // Only support POST - technically gRPC can use GET, but we don't use any of those methods
-        corsHandler.setAllowedMethods(Set.of("POST"));
-
-        // Required request headers for gRPC, gRPC-web, flight, and deephaven
-        corsHandler.setAllowedHeaders(Set.of(
-                // Required for CORS itself to work
-                HttpHeader.ORIGIN.asString(),
-                HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.asString(),
-
-                // Required for gRPC
-                GrpcUtil.CONTENT_TYPE_KEY.name(),
-                GrpcUtil.TIMEOUT_KEY.name(),
-
-                // Optional for gRPC
-                GrpcUtil.MESSAGE_ENCODING_KEY.name(),
-                GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY.name(),
-                GrpcUtil.CONTENT_ENCODING_KEY.name(),
-                GrpcUtil.CONTENT_ACCEPT_ENCODING_KEY.name(),
-
-                // Required for gRPC-web
-                "x-grpc-web",
-                // Optional for gRPC-web
-                "x-user-agent",
-
-                // Required for Flight auth 1/2
-                AuthConstants.TOKEN_NAME,
-                Auth2Constants.AUTHORIZATION_HEADER,
-
-                // Required for DH gRPC browser bidi stream support
-                BrowserStreamInterceptor.TICKET_HEADER_NAME,
-                BrowserStreamInterceptor.SEQUENCE_HEADER_NAME,
-                BrowserStreamInterceptor.HALF_CLOSE_HEADER_NAME));
-
-        // Response headers that the browser will need to be able to decode
-        corsHandler.setExposedHeaders(Set.of(
-                Auth2Constants.AUTHORIZATION_HEADER,
-                GrpcUtil.CONTENT_TYPE_KEY.name(),
-                InternalStatus.CODE_KEY.name(),
-                InternalStatus.MESSAGE_KEY.name(),
-                // Not used (yet?), see io.grpc.protobuf.StatusProto
-                "grpc-status-details-bin"));
-        corsHandler.setHandler(context);
+        final CrossOriginHandler corsHandler = createCrossOriginHandler(context);
 
         // Optionally wrap the webapp in a gzip handler
         final Handler handler;
         if (config.httpCompressionOrDefault()) {
-            final GzipHandler gzipHandler = new GzipHandler();
-            // The default of 32 bytes seems a bit small.
-            gzipHandler.setMinGzipSize(1024);
-            // The GzipHandler documentation says GET is the default, but the constructor shows both GET and POST.
-            // This should ensure our gRPC messages don't get compressed for now, but we may need to be more explicit in
-            // the future as gRPC can technically operate over GET.
-            gzipHandler.setIncludedMethods(HttpMethod.GET.asString());
-            // Otherwise, the other defaults seem reasonable.
-            gzipHandler.setHandler(corsHandler);
-            handler = gzipHandler;
+            handler = createGzipHandler(corsHandler);
         } else {
             handler = corsHandler;
         }
+
         jetty.setHandler(handler);
+    }
+
+    /**
+     * Initialize the resources for the server, including the js-plugins filesystem. We don't do this in the constructor
+     * so that we can defer resources being opened until after JS plugins have had a chance to be registered.
+     */
+    private void initResources() {
+        List<String> urls = ServerResources.resourcesFromServiceLoader(Configuration.getInstance());
+
+        // Build resources List
+        ArrayList<Resource> resources = new ArrayList<>(urls.stream().map(url -> {
+            Resource resource = context.getResourceFactory().newResource(url);
+            Require.neqNull(resource, "newResource(" + url + ")");
+            return resource;
+        }).toList());
+
+        // Note that creating the jsPlugins resource will open the backing .zip file. Attempting to register any JS
+        // plugins after this point will fail since they need to write to the filesystem. The general order of setup
+        // should be 1) Construct the server. 2) Register JS plugins. 3) Create the JS plugins resource. 4) Start the
+        // server. This is managed by DeephavenApiServer.
+        Resource jsPluginsResource = context.getResourceFactory().newResource(jsPlugins.filesystem());
+        resources.add(new PathPrefixResource("/js-plugins/", jsPluginsResource));
+
+        Resource combinedResource = ResourceFactory.combine(resources);
+        context.setBaseResource(combinedResource);
+
+        // Create a HttpContent.Factory that can control caching (e.g. generating strong ETag headers) for static
+        // resources.
+        HttpContent.Factory controlledCacheHttpContentFactory = ControlledCacheHttpContentFactory.create(
+                combinedResource,
+                jetty.getByteBufferPool(),
+                jetty.getMimeTypes());
+
+        // Setting this attribute will override the default HttpContent.Factory created by the ResourceServlet.
+        context.setAttribute(HttpContent.Factory.class.getName(), controlledCacheHttpContentFactory);
     }
 
     @Override
     public void start() throws IOException {
         try {
+            initResources();
             jetty.start();
         } catch (RuntimeException exception) {
             throw exception;
@@ -406,15 +364,70 @@ public class JettyBackedGrpcServer implements GrpcServer {
         return serverConnector;
     }
 
-    private static ServletHolder servletHolder(String name, URI filesystemUri) {
-        final ServletHolder jsPlugins = new ServletHolder(name, ResourceServlet.class);
-        // Note, the URI needs explicitly be parseable as a directory URL ending in "!/", a requirement of the jetty
-        // resource creation implementation, see
-        // org.eclipse.jetty.util.resource.Resource.newResource(java.lang.String, boolean)
-        jsPlugins.setInitParameter("baseResource", filesystemUri.toString());
-        jsPlugins.setInitParameter("pathInfoOnly", "true");
-        jsPlugins.setInitParameter("dirAllowed", "false");
-        jsPlugins.setAsyncSupported(true);
-        return jsPlugins;
+    private static CrossOriginHandler createCrossOriginHandler(Handler handler) {
+        // If requested, permit CORS requests
+        CrossOriginHandler corsHandler = new CrossOriginHandler();
+        // Permit all origins
+        corsHandler.setAllowedOriginPatterns(Set.of("*"));
+
+        // Only support POST - technically gRPC can use GET, but we don't use any of those methods
+        corsHandler.setAllowedMethods(Set.of("POST"));
+
+        // Required request headers for gRPC, gRPC-web, flight, and deephaven
+        corsHandler.setAllowedHeaders(Set.of(
+                // Required for CORS itself to work
+                HttpHeader.ORIGIN.asString(),
+                HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN.asString(),
+
+                // Required for gRPC
+                GrpcUtil.CONTENT_TYPE_KEY.name(),
+                GrpcUtil.TIMEOUT_KEY.name(),
+
+                // Optional for gRPC
+                GrpcUtil.MESSAGE_ENCODING_KEY.name(),
+                GrpcUtil.MESSAGE_ACCEPT_ENCODING_KEY.name(),
+                GrpcUtil.CONTENT_ENCODING_KEY.name(),
+                GrpcUtil.CONTENT_ACCEPT_ENCODING_KEY.name(),
+
+                // Required for gRPC-web
+                "x-grpc-web",
+                // Optional for gRPC-web
+                "x-user-agent",
+
+                // Required for Flight auth 1/2
+                AuthConstants.TOKEN_NAME,
+                Auth2Constants.AUTHORIZATION_HEADER,
+
+                // Required for DH gRPC browser bidi stream support
+                BrowserStreamInterceptor.TICKET_HEADER_NAME,
+                BrowserStreamInterceptor.SEQUENCE_HEADER_NAME,
+                BrowserStreamInterceptor.HALF_CLOSE_HEADER_NAME));
+
+        // Response headers that the browser will need to be able to decode
+        corsHandler.setExposedHeaders(Set.of(
+                Auth2Constants.AUTHORIZATION_HEADER,
+                GrpcUtil.CONTENT_TYPE_KEY.name(),
+                InternalStatus.CODE_KEY.name(),
+                InternalStatus.MESSAGE_KEY.name(),
+                // Not used (yet?), see io.grpc.protobuf.StatusProto
+                "grpc-status-details-bin"));
+
+        corsHandler.setHandler(handler);
+
+        return corsHandler;
     }
+
+    private static @NotNull GzipHandler createGzipHandler(Handler handler) {
+        final GzipHandler gzipHandler = new GzipHandler();
+        // The default of 32 bytes seems a bit small.
+        gzipHandler.setMinGzipSize(1024);
+        // The GzipHandler documentation says GET is the default, but the constructor shows both GET and POST.
+        // This should ensure our gRPC messages don't get compressed for now, but we may need to be more explicit in
+        // the future as gRPC can technically operate over GET.
+        gzipHandler.setIncludedMethods(HttpMethod.GET.asString());
+        // Otherwise, the other defaults seem reasonable.
+        gzipHandler.setHandler(handler);
+        return gzipHandler;
+    }
+
 }

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/PathPrefixResource.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/PathPrefixResource.java
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.jetty;
+
+import io.deephaven.base.verify.Assert;
+import org.eclipse.jetty.util.resource.Resource;
+
+/**
+ * A {@link Resource} wrapper that only resolves URIs that start with a specific path prefix. This is useful for
+ * creating resources that are only valid for a specific sub-path of the server without requiring servlet apis.
+ */
+public class PathPrefixResource extends WrappedResource {
+    public PathPrefixResource(String pathPrefix, Resource wrapped) {
+        super(wrapped);
+        Assert.neqNull(wrapped, "wrapped");
+        this.pathPrefix = pathPrefix;
+    }
+
+    private final String pathPrefix;
+
+    @Override
+    public Resource resolve(String subUriPath) {
+        if (!subUriPath.startsWith(pathPrefix)) {
+            // It would be nice to just return null here, but CombinedResource has a bug where it does not properly
+            // handle null resources, so we return an empty resource instead.
+            return new EmptyResource();
+        }
+
+        return super.resolve(subUriPath.substring(pathPrefix.length()));
+    }
+}

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/JettyFlightRoundTripTest.java
@@ -59,24 +59,33 @@ public class JettyFlightRoundTripTest extends FlightMessageRoundTripTest {
     }
 
     @Test
+    @DeferServerStart
     public void jsPlugins() throws Exception {
         // Note: JettyFlightRoundTripTest is not the most minimal / appropriate bootstrapping for this test, but it is
         // the most convenient since it has all of the necessary prerequisites
         new Example123Registration().registerInto(component.registration());
+
+        startServer();
+
         testJsPluginExamples(false, true, true);
     }
 
     @Test
+    @DeferServerStart
     public void jsPluginsFromManifest() throws Exception {
         // Note: JettyFlightRoundTripTest is not the most minimal / appropriate bootstrapping for this test, but it is
         // the most convenient since it has all of the necessary prerequisites
         final Path manifestRoot = Path.of(Sentinel.class.getResource("examples").toURI());
         new JsPluginsManifestRegistration(manifestRoot)
                 .registerInto(component.registration());
+
+        startServer();
+
         testJsPluginExamples(false, false, true);
     }
 
     @Test
+    @DeferServerStart
     public void jsPluginsFromNpmPackages() throws Exception {
         // Note: JettyFlightRoundTripTest is not the most minimal / appropriate bootstrapping for this test, but it is
         // the most convenient since it has all of the necessary prerequisites
@@ -87,6 +96,9 @@ public class JettyFlightRoundTripTest extends FlightMessageRoundTripTest {
                 .registerInto(component.registration());
         new JsPluginsNpmPackageRegistration(example2Root)
                 .registerInto(component.registration());
+
+        startServer();
+
         testJsPluginExamples(true, true, false);
     }
 

--- a/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -88,17 +88,18 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.jetbrains.annotations.Nullable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -258,16 +259,31 @@ public abstract class FlightMessageRoundTripTest {
         MainHelper.bootstrapProjectDirectories();
     }
 
-    @Before
-    public void setup() throws IOException, InterruptedException {
+    /**
+     * Setup run before each test. Note that this method is not annotated with {@link Before} because we want to control
+     * when the server starts using the {@link SetupServerRule}.
+     */
+    public void setupBefore() throws IOException, InterruptedException {
         logBuffer = new LogBuffer(128);
         LogBufferGlobal.setInstance(logBuffer);
 
         component = component();
+
+        // JS plugins must be registered after the server is created but before it is started (this pattern is used in
+        // DeephavenApiServer). The default test configuration will create the server here and then start the server in
+        // in the SetupServerRule. For tests that need to register JS plugins, they can defer the server start using
+        // the @DeferServerStart annotation. Tests can then register plugins and manually start the server.
+        server = component.server();
+    }
+
+    /**
+     * Starts the server. Gets automatically called by the {@link SetupServerRule} unless the test is annotated with a
+     * {@link DeferServerStart} annotation.
+     */
+    public void startServer() throws IOException, InterruptedException {
         // open execution context immediately so it can be used when resolving `scriptSession`
         executionContext = component.executionContext().open();
 
-        server = component.server();
         server.start();
         localPort = server.getPort();
         serverScheduler = (Scheduler.DelegatingImpl) component.serverScheduler();
@@ -357,6 +373,38 @@ public abstract class FlightMessageRoundTripTest {
         }
     }
 
+    /**
+     * Annotation to defer auto server start. See {@link SetupServerRule}.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DeferServerStart {
+    }
+
+    /**
+     * A JUnit rule that sets up a server before a test runs. The server will also be started unless the test is
+     * annotated with a {@link DeferServerStart} annotation.
+     */
+    public class SetupServerRule implements TestRule {
+        @Override
+        public Statement apply(Statement statement, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    setupBefore();
+
+                    boolean autoStart = description.getAnnotation(DeferServerStart.class) == null;
+                    if (autoStart) {
+                        startServer();
+                    }
+                    statement.evaluate();
+                }
+            };
+        }
+    }
+
+    @Rule
+    public final SetupServerRule startServerRule = new SetupServerRule();
+
     @Rule
     public final ExternalResource livenessRule = new ExternalResource() {
         SafeCloseable scope;
@@ -387,7 +435,7 @@ public abstract class FlightMessageRoundTripTest {
     }
 
     @Test
-    public void testLoginHandshakeBasicAuth() {
+    public void testLoginHandshakeBasicAuth() throws IOException, InterruptedException {
         closeClient();
         flightClient = FlightClient.builder().location(serverLocation)
                 .allocator(allocator)


### PR DESCRIPTION
DH-18998, DH-18999: Enabled etags for static resources

### Testing
**Initial page load**
- Activate a venv and run `./gradlew :web-client-api:gwtCompile server-jetty-app:run -Panonymous` (note that plugins should not be installed yet)
- Open http://localhost:10000
- Open chrome dev tools network inspector and check "Disable cache"
- Refresh the page

Verify:
| Route | Cache-Control | Has ETag | Has Last-Modified | | ------ | -------------- | ---------- | ------------------ | | /ide/ | no-cache, must-revalidate, pre-check=0, post-check=0 | Yes | No |
| /ide/[some-js-or-css-file] | max-age=31536000, public, immutable | Yes | No |
| /ide/jsapi/* | no-cache, must-revalidate, pre-check=0, post-check=0 | Yes | No |
| /ide/js-plugins/* | no-cache, must-revalidate, pre-check=0, post-check=0 | Yes | No |

**Cached Page Load**
- Uncheck "Disable cache"
- Refresh the page

Verify:
| Route | Status |
| ------ | ------ |
| /ide/ | 304 |
| /ide/[some-js-or-css-file] | 200 (Size column should show from disk or memory cache) |
| /ide/jsapi/* | 304 |
| /ide/js-plugins/* | 304 |

**JS API Content Change**
- Stop server
- Add a console warn to CoreClient.java constructor: ```java public CoreClient(String serverUrl, @TsTypeRef(ConnectOptions.class) @JsOptional Object connectOptions) {
       JsLog.warn("xxx new CoreClient with connection");
       ideConnection = new IdeConnection(serverUrl, connectOptions);
   }
   ```
- run `./gradlew :web-client-api:gwtCompile server-jetty-app:run -Panonymous`
- "Disable cache" should still be unchecked from previous section
- Make note of the etag response header for `/ide/jsapi/dh-core.js`
- Refresh the page
- `/ide/jsapi/dh-core.js` should now show a 200 status and, the etag response header should have changed

**JS Plugin Content Change**
- Stop server
- Run `pip install deephaven-plugin-ui`
- run `./gradlew :web-client-api:gwtCompile server-jetty-app:run -Panonymous`
- "Disable cache" should still be unchecked from previous section
- Make note of the etag response header for `/ide/js-plugins/manifest.json`
- Refresh the page
- `/ide/js-plugins/manifest.json` should now show a 200 status and, the etag response header should have changed