### PR TITLE
chore: Update gradle-maven-publish-plugin to 0.34.0

### DIFF
--- a/.github/workflows/nightly-publish-ci.yml
+++ b/.github/workflows/nightly-publish-ci.yml
@@ -46,9 +46,7 @@ jobs:
       - name: Publish to Central Portal snapshots repository
         # We are not worried here about using --no-parallel (as we are with release publishing), since publishing
         # snapshots does not even create staging repositories.
-        # Note: --no-configuration-cache is documented as necessary due https://github.com/gradle/gradle/issues/22779
-        # from https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-automatic-publishing
-        run: ./gradlew --no-configuration-cache publishToMavenCentral
+        run: ./gradlew publishToMavenCentral
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -60,9 +60,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/release/v') }}
         # We need to be explicit here about no parallelism to ensure we don't create disjointed staging repositories.
         # Edit: unclear if above note is still possible with the new portal API / plugin implementation.
-        # Note: --no-configuration-cache is documented as necessary due https://github.com/gradle/gradle/issues/22779
-        # from https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-automatic-publishing
-        run: ./gradlew --no-parallel --no-configuration-cache server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publishToMavenCentral
+        run: ./gradlew --no-parallel server-netty-app:build server-jetty-app:build py-server:build py-embedded-server:build py-client:build py-client-ticking:build web-client-api:types:build publishToMavenCentral
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     implementation "com.gradleup.shadow:shadow-gradle-plugin:8.3.8"
 
-    implementation('com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.33.0') {
+    implementation('com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.34.0') {
         because('needed by plugin java-publishing-conventions')
     }
 }


### PR DESCRIPTION
This removes the need for the `--no-configuration-cache` publishing workaround, see https://github.com/vanniktech/gradle-maven-publish-plugin/pull/1071

See https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.34.0