### PR TITLE
feat: Enable nightly check for rc branches

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -7,7 +7,7 @@ on:
     # 2AM EST == 6AM UTC
     - cron:  '0 6 * * *'
   push:
-    branches: [ 'nightly/**', 'release/v*', 'dependabot/**', 'coverage/**']
+    branches: [ 'nightly/**', 'release/v*', 'dependabot/**', 'coverage/**', 'rc/v*']
 
 jobs:
   nightly:


### PR DESCRIPTION
This will enable release managers to verify that nightly checks have succeeded before kicking off a release.