### PR TITLE
fix: DH-20002: Mismatched Tree Table ID and Parent Column Results in Poor Error Message.

### DIFF
--- a/engine/api/src/main/java/io/deephaven/engine/table/impl/NoSuchColumnException.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/impl/NoSuchColumnException.java
@@ -126,7 +126,8 @@ public class NoSuchColumnException extends IllegalArgumentException {
      * @param presentColumns the column names present in the table
      * @param missingColumn the request column name that was not found
      */
-    public NoSuchColumnException(final String messagePrefix, final List<String> presentColumns, final String missingColumn) {
+    public NoSuchColumnException(final String messagePrefix, final List<String> presentColumns,
+            final String missingColumn) {
         this(messagePrefix + String.format(DEFAULT_FORMAT_STR,
                 missingColumn,
                 String.join(DELIMITER, presentColumns)));

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/TreeTableImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/hierarchical/TreeTableImpl.java
@@ -251,14 +251,19 @@ public class TreeTableImpl extends HierarchicalTableImpl<TreeTable, TreeTableImp
             @Nullable final List<ColumnDefinition<?>> availableColumnDefinitions) {
         final ColumnDefinition<?> idDef = source.getDefinition().getColumn(identifierColumn.name());
         if (idDef == null) {
-            throw new NoSuchColumnException("tree identifier column: ", source.getDefinition().getColumnNames(), identifierColumn.name());
+            throw new NoSuchColumnException("tree identifier column: ", source.getDefinition().getColumnNames(),
+                    identifierColumn.name());
         }
         final ColumnDefinition<?> parentDef = source.getDefinition().getColumn(parentIdentifierColumn.name());
         if (parentDef == null) {
-            throw new NoSuchColumnException("tree parent column: ", source.getDefinition().getColumnNames(), parentIdentifierColumn.name());
+            throw new NoSuchColumnException("tree parent column: ", source.getDefinition().getColumnNames(),
+                    parentIdentifierColumn.name());
         }
         if (!idDef.hasCompatibleDataType(parentDef)) {
-            throw new InvalidColumnException("tree parent and identifier columns must have the same data type, but parent is " + parentDef.describeForCompatibility() + " and identifier is " + idDef.describeForCompatibility());
+            throw new InvalidColumnException(
+                    "tree parent and identifier columns must have the same data type, but parent is "
+                            + parentDef.describeForCompatibility() + " and identifier is "
+                            + idDef.describeForCompatibility());
         }
         final QueryTable tree = computeTree(source, parentIdentifierColumn);
         final QueryTable sourceRowLookupTable = computeSourceRowLookupTable(source, identifierColumn);

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestTreeTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestTreeTable.java
@@ -102,14 +102,22 @@ public class TestTreeTable extends RefreshingTableTestCase {
 
     @Test
     public void testMismatchedParentAndId() {
-        final Table source = emptyTable(10).update("ID=ii", "Parent=ii == 0 ? null : 63 - Long.numberOfLeadingZeros(ii)");
+        final Table source =
+                emptyTable(10).update("ID=ii", "Parent=ii == 0 ? null : 63 - Long.numberOfLeadingZeros(ii)");
 
-        final NoSuchColumnException missingParent = Assert.assertThrows(NoSuchColumnException.class, () -> source.tree("ID", "FooBar"));
-        assertEquals("tree parent column: Unknown column names [FooBar], available column names are [ID, Parent]", missingParent.getMessage());
-        final NoSuchColumnException missingId = Assert.assertThrows(NoSuchColumnException.class, () ->  source.tree("FooBar", "Parent"));
-        assertEquals("tree identifier column: Unknown column names [FooBar], available column names are [ID, Parent]", missingId.getMessage());
+        final NoSuchColumnException missingParent =
+                Assert.assertThrows(NoSuchColumnException.class, () -> source.tree("ID", "FooBar"));
+        assertEquals("tree parent column: Unknown column names [FooBar], available column names are [ID, Parent]",
+                missingParent.getMessage());
+        final NoSuchColumnException missingId =
+                Assert.assertThrows(NoSuchColumnException.class, () -> source.tree("FooBar", "Parent"));
+        assertEquals("tree identifier column: Unknown column names [FooBar], available column names are [ID, Parent]",
+                missingId.getMessage());
 
-        final InvalidColumnException ice = Assert.assertThrows(InvalidColumnException.class, () -> source.tree("ID", "Parent"));
-        assertEquals("tree parent and identifier columns must have the same data type, but parent is [Parent, int] and identifier is [ID, long]", ice.getMessage());
+        final InvalidColumnException ice =
+                Assert.assertThrows(InvalidColumnException.class, () -> source.tree("ID", "Parent"));
+        assertEquals(
+                "tree parent and identifier columns must have the same data type, but parent is [Parent, int] and identifier is [ID, long]",
+                ice.getMessage());
     }
 }


### PR DESCRIPTION
Previously, the error message was a class cast exception in the middle of a snapshot, rather than something meaningful at tree creation time.