### PR TITLE
fix: DH-18483: Guard against nulls when transforming filter messages (#7057)

### DIFF
--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterFactory.java
@@ -26,6 +26,7 @@ import io.deephaven.proto.backplane.grpc.NotCondition;
 import io.deephaven.proto.backplane.grpc.Reference;
 import io.deephaven.proto.backplane.grpc.Value;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.text.DecimalFormat;
 import java.util.List;
@@ -224,12 +225,14 @@ public class FilterFactory implements FilterVisitor<WhereFilter> {
     }
 
     @Override
-    public WhereFilter onInvoke(String method, Value target, List<Value> argumentsList) {
-        return generateConditionFilter(Condition.newBuilder().setInvoke(InvokeCondition.newBuilder()
+    public WhereFilter onInvoke(String method, @Nullable Value target, List<Value> argumentsList) {
+        InvokeCondition.Builder partialInvoke = InvokeCondition.newBuilder()
                 .setMethod(method)
-                .setTarget(target)
-                .addAllArguments(argumentsList)
-                .build()).build());
+                .addAllArguments(argumentsList);
+        if (target != null) {
+            partialInvoke.setTarget(target);
+        }
+        return generateConditionFilter(Condition.newBuilder().setInvoke(partialInvoke).build());
     }
 
     @Override

--- a/server/src/main/java/io/deephaven/server/table/ops/filter/FilterPrinter.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/FilterPrinter.java
@@ -11,6 +11,7 @@ import io.deephaven.proto.backplane.grpc.MatchType;
 import io.deephaven.proto.backplane.grpc.Reference;
 import io.deephaven.proto.backplane.grpc.Value;
 import org.apache.commons.text.StringEscapeUtils;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -164,7 +165,7 @@ public class FilterPrinter implements FilterVisitor<Void> {
     }
 
     @Override
-    public Void onInvoke(String method, Value target, List<Value> argumentsList) {
+    public Void onInvoke(String method, @Nullable Value target, List<Value> argumentsList) {
         if (target != null) {
             accept(target);
             sb.append(".");

--- a/server/src/main/java/io/deephaven/server/table/ops/filter/NormalizeNots.java
+++ b/server/src/main/java/io/deephaven/server/table/ops/filter/NormalizeNots.java
@@ -10,6 +10,7 @@ import io.deephaven.proto.backplane.grpc.MatchType;
 import io.deephaven.proto.backplane.grpc.Reference;
 import io.deephaven.proto.backplane.grpc.Value;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -139,8 +140,11 @@ public class NormalizeNots extends AbstractNormalizeFilters {
         }
 
         @Override
-        public Condition onInvoke(String method, Value target, List<Value> argumentsList) {
+        public Condition onInvoke(String method, @Nullable Value target, List<Value> argumentsList) {
             // This operation doesn't have a corresponding NOT, we have to wrap them as before
+            if (target == null) {
+                return NormalizeFilterUtil.doInvert(NormalizeFilterUtil.doInvoke(method, argumentsList));
+            }
             return NormalizeFilterUtil.doInvert(NormalizeFilterUtil.doInvoke(method, target, argumentsList));
         }
 

--- a/server/src/test/java/io/deephaven/server/table/ops/filter/NormalizeNotsTest.java
+++ b/server/src/test/java/io/deephaven/server/table/ops/filter/NormalizeNotsTest.java
@@ -104,6 +104,14 @@ public class NormalizeNotsTest extends AbstractNormalizingFilterTest {
         assertFilterEquals("not(not(invoke))", not(not(invoke)), invoke);
     }
 
+    @Test
+    public void testNotInvokeStatic() {
+        // Here we aren't testing if the not is normalized away, but both that it is retained and that there
+        // are no errors producing/normalizing it.
+        Condition invoke = invoke("java.lang.Double.isNaN", null, literal(7));
+        assertFilterEquals("not(invoke)", not(invoke), not(invoke));
+    }
+
     @Override
     protected Condition execute(Condition f) {
         return NormalizeNots.exec(f);

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/TableManipulationTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/TableManipulationTestGwt.java
@@ -598,6 +598,14 @@ public class TableManipulationTestGwt extends AbstractAsyncGwtTestCase {
                     table.setViewport(0, 0, null);
                     return assertUpdateReceived(table, 1, 2011);
                 })
+                .then(table -> {
+                    // static invoke with no match
+                    table.applyFilter(new FilterCondition[] {
+                            FilterCondition.invoke("and", FilterValue.ofBoolean(false))
+                    });
+                    table.setViewport(0, 0, null);
+                    return assertUpdateReceived(table, 0, 2012);
+                })
                 .then(this::finish).catch_(this::report);
     }
 


### PR DESCRIPTION
Fixes DH-18483