### PR TITLE
fix(cpp/client): DH-20122: Link to stdc++fs only on Linux

### DIFF
--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -150,5 +150,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC Arrow::arrow_shared)
 target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::libprotobuf)
 target_link_libraries(${PROJECT_NAME} PRIVATE gRPC::grpc++)
 target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
-# Required for GCC before 9.1 on some platforms, harmless on the rest.
-target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
+# Required for GCC before 9.1 on some Linux platforms, harmless on the rest.
+if (LINUX)
+    target_link_libraries(${PROJECT_NAME} PRIVATE stdc++fs)
+endif()


### PR DESCRIPTION
Windows doesn't seem to have this library so it breaks our Windows client builds.