### PR TITLE
refactor: DH-20135: migrate javapoet

### DIFF
--- a/authorization-codegen/build.gradle
+++ b/authorization-codegen/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation platform(libs.grpc.bom)
     implementation libs.grpc.services
 
-    implementation libs.squareup.javapoet
+    implementation libs.javapoet
 
     implementation libs.protobuf.java
 }

--- a/authorization-codegen/src/main/java/io/deephaven/auth/codegen/GenerateContextualAuthWiring.java
+++ b/authorization-codegen/src/main/java/io/deephaven/auth/codegen/GenerateContextualAuthWiring.java
@@ -5,12 +5,12 @@ package io.deephaven.auth.codegen;
 
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.compiler.PluginProtos;
-import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.FieldSpec;
-import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeSpec;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.FieldSpec;
+import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeSpec;
 import io.deephaven.auth.AuthContext;
 import io.deephaven.engine.table.Table;
 

--- a/authorization-codegen/src/main/java/io/deephaven/auth/codegen/GenerateServiceAuthWiring.java
+++ b/authorization-codegen/src/main/java/io/deephaven/auth/codegen/GenerateServiceAuthWiring.java
@@ -6,12 +6,12 @@ package io.deephaven.auth.codegen;
 import com.google.common.base.Strings;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.compiler.PluginProtos;
-import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.FieldSpec;
-import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeSpec;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.FieldSpec;
+import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeSpec;
 import io.deephaven.auth.AuthContext;
 import io.grpc.ServerServiceDefinition;
 

--- a/authorization/README.md
+++ b/authorization/README.md
@@ -30,7 +30,7 @@ Here is a sample bash script to generate the provided authorizing wiring if you 
 DEEPHAVEN_VERSION="$(./gradlew printVersion -q)"
 OUT_DIR=authorization/src/main/java/
 PROTO_DIR=proto/proto-backplane-grpc/src/main/proto/
-ROOT_DIR=$PROTO_DIR/deephaven/proto
+ROOT_DIR=$PROTO_DIR/deephaven_core/proto
 
 DEEPHAVEN_VERSION=${DEEPHAVEN_VERSION} PATH=authorization-codegen:$PATH protoc --service-auth-wiring_out=$OUT_DIR -I $PROTO_DIR    \
      $ROOT_DIR/application.proto                                        \

--- a/engine/table/build.gradle
+++ b/engine/table/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation libs.f4b6a3.uuid.creator
     // TODO(deephaven-core#3204): t-digest 3.3 appears to have higher errors than 3.2
     implementation libs.tdunning.t.digest
-    implementation libs.squareup.javapoet
+    implementation libs.javapoet
     implementation libs.classgraph
     implementation libs.dsi.fastutil
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/TypedAsOfJoinFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/asofjoin/TypedAsOfJoinFactory.java
@@ -3,7 +3,7 @@
 //
 package io.deephaven.engine.table.impl.asofjoin;
 
-import com.squareup.javapoet.CodeBlock;
+import com.palantir.javapoet.CodeBlock;
 import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.impl.by.typed.HasherConfig;
 import io.deephaven.util.QueryConstants;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/HasherConfig.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/HasherConfig.java
@@ -3,9 +3,9 @@
 //
 package io.deephaven.engine.table.impl.by.typed;
 
-import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterSpec;
+import com.palantir.javapoet.CodeBlock;
+import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterSpec;
 import groovyjarjarantlr4.v4.runtime.misc.NotNull;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.ChunkType;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/TypedAggregationFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/TypedAggregationFactory.java
@@ -3,8 +3,8 @@
 //
 package io.deephaven.engine.table.impl.by.typed;
 
-import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.MethodSpec;
+import com.palantir.javapoet.CodeBlock;
+import com.palantir.javapoet.MethodSpec;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.util.type.TypeUtils;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/TypedHasherFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/TypedHasherFactory.java
@@ -4,7 +4,7 @@
 package io.deephaven.engine.table.impl.by.typed;
 
 import com.google.common.io.BaseEncoding;
-import com.squareup.javapoet.*;
+import com.palantir.javapoet.*;
 import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.api.NaturalJoinType;
 import io.deephaven.base.verify.Assert;
@@ -729,7 +729,7 @@ public class TypedHasherFactory {
             TypeSpec.Builder hasherBuilder) {
         CodeBlock.Builder constructorCodeBuilder = CodeBlock.builder();
         final String extraSuper = hasherConfig.extraConstructorParameters.isEmpty() ? ""
-                : ", " + hasherConfig.extraConstructorParameters.stream().map(spec -> spec.name)
+                : ", " + hasherConfig.extraConstructorParameters.stream().map(ParameterSpec::name)
                         .collect(Collectors.joining(", "));
 
         if (hasherConfig.includeOriginalSources) {
@@ -1012,7 +1012,7 @@ public class TypedHasherFactory {
     private static @NotNull String getExtraMigrateParams(List<ParameterSpec> hasherConfig) {
         final String extraParamNames;
         if (!hasherConfig.isEmpty()) {
-            extraParamNames = ", " + hasherConfig.stream().map(ps -> ps.name)
+            extraParamNames = ", " + hasherConfig.stream().map(ParameterSpec::name)
                     .collect(Collectors.joining(", "));
         } else {
             extraParamNames = "";

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/TypedHasherFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/typed/TypedHasherFactory.java
@@ -842,8 +842,7 @@ public class TypedHasherFactory {
         for (int ii = 0; ii < chunkTypes.length; ++ii) {
             builder.addStatement("destKeyArray$L[destinationTableLocation] = k$L", ii, ii);
         }
-        builder.addStatement("destState[destinationTableLocation] = originalStateArray[sourceBucket]",
-                hasherConfig.mainStateName);
+        builder.addStatement("destState[destinationTableLocation] = originalStateArray[sourceBucket]");
         if (!hasherConfig.alwaysMoveMain) {
             builder.beginControlFlow("if (sourceBucket != destinationTableLocation)");
         }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/multijoin/TypedMultiJoinFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/multijoin/TypedMultiJoinFactory.java
@@ -3,7 +3,7 @@
 //
 package io.deephaven.engine.table.impl.multijoin;
 
-import com.squareup.javapoet.CodeBlock;
+import com.palantir.javapoet.CodeBlock;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.engine.table.impl.by.typed.HasherConfig;
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/TypedNaturalJoinFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/TypedNaturalJoinFactory.java
@@ -3,7 +3,7 @@
 //
 package io.deephaven.engine.table.impl.naturaljoin;
 
-import com.squareup.javapoet.CodeBlock;
+import com.palantir.javapoet.CodeBlock;
 import io.deephaven.api.NaturalJoinType;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.LongChunk;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/TypedNaturalJoinFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/naturaljoin/TypedNaturalJoinFactory.java
@@ -273,7 +273,7 @@ public class TypedNaturalJoinFactory {
 
     public static void rightIncrementalModify(HasherConfig<?> hasherConfig, boolean alternate,
             CodeBlock.Builder builder) {
-        builder.addStatement("final long oldRightRow = rightRowKey.getUnsafe(tableLocation)", RowSet.class);
+        builder.addStatement("final long oldRightRow = rightRowKey.getUnsafe(tableLocation)");
         builder.addStatement(
                 "modifiedTrackerCookieSource.set(tableLocation, modifiedSlotTracker.addMain(modifiedTrackerCookieSource.getUnsafe(tableLocation), tableLocation, oldRightRow, $T.FLAG_RIGHT_MODIFY_PROBE))",
                 NaturalJoinModifiedSlotTracker.class);
@@ -365,7 +365,7 @@ public class TypedNaturalJoinFactory {
         builder.addStatement("final long duplicateLocation = duplicateLocationFromRowKey(existingRightRowKey)");
         builder.addStatement(
                 "rightSideDuplicateRowSets.getUnsafe(duplicateLocation).insert(rowKeyChunk.get(chunkPosition))");
-        builder.nextControlFlow("else", RowSet.class);
+        builder.nextControlFlow("else");
 
         builder.beginControlFlow("if (addOnly && joinType == NaturalJoinType.FIRST_MATCH) ");
         builder.addStatement("// nop, we already have the first match");

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/TypedUpdateByFactory.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/hashing/TypedUpdateByFactory.java
@@ -3,7 +3,7 @@
 //
 package io.deephaven.engine.table.impl.updateby.hashing;
 
-import com.squareup.javapoet.CodeBlock;
+import com.palantir.javapoet.CodeBlock;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.engine.rowset.RowSetFactory;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ rdblue = "0.1.1"
 selenium = "4.30.0"
 slf4j = "2.0.17"
 snappy = "1.1.10.8"
-squareup = "1.13.0"
+javapoet = "0.7.0"
 sslcontext = "9.1.0"
 tdunning = "3.3"
 trove = "3.0.3"
@@ -304,7 +304,7 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 
 snappy-java = { module = "org.xerial.snappy:snappy-java", version.ref = "snappy" }
 
-squareup-javapoet = { module = "com.squareup:javapoet", version.ref = "squareup" }
+javapoet = { module = "com.palantir.javapoet:javapoet", version.ref = "javapoet" }
 
 sslcontext-kickstart = { module = "io.github.hakky54:sslcontext-kickstart", version.ref = "sslcontext" }
 sslcontext-kickstart-jetty = { module = "io.github.hakky54:sslcontext-kickstart-for-jetty", version.ref = "sslcontext" }

--- a/replication/reflective/build.gradle
+++ b/replication/reflective/build.gradle
@@ -8,7 +8,7 @@ description 'Reflective Replicators: Source code generators and replicators with
 dependencies {
     implementation project(':replication-util')
     implementation project(':engine-table')
-    implementation libs.squareup.javapoet
+    implementation libs.javapoet
     implementation libs.trove
     implementation libs.commons.io
     implementation libs.commons.lang3

--- a/replication/reflective/src/main/java/io/deephaven/replicators/GenerateArrowColumnSourceTests.java
+++ b/replication/reflective/src/main/java/io/deephaven/replicators/GenerateArrowColumnSourceTests.java
@@ -3,16 +3,16 @@
 //
 package io.deephaven.replicators;
 
-import com.squareup.javapoet.AnnotationSpec;
-import com.squareup.javapoet.ArrayTypeName;
-import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.FieldSpec;
-import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeName;
-import com.squareup.javapoet.TypeSpec;
+import com.palantir.javapoet.AnnotationSpec;
+import com.palantir.javapoet.ArrayTypeName;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.CodeBlock;
+import com.palantir.javapoet.FieldSpec;
+import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeName;
+import com.palantir.javapoet.TypeSpec;
 
 import javax.lang.model.element.Modifier;
 import java.io.File;

--- a/replication/reflective/src/main/java/io/deephaven/replicators/GenerateArrowColumnSources.java
+++ b/replication/reflective/src/main/java/io/deephaven/replicators/GenerateArrowColumnSources.java
@@ -3,15 +3,15 @@
 //
 package io.deephaven.replicators;
 
-import com.squareup.javapoet.AnnotationSpec;
-import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeName;
-import com.squareup.javapoet.TypeSpec;
-import com.squareup.javapoet.TypeVariableName;
-import com.squareup.javapoet.WildcardTypeName;
+import com.palantir.javapoet.AnnotationSpec;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterizedTypeName;
+import com.palantir.javapoet.TypeName;
+import com.palantir.javapoet.TypeSpec;
+import com.palantir.javapoet.TypeVariableName;
+import com.palantir.javapoet.WildcardTypeName;
 import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableDoubleChunk;

--- a/replication/reflective/src/main/java/io/deephaven/replicators/ReplicateTypedHashers.java
+++ b/replication/reflective/src/main/java/io/deephaven/replicators/ReplicateTypedHashers.java
@@ -3,11 +3,11 @@
 //
 package io.deephaven.replicators;
 
-import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.ParameterSpec;
-import com.squareup.javapoet.TypeSpec;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.MethodSpec;
+import com.palantir.javapoet.ParameterSpec;
+import com.palantir.javapoet.TypeSpec;
 import io.deephaven.chunk.ChunkType;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.impl.asofjoin.RightIncrementalAsOfJoinStateManagerTypedBase;
@@ -59,7 +59,7 @@ public class ReplicateTypedHashers {
         }
 
         final String extraInit = hasherConfig.extraConstructorParameters.isEmpty() ? ""
-                : ", " + hasherConfig.extraConstructorParameters.stream().map(spec -> spec.name)
+                : ", " + hasherConfig.extraConstructorParameters.stream().map(ParameterSpec::name)
                         .collect(Collectors.joining(", "));
 
         final MethodSpec.Builder dispatchMethodBuilder = MethodSpec.methodBuilder("dispatch")
@@ -122,7 +122,7 @@ public class ReplicateTypedHashers {
                 "Invalid chunk type for typed hashers: ");
 
         final String extraInit = hasherConfig.extraConstructorParameters.isEmpty() ? ""
-                : ", " + hasherConfig.extraConstructorParameters.stream().map(spec -> spec.name)
+                : ", " + hasherConfig.extraConstructorParameters.stream().map(ParameterSpec::name)
                         .collect(Collectors.joining(", "));
 
         final ChunkType[] array = new ChunkType[1];
@@ -160,7 +160,7 @@ public class ReplicateTypedHashers {
         addHasherParametersAndReturnType(doubleDispatchBuilder, baseClass, hasherConfig.extraConstructorParameters);
 
         final String extraInit = hasherConfig.extraConstructorParameters.isEmpty() ? ""
-                : ", " + hasherConfig.extraConstructorParameters.stream().map(spec -> spec.type + " " + spec.name)
+                : ", " + hasherConfig.extraConstructorParameters.stream().map(spec -> spec.type() + " " + spec.name())
                         .collect(Collectors.joining(", "));
 
         doubleDispatchBuilder.beginControlFlow("switch (chunkType0)");


### PR DESCRIPTION
square’s javapoet library is deprecated https://github.com/square/javapoet?tab=readme-ov-file#deprecated
    
The recommended replacement is https://github.com/palantir/javapoet. It seems to be a clean fork of the original with bug fixes, new features, ongoing maintenance, and releases. A quick audit of the repo shows it is using gradle instead of maven.

A couple of code changes were necessary. 1) Instead of referencing field members directly, we must now reference the proper method. 2) Extraneous arguments can no longer be passed to code generation methods.

This also fixes authorization codegen documentation to correctly reference the directory `deephaven_core` (as opposed to `deephaven`); this was an oversight from #6379.