### PR TITLE
fix: DH-20146: make codec-api and implementations Java 8 compatible

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -18,11 +18,11 @@ def testRuntimeVendor = project.hasProperty('testRuntimeVendor') ?  JvmVendorSpe
 if (languageLevel > compilerVersion) {
   throw new IllegalArgumentException("languageLevel must be less than or equal to compilerVersion")
 }
-if (languageLevel < 11) {
-  throw new IllegalArgumentException("languageLevel must be greater than or equal to 11")
+if (languageLevel < 8) {
+  throw new IllegalArgumentException("languageLevel must be greater than or equal to 8")
 }
-if (testLanguageLevel < 11) {
-  throw new IllegalArgumentException("testLanguageLevel must be greater than or equal to 11")
+if (testLanguageLevel < 8) {
+  throw new IllegalArgumentException("testLanguageLevel must be greater than or equal to 8")
 }
 if (runtimeVersion < languageLevel) {
   project.logger.lifecycle("runtimeVersion was set to ${runtimeVersion}, updating to ${languageLevel} to match languageLevel")

--- a/codec/api/gradle.properties
+++ b/codec/api/gradle.properties
@@ -1,1 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
+languageLevel=8

--- a/codec/builtin/build.gradle
+++ b/codec/builtin/build.gradle
@@ -8,7 +8,6 @@ description 'Codec Builtin: Deephaven builtin codec implementations'
 dependencies {
     api project(":codec-api")
 
-    implementation project(":Base")
     implementation project(":engine-query-constants")
 
     compileOnly libs.jetbrains.annotations

--- a/codec/builtin/gradle.properties
+++ b/codec/builtin/gradle.properties
@@ -1,1 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
+languageLevel=8

--- a/codec/builtin/src/main/java/io/deephaven/util/codec/CodecUtil.java
+++ b/codec/builtin/src/main/java/io/deephaven/util/codec/CodecUtil.java
@@ -3,7 +3,6 @@
 //
 package io.deephaven.util.codec;
 
-import io.deephaven.base.string.EncodingInfo;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.BufferOverflowException;
@@ -31,7 +30,7 @@ class CodecUtil {
     public static void putUtf8String(@NotNull final ByteBuffer destination, @NotNull final String value) {
         final int initialPosition = destination.position();
         destination.position(initialPosition + Integer.BYTES);
-        final CharsetEncoder encoder = EncodingInfo.UTF_8.getEncoder().reset();
+        final CharsetEncoder encoder = EncodingInfoUtf8.getEncoder().reset();
         if (!encoder.encode(CharBuffer.wrap(value), destination, true).isUnderflow()
                 || !encoder.flush(destination).isUnderflow()) {
             throw new BufferOverflowException();
@@ -51,7 +50,7 @@ class CodecUtil {
     public static String getUtf8String(@NotNull final ByteBuffer source) {
         final int length = source.getInt();
         final int initialLimit = source.limit();
-        final CharsetDecoder decoder = EncodingInfo.UTF_8.getDecoder().reset();
+        final CharsetDecoder decoder = EncodingInfoUtf8.getDecoder().reset();
         if (length > source.remaining()) {
             throw new BufferUnderflowException();
         }

--- a/codec/builtin/src/main/java/io/deephaven/util/codec/EncodingInfoUtf8.java
+++ b/codec/builtin/src/main/java/io/deephaven/util/codec/EncodingInfoUtf8.java
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.util.codec;
+
+import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Internal, stripped down version of io.deephaven.base.string.EncodingInfo, so
+ * {@link CodecUtil#getUtf8String(ByteBuffer)} and {@link CodecUtil#putUtf8String(ByteBuffer, String)} can still use it.
+ */
+final class EncodingInfoUtf8 {
+
+    private static final ThreadLocal<SoftReference<CharsetEncoder>> ENCODER =
+            ThreadLocal.withInitial(() -> new SoftReference<>(makeEncoder()));
+    private static final ThreadLocal<SoftReference<CharsetDecoder>> DECODER =
+            ThreadLocal.withInitial(() -> new SoftReference<>(makeDecoder()));
+
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+    private static CharsetEncoder makeEncoder() {
+        return CHARSET.newEncoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    }
+
+    public static CharsetEncoder getEncoder() {
+        CharsetEncoder encoder = EncodingInfoUtf8.ENCODER.get().get();
+        if (encoder == null) {
+            EncodingInfoUtf8.ENCODER.set(new SoftReference<>(encoder = makeEncoder()));
+        }
+        return encoder;
+    }
+
+    private static CharsetDecoder makeDecoder() {
+        return CHARSET.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    }
+
+    public static CharsetDecoder getDecoder() {
+        CharsetDecoder decoder = EncodingInfoUtf8.DECODER.get().get();
+        if (decoder == null) {
+            EncodingInfoUtf8.DECODER.set(new SoftReference<>(decoder = makeDecoder()));
+        }
+        return decoder;
+    }
+}

--- a/engine/query-constants/gradle.properties
+++ b/engine/query-constants/gradle.properties
@@ -1,1 +1,2 @@
 io.deephaven.project.ProjectType=JAVA_PUBLIC
+languageLevel=8


### PR DESCRIPTION
This contains a few minor gradle language level reverts from #6695, as well as a minor copy of EncodingInfo remove codec's dependency on Base, to make codec-api and implementations Java 8 compatible.

Cherry-pick of #7081