### PR TITLE
fix: DH-20184: Blank Py ODBC doc page

### DIFF
--- a/py/server/deephaven/dbc/odbc.py
+++ b/py/server/deephaven/dbc/odbc.py
@@ -7,19 +7,22 @@
 Turbodbc is DB-API 2.0 compliant, provides access to relational databases via the ODBC interface and more
 importantly it has optimized, built-in Apache Arrow support when fetching ODBC result sets. This enables Deephaven to
 achieve maximum efficiency when ingesting relational data. """
+import warnings
 
 from deephaven import DHError
 from deephaven import arrow as dharrow
 from deephaven.table import Table
 
 try:
+    import turbodbc
+    # this import is necessary to ensure that the turbodbc module is built with the Apache Arrow support
     import turbodbc.cursor
 except ImportError:
-    raise DHError(message="import turbodbc failed, please install turbodbc, the ODBC driver manager, and the targeted "
-                          "database driver first.")
+    warnings.warn(message="import turbodbc failed, please install turbodbc with arrow support, the ODBC driver manager,"
+                          "and the target database driver first.", stacklevel=2)
+    turbodbc = None
 
-
-def read_cursor(cursor: turbodbc.cursor.Cursor) -> Table:
+def read_cursor(cursor: 'turbodbc.cursor.Cursor') -> Table:
     """Converts the result set of the provided cursor into a Deephaven table.
 
     Args:
@@ -32,6 +35,9 @@ def read_cursor(cursor: turbodbc.cursor.Cursor) -> Table:
     Raises:
         DHError, TypeError
     """
+    if turbodbc is None:
+        raise DHError(message="turbodbc is not installed, please install it, the ODBC driver manager, and the target "
+                          "database driver first before calling this function.")
 
     if not isinstance(cursor, turbodbc.cursor.Cursor):
         raise TypeError(f"expect {turbodbc.cursor.Cursor} got {type(cursor)} instead.")


### PR DESCRIPTION
Warning only when import fails, raise exception when actually called