### PR TITLE
chore: Exclude gradle wrapper from LFS.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.parquet filter=lfs diff=lfs merge=lfs -text
 *.jar filter=lfs diff=lfs merge=lfs -text
+gradle/wrapper/gradle-wrapper.jar !filter !diff !merge -text


### PR DESCRIPTION
With the iceberg jar in lfs matching all JARs in the repo, the existing gradle-wrapper.jar produces an error on various resets:

```[charleswright@MacBook-Pro-8 ~/code/deephaven-core]$ git reset --hard upstream/main
HEAD is now at c626e04b9e feat: DH-20126: Permit Resolvers without Ticket Prefix, Ticket Resolvers with ServiceLoader (#7134)
Encountered 1 file that should have been a pointer, but wasn't:
	gradle/wrapper/gradle-wrapper.jar
```

This changes the .gitattributes to exclude it; which seems reasonable given that the file is 43K.