### PR TITLE
chore: DH-20260: Improve the query compiler error message.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/context/QueryCompilerImpl.java
@@ -41,7 +41,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -606,7 +605,9 @@ public class QueryCompilerImpl implements QueryCompiler, LogOutputAppendable {
 
                 // However, regardless of A-C, there will be *some* class being found
                 if (clazz == null) {
-                    throw new IllegalStateException("Should have been able to load *some* class here");
+                    throw new IllegalStateException("Unable to load class after delay of " + CODEGEN_TIMEOUT_MS
+                            + ".  state index=" + ii + ", fqClassName=" + state.fqClassName + ", parameterClasses"
+                            + request.parameterClasses() + ", destination=" + getClassDestination().getAbsolutePath());
                 }
 
                 if (completeIfResultMatchesQueryCompilerRequest(state.packageName, request, resolver, clazz)) {


### PR DESCRIPTION
When purposefully broken the exception has text of:
```
java.lang.IllegalStateException: Unable to load class after delay of 10000.  state index=0, fqClassName=io.deephaven.temp.c_cf972c66ad042260f9af1bb9be14bd65744726a6e4568fc5a065a9d5ed490c7ev65_0.Formula, parameterClasses{}, destination=/Users/charleswright/code/deephaven-core/tmp/workspace/io.deephaven.engine.context.QueryCompiler.createForUnitTests
```