### PR TITLE
fix(cpp-client): DH-20266: Improve C++ Windows build times by providing the /MP flag

### DIFF
--- a/cpp-client/build-windows-clients.bat
+++ b/cpp-client/build-windows-clients.bat
@@ -61,7 +61,7 @@ echo *** CONFIGURING DEEPHAVEN BUILD ***
 cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=%DHINSTALL% -DX_VCPKG_APPLOCAL_DEPS_INSTALL=ON || exit /b
 
 echo *** BUILDING C++ CLIENT ***
-cmake --build build --config RelWithDebInfo --target install -- /p:CL_MPCount=16 -m:1 || exit /b
+cmake --build build --config RelWithDebInfo --target install -- /m:1 || exit /b
 
 exit /b 0
 

--- a/cpp-client/deephaven/dhclient/CMakeLists.txt
+++ b/cpp-client/deephaven/dhclient/CMakeLists.txt
@@ -134,7 +134,7 @@ if (WIN32)
     set_property(TARGET ${PROJECT_NAME} PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
     # /Wall is a bit too chatty so we stick with /W3
     # /bigobj needed because ticking/immer_table_state.cc compiles to something too large apparently
-    target_compile_options(${PROJECT_NAME} PRIVATE /W3 /bigobj)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W3 /bigobj /MP)
 endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE include/private)

--- a/cpp-client/deephaven/dhcore/CMakeLists.txt
+++ b/cpp-client/deephaven/dhcore/CMakeLists.txt
@@ -138,7 +138,7 @@ foreach (whichlib dhcore dhcore_static)
   if (WIN32)
     # /Wall is a bit too chatty so we stick with /W3
     # /bigobj needed because ticking/immer_table_state.cc compiles to something too large apparently
-    target_compile_options(${whichlib} PRIVATE /W3 /bigobj)
+    target_compile_options(${whichlib} PRIVATE /W3 /bigobj /MP)
 
     target_compile_definitions(${whichlib} PRIVATE _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
     target_link_libraries(${whichlib} PRIVATE ws2_32)

--- a/cpp-client/deephaven/tests/CMakeLists.txt
+++ b/cpp-client/deephaven/tests/CMakeLists.txt
@@ -45,7 +45,7 @@ if (LINUX)
 endif()
 
 if (WIN32)
-    target_compile_options(dhclient_tests PRIVATE /W3)
+    target_compile_options(dhclient_tests PRIVATE /W3 /MP)
 endif()
 
 target_include_directories(dhclient_tests PRIVATE include/private)


### PR DESCRIPTION
The flag permits compiling concurrently with multiple cores. We have wanted to do this before but we never landed on the correct set of flags.

This PR:
1. Adds the `/MP` flag to the dhclient, dhcore, and tests projects
2. Removes `/p:CL_MPCount=16` from `build-windows-clients.bat`. Removing this flag allows the build system to choose the "right" number of cores to use rather than setting to be a fixed 16.
3. Keeps the "m" flag but changes the character controlling it from `-` to `/`.  Both work but we change it to `/` for consistency.

(BTW: the m flag controls the concurrency of building multiple PROJECTS at the same time, and we may not be ready for that kind of concurrency)
