### PR TITLE
ci: Change symlinks for reference docs to link unversioned to main

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -30,7 +30,10 @@ jobs:
           remote_user: ${{ secrets.DOCS_USER }}
           remote_key: ${{ secrets.DEEPHAVEN_CORE_SSH_KEY }}
   symlink:
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v') }}
+    # Unversioned links (latest) should take to the default which is main on the docs site.
+    # May change in the future to the latest stable release. If so, that should add a check
+    # that the ref starts with release/v and then use that version instead of main.
+    if: ${{ github.event_name == 'push' }}
     needs: [javadoc, typedoc, pydoc, cppdoc, rdoc, protodoc]
     runs-on: ubuntu-24.04
     steps:
@@ -38,8 +41,7 @@ jobs:
         run: |
           mkdir -p tmp-deephaven-core-v2/symlinks
           cd tmp-deephaven-core-v2/symlinks
-          ln -s ../${{ github.ref_name }} latest
-          ln -s ../main next
+          ln -s ../main latest
           
       - name: Deploy Symlinks
         uses: burnett01/rsync-deployments@5.2


### PR DESCRIPTION
This is causing some failures in our nightly link checking because a few pages link to javadocs (without a version) and those pages don't exist yet as they are pointing to `0.39.8` javadocs.

This changes to point the versionless links to `main` which matches the versioning on the site. We may want to change this in the future, but for now this fixes those links.