### PR TITLE
ci: Fix doc previews sometimes being 1 commit behind

### DIFF
--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -65,7 +65,7 @@ jobs:
       ##########
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           sparse-checkout: /docs/
           sparse-checkout-cone-mode: false
           lfs: true


### PR DESCRIPTION
Looks like the `merge_commit` is created in the background and sometimes doesn't exist on the PR until after the action has started. There is a thread with [comment](https://github.com/actions/checkout/issues/518#issuecomment-1798824665) noting the same issue after the first person recommended using `merge_commit.sha`

This changes to just use the SHA of the PR instead of the merge since it doesn't always exist or is sometimes a commit behind if GitHub hasn't generated a new merge commit behind the scenes when the action runs on a PR update.