### PR TITLE
fix: DH-20307: Throw errors when worker connection has been Disconnected

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/CoreClient.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/CoreClient.java
@@ -122,7 +122,9 @@ public class CoreClient extends HasEventHandling {
         LazyPromise<Void> loginPromise = new LazyPromise<>();
         ideConnection.addEventListenerOneShot(
                 EventPair.of(QueryInfoConstants.EVENT_CONNECT, ignore -> loginPromise.succeed(null)),
-                EventPair.of(CoreClient.EVENT_RECONNECT_AUTH_FAILED, loginPromise::fail));
+                EventPair.of(CoreClient.EVENT_DISCONNECT, loginPromise::fail),
+                EventPair.of(CoreClient.EVENT_RECONNECT_AUTH_FAILED, loginPromise::fail),
+                EventPair.of(CoreClient.EVENT_REQUEST_FAILED, loginPromise::fail));
         Promise<Void> login = loginPromise.asPromise();
 
         if (alreadyRunning) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/ReconnectState.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/ReconnectState.java
@@ -72,11 +72,6 @@ public class ReconnectState {
      * After the connection closes or attempt fails, should be called.
      */
     public void failed() {
-        if (state == State.Disconnected) {
-            // we deliberately disconnected, don't try to reconnect
-            JsLog.debug("Connection failed after deliberate disconnect, not attempting reconnect", this);
-            return;
-        }
         if (state == State.Failed) {
             // dup call, we haven't yet tried reconnect yet or reached max tries, ignore
             JsLog.debug("Already queued new connection attempt", this);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -332,6 +332,12 @@ public class WorkerConnection {
 
                     return Promise.resolve((Object) null);
                 }, fail -> {
+                    // Connection was explicitly closed. We don't want to change
+                    // the status unless a `forceReconnect` is called.
+                    if (state == State.Disconnected) {
+                        return null;
+                    }
+
                     // this is non-recoverable, connection/auth/registration failed, but we'll let it start again when
                     // state changes
                     state = State.Failed;


### PR DESCRIPTION
DH-20307: Don't attempt to reconnect when connections are explicitly closed.

This PR is necessary to support fixes made in [deephaven-ent/iris/#3518](https://github.com/deephaven-ent/iris/pull/3518). Specifically, there is a race condition where a created Core+ JS API client can fail login and will continue to spam the server with login attempts that will never succeed. That PR handles the client side piece of this by explicitly disconnecting the client when this happens. The server side fix is to stop attempting to reconnect if a connection is explicitly closed.

### Testing
I have tested the 2 PRs together and have seen that this PR + the other PR stops the rogue connection spamming. I have only seen change in `connectToWorker` method of `WorkerConnection.java` actually get hit, but I have also not observed any problems caused by it.