### PR TITLE
ci: Skip Java checks if only docs have changed

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -3,8 +3,12 @@ name: Check CI
 on:
   pull_request:
     branches: [ 'main', 'rc/v*' ]
+    paths-ignore:
+      - 'docs/**'
   push:
     branches: [ 'main', 'check/**', 'release/v*' ]
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Skip the ci-check workflow if only docs have changed. This check takes 30+ minutes and should be unnecessary for docs only PRs/commits.

This is a direct example in the [GitHub docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-path)