### PR TITLE
revert: "ci: Skip Java checks if only docs have changed"

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -3,12 +3,8 @@ name: Check CI
 on:
   pull_request:
     branches: [ 'main', 'rc/v*' ]
-    paths-ignore:
-      - 'docs/**'
   push:
     branches: [ 'main', 'check/**', 'release/v*' ]
-    paths-ignore:
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -3,12 +3,8 @@ name: Publish CI
 on:
   push:
     branches: [ 'main', 'release/v*' ]
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     branches: [ 'main', 'rc/v*' ]
-    paths-ignore:
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -3,12 +3,8 @@ name: Quick CI
 on:
   pull_request:
     branches: [ 'main', 'rc/v*' ]
-    paths-ignore:
-      - 'docs/**'
   push:
     branches: [ 'main', 'check/**', 'release/v*' ]
-    paths-ignore:
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Reverts deephaven/deephaven-core#7187

These are still required checks, and by skipping these steps the PR will always be pending and blocked from merging. E.g. https://github.com/deephaven/deephaven-core/pull/7171
<img width="962" height="434" alt="image" src="https://github.com/user-attachments/assets/12134bea-4abb-4925-a17d-95a4b20a1041" />

So we still need to report the status as "done", just while skipping the work... there's a discussion on GitHub around this: https://github.com/orgs/community/discussions/44490

I'll look into the best solution, for now I'm reverting to allow PRs to be able to merge again.