### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,7 +76,7 @@ selenium = "4.30.0"
 slf4j = "2.0.17"
 snappy = "1.1.10.8"
 squareup = "1.13.0"
-sslcontext = "9.1.0"
+ayza = "10.0.0"
 tdunning = "3.3"
 trove = "3.0.3"
 undercouch = "2.18.0"
@@ -305,9 +305,9 @@ snappy-java = { module = "org.xerial.snappy:snappy-java", version.ref = "snappy"
 
 squareup-javapoet = { module = "com.squareup:javapoet", version.ref = "squareup" }
 
-sslcontext-kickstart = { module = "io.github.hakky54:sslcontext-kickstart", version.ref = "sslcontext" }
-sslcontext-kickstart-jetty = { module = "io.github.hakky54:sslcontext-kickstart-for-jetty", version.ref = "sslcontext" }
-sslcontext-kickstart-netty = { module = "io.github.hakky54:sslcontext-kickstart-for-netty", version.ref = "sslcontext" }
+ayza = { module = "io.github.hakky54:ayza", version.ref = "ayza" }
+ayza-jetty = { module = "io.github.hakky54:ayza-for-jetty", version.ref = "ayza" }
+ayza-netty = { module = "io.github.hakky54:ayza-for-netty", version.ref = "ayza" }
 
 tdunning-t-digest = { module = "com.tdunning:t-digest", version.ref = "tdunning" }
 

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -11,6 +11,6 @@ The projects under [ssl/](.) are meant to service the needs of clients and serve
 ### kickstart
 
 [ssl-kickstart](kickstart) serves as an implementation/adapter role, guided by
-[sslcontext-kickstart](https://github.com/Hakky54/sslcontext-kickstart). This handles the translation from the 
+[ayza](https://github.com/Hakky54/ayza). This handles the translation from the 
 configuration objects into JDK-native SSL objects, which can then be used in the construction of specific client or
 server libraries. 

--- a/ssl/config/src/main/java/io/deephaven/ssl/config/package-info.java
+++ b/ssl/config/src/main/java/io/deephaven/ssl/config/package-info.java
@@ -9,6 +9,6 @@
  *
  * <p>
  * While not exposed to the end-user, the overall configuration structure is guided by
- * <a href="https://github.com/Hakky54/sslcontext-kickstart">sslcontext-kickstart</a>.
+ * <a href="https://github.com/Hakky54/ayza">ayza</a>.
  */
 package io.deephaven.ssl.config;


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

It should also close the following PR: https://github.com/deephaven/deephaven-core/pull/7158

Sorry for the inconvenience