### PR TITLE
fix: DH-20413: Expand UpdateBy timestamp column types

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -1385,13 +1385,18 @@ public abstract class UpdateBy {
                 "OperatorCollection TableDef",
                 "Source TableDef");
 
-        // Verify the timestamp column is a supported data type (currently long and Instant)
+        // Verify the timestamp column is a supported data type (already long or can be reinterpreted as long)
         if (operatorCollection.timestampColumnName != null) {
             final ColumnSource<?> timestampSource = source.getColumnSource(operatorCollection.timestampColumnName);
-            if (!timestampSource.allowsReinterpret(long.class)) {
-                final Class<?> type = timestampSource.getType();
-                throw new IllegalArgumentException("Unsupported timestamp column type " + type +
-                        " for column '" + operatorCollection.timestampColumnName + "'");
+            final Class<?> timestampType = timestampSource.getType();
+            if (timestampType != long.class && timestampType != Long.class) {
+                // Can we reinterpret the column as a long
+                final ColumnSource<?> reinterpreted = ReinterpretUtils.maybeConvertToPrimitive(timestampSource);
+                final Class<?> reinterpretedType = reinterpreted.getType();
+                if (reinterpretedType != long.class && reinterpretedType != Long.class) {
+                    throw new IllegalArgumentException("Unsupported timestamp column type " + timestampType +
+                            " for column '" + operatorCollection.timestampColumnName + "'");
+                }
             }
         }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
@@ -507,4 +507,18 @@ public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateError
                     t.updateBy(UpdateByOperation.RollingSum("ts", prevTime, postTime, "data"));
         }
     }
+
+
+    @Test
+    public void testDH20413() {
+        final Table expected = TableTools.timeTable("PT1S").update("X=ii")
+                .updateBy(RollingAvg("Timestamp", Duration.ofSeconds(5), Duration.ofSeconds(5), "AvgX=X"));
+
+        final Table actual = TableTools.timeTable("PT1S").update("X=ii")
+                .reverse()
+                .updateBy(RollingAvg("Timestamp", Duration.ofSeconds(5), Duration.ofSeconds(5), "AvgX=X"))
+                .reverse();
+
+        assertTableEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
#7147 added a descriptive error to `UpdateBy` operations that are time based but the timestamp column data type is unsupported.

This PR uses a different (and more correct) method to test compatibility.