### PR TITLE
fix: DH-20416: fix docs-ci workflow so it doesn't fail on forks

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   makedirs:
+    if: {{ github.repository_owner == 'deephaven' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Make Directories
@@ -73,7 +74,7 @@ jobs:
         run: ./docs/validate
 
   core-docs-sync:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'deephaven' }}
     permissions:
       id-token: write # Required to upload to AWS
       contents: read

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   makedirs:
-    if: {{ github.repository_owner == 'deephaven' }}
+    if: ${{ github.repository_owner == 'deephaven' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Make Directories


### PR DESCRIPTION
docs-ci relies on secrets that forks don’t have. It should be protected by an ‘if’ conditional so it doesn’t needlessly fail.
