### PR TITLE
fix: DH-20419: Ensure no leading/trailing spaces in auth headers

### DIFF
--- a/java-client/session/src/main/java/io/deephaven/client/impl/AuthenticationCallCredentials.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/AuthenticationCallCredentials.java
@@ -21,7 +21,7 @@ class AuthenticationCallCredentials extends CallCredentials {
     @Override
     public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
         final Metadata headers = new Metadata();
-        headers.put(AUTHORIZATION_HEADER, authenticationTypeAndValue);
+        headers.put(AUTHORIZATION_HEADER, authenticationTypeAndValue.trim());
         applier.apply(headers);
     }
 

--- a/py/server/deephaven/barrage.py
+++ b/py/server/deephaven/barrage.py
@@ -155,7 +155,10 @@ def barrage_session(host: str,
             target_uri = f"dh+plain://{target_uri}"
 
         j_client_config = _build_client_config(target_uri, tls_root_certs, extra_headers)
-        auth = f"{auth_type} {auth_token}"
+        if not auth_token:
+            auth = auth_type
+        else:
+            auth = f"{auth_type} {auth_token}"
 
         try:
             return _get_barrage_session_via_api_server(j_client_config, auth)


### PR DESCRIPTION
This change fixes both the python code to ensure it doesn't pass a space, and also the java code to ensure that any extra spaces are always removed.