### PR TITLE
chore: Add codeowners for /gradle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,4 @@
 *.proto @devinrsmith @nbauernfeind @niloc132 @rcaudy @cpwright
 *.gwt.xml @niloc132 @rcaudy @nbauernfeind @cpwright
 /docs/**/*.md @margaretkennedy @jjbrosnan @rcaudy @elijahpetty
+/gradle @devinrsmith @rcaudy


### PR DESCRIPTION
This is mostly about having visibility into libs.versions.toml changes.