### PR TITLE
fix: DH-20448, DH-20449: Better schema information for complex types

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
@@ -222,6 +222,13 @@ public class DefaultChunkReaderFactory implements ChunkReader.Factory {
                 return reader;
             }
         } else if (!isSpecialType) {
+            if (field.getType().getTypeID() == ArrowType.ArrowTypeID.Utf8) {
+                // Server wants to send us utf8 for some column type, but we don't have a way to handle it, give a
+                // useful error
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
+                        "Column with type %s cannot be serialized directly. Consider an updateView() expression to convert to String, register ChunkReaderFactory/ChunkWriterFactory types for custom serialization.",
+                        typeInfo.type().getCanonicalName()));
+            }
             throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
                     "No known Barrage ChunkReader for arrow type %s to %s. \nSupported types: \n\t%s",
                     field.getType().toString(),

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
@@ -226,7 +226,7 @@ public class DefaultChunkReaderFactory implements ChunkReader.Factory {
                 // Server wants to send us utf8 for some column type, but we don't have a way to handle it, give a
                 // useful error
                 throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
-                        "Column with type %s cannot be serialized directly. Consider an updateView() expression to convert to String, register ChunkReaderFactory/ChunkWriterFactory types for custom serialization.",
+                        "Column with type %s cannot be serialized directly. Consider an updateView() expression to convert to String or registering ChunkReaderFactory/ChunkWriterFactory types for custom serialization.",
                         typeInfo.type().getCanonicalName()));
             }
             throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -1117,9 +1117,17 @@ public class BarrageUtil {
 
         final FieldType fieldType = arrowFieldTypeFor(type, metadata, columnAsList);
         if (fieldType.getType().isComplex()) {
-            if (type.isArray() || Vector.class.isAssignableFrom(type)) {
+            if (type.isArray()) {
                 children = Collections.singletonList(arrowFieldFor(
                         "", componentType, componentType == null ? null : componentType.getComponentType(),
+                        Collections.emptyMap(),
+                        false));
+            } else if (Vector.class.isAssignableFrom(type)) {
+                Class<?> vectorComponentType =
+                        componentType == null ? VectorExpansionKernel.getComponentType(type, null) : componentType;
+                children = Collections.singletonList(arrowFieldFor(
+                        "", vectorComponentType,
+                        vectorComponentType == null ? null : vectorComponentType.getComponentType(),
                         Collections.emptyMap(),
                         false));
             } else {
@@ -1184,37 +1192,39 @@ public class BarrageUtil {
             case Double:
                 return Types.MinorType.FLOAT8.getType();
             case Object:
-                if (type.isArray()) {
-                    if (type.getComponentType() == byte.class && !columnAsList) {
+                if (type != null) {
+                    if (type.isArray()) {
+                        if (type.getComponentType() == byte.class && !columnAsList) {
+                            return Types.MinorType.VARBINARY.getType();
+                        }
+                        return Types.MinorType.LIST.getType();
+                    }
+                    if (Vector.class.isAssignableFrom(type)) {
+                        return Types.MinorType.LIST.getType();
+                    }
+                    if (type == LocalDate.class) {
+                        return Types.MinorType.DATEMILLI.getType();
+                    }
+                    if (type == LocalTime.class) {
+                        return Types.MinorType.TIMENANO.getType();
+                    }
+                    if (type == BigDecimal.class
+                            || type == BigInteger.class
+                            || type == Schema.class) {
                         return Types.MinorType.VARBINARY.getType();
                     }
-                    return Types.MinorType.LIST.getType();
-                }
-                if (Vector.class.isAssignableFrom(type)) {
-                    return Types.MinorType.LIST.getType();
-                }
-                if (type == LocalDate.class) {
-                    return Types.MinorType.DATEMILLI.getType();
-                }
-                if (type == LocalTime.class) {
-                    return Types.MinorType.TIMENANO.getType();
-                }
-                if (type == BigDecimal.class
-                        || type == BigInteger.class
-                        || type == Schema.class) {
-                    return Types.MinorType.VARBINARY.getType();
-                }
-                if (type == Instant.class || type == ZonedDateTime.class) {
-                    return NANO_SINCE_EPOCH_TYPE;
-                }
-                if (type == Duration.class) {
-                    return NANO_DURATION_TYPE;
-                }
-                if (type == Period.class) {
-                    return new ArrowType.Interval(IntervalUnit.YEAR_MONTH);
-                }
-                if (type == PeriodDuration.class) {
-                    return new ArrowType.Interval(IntervalUnit.MONTH_DAY_NANO);
+                    if (type == Instant.class || type == ZonedDateTime.class) {
+                        return NANO_SINCE_EPOCH_TYPE;
+                    }
+                    if (type == Duration.class) {
+                        return NANO_DURATION_TYPE;
+                    }
+                    if (type == Period.class) {
+                        return new ArrowType.Interval(IntervalUnit.YEAR_MONTH);
+                    }
+                    if (type == PeriodDuration.class) {
+                        return new ArrowType.Interval(IntervalUnit.MONTH_DAY_NANO);
+                    }
                 }
 
                 // everything gets converted to a string

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/BarrageUtil.java
@@ -1118,8 +1118,9 @@ public class BarrageUtil {
         final FieldType fieldType = arrowFieldTypeFor(type, metadata, columnAsList);
         if (fieldType.getType().isComplex()) {
             if (type.isArray()) {
+                Assert.eq(componentType, "componentType", type.getComponentType(), "type.getComponentType()");
                 children = Collections.singletonList(arrowFieldFor(
-                        "", componentType, componentType == null ? null : componentType.getComponentType(),
+                        "", componentType, componentType.getComponentType(),
                         Collections.emptyMap(),
                         false));
             } else if (Vector.class.isAssignableFrom(type)) {

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/BarrageChunkFactoryTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/BarrageChunkFactoryTest.java
@@ -1413,7 +1413,7 @@ public class BarrageChunkFactoryTest {
             new Utf8RoundTripTest(BarrageChunkFactoryTest.class, new ArrowType.Utf8()).runTest();
             Assert.statementNeverExecuted("Should have thrown an exception");
         } catch (FlightRuntimeException fre) {
-            assertTrue(fre.getMessage().contains("No known Barrage ChunkReader"));
+            assertTrue(fre.getMessage().contains("cannot be serialized directly. Consider an updateView()"));
         }
     }
 

--- a/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -59,6 +59,7 @@ import io.deephaven.util.SafeCloseable;
 import io.deephaven.util.mutable.MutableInt;
 import io.deephaven.vector.DoubleVector;
 import io.deephaven.vector.IntVector;
+import io.deephaven.vector.ObjectVector;
 import io.grpc.*;
 import io.grpc.CallOptions;
 import org.apache.arrow.flight.*;
@@ -619,6 +620,175 @@ public abstract class FlightMessageRoundTripTest {
             // row count should match what we expect
             assertEquals(10, totalRowCount);
         }
+    }
+
+    @Test
+    public void testComplexTypedTable() throws Exception {
+        Flight.Ticket simpleTableTicket = FlightExportTicketHelper.exportIdToFlightTicket(1);
+        currentSession.newExport(simpleTableTicket, "test")
+                .submit(() -> TableTools.emptyTable(1)
+                        .update("triplevector_int=i", "triplevector_string=``").groupBy()
+                        .update("doublevector_int=i", "doublevector_string=``").groupBy()
+                        .update("vector_int=i", "vector_string=``").groupBy()
+                        .update("array_int=new int[]{i}", "doublearray_int=new int[][] {{i}}",
+                                "array_string=new String[]{``}",
+                                "doublearray_string=new String[][]{{``}}"));
+
+        Map<String, Field> arrowFieldTypeMap = new HashMap<>();
+        Map<String, String> dhTypeMap = new HashMap<>();
+        Map<String, String> dhComponentTypeMap = new HashMap<>();
+        int seen = 0;
+        try (FlightStream stream = flightClient.getStream(new Ticket(simpleTableTicket.getTicket().toByteArray()))) {
+            Schema schema = stream.getSchema();
+            for (Field field : schema.getFields()) {
+                if (!field.getName().isBlank()) {
+                    seen++;
+                    switch (field.getName()) {
+                        case "triplevector_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            // Even though this is a primitive int vector, the third layer of wrapping means it has to
+                            // be made into a string
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(ObjectVector.class.getName(),
+                                    field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "triplevector_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            // Even though this is a ObjectVector<String>, the third layer of wrapping means it has to
+                            // be made into a string
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(ObjectVector.class.getName(),
+                                    field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "doublevector_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, grandChild.getType().getTypeID());
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(IntVector.class.getName(), field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "doublevector_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(ObjectVector.class.getName(),
+                                    field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "vector_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, child.getType().getTypeID());
+                            assertEquals(IntVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals("int", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "vector_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, child.getType().getTypeID());
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals("java.lang.String", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "array_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, child.getType().getTypeID());
+                            assertEquals("int[]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("int", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "doublearray_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, grandChild.getType().getTypeID());
+                            assertEquals("int[][]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("int[]", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "array_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, child.getType().getTypeID());
+                            assertEquals("java.lang.String[]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("java.lang.String", field.getMetadata().get("deephaven:componentType"));
+
+                            break;
+                        }
+                        case "doublearray_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+                            assertEquals("java.lang.String[][]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("java.lang.String[]", field.getMetadata().get("deephaven:componentType"));
+
+                            break;
+                        }
+                        default:
+                            fail("Unexpected field: " + field.getName());
+                    }
+                    arrowFieldTypeMap.put(field.getName(), field);
+                    dhTypeMap.put(field.getName(), field.getMetadata().get("deephaven:type"));
+                    dhComponentTypeMap.put(field.getName(), field.getMetadata().get("deephaven:componentType"));
+                }
+            }
+        }
+        assertEquals(10, seen);
     }
 
     @Test

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
@@ -267,7 +267,8 @@ public class WebChunkReaderFactory implements ChunkReader.Factory {
                     listMode = ListChunkReader.Mode.VARIABLE;
                 }
 
-                if (typeInfo.componentType() == byte.class && listMode == ListChunkReader.Mode.VARIABLE) {
+                Class<?> componentType = typeInfo.componentType();
+                if (componentType == byte.class && listMode == ListChunkReader.Mode.VARIABLE) {
                     // special case for byte[]
                     return (fieldNodeIter, bufferInfoIter, is, outChunk, outOffset,
                             totalRows) -> (T) extractChunkFromInputStream(
@@ -278,10 +279,10 @@ public class WebChunkReaderFactory implements ChunkReader.Factory {
                                     outChunk, outOffset, totalRows);
                 }
 
-                // noinspection DataFlowIssue
+                // noinspection DataFlowIssue,ConstantValue
                 final BarrageTypeInfo<Field> componentTypeInfo = new BarrageTypeInfo<>(
-                        typeInfo.componentType(),
-                        typeInfo.componentType().getComponentType(),
+                        componentType,
+                        componentType == null ? null : componentType.getComponentType(),
                         typeInfo.arrowField().children(0));
                 final ChunkType chunkType = ListChunkReader.getChunkTypeFor(componentTypeInfo.type());
                 final ExpansionKernel<?> kernel =


### PR DESCRIPTION
Enables JS and Arrow clients to handle any reasonable data, and provides a better error for BarrageTable clients when more serialization support needs to be added.