### PR TITLE
fix: DH-20448, DH-20449: Better schema information for complex types …

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DefaultChunkReaderFactory.java
@@ -222,6 +222,13 @@ public class DefaultChunkReaderFactory implements ChunkReader.Factory {
                 return reader;
             }
         } else if (!isSpecialType) {
+            if (field.getType().getTypeID() == ArrowType.ArrowTypeID.Utf8) {
+                // Server wants to send us utf8 for some column type, but we don't have a way to handle it, give a
+                // useful error
+                throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
+                        "Column with type %s cannot be serialized directly. Consider an updateView() expression to convert to String or registering ChunkReaderFactory/ChunkWriterFactory types for custom serialization.",
+                        typeInfo.type().getCanonicalName()));
+            }
             throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
                     "No known Barrage ChunkReader for arrow type %s to %s. \nSupported types: \n\t%s",
                     field.getType().toString(),

--- a/server/jetty/src/test/java/io/deephaven/server/jetty/BarrageChunkFactoryTest.java
+++ b/server/jetty/src/test/java/io/deephaven/server/jetty/BarrageChunkFactoryTest.java
@@ -1413,7 +1413,7 @@ public class BarrageChunkFactoryTest {
             new Utf8RoundTripTest(BarrageChunkFactoryTest.class, new ArrowType.Utf8()).runTest();
             Assert.statementNeverExecuted("Should have thrown an exception");
         } catch (FlightRuntimeException fre) {
-            assertTrue(fre.getMessage().contains("No known Barrage ChunkReader"));
+            assertTrue(fre.getMessage().contains("cannot be serialized directly. Consider an updateView()"));
         }
     }
 

--- a/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
+++ b/server/src/test/java/io/deephaven/server/barrage/BarrageMessageRoundTripTest.java
@@ -6,6 +6,7 @@ package io.deephaven.server.barrage;
 import dagger.BindsInstance;
 import dagger.Component;
 import io.deephaven.api.ColumnName;
+import io.deephaven.api.RawString;
 import io.deephaven.api.Selectable;
 import io.deephaven.base.Pair;
 import io.deephaven.base.verify.Assert;
@@ -19,6 +20,9 @@ import io.deephaven.engine.table.impl.InstrumentedTableUpdateListener;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.TableUpdateValidator;
+import io.deephaven.engine.table.impl.select.FunctionalColumn;
+import io.deephaven.engine.table.impl.select.SelectColumnFactory;
+import io.deephaven.engine.table.impl.select.WhereFilterFactory;
 import io.deephaven.engine.table.impl.util.BarrageMessage;
 import io.deephaven.engine.table.vectors.IntVectorColumnWrapper;
 import io.deephaven.engine.testutil.*;
@@ -33,6 +37,7 @@ import io.deephaven.extensions.barrage.table.BarrageTable;
 import io.deephaven.extensions.barrage.util.BarrageMessageReaderImpl;
 import io.deephaven.extensions.barrage.util.BarrageUtil;
 import io.deephaven.extensions.barrage.util.ExposedByteArrayOutputStream;
+import io.deephaven.extensions.barrage.util.GrpcMarshallingException;
 import io.deephaven.server.arrow.ArrowModule;
 import io.deephaven.server.session.SessionService;
 import io.deephaven.server.util.Scheduler;
@@ -40,8 +45,10 @@ import io.deephaven.server.util.TestControlledScheduler;
 import io.deephaven.test.types.OutOfBandTest;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.annotations.ReferentialIntegrity;
+import io.deephaven.util.annotations.ScriptApi;
 import io.deephaven.util.mutable.MutableInt;
 import io.deephaven.vector.IntVector;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -55,10 +62,13 @@ import java.io.StringWriter;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import static io.deephaven.engine.table.impl.remote.ConstructSnapshot.SNAPSHOT_CHUNK_SIZE;
 import static io.deephaven.engine.testutil.TstUtils.*;
 import static io.deephaven.engine.util.TableTools.col;
+import static io.deephaven.engine.util.TableTools.emptyTable;
 
 @Category(OutOfBandTest.class)
 public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
@@ -160,6 +170,8 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
         private final Queue<BarrageMessage> commandQueue = new ArrayDeque<>();
         private final DummyObserver dummyObserver;
 
+        private UnaryOperator<QueryTable> transform = null;
+
         // The replicated table's TableUpdateValidator will be confused if the table is a viewport. Instead we rely on
         // comparing the producer table to the consumer table to validate contents are correct.
         RemoteClient(final RowSet viewport, final BitSet subscribedColumns,
@@ -216,6 +228,10 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
             }
         }
 
+        public void setTransform(UnaryOperator<QueryTable> transform) {
+            this.transform = transform;
+        }
+
         public void doSubscribe() {
             subscribed = true;
             final BarrageSubscriptionOptions options = BarrageSubscriptionOptions.builder()
@@ -244,6 +260,11 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
                 }
                 expected = (QueryTable) expected.view(columns);
                 toCheck = (QueryTable) toCheck.view(columns);
+            }
+
+            if (transform != null) {
+                expected = transform.apply(expected);
+                toCheck = transform.apply(toCheck);
             }
 
             // Data should be identical and in-order.
@@ -1489,8 +1510,98 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
         remoteNugget.validate("end-of-test tables should match");
     }
 
+    public void testNestedArrays() {
+        // Two cases that aren't expected to work in the java client, since it doesn't have enough type info:
+        // * triply nested groupBy(), where we have ObjectVector of ObjectVector of some vector
+        // * double nested groupBy() where the inner type is not a primitive
+        final Table queryTable = TableTools.emptyTable(1)
+                // .update("triplevector_int=i", "triplevector_string=``").groupBy()
+                .update("doublevector_int=i"/* , "doublevector_string=``" */).groupBy()
+                .update("vector_int=i", "vector_string=``").groupBy()
+                .update("array_int=new int[]{i}", "doublearray_int=new int[][] {{i}}",
+                        "array_string=new String[]{``}",
+                        "doublearray_string=new String[][]{{``}}");
+        queryTable.setRefreshing(true);
+        final BitSet allColumns = new BitSet(queryTable.getColumnSourceMap().size());
+        for (int i = 0; i < queryTable.getColumnSourceMap().size(); i++) {
+            allColumns.set(i);
+        }
+        final RemoteNugget remoteNugget = new RemoteNugget(() -> queryTable);
+
+        final RemoteClient remoteClient =
+                remoteNugget.newClient(RowSetFactory.fromRange(0, 0), allColumns, "snapshot");
+        remoteClient.setTransform(t -> {
+            // Based on the column type, if we see an array turn it into a string. While this seems to mask the types
+            // that we're getting over the wire, it doesn't function correctly without those types having arrived, so we
+            // should still be correctly validating the table.
+            return (QueryTable) t.updateView(t.getDefinition().getColumnNameMap().entrySet().stream()
+                    .map(entry -> {
+                        String colName = entry.getKey();
+                        Class<?> type = entry.getValue().getDataType();
+                        if (type.isArray()) {
+                            return Selectable.of(
+                                    ColumnName.of(colName),
+                                    RawString
+                                            .of("io.deephaven.server.barrage.BarrageMessageRoundTripTest.arrayToString("
+                                                    + colName + ")"));
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()));
+        });
+        // Obtain snapshot of original viewport.
+        flushProducerTable();
+        remoteNugget.flushClientEvents();
+        final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+        updateGraph.runWithinUnitTestCycle(updateSourceCombiner::run);
+        remoteNugget.validate("snapshot");
+    }
+
+    public void testFailingNestedVectors() {
+        // Same as testNestedArrays, except we verify that we get expected exceptions for cases where BarrageTable can't
+        // handle the type
+        final Table failingTable = TableTools.emptyTable(1)
+                .update("triplevector_int=i", "triplevector_string=``").groupBy()
+                .update("doublevector_string=``").groupBy()
+                .groupBy();
+
+        failingTable.setRefreshing(true);
+        for (int i = 0; i < failingTable.getColumnSourceMap().size(); i++) {
+            BitSet oneColumn = new BitSet(failingTable.getColumnSourceMap().size());
+            oneColumn.set(i);
+            final RemoteNugget remoteNugget = new RemoteNugget(() -> failingTable);
+
+            final RemoteClient remoteClient =
+                    remoteNugget.newClient(RowSetFactory.fromRange(0, 0), oneColumn, "snapshot");
+            flushProducerTable();
+            remoteNugget.flushClientEvents();
+            final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+            updateGraph.runWithinUnitTestCycle(updateSourceCombiner::run);
+
+            assertNotNull(remoteClient.dummyObserver.failure);
+            assertTrue(remoteClient.dummyObserver.failure.getCause() instanceof GrpcMarshallingException);
+            assertTrue(remoteClient.dummyObserver.failure.getCause().getCause() instanceof StatusRuntimeException);
+            StatusRuntimeException sre =
+                    (StatusRuntimeException) remoteClient.dummyObserver.failure.getCause().getCause();
+            assertTrue(sre.getMessage().contains("Column with type java.lang.Object cannot be serialized directly"));
+        }
+    }
+
+    // Helpers for testNestedArrays
+    @ScriptApi
+    public static String arrayToString(int[] arr) {
+        return Arrays.toString(arr);
+    }
+
+    @ScriptApi
+    public static String arrayToString(Object[] arr) {
+        return Arrays.deepToString(arr);
+    }
+
     public static class DummyObserver implements StreamObserver<BarrageMessageWriter.MessageView> {
         volatile boolean completed = false;
+        volatile Throwable failure = null;
 
         private final BarrageDataMarshaller marshaller;
         private final Queue<BarrageMessage> receivedCommands;
@@ -1513,11 +1624,13 @@ public class BarrageMessageRoundTripTest extends RefreshingTableTestCase {
                         if (message != null) {
                             receivedCommands.add(message);
                         }
-                    } catch (final IOException e) {
+                    } catch (final Exception e) {
+                        this.failure = e;
                         throw new IllegalStateException("Failed to parse barrage message: ", e);
                     }
                 });
-            } catch (final IOException e) {
+            } catch (final Exception e) {
+                this.failure = e;
                 throw new IllegalStateException("Failed to parse barrage message: ", e);
             }
         }

--- a/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
+++ b/server/test-utils/src/main/java/io/deephaven/server/test/FlightMessageRoundTripTest.java
@@ -59,6 +59,7 @@ import io.deephaven.util.SafeCloseable;
 import io.deephaven.util.mutable.MutableInt;
 import io.deephaven.vector.DoubleVector;
 import io.deephaven.vector.IntVector;
+import io.deephaven.vector.ObjectVector;
 import io.grpc.*;
 import io.grpc.CallOptions;
 import org.apache.arrow.flight.*;
@@ -619,6 +620,175 @@ public abstract class FlightMessageRoundTripTest {
             // row count should match what we expect
             assertEquals(10, totalRowCount);
         }
+    }
+
+    @Test
+    public void testComplexTypedTable() throws Exception {
+        Flight.Ticket simpleTableTicket = FlightExportTicketHelper.exportIdToFlightTicket(1);
+        currentSession.newExport(simpleTableTicket, "test")
+                .submit(() -> TableTools.emptyTable(1)
+                        .update("triplevector_int=i", "triplevector_string=``").groupBy()
+                        .update("doublevector_int=i", "doublevector_string=``").groupBy()
+                        .update("vector_int=i", "vector_string=``").groupBy()
+                        .update("array_int=new int[]{i}", "doublearray_int=new int[][] {{i}}",
+                                "array_string=new String[]{``}",
+                                "doublearray_string=new String[][]{{``}}"));
+
+        Map<String, Field> arrowFieldTypeMap = new HashMap<>();
+        Map<String, String> dhTypeMap = new HashMap<>();
+        Map<String, String> dhComponentTypeMap = new HashMap<>();
+        int seen = 0;
+        try (FlightStream stream = flightClient.getStream(new Ticket(simpleTableTicket.getTicket().toByteArray()))) {
+            Schema schema = stream.getSchema();
+            for (Field field : schema.getFields()) {
+                if (!field.getName().isBlank()) {
+                    seen++;
+                    switch (field.getName()) {
+                        case "triplevector_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            // Even though this is a primitive int vector, the third layer of wrapping means it has to
+                            // be made into a string
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(ObjectVector.class.getName(),
+                                    field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "triplevector_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            // Even though this is a ObjectVector<String>, the third layer of wrapping means it has to
+                            // be made into a string
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(ObjectVector.class.getName(),
+                                    field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "doublevector_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, grandChild.getType().getTypeID());
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(IntVector.class.getName(), field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "doublevector_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals(ObjectVector.class.getName(),
+                                    field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "vector_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, child.getType().getTypeID());
+                            assertEquals(IntVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals("int", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "vector_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, child.getType().getTypeID());
+                            assertEquals(ObjectVector.class.getName(), field.getMetadata().get("deephaven:type"));
+                            assertEquals("java.lang.String", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "array_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, child.getType().getTypeID());
+                            assertEquals("int[]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("int", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "doublearray_int": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Int, grandChild.getType().getTypeID());
+                            assertEquals("int[][]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("int[]", field.getMetadata().get("deephaven:componentType"));
+                            break;
+                        }
+                        case "array_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, child.getType().getTypeID());
+                            assertEquals("java.lang.String[]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("java.lang.String", field.getMetadata().get("deephaven:componentType"));
+
+                            break;
+                        }
+                        case "doublearray_string": {
+                            assertEquals(ArrowType.ArrowTypeID.List, field.getType().getTypeID());
+                            List<Field> children = field.getChildren();
+                            assertEquals(1, children.size());
+                            Field child = children.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.List, child.getType().getTypeID());
+                            List<Field> grandChildren = child.getChildren();
+                            assertEquals(1, grandChildren.size());
+                            Field grandChild = grandChildren.get(0);
+                            assertEquals(ArrowType.ArrowTypeID.Utf8, grandChild.getType().getTypeID());
+                            assertEquals("java.lang.String[][]", field.getMetadata().get("deephaven:type"));
+                            assertEquals("java.lang.String[]", field.getMetadata().get("deephaven:componentType"));
+
+                            break;
+                        }
+                        default:
+                            fail("Unexpected field: " + field.getName());
+                    }
+                    arrowFieldTypeMap.put(field.getName(), field);
+                    dhTypeMap.put(field.getName(), field.getMetadata().get("deephaven:type"));
+                    dhComponentTypeMap.put(field.getName(), field.getMetadata().get("deephaven:componentType"));
+                }
+            }
+        }
+        assertEquals(10, seen);
     }
 
     @Test

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
@@ -267,7 +267,8 @@ public class WebChunkReaderFactory implements ChunkReader.Factory {
                     listMode = ListChunkReader.Mode.VARIABLE;
                 }
 
-                if (typeInfo.componentType() == byte.class && listMode == ListChunkReader.Mode.VARIABLE) {
+                Class<?> componentType = typeInfo.componentType();
+                if (componentType == byte.class && listMode == ListChunkReader.Mode.VARIABLE) {
                     // special case for byte[]
                     return (fieldNodeIter, bufferInfoIter, is, outChunk, outOffset,
                             totalRows) -> (T) extractChunkFromInputStream(
@@ -278,10 +279,10 @@ public class WebChunkReaderFactory implements ChunkReader.Factory {
                                     outChunk, outOffset, totalRows);
                 }
 
-                // noinspection DataFlowIssue
+                // noinspection DataFlowIssue,ConstantValue
                 final BarrageTypeInfo<Field> componentTypeInfo = new BarrageTypeInfo<>(
-                        typeInfo.componentType(),
-                        typeInfo.componentType().getComponentType(),
+                        componentType,
+                        componentType == null ? null : componentType.getComponentType(),
                         typeInfo.arrowField().children(0));
                 final ChunkType chunkType = ListChunkReader.getChunkTypeFor(componentTypeInfo.type());
                 final ExpansionKernel<?> kernel =


### PR DESCRIPTION
…(#7228)

Enables JS and Arrow clients to handle any reasonable data, and provides a better error for BarrageTable clients when more serialization support needs to be added.