### PR TITLE
docs: Nightly validation fixes

### DIFF
--- a/docs/groovy/how-to-guides/data-import-export/iceberg.md
+++ b/docs/groovy/how-to-guides/data-import-export/iceberg.md
@@ -71,7 +71,7 @@ restAdapter = IcebergTools.createAdapter(
 
 If you are working with a REST catalog backed by S3 storage, you can use the more specific [`createS3Rest`](https://deephaven.io/core/javadoc/io/deephaven/iceberg/util/IcebergToolsS3.html#createS3Rest(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)) method:
 
-```groovy docker-config=iceberg test-set=1 order=null
+```groovy docker-config=iceberg test-set=1 order=null reset
 import io.deephaven.iceberg.util.*
 
 restAdapter = IcebergToolsS3.createS3Rest(
@@ -195,7 +195,9 @@ sourceDef = source2024.getDefinition()
 
 Then, create an [`IcebergTableAdapter`](/core/javadoc/io/deephaven/iceberg/util/IcebergTableAdapter.html) from the `source2024` table's definition, and a table identifier, which must include the Iceberg namespace (`nyc`):
 
-```groovy docker-config=iceberg test-set=1 order=null
+<!-- This reset is needed because another example also creates nyc.source table and that throws an error if it already exists -->
+
+```groovy docker-config=iceberg test-set=1 order=null reset
 sourceAdapter = restAdapter.createTable("nyc.source", sourceDef)
 ```
 

--- a/docs/groovy/reference/data-import-export/Iceberg/iceberg-table-writer.md
+++ b/docs/groovy/reference/data-import-export/Iceberg/iceberg-table-writer.md
@@ -28,7 +28,7 @@ When constructing an `IcebergTableWriter`, the [`IcebergWriteInstructions`](./ic
 
 The following example creates an `IcebergTableWriter` from an [`IcebergTableAdapter`](./iceberg-table-adapter.md) and appends two tables with identical definitions to an Iceberg table. It uses the Docker deployment defined in the [Deephaven and Iceberg](../../../how-to-guides/data-import-export/iceberg.md#a-deephaven-deployment-for-iceberg) guide.
 
-```groovy docker-config=iceberg order=sourceData2024,sourceData2025
+```groovy docker-config=iceberg order=sourceData2024,sourceData2025 reset
 import io.deephaven.iceberg.util.*
 import io.deephaven.extensions.s3.*
 import org.apache.iceberg.catalog.*

--- a/docs/groovy/tutorials/crash-course/configure.md
+++ b/docs/groovy/tutorials/crash-course/configure.md
@@ -45,7 +45,7 @@ Even with a standard deployment, you may need to install new Java packages at so
 
 Large datasets require significant memory — often much more than the 4G that Deephaven allocates by default. Fortunately, it's easy to give Deephaven more memory.
 
-If you're using Docker-installed Deephaven, Docker itself imposes memory constraints on processes it runs - you can raise this ceiling in [Docker Desktop](https://docs.docker.com/desktop/settings/mac/#resources) by going to `Settings > Resources` and raising the memory parameter. Then, you can specify the memory allocated to Deephaven with the `-Xmx` flag. Here's the command to pull and run the latest version of the Deephaven server with 16G of RAM:
+If you're using Docker-installed Deephaven, Docker itself imposes memory constraints on processes it runs - you can raise this ceiling in [Docker Desktop](https://docs.docker.com/desktop/settings-and-maintenance/settings/#resources) by going to `Settings > Resources` and raising the memory parameter. Then, you can specify the memory allocated to Deephaven with the `-Xmx` flag. Here's the command to pull and run the latest version of the Deephaven server with 16G of RAM:
 
 ```bash skip-test
 docker run --rm --name deephaven -p 10000:10000 --env START_OPTS=-Xmx16g ghcr.io/deephaven/server-slim:latest

--- a/docs/python/getting-started/crash-course/configure.md
+++ b/docs/python/getting-started/crash-course/configure.md
@@ -69,7 +69,7 @@ Package persistence will not be a problem if you're using pip-installed Deephave
 
 Large datasets require significant memory — often much more than the 4G that Deephaven allocates by default. Fortunately, it's easy to give Deephaven more memory, whether you have a Docker or a pip installation.
 
-If you're using Docker-installed Deephaven, Docker itself imposes memory constraints on processes it runs - you can raise this ceiling in [Docker Desktop](https://docs.docker.com/desktop/settings/mac/#resources) by going to `Settings > Resources` and raising the memory parameter. Then, you can specify the memory allocated to Deephaven with the `-Xmx` flag. Here's the command to pull and run the latest version of the Deephaven server with 16G of RAM:
+If you're using Docker-installed Deephaven, Docker itself imposes memory constraints on processes it runs - you can raise this ceiling in [Docker Desktop](https://docs.docker.com/desktop/settings-and-maintenance/settings/#resources) by going to `Settings > Resources` and raising the memory parameter. Then, you can specify the memory allocated to Deephaven with the `-Xmx` flag. Here's the command to pull and run the latest version of the Deephaven server with 16G of RAM:
 
 ```bash skip-test
 docker run --rm --name deephaven -p 10000:10000 --env START_OPTS=-Xmx16g ghcr.io/deephaven/server:latest

--- a/docs/python/getting-started/crash-course/export-data.md
+++ b/docs/python/getting-started/crash-course/export-data.md
@@ -144,7 +144,7 @@ deephaven_table = my_iceberg_table_adapter.table(
 
 Similarly, this code writes a Deephaven table to an Iceberg table. If the target table does not exist, it will be created.
 
-```python test-set=6 docker-config=iceberg order=null
+```python docker-config=iceberg order=null
 from deephaven.experimental import iceberg
 from deephaven import new_table
 from deephaven.column import int_col, string_col
@@ -217,7 +217,7 @@ Deephaven provides a seamless way to convert tables to [Pandas DataFrames](https
 
 To convert a Deephaven table to a Pandas DataFrame, use the `to_pandas()` function.
 
-```python test-set=6 order=iris,iris_df
+```python order=iris,iris_df
 from deephaven import read_csv
 from deephaven.pandas import to_pandas
 
@@ -234,7 +234,7 @@ iris_df = to_pandas(iris)
 
 You can also convert a Pandas DataFrame back to a Deephaven table using `to_table()` from the same module.
 
-```python test-set=6 order=sample_df,deephaven_table_from_df
+```python order=sample_df,deephaven_table_from_df
 import pandas as pd
 from deephaven.pandas import to_table
 


### PR DESCRIPTION
Looks like a docker link moved URLs.

A groovy example that failed snapshots after I properly committed the iceberg config files. This is because 2 examples were trying to create the same table in the same instance. Reset flag makes them get fresh instances.

I am hoping the Python fix works. It's saying the example file doesn't exist which is weird, but the snippet doesn't belong in a test set. It's possible the iceberg config it was running with isn't including the example data container. That's my current guess without spending too much time on this.