### PR TITLE
docs: Add reset tag to example that creates thread

### DIFF
--- a/docs/groovy/how-to-guides/dynamic-table-writer.md
+++ b/docs/groovy/how-to-guides/dynamic-table-writer.md
@@ -88,7 +88,7 @@ The following example adds new data to the publisher with [`emptyTable`](./new-a
 > [!IMPORTANT]
 > A ticking table in a thread must be updated from within an [execution context](../conceptual/execution-context.md).
 
-```groovy ticking-table order=null
+```groovy ticking-table order=null reset
 import io.deephaven.engine.context.ExecutionContext
 import io.deephaven.csv.util.MutableBoolean
 import io.deephaven.engine.table.ColumnDefinition


### PR DESCRIPTION
I think this is the culprit for the still failing nightly test. If not, I'll need to add some more logging to the snapshot tool to figure out what's going on