### PR TITLE
ci: Skip Java checks if only docs have changed while still passing required checks

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -11,8 +11,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      non-docs: ${{ steps.filter.outputs.non-docs }}
+    steps:
+      - name: Check for non-docs changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non-docs:
+              - '!docs/**'
+
   checks:
     runs-on: ubuntu-24.04
+    needs: changes
+    if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
       - name: Free Disk Space
         uses: endersonmenezes/free-disk-space@v2

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           filters: |
             non-docs:
-              - 'docs/**'
+              - '!docs/**'
 
   checks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           filters: |
             non-docs:
-              - '!docs/**'
+              - 'docs/**'
 
   checks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -11,7 +11,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      non-docs: ${{ steps.filter.outputs.non-docs }}
+    steps:
+      - name: Check for non-docs changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non-docs:
+              - '!docs/**'
+
   publish:
+    needs: changes
+    if: ${{ needs.changes.outputs.non-docs == 'true' }}
     runs-on: ubuntu-24.04
     permissions:
       id-token: write

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -11,8 +11,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      non-docs: ${{ steps.filter.outputs.non-docs }}
+    steps:
+      - name: Check for non-docs changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            non-docs:
+              - '!docs/**'
+
   quick:
     runs-on: ubuntu-24.04
+    needs: changes
+    if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -52,6 +67,8 @@ jobs:
 
   verify-python-min-version:
     runs-on: ubuntu-24.04
+    needs: changes
+    if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Improved version of #7187 which was reverted

This should instead still run the workflow, but skip the job which will mark it as passed for required checks. If doing at the workflow level, the entire workflow is skipped and there is no status reported for the required checks.