### PR TITLE
ci: Fix skipping checks for docs only changes on push

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -16,6 +16,10 @@ jobs:
     outputs:
       non-docs: ${{ steps.filter.outputs.non-docs }}
     steps:
+      # Must checkout for push, but not pull_request according to the action
+      - name: Checkout on push
+        if: github.event_name == 'push'
+        uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter
         uses: dorny/paths-filter@v3

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -17,8 +17,8 @@ jobs:
       non-docs: ${{ steps.filter.outputs.non-docs }}
     steps:
       # Must checkout for push, but not pull_request according to the action
-      - name: Checkout on push
-        if: github.event_name == 'push'
+      - name: Checkout
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -16,6 +16,10 @@ jobs:
     outputs:
       non-docs: ${{ steps.filter.outputs.non-docs }}
     steps:
+      # Must checkout for push, but not pull_request according to the action
+      - name: Checkout on push
+        if: github.event_name == 'push'
+        uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter
         uses: dorny/paths-filter@v3

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -17,8 +17,8 @@ jobs:
       non-docs: ${{ steps.filter.outputs.non-docs }}
     steps:
       # Must checkout for push, but not pull_request according to the action
-      - name: Checkout on push
-        if: github.event_name == 'push'
+      - name: Checkout
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -16,6 +16,10 @@ jobs:
     outputs:
       non-docs: ${{ steps.filter.outputs.non-docs }}
     steps:
+      # Must checkout for push, but not pull_request according to the action
+      - name: Checkout on push
+        if: github.event_name == 'push'
+        uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter
         uses: dorny/paths-filter@v3

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -17,8 +17,8 @@ jobs:
       non-docs: ${{ steps.filter.outputs.non-docs }}
     steps:
       # Must checkout for push, but not pull_request according to the action
-      - name: Checkout on push
-        if: github.event_name == 'push'
+      - name: Checkout
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter


### PR DESCRIPTION
Didn't realize you needed to explicitly checkout for the paths-filter action when it's used outside of pull_request