### PR TITLE
fix: DH-20540: Ensure DataIndex pushdown is not short-circuited

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BasePushdownFilterContext.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BasePushdownFilterContext.java
@@ -81,6 +81,10 @@ public class BasePushdownFilterContext implements PushdownFilterContext {
     public BasePushdownFilterContext(
             final WhereFilter filter,
             final List<ColumnSource<?>> columnSources) {
+        if (!filter.permitParallelization()) {
+            throw new IllegalArgumentException(
+                    "filter must be stateless, but does not permit parallelization: " + filter);
+        }
         this.filter = filter;
         this.columnSources = columnSources;
 
@@ -137,12 +141,14 @@ public class BasePushdownFilterContext implements PushdownFilterContext {
     }
 
     public final boolean supportsInMemoryDataIndexFiltering() {
-        // TODO: is there a cheap way to check if this filter may not support in-memory data index?
+        // Note: if there is a cheap way to check if the filter will never be applicable for an in-memory data index, we
+        // would like to add that check here.
         return true;
     }
 
     public final boolean supportsDeferredDataIndexFiltering() {
-        // TODO: is there a cheap way to check if this filter may not support deferred data index?
+        // Note: if there is a cheap way to check if the filter will never be applicable for a deferred data index, we
+        // would like to add that check here.
         return true;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/BasePushdownFilterContext.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/BasePushdownFilterContext.java
@@ -54,8 +54,7 @@ public class BasePushdownFilterContext implements PushdownFilterContext {
 
     private final boolean isRangeFilter;
     private final boolean isMatchFilter;
-    private final boolean supportsChunkFilter;
-    private final boolean filterSupportsPushdown;
+    private final boolean supportsDictionaryFiltering;
 
     private long executedFilterCost;
 
@@ -94,13 +93,11 @@ public class BasePushdownFilterContext implements PushdownFilterContext {
         final boolean isConditionFilter = filter instanceof ConditionFilter;
 
         // TODO (DH-19666): Multi column filters are not supported yet
-        filterSupportsPushdown = isRangeFilter || isMatchFilter ||
-                (isConditionFilter && ((ConditionFilter) filter).getNumInputsUsed() == 1);
         // Do not use columnSources.size(), multiple logical columns may alias (rename) the same physical column,
         // yielding a single entry.
-
-        supportsChunkFilter = filterSupportsPushdown &&
-                ((filter instanceof ExposesChunkFilter && ((ExposesChunkFilter) filter).chunkFilter().isPresent())
+        supportsDictionaryFiltering = (isRangeFilter || isMatchFilter
+                || (isConditionFilter && ((ConditionFilter) filter).getNumInputsUsed() == 1))
+                && ((filter instanceof ExposesChunkFilter && ((ExposesChunkFilter) filter).chunkFilter().isPresent())
                         || isConditionFilter);
 
         filterNullBehavior = null; // lazily initialized
@@ -124,34 +121,43 @@ public class BasePushdownFilterContext implements PushdownFilterContext {
     }
 
     /**
-     * Whether this is a simple range filter, not implemented by a ConditionFilter.
+     * Whether this filter supports parquet dictionary filtering, which necessitates direct chunk filtering, i.e., it
+     * can be applied to a chunk of data rather than a table. This includes any filter that implements {#@link
+     * ExposesChunkFilter} or {@link ConditionFilter} with exactly one column.
      */
-    public boolean isRangeFilter() {
-        return isRangeFilter;
+    public final boolean supportsDictionaryFiltering() {
+        return supportsDictionaryFiltering;
     }
 
     /**
-     * Whether this is a MatchFilter.
+     * Whether this filter supports filtering based on parquet metadata.
      */
-    public boolean isMatchFilter() {
-        return isMatchFilter;
+    public final boolean supportsMetadataFiltering() {
+        return isRangeFilter || isMatchFilter;
+    }
+
+    public final boolean supportsInMemoryDataIndexFiltering() {
+        // TODO: is there a cheap way to check if this filter may not support in-memory data index?
+        return true;
+    }
+
+    public final boolean supportsDeferredDataIndexFiltering() {
+        // TODO: is there a cheap way to check if this filter may not support deferred data index?
+        return true;
     }
 
     /**
-     * Whether this filter supports pushdown-based filtering. This includes simple range filters, match filters, and
-     * ConditionFilters with exactly one column.
+     * The filter to use for parquet metadata filtering. Can only call when {@link #supportsMetadataFiltering()} is
+     * {@code true}.
      */
-    public boolean filterSupportsPushdown() {
-        return filterSupportsPushdown;
-    }
-
-    /**
-     * Whether this filter supports direct chunk filtering, i.e., it can be applied to a chunk of data rather than a
-     * table. This includes any filter that implements {#@link ExposesChunkFilter} or {@link ConditionFilter} with
-     * exactly one column.
-     */
-    public boolean supportsChunkFilter() {
-        return supportsChunkFilter;
+    public final WhereFilter filterForMetadataFiltering() {
+        if (isRangeFilter) {
+            return ((RangeFilter) filter).getRealFilter();
+        }
+        if (isMatchFilter) {
+            return filter;
+        }
+        throw new IllegalStateException("Should only use when supportsMetadataFiltering is true");
     }
 
     /**
@@ -192,14 +198,15 @@ public class BasePushdownFilterContext implements PushdownFilterContext {
 
     /**
      * Create a {@link UnifiedChunkFilter} for the {@link WhereFilter} that efficiently filters chunks of data. Every
-     * thread that uses this should create its own instance and must close it after use.
+     * thread that uses this should create its own instance and must close it after use. Can only call when
+     * {@link #supportsDictionaryFiltering()} is {@code true}
      *
      * @param maxChunkSize the maximum size of the chunk that will be filtered
      * @return the initialized {@link UnifiedChunkFilter}
      */
     public final UnifiedChunkFilter createChunkFilter(final int maxChunkSize) {
-        if (!supportsChunkFilter) {
-            throw new UnsupportedOperationException("Filter does not support chunk filtering: " + Strings.of(filter));
+        if (!supportsDictionaryFiltering) {
+            throw new IllegalStateException("Filter does not support chunk filtering: " + Strings.of(filter));
         }
         if (filter instanceof ExposesChunkFilter) {
             final ChunkFilter chunkFilter = ((ExposesChunkFilter) filter).chunkFilter()

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocation.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/AbstractTableLocation.java
@@ -254,6 +254,11 @@ public abstract class AbstractTableLocation
         }
     }
 
+    protected boolean hasAnyCachedDataIndex() {
+        final KeyedObjectHashMap<List<String>, CachedDataIndex> localCachedDataIndexes = cachedDataIndexes;
+        return localCachedDataIndexes != null && !localCachedDataIndexes.isEmpty();
+    }
+
     @Override
     public boolean hasCachedDataIndex(@NotNull final String... columns) {
         final List<String> columnNames = new ArrayList<>(columns.length);

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -536,7 +536,7 @@ public class ParquetTableLocation extends AbstractTableLocation {
             final boolean isApplicable;
             switch (mode) {
                 case ParquetRowGroupMetadata:
-                    // TODO: check if there are any stats in parquet?
+                    // Note: it should be possible to check if there is any statistics
                     isApplicable = true;
                     break;
                 case InMemoryDataIndex:

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -14,18 +14,9 @@ import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.engine.liveness.LivenessScopeStack;
 import io.deephaven.engine.primitive.iterator.CloseableIterator;
-import io.deephaven.engine.rowset.RowSequence;
-import io.deephaven.engine.rowset.RowSet;
-import io.deephaven.engine.rowset.RowSetBuilderRandom;
-import io.deephaven.engine.rowset.RowSetBuilderSequential;
-import io.deephaven.engine.rowset.RowSetFactory;
-import io.deephaven.engine.rowset.WritableRowSet;
+import io.deephaven.engine.rowset.*;
 import io.deephaven.engine.rowset.chunkattributes.OrderedRowKeys;
-import io.deephaven.engine.table.BasicDataIndex;
-import io.deephaven.engine.table.ChunkSource;
-import io.deephaven.engine.table.ColumnDefinition;
-import io.deephaven.engine.table.ColumnSource;
-import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.BasePushdownFilterContext;
 import io.deephaven.engine.table.impl.PushdownFilterContext;
 import io.deephaven.engine.table.impl.PushdownResult;
@@ -34,26 +25,9 @@ import io.deephaven.engine.table.impl.chunkattributes.DictionaryKeys;
 import io.deephaven.engine.table.impl.chunkfilter.ChunkFilter;
 import io.deephaven.engine.table.impl.chunkfilter.LongChunkMatchFilterFactory;
 import io.deephaven.engine.table.impl.dataindex.StandaloneDataIndex;
-import io.deephaven.engine.table.impl.locations.ColumnLocation;
-import io.deephaven.engine.table.impl.locations.TableDataException;
-import io.deephaven.engine.table.impl.locations.TableKey;
-import io.deephaven.engine.table.impl.locations.TableLocationState;
+import io.deephaven.engine.table.impl.locations.*;
 import io.deephaven.engine.table.impl.locations.impl.AbstractTableLocation;
-import io.deephaven.engine.table.impl.select.ByteRangeFilter;
-import io.deephaven.engine.table.impl.select.CharRangeFilter;
-import io.deephaven.engine.table.impl.select.ComparableRangeFilter;
-import io.deephaven.engine.table.impl.select.DoubleRangeFilter;
-import io.deephaven.engine.table.impl.select.FloatRangeFilter;
-import io.deephaven.engine.table.impl.select.FunctionalColumn;
-import io.deephaven.engine.table.impl.select.InstantRangeFilter;
-import io.deephaven.engine.table.impl.select.IntRangeFilter;
-import io.deephaven.engine.table.impl.select.LongRangeFilter;
-import io.deephaven.engine.table.impl.select.MatchFilter;
-import io.deephaven.engine.table.impl.select.MultiSourceFunctionalColumn;
-import io.deephaven.engine.table.impl.select.ShortRangeFilter;
-import io.deephaven.engine.table.impl.select.SingleSidedComparableRangeFilter;
-import io.deephaven.engine.table.impl.select.SourceColumn;
-import io.deephaven.engine.table.impl.select.WhereFilter;
+import io.deephaven.engine.table.impl.select.*;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSourceManager;
 import io.deephaven.engine.table.impl.sources.regioned.RegionedPageStore;
@@ -91,17 +65,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalInt;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
 import java.util.function.Predicate;
@@ -110,10 +74,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.deephaven.parquet.base.ParquetFileReader.FILE_URI_SCHEME;
-import static io.deephaven.parquet.table.ParquetTableWriter.GROUPING_BEGIN_POS_COLUMN_NAME;
+import static io.deephaven.parquet.table.ParquetTableWriter.*;
 import static io.deephaven.parquet.table.ParquetTableWriter.GROUPING_END_POS_COLUMN_NAME;
-import static io.deephaven.parquet.table.ParquetTableWriter.GROUPING_KEY_COLUMN_NAME;
-import static io.deephaven.parquet.table.ParquetTableWriter.INDEX_ROW_SET_COLUMN_NAME;
 import static io.deephaven.util.QueryConstants.NULL_LONG;
 
 public class ParquetTableLocation extends AbstractTableLocation {
@@ -773,7 +735,6 @@ public class ParquetTableLocation extends AbstractTableLocation {
                         continue;
                     }
                     try (final PushdownResult ignored = result) {
-                        // TODO: note, this is a change in behavior
                         result = pushdownDataIndex(selection, filter, renameMap, dataIndex, result);
                     }
                     break;
@@ -788,15 +749,12 @@ public class ParquetTableLocation extends AbstractTableLocation {
                     break;
                 }
                 case DeferredDataIndex: {
-                    // If we have a data index, apply the filter to the data index table and retain the incoming maybe
-                    // rows.
                     final BasicDataIndex dataIndex =
                             hasDataIndex(parquetColumnNames) ? getDataIndex(parquetColumnNames) : null;
                     if (dataIndex == null) {
                         continue;
                     }
                     try (final PushdownResult ignored = result) {
-                        // Assuming this applies successfully, we sh
                         result = pushdownDataIndex(selection, filter, renameMap, dataIndex, result);
                     }
                     break;
@@ -815,6 +773,8 @@ public class ParquetTableLocation extends AbstractTableLocation {
     // ---------------------------------------------------------------------------------------------------------------
     // The following should be _cheap_ checks that don't require materializing Parquet metadata to check.
     // ---------------------------------------------------------------------------------------------------------------
+    // Note: in the future, we this would be an easy way to allow turning off Parquet pushdown on a location by location
+    // basis; we could expose the options through ParquetInstructions
 
     private boolean supportsMetadataFiltering() {
         return true;

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/location/ParquetTableLocationTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/location/ParquetTableLocationTest.java
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.parquet.table.location;
+
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParquetTableLocationTest {
+    @Test
+    public void testCostSortedValues() {
+        assertThat(ParquetTableLocation.PushdownMode.costSortedValues()
+                .stream()
+                .mapToLong(ParquetTableLocation.PushdownMode::filterCost))
+                .isSorted();
+    }
+}


### PR DESCRIPTION
This adds some more structuring to BasePushdownFilterContext and ParquetTableLocation to make it more obvious what pushdown filter operations should be tried, and making sure we are only short-circuiting when no pushdown will be applied.

Additonally, this ensures that the cost estimate and pushdown filtering occurs in cost-order.