### PR TITLE
fix: DH-2563: Improve juli log level translation

### DIFF
--- a/Util/src/main/java/io/deephaven/util/BridgingLogHandler.java
+++ b/Util/src/main/java/io/deephaven/util/BridgingLogHandler.java
@@ -10,7 +10,6 @@ import io.deephaven.io.log.impl.LogOutputStringImpl;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -136,13 +135,18 @@ public final class BridgingLogHandler extends Handler {
         return log.getEntry(mapLevel(level), 1000 * timeMillis, throwable);
     }
 
-    private static final Map<Level, LogLevel> LEVEL_MAPPINGS = new HashMap<>();
-    static {
-        LEVEL_MAPPINGS.put(Level.WARNING, LogLevel.WARN);
-        LEVEL_MAPPINGS.put(Level.SEVERE, LogLevel.ERROR);
-    }
+    // Reflects org.slf4j.bridge.SLF4JBridgeHandler level mappings
+    private static final Map<Level, LogLevel> LEVEL_MAPPINGS = Map.of(
+            Level.SEVERE, LogLevel.ERROR,
+            Level.WARNING, LogLevel.WARN,
+            Level.INFO, LogLevel.INFO,
+            Level.CONFIG, LogLevel.INFO,
+            Level.FINE, LogLevel.DEBUG,
+            Level.FINER, LogLevel.TRACE,
+            Level.FINEST, LogLevel.TRACE
+    );
 
-    private static io.deephaven.io.log.LogLevel mapLevel(final Level level) {
+    private static LogLevel mapLevel(final Level level) {
         final LogLevel mapping = LEVEL_MAPPINGS.get(level);
         if (mapping != null) {
             return mapping;

--- a/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
+++ b/grpc-java/grpc-servlet-jakarta/src/main/java/io/grpc/servlet/jakarta/AsyncServletOutputStreamWriter.java
@@ -87,7 +87,7 @@ final class AsyncServletOutputStreamWriter {
             @Override
             public void fine(String str, Object... params) {
                 if (logger.isLoggable(FINE)) {
-                    logger.log(FINE, "[" + logId + "]" + str, params);
+                    logger.log(FINE, "[" + logId + "] " + str, params);
                 }
             }
 


### PR DESCRIPTION
Note that this class is not currently used within DHC itself, but should have the correct mappings in case it were to be used.

Also adds a missing space in some grpc-servlet log messages.