### PR TITLE
chore: DH-20611: Add dependency constraint on json-smart

### DIFF
--- a/extensions/flight-sql/build.gradle
+++ b/extensions/flight-sql/build.gradle
@@ -32,6 +32,11 @@ dependencies {
     // :sql does not expose calcite as a dependency (maybe it should?); in the meantime, we want to make sure we can
     // provide reasonable error messages to the client
     implementation libs.calcite.core
+    constraints {
+        implementation(libs.json.smart) {
+            because 'CVE-2024-57699'
+        }
+    }
 
     implementation libs.dagger
     implementation libs.arrow.flight.sql

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,11 @@ awssdk = "2.29.52"
 aws-s3-tables-catalog-for-iceberg = "0.1.6"
 # See dependency matrix for particular gRPC versions at https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
 boringssl = "2.0.61.Final"
+
+# Note: when bumping Calcite version, see if we still need the version constraint for json-smart
 calcite = "1.39.0"
+json-smart = "2.5.2"
+
 classgraph = "4.8.180"
 commons-compress = "1.27.1"
 commons-io = "2.20.0"
@@ -131,6 +135,7 @@ s3-tables-catalog-for-iceberg = { module = "software.amazon.s3tables:s3-tables-c
 boringssl = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "boringssl" }
 
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }
+json-smart = { module = "net.minidev:json-smart", version.ref = "json-smart" }
 
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -9,6 +9,11 @@ description = 'The Deephaven SQL parser'
 dependencies {
     api project(':qst')
     implementation libs.calcite.core
+    constraints {
+        implementation(libs.json.smart) {
+            because 'CVE-2024-57699'
+        }
+    }
 
     compileOnly project(':util-immutables')
     annotationProcessor libs.immutables.value


### PR DESCRIPTION
This ensures that the transitive dependency of json-smart we inherit from calcite is not vulnerable to
https://nvd.nist.gov/vuln/detail/CVE-2024-57699.

Cherry-pick of #7288