### PR TITLE
fix: DH-20614: correct PartitionAwareSourceTable partition column filter handling

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
@@ -321,7 +321,7 @@ public class PartitionAwareSourceTable extends SourceTable<PartitionAwareSourceT
 
             // similarly, anytime we prioritize a partitioning filter, we record the barriers that it declares. A filter
             // that respects no barriers, or only those prioritized barriers may also be prioritized. A filter that
-            // respects any barrier which was not in partition filters (meaning it must be in in otherFilters - because
+            // respects any barrier which was not in partition filters (meaning it must be in otherFilters - because
             // otherwise you would be respecting an undeclared barrier); cannot be prioritized because that would jump
             // the barrier.
             if (serialFilterFound || missingBarrier) {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PartitionAwareSourceTable.java
@@ -11,6 +11,7 @@ import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.filter.ExtractBarriers;
 import io.deephaven.engine.table.impl.filter.ExtractInnerConjunctiveFilters;
 import io.deephaven.engine.table.impl.filter.ExtractRespectedBarriers;
+import io.deephaven.engine.table.impl.filter.ExtractSerialFilters;
 import io.deephaven.engine.table.impl.select.analyzers.SelectAndViewAnalyzer;
 import io.deephaven.engine.updategraph.UpdateSourceRegistrar;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceRecorder;
@@ -305,7 +306,8 @@ public class PartitionAwareSourceTable extends SourceTable<PartitionAwareSourceT
         for (WhereFilter whereFilter : whereFilters) {
             whereFilter.init(definition, compilationProcessor);
 
-            if (!whereFilter.permitParallelization()) {
+            // Test for user-mandated serial filters (e.g. FilterSerial.of() or Filter.serial())
+            if (!ExtractSerialFilters.of(whereFilter).isEmpty()) {
                 serialFilterFound = true;
             }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/filter/ExtractSerialFilters.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/filter/ExtractSerialFilters.java
@@ -1,0 +1,147 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.filter;
+
+import io.deephaven.api.RawString;
+import io.deephaven.api.expression.Function;
+import io.deephaven.api.expression.Method;
+import io.deephaven.api.filter.*;
+import io.deephaven.api.filter.Filter.Visitor;
+import io.deephaven.engine.table.impl.select.*;
+
+import java.util.*;
+
+/**
+ * Performs a recursive filter extraction against {@code filter}. If {@code filter}, or any sub-filter, is a
+ * {@link FilterSerial} or {@link WhereFilterSerialImpl}, the filter will be included in the returned collection.
+ * Otherwise, an empty collection will be returned.
+ */
+public enum ExtractSerialFilters implements Visitor<Collection<Filter>>, WhereFilter.Visitor<Collection<Filter>> {
+    INSTANCE;
+
+    public static Collection<Filter> of(Filter filter) {
+        if (filter instanceof WhereFilter) {
+            final Collection<Filter> retVal =
+                    ((WhereFilter) filter).walkWhereFilter(INSTANCE);
+            return retVal == null ? Collections.emptyList() : retVal;
+        }
+        return filter.walk(INSTANCE);
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterIsNull isNull) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterComparison comparison) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterIn in) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterNot<?> not) {
+        return not.filter().walk(this);
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterOr ors) {
+        final Set<Filter> serialFilters = new HashSet<>();
+        for (final Filter filter : ors.filters()) {
+            serialFilters.addAll(of(filter));
+        }
+        return serialFilters;
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterAnd ands) {
+        final Set<Filter> serialFilters = new HashSet<>();
+        for (final Filter filter : ands.filters()) {
+            serialFilters.addAll(of(filter));
+        }
+        return serialFilters;
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterPattern pattern) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterSerial serial) {
+        return List.of(serial); // return this filter
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterWithDeclaredBarriers declaredBarrier) {
+        return of(declaredBarrier.filter());
+    }
+
+    @Override
+    public Collection<Filter> visit(FilterWithRespectedBarriers respectedBarrier) {
+        return of(respectedBarrier.filter());
+    }
+
+    @Override
+    public Collection<Filter> visit(Function function) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visit(Method method) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visit(boolean literal) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visit(RawString rawString) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Filter> visitWhereFilter(WhereFilterInvertedImpl filter) {
+        return of(filter.getWrappedFilter());
+    }
+
+    @Override
+    public Collection<Filter> visitWhereFilter(WhereFilterSerialImpl filter) {
+        return List.of(filter); // return this filter
+    }
+
+    @Override
+    public Collection<Filter> visitWhereFilter(WhereFilterWithDeclaredBarriersImpl filter) {
+        return of(filter.getWrappedFilter());
+    }
+
+    @Override
+    public Collection<Filter> visitWhereFilter(WhereFilterWithRespectedBarriersImpl filter) {
+        return of(filter.getWrappedFilter());
+    }
+
+    @Override
+    public Collection<Filter> visitWhereFilter(DisjunctiveFilter disjunctiveFilters) {
+        final Set<Filter> serialFilters = new HashSet<>();
+        for (final Filter filter : disjunctiveFilters.getFilters()) {
+            serialFilters.addAll(of(filter));
+        }
+        return serialFilters;
+    }
+
+    @Override
+    public Collection<Filter> visitWhereFilter(ConjunctiveFilter conjunctiveFilters) {
+        final Set<Filter> serialFilters = new HashSet<>();
+        for (final Filter filter : conjunctiveFilters.getFilters()) {
+            serialFilters.addAll(of(filter));
+        }
+        return serialFilters;
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/filter/ExtractSerialFilters.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/filter/ExtractSerialFilters.java
@@ -51,7 +51,7 @@ public enum ExtractSerialFilters implements Visitor<Collection<Filter>>, WhereFi
 
     @Override
     public Collection<Filter> visit(FilterOr ors) {
-        final Set<Filter> serialFilters = new HashSet<>();
+        final List<Filter> serialFilters = new ArrayList<>();
         for (final Filter filter : ors.filters()) {
             serialFilters.addAll(of(filter));
         }
@@ -60,7 +60,7 @@ public enum ExtractSerialFilters implements Visitor<Collection<Filter>>, WhereFi
 
     @Override
     public Collection<Filter> visit(FilterAnd ands) {
-        final Set<Filter> serialFilters = new HashSet<>();
+        final List<Filter> serialFilters = new ArrayList<>();
         for (final Filter filter : ands.filters()) {
             serialFilters.addAll(of(filter));
         }
@@ -129,7 +129,7 @@ public enum ExtractSerialFilters implements Visitor<Collection<Filter>>, WhereFi
 
     @Override
     public Collection<Filter> visitWhereFilter(DisjunctiveFilter disjunctiveFilters) {
-        final Set<Filter> serialFilters = new HashSet<>();
+        final List<Filter> serialFilters = new ArrayList<>();
         for (final Filter filter : disjunctiveFilters.getFilters()) {
             serialFilters.addAll(of(filter));
         }
@@ -138,7 +138,7 @@ public enum ExtractSerialFilters implements Visitor<Collection<Filter>>, WhereFi
 
     @Override
     public Collection<Filter> visitWhereFilter(ConjunctiveFilter conjunctiveFilters) {
-        final Set<Filter> serialFilters = new HashSet<>();
+        final List<Filter> serialFilters = new ArrayList<>();
         for (final Filter filter : conjunctiveFilters.getFilters()) {
             serialFilters.addAll(of(filter));
         }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
@@ -31,6 +31,7 @@ import io.deephaven.engine.table.impl.util.JobScheduler;
 import io.deephaven.engine.table.impl.verify.TableAssertions;
 import io.deephaven.engine.testutil.*;
 import io.deephaven.engine.testutil.QueryTableTestBase.TableComparator;
+import io.deephaven.engine.testutil.filters.ParallelizedRowSetCapturingFilter;
 import io.deephaven.engine.testutil.filters.RowSetCapturingFilter;
 import io.deephaven.engine.testutil.generator.*;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
@@ -2391,20 +2392,6 @@ public abstract class QueryTableWhereTest {
         testRowKeyAgnosticColumnSource(
                 NullValueColumnSource.getInstance(Instant.class, null),
                 "A", "A = null", "A != null");
-    }
-
-    /**
-     * Private helper to force parallelization of the RowSetCapturingFilter.
-     */
-    private class ParallelizedRowSetCapturingFilter extends RowSetCapturingFilter {
-        public ParallelizedRowSetCapturingFilter(Filter filter) {
-            super(filter);
-        }
-
-        @Override
-        public boolean permitParallelization() {
-            return true;
-        }
     }
 
     private void testRowKeyAgnosticColumnSource(

--- a/engine/test-utils/src/main/java/io/deephaven/engine/testutil/filters/ParallelizedRowSetCapturingFilter.java
+++ b/engine/test-utils/src/main/java/io/deephaven/engine/testutil/filters/ParallelizedRowSetCapturingFilter.java
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.testutil.filters;
+
+import io.deephaven.api.filter.Filter;
+
+/**
+ * Helper to force parallelization of the RowSetCapturingFilter.
+ */
+public class ParallelizedRowSetCapturingFilter extends RowSetCapturingFilter {
+    public ParallelizedRowSetCapturingFilter(Filter filter) {
+        super(filter);
+    }
+
+    @Override
+    public boolean permitParallelization() {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR corrects a logic error in #6885 that forced conditional filters on partitioning columns to be evaluated after coalescing the table (instead of being applied to the partiitions).