### PR TITLE
ci: Fix nightly docs check notification

### DIFF
--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -60,7 +60,6 @@ jobs:
     steps:
       - name: Slack Notification
         uses: slackapi/slack-github-action@v1.23.0
-        if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVREL}}
         with:


### PR DESCRIPTION
Noticed I got an email the nightly failed, but didn't see a Slack notification. When I combined the notifications I didn't remove the `failure` check for the step, so it wasn't actually notifying :facepalm:

The `failure` check is on the notify job and shouldn't be on the step