### PR TITLE
fix(csharp/client): DH-20569: Core+ client honors ClientOpions.OverrideAuthority

### DIFF
--- a/csharp/client/Dh_NetClient/ClientOptions.cs
+++ b/csharp/client/Dh_NetClient/ClientOptions.cs
@@ -45,21 +45,14 @@ public class ClientOptions {
   public string ClientPrivateKey { get; set; } = "";
 
   /// <summary>
-  /// Integer-valued channel options set for server connections.
+  /// This flag indicates that we want to override the default SSL authentication algorithm.
   /// </summary>
-  public IReadOnlyList<(string, int)> IntOptions => _intOptions;
-
-  /// <summary>
-  /// String-valued channel options set for server connections.
-  /// </summary>
-  public IReadOnlyList<(string, string)> StringOptions => _stringOptions;
+  public bool OverrideAuthority { get; set; } = false;
 
   /// <summary>
   /// Extra headers that should be sent with each outgoing server request.
   /// </summary>
   public IReadOnlyList<(string, string)> ExtraHeaders => _extraHeaders;
-  private readonly List<(string, int)> _intOptions = [];
-  private readonly List<(string, string)> _stringOptions = [];
   private readonly List<(string, string)> _extraHeaders = [];
 
   /// <summary>
@@ -153,31 +146,6 @@ public class ClientOptions {
   /// <returns>this, so that methods can be chained.</returns>
   public ClientOptions SetClientPrivateKey(string clientPrivateKey) {
     ClientPrivateKey = clientPrivateKey;
-    return this;
-  }
-
-  /// <summary>
-  /// Adds an int-valued option for the configuration of the underlying gRPC channels.
-  /// See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
-  /// </summary>
-  /// <example>copt.setIntOption("grpc.min_reconnect_backoff_ms", 2000)</example>
-  /// <param name="opt">The option key</param>
-  /// <param name="val">The option value</param>
-  /// <returns>this, so that methods can be chained.</returns>
-  public ClientOptions AddIntOption(string opt, int val) {
-    _intOptions.Add((opt, val));
-    return this;
-  }
-
-  /// <summary>
-  /// Adds a string-valued option for the configuration of the underlying gRPC channels.
-  /// See https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html for a list of available options.
-  /// </summary>
-  /// <param name="opt">The option key</param>
-  /// <param name="val">The option value</param>
-  /// <returns>this, so that methods can be chained.</returns>
-  public ClientOptions AddStringOption(string opt, string val) {
-    _stringOptions.Add((opt, val));
     return this;
   }
 

--- a/csharp/client/Dh_NetClient/util/GrpcUtil.cs
+++ b/csharp/client/Dh_NetClient/util/GrpcUtil.cs
@@ -23,7 +23,7 @@ public static class GrpcUtil {
       throw new Exception("GrpcUtil.MakeChannelOptions: UseTls is false but pem provided");
     }
 
-    if (clientOptions.TlsRootCerts.IsEmpty()) {
+    if (clientOptions.TlsRootCerts.IsEmpty() || !clientOptions.OverrideAuthority) {
       return channelOptions;
     }
 


### PR DESCRIPTION
This changes the custom certificate checking logic so that it only runs if `ClientOptions.OverrideAuthority` is set.