### PR TITLE
docs: Update deprecation for snapshot to point to new method

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -362,6 +362,9 @@ public class TableViewportSubscription extends AbstractTableSubscription {
         return promise.asPromise();
     }
 
+    /**
+     * @deprecated Use {@link JsTable#createSnapshot(Object)} instead
+     */
     @JsMethod
     @Deprecated
     public Promise<TableData> snapshot(JsRangeSet rows, Column[] columns) {


### PR DESCRIPTION
- We deprecated it but didn't say what new method to use
