### PR TITLE
fix: DH-20464: cherry-pick filter barrier support for ParquetTableLocation data indexes

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -220,6 +220,13 @@ public class QueryTable extends BaseTable<QueryTable> {
     public static boolean USE_DATA_INDEX_FOR_JOINS =
             Configuration.getInstance().getBooleanWithDefault("QueryTable.useDataIndexForJoins", true);
 
+    /**
+     * Before using a data index for a where filter, ensure that the index table size is at most this fraction of the
+     * size of the rows remaining to be filtered. If the fraction is greater than this threshold, then the engine will
+     * ignore the index table and filter the rows directly.
+     */
+    public static double DATA_INDEX_FOR_WHERE_THRESHOLD =
+            Configuration.getInstance().getDoubleWithDefault("QueryTable.dataIndexForWhereThreshold", 0.25);
 
     /**
      * For a static select(), we would prefer to flatten the table to avoid using memory unnecessarily (because the data

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/filter/ExtractFilterWithoutBarriers.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/filter/ExtractFilterWithoutBarriers.java
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.filter;
+
+import io.deephaven.base.verify.Assert;
+import io.deephaven.engine.table.impl.select.*;
+
+/**
+ * Extract a simple filter from a {@link WhereFilter}, walking the tree and removing all barrier and serial wrappers.
+ */
+public class ExtractFilterWithoutBarriers implements WhereFilter.Visitor<WhereFilter> {
+    public static final ExtractFilterWithoutBarriers INSTANCE = new ExtractFilterWithoutBarriers();
+
+    public static WhereFilter of(final WhereFilter filter) {
+        return filter.walkWhereFilter(INSTANCE);
+    }
+
+    @Override
+    public WhereFilter visitWhereFilter(final WhereFilter filter) {
+        final WhereFilter retValue = WhereFilter.Visitor.super.visitWhereFilter(filter);
+        if (retValue == null) {
+            return filter;
+        }
+        return retValue;
+    }
+
+    @Override
+    public WhereFilter visitWhereFilter(final WhereFilterInvertedImpl filter) {
+        return filter; // do not unwrap
+    }
+
+    @Override
+    public WhereFilter visitWhereFilter(final WhereFilterSerialImpl filter) {
+        return of(filter.getWrappedFilter()); // must unwrap
+    }
+
+    @Override
+    public WhereFilter visitWhereFilter(final WhereFilterWithDeclaredBarriersImpl filter) {
+        return of(filter.getWrappedFilter()); // must unwrap
+    }
+
+    @Override
+    public WhereFilter visitWhereFilter(final WhereFilterWithRespectedBarriersImpl filter) {
+        return of(filter.getWrappedFilter()); // must unwrap
+    }
+
+    @Override
+    public WhereFilter visitWhereFilter(final DisjunctiveFilter filter) {
+        final WhereFilter[] innerUnwrapped = filter.getFilters().stream()
+                .map(this::visitWhereFilter)
+                .toArray(WhereFilter[]::new);
+
+        // Verify we have exactly the same number of filters after unwrapping.
+        Assert.eq(innerUnwrapped.length, "innerUnwrapped.length", filter.getFilters().size(),
+                "filter.getFilters()..size()");
+
+        // return a single DisjunctiveFilter containing all the unwrapped inner filters.
+        return DisjunctiveFilter.of(innerUnwrapped);
+    }
+
+    @Override
+    public WhereFilter visitWhereFilter(final ConjunctiveFilter filter) {
+        final WhereFilter[] innerUnwrapped = filter.getFilters().stream()
+                .map(this::visitWhereFilter)
+                .toArray(WhereFilter[]::new);
+
+        // Verify we have exactly the same number of filters after unwrapping.
+        Assert.eq(innerUnwrapped.length, "innerUnwrapped.length", filter.getFilters().size(),
+                "filter.getFilters()..size()");
+
+        // return a single ConjunctiveFilter containing all the unwrapped inner filters.
+        return ConjunctiveFilter.of(innerUnwrapped);
+    }
+}

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -4,6 +4,7 @@
 package io.deephaven.parquet.table.location;
 
 import io.deephaven.api.ColumnName;
+import io.deephaven.api.Pair;
 import io.deephaven.api.SortColumn;
 import io.deephaven.base.verify.Assert;
 import io.deephaven.base.verify.Require;
@@ -16,6 +17,7 @@ import io.deephaven.engine.table.impl.PushdownFilterContext;
 import io.deephaven.engine.table.impl.PushdownResult;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.dataindex.StandaloneDataIndex;
+import io.deephaven.engine.table.impl.filter.ExtractFilterWithoutBarriers;
 import io.deephaven.engine.table.impl.locations.*;
 import io.deephaven.engine.table.impl.locations.impl.AbstractTableLocation;
 import io.deephaven.engine.table.impl.select.*;
@@ -860,20 +862,27 @@ public class ParquetTableLocation extends AbstractTableLocation {
             final PushdownResult result) {
         final RowSetBuilderRandom matchingBuilder = RowSetFactory.builderRandom();
         try (final SafeCloseable ignored = LivenessScopeStack.open()) {
-            final WhereFilter copiedFilter = filter.copy();
-            copiedFilter.init(dataIndex.table().getDefinition());
-
-            // TODO: When https://deephaven.atlassian.net/browse/DH-19443 is implemented, we should be able
-            // to use the filter directly on the index table.
-            final Collection<io.deephaven.api.Pair> renamePairs = renameMap.entrySet().stream()
-                    .map(entry -> io.deephaven.api.Pair.of(ColumnName.of(entry.getValue()),
-                            ColumnName.of(entry.getKey())))
-                    .collect(Collectors.toList());
-            final Table renamedIndexTable = dataIndex.table().renameColumns(renamePairs);
-
+            final long threshold = (long) (dataIndex.table().size() / QueryTable.DATA_INDEX_FOR_WHERE_THRESHOLD);
+            if (result.maybeMatch().size() <= threshold) {
+                return result.copy();
+            }
+            // Extract the fundamental filter, ignoring barriers and serial wrappers.
+            final WhereFilter copiedFilter = ExtractFilterWithoutBarriers.of(filter).copy();
+            final Table toFilter;
+            if (!renameMap.isEmpty()) {
+                // TODO: When https://deephaven.atlassian.net/browse/DH-19443 is implemented, we should be able
+                // to use the filter directly on the index table without renaming.
+                final Collection<Pair> renamePairs = renameMap.entrySet().stream()
+                        .map(entry -> io.deephaven.api.Pair.of(ColumnName.of(entry.getValue()),
+                                ColumnName.of(entry.getKey())))
+                        .collect(Collectors.toList());
+                toFilter = dataIndex.table().renameColumns(renamePairs);
+            } else {
+                toFilter = dataIndex.table();
+            }
             // Apply the filter to the data index table
             try {
-                final Table filteredTable = renamedIndexTable.where(copiedFilter);
+                final Table filteredTable = toFilter.where(copiedFilter);
 
                 try (final CloseableIterator<RowSet> it =
                         ColumnVectors.ofObject(filteredTable, dataIndex.rowSetColumnName(), RowSet.class).iterator()) {


### PR DESCRIPTION
If we execute a filter with a barrier against a parquet table, the engine may apply the filter to the location index table. This will fail and raise an exception because the engine cannot honor the barrier in isolation. The exception is trapped and results in no filtering against the table.

DH-20464 corrects this, this is a cherry pick of the corrective code and a test that verifies the fix. This does not port the entire scope of the original PR.