### PR TITLE
fix: DH-20652: retain column definitions when columns retained

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -1732,7 +1732,9 @@ public class QueryTable extends BaseTable<QueryTable> {
                         final TrackingRowSet resultRowSet = analyzer.flatResult() && !rowSet.isFlat()
                                 ? RowSetFactory.flat(rowSet.size()).toTracking()
                                 : rowSet;
-                        resultTable = new QueryTable(resultRowSet, analyzerContext.getPublishedColumnSources());
+                        final Map<String, ColumnSource<?>> newMap = analyzerContext.getPublishedColumnSources();
+                        final TableDefinition resultDef = TableDefinition.inferFrom(this, newMap);
+                        resultTable = new QueryTable(resultDef, resultRowSet, newMap);
                         if (liveResultCapture != null) {
                             analyzer.startTrackingPrev();
                             final Map<String, String[]> effects = analyzerContext.calcEffects();
@@ -1924,8 +1926,11 @@ public class QueryTable extends BaseTable<QueryTable> {
                                                 publishTheseSources, true, viewColumns);
                                 final SelectColumn[] processedViewColumns = analyzerContext.getProcessedColumns()
                                         .toArray(SelectColumn[]::new);
-                                QueryTable queryTable = new QueryTable(
-                                        rowSet, analyzerContext.getPublishedColumnSources());
+                                final Map<String, ColumnSource<?>> resultMap =
+                                        analyzerContext.getPublishedColumnSources();
+                                final TableDefinition tableDef = TableDefinition.inferFrom(this,
+                                        analyzerContext.getPublishedColumnSources());
+                                QueryTable queryTable = new QueryTable(tableDef, rowSet, resultMap);
                                 if (sc != null) {
                                     final Map<String, String[]> effects = analyzerContext.calcEffects();
                                     final TableUpdateListener listener =
@@ -2014,8 +2019,10 @@ public class QueryTable extends BaseTable<QueryTable> {
                                         this, SelectAndViewAnalyzer.Mode.VIEW_LAZY, true, true, selectColumns);
                         final SelectColumn[] processedColumns = analyzerContext.getProcessedColumns()
                                 .toArray(SelectColumn[]::new);
-                        final QueryTable result = new QueryTable(
-                                rowSet, analyzerContext.getPublishedColumnSources());
+
+                        final Map<String, ColumnSource<?>> newMap = analyzerContext.getPublishedColumnSources();
+                        final TableDefinition resultDef = TableDefinition.inferFrom(this, newMap);
+                        final QueryTable result = new QueryTable(resultDef, rowSet, newMap);
                         if (isRefreshing()) {
                             addUpdateListener(new ListenerImpl(
                                     "lazyUpdate(" + Arrays.deepToString(processedColumns) + ')', this, result));
@@ -2051,7 +2058,8 @@ public class QueryTable extends BaseTable<QueryTable> {
                                 createSnapshotControlIfRefreshing(OperationSnapshotControl::new);
 
                         initializeWithSnapshot("dropColumns", snapshotControl, (usePrev, beforeClockValue) -> {
-                            final QueryTable resultTable = new QueryTable(rowSet, newColumns);
+                            final TableDefinition resultDef = TableDefinition.inferFrom(this, newColumns);
+                            final QueryTable resultTable = new QueryTable(resultDef, rowSet, newColumns);
                             propagateFlatness(resultTable);
 
                             copyAttributes(resultTable, CopyAttributeOperation.DropColumns);
@@ -2173,7 +2181,8 @@ public class QueryTable extends BaseTable<QueryTable> {
                     final OperationSnapshotControl snapshotControl =
                             createSnapshotControlIfRefreshing(OperationSnapshotControl::new);
                     initializeWithSnapshot("renameColumns", snapshotControl, (usePrev, beforeClockValue) -> {
-                        final QueryTable resultTable = new QueryTable(rowSet, newColumns);
+                        final TableDefinition resultDef = TableDefinition.inferFrom(this, newColumns);
+                        final QueryTable resultTable = new QueryTable(resultDef, rowSet, newColumns);
                         propagateFlatness(resultTable);
 
                         copyAttributes(resultTable, CopyAttributeOperation.RenameColumns);
@@ -2556,7 +2565,7 @@ public class QueryTable extends BaseTable<QueryTable> {
     }
 
     public Table silent() {
-        return new QueryTable(getRowSet(), getColumnSourceMap());
+        return new QueryTable(getDefinition(), getRowSet(), getColumnSourceMap());
     }
 
     private Table snapshot(String nuggetName, Table baseTable, boolean doInitialSnapshot,
@@ -2974,7 +2983,7 @@ public class QueryTable extends BaseTable<QueryTable> {
         try (final SafeCloseable ignored = ExecutionContext.getContext().withUpdateGraph(updateGraph).open()) {
             final LinkedHashMap<String, ColumnSource<?>> columns = new LinkedHashMap<>(this.columns);
             columns.putAll(additionalSources);
-            final TableDefinition definition = TableDefinition.inferFrom(columns);
+            final TableDefinition definition = TableDefinition.inferFrom(this, columns);
             return new QueryTable(definition, rowSet, columns, null, null);
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/BucketedPartitionedUpdateByManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/BucketedPartitionedUpdateByManager.java
@@ -76,7 +76,8 @@ class BucketedPartitionedUpdateByManager extends UpdateBy {
         super(source, windows, inputSources, timestampColumnName, rowRedirection, control);
 
         // this table will always have the rowset of the source
-        result = new QueryTable(source.getRowSet(), resultSources);
+        final TableDefinition resultDef = TableDefinition.inferFrom(source, resultSources);
+        result = new QueryTable(resultDef, source.getRowSet(), resultSources);
 
         final Table transformedTable = LivenessScopeStack.computeEnclosed(() -> {
             final PartitionedTable partitioned = source.partitionedAggBy(List.of(), true, null, byColumnNames);

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByBucketHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateByBucketHelper.java
@@ -88,7 +88,8 @@ class UpdateByBucketHelper extends IntrusiveDoublyLinkedNode.Impl<UpdateByBucket
         this.failureNotifier = failureNotifier;
         this.bucketKeyValues = bucketKeyValues;
 
-        result = new QueryTable(source.getRowSet(), resultSources);
+        final TableDefinition resultDef = TableDefinition.inferFrom(source, resultSources);
+        result = new QueryTable(resultDef, source.getRowSet(), resultSources);
 
         // do we need a timestamp SSA?
         this.timestampColumnName = timestampColumnName;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/ZeroKeyUpdateByManager.java
@@ -10,6 +10,7 @@ import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.rowset.RowSetShiftData;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.ModifiedColumnSet;
+import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.TableUpdateImpl;
 import io.deephaven.engine.table.impl.util.RowRedirection;
@@ -60,7 +61,8 @@ public class ZeroKeyUpdateByManager extends UpdateBy {
         final String bucketDescription = this + "-bucket-[]";
 
         if (source.isRefreshing()) {
-            result = new QueryTable(source.getRowSet(), resultSources);
+            final TableDefinition resultDef = TableDefinition.inferFrom(source, resultSources);
+            result = new QueryTable(resultDef, source.getRowSet(), resultSources);
 
             // create input and output modified column sets
             forAllOperators(op -> {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestUpdateByGeneral.java
@@ -8,7 +8,10 @@ import io.deephaven.api.updateby.BadDataBehavior;
 import io.deephaven.api.updateby.OperationControl;
 import io.deephaven.api.updateby.UpdateByOperation;
 import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.NoSuchColumnException;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.UpdateErrorReporter;
@@ -46,6 +49,7 @@ import static io.deephaven.engine.testutil.TstUtils.*;
 import static io.deephaven.engine.testutil.testcase.RefreshingTableTestCase.simulateShiftAwareStep;
 import static io.deephaven.engine.util.TableTools.*;
 import static io.deephaven.time.DateTimeUtils.MINUTE;
+import static org.junit.Assert.assertTrue;
 
 @Category(OutOfBandTest.class)
 public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateErrorReporter {
@@ -520,5 +524,63 @@ public class TestUpdateByGeneral extends BaseUpdateByTest implements UpdateError
                 .reverse();
 
         assertTableEquals(expected, actual);
+    }
+
+    @Test
+    public void testUpdateByValidateColumnDefinition() {
+        final Map<String, ColumnSource<?>> columnSourceMap = Map.of(
+                "String", TableTools.objColSource("c", "e", "g"),
+                "Int", colSource(2, 4, 6),
+                "Double", colSource(1.0, 2.0, 3.0));
+
+        final TableDefinition partitioningDef = TableDefinition.of(
+                ColumnDefinition.ofString("String").withPartitioning(),
+                ColumnDefinition.ofInt("Int"),
+                ColumnDefinition.ofDouble("Double").withNormal());
+        final Table sourceTable = new QueryTable(partitioningDef, i(0, 1, 2).toTracking(), columnSourceMap);
+
+        Table result;
+
+        result = sourceTable.updateBy(CumSum("SumInt=Int"));
+        assertTrue(result.getDefinition().getColumn("String").isPartitioning());
+        assertTrue(result.getDefinition().getColumn("Int").isDirect());
+        assertTrue(result.getDefinition().getColumn("Double").isDirect());
+
+        final Table refreshingTable = new QueryTable(partitioningDef, i(0, 2).toTracking(), columnSourceMap);
+        refreshingTable.setRefreshing(true);
+
+        result = refreshingTable.updateBy(CumSum("SumInt=Int"));
+        assertTrue(result.getDefinition().getColumn("String").isPartitioning());
+        assertTrue(result.getDefinition().getColumn("Int").isDirect());
+        assertTrue(result.getDefinition().getColumn("Double").isDirect());
+    }
+
+    @Test
+    public void testUpdateByBucketedValidateColumnDefinition() {
+        final Map<String, ColumnSource<?>> columnSourceMap = Map.of(
+                "String", TableTools.objColSource("c", "e", "g"),
+                "Int", colSource(2, 4, 6),
+                "Double", colSource(1.0, 2.0, 3.0));
+
+        final TableDefinition partitioningDef = TableDefinition.of(
+                ColumnDefinition.ofString("String").withPartitioning(),
+                ColumnDefinition.ofInt("Int"),
+                ColumnDefinition.ofDouble("Double").withNormal());
+        final Table sourceTable = new QueryTable(partitioningDef, i(0, 1, 2).toTracking(), columnSourceMap);
+
+        Table result;
+
+        result = sourceTable.updateBy(CumSum("SumInt=Int"), "String");
+        assertTrue(result.getDefinition().getColumn("String").isPartitioning());
+        assertTrue(result.getDefinition().getColumn("Int").isDirect());
+        assertTrue(result.getDefinition().getColumn("Double").isDirect());
+
+        final Table refreshingTable = new QueryTable(partitioningDef, i(0, 2).toTracking(), columnSourceMap);
+        refreshingTable.setRefreshing(true);
+
+        result = refreshingTable.updateBy(CumSum("SumInt=Int"), "String");
+        assertTrue(result.getDefinition().getColumn("String").isPartitioning());
+        assertTrue(result.getDefinition().getColumn("Int").isDirect());
+        assertTrue(result.getDefinition().getColumn("Double").isDirect());
     }
 }


### PR DESCRIPTION
This PR fixes issue DH-20652 by implementing a mechanism to retain column definitions when columns are retained through table operations like dropColumns, renameColumns, update, updateView, and select.

Key Changes:

- Added a new TableDefinition.inferFrom(sourceTable, newSources) method that preserves column definitions from the source table when the same column sources are reused
- Updated QueryTable operations and updateBy managers to use the new inferFrom method
- Added comprehensive test coverage across multiple test files