### PR TITLE
fix: DH-20307: Throw errors when worker connection has been Disconnec…

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/CoreClient.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/CoreClient.java
@@ -122,7 +122,9 @@ public class CoreClient extends HasEventHandling {
         LazyPromise<Void> loginPromise = new LazyPromise<>();
         ideConnection.addEventListenerOneShot(
                 EventPair.of(QueryInfoConstants.EVENT_CONNECT, ignore -> loginPromise.succeed(null)),
-                EventPair.of(CoreClient.EVENT_RECONNECT_AUTH_FAILED, loginPromise::fail));
+                EventPair.of(CoreClient.EVENT_DISCONNECT, loginPromise::fail),
+                EventPair.of(CoreClient.EVENT_RECONNECT_AUTH_FAILED, loginPromise::fail),
+                EventPair.of(CoreClient.EVENT_REQUEST_FAILED, loginPromise::fail));
         Promise<Void> login = loginPromise.asPromise();
 
         if (alreadyRunning) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -332,6 +332,12 @@ public class WorkerConnection {
 
                     return Promise.resolve((Object) null);
                 }, fail -> {
+                    // Connection was explicitly closed. We don't want to change
+                    // the status unless a `forceReconnect` is called.
+                    if (state == State.Disconnected) {
+                        return null;
+                    }
+
                     // this is non-recoverable, connection/auth/registration failed, but we'll let it start again when
                     // state changes
                     state = State.Failed;
@@ -909,8 +915,9 @@ public class WorkerConnection {
 
     public Promise<Object> whenServerReady(String operationName) {
         switch (state) {
-            case Failed:
             case Disconnected:
+                throw new IllegalStateException("Can't " + operationName + " while connection is closed");
+            case Failed:
                 state = State.Reconnecting;
                 newSessionReconnect.initialConnection();
                 // deliberate fall-through
@@ -1389,8 +1396,9 @@ public class WorkerConnection {
             case Connected:
                 LazyPromise.runLater(() -> callback.accept(null, null));
                 break;
-            case Failed:
             case Disconnected:
+                throw new IllegalStateException("Can't add onOpen callback when connection is closed");
+            case Failed:
                 state = State.Reconnecting;
                 newSessionReconnect.initialConnection();
                 // intentional fall-through


### PR DESCRIPTION
rc/0.40.x version of (#7175)

DH-20307: Don't attempt to reconnect when connections are explicitly closed.

This PR is necessary to support fixes made in
[deephaven-ent/iris/#3518](https://github.com/deephaven-ent/iris/pull/3518). Specifically, there is a race condition where a created Core+ JS API client can fail login and will continue to spam the server with login attempts that will never succeed. That PR handles the client side piece of this by explicitly disconnecting the client when this happens. The server side fix is to stop attempting to reconnect if a connection is explicitly closed.

### Testing
I have tested the 2 PRs together and have seen that this PR + the other PR stops the rogue connection spamming. I have only seen change in `connectToWorker` method of `WorkerConnection.java` actually get hit, but I have also not observed any problems caused by it. (#DH-20307)