### PR TITLE
fix(csharp/client): DH-20569: Use custom truststore if specified, even if no override authority

### DIFF
--- a/csharp/client/Dh_NetClient/util/GrpcUtil.cs
+++ b/csharp/client/Dh_NetClient/util/GrpcUtil.cs
@@ -25,7 +25,10 @@ public static class GrpcUtil {
       throw new Exception("GrpcUtil.MakeChannelOptions: UseTls is false but pem provided");
     }
 
-    if (clientOptions.TlsRootCerts.IsEmpty() || clientOptions.OverrideAuthority == null) {
+    if (clientOptions.TlsRootCerts.IsEmpty()) {
+      if (clientOptions.OverrideAuthority != null) {
+        throw new Exception("GrpcUtil.MakeChannelOptions: TlsRootCerts empty but OverrideAuthority exists");
+      }
       return channelOptions;
     }
 
@@ -39,9 +42,11 @@ public static class GrpcUtil {
         return false;
       }
 
-      var subjectName = cert.GetNameInfo(X509NameType.SimpleName, false);
-      if (subjectName != clientOptions.OverrideAuthority) {
-        return false;
+      if (clientOptions.OverrideAuthority != null) {
+        var subjectName = cert.GetNameInfo(X509NameType.SimpleName, false);
+        if (subjectName != clientOptions.OverrideAuthority) {
+          return false;
+        }
       }
 
       var certColl = new X509Certificate2Collection();


### PR DESCRIPTION
I previously assumed that there would not be a custom truststore unless there is also an override authority.

Gplus taught me that these are orthogonal concepts: that you can indeed have a custom truststore even if override authority is not set.