### PR TITLE
fix: DH-21105: Remove hard-coded stateful ViewColumnSource constructors

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumnLong.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/FunctionalColumnLong.java
@@ -174,7 +174,7 @@ public class FunctionalColumnLong<S> implements SelectColumn {
                 final FunctionalColumnFillContext ctx = (FunctionalColumnFillContext) fillContext;
                 ctx.chunkFiller.fillPrevByIndices(this, rowSequence, destination);
             }
-        }, false);
+        }, isStateless());
     }
 
     private static class FunctionalColumnFillContext implements Formula.FillContext {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/select/MultiSourceFunctionalColumn.java
@@ -166,7 +166,7 @@ public class MultiSourceFunctionalColumn<D> implements SelectColumn {
                 final FunctionalColumnFillContext ctx = (FunctionalColumnFillContext) fillContext;
                 ctx.chunkFiller.fillPrevByIndices(this, rowSequence, destination);
             }
-        }, false);
+        }, isStateless());
     }
 
     private static class FunctionalColumnFillContext implements Formula.FillContext {


### PR DESCRIPTION
This PR fixes a bug where MultiSourceFunctionalColumn and FunctionalColumnLong were hard-coding the isStateless parameter as false when constructing ViewColumnSource instances, instead of using the isStateless() method. This prevented these classes from respecting the global QueryTable.STATELESS_SELECT_BY_DEFAULT configuration, which controls whether formulas can be processed in parallel by the engine.

- Corrected MultiSourceFunctionalColumn.getDataView() to use isStateless() instead of hard-coded false
- Corrected FunctionalColumnLong.getDataView() to use isStateless() instead of hard-coded false