### PR TITLE
fix: DH-21128: Always call Java Consumer's accept method regardless of  whether partition value is provided

### DIFF
--- a/py/server/deephaven/experimental/table_data_service.py
+++ b/py/server/deephaven/experimental/table_data_service.py
@@ -402,7 +402,6 @@ class TableDataService(JObjectWrapper):
             j_tbl_location_key = _JTableLocationKeyImpl(pt_location_key)
             if pt_table is None or pt_table.to_batches() is None:
                 location_cb.accept(
-                    # location_cb.apply(
                     j_tbl_location_key,
                     jpy.array("java.nio.ByteBuffer", []),
                 )
@@ -459,7 +458,6 @@ class TableDataService(JObjectWrapper):
             j_tbl_location_key = _JTableLocationKeyImpl(pt_location_key)
             if pt_table is None:
                 location_cb.accept(
-                    # location_cb.apply(
                     j_tbl_location_key,
                     jpy.array("java.nio.ByteBuffer", []),
                 )


### PR DESCRIPTION
Two new tests are added to cover the no-partition cases. However, the ticking table test seems to reveal a dead-lock situation, which could be a problem of the test data service.

Closes #7469 