### PR TITLE
fix: DH-20658: Complete wrapping of the structured Filters in Core Py API

### DIFF
--- a/py/server/deephaven/filters.py
+++ b/py/server/deephaven/filters.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from enum import Enum
-from typing import Union
+from typing import Callable, Union
 
 import jpy
 
@@ -112,7 +112,7 @@ class Filter(ConcurrencyControl["Filter"], JObjectWrapper):
         Returns:
             a new not Filter
         """
-        return Filter(j_filter=getattr(_JFilter, "not")(self.j_filter))
+        return Filter(j_filter=_JFilterNot.of(self.j_filter))
 
     @classmethod
     def from_(
@@ -295,7 +295,7 @@ def in_(col: str, values: Sequence[Union[bool, int, float, str]]) -> Filter:
         raise DHError(e, "failed to create an in filter.") from e
 
 
-_FILTER_COMPARISON_MAP: dict = {
+_FILTER_COMPARISON_MAP: dict[str, Callable] = {
     "eq": _JFilterComparison.eq,
     "ne": _JFilterComparison.neq,
     "lt": _JFilterComparison.lt,

--- a/py/server/tests/test_filters.py
+++ b/py/server/tests/test_filters.py
@@ -128,7 +128,6 @@ class FilterTestCase(BaseTestCase):
             with self.assertRaises(DHError) as cm:
                 filter_in = in_("A", [2, "3"])
                 t.where(filter_in)
-            print(cm.exception)
 
             # inconsistent behavior observed, should fail with https://deephaven.atlassian.net/browse/DH-21232 fixed
             filter_in = in_("B", [2, "3"])


### PR DESCRIPTION
Note:
1.  no wrapping of the cyclic referencing `Expression`  class or the `Literal` class, in favor of the native Python types
2. no wrapping of the `Function` and `Method` classes;  workaround exists in the form of the class method `from_` that takes in a raw string and returns a Filter object
