### PR TITLE
fix: DH-21266: migrate lz4 dependency

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-common-conventions.gradle
@@ -4,21 +4,19 @@ plugins {
     id 'io.deephaven.java-license-conventions'
     id 'io.deephaven.java-toolchain-conventions'
     id 'io.deephaven.java-jar-conventions'
+    id 'io.deephaven.java-resolution-conventions'
 }
 
 project.tasks.getByName('quick').dependsOn project.tasks.withType(JavaCompile)
 
-configurations.all({ c ->
+configurations.configureEach({ c ->
     // Make dynamic versions illegal.
-    c.dependencies.all({
+    c.dependencies.configureEach({
         Dependency dep ->
             if (dep.version && dep.version.endsWith('+')) {
                 throw new GradleException("Dynamic versions not allowed ($dep found in $path)")
             }
     })
-    c.resolutionStrategy {
-        cacheChangingModulesFor 0, 'seconds'
-    }
 })
 
 tasks.named(LifecycleBasePlugin.CLEAN_TASK_NAME) {

--- a/buildSrc/src/main/groovy/io.deephaven.java-resolution-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-resolution-conventions.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+configurations.configureEach {
+    resolutionStrategy {
+        capabilitiesResolution {
+            // There is a gradle bug with relocated artifacts that declare capabilities as conflicting with the artifact
+            // they are relocated from:
+            // https://github.com/gradle/gradle/issues/35916
+            // https://github.com/gradle/gradle/issues/1256
+            // https://github.com/yawkat/lz4-java/wiki/Gradle-and-org.lz4:lz4%E2%80%90java:1.8.1
+            withCapability('org.lz4:lz4-java') {
+                select(candidates.find { ((ModuleComponentIdentifier) it.id).group == 'at.yawk.lz4' })
+            }
+        }
+        cacheChangingModulesFor 0, 'seconds'
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ jsinterop = "2.0.2"
 # google is annoying, and have different versions released for the same groupId
 jsinterop-base = "1.0.3"
 logback = "1.5.23"
-lz4 = "1.8.0"
+lz4 = "1.10.2"
 mindrot = "0.4"
 nidi = "0.18.1"
 oshi = "5.8.3"
@@ -275,7 +275,7 @@ jsinterop-base = { module = "com.google.jsinterop:base", version.ref = "jsintero
 
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
-lz4-java = { module = "org.lz4:lz4-java", version.ref = "lz4" }
+lz4-java = { module = "at.yawk.lz4:lz4-java", version.ref = "lz4" }
 
 mindrot-jbcrypt = { module = "org.mindrot:jbcrypt", version.ref = "mindrot" }
 


### PR DESCRIPTION
Fixes CVE-2025-12183 and CVE-2025-66566