### PR TITLE
chore: Update Javadoc tasks to use the project's default Java toolchain

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.java-toolchain-conventions.gradle
@@ -74,6 +74,13 @@ def groovyCompilerLauncher = javaToolchains.launcherFor {
   }
 } as Provider<JavaLauncher>
 
+def javadocTool_ = javaToolchains.javadocToolFor {
+    languageVersion = JavaLanguageVersion.of(compilerVersion)
+    if (compilerVendor != null) {
+        vendor = compilerVendor
+    }
+} as Provider<JavadocTool>
+
 tasks.withType(JavaCompile).configureEach {
   javaCompiler.set compiler
 
@@ -126,6 +133,9 @@ tasks.withType(GroovyCompile).configureEach {
   }
 }
 
+tasks.withType(Javadoc).configureEach {
+    javadocTool.set javadocTool_
+}
 
 def createCompilerDirectives = tasks.register('createCompilerDirectives') {
   def compilerDirectivesFile = project.layout.buildDirectory.file('dh-compiler-directives.txt')

--- a/buildSrc/src/main/groovy/io.deephaven.javadoc-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.javadoc-conventions.gradle
@@ -1,12 +1,11 @@
+plugins {
+    id 'java'
+    id 'io.deephaven.java-toolchain-conventions'
+}
+
 // Neither plain withType(Javadoc) {..} nor withType(Javadoc).all {..} will work here, somehow
 // this breaks sourcesets in some projects.
 tasks.withType(Javadoc).configureEach {
-    javadocTool = javaToolchains.javadocToolFor{javadocSpec ->
-        // Javadoc version >=11 is needed for search
-        // Javadoc version >12 is needed to avoid javadoc bugs in linking with modules
-        javadocSpec.languageVersion = JavaLanguageVersion.of(17)
-    }
-
     options.encoding = 'UTF-8'
 
     doFirst {
@@ -19,5 +18,5 @@ tasks.withType(Javadoc).configureEach {
     }
 
     // Don't fail on warnings, let specific projects enable this if desired
-//  options.addBooleanOption('Xwerror', true)
+    //options.addBooleanOption('Werror', true)
 }

--- a/combined-javadoc/build.gradle
+++ b/combined-javadoc/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'io.deephaven.project.register'
     id 'java'
+    id 'io.deephaven.javadoc-conventions'
 }
 
 configurations {
@@ -30,7 +31,7 @@ def allJavadoc = tasks.register 'allJavadoc', Javadoc, {
         jdoc.options.overview = new File(javaDocOverviewLocation)
 
         // Fail on warnings to ensure correctness for our published docs
-        jdoc.options.addBooleanOption('Xwerror', true)
+        jdoc.options.addBooleanOption('Werror', true)
 
         def isForJavadocs = { Project p -> return io.deephaven.project.util.CombinedJavadoc.includeProject(p) }
 
@@ -52,8 +53,6 @@ def allJavadoc = tasks.register 'allJavadoc', Javadoc, {
         jdoc.destinationDir = file("${buildDir}/docs/javadoc")
         jdoc.dependsOn(writeJavadocVersion)
 }
-
-apply plugin: 'io.deephaven.javadoc-conventions'
 
 artifacts {
     combinedJavadoc allJavadoc

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteAsBooleanColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/ByteAsBooleanColumnSource.java
@@ -15,7 +15,7 @@ import io.deephaven.chunk.*;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Reinterpret result {@link ColumnSource} implementations that translates {@link byte} to {@code Boolean} values.
+ * Reinterpret result {@link ColumnSource} implementations that translates {@code byte} to {@code Boolean} values.
  */
 public class ByteAsBooleanColumnSource extends AbstractColumnSource<Boolean>
         implements MutableColumnSourceGetDefaults.ForBoolean, FillUnordered<Values> {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/WritableByteAsBooleanColumnSource.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/WritableByteAsBooleanColumnSource.java
@@ -14,7 +14,7 @@ import io.deephaven.util.BooleanUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Reinterpret result {@link ColumnSource} implementations that translates {@link byte} to {@code Boolean} values.
+ * Reinterpret result {@link ColumnSource} implementations that translates {@code byte} to {@code Boolean} values.
  */
 public class WritableByteAsBooleanColumnSource extends ByteAsBooleanColumnSource
         implements MutableColumnSourceGetDefaults.ForBoolean, WritableColumnSource<Boolean> {

--- a/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
+++ b/java-client/session/src/main/java/io/deephaven/client/impl/SessionImpl.java
@@ -54,9 +54,6 @@ import java.util.function.Function;
 /**
  * A {@link Session} implementation that uses {@link io.deephaven.proto.backplane.grpc.BatchTableRequest batch requests}
  * and memoizes based on {@link io.deephaven.qst.table.TableSpec} equality.
- *
- * <p>
- * {@inheritDoc}
  */
 public final class SessionImpl extends SessionBase {
     private static final Logger log = LoggerFactory.getLogger(SessionImpl.class);

--- a/qst/type/src/main/java/io/deephaven/qst/type/CharType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/CharType.java
@@ -7,7 +7,7 @@ import io.deephaven.annotations.SingletonStyle;
 import org.immutables.value.Value.Immutable;
 
 /**
- * The primitive {@link char} type.
+ * The primitive {@code char} type.
  */
 @Immutable
 @SingletonStyle

--- a/qst/type/src/main/java/io/deephaven/qst/type/DoubleType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/DoubleType.java
@@ -7,7 +7,7 @@ import io.deephaven.annotations.SingletonStyle;
 import org.immutables.value.Value.Immutable;
 
 /**
- * The primitive {@link double} type.
+ * The primitive {@code double} type.
  */
 @Immutable
 @SingletonStyle

--- a/qst/type/src/main/java/io/deephaven/qst/type/FloatType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/FloatType.java
@@ -7,7 +7,7 @@ import io.deephaven.annotations.SingletonStyle;
 import org.immutables.value.Value.Immutable;
 
 /**
- * The primitive {@link float} type.
+ * The primitive {@code float} type.
  */
 @Immutable
 @SingletonStyle

--- a/qst/type/src/main/java/io/deephaven/qst/type/IntType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/IntType.java
@@ -7,7 +7,7 @@ import io.deephaven.annotations.SingletonStyle;
 import org.immutables.value.Value.Immutable;
 
 /**
- * The primitive {@link int} type.
+ * The primitive {@code int} type.
  */
 @Immutable
 @SingletonStyle

--- a/qst/type/src/main/java/io/deephaven/qst/type/LongType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/LongType.java
@@ -7,7 +7,7 @@ import io.deephaven.annotations.SingletonStyle;
 import org.immutables.value.Value.Immutable;
 
 /**
- * The primitive {@link long} type.
+ * The primitive {@code long} type.
  */
 @Immutable
 @SingletonStyle

--- a/qst/type/src/main/java/io/deephaven/qst/type/ShortType.java
+++ b/qst/type/src/main/java/io/deephaven/qst/type/ShortType.java
@@ -7,7 +7,7 @@ import io.deephaven.annotations.SingletonStyle;
 import org.immutables.value.Value.Immutable;
 
 /**
- * The primitive {@link short} type.
+ * The primitive {@code short} type.
  */
 @Immutable
 @SingletonStyle


### PR DESCRIPTION
This updates the Javadoc tasks to the project's default Java toolchain, currently Java 21. This also updates the `combined-javadoc:allJavadoc` task to use the option `-Werror` to elevate javadoc warnings into errors, which was standardized in Java 15 (as opposed to the hidden option `-Xwerror`), see https://bugs.openjdk.org/browse/JDK-8196116.

The javadoc update also pointed out a couple of javadoc issues that are also fixed in this PR.