### PR TITLE
chore: DH-21421: Update Java style guide for record formatting

### DIFF
--- a/Plot/src/main/java/io/deephaven/plot/ChartImpl.java
+++ b/Plot/src/main/java/io/deephaven/plot/ChartImpl.java
@@ -378,6 +378,7 @@ public class ChartImpl implements Chart, PlotExceptionCause {
     public ChartTitle getChartTitle() {
         return chartTitle;
     }
+
     ////////////////////////// convenience //////////////////////////
 
 

--- a/engine/api/src/main/java/io/deephaven/engine/table/MultiJoinFactory.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/MultiJoinFactory.java
@@ -34,18 +34,18 @@ import java.util.ServiceLoader;
  * </p>
  *
  * <pre>{@code
- *     private Table doIterativeMultiJoin(String [] keyColumns, List<? extends Table> inputTables) {
- *         final List<Table> keyTables = inputTables.stream().map(t -> t.view(keyColumns)).collect(Collectors.toList());
- *         final Table base = TableTools.merge(keyTables).selectDistinct(keyColumns);
+ * private Table doIterativeMultiJoin(String[] keyColumns, List<? extends Table> inputTables) {
+ *     final List<Table> keyTables = inputTables.stream().map(t -> t.view(keyColumns)).collect(Collectors.toList());
+ *     final Table base = TableTools.merge(keyTables).selectDistinct(keyColumns);
  *
- *         Table result = base;
- *         for (int ii = 0; ii < inputTables.size(); ++ii) {
- *             result = result.naturalJoin(inputTables.get(ii), Arrays.asList(keyColumns));
- *         }
+ *     Table result = base;
+ *     for (int ii = 0; ii < inputTables.size(); ++ii) {
+ *         result = result.naturalJoin(inputTables.get(ii), Arrays.asList(keyColumns));
+ *     }
  *
- *         return result;
- *     }
- *     }
+ *     return result;
+ * }
+ * }
  * </pre>
  */
 

--- a/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/WritableRowSetImplTest.java
+++ b/engine/rowset/src/test/java/io/deephaven/engine/rowset/impl/WritableRowSetImplTest.java
@@ -1894,6 +1894,7 @@ public class WritableRowSetImplTest extends TestCase {
     // RowSet modified = readIndices.get("modifiedIndices");
     //
     //// Assert.eq(saveModified2, "saveModified2", modified, "modified");
+
     //
     //
     //

--- a/style/eclipse-java-google-style.xml
+++ b/style/eclipse-java-google-style.xml
@@ -58,7 +58,6 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="16"/>
-<setting id="org.eclipse.jdt.core.compiler.source" value="1.7"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration.count_dependent" value="16|4|48"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
@@ -201,7 +200,6 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation.count_dependent" value="16|-1|16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="1585"/>
-<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7"/>
 <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
@@ -284,7 +282,6 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>


### PR DESCRIPTION
Some experimentation with records and sealed classes produced very bad code; it seems like this is a [known issue w/ the eclipse style guide](https://github.com/diffplug/spotless/issues/951) when setting the source level to 1.7.