### PR TITLE
fix: DH-21451: make Python packages: pytz and zoneinfo soft deps

### DIFF
--- a/py/server/deephaven/time.py
+++ b/py/server/deephaven/time.py
@@ -18,7 +18,7 @@ except ImportError:
     pytz = None  # type: ignore[assignment]
 
 try:
-    import zoneinfo
+    import zoneinfo # novermin
 except ImportError:
     zoneinfo = None  # type: ignore[assignment]
 
@@ -239,10 +239,8 @@ def _tzinfo_to_j_time_zone(tzi: datetime.tzinfo) -> TimeZone:
         return _JDateTimeUtils.parseTimeZone(tzi.zone)
 
     # Handle zoneinfo time zones
-    if sys.version_info >= (3, 9):
-        # novermin
-        if zoneinfo and isinstance(tzi, zoneinfo.ZoneInfo):
-            return _JDateTimeUtils.parseTimeZone(tzi.key)
+    if zoneinfo and isinstance(tzi, zoneinfo.ZoneInfo):
+        return _JDateTimeUtils.parseTimeZone(tzi.key)
 
     # Handle constant UTC offset time zones (datetime.timezone)
 


### PR DESCRIPTION
This fix is needed for users who use the pip-installed server in Python 3.11+ or in modified docker images with Python 3.11+