### PR TITLE
chore: Remove old CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@
 /engine/function/ @chipkent @kosak @rcaudy @cpwright
 /py @chipkent @jmao-denver @rcaudy @cpwright
 /R @chipkent @rcaudy @cpwright @kosak
-*.proto @devinrsmith @nbauernfeind @niloc132 @rcaudy @cpwright
-*.gwt.xml @niloc132 @rcaudy @nbauernfeind @cpwright
+*.proto @devinrsmith @niloc132 @rcaudy @cpwright
+*.gwt.xml @niloc132 @rcaudy @cpwright
 /docs/**/*.md @margaretkennedy @elijahpetty @rcaudy
 /gradle @devinrsmith @rcaudy


### PR DESCRIPTION
The CODEOWNERS file still worked, but viewing it on GitHub showed a warning that it was invalid b/c there was a non-collaborator in the file now

Just kind of scatter shooting w/ reviewers as this is a simple change