### PR TITLE
docs: Link fix/remove

### DIFF
--- a/docs/groovy/getting-started/launch-build.md
+++ b/docs/groovy/getting-started/launch-build.md
@@ -46,9 +46,6 @@ You can download a ZIP file of the repository from GitHub. However, this is not 
 
 The following instructions are a condensed version of instructions found in the [deephaven-core repository](https://github.com/deephaven/deephaven-core). For the full instructions with explanations of configuration parameters, SSL, and more, see the [README](https://github.com/deephaven/deephaven-core/blob/main/server/jetty-app/README.md).
 
-> [!NOTE]
-> The following steps show how to build and run Deephaven with Groovy from source. For Python, see [here](/core/docs/getting-started/launch-build/).
-
 ### Clone the deephaven-core repository
 
 Once all of the required dependencies are installed and functioning, clone [https://github.com/deephaven/deephaven-core](https://github.com/deephaven/deephaven-core). If you use `git`, clone it like this:

--- a/docs/python/getting-started/launch-build.md
+++ b/docs/python/getting-started/launch-build.md
@@ -56,9 +56,6 @@ You can download a ZIP file of the repository from GitHub. However, this is not 
 
 The following instructions are a condensed version of instructions found in the [deephaven-core repository](https://github.com/deephaven/deephaven-core). For the full instructions with explanations of configuration parameters, SSL, and more, see the [README](https://github.com/deephaven/deephaven-core/blob/main/server/jetty-app/README.md).
 
-> [!NOTE]
-> The following steps show how to build and run Deephaven with Python from source. For Groovy, see [here](/core/groovy/docs/how-to-guides/launch-build/).
-
 ### Clone the deephaven-core repository
 
 Once all of the required dependencies are installed and functioning, clone [https://github.com/deephaven/deephaven-core](https://github.com/deephaven/deephaven-core). If you use `git`, clone it like this:


### PR DESCRIPTION
Salmon doesn't handle these relative links well. I think since users can swap to the Groovy/Python version with the tab at the top, we can just remove this note.