### PR TITLE
feat: DH-21579: add allow_string parameter to python instant_val

### DIFF
--- a/py/server/deephaven/json/__init__.py
+++ b/py/server/deephaven/json/__init__.py
@@ -1061,6 +1061,7 @@ def instant_val(
     allow_null: bool = True,
     number_format: Literal[None, "s", "ms", "us", "ns"] = None,
     allow_decimal: bool = False,
+    allow_string: bool = False,
     on_missing: Optional[InstantLike] = None,
     on_null: Optional[InstantLike] = None,
 ) -> JsonValue:
@@ -1108,7 +1109,9 @@ def instant_val(
             "s" is for seconds, "ms" is for milliseconds, "us" is for microseconds, and "ns" is for nanoseconds since
             the epoch. When not set, a JSON string in the ISO-8601 format is expected.
         allow_decimal (bool): if the Instant value is allowed to be a JSON decimal type, default is False. Only valid
-            when number_format is specified.
+            when number_format is True.
+        allow_string (bool): if the Instant value is allowed to be a JSON string type, default is False. Is only
+            relevant when number_format is True.
         on_missing (Optional[InstantLike]): the value to use when the JSON value is missing and allow_missing is True, default is None.
         on_null (Optional[InstantLike]): the value to use when the JSON value is null and allow_null is True, default is None.
 
@@ -1127,6 +1130,7 @@ def instant_val(
             allow_null,
             allow_int=True,
             allow_decimal=allow_decimal,
+            allow_string=allow_string,
         )
         if number_format == "s":
             builder.format(_EPOCH_SECONDS)

--- a/py/server/tests/test_json.py
+++ b/py/server/tests/test_json.py
@@ -104,6 +104,18 @@ class JsonTestCase(BaseTestCase):
             instant_val(on_missing=datetime.fromtimestamp(0))
         with self.subTest("on_null"):
             instant_val(on_null=datetime.fromtimestamp(0))
+        with self.subTest("number_format s"):
+            instant_val(number_format="s")
+            instant_val(number_format="s", allow_string=True)
+        with self.subTest("number_format ms"):
+            instant_val(number_format="ms")
+            instant_val(number_format="ms", allow_string=True)
+        with self.subTest("number_format us"):
+            instant_val(number_format="us")
+            instant_val(number_format="us", allow_string=True)
+        with self.subTest("number_format ns"):
+            instant_val(number_format="ns")
+            instant_val(number_format="ns", allow_string=True)
 
     def test_any(self):
         self.all_same_json([any_val(), dtypes.JObject, object])


### PR DESCRIPTION
This allows python to properly configure a JSON value as a JSON string that encodes a number of temporal units (seconds, millis, micros, nanos) since the epoch. For example, the JSON string with number of seconds since the epoch

```json
"1770051098"
```

can now be represented in python by

```python
instant_val(number_format="s", allow_string=True)
```

This functionality is already present on the Java side via a "lenient" `io.deephaven.json.InstantNumberValue`, which already allows JSON string types.