### PR TITLE
fix(csharp/client): DH-21586: Increase MaxReceiveMessageSize to 100M

### DIFF
--- a/csharp/client/Dh_NetClient/util/GrpcUtil.cs
+++ b/csharp/client/Dh_NetClient/util/GrpcUtil.cs
@@ -19,7 +19,10 @@ public static class GrpcUtil {
   }
 
   public static GrpcChannelOptions MakeChannelOptions(ClientOptions clientOptions) {
-    var channelOptions = new GrpcChannelOptions();
+    var channelOptions = new GrpcChannelOptions {
+      // Match outgoing size in io.deephaven.extensions.barrage.BarrageMessageWriterImpl
+      MaxReceiveMessageSize = 100 * 1024 * 1024
+    };
 
     if (!clientOptions.UseTls && !clientOptions.TlsRootCerts.IsEmpty()) {
       throw new Exception("GrpcUtil.MakeChannelOptions: UseTls is false but pem provided");


### PR DESCRIPTION
On the writer side, in `io.deephaven.extensions.barrage.BarrageMessageWriterImpl` , Barrage sets `maxOutboundMessageSize` to 100 * 1024 * 1024. We need to change the receive side to match.