### PR TITLE
docs: Fix GIL link

### DIFF
--- a/docs/python/how-to-guides/partitioned-tables.md
+++ b/docs/python/how-to-guides/partitioned-tables.md
@@ -332,7 +332,7 @@ Partitioned tables can improve performance in a couple of different ways.
 #### Parallelization
 
 > [!CAUTION]
-> Python's [Global Interpreter Lock (GIL)](https://wiki.python.org/moin/GlobalInterpreterLock) prevents threads from running concurrently. To maximize parallelization, users should be careful not to invoke Python code unnecessarily in partitioned tables.
+> Python's [Global Interpreter Lock (GIL)](https://docs.python.org/3/glossary.html#term-global-interpreter-lock) prevents threads from running concurrently. To maximize parallelization, users should be careful not to invoke Python code unnecessarily in partitioned tables.
 
 Partitioned tables can also improve query performance by parallelizing things that standard tables cannot. Take, for example, an as-of join between two tables. If the tables are partitioned by the exact match columns, then the join operation is done in parallel.
 


### PR DESCRIPTION
Turned up as a 404 in the nightly check. Replaced with non-deprecated/in-archival-process link.