### PR TITLE
feat: DH-21652: remove Core logger row flags

### DIFF
--- a/Stats/src/main/java/io/deephaven/stats/StatsIntradayLogger.java
+++ b/Stats/src/main/java/io/deephaven/stats/StatsIntradayLogger.java
@@ -7,7 +7,10 @@ import io.deephaven.base.stats.Counter;
 import io.deephaven.base.stats.HistogramState;
 import io.deephaven.base.stats.State;
 
-public interface StatsIntradayLogger {
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface StatsIntradayLogger extends Closeable {
     /**
      * Convert a type tag to a friendly representation.
      * 
@@ -35,5 +38,8 @@ public interface StatsIntradayLogger {
         @Override
         public void log(String intervalName, long now, long appNow, char typeTag, String compactName, long n, long sum,
                 long last, long min, long max, long avg, long sum2, long stdev) {}
+
+        @Override
+        public void close() throws IOException {}
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ProcessInfoImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/ProcessInfoImpl.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 class ProcessInfoImpl {
 
     private final ProcessUniqueId id;
-    private final ProcessInfoLogLogger delegate;
+    private ProcessInfoLogLogger delegate;
     private Table table;
 
     public ProcessInfoImpl(ProcessUniqueId id, ProcessInfoLogLogger delegate) {
@@ -30,6 +30,8 @@ class ProcessInfoImpl {
         final Visitor visitor = new Visitor();
         pInfo.traverse(visitor);
         table = visitor.table();
+        delegate.close();
+        delegate = null;
     }
 
     public Table table() {

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/QueryOperationPerformanceImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/QueryOperationPerformanceImpl.java
@@ -8,7 +8,6 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
 import io.deephaven.engine.tablelogger.QueryOperationPerformanceLogLogger;
 import io.deephaven.stream.StreamToBlinkTableAdapter;
-import io.deephaven.tablelogger.Row.Flags;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -37,10 +36,8 @@ class QueryOperationPerformanceImpl implements QueryOperationPerformanceLogLogge
     }
 
     @Override
-    public void log(
-            @NotNull final Flags flags,
-            @NotNull final QueryPerformanceNugget nugget) throws IOException {
+    public void log(@NotNull QueryPerformanceNugget nugget) throws IOException {
         publisher.add(nugget);
-        qoplLogger.log(flags, nugget);
+        qoplLogger.log(nugget);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/QueryPerformanceImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/QueryPerformanceImpl.java
@@ -8,7 +8,6 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
 import io.deephaven.engine.tablelogger.QueryPerformanceLogLogger;
 import io.deephaven.stream.StreamToBlinkTableAdapter;
-import io.deephaven.tablelogger.Row.Flags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,11 +37,8 @@ class QueryPerformanceImpl implements QueryPerformanceLogLogger {
     }
 
     @Override
-    public void log(
-            @NotNull final Flags flags,
-            @NotNull final QueryPerformanceNugget nugget,
-            @Nullable final Exception exception) throws IOException {
+    public void log(@NotNull QueryPerformanceNugget nugget, @Nullable Exception exception) throws IOException {
         publisher.add(nugget, exception);
-        qplLogger.log(flags, nugget, exception);
+        qplLogger.log(nugget, exception);
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/util/StatsImpl.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/util/StatsImpl.java
@@ -52,4 +52,9 @@ class StatsImpl implements StatsIntradayLogger {
             throw new UncheckedIOException(e);
         }
     }
+
+    @Override
+    public void close() throws IOException {
+        logger.close();
+    }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/tablelogger/ProcessInfoLogLogger.java
+++ b/engine/table/src/main/java/io/deephaven/engine/tablelogger/ProcessInfoLogLogger.java
@@ -3,29 +3,25 @@
 //
 package io.deephaven.engine.tablelogger;
 
-import io.deephaven.tablelogger.Row;
-import io.deephaven.tablelogger.Row.Flags;
-
+import java.io.Closeable;
 import java.io.IOException;
-
-import static io.deephaven.tablelogger.TableLogger.DEFAULT_INTRADAY_LOGGER_FLAGS;
 
 /**
  * Logs data that describes JVM parameters. This is useful to check a worker's configuration.
  */
-public interface ProcessInfoLogLogger {
-    default void log(final String id, final String type, final String key, final String value) throws IOException {
-        log(DEFAULT_INTRADAY_LOGGER_FLAGS, id, type, key, value);
-    }
-
-    void log(final Row.Flags flags, final String id, final String type, final String key, final String value)
-            throws IOException;
+public interface ProcessInfoLogLogger extends Closeable {
+    void log(final String id, final String type, final String key, final String value) throws IOException;
 
     enum Noop implements ProcessInfoLogLogger {
         INSTANCE;
 
         @Override
-        public void log(Flags flags, String id, String type, String key, String value) throws IOException {
+        public void log(String id, String type, String key, String value) throws IOException {
+
+        }
+
+        @Override
+        public void close() throws IOException {
 
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/tablelogger/ProcessMetricsLogLogger.java
+++ b/engine/table/src/main/java/io/deephaven/engine/tablelogger/ProcessMetricsLogLogger.java
@@ -3,34 +3,28 @@
 //
 package io.deephaven.engine.tablelogger;
 
-import io.deephaven.tablelogger.Row;
-import io.deephaven.tablelogger.Row.Flags;
-
+import java.io.Closeable;
 import java.io.IOException;
-
-import static io.deephaven.tablelogger.TableLogger.DEFAULT_INTRADAY_LOGGER_FLAGS;
 
 /**
  * Logs data that gives insight to process statistics such as heap usage and page fault counts.
  */
-public interface ProcessMetricsLogLogger {
-    default void log(final long timestamp, final String processId, final String name, final String interval,
+public interface ProcessMetricsLogLogger extends Closeable {
+    void log(final long timestamp, final String processId, final String name, final String interval,
             final String type, final long n, final long sum, final long last, final long min, final long max,
-            final long avg, final long sum2, final long stdev) throws IOException {
-        log(DEFAULT_INTRADAY_LOGGER_FLAGS, timestamp, processId, name, interval, type, n, sum, last, min, max, avg,
-                sum2, stdev);
-    }
-
-    void log(final Row.Flags flags, final long timestamp, final String processId, final String name,
-            final String interval, final String type, final long n, final long sum, final long last, final long min,
-            final long max, final long avg, final long sum2, final long stdev) throws IOException;
+            final long avg, final long sum2, final long stdev) throws IOException;
 
     enum Noop implements ProcessMetricsLogLogger {
         INSTANCE;
 
         @Override
-        public void log(Flags flags, long timestamp, String processId, String name, String interval, String type,
-                long n, long sum, long last, long min, long max, long avg, long sum2, long stdev) throws IOException {
+        public void log(long timestamp, String processId, String name, String interval, String type, long n, long sum,
+                long last, long min, long max, long avg, long sum2, long stdev) throws IOException {
+
+        }
+
+        @Override
+        public void close() throws IOException {
 
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/tablelogger/QueryOperationPerformanceLogLogger.java
+++ b/engine/table/src/main/java/io/deephaven/engine/tablelogger/QueryOperationPerformanceLogLogger.java
@@ -4,31 +4,24 @@
 package io.deephaven.engine.tablelogger;
 
 import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
-import io.deephaven.tablelogger.Row;
-import io.deephaven.tablelogger.Row.Flags;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-
-import static io.deephaven.tablelogger.TableLogger.DEFAULT_INTRADAY_LOGGER_FLAGS;
 
 /**
  * Logs data that describes performance details on initialization times and memory usage of specific operations within
  * queries.
  */
 public interface QueryOperationPerformanceLogLogger {
-    default void log(@NotNull final QueryPerformanceNugget nugget) throws IOException {
-        log(DEFAULT_INTRADAY_LOGGER_FLAGS, nugget);
-    }
-
-    void log(@NotNull Row.Flags flags, @NotNull QueryPerformanceNugget nugget) throws IOException;
+    void log(@NotNull final QueryPerformanceNugget nugget) throws IOException;
 
     enum Noop implements QueryOperationPerformanceLogLogger {
         INSTANCE;
 
+
         @Override
-        public void log(
-                @NotNull final Flags flags,
-                @NotNull final QueryPerformanceNugget nugget) throws IOException {}
+        public void log(@NotNull QueryPerformanceNugget nugget) throws IOException {
+
+        }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/tablelogger/QueryPerformanceLogLogger.java
+++ b/engine/table/src/main/java/io/deephaven/engine/tablelogger/QueryPerformanceLogLogger.java
@@ -4,27 +4,17 @@
 package io.deephaven.engine.tablelogger;
 
 import io.deephaven.engine.table.impl.perf.QueryPerformanceNugget;
-import io.deephaven.tablelogger.Row;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-
-import static io.deephaven.tablelogger.TableLogger.DEFAULT_INTRADAY_LOGGER_FLAGS;
 
 /**
  * Logs data that describes the query-level performance for each worker. A given worker may be running multiple queries;
  * each will have its own set of query performance log entries.
  */
 public interface QueryPerformanceLogLogger {
-    default void log(
-            @NotNull final QueryPerformanceNugget nugget,
-            @Nullable final Exception exception) throws IOException {
-        log(DEFAULT_INTRADAY_LOGGER_FLAGS, nugget, exception);
-    }
-
     void log(
-            @NotNull final Row.Flags flags,
             @NotNull final QueryPerformanceNugget nugget,
             @Nullable final Exception exception) throws IOException;
 
@@ -32,9 +22,8 @@ public interface QueryPerformanceLogLogger {
         INSTANCE;
 
         @Override
-        public void log(
-                @NotNull final Row.Flags flags,
-                @NotNull final QueryPerformanceNugget nugget,
-                @Nullable final Exception exception) {}
+        public void log(@NotNull QueryPerformanceNugget nugget, @Nullable Exception exception) throws IOException {
+
+        }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/tablelogger/ServerStateLogLogger.java
+++ b/engine/table/src/main/java/io/deephaven/engine/tablelogger/ServerStateLogLogger.java
@@ -3,41 +3,32 @@
 //
 package io.deephaven.engine.tablelogger;
 
-import io.deephaven.tablelogger.Row;
-import io.deephaven.tablelogger.Row.Flags;
-
+import java.io.Closeable;
 import java.io.IOException;
-
-import static io.deephaven.tablelogger.TableLogger.DEFAULT_INTRADAY_LOGGER_FLAGS;
 
 /**
  * Logs data that describes the top-level view of the free and total memory available to the process.
  */
-public interface ServerStateLogLogger {
-    default void log(final long intervalStartTime, final int intervalDurationMicros, final int totalMemoryMiB,
+public interface ServerStateLogLogger extends Closeable {
+    void log(final long intervalStartTime, final int intervalDurationMicros, final int totalMemoryMiB,
             final int freeMemoryMiB, final short intervalCollections, final int intervalCollectionTimeMicros,
             final short intervalUGPCyclesOnBudget, final int[] intervalUGPCyclesTimeMicros,
             final short intervalUGPCyclesSafePoints, final int intervalUGPCyclesSafePointTimeMicros)
-            throws IOException {
-        log(DEFAULT_INTRADAY_LOGGER_FLAGS, intervalStartTime, intervalDurationMicros, totalMemoryMiB, freeMemoryMiB,
-                intervalCollections, intervalCollectionTimeMicros, intervalUGPCyclesOnBudget,
-                intervalUGPCyclesTimeMicros, intervalUGPCyclesSafePoints, intervalUGPCyclesSafePointTimeMicros);
-    }
-
-    void log(final Row.Flags flags, final long intervalStartTime, final int intervalDurationMicros,
-            final int totalMemoryMiB, final int freeMemoryMiB, final short intervalCollections,
-            final int intervalCollectionTimeMicros, final short intervalUGPCyclesOnBudget,
-            final int[] intervalUGPCyclesTimeMicros, final short intervalUGPCyclesSafePoints,
-            final int intervalUGPCyclesSafePointTimeMicros) throws IOException;
+            throws IOException;
 
     enum Noop implements ServerStateLogLogger {
         INSTANCE;
 
         @Override
-        public void log(Flags flags, long intervalStartTime, int intervalDurationMicros, int totalMemoryMiB,
-                int freeMemoryMiB, short intervalCollections, int intervalCollectionTimeMicros,
-                short intervalUGPCyclesOnBudget, int[] intervalUGPCyclesTimeMicros, short intervalUGPCyclesSafePoints,
+        public void log(long intervalStartTime, int intervalDurationMicros, int totalMemoryMiB, int freeMemoryMiB,
+                short intervalCollections, int intervalCollectionTimeMicros, short intervalUGPCyclesOnBudget,
+                int[] intervalUGPCyclesTimeMicros, short intervalUGPCyclesSafePoints,
                 int intervalUGPCyclesSafePointTimeMicros) throws IOException {
+
+        }
+
+        @Override
+        public void close() throws IOException {
 
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/tablelogger/UpdatePerformanceAncestorLogger.java
+++ b/engine/table/src/main/java/io/deephaven/engine/tablelogger/UpdatePerformanceAncestorLogger.java
@@ -3,30 +3,22 @@
 //
 package io.deephaven.engine.tablelogger;
 
-import io.deephaven.tablelogger.Row.Flags;
-
 import java.io.IOException;
-
-import static io.deephaven.tablelogger.TableLogger.DEFAULT_INTRADAY_LOGGER_FLAGS;
 
 /**
  * Logs data that describes the relationships between a {@link io.deephaven.engine.table.impl.perf.PerformanceEntry} and
  * its ancestors.
  */
 public interface UpdatePerformanceAncestorLogger {
-    default void log(final String updateGraphName, final long id, final String description, final long[] ancestors)
-            throws IOException {
-        log(DEFAULT_INTRADAY_LOGGER_FLAGS, updateGraphName, id, description, ancestors);
-    }
-
-    void log(final Flags flags, final String updateGraphName, final long id, final String description,
-            final long[] ancestors) throws IOException;
+    void log(final String updateGraphName, final long id, final String description, final long[] ancestors)
+            throws IOException;
 
     enum Noop implements UpdatePerformanceAncestorLogger {
         INSTANCE;
 
         @Override
-        public void log(Flags flags, final String updateGraphName, final long id, final String description,
-                final long[] ancestors) {}
+        public void log(String updateGraphName, long id, String description, long[] ancestors) throws IOException {
+
+        }
     }
 }

--- a/engine/table/src/main/java/io/deephaven/engine/tablelogger/UpdatePerformanceLogLogger.java
+++ b/engine/table/src/main/java/io/deephaven/engine/tablelogger/UpdatePerformanceLogLogger.java
@@ -6,30 +6,22 @@ package io.deephaven.engine.tablelogger;
 import io.deephaven.engine.table.impl.perf.PerformanceEntry;
 import io.deephaven.engine.table.impl.perf.UpdatePerformanceTracker;
 import io.deephaven.engine.table.impl.perf.UpdatePerformanceTracker.IntervalLevelDetails;
-import io.deephaven.tablelogger.Row;
-import io.deephaven.tablelogger.Row.Flags;
 
 import java.io.IOException;
-
-import static io.deephaven.tablelogger.TableLogger.DEFAULT_INTRADAY_LOGGER_FLAGS;
 
 /**
  * Logs data that describes what a worker spent time on during its data refresh cycle.
  */
 public interface UpdatePerformanceLogLogger {
-    default void log(final UpdatePerformanceTracker.IntervalLevelDetails intervalLevelDetails,
-            final PerformanceEntry performanceEntry) throws IOException {
-        log(DEFAULT_INTRADAY_LOGGER_FLAGS, intervalLevelDetails, performanceEntry);
-    }
-
-    void log(final Row.Flags flags, final UpdatePerformanceTracker.IntervalLevelDetails intervalLevelDetails,
+    void log(final UpdatePerformanceTracker.IntervalLevelDetails intervalLevelDetails,
             final PerformanceEntry performanceEntry) throws IOException;
 
     enum Noop implements UpdatePerformanceLogLogger {
         INSTANCE;
 
         @Override
-        public void log(Flags flags, IntervalLevelDetails intervalLevelDetails, PerformanceEntry performanceEntry) {
+        public void log(IntervalLevelDetails intervalLevelDetails, PerformanceEntry performanceEntry)
+                throws IOException {
 
         }
     }

--- a/engine/table/src/main/java/io/deephaven/stats/Driver.java
+++ b/engine/table/src/main/java/io/deephaven/stats/Driver.java
@@ -4,13 +4,38 @@
 package io.deephaven.stats;
 
 import io.deephaven.base.clock.Clock;
+import io.deephaven.util.process.ProcessEnvironment;
+import io.deephaven.util.process.ShutdownManager;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A Deephaven-side shim for {@link io.deephaven.stats.StatsDriver}.
  */
 public class Driver {
+    private static final long SHUTDOWN_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(1);
+
     public static void start(Clock clock, StatsIntradayLogger intraday, boolean getFdStats) {
-        new StatsDriver(clock, intraday, getFdStats);
+        final StatsDriver statsDriver = new StatsDriver(clock, intraday, getFdStats);
+        final ShutdownManager shutdownManager = ProcessEnvironment.getGlobalShutdownManager();
+        // TODO(DH-21651): Improve shutdown ordering constraints
+        final long[] deadline = new long[1];
+        shutdownManager.registerTask(ShutdownManager.OrderingCategory.FIRST, () -> {
+            deadline[0] = System.nanoTime() + SHUTDOWN_TIMEOUT_NANOS;
+            statsDriver.shutdownScheduler();
+        });
+        shutdownManager.registerTask(ShutdownManager.OrderingCategory.MIDDLE, () -> {
+            final long remainingNanos = deadline[0] - System.nanoTime();
+            try (final StatsDriver ignored = statsDriver) {
+                statsDriver.awaitSchedulerTermination(remainingNanos, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
         new GcEventStats().install();
     }
 }


### PR DESCRIPTION
Removes the unused row flag log variants from ProcessInfoLogLogger, ProcessMetricsLogLogger, QueryOperationPerformanceLogLogger, QueryPerformanceLogLogger, ServerStateLogLogger,
UpdatePerformanceAncestorLogger, UpdatePerformanceLogLogger.

Adds shutdown closing logic for ServerStateLogLogger and ProcessMetricsLogLogger.

Adds explicit closing of ProcessInfoLogLogger once the process info has been logged.

Cherry-pick of #7668