### PR TITLE
feat: DH-21799: Build Deephaven Core C# library for both net8.0 and net10.0

### DIFF
--- a/csharp/client/Dh_NetClient/Dh_NetClient.csproj
+++ b/csharp/client/Dh_NetClient/Dh_NetClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Deephaven.Dh_NetClient</RootNamespace>
@@ -39,9 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="README-nuget.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
+    <None Include="$(MSBuildProjectDirectory)\README-nuget.md"
+        Pack="true"
+        PackagePath="\"
+        Link="README-nuget.md"
+        Visible="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The reason the README-nuget.md clause had to change is because .NET gets confused trying to find that file in the multitarget scenario.