### PR TITLE
chore(gradle): bump io.airlift:aircompressor from 2.0.2 to 2.0.3 (#7735)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 adbc = "0.21.0"
-airlift = "2.0.2"
+airlift = "2.0.3"
 arrow = "18.3.0"
 autoservice = "1.1.1"
 avro = "1.12.1"


### PR DESCRIPTION
Cherry-pick of #7735 

Bumps [io.airlift:aircompressor](https://github.com/airlift/aircompressor) from 2.0.2 to 2.0.3.
- [Release notes](https://github.com/airlift/aircompressor/releases)
- [Commits](airlift/aircompressor@2.0.2...2.0.3)

---
updated-dependencies:
- dependency-name: io.airlift:aircompressor dependency-version: 2.0.3 dependency-type: direct:production update-type: version-update:semver-patch ...