### PR TITLE
fix: DH-21891: Remove numba from install-required of Core Py API

### DIFF
--- a/Integrations/build.gradle
+++ b/Integrations/build.gradle
@@ -109,7 +109,7 @@ def runInDocker = { String name, String sourcePath, List<String> command, Closur
             // copy in the contents that we do expect to change as the project updates
             copyFile 'python', '/python'
             copyFile 'classpath', '/classpath'
-            runCommand '''pip3 install /python/client'''
+            runCommand '''pip3 install /python/client numba'''
             runCommand '''pip3 install coverage'''
         }
         entrypoint = command

--- a/py/server/setup.py
+++ b/py/server/setup.py
@@ -65,11 +65,6 @@ setup(
         "numpy",
         "pandas>=1.5.0",
         "pyarrow",
-        # TODO(deephaven-core#3082): Clarify dependency requirements wrt numba
-        # It took 6 months for numba to support 3.11 after it was released, we want to make sure deephaven-core will be
-        # installable when 3.13 is out. When we decide to upgrade to 3.13 or higher for testing/production, CI check
-        # will alert us that numba isn't available.
-        'numba; python_version < "3.13"',
     ],
     extras_require={
         "autocomplete": ["jedi==0.19.1", "docstring_parser>=0.16"],


### PR DESCRIPTION
numba has already been made as a soft dep instead of a hard one. Users would need to explicitly opt in  to use numba by installing it themselves.