### PR TITLE
docs: DOC-1261: Add weekly CI check for auto-import documentation sync

### DIFF
--- a/.github/workflows/autoimport-docs-check.yml
+++ b/.github/workflows/autoimport-docs-check.yml
@@ -1,0 +1,77 @@
+name: Auto-Import Docs Sync Check
+
+on:
+  schedule:
+    # Run weekly on Sundays at 3AM UTC
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which docs to check'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - python
+          - groovy
+          - both
+  pull_request:
+    paths:
+      - 'engine/table/src/main/java/io/deephaven/engine/table/lang/impl/QueryLibraryImportsDefaults.java'
+      - 'docs/tools/autoimport/**'
+
+jobs:
+  check-autoimport-docs:
+    if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          lfs: false
+
+      - name: Check if QueryLibraryImportsDefaults changed (PR only)
+        if: ${{ github.event_name == 'pull_request' }}
+        id: check-changed
+        run: |
+          echo "QueryLibraryImportsDefaults.java was modified in this PR."
+          echo "This may require updating the auto-imported function documentation."
+          echo ""
+          echo "If you've added, removed, or modified auto-imported functions, please:"
+          echo "  1. Follow the instructions in docs/tools/autoimport/README.md"
+          echo "  2. Run the generator script in a Deephaven session"
+          echo "  3. Copy the output to docs/python/reference/query-language/query-library/auto-imported/"
+          echo "  4. Copy the output to docs/groovy/reference/query-language/query-library/auto-imported/"
+          echo "  5. Run ./docs/format && ./docs/updateSnapshots"
+
+      - name: Run sync check (scheduled/manual only)
+        if: ${{ github.event_name != 'pull_request' }}
+        id: sync-check
+        run: |
+          chmod +x docs/tools/autoimport/check_autoimport_sync.sh
+          TARGET="${{ github.event.inputs.target || 'both' }}"
+          if ! docs/tools/autoimport/check_autoimport_sync.sh "$TARGET"; then
+            echo "sync_failed=true" >> $GITHUB_OUTPUT
+          else
+            echo "sync_failed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Slack notification on sync failure
+        if: ${{ github.event_name == 'schedule' && steps.sync-check.outputs.sync_failed == 'true' && github.repository_owner == 'deephaven' }}
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "slack_message": "Auto-import documentation sync check failed. Documentation may be out of sync with QueryLibraryImportsDefaults. See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_DDL_DEVREL }}
+
+      - name: Fail if sync check failed
+        if: ${{ github.event_name != 'pull_request' && steps.sync-check.outputs.sync_failed == 'true' }}
+        run: |
+          echo "Auto-import documentation is out of sync!"
+          exit 1

--- a/.github/workflows/autoimport-docs-check.yml
+++ b/.github/workflows/autoimport-docs-check.yml
@@ -3,29 +3,34 @@ name: Auto-Import Docs Sync Check
 on:
   schedule:
     # Run weekly on Sundays at 3AM UTC
-    - cron: '0 3 * * 0'
+    - cron: "0 3 * * 0"
   workflow_dispatch:
     inputs:
       target:
-        description: 'Which docs to check'
+        description: "Which docs to check"
         required: false
-        default: 'both'
+        default: "both"
         type: choice
         options:
           - python
           - groovy
           - both
+      image_tag:
+        description: "Deephaven server image tag to test against"
+        required: false
+        default: "edge"
+        type: string
   pull_request:
     paths:
-      - 'engine/table/src/main/java/io/deephaven/engine/table/lang/impl/QueryLibraryImportsDefaults.java'
-      - 'docs/tools/autoimport/**'
+      - "engine/table/src/main/java/io/deephaven/engine/table/lang/impl/QueryLibraryImportsDefaults.java"
+      - "docs/tools/autoimport/**"
 
 jobs:
   check-autoimport-docs:
     if: ${{ github.repository_owner == 'deephaven' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -52,7 +57,9 @@ jobs:
         run: |
           chmod +x docs/tools/autoimport/check_autoimport_sync.sh
           TARGET="${{ github.event.inputs.target || 'both' }}"
-          if ! docs/tools/autoimport/check_autoimport_sync.sh "$TARGET"; then
+          IMAGE_TAG="${{ github.event.inputs.image_tag || 'edge' }}"
+          echo "Testing against ghcr.io/deephaven/server:$IMAGE_TAG"
+          if ! docs/tools/autoimport/check_autoimport_sync.sh "$TARGET" "$IMAGE_TAG"; then
             echo "sync_failed=true" >> $GITHUB_OUTPUT
           else
             echo "sync_failed=false" >> $GITHUB_OUTPUT

--- a/docs/tools/autoimport/README.md
+++ b/docs/tools/autoimport/README.md
@@ -144,10 +144,14 @@ You can manually run the sync check from the GitHub Actions tab:
 To check locally if docs are in sync:
 
 ```bash
+# Check against default image (edge)
 ./docs/tools/autoimport/check_autoimport_sync.sh
+
+# Check against a specific version
+./docs/tools/autoimport/check_autoimport_sync.sh both 0.36.0
 ```
 
-This requires Docker to be running.
+This requires Docker to be running. The script defaults to the `edge` tag (latest development build).
 
 ### What happens on failure
 

--- a/docs/tools/autoimport/README.md
+++ b/docs/tools/autoimport/README.md
@@ -122,6 +122,42 @@ The script requires:
 - `requests` - For HTTP requests (installed automatically)
 - Deephaven Python client libraries (available in Deephaven session)
 
+## CI Integration
+
+A GitHub Action (`autoimport-docs-check.yml`) monitors the auto-import documentation for sync issues:
+
+### Automatic checks
+
+- **Weekly schedule**: Runs every Sunday at 3AM UTC to detect drift
+- **PR trigger**: Warns when `QueryLibraryImportsDefaults.java` is modified
+
+### Manual trigger
+
+You can manually run the sync check from the GitHub Actions tab:
+
+1. Go to Actions → "Auto-Import Docs Sync Check"
+2. Click "Run workflow"
+3. Select which docs to check (python, groovy, or both)
+
+### Local sync check
+
+To check locally if docs are in sync:
+
+```bash
+./docs/tools/autoimport/check_autoimport_sync.sh
+```
+
+This requires Docker to be running.
+
+### What happens on failure
+
+- **Scheduled runs**: Sends a Slack notification to #ddl-devrel
+- **Manual runs**: Fails the workflow with details about which files differ
+
+### Required secrets
+
+The workflow requires a `SLACK_WEBHOOK_DDL_DEVREL` secret configured in the repository settings for Slack notifications.
+
 ## Notes
 
 - The script must run inside a Deephaven session because it uses `jpy` to introspect Java classes.

--- a/docs/tools/autoimport/check_autoimport_sync.sh
+++ b/docs/tools/autoimport/check_autoimport_sync.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Check if auto-imported function documentation is in sync with the code.
+# This script runs the generator inside a Deephaven Docker container and
+# compares the output with the committed documentation.
+#
+# Usage: ./check_autoimport_sync.sh [python|groovy|both]
+#
+# Exit codes:
+#   0 - Documentation is in sync
+#   1 - Documentation is out of sync (differences found)
+#   2 - Script error
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TARGET="${1:-both}"
+
+# Directories
+PYTHON_DOCS_DIR="$REPO_ROOT/docs/python/reference/query-language/query-library/auto-imported"
+GROOVY_DOCS_DIR="$REPO_ROOT/docs/groovy/reference/query-language/query-library/auto-imported"
+TEMP_DIR=$(mktemp -d)
+OUTPUT_DIR="$TEMP_DIR/autoimport_output"
+
+cleanup() {
+    echo "Cleaning up..."
+    if [ -n "$CONTAINER_ID" ]; then
+        docker stop "$CONTAINER_ID" 2>/dev/null || true
+        docker rm "$CONTAINER_ID" 2>/dev/null || true
+    fi
+    rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+echo "=== Auto-Import Documentation Sync Check ==="
+echo "Repository root: $REPO_ROOT"
+echo "Target: $TARGET"
+echo "Temp directory: $TEMP_DIR"
+echo ""
+
+# Copy the generator script to temp directory
+cp "$SCRIPT_DIR/generate_autoimport_docs.py" "$TEMP_DIR/"
+
+# Modify the script to output to /data/autoimport_output
+# (already configured in the script)
+
+echo "Starting Deephaven server..."
+CONTAINER_ID=$(docker run -d \
+    --rm \
+    -v "$TEMP_DIR:/data" \
+    -p 10042:10000 \
+    ghcr.io/deephaven/server:latest)
+
+echo "Container ID: $CONTAINER_ID"
+echo "Waiting for server to be ready..."
+
+# Wait for server to be ready (up to 120 seconds)
+MAX_WAIT=120
+WAIT_COUNT=0
+until curl -s http://localhost:10042/ide/get_heap_info > /dev/null 2>&1; do
+    sleep 2
+    WAIT_COUNT=$((WAIT_COUNT + 2))
+    if [ $WAIT_COUNT -ge $MAX_WAIT ]; then
+        echo "ERROR: Server did not start within $MAX_WAIT seconds"
+        docker logs "$CONTAINER_ID"
+        exit 2
+    fi
+    echo "  Waiting... ($WAIT_COUNT/$MAX_WAIT seconds)"
+done
+
+echo "Server is ready!"
+echo ""
+echo "Running generator script (this may take several minutes)..."
+
+# Run the script inside the container
+docker exec "$CONTAINER_ID" python -c "exec(open('/data/generate_autoimport_docs.py').read())"
+
+echo ""
+echo "Generation complete. Comparing output..."
+echo ""
+
+# Check if output was generated
+if [ ! -d "$OUTPUT_DIR" ]; then
+    echo "ERROR: Output directory not created"
+    exit 2
+fi
+
+# Compare function
+compare_docs() {
+    local lang="$1"
+    local docs_dir="$2"
+    local has_diff=0
+    
+    echo "=== Checking $lang documentation ==="
+    
+    if [ ! -d "$docs_dir" ]; then
+        echo "WARNING: Documentation directory does not exist: $docs_dir"
+        return 1
+    fi
+    
+    # Compare each generated file (excluding index.md which has language-specific content)
+    for generated_file in "$OUTPUT_DIR"/*.md; do
+        filename=$(basename "$generated_file")
+        
+        # Skip index.md as it has language-specific content
+        if [ "$filename" = "index.md" ]; then
+            continue
+        fi
+        
+        committed_file="$docs_dir/$filename"
+        
+        if [ ! -f "$committed_file" ]; then
+            echo "  MISSING: $filename not found in $lang docs"
+            has_diff=1
+            continue
+        fi
+        
+        # Compare files (ignoring trailing whitespace)
+        if ! diff -q -B "$generated_file" "$committed_file" > /dev/null 2>&1; then
+            echo "  CHANGED: $filename"
+            echo "    Diff preview (first 20 lines):"
+            diff -u "$committed_file" "$generated_file" | head -30 | sed 's/^/      /'
+            has_diff=1
+        else
+            echo "  OK: $filename"
+        fi
+    done
+    
+    return $has_diff
+}
+
+EXIT_CODE=0
+
+if [ "$TARGET" = "python" ] || [ "$TARGET" = "both" ]; then
+    if ! compare_docs "Python" "$PYTHON_DOCS_DIR"; then
+        EXIT_CODE=1
+    fi
+    echo ""
+fi
+
+if [ "$TARGET" = "groovy" ] || [ "$TARGET" = "both" ]; then
+    if ! compare_docs "Groovy" "$GROOVY_DOCS_DIR"; then
+        EXIT_CODE=1
+    fi
+    echo ""
+fi
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "=== SUCCESS: All auto-import documentation is in sync ==="
+else
+    echo "=== FAILURE: Auto-import documentation is out of sync ==="
+    echo ""
+    echo "To update the documentation, run:"
+    echo "  1. Follow the instructions in docs/tools/autoimport/README.md"
+    echo "  2. Copy the generated files to the appropriate docs directory"
+    echo "  3. Run ./docs/format && ./docs/updateSnapshots"
+fi
+
+exit $EXIT_CODE

--- a/docs/tools/autoimport/check_autoimport_sync.sh
+++ b/docs/tools/autoimport/check_autoimport_sync.sh
@@ -4,7 +4,14 @@
 # This script runs the generator inside a Deephaven Docker container and
 # compares the output with the committed documentation.
 #
-# Usage: ./check_autoimport_sync.sh [python|groovy|both]
+# Usage: ./check_autoimport_sync.sh [python|groovy|both] [image_tag]
+#
+# Arguments:
+#   target    - Which docs to check: python, groovy, or both (default: both)
+#   image_tag - Docker image tag to use (default: edge)
+#
+# Environment variables:
+#   DEEPHAVEN_IMAGE_TAG - Alternative way to specify image tag
 #
 # Exit codes:
 #   0 - Documentation is in sync
@@ -16,6 +23,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 TARGET="${1:-both}"
+IMAGE_TAG="${2:-${DEEPHAVEN_IMAGE_TAG:-edge}}"
+IMAGE="ghcr.io/deephaven/server:${IMAGE_TAG}"
 
 # Directories
 PYTHON_DOCS_DIR="$REPO_ROOT/docs/python/reference/query-language/query-library/auto-imported"
@@ -37,6 +46,7 @@ trap cleanup EXIT
 echo "=== Auto-Import Documentation Sync Check ==="
 echo "Repository root: $REPO_ROOT"
 echo "Target: $TARGET"
+echo "Server image: $IMAGE"
 echo "Temp directory: $TEMP_DIR"
 echo ""
 
@@ -51,7 +61,7 @@ CONTAINER_ID=$(docker run -d \
     --rm \
     -v "$TEMP_DIR:/data" \
     -p 10042:10000 \
-    ghcr.io/deephaven/server:latest)
+    "$IMAGE")
 
 echo "Container ID: $CONTAINER_ID"
 echo "Waiting for server to be ready..."


### PR DESCRIPTION
Adds a GitHub Action workflow that:
- Runs weekly (Sundays 3AM UTC) to check if auto-import docs are in sync
- Sends Slack notification to #ddl-devrel on failure
- Can be manually triggered from Actions tab
- Warns on PRs that modify QueryLibraryImportsDefaults.java

Also adds check_autoimport_sync.sh script for local verification.