### PR TITLE
chore: Remove myself from codeowners for workflow files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # security implications.
 #
 # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-/.github/workflows/ @devinrsmith @jcferretti @JamesXNelson @mofojed @rcaudy
+/.github/workflows/ @devinrsmith @jcferretti @JamesXNelson @rcaudy
 
 /CODE_OF_CONDUCT.md @chipkent @rcaudy
 /CONTRIBUTING.md @chipkent @rcaudy


### PR DESCRIPTION
I largely don't touch the core repo, I should probably not be an owner of these.