### PR TITLE
feat: Support reading Parquet ENUM logical type as String

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -393,8 +393,7 @@ public class ParquetSchemaReader {
 
             @Override
             public Optional<Class<?>> visit(final LogicalTypeAnnotation.EnumLogicalTypeAnnotation enumLogicalType) {
-                errorString.setValue("EnumLogicalType");
-                return Optional.empty();
+                return Optional.of(String.class);
             }
 
             @Override

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -361,22 +361,9 @@ public class ParquetSchemaReader {
         return new LogicalTypeAnnotation.LogicalTypeAnnotationVisitor<Class<?>>() {
             @Override
             public Optional<Class<?>> visit(final LogicalTypeAnnotation.StringLogicalTypeAnnotation stringLogicalType) {
-                final ColumnDescriptor column = currentColumn.getValue();
-                final String columnName = column.getPath()[0];
-                final ColumnTypeInfo columnTypeInfo = nonDefaultTypeColumns.get(columnName);
-                final ColumnTypeInfo.SpecialType specialType =
-                        columnTypeInfo == null ? null : columnTypeInfo.specialType().orElse(null);
-                if (specialType != null) {
-                    if (specialType == ColumnTypeInfo.SpecialType.StringSet) {
-                        return Optional.of(StringSet.class);
-                    }
-                    if (specialType != ColumnTypeInfo.SpecialType.Vector) {
-                        throw new UncheckedDeephavenException("Type " + column.getPrimitiveType()
-                                + " for column " + Arrays.toString(column.getPath())
-                                + " with unknown or incompatible special type " + specialType);
-                    }
-                }
-                return Optional.of(String.class);
+                // Delegate to the shared helper so STRING and ENUM are resolved identically,
+                // including any Deephaven-specific SpecialType metadata (StringSet, Vector).
+                return visitStringLike(currentColumn.getValue(), nonDefaultTypeColumns);
             }
 
             @Override
@@ -393,7 +380,10 @@ public class ParquetSchemaReader {
 
             @Override
             public Optional<Class<?>> visit(final LogicalTypeAnnotation.EnumLogicalTypeAnnotation enumLogicalType) {
-                return Optional.of(String.class);
+                // ENUM is physically identical to STRING (UTF-8 encoded BINARY). Delegate to the
+                // shared helper so any future Deephaven SpecialType metadata on ENUM columns is
+                // handled consistently with STRING columns.
+                return visitStringLike(currentColumn.getValue(), nonDefaultTypeColumns);
             }
 
             @Override
@@ -499,5 +489,31 @@ public class ParquetSchemaReader {
                 return Optional.empty();
             }
         };
+    }
+
+    /**
+     * Shared resolution logic for string-like logical types (STRING and ENUM). Both are physically BINARY with UTF-8
+     * encoding, so they map to the same Java types. Centralising the logic here ensures that any Deephaven-specific
+     * {@link ColumnTypeInfo.SpecialType} metadata (e.g. {@code StringSet}, {@code Vector}) is respected for both
+     * annotations consistently, including any new special types added in the future.
+     */
+    private static Optional<Class<?>> visitStringLike(
+            final ColumnDescriptor column,
+            final Map<String, ColumnTypeInfo> nonDefaultTypeColumns) {
+        final String columnName = column.getPath()[0];
+        final ColumnTypeInfo columnTypeInfo = nonDefaultTypeColumns.get(columnName);
+        final ColumnTypeInfo.SpecialType specialType =
+                columnTypeInfo == null ? null : columnTypeInfo.specialType().orElse(null);
+        if (specialType != null) {
+            if (specialType == ColumnTypeInfo.SpecialType.StringSet) {
+                return Optional.of(StringSet.class);
+            }
+            if (specialType != ColumnTypeInfo.SpecialType.Vector) {
+                throw new UncheckedDeephavenException("Type " + column.getPrimitiveType()
+                        + " for column " + Arrays.toString(column.getPath())
+                        + " with unknown or incompatible special type " + specialType);
+            }
+        }
+        return Optional.of(String.class);
     }
 }

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/MinMaxFromStatistics.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/MinMaxFromStatistics.java
@@ -392,7 +392,8 @@ final class MinMaxFromStatistics {
             @NotNull final Consumer<String> maxSetter) {
         final PrimitiveType parquetColType = statistics.type();
         final LogicalTypeAnnotation logicalType = parquetColType.getLogicalTypeAnnotation();
-        if (logicalType instanceof LogicalTypeAnnotation.StringLogicalTypeAnnotation) {
+        if (logicalType instanceof LogicalTypeAnnotation.StringLogicalTypeAnnotation
+                || logicalType instanceof LogicalTypeAnnotation.EnumLogicalTypeAnnotation) {
             verifyPrimitive(statistics, PrimitiveType.PrimitiveTypeName.BINARY);
             final String minString = statistics.minAsString();
             final String maxString = statistics.maxAsString();

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetColumnLocation.java
@@ -537,6 +537,12 @@ final class ParquetColumnLocation<ATTR extends Values> extends AbstractColumnLoc
 
         @Override
         public Optional<ToPage<ATTR, ?>> visit(
+                final LogicalTypeAnnotation.EnumLogicalTypeAnnotation enumLogicalType) {
+            return Optional.of(ToStringPage.create(pageType, columnChunkReader.getDictionarySupplier()));
+        }
+
+        @Override
+        public Optional<ToPage<ATTR, ?>> visit(
                 final LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampLogicalType) {
             if (timestampLogicalType.isAdjustedToUTC()) {
                 // The column will be stored as nanoseconds elapsed since epoch as long values

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -5019,15 +5019,16 @@ public final class ParquetTableReadWriteTest {
         for (final Binary v : values) {
             stats.updateStats(v);
         }
-        try (final java.io.OutputStream os = Files.newOutputStream(dest.toPath())) {
-            final ParquetFileWriter fileWriter = new ParquetFileWriter(dest.toURI(), os,
-                    ParquetInstructions.EMPTY.getTargetPageSize(), new HeapByteBufferAllocator(), schema,
-                    "UNCOMPRESSED", Collections.emptyMap(), NullParquetMetadataFileWriter.INSTANCE, true);
+        // ParquetFileWriter is AutoCloseable, so nest it in its own try-with-resources to
+        // guarantee the file is finalised even if an exception is thrown mid-write.
+        try (final java.io.OutputStream os = Files.newOutputStream(dest.toPath());
+                final ParquetFileWriter fileWriter = new ParquetFileWriter(dest.toURI(), os,
+                        ParquetInstructions.EMPTY.getTargetPageSize(), new HeapByteBufferAllocator(), schema,
+                        "UNCOMPRESSED", Collections.emptyMap(), NullParquetMetadataFileWriter.INSTANCE, true)) {
             final RowGroupWriter rowGroupWriter = fileWriter.addRowGroup(values.length);
             try (final ColumnWriter columnWriter = rowGroupWriter.addColumn("status")) {
                 columnWriter.addPageNoNulls(values, values.length, stats);
             }
-            fileWriter.close();
         }
         checkSingleTable(newTable(stringCol("status", "RED", "GREEN", "BLUE")), dest);
     }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -50,8 +50,12 @@ import io.deephaven.engine.util.TableTools;
 import io.deephaven.engine.util.file.TrackedFileHandleFactory;
 import io.deephaven.parquet.base.BigDecimalParquetBytesCodec;
 import io.deephaven.parquet.base.BigIntegerParquetBytesCodec;
+import io.deephaven.parquet.base.ColumnWriter;
 import io.deephaven.parquet.base.InvalidParquetFileException;
+import io.deephaven.parquet.base.NullParquetMetadataFileWriter;
 import io.deephaven.parquet.base.NullStatistics;
+import io.deephaven.parquet.base.ParquetFileWriter;
+import io.deephaven.parquet.base.RowGroupWriter;
 import io.deephaven.parquet.base.materializers.ParquetMaterializerUtils;
 import io.deephaven.parquet.table.location.ParquetTableLocation;
 import io.deephaven.parquet.table.location.ParquetTableLocationKey;
@@ -76,6 +80,7 @@ import junit.framework.TestCase;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.mutable.MutableFloat;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.statistics.DoubleStatistics;
 import org.apache.parquet.column.statistics.IntStatistics;
@@ -133,6 +138,7 @@ import static io.deephaven.parquet.table.ParquetTools.writeTables;
 import static io.deephaven.util.QueryConstants.*;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
@@ -5000,6 +5006,30 @@ public final class ParquetTableReadWriteTest {
         assertTrue(result.getDefinition().getColumn("String").isDirect());
         assertTrue(result.getDefinition().getColumn("Int").isDirect());
         assertTrue(result.getDefinition().getColumn("Double").isDirect());
+    }
+
+    @Test
+    public void testReadEnumLogicalTypeAsString() throws IOException {
+        final MessageType schema = Types.buildMessage()
+                .required(BINARY).as(LogicalTypeAnnotation.enumType()).named("status")
+                .named("schema");
+        final File dest = new File(rootFile, "enum_logical_type.parquet");
+        final Binary[] values = {Binary.fromString("RED"), Binary.fromString("GREEN"), Binary.fromString("BLUE")};
+        final Statistics<?> stats = Statistics.createStats(schema.getType("status"));
+        for (final Binary v : values) {
+            stats.updateStats(v);
+        }
+        try (final java.io.OutputStream os = Files.newOutputStream(dest.toPath())) {
+            final ParquetFileWriter fileWriter = new ParquetFileWriter(dest.toURI(), os,
+                    ParquetInstructions.EMPTY.getTargetPageSize(), new HeapByteBufferAllocator(), schema,
+                    "UNCOMPRESSED", Collections.emptyMap(), NullParquetMetadataFileWriter.INSTANCE, true);
+            final RowGroupWriter rowGroupWriter = fileWriter.addRowGroup(values.length);
+            try (final ColumnWriter columnWriter = rowGroupWriter.addColumn("status")) {
+                columnWriter.addPageNoNulls(values, values.length, stats);
+            }
+            fileWriter.close();
+        }
+        checkSingleTable(newTable(stringCol("status", "RED", "GREEN", "BLUE")), dest);
     }
 
     private void assertTableStatistics(Table inputTable, File dest) {

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/location/MinMaxFromStatisticsTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/location/MinMaxFromStatisticsTest.java
@@ -649,6 +649,21 @@ public class MinMaxFromStatisticsTest {
     }
 
     @Test
+    public void enumLogicalStatisticsAreRejected() {
+        // ENUM logical type is currently not supported for string min/max statistics
+        final PrimitiveType colType = Types.required(PrimitiveType.PrimitiveTypeName.BINARY)
+                .as(LogicalTypeAnnotation.enumType())
+                .named("enumBinary");
+        final Statistics<?> stats = buildStats(
+                colType, "ALPHA".getBytes(StandardCharsets.UTF_8), "ZETA".getBytes(StandardCharsets.UTF_8), 0L);
+        final MutableObject<String> min = new MutableObject<>();
+        final MutableObject<String> max = new MutableObject<>();
+        assertRejected(
+                MinMaxFromStatistics.getMinMaxForStrings(stats, min::setValue, max::setValue),
+                min, max);
+    }
+
+    @Test
     public void binaryWithoutStringLogicalTypeIsRejected() {
         final PrimitiveType colType = Types.required(PrimitiveType.PrimitiveTypeName.BINARY).named("rawBinary");
         final Statistics<?> stats = buildStats(

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/location/MinMaxFromStatisticsTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/location/MinMaxFromStatisticsTest.java
@@ -649,8 +649,7 @@ public class MinMaxFromStatisticsTest {
     }
 
     @Test
-    public void enumLogicalStatisticsAreRejected() {
-        // ENUM logical type is currently not supported for string min/max statistics
+    public void enumLogicalStatisticsAreMaterialised() {
         final PrimitiveType colType = Types.required(PrimitiveType.PrimitiveTypeName.BINARY)
                 .as(LogicalTypeAnnotation.enumType())
                 .named("enumBinary");
@@ -658,9 +657,10 @@ public class MinMaxFromStatisticsTest {
                 colType, "ALPHA".getBytes(StandardCharsets.UTF_8), "ZETA".getBytes(StandardCharsets.UTF_8), 0L);
         final MutableObject<String> min = new MutableObject<>();
         final MutableObject<String> max = new MutableObject<>();
-        assertRejected(
+        assertMatches(
                 MinMaxFromStatistics.getMinMaxForStrings(stats, min::setValue, max::setValue),
-                min, max);
+                min, "ALPHA",
+                max, "ZETA");
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/deephaven/deephaven-core/issues/7723

## Background

Parquet's `ENUM` logical type is physically identical to `STRING`: both annotate a `BINARY` column with UTF-8 encoded bytes. The only difference is the label. External tools such as Spark and PyArrow use `ENUM` to indicate a column holds a finite set of string values, but the wire format is the same.

Deephaven's read pipeline has three stages where logical type is dispatched. All three previously had no handling for `EnumLogicalTypeAnnotation`, causing ENUM-annotated columns from externally produced files to fail on read.

## Changes

### Stage 1 — Schema to Java type (`ParquetSchemaReader`)

**Before:** `visit(EnumLogicalTypeAnnotation)` set an error string and returned `Optional.empty()`, so the column was unresolvable.

**After:** Returns `Optional.of(String.class)`, the same result as `visit(StringLogicalTypeAnnotation)`.

### Stage 2 — Column data to chunk (`ParquetColumnLocation`)

**Before:** No `visit(EnumLogicalTypeAnnotation)` override existed, so the visitor returned `Optional.empty()` and the read failed at runtime.

**After:** A new override delegates to `ToStringPage.create(...)`, the same decoder used for `STRING` columns.

### Stage 3 — Pushdown statistics (`MinMaxFromStatistics`)

**Before:** `getMinMaxForStrings` only accepted `StringLogicalTypeAnnotation`, so ENUM columns returned `false` and forced a full scan on every filter.

**After:** The condition adds `|| instanceof EnumLogicalTypeAnnotation`, enabling min/max pushdown for ENUM columns.

## Tests

- `MinMaxFromStatisticsTest.enumLogicalStatisticsAreMaterialised` — unit test verifying ENUM statistics are extracted as strings.
- `ParquetTableReadWriteTest.testReadEnumLogicalTypeAsString` — end-to-end test that writes a Parquet file with a `BINARY+ENUM` column and reads it back, verifying the column materializes as `String` with correct values.