### PR TITLE
fix: no-ticket: Disable kafka-native integration test

### DIFF
--- a/extensions/kafka/build.gradle
+++ b/extensions/kafka/build.gradle
@@ -3,10 +3,17 @@ plugins {
     id 'io.deephaven.project.register'
 }
 
-evaluationDependsOn Docker.registryProject('cp-kafka')
-evaluationDependsOn Docker.registryProject('kafka')
-evaluationDependsOn Docker.registryProject('kafka-native')
-evaluationDependsOn Docker.registryProject('redpanda')
+def kafka_images = [
+        'cp-kafka',
+        'kafka',
+        // Disabling kafka-native for now, as it occasionally has segmentation fault on startup
+        // https://issues.apache.org/jira/browse/KAFKA-20314
+        // 'kafka-native',
+        'redpanda'
+]
+kafka_images.each { name ->
+    evaluationDependsOn Docker.registryProject(name)
+}
 
 description 'Kafka: Integrating Engine tables with Kafka'
 
@@ -78,17 +85,10 @@ tasks.register('testOutOfBand', Test) {
         includeTags("testcontainers")
     }
 
-    dependsOn Docker.registryTask(project, 'cp-kafka')
-    systemProperty 'testcontainers.cp-kafka.image', Docker.localImageName('cp-kafka')
-
-    dependsOn Docker.registryTask(project, 'kafka')
-    systemProperty 'testcontainers.kafka.image', Docker.localImageName('kafka')
-
-    dependsOn Docker.registryTask(project, 'kafka-native')
-    systemProperty 'testcontainers.kafka-native.image', Docker.localImageName('kafka-native')
-
-    dependsOn Docker.registryTask(project, 'redpanda')
-    systemProperty 'testcontainers.redpanda.image', Docker.localImageName('redpanda')
+    kafka_images.each { name ->
+        dependsOn Docker.registryTask(project, name)
+        systemProperty "testcontainers.${name}.image", Docker.localImageName(name)
+    }
 
     // Kafka client logging is very verbose; tune it down to only log warn or more severe
     systemProperty 'org.slf4j.simpleLogger.log.org.apache.kafka', 'warn'

--- a/extensions/kafka/src/test/java/io/deephaven/kafka/KafkaToolsIntegrationTest.java
+++ b/extensions/kafka/src/test/java/io/deephaven/kafka/KafkaToolsIntegrationTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
@@ -75,6 +76,7 @@ class KafkaToolsIntegrationTest {
     @EnumSource
     @Timeout(10)
     void simpleKeySimpleValue(final KafkaService kafkaService, final TestInfo testInfo) throws Exception {
+        Assumptions.assumeTrue(kafkaService.isEnabled());
         kafkaService.init();
         final String topic = sanitizedTopicName(testInfo);
         final String keyName = "Key";
@@ -136,6 +138,7 @@ class KafkaToolsIntegrationTest {
     @EnumSource
     @Timeout(10)
     void jsonKeySimpleValue(final KafkaService kafkaService, final TestInfo testInfo) throws Exception {
+        Assumptions.assumeTrue(kafkaService.isEnabled());
         kafkaService.init();
         final String topic = sanitizedTopicName(testInfo);
         final String keyName = "Foo";
@@ -198,6 +201,7 @@ class KafkaToolsIntegrationTest {
     @EnumSource
     @Timeout(10)
     void jsonKeyJsonValue(final KafkaService kafkaService, final TestInfo testInfo) throws Exception {
+        Assumptions.assumeTrue(kafkaService.isEnabled());
         kafkaService.init();
         final String topic = sanitizedTopicName(testInfo);
         final String fooName = "Foo";

--- a/extensions/kafka/src/test/java/io/deephaven/kafka/testcontainers/KafkaService.java
+++ b/extensions/kafka/src/test/java/io/deephaven/kafka/testcontainers/KafkaService.java
@@ -12,10 +12,11 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 public enum KafkaService {
-    CONFLUENT_KAFKA {
+    CONFLUENT_KAFKA(SingletonContainers.Name.CONFLUENT_KAFKA) {
         @Override
         public void init() {
             ConfluentKafka.init();
@@ -26,7 +27,7 @@ public enum KafkaService {
             return ConfluentKafka.propertiesMap();
         }
     },
-    KAFKA {
+    KAFKA(SingletonContainers.Name.KAFKA) {
         @Override
         public void init() {
             Kafka.init();
@@ -37,7 +38,7 @@ public enum KafkaService {
             return Kafka.propertiesMap();
         }
     },
-    KAFKA_NATIVE {
+    KAFKA_NATIVE(SingletonContainers.Name.KAFKA_NATIVE) {
         @Override
         public void init() {
             KafkaNative.init();
@@ -48,7 +49,7 @@ public enum KafkaService {
             return KafkaNative.propertiesMap();
         }
     },
-    REDPANDA {
+    REDPANDA(SingletonContainers.Name.REDPANDA) {
         @Override
         public void init() {
             Redpanda.init();
@@ -60,19 +61,29 @@ public enum KafkaService {
         }
     };
 
+    private final SingletonContainers.Name name;
+
+    KafkaService(SingletonContainers.Name name) {
+        this.name = Objects.requireNonNull(name);
+    }
+
+    public final boolean isEnabled() {
+        return name.isEnabled();
+    }
+
     public abstract void init();
 
     public abstract Map<String, Object> propertiesMap();
 
-    public AdminClient admin() {
+    public final AdminClient admin() {
         return AdminClient.create(propertiesMap());
     }
 
-    public <K, V> KafkaProducer<K, V> producer(Serializer<K> key, Serializer<V> value) {
+    public final <K, V> KafkaProducer<K, V> producer(Serializer<K> key, Serializer<V> value) {
         return new KafkaProducer<>(propertiesMap(), key, value);
     }
 
-    public Properties properties() {
+    public final Properties properties() {
         final Properties properties = new Properties();
         properties.putAll(propertiesMap());
         return properties;

--- a/extensions/kafka/src/test/java/io/deephaven/kafka/testcontainers/SingletonContainers.java
+++ b/extensions/kafka/src/test/java/io/deephaven/kafka/testcontainers/SingletonContainers.java
@@ -11,6 +11,7 @@ import org.testcontainers.redpanda.RedpandaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
+import java.util.Objects;
 
 final class SingletonContainers {
 
@@ -20,7 +21,7 @@ final class SingletonContainers {
      * an ad-hoc basis (by setting the appropriate system property, or by temporarily updating the docker/registry/), or
      * more permanently by adding variants with explicit versions, ie, KAFKA_3_9, KAFKA_4_0, KAFKA_4_1, etc.
      */
-    private enum Name {
+    public enum Name {
         // @formatter:off
         CONFLUENT_KAFKA("cp-kafka", "confluentinc/cp-kafka"),
         KAFKA("kafka", "apache/kafka"),
@@ -28,11 +29,20 @@ final class SingletonContainers {
         REDPANDA("redpanda", "redpandadata/redpanda");
         // @formatter:on
 
-        private final DockerImageName imageName;
+        private final String deephavenImageName;
+        private final String canonicalImageName;
 
-        Name(String deephavenName, String imageName) {
-            final String value = System.getProperty(String.format("testcontainers.%s.image", deephavenName));
-            this.imageName = DockerImageName.parse(value).asCompatibleSubstituteFor(imageName);
+        Name(String deephavenName, String canonicalImageName) {
+            this.deephavenImageName = System.getProperty(String.format("testcontainers.%s.image", deephavenName));
+            this.canonicalImageName = Objects.requireNonNull(canonicalImageName);
+        }
+
+        public boolean isEnabled() {
+            return deephavenImageName != null;
+        }
+
+        public DockerImageName imageName() {
+            return DockerImageName.parse(deephavenImageName).asCompatibleSubstituteFor(canonicalImageName);
         }
     }
 
@@ -49,7 +59,7 @@ final class SingletonContainers {
 
     public static final class ConfluentKafka {
         private static final ConfluentKafkaContainer CONTAINER =
-                new ConfluentKafkaContainer(Name.CONFLUENT_KAFKA.imageName);
+                new ConfluentKafkaContainer(Name.CONFLUENT_KAFKA.imageName());
 
         static {
             startAndAddShutdownHook(CONTAINER);
@@ -71,7 +81,7 @@ final class SingletonContainers {
     }
 
     public static final class Kafka {
-        private static final KafkaContainer CONTAINER = new KafkaContainer(Name.KAFKA.imageName);
+        private static final KafkaContainer CONTAINER = new KafkaContainer(Name.KAFKA.imageName());
 
         static {
             startAndAddShutdownHook(CONTAINER);
@@ -93,7 +103,7 @@ final class SingletonContainers {
     }
 
     public static final class KafkaNative {
-        private static final KafkaContainer CONTAINER = new KafkaContainer(Name.KAFKA_NATIVE.imageName);
+        private static final KafkaContainer CONTAINER = new KafkaContainer(Name.KAFKA_NATIVE.imageName());
 
         static {
             startAndAddShutdownHook(CONTAINER);
@@ -115,7 +125,7 @@ final class SingletonContainers {
     }
 
     public static final class Redpanda {
-        private static final RedpandaContainer CONTAINER = new RedpandaContainer(Name.REDPANDA.imageName);
+        private static final RedpandaContainer CONTAINER = new RedpandaContainer(Name.REDPANDA.imageName());
 
         static {
             startAndAddShutdownHook(CONTAINER);


### PR DESCRIPTION
There is occasionally a segmentation fault when starting the kafka-native image, see https://issues.apache.org/jira/browse/KAFKA-20314