### PR TITLE
chore: no-ticket: bump hadoop-common, add testing

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.hadoop-common-dependencies.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.hadoop-common-dependencies.gradle
@@ -10,13 +10,14 @@ dependencies {
         // done for woodstox, shaded-guava, etc. below. Or we can replace setTransitive(false) here with more
         // exclusions (we want to avoid pulling in netty, loggers, jetty-util, guice and asm).
     }
+    // See testing in extensions-hadoop-common-test that justifies these dependencies.
     runtimeOnly(libs.woodstox.core) {
         because "hadoop-common required dependency for Configuration"
     }
     runtimeOnly(libs.hadoop.shaded.guava) {
         because "hadoop-common required dependency for Configuration"
     }
-    runtimeOnly(libs.commons.collections) {
+    runtimeOnly(libs.commons.collections4) {
         because "hadoop-common required dependency for Configuration"
     }
 }

--- a/extensions/hadoop-common-test/build.gradle
+++ b/extensions/hadoop-common-test/build.gradle
@@ -16,6 +16,11 @@ testing {
                 implementation libs.assertj
                 implementation libs.slf4j.api
                 runtimeOnly libs.slf4j.simple
+
+                implementation platform(libs.junit.bom)
+                implementation libs.junit.jupiter
+                runtimeOnly libs.junit.jupiter.engine
+                runtimeOnly libs.junit.platform.launcher
             }
         }
         test {

--- a/extensions/hadoop-common-test/build.gradle
+++ b/extensions/hadoop-common-test/build.gradle
@@ -56,8 +56,6 @@ testing {
                 }
             }
             dependencies {
-                implementation project(':extensions-parquet-base')
-
                 runtimeOnly libs.woodstox.core
                 runtimeOnly libs.commons.collections4
                 // runtimeOnly libs.hadoop.shaded.guava

--- a/extensions/hadoop-common-test/build.gradle
+++ b/extensions/hadoop-common-test/build.gradle
@@ -1,0 +1,73 @@
+plugins {
+    id 'java'
+    id 'jvm-test-suite'
+    id 'io.deephaven.project.register'
+}
+
+testing {
+    suites {
+        configureEach {
+            useJUnitJupiter()
+            dependencies {
+                implementation(libs.hadoop.common) {
+                    transitive = false
+                }
+
+                implementation libs.assertj
+                implementation libs.slf4j.api
+                runtimeOnly libs.slf4j.simple
+            }
+        }
+        test {
+            dependencies {
+                runtimeOnly libs.woodstox.core
+                runtimeOnly libs.commons.collections4
+                runtimeOnly libs.hadoop.shaded.guava
+            }
+        }
+        missingWoodstoxTest(JvmTestSuite) {
+            sources {
+                java {
+                    srcDirs = ['src/missingWoodstoxTest/java']
+                }
+            }
+            dependencies {
+                // runtimeOnly libs.woodstox.core
+                runtimeOnly libs.commons.collections4
+                runtimeOnly libs.hadoop.shaded.guava
+            }
+        }
+        missingCollections4Test(JvmTestSuite) {
+            sources {
+                java {
+                    srcDirs = ['src/missingCollections4Test/java']
+                }
+            }
+            dependencies {
+                runtimeOnly libs.woodstox.core
+                // runtimeOnly libs.commons.collections4
+                runtimeOnly libs.hadoop.shaded.guava
+            }
+        }
+        missingHadoopShadedGuavaTest(JvmTestSuite) {
+            sources {
+                java {
+                    srcDirs = ['src/missingHadoopShadedGuavaTest/java']
+                }
+            }
+            dependencies {
+                implementation project(':extensions-parquet-base')
+
+                runtimeOnly libs.woodstox.core
+                runtimeOnly libs.commons.collections4
+                // runtimeOnly libs.hadoop.shaded.guava
+            }
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn(testing.suites.missingWoodstoxTest)
+    dependsOn(testing.suites.missingCollections4Test)
+    dependsOn(testing.suites.missingHadoopShadedGuavaTest)
+}

--- a/extensions/hadoop-common-test/gradle.properties
+++ b/extensions/hadoop-common-test/gradle.properties
@@ -1,0 +1,1 @@
+io.deephaven.project.ProjectType=JAVA_LOCAL

--- a/extensions/hadoop-common-test/src/missingCollections4Test/java/io/deephaven/MissingCollections4Test.java
+++ b/extensions/hadoop-common-test/src/missingCollections4Test/java/io/deephaven/MissingCollections4Test.java
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+class MissingCollections4Test {
+    /**
+     * If this test is able to successfully create a Configuration, it likely means that hadoop Configuration no longer
+     * depends on collections4, and we should likely remove it from hadoop-common-dependencies.
+     */
+    @Test
+    void constructConfiguration() {
+        try {
+            new Configuration();
+            failBecauseExceptionWasNotThrown(NoClassDefFoundError.class);
+        } catch (final NoClassDefFoundError e) {
+            assertThat(e).hasMessage("org/apache/commons/collections4/map/UnmodifiableMap");
+            assertThat(e).hasCauseInstanceOf(ClassNotFoundException.class);
+        }
+    }
+}

--- a/extensions/hadoop-common-test/src/missingHadoopShadedGuavaTest/java/io/deephaven/MissingHadoopShadedGuavaTest.java
+++ b/extensions/hadoop-common-test/src/missingHadoopShadedGuavaTest/java/io/deephaven/MissingHadoopShadedGuavaTest.java
@@ -4,12 +4,12 @@
 package io.deephaven;
 
 import org.apache.hadoop.conf.Configuration;
-import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 class MissingHadoopShadedGuavaTest {
@@ -37,6 +37,7 @@ class MissingHadoopShadedGuavaTest {
         final Configuration configuration = new Configuration();
         try {
             configuration.get("some.property");
+            failBecauseExceptionWasNotThrown(NoClassDefFoundError.class);
         } catch (final NoClassDefFoundError e) {
             assertThat(e).hasMessage("org/apache/hadoop/thirdparty/com/google/common/collect/Interners");
             assertThat(e).hasCauseInstanceOf(ClassNotFoundException.class);
@@ -53,6 +54,7 @@ class MissingHadoopShadedGuavaTest {
         final Configuration configuration = new Configuration();
         try {
             configuration.set("some.property", "some.value");
+            failBecauseExceptionWasNotThrown(NoClassDefFoundError.class);
         } catch (final NoClassDefFoundError e) {
             assertThat(e).hasMessage("org/apache/hadoop/thirdparty/com/google/common/collect/Interners");
             assertThat(e).hasCauseInstanceOf(ClassNotFoundException.class);

--- a/extensions/hadoop-common-test/src/missingHadoopShadedGuavaTest/java/io/deephaven/MissingHadoopShadedGuavaTest.java
+++ b/extensions/hadoop-common-test/src/missingHadoopShadedGuavaTest/java/io/deephaven/MissingHadoopShadedGuavaTest.java
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven;
+
+import org.apache.hadoop.conf.Configuration;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+class MissingHadoopShadedGuavaTest {
+
+    // We can't test both getProperty and setProperty in the same JVM given the stateful nature classloading errors.
+    // We _could_ create a separate class and use `forkEvery = 1`, but that is extra test orchestration that doesn't add
+    // much value. We'll choose to randomly test one of them for any given test run. (This could theoretically cause
+    // issues if something downstream alerted about tests that flapped from "SUCCESS" to "IGNORED", but we don't have
+    // anything like that right now.)
+    private static final boolean TEST_GET_PROPERTY = ThreadLocalRandom.current().nextBoolean();
+    private static final boolean TEST_SET_PROPERTY = !TEST_GET_PROPERTY;
+
+    @Test
+    void constructConfiguration() {
+        new Configuration();
+    }
+
+    /**
+     * If this test is able to successfully get a property, it likely means that hadoop Configuration no longer depends
+     * on hadoop-shaded-guava, and we should likely remove it from hadoop-common-dependencies.
+     */
+    @Test
+    void getProperty() {
+        assumeThat(TEST_GET_PROPERTY).isTrue();
+        final Configuration configuration = new Configuration();
+        try {
+            configuration.get("some.property");
+        } catch (final NoClassDefFoundError e) {
+            assertThat(e).hasMessage("org/apache/hadoop/thirdparty/com/google/common/collect/Interners");
+            assertThat(e).hasCauseInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    /**
+     * If this test is able to successfully set a property, it likely means that hadoop Configuration no longer depends
+     * on hadoop-shaded-guava, and we should likely remove it from hadoop-common-dependencies.
+     */
+    @Test
+    void setProperty() {
+        assumeThat(TEST_SET_PROPERTY).isTrue();
+        final Configuration configuration = new Configuration();
+        try {
+            configuration.set("some.property", "some.value");
+        } catch (final NoClassDefFoundError e) {
+            assertThat(e).hasMessage("org/apache/hadoop/thirdparty/com/google/common/collect/Interners");
+            assertThat(e).hasCauseInstanceOf(ClassNotFoundException.class);
+        }
+    }
+}

--- a/extensions/hadoop-common-test/src/missingWoodstoxTest/java/io/deephaven/MissingWoodstoxTest.java
+++ b/extensions/hadoop-common-test/src/missingWoodstoxTest/java/io/deephaven/MissingWoodstoxTest.java
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+class MissingWoodstoxTest {
+
+    /**
+     * If this test is able to successfully create a Configuration, it likely means that hadoop Configuration no longer
+     * depends on woodstox, and we should likely remove it from hadoop-common-dependencies.
+     */
+    @Test
+    void constructConfiguration() {
+        try {
+            new Configuration();
+            failBecauseExceptionWasNotThrown(NoClassDefFoundError.class);
+        } catch (final NoClassDefFoundError e) {
+            assertThat(e).hasMessage("com/ctc/wstx/io/InputBootstrapper");
+            assertThat(e).hasCauseInstanceOf(ClassNotFoundException.class);
+        }
+    }
+}

--- a/extensions/hadoop-common-test/src/test/java/io/deephaven/HadoopCommonDependenciesTest.java
+++ b/extensions/hadoop-common-test/src/test/java/io/deephaven/HadoopCommonDependenciesTest.java
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HadoopCommonDependenciesTest {
+    @Test
+    void constructConfiguration() {
+        new Configuration();
+    }
+
+    @Test
+    void getProperty() {
+        final Configuration configuration = new Configuration();
+        assertThat(configuration.get("some.property")).isNull();
+    }
+
+    @Test
+    void setProperty() {
+        final Configuration configuration = new Configuration();
+        configuration.set("some.property", "some.value");
+        assertThat(configuration.get("some.property")).isEqualTo("some.value");
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ guava = "33.4.8-jre"
 gwt = "2.12.2"
 # used by GwtTools
 gwtJetty = "9.4.44.v20210927"
-hadoop = "3.4.1"
+hadoop = "3.4.3"
 hdrhistogram = "2.2.2"
 iceberg = "1.10.1"
 immutables = "2.12.1"
@@ -210,8 +210,8 @@ gwt-user = { module = "org.gwtproject:gwt-user", version.ref = "gwt" }
 hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
 # These are transitive, inlined versions; see io.deephaven.hadoop-common-dependencies
 woodstox-core = { module = "com.fasterxml.woodstox:woodstox-core", version = "6.6.2" }
-hadoop-shaded-guava = { module = "org.apache.hadoop.thirdparty:hadoop-shaded-guava", version = "1.3.0" }
-commons-collections = { module = "commons-collections:commons-collections", version = "3.2.2" }
+hadoop-shaded-guava = { module = "org.apache.hadoop.thirdparty:hadoop-shaded-guava", version = "1.5.0" }
+commons-collections4 = { module = "org.apache.commons:commons-collections4", version = "4.4" }
 
 hdrhistogram = { module = "org.hdrhistogram:HdrHistogram", version.ref = "hdrhistogram" }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -301,6 +301,9 @@ project(':extensions-json-jackson').projectDir = file('extensions/json-jackson')
 include(':extensions-bson-jackson')
 project(':extensions-bson-jackson').projectDir = file('extensions/bson-jackson')
 
+include(':extensions-hadoop-common-test')
+project(':extensions-hadoop-common-test').projectDir = file('extensions/hadoop-common-test')
+
 include(':plugin')
 
 include(':plugin-options')


### PR DESCRIPTION
This bumps hadoop-common from 3.4.1 to 3.4.3 and adds explicit testing to prove hadoop Configuration "works" and classpath testing to prove that without the dependency, hadoop Configuration is "broken".

As part of this bump, the transitive dependencies are as follows:
 * `commons-collections:commons-collections` was changed to `org.apache.commons:commons-collections4`
 * `hadoop-shaded-guava` was bumped from 1.3.0 to 1.5.0
 * `woodstox-core` was left unchanged (still newer than hadoop-common's version)