### PR TITLE
chore: no-ticket: bump jpy to 1.4.0

### DIFF
--- a/docker/registry/server-base/gradle.properties
+++ b/docker/registry/server-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:3619019768f893b47c3cece1095cc84b4d5d5308a5e9650d790b912142f1d032
+deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:ff6c1c32eaa1e4b1d450cf6fc51afa30e1f7c77086a0199a0bf4fa61b0677127

--- a/docker/registry/server-base/gradle.properties
+++ b/docker/registry/server-base/gradle.properties
@@ -1,3 +1,3 @@
 io.deephaven.project.ProjectType=DOCKER_REGISTRY
 deephaven.registry.imageName=ghcr.io/deephaven/server-base:edge
-deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:9a8f04b1c5f64cd0ae27e048e323b72742536a7327fc62ff6fd48b3fe216139d
+deephaven.registry.imageId=ghcr.io/deephaven/server-base@sha256:3619019768f893b47c3cece1095cc84b4d5d5308a5e9650d790b912142f1d032

--- a/docker/server-jetty/src/main/server-jetty/requirements.txt
+++ b/docker/server-jetty/src/main/server-jetty/requirements.txt
@@ -1,20 +1,19 @@
-adbc-driver-manager==1.9.0
-adbc-driver-postgresql==1.9.0
-connectorx==0.4.4; platform.machine == 'x86_64'
+adbc-driver-manager==1.11.0
+adbc-driver-postgresql==1.11.0
+connectorx==0.4.5; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
-docstring_parser==0.17.0
-importlib_resources==6.5.2
+docstring_parser==0.18.0
+importlib_resources==7.1.0
 java-utilities==0.3.0
 jedi==0.19.1
-jpy==1.3.0
-llvmlite==0.45.1
-numba==0.62.1
-numpy==2.3.4
-pandas==2.3.3
-parso==0.8.5
-pyarrow==22.0.0
+jpy==1.4.0
+llvmlite==0.47.0
+numba==0.65.0
+numpy==2.4.4
+packaging==26.1
+pandas==3.0.2
+parso==0.8.6
+pyarrow==24.0.0
 python-dateutil==2.9.0.post0
-pytz==2025.2
 six==1.17.0
 typing_extensions==4.15.0
-tzdata==2025.2

--- a/docker/server-jetty/src/main/server-jetty/requirements.txt
+++ b/docker/server-jetty/src/main/server-jetty/requirements.txt
@@ -9,11 +9,13 @@ jedi==0.19.1
 jpy==1.4.0
 llvmlite==0.47.0
 numba==0.65.0
-numpy==2.4.4
+numpy==2.3.5
 packaging==26.1
-pandas==3.0.2
+pandas==2.3.3
 parso==0.8.6
 pyarrow==24.0.0
 python-dateutil==2.9.0.post0
+pytz==2026.1.post1
 six==1.17.0
 typing_extensions==4.15.0
+tzdata==2026.1

--- a/docker/server/src/main/server-netty/requirements.txt
+++ b/docker/server/src/main/server-netty/requirements.txt
@@ -1,20 +1,19 @@
-adbc-driver-manager==1.9.0
-adbc-driver-postgresql==1.9.0
-connectorx==0.4.4; platform.machine == 'x86_64'
+adbc-driver-manager==1.11.0
+adbc-driver-postgresql==1.11.0
+connectorx==0.4.5; platform.machine == 'x86_64'
 deephaven-plugin==0.6.0
-docstring_parser==0.17.0
-importlib_resources==6.5.2
+docstring_parser==0.18.0
+importlib_resources==7.1.0
 java-utilities==0.3.0
 jedi==0.19.1
-jpy==1.3.0
-llvmlite==0.45.1
-numba==0.62.1
-numpy==2.3.4
-pandas==2.3.3
-parso==0.8.5
-pyarrow==22.0.0
+jpy==1.4.0
+llvmlite==0.47.0
+numba==0.65.0
+numpy==2.4.4
+packaging==26.1
+pandas==3.0.2
+parso==0.8.6
+pyarrow==24.0.0
 python-dateutil==2.9.0.post0
-pytz==2025.2
 six==1.17.0
 typing_extensions==4.15.0
-tzdata==2025.2

--- a/docker/server/src/main/server-netty/requirements.txt
+++ b/docker/server/src/main/server-netty/requirements.txt
@@ -9,11 +9,13 @@ jedi==0.19.1
 jpy==1.4.0
 llvmlite==0.47.0
 numba==0.65.0
-numpy==2.4.4
+numpy==2.3.5
 packaging==26.1
-pandas==3.0.2
+pandas==2.3.3
 parso==0.8.6
 pyarrow==24.0.0
 python-dateutil==2.9.0.post0
+pytz==2026.1.post1
 six==1.17.0
 typing_extensions==4.15.0
+tzdata==2026.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ jdom2 = "2.0.6.1"
 jetbrains = "26.1.0"
 jetty = "12.0.33"
 jetty11 = "11.0.20"
-jpy = "1.3.0"
+jpy = "1.4.0"
 jsinterop = "2.1.0"
 # google is annoying, and have different versions released for the same groupId
 jsinterop-base = "1.1.1"

--- a/py/server/setup.py
+++ b/py/server/setup.py
@@ -60,7 +60,7 @@ setup(
     keywords="Deephaven Development",
     python_requires=">=3.9",
     install_requires=[
-        "jpy>=1.1.0",
+        "jpy>=1.4.0",
         "deephaven-plugin>=0.6.0",
         "numpy",
         "pandas>=1.5.0",


### PR DESCRIPTION
Need follow-up for https://deephaven.atlassian.net/browse/DH-22358 and https://deephaven.atlassian.net/browse/DH-22359