### PR TITLE
fix: DH-22298: Don't send Jetty version in http responses by default

### DIFF
--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -116,6 +116,9 @@ http.add.header.Cross-Origin-Embedder-Policy.value = require-corp
 http.add.header.Cross-Origin-Opener-Policy.enabled = true
 http.add.header.Cross-Origin-Opener-Policy.value = same-origin
 
+# Enabled
+envoy.add.header.X-Deephaven-Community-Version.enabled = true
+
 # As of Core 0.40.0, the ColumnExpressionValidator defaults to "parsed", which is configured below.  In versions 0.39.0
 # and earlier, the "method_name" validator was used.  To restore the older behavior, set ColumnExpressionValidator to
 # "method_name".    

--- a/props/configs/src/main/resources/dh-defaults.prop
+++ b/props/configs/src/main/resources/dh-defaults.prop
@@ -116,9 +116,6 @@ http.add.header.Cross-Origin-Embedder-Policy.value = require-corp
 http.add.header.Cross-Origin-Opener-Policy.enabled = true
 http.add.header.Cross-Origin-Opener-Policy.value = same-origin
 
-# Enabled
-envoy.add.header.X-Deephaven-Community-Version.enabled = true
-
 # As of Core 0.40.0, the ColumnExpressionValidator defaults to "parsed", which is configured below.  In versions 0.39.0
 # and earlier, the "method_name" validator was used.  To restore the older behavior, set ColumnExpressionValidator to
 # "method_name".    

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
@@ -355,7 +355,8 @@ public class JettyBackedGrpcServer implements GrpcServer {
     private static ServerConnector createConnector(Server server, JettyConfig config) {
         // https://www.eclipse.org/jetty/documentation/jetty-11/programming-guide/index.html#pg-server-http-connector-protocol-http2-tls
         final HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.setSendServerVersion(Configuration.getInstance().getBooleanWithDefault("http.send.server.version", false));
+        httpConfig.setSendServerVersion(
+                Configuration.getInstance().getBooleanWithDefault("http.send.server.version", false));
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
         if (!config.extraHeaders().isEmpty()) {

--- a/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
+++ b/server/jetty-11/src/main/java/io/deephaven/server/jetty11/JettyBackedGrpcServer.java
@@ -355,6 +355,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
     private static ServerConnector createConnector(Server server, JettyConfig config) {
         // https://www.eclipse.org/jetty/documentation/jetty-11/programming-guide/index.html#pg-server-http-connector-protocol-http2-tls
         final HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setSendServerVersion(Configuration.getInstance().getBooleanWithDefault("http.send.server.version", false));
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
         if (!config.extraHeaders().isEmpty()) {

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -298,7 +298,8 @@ public class JettyBackedGrpcServer implements GrpcServer {
     private static ServerConnector createConnector(Server server, JettyConfig config) {
         // https://www.eclipse.org/jetty/documentation/jetty-11/programming-guide/index.html#pg-server-http-connector-protocol-http2-tls
         final HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.setSendServerVersion(Configuration.getInstance().getBooleanWithDefault("http.send.server.version", false));
+        httpConfig.setSendServerVersion(
+                Configuration.getInstance().getBooleanWithDefault("http.send.server.version", false));
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
         if (!config.extraHeaders().isEmpty()) {

--- a/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
+++ b/server/jetty/src/main/java/io/deephaven/server/jetty/JettyBackedGrpcServer.java
@@ -298,6 +298,7 @@ public class JettyBackedGrpcServer implements GrpcServer {
     private static ServerConnector createConnector(Server server, JettyConfig config) {
         // https://www.eclipse.org/jetty/documentation/jetty-11/programming-guide/index.html#pg-server-http-connector-protocol-http2-tls
         final HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setSendServerVersion(Configuration.getInstance().getBooleanWithDefault("http.send.server.version", false));
         httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         httpConfig.addCustomizer(new AllowedHttpMethodsCustomizer(config.allowedHttpMethods()));
         if (!config.extraHeaders().isEmpty()) {


### PR DESCRIPTION
This can be re-enabled by setting the config property `http.send.server.version` to true.