### PR TITLE
docs: DOC-1339: Update notebook storage path and add persistence warning

### DIFF
--- a/docs/groovy/how-to-guides/user-interface/file-explorer.md
+++ b/docs/groovy/how-to-guides/user-interface/file-explorer.md
@@ -11,7 +11,10 @@ The File Explorer stores these notebooks, with options to create new notebooks o
 - Right-click any item to delete or rename that file.
 - Drag any item into or out of a folder to organize your files.
 
-Similar to your example data, these files are stored within your Deephaven Docker container, in `/data/notebooks`. See our concept guide, [Access your file system with Docker data volumes](../../conceptual/docker-data-volumes.md) for more information.
+Notebooks are stored within your Deephaven Docker container, in `/data/storage/notebooks`.
+
+> [!WARNING]
+> Notebooks stored inside the container are lost when the container is removed, unless you mount a persistent Docker volume at `/data`. See [Access your file system with Docker data volumes](../../conceptual/docker-data-volumes.md) for instructions on persisting your notebooks across container restarts and removals.
 
 ## Create and organize notebooks
 

--- a/docs/python/how-to-guides/user-interface/file-explorer.md
+++ b/docs/python/how-to-guides/user-interface/file-explorer.md
@@ -11,7 +11,10 @@ The File Explorer stores these notebooks, with options to create new notebooks o
 - Right-click any item to delete or rename that file.
 - Drag any item into or out of a folder to organize your files.
 
-Similar to your example data, these files are stored within your Deephaven Docker container, in `/data/notebooks`. See our concept guide, [Access your file system with Docker data volumes](../../conceptual/docker-data-volumes.md) for more information.
+Notebooks are stored within your Deephaven Docker container, in `/data/storage/notebooks`.
+
+> [!WARNING]
+> Notebooks stored inside the container are lost when the container is removed, unless you mount a persistent Docker volume at `/data`. See [Access your file system with Docker data volumes](../../conceptual/docker-data-volumes.md) for instructions on persisting your notebooks across container restarts and removals.
 
 ## Create and organize notebooks
 


### PR DESCRIPTION
- Corrected notebook storage path from `/data/notebooks` to `/data/storage/notebooks`
- Added warning about notebook loss when container is removed without persistent volume
- Clarified Docker volume mounting instructions for notebook persistence