### PR TITLE
docs: DOC-1300: Add section on manually triggering PUG refresh

### DIFF
--- a/docs/groovy/conceptual/periodic-update-graph-configuration.md
+++ b/docs/groovy/conceptual/periodic-update-graph-configuration.md
@@ -108,4 +108,4 @@ The `OperationInitializerThreadPool.threads` property allows multithreading duri
 - [Parallelizing queries](./query-engine/parallelization.md)
 - [Partitioned tables](../how-to-guides/partitioned-tables.md)
 - [`PeriodicUpdateGraph` Javadoc](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/updategraph/impl/PeriodicUpdateGraph.html)
-- [`TablePublisher`](../reference/table-operations/create/table-publisher.md)
+- [`TablePublisher`](../reference/table-operations/create/TablePublisher.md)

--- a/docs/groovy/conceptual/periodic-update-graph-configuration.md
+++ b/docs/groovy/conceptual/periodic-update-graph-configuration.md
@@ -86,7 +86,7 @@ import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph
 PeriodicUpdateGraph.getInstance("DEFAULT").requestRefresh()
 ```
 
-This does not bypass the normal update cycle—it simply asks the PUG to begin the next cycle as soon as practicable. Updates are still processed in the usual order.
+This does not bypass the normal update cycle - it simply asks the PUG to begin the next cycle as soon as practicable. Updates are still processed in the usual order.
 
 ## Operation Initializer Thread Pool
 

--- a/docs/groovy/conceptual/periodic-update-graph-configuration.md
+++ b/docs/groovy/conceptual/periodic-update-graph-configuration.md
@@ -75,6 +75,19 @@ Use of this property is designed to reduce latency while preventing the PUG from
 
 The `PeriodicUpdateGraph` supports executing within context of a unit test. When this property is set to `true`, added sources are ignored and refresh actions are manually taken by the test harness. The PUG may not be started. This should never be used outside the context of a unit test. As such, the default value is `false`.
 
+## Manually triggering a refresh
+
+By default, the PUG runs on a periodic timer controlled by [`targetCycleDurationMillis`](#targetcycledurationmillis). In some cases, it can be appropriate to trigger the update cycle immediately rather than waiting for the next scheduled tick. A common example is when data is published within the server process — for example, via a `TablePublisher` or a `StreamToBlinkTableAdapter` — and you want the new data handled immediately rather than waiting up to one full cycle duration.
+
+You can request an immediate refresh by calling `requestRefresh()` on the update graph:
+
+```groovy
+import io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph
+PeriodicUpdateGraph.getInstance("DEFAULT").requestRefresh()
+```
+
+This does not bypass the normal update cycle—it simply asks the PUG to begin the next cycle as soon as practicable. Updates are still processed in the usual order.
+
 ## Operation Initializer Thread Pool
 
 The Operation Initializer Thread Pool has one user-configurable property:
@@ -87,10 +100,12 @@ The `OperationInitializerThreadPool.threads` property allows multithreading duri
 
 ## Related documentation
 
-- [Partitioned tables](../how-to-guides/partitioned-tables.md)
-- [Deephaven's design](./deephaven-design.md)
-- [Incremental update model](./table-update-model.md)
-- [The Deephaven DAG](./dag.md)
 - [Core API design](./deephaven-core-api.md)
+- [Deephaven's design](./deephaven-design.md)
+- [The Deephaven DAG](./dag.md)
+- [Incremental update model](./table-update-model.md)
 - [Multithreading in Deephaven](./query-engine/engine-locking.md)
 - [Parallelizing queries](./query-engine/parallelization.md)
+- [Partitioned tables](../how-to-guides/partitioned-tables.md)
+- [`PeriodicUpdateGraph` Javadoc](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/updategraph/impl/PeriodicUpdateGraph.html)
+- [`TablePublisher`](../reference/table-operations/create/table-publisher.md)

--- a/docs/groovy/snapshots/7152b406ae5413c5a588392eba3650ff.json
+++ b/docs/groovy/snapshots/7152b406ae5413c5a588392eba3650ff.json
@@ -1,0 +1,1 @@
+{"file":"conceptual/periodic-update-graph-configuration.md","objects":{}}

--- a/docs/python/conceptual/periodic-update-graph-configuration.md
+++ b/docs/python/conceptual/periodic-update-graph-configuration.md
@@ -80,7 +80,7 @@ The `PeriodicUpdateGraph` supports executing within context of a unit test. When
 
 ## Manually triggering a refresh
 
-By default, the PUG runs on a periodic timer controlled by [`targetCycleDurationMillis`](#targetcycledurationmillis). In some cases, it can be appropriate to trigger the update cycle immediately rather than waiting for the next scheduled tick. A common example is when data is published within the server process — for example, via a [`TablePublisher`](../reference/table-operations/create/table-publisher.md) or a `StreamToBlinkTableAdapter` — and you want the new data handled immediately rather than waiting up to one full cycle duration.
+By default, the PUG runs on a periodic timer controlled by [`targetCycleDurationMillis`](#targetcycledurationmillis). In some cases, it can be appropriate to trigger the update cycle immediately rather than waiting for the next scheduled tick. A common example is when data is published within the server process — for example, via a [`TablePublisher`](../reference/table-operations/create/TablePublisher.md) or a `StreamToBlinkTableAdapter` — and you want the new data handled immediately rather than waiting up to one full cycle duration.
 
 You can request an immediate refresh by calling `requestRefresh()` on the update graph:
 

--- a/docs/python/conceptual/periodic-update-graph-configuration.md
+++ b/docs/python/conceptual/periodic-update-graph-configuration.md
@@ -78,6 +78,23 @@ Use of this property is designed to reduce latency while preventing the PUG from
 
 The `PeriodicUpdateGraph` supports executing within context of a unit test. When this property is set to `true`, added sources are ignored and refresh actions are manually taken by the test harness. The PUG may not be started. This should never be used outside the context of a unit test. As such, the default value is `false`.
 
+## Manually triggering a refresh
+
+By default, the PUG runs on a periodic timer controlled by [`targetCycleDurationMillis`](#targetcycledurationmillis). In some cases, it can be appropriate to trigger the update cycle immediately rather than waiting for the next scheduled tick. A common example is when data is published within the server process — for example, via a [`TablePublisher`](../reference/table-operations/create/table-publisher.md) or a `StreamToBlinkTableAdapter` — and you want the new data handled immediately rather than waiting up to one full cycle duration.
+
+You can request an immediate refresh by calling `requestRefresh()` on the update graph:
+
+```python
+import jpy
+
+_JPeriodicUpdateGraph = jpy.get_type(
+    "io.deephaven.engine.updategraph.impl.PeriodicUpdateGraph"
+)
+_JPeriodicUpdateGraph.getInstance("DEFAULT").requestRefresh()
+```
+
+This does not bypass the normal update cycle—it simply asks the PUG to begin the next cycle as soon as practicable. Updates are still processed in the usual order.
+
 ## Operation Initializer Thread Pool
 
 The Operation Initializer Thread Pool has one user-configurable property:
@@ -93,10 +110,12 @@ The `OperationInitializerThreadPool.threads` property allows multithreading duri
 
 ## Related documentation
 
-- [Partitioned tables](../how-to-guides/partitioned-tables.md)
-- [Deephaven's design](./deephaven-design.md)
-- [Incremental update model](./table-update-model.md)
-- [The Deephaven DAG](./dag.md)
 - [Core API design](./deephaven-core-api.md)
+- [Deephaven's design](./deephaven-design.md)
+- [The Deephaven DAG](./dag.md)
+- [Incremental update model](./table-update-model.md)
 - [Multithreading in Deephaven](./query-engine/engine-locking.md)
 - [Parallelizing queries](./query-engine/parallelization.md)
+- [Partitioned tables](../how-to-guides/partitioned-tables.md)
+- [`PeriodicUpdateGraph` Javadoc](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/updategraph/impl/PeriodicUpdateGraph.html)
+- [`TablePublisher`](../reference/table-operations/create/table-publisher.md)

--- a/docs/python/conceptual/periodic-update-graph-configuration.md
+++ b/docs/python/conceptual/periodic-update-graph-configuration.md
@@ -118,4 +118,4 @@ The `OperationInitializerThreadPool.threads` property allows multithreading duri
 - [Parallelizing queries](./query-engine/parallelization.md)
 - [Partitioned tables](../how-to-guides/partitioned-tables.md)
 - [`PeriodicUpdateGraph` Javadoc](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/updategraph/impl/PeriodicUpdateGraph.html)
-- [`TablePublisher`](../reference/table-operations/create/table-publisher.md)
+- [`TablePublisher`](../reference/table-operations/create/TablePublisher.md)

--- a/docs/python/conceptual/periodic-update-graph-configuration.md
+++ b/docs/python/conceptual/periodic-update-graph-configuration.md
@@ -93,7 +93,7 @@ _JPeriodicUpdateGraph = jpy.get_type(
 _JPeriodicUpdateGraph.getInstance("DEFAULT").requestRefresh()
 ```
 
-This does not bypass the normal update cycle—it simply asks the PUG to begin the next cycle as soon as practicable. Updates are still processed in the usual order.
+This does not bypass the normal update cycle - it simply asks the PUG to begin the next cycle as soon as practicable. Updates are still processed in the usual order.
 
 ## Operation Initializer Thread Pool
 

--- a/docs/python/snapshots/016aaf3205b187b7ea5e7b2542f3dabe.json
+++ b/docs/python/snapshots/016aaf3205b187b7ea5e7b2542f3dabe.json
@@ -1,0 +1,1 @@
+{"file":"conceptual/periodic-update-graph-configuration.md","objects":{}}


### PR DESCRIPTION
Add documentation explaining how to manually trigger a PeriodicUpdateGraph refresh using `requestRefresh()`, with code examples for both Groovy and Python. Reorganize related documentation links alphabetically and add links to PeriodicUpdateGraph Javadoc and TablePublisher.