### PR TITLE
chore(cpp-client): DH-22561: Update Windows build instructions to VS2026

### DIFF
--- a/cpp-client/README-windows.md
+++ b/cpp-client/README-windows.md
@@ -20,7 +20,7 @@ dependencies will be explained in the section for each client.
 
 ### Software prerequisites
 
-1. Install Visual Studio 2022 Community Edition (or Professional, or Enterprise)
+1. Install Visual Studio 2026 Community Edition (or Professional, or Enterprise)
    from here:
 
    https://visualstudio.microsoft.com/downloads/
@@ -29,7 +29,7 @@ dependencies will be explained in the section for each client.
    * "Desktop development with C++"
    * "Python development"
 
-2. Install Python 3.10 from the Microsoft Store
+2. Install Python 3.13 from the Microsoft Store
 
 3. Install Java JDK 21 for Windows from
 
@@ -48,7 +48,7 @@ dependencies will be explained in the section for each client.
 1. Start a x64 Native Tools Command Prompt. Note this is NOT the regular Command Prompt,
    nor is it the Visual Studio Developer Command Prompt. 
 
-* `Start -> V -> Visual Studio 2022 -> x64 Native Tools Command Prompt for VS 2022`
+* `Start -> V -> Visual Studio 2026 -> x64 Native Tools Command Prompt for VS`
 
 2. (Optional) override environment variables
 
@@ -72,7 +72,7 @@ Download the build script:
 
 ```
 cd %HOMEDRIVE%%HOMEPATH%
-curl -O https://raw.githubusercontent.com/deephaven/deephaven-core/refs/heads/main/cpp-client/build-windows-clients.bat`
+curl -O https://raw.githubusercontent.com/deephaven/deephaven-core/refs/heads/main/cpp-client/build-windows-clients.bat
 ```
 
 ## Building the clients


### PR DESCRIPTION
Small changes to build instructions.
Also note the absence of version number at the end of this string is deliberate.

`Start -> V -> Visual Studio 2026 -> x64 Native Tools Command Prompt for VS`

Microsoft seems to be migrating to a world where VS is just called VS and not VS 2026
