### PR TITLE
docs: DOC-1366: Fix typos and add memory considerations for Python UDFs

### DIFF
--- a/docs/python/conceptual/python-java-boundary.md
+++ b/docs/python/conceptual/python-java-boundary.md
@@ -21,7 +21,7 @@ The Python-Java boundary can be crossed numerous times throughout a single query
 
 Here's a screenshot showing execution times between the built-in query language [`sin`](https://deephaven.io/core/javadoc/io/deephaven/function/Numeric.html#sin(double)) function, and [`numpy.sin`](https://numpy.org/doc/stable/reference/generated/numpy.sin.html):
 
-![Print statements. The built-in sine function took 0.045 seconds, while Numpy's sine function took 1.341 seconds](../assets/conceptual/sine-timed.png)
+![Print statements. The built-in sin function took 0.045 seconds, while Numpy's sine function took 1.341 seconds](../assets/conceptual/sine-timed.png)
 
 That's a pretty significant difference in execution time. Below is the code that produces it:
 
@@ -90,18 +90,18 @@ Deephaven uses the Java date-time class. Their proper and efficient use deserves
 
 Efficient queries typically make minimal Python-Java boundary crossings. They all have one thing in common:
 
-**They use methods and variables built-in to the query language.**
+**They use Java methods and variables built-in to the query language.**
+
+When there is a one-to-one translation for a function; you should prefer to use the Java equivalent. If there is no Java equivalent, simply be aware of the size of your data and the number of boundary crossings. In the above example, processing 100,000 rows took an additional 13 milliseconds. If as in this case your data is not large, then 13ms is very likely an acceptable trade-off for simple development.
 
 ## Memory considerations
 
 When using Python user-defined functions (UDFs) in Deephaven query strings, Python memory is allocated outside the Java heap. This has important implications:
 
-- **Python memory is not bounded by the Java heap** — The `-Xmx` JVM setting controls only the Java heap size. Python objects created by UDFs exist in a separate memory space that can grow independently.
+- **Configure Additional Memory** - If a query is known to use significant Python resources you should configure "Additional Memory" in the Code Studio or Advanced Settings in the Persistent Query configuration. On bare metal or podman, this setting is advisory and not enforced; it simply prevents the dispatcher from starting more queries. On Kubernetes, this permits the pod to use more memory.
+- **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. In a Kubernetes environment, if the worker's allocated heap and non-heap memory exceed the permitted size; that worker is terminated. In a bare metal environment, the kernel may select any process co-located with the worker on the same machine. Therefore, it is best practice to segregate infrastructure processes from query processes. It is not possible to segregate the Query Dispatcher process, which starts workers. If the OOM killer selects the dispatcher, then all workers on the machine terminate.
 - **Unbounded memory growth** — Python objects allocated during UDF execution can accumulate over time, especially in long-running or high-throughput queries. This can lead to resident memory far exceeding the configured Java heap size.
 - **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. In Deephaven Enterprise environments, this can affect the dispatcher process, potentially bringing down all child workers.
-
-> [!CAUTION]
-> A query with a 16 GB Java heap using Python UDFs heavily can grow to 100 GB or more of resident memory. Monitor system memory usage when deploying Python-heavy queries in production.
 
 ### Recommendations
 
@@ -110,7 +110,6 @@ To minimize memory risks when using Python UDFs:
 - **Convert performance-critical UDFs to Java** — For frequently called functions, consider implementing them in Java or using built-in query language functions instead.
 - **Avoid allocating large Python objects in UDFs** — Minimize the creation of large data structures within UDF code.
 - **Monitor resident memory** — Track total process memory, not just Java heap usage, for queries using Python UDFs.
-- **Use vectorized operations when possible** — NumPy vectorized operations on entire columns (outside query strings) are often more memory-efficient than per-row UDF calls.
 
 ## The Python API under the hood
 

--- a/docs/python/conceptual/python-java-boundary.md
+++ b/docs/python/conceptual/python-java-boundary.md
@@ -40,7 +40,7 @@ for idx in range(n_tries):
 end = time()
 elapsed = (end - start) / n_tries
 
-print(f"Built-in `sin` function - {(elapsed):.3f} seconds.")
+print(f"Built-in sin function - {(elapsed):.3f} seconds.")
 
 start = time()
 for idx in range(n_tries):
@@ -48,7 +48,7 @@ for idx in range(n_tries):
 end = time()
 elapsed = (end - start) / n_tries
 
-print(f"NumPy `sin` function - {(elapsed):.3f} seconds.")
+print(f"NumPy sin function - {(elapsed):.3f} seconds.")
 ```
 
 Why is [NumPy](https://numpy.org/) so much slower?

--- a/docs/python/conceptual/python-java-boundary.md
+++ b/docs/python/conceptual/python-java-boundary.md
@@ -3,7 +3,7 @@ title: The Python-Java boundary and how it affects query efficiency
 sidebar_label: Python-Java boundary
 ---
 
-This guide discusses the relationship between Python and Java in Deephaven Python queries and it how it affects query efficiency.
+This guide discusses the relationship between Python and Java in Deephaven Python queries and how it affects query efficiency.
 
 ## From Python to Java
 
@@ -21,7 +21,7 @@ The Python-Java boundary can be crossed numerous times throughout a single query
 
 Here's a screenshot showing execution times between the built-in query language [`sin`](https://deephaven.io/core/javadoc/io/deephaven/function/Numeric.html#sin(double)) function, and [`numpy.sin`](https://numpy.org/doc/stable/reference/generated/numpy.sin.html):
 
-![Print statements. The built-in sine function took 0.045 sect=onds, while Numpy's sine function took 1.341 seconds](../assets/conceptual/sine-timed.png)
+![Print statements. The built-in sine function took 0.045 seconds, while Numpy's sine function took 1.341 seconds](../assets/conceptual/sine-timed.png)
 
 That's a pretty significant difference in execution time. Below is the code that produces it:
 
@@ -32,7 +32,7 @@ from time import time
 
 n_tries = 100
 
-source = empty_table(100_000).update(["X = 0.1 * i"])
+source = empty_table(100_000).update(["X = 0.1 * ii"])
 
 start = time()
 for idx in range(n_tries):
@@ -92,6 +92,26 @@ Efficient queries typically make minimal Python-Java boundary crossings. They al
 
 **They use methods and variables built-in to the query language.**
 
+## Memory considerations
+
+When using Python user-defined functions (UDFs) in Deephaven query strings, Python memory is allocated outside the Java heap. This has important implications:
+
+- **Python memory is not bounded by the Java heap** — The `-Xmx` JVM setting controls only the Java heap size. Python objects created by UDFs exist in a separate memory space that can grow independently.
+- **Unbounded memory growth** — Python objects allocated during UDF execution can accumulate over time, especially in long-running or high-throughput queries. This can lead to resident memory far exceeding the configured Java heap size.
+- **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. In Deephaven Enterprise environments, this can affect the dispatcher process, potentially bringing down all child workers.
+
+> [!CAUTION]
+> A query with a 16 GB Java heap using Python UDFs heavily can grow to 100 GB or more of resident memory. Monitor system memory usage when deploying Python-heavy queries in production.
+
+### Recommendations
+
+To minimize memory risks when using Python UDFs:
+
+- **Convert performance-critical UDFs to Java** — For frequently called functions, consider implementing them in Java or using built-in query language functions instead.
+- **Avoid allocating large Python objects in UDFs** — Minimize the creation of large data structures within UDF code.
+- **Monitor resident memory** — Track total process memory, not just Java heap usage, for queries using Python UDFs.
+- **Use vectorized operations when possible** — NumPy vectorized operations on entire columns (outside query strings) are often more memory-efficient than per-row UDF calls.
+
 ## The Python API under the hood
 
 Deephaven's Python API wraps its engine, written in Java, in Python. It adds small amounts of initialization overhead all for the sake of ease of use. For example, the [`update`](../reference/table-operations/select/update.md) table operation creates a new table containing new, in-memory columns for each operation given in a list. Below is a simplified snippet of the Python source code for a Deephaven table with the `update` method.
@@ -121,4 +141,7 @@ Much of Deephaven's Python API looks like this under the hood. It serves two pri
 
 ## Related documentation
 
+- [Query string overview](../how-to-guides/query-string-overview.md)
+- [Python functions in query strings](../how-to-guides/python-functions.md)
+- [Built-in query language functions](../how-to-guides/built-in-functions.md)
 - [Time in Deephaven](../conceptual/time-in-deephaven.md)

--- a/docs/python/conceptual/python-java-boundary.md
+++ b/docs/python/conceptual/python-java-boundary.md
@@ -21,7 +21,7 @@ The Python-Java boundary can be crossed numerous times throughout a single query
 
 Here's a screenshot showing execution times between the built-in query language [`sin`](https://deephaven.io/core/javadoc/io/deephaven/function/Numeric.html#sin(double)) function, and [`numpy.sin`](https://numpy.org/doc/stable/reference/generated/numpy.sin.html):
 
-![Print statements. The built-in sin function took 0.045 seconds, while Numpy's sine function took 1.341 seconds](../assets/conceptual/sine-timed.png)
+![Print statements. The built-in sin function took 0.045 seconds, while NumPy's `sin` function took 1.341 seconds](../assets/conceptual/sine-timed.png)
 
 That's a pretty significant difference in execution time. Below is the code that produces it:
 
@@ -40,7 +40,7 @@ for idx in range(n_tries):
 end = time()
 elapsed = (end - start) / n_tries
 
-print(f"Built-in sine function - {(elapsed):.3f} seconds.")
+print(f"Built-in `sin` function - {(elapsed):.3f} seconds.")
 
 start = time()
 for idx in range(n_tries):
@@ -48,7 +48,7 @@ for idx in range(n_tries):
 end = time()
 elapsed = (end - start) / n_tries
 
-print(f"NumPy sine function - {(elapsed):.3f} seconds.")
+print(f"NumPy `sin` function - {(elapsed):.3f} seconds.")
 ```
 
 Why is [NumPy](https://numpy.org/) so much slower?
@@ -58,7 +58,7 @@ Why is [NumPy](https://numpy.org/) so much slower?
 - When creating `result_numpy`, the query engine uses NumPy's [`sin`](https://numpy.org/doc/stable/reference/generated/numpy.sin.html) method. So, it has to cross the Python-Java boundary twice on each iteration.
   - The first time, it goes from Java to Python to calculate the sine of `X`.
   - The second time, it converts the result from Python to Java.
-  - Deephaven handles data in chunks, so each of these boundary crossings happen for every chunk. There are multiple chunks in 100,000 rows.
+  - Deephaven handles data in chunks, so each of these boundary crossings happens for every chunk. There are multiple chunks in 100,000 rows.
 
 ## What's built into the query language?
 
@@ -76,15 +76,9 @@ Deephaven is written in Java under the hood, so all Java built-in classes are av
   - [java.util.Collections](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Collections.html) - Routines that operate on or return collections.
   - [java.util.Random](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Random.html) - Routines to generate pseudorandom numbers.
 
-Not only that, but Deephaven has its own classes and methods built into the query language.
+Not only that, but Deephaven has its own [classes and methods built into the query language](../how-to-guides/built-in-functions.md).
 
-<!--TODO:
-
-## Deephaven date-times
-
-Deephaven uses the Java date-time class. Their proper and efficient use deserves its own guide. See new guide to learn more.
-
--->
+For guidance on using date-time types efficiently, see [Time in Deephaven](./time-in-deephaven.md).
 
 ## How to minimize the number of boundary crossings
 
@@ -92,16 +86,14 @@ Efficient queries typically make minimal Python-Java boundary crossings. They al
 
 **They use Java methods and variables built-in to the query language.**
 
-When there is a one-to-one translation for a function; you should prefer to use the Java equivalent. If there is no Java equivalent, simply be aware of the size of your data and the number of boundary crossings. In the above example, processing 100,000 rows took an additional 13 milliseconds. If as in this case your data is not large, then 13ms is very likely an acceptable trade-off for simple development.
+When there is a one-to-one translation for a function, you should prefer to use the Java equivalent. If there is no Java equivalent, simply be aware of the size of your data and the number of boundary crossings. In the above example, processing 100,000 rows took an additional 13 milliseconds. If as in this case your data is not large, then 13ms is very likely an acceptable trade-off for simple development.
 
 ## Memory considerations
 
-When using Python user-defined functions (UDFs) in Deephaven query strings, Python memory is allocated outside the Java heap. This has important implications:
+When using [Python user-defined functions (UDFs)](../how-to-guides/python-functions.md) in Deephaven query strings, Python memory is allocated outside the Java heap. This has important implications:
 
-- **Configure Additional Memory** - If a query is known to use significant Python resources you should configure "Additional Memory" in the Code Studio or Advanced Settings in the Persistent Query configuration. On bare metal or podman, this setting is advisory and not enforced; it simply prevents the dispatcher from starting more queries. On Kubernetes, this permits the pod to use more memory.
-- **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. In a Kubernetes environment, if the worker's allocated heap and non-heap memory exceed the permitted size; that worker is terminated. In a bare metal environment, the kernel may select any process co-located with the worker on the same machine. Therefore, it is best practice to segregate infrastructure processes from query processes. It is not possible to segregate the Query Dispatcher process, which starts workers. If the OOM killer selects the dispatcher, then all workers on the machine terminate.
+- **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. In a Kubernetes environment, if the worker's allocated heap and non-heap memory exceed the permitted size, that worker is terminated. In a bare metal environment, the kernel may select any process co-located with the worker on the same machine. If the OOM killer selects the dispatcher, all workers on the machine terminate.
 - **Unbounded memory growth** — Python objects allocated during UDF execution can accumulate over time, especially in long-running or high-throughput queries. This can lead to resident memory far exceeding the configured Java heap size.
-- **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. In Deephaven Enterprise environments, this can affect the dispatcher process, potentially bringing down all child workers.
 
 ### Recommendations
 
@@ -110,6 +102,8 @@ To minimize memory risks when using Python UDFs:
 - **Convert performance-critical UDFs to Java** — For frequently called functions, consider implementing them in Java or using built-in query language functions instead.
 - **Avoid allocating large Python objects in UDFs** — Minimize the creation of large data structures within UDF code.
 - **Monitor resident memory** — Track total process memory, not just Java heap usage, for queries using Python UDFs.
+- **Configure additional memory** — If a query is known to use significant Python resources, configure "Additional Memory" in the Code Studio or Advanced Settings in the Persistent Query configuration. On bare metal or Podman, this setting is advisory and not enforced; it simply prevents the dispatcher from starting more queries. On Kubernetes, this permits the pod to use more memory.
+- **Segregate infrastructure processes from query processes** — This reduces the risk of the OOM killer affecting critical infrastructure. Note that the Query Dispatcher process, which starts workers, cannot be segregated.
 
 ## The Python API under the hood
 
@@ -120,12 +114,13 @@ import jpy
 
 _J_Table = jpy.get_type("io.deephaven.engine.table.Table")
 
+
 class Table:
     def __init__(self, j_table: jpy.JType):
         self.j_table = jpy.cast(j_table, _J_Table)
 
-     def update(self, formulas: Sequence[str]) -> Table:
-         return Table(j_table=self.j_table.update(*formulas))
+    def update(self, formulas: Sequence[str]) -> Table:
+        return Table(j_table=self.j_table.update(*formulas))
 ```
 
 - The Python class `deephaven.table.Table` is a wrapper around the Java class, `io.deephaven.engine.table.Table`. This allows for a Pythonic interface for a Java method.

--- a/docs/python/conceptual/python-java-boundary.md
+++ b/docs/python/conceptual/python-java-boundary.md
@@ -100,7 +100,7 @@ When using [Python user-defined functions (UDFs)](../how-to-guides/python-functi
 To minimize memory risks when using Python UDFs:
 
 - **Convert performance-critical UDFs to Java** — For frequently called functions, consider implementing them in Java or using built-in query language functions instead.
-- **Avoid returning large Python objects in UDFs** — They can remain in Python memory for extended periods, and if not freed in a timely manner, may cause a Python `MemoryError` and crash the worker process. Instead, when possible, have UDFs return only the data needed for table columns, which are typically primitive types and text. In situations where Java is not actively garbage collecting unused table columns that store Python objects, `deephaven.gc_collect()` can be used to attempt to trigger Java GC, but keep in mind that it is advisory only.
+- **Avoid returning large Python objects in UDFs** — They can remain in Python memory for extended periods, and if not freed in a timely manner, may cause a Python `MemoryError` and crash the worker process. Instead, when possible, have UDFs return only the data needed for table columns, which are typically primitive types and text. In situations where Java is not actively garbage collecting unused table columns that store Python objects, you can use `deephaven.gc_collect()` to attempt to trigger Java GC, but keep in mind that it is advisory only.
 - **Monitor resident memory** — Track total process memory, not just Java heap usage, for queries using Python UDFs.
 
 ## The Python API under the hood

--- a/docs/python/conceptual/python-java-boundary.md
+++ b/docs/python/conceptual/python-java-boundary.md
@@ -92,7 +92,7 @@ When there is a one-to-one translation for a function, you should prefer to use 
 
 When using [Python user-defined functions (UDFs)](../how-to-guides/python-functions.md) in Deephaven query strings, Python memory is allocated outside the Java heap. This has important implications:
 
-- **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. In a Kubernetes environment, if the worker's allocated heap and non-heap memory exceed the permitted size, that worker is terminated. In a bare metal environment, the kernel may select any process co-located with the worker on the same machine. If the OOM killer selects the dispatcher, all workers on the machine terminate.
+- **OOM risk** — When total process memory grows too large, the Linux Out-Of-Memory (OOM) killer may terminate processes. This can happen when the combined Java heap and Python memory exceed the available system or container memory.
 - **Unbounded memory growth** — Python objects allocated during UDF execution can accumulate over time, especially in long-running or high-throughput queries. This can lead to resident memory far exceeding the configured Java heap size.
 
 ### Recommendations
@@ -100,10 +100,8 @@ When using [Python user-defined functions (UDFs)](../how-to-guides/python-functi
 To minimize memory risks when using Python UDFs:
 
 - **Convert performance-critical UDFs to Java** — For frequently called functions, consider implementing them in Java or using built-in query language functions instead.
-- **Avoid allocating large Python objects in UDFs** — Minimize the creation of large data structures within UDF code.
+- **Avoid returning large Python objects in UDFs** — They can remain in Python memory for extended periods, and if not freed in a timely manner, may cause a Python `MemoryError` and crash the worker process. Instead, when possible, have UDFs return only the data needed for table columns, which are typically primitive types and text. In situations where Java is not actively garbage collecting unused table columns that store Python objects, `deephaven.gc_collect()` can be used to attempt to trigger Java GC, but keep in mind that it is advisory only.
 - **Monitor resident memory** — Track total process memory, not just Java heap usage, for queries using Python UDFs.
-- **Configure additional memory** — If a query is known to use significant Python resources, configure "Additional Memory" in the Code Studio or Advanced Settings in the Persistent Query configuration. On bare metal or Podman, this setting is advisory and not enforced; it simply prevents the dispatcher from starting more queries. On Kubernetes, this permits the pod to use more memory.
-- **Segregate infrastructure processes from query processes** — This reduces the risk of the OOM killer affecting critical infrastructure. Note that the Query Dispatcher process, which starts workers, cannot be segregated.
 
 ## The Python API under the hood
 

--- a/docs/python/how-to-guides/python-classes.md
+++ b/docs/python/how-to-guides/python-classes.md
@@ -5,6 +5,9 @@ sidebar_label: Classes & Objects
 
 The ability to use your own custom Python [variables](./python-variables.md), [functions](./python-functions.md), classes, and objects in Deephaven query strings is one of its most powerful features. The use of Python classes in query strings follows some basic rules, which are outlined in this guide.
 
+> [!CAUTION]
+> Python classes and objects in query strings have [performance and memory implications](../conceptual/python-java-boundary.md). Python memory grows outside the Java heap and can lead to significant resident memory growth. For performance-critical or high-throughput queries, consider using [built-in query language functions](./built-in-functions.md) instead.
+
 > [!IMPORTANT]
 > Deephaven does not currently support Python [type hints](./python-functions.md#type-hints) for classes. If you want to ensure that the data types of class variables and methods are correct, you must use [type casts](./casting.md) in the query strings.
 

--- a/docs/python/how-to-guides/python-functions.md
+++ b/docs/python/how-to-guides/python-functions.md
@@ -5,6 +5,9 @@ sidebar_label: Functions
 
 The ability to use your own custom Python [variables](./python-variables.md), functions, and [classes](./python-classes.md) in Deephaven query strings is one of its most powerful features. The use of custom Python functions in query strings follows some basic rules, which are outlined in this guide.
 
+> [!CAUTION]
+> Python functions in query strings have [performance and memory implications](../conceptual/python-java-boundary.md). Python memory grows outside the Java heap and can lead to significant resident memory growth. For performance-critical or high-throughput queries, consider using [built-in query language functions](./built-in-functions.md) instead.
+
 ## Call a Python function in a query string
 
 Python functions can be called in query strings just like they can be called in Python code. They follow [query scope](./query-scope.md) rules, which are similar to Python's [LEGB](https://realpython.com/python-scope-legb-rule/) scoping. The following example calls a user-defined Python function in a query string to create a new column in a table:

--- a/docs/python/how-to-guides/query-string-overview.md
+++ b/docs/python/how-to-guides/query-string-overview.md
@@ -132,7 +132,7 @@ For more on query language built-in constants, variables, and functions, see:
 Deephaven's Python-Java interoperability allows you to use Python code in query strings. This powerful feature is facilitated by [jpy](./use-jpy.md), a bidirectional Python-Java bridge usable from both languages.
 
 > [!CAUTION]
-> Care should be taken when calling Python in query strings for [performance reasons](../conceptual/python-java-boundary.md).
+> Care should be taken when calling Python in query strings for [performance and memory reasons](../conceptual/python-java-boundary.md).
 
 The following example uses a Python variable, function, and class in a query string.
 


### PR DESCRIPTION
- Fix typo: "it how it affects" → "how it affects"
- Fix typo: "sect=onds" → "seconds"
- Fix example: use `ii` instead of `i` for consistency
- Add new "Memory considerations" section explaining Python memory growth outside Java heap
- Add caution callouts to Python functions and classes guides about performance/memory implications
- Add related documentation links to query string overview and built-in functions