### PR TITLE
docs: Add warning about empty first update cycle when resolving URIs

### DIFF
--- a/docs/groovy/how-to-guides/use-uris.md
+++ b/docs/groovy/how-to-guides/use-uris.md
@@ -88,6 +88,27 @@ table = resolve("dh+plain://hostname:9876/scope/table_name")
 
 The `resolve` method connects to the specified Deephaven instance, retrieves the table, and returns it as a local reference that you can use in your code.
 
+> [!CAUTION]
+> When you resolve a URI, the first update cycle of the subscribed table is empty. If you run `resolve` and immediately operate on the table data in the same code block, you'll see an empty table. To work with the actual data, either:
+>
+> - **In a notebook**: Run the `resolve` call in a separate cell before operating on the table.
+> - **In a script**: Use `table.awaitUpdate()` to wait for the table to populate before accessing its data.
+
+For example, the following code always prints 0:
+
+```groovy skip-test
+remoteTable = resolve("dh+plain://hostname/scope/someTable")
+println remoteTable.size()  // Always prints 0 in the same code block
+```
+
+To get the actual table size, use `awaitUpdate()` to wait for the table to populate:
+
+```groovy skip-test
+remoteTable = resolve("dh+plain://hostname/scope/someTable")
+remoteTable.awaitUpdate()
+println remoteTable.size()  // Prints the actual size
+```
+
 Let's explore this with a couple of examples.
 
 ## Share tables locally

--- a/docs/groovy/how-to-guides/use-uris.md
+++ b/docs/groovy/how-to-guides/use-uris.md
@@ -89,16 +89,16 @@ table = resolve("dh+plain://hostname:9876/scope/table_name")
 The `resolve` method connects to the specified Deephaven instance, retrieves the table, and returns it as a local reference that you can use in your code.
 
 > [!CAUTION]
-> When you resolve a URI, the first update cycle of the subscribed table is empty. If you run `resolve` and immediately operate on the table data in the same code block, you'll see an empty table. To work with the actual data, either:
+> When you resolve a URI, the first update cycle of the subscribed table is empty. If you run `resolve` and immediately operate on the table data in the same execution, you may see an empty table. To work with the actual data, either:
 >
-> - **In a notebook**: Run the `resolve` call in a separate cell before operating on the table.
+> - **In a notebook**: Run the `resolve` call in a separate execution before operating on the table.
 > - **In a script**: Use `table.awaitUpdate()` to wait for the table to populate before accessing its data.
 
-For example, the following code always prints 0:
+For example, the following code often prints 0:
 
 ```groovy skip-test
 remoteTable = resolve("dh+plain://hostname/scope/someTable")
-println remoteTable.size()  // Always prints 0 in the same code block
+println remoteTable.size()  // Often prints 0 before the table populates
 ```
 
 To get the actual table size, use `awaitUpdate()` to wait for the table to populate:

--- a/docs/python/how-to-guides/use-uris.md
+++ b/docs/python/how-to-guides/use-uris.md
@@ -88,6 +88,27 @@ table = resolve("dh+plain://hostname:9876/scope/table_name")
 
 The `resolve` function connects to the specified Deephaven instance, retrieves the table, and returns it as a local reference that you can use in your code.
 
+> [!CAUTION]
+> When you resolve a URI, the first update cycle of the subscribed table is empty. If you run `resolve` and immediately operate on the table data in the same code block, you'll see an empty table. To work with the actual data, either:
+>
+> - **In a notebook**: Run the `resolve` call in a separate cell before operating on the table.
+> - **In a script**: Use `table.await_update()` to wait for the table to populate before accessing its data.
+
+For example, the following code always prints 0:
+
+```python skip-test
+remote_table = resolve("dh+plain://hostname/scope/some_table")
+print(remote_table.size)  # Always prints 0 in the same code block
+```
+
+To get the actual table size, use `await_update()` to wait for the table to populate:
+
+```python skip-test
+remote_table = resolve("dh+plain://hostname/scope/some_table")
+remote_table.await_update()
+print(remote_table.size)  # Prints the actual size
+```
+
 Let's explore this with a couple of examples.
 
 ## Share tables locally

--- a/docs/python/how-to-guides/use-uris.md
+++ b/docs/python/how-to-guides/use-uris.md
@@ -89,16 +89,16 @@ table = resolve("dh+plain://hostname:9876/scope/table_name")
 The `resolve` function connects to the specified Deephaven instance, retrieves the table, and returns it as a local reference that you can use in your code.
 
 > [!CAUTION]
-> When you resolve a URI, the first update cycle of the subscribed table is empty. If you run `resolve` and immediately operate on the table data in the same code block, you'll see an empty table. To work with the actual data, either:
+> When you resolve a URI, the first update cycle of the subscribed table is empty. If you run `resolve` and immediately operate on the table data in the same execution, you may see an empty table. To work with the actual data, either:
 >
-> - **In a notebook**: Run the `resolve` call in a separate cell before operating on the table.
+> - **In a notebook**: Run the `resolve` call in a separate execution before operating on the table.
 > - **In a script**: Use `table.await_update()` to wait for the table to populate before accessing its data.
 
-For example, the following code always prints 0:
+For example, the following code often prints 0:
 
 ```python skip-test
 remote_table = resolve("dh+plain://hostname/scope/some_table")
-print(remote_table.size)  # Always prints 0 in the same code block
+print(remote_table.size)  # Often prints 0 before the table populates
 ```
 
 To get the actual table size, use `await_update()` to wait for the table to populate:


### PR DESCRIPTION
Add caution note and examples explaining that resolved tables are empty on first update cycle. Document workarounds using separate cells in notebooks or `awaitUpdate()`/`await_update()` in scripts.