### PR TITLE
fix: DH-22589: Permit ObjectVector#get and #iterator in user expressions

### DIFF
--- a/engine/vector/src/main/java/io/deephaven/vector/ObjectVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/ObjectVector.java
@@ -244,6 +244,7 @@ public interface ObjectVector<COMPONENT_TYPE> extends Vector<ObjectVector<COMPON
      */
     abstract class Indirect<COMPONENT_TYPE> implements ObjectVector<COMPONENT_TYPE> {
 
+        @UserInvocationPermitted({"vector"})
         @Override
         public COMPONENT_TYPE[] toArray() {
             final int size = intSize("ObjectVector.toArray");

--- a/engine/vector/src/main/java/io/deephaven/vector/ObjectVector.java
+++ b/engine/vector/src/main/java/io/deephaven/vector/ObjectVector.java
@@ -9,6 +9,7 @@ import io.deephaven.engine.primitive.value.iterator.ValueIterator;
 import io.deephaven.qst.type.GenericVectorType;
 import io.deephaven.qst.type.GenericType;
 import io.deephaven.util.annotations.FinalDefault;
+import io.deephaven.util.annotations.UserInvocationPermitted;
 import io.deephaven.util.compare.ObjectComparisons;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import org.jetbrains.annotations.NotNull;
@@ -38,6 +39,7 @@ public interface ObjectVector<COMPONENT_TYPE> extends Vector<ObjectVector<COMPON
      * @param index An offset into this ObjectVector
      * @return The element at the specified offset, or {@code null}
      */
+    @UserInvocationPermitted({"vector"})
     COMPONENT_TYPE get(long index);
 
     @Override
@@ -58,6 +60,7 @@ public interface ObjectVector<COMPONENT_TYPE> extends Vector<ObjectVector<COMPON
     @Override
     Class<COMPONENT_TYPE> getComponentType();
 
+    @UserInvocationPermitted({"vector"})
     @Override
     @FinalDefault
     default ValueIterator<COMPONENT_TYPE> iterator() {

--- a/server/src/test/java/io/deephaven/server/table/validation/methodlist/TestColumnExpressionValidator.java
+++ b/server/src/test/java/io/deephaven/server/table/validation/methodlist/TestColumnExpressionValidator.java
@@ -468,10 +468,20 @@ public class TestColumnExpressionValidator {
 
     @Test
     public void testVectorAnnotations() {
-        final Table input = TableTools.emptyTable(10).update("A=ii").groupBy();
+        final Table input = TableTools.emptyTable(10)
+                .update("B=(byte)ii", "C=(char)ii", "S=(short)ii", "I=(int)ii", "L=(long)ii", "F=(float)ii",
+                        "D=(double)ii")
+                .groupBy();
         final ColumnExpressionValidator validator = ExpressionValidatorModule
                 .getParsingColumnExpressionValidatorFromConfiguration(Configuration.getInstance());
-        final String[] expressions = new String[] {"A0=A.get(0)", "AS=A.size()", "SV=A.subVector(0, 10)"};
+        final String[] expressions = new String[] {
+                "B0=B.get(0)", "BS=B.size()", "BSV=B.subVector(0, 10)",
+                "C0=C.get(0)", "CS=C.size()", "CSV=C.subVector(0, 10)",
+                "S0=S.get(0)", "SS=S.size()", "SSV=S.subVector(0, 10)",
+                "I0=I.get(0)", "IS=I.size()", "ISV=I.subVector(0, 10)",
+                "L0=L.get(0)", "LS=L.size()", "LSV=L.subVector(0, 10)",
+                "F0=F.get(0)", "FS=F.size()", "FSV=F.subVector(0, 10)",
+                "D0=D.get(0)", "DS=D.size()", "DSV=D.subVector(0, 10)"};
 
         validator.validateColumnExpressions(SelectColumnFactory.getExpressions(expressions), expressions,
                 input.getDefinition());

--- a/server/src/test/java/io/deephaven/server/table/validation/methodlist/TestColumnExpressionValidator.java
+++ b/server/src/test/java/io/deephaven/server/table/validation/methodlist/TestColumnExpressionValidator.java
@@ -478,6 +478,19 @@ public class TestColumnExpressionValidator {
     }
 
     @Test
+    public void testVectorAnnotationsObject() {
+        // ObjectVector<String> — produced by groupBy() on a String column
+        final Table input = TableTools.emptyTable(10).update("A=Long.toString(ii)").groupBy();
+        final ColumnExpressionValidator validator = ExpressionValidatorModule
+                .getParsingColumnExpressionValidatorFromConfiguration(Configuration.getInstance());
+        final String[] expressions =
+                new String[] {"A0=A.get(0)", "AS=A.size()", "SV=A.subVector(0, 10)", "IT=A.iterator()"};
+
+        validator.validateColumnExpressions(SelectColumnFactory.getExpressions(expressions), expressions,
+                input.getDefinition());
+    }
+
+    @Test
     public void testStructuredFiltersNameValidator() {
         testStructuredFiltersValidator(new MethodNameColumnExpressionValidator(),
                 new MethodNameColumnExpressionValidator(Set.of(), Set.of()));


### PR DESCRIPTION
## Pull request overview

This PR updates Deephaven’s user-expression method-permission surface for `ObjectVector` to match the primitive vector interfaces, unblocking common formulas on grouped object columns (e.g., `A.get(0)` on a grouped `String` column).

**Changes:**
- Annotate `ObjectVector#get(long)` and `ObjectVector#iterator()` with `@UserInvocationPermitted({"vector"})` so they are allowed in user formulas.
- Add a regression test covering `ObjectVector<String>` usage from `groupBy()` and validating `get`, `size`, `subVector`, and `iterator` are permitted.