### PR TITLE
docs: DOC-640: Add local development guide for Deephaven libraries

### DIFF
--- a/docs/groovy/how-to-guides/local-development.md
+++ b/docs/groovy/how-to-guides/local-development.md
@@ -13,7 +13,7 @@ Deephaven artifacts are published to Maven Central, so no credentials are requir
 
 Add the Maven Central repository and Deephaven dependencies to your `build.gradle`:
 
-```groovy
+```groovy skip-test
 repositories {
     mavenCentral()
 }
@@ -69,7 +69,7 @@ Browse all available modules on [Maven Central](https://mvnrepository.com/artifa
 
 ## Local unit testing
 
-To use Deephaven table operations in unit tests, you need to open an [ExecutionContext](../../conceptual/execution-context.md).
+To use Deephaven table operations in unit tests, you need to open an [`ExecutionContext`](../../conceptual/execution-context.md).
 
 ### JVM configuration
 
@@ -81,7 +81,7 @@ Deephaven logs JVM internal stats that require the following JVM argument:
 
 Add this to your Gradle test task:
 
-```groovy
+```groovy skip-test
 test {
     jvmArgs '--add-exports=java.management/sun.management=ALL-UNNAMED'
 }
@@ -103,7 +103,7 @@ Or in Maven:
 
 Use JUnit with an ExecutionContext to test table operations:
 
-```java
+```java skip-test
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.context.TestExecutionContext;
 import io.deephaven.engine.table.Table;
@@ -139,7 +139,7 @@ public class MyTableUtilsTest {
 
 Load test data from CSV or Parquet files in your test resources:
 
-```java
+```java skip-test
 import io.deephaven.csv.CsvTools;
 import io.deephaven.parquet.table.ParquetTools;
 
@@ -152,6 +152,6 @@ Table parquetTable = ParquetTools.readTable(getClass().getResource("/test-data.p
 
 ## Related documentation
 
-- [Execution context](../../conceptual/execution-context.md)
+- [Execution context](../conceptual/execution-context.md)
 - [Extract table values](./extract-table-value.md)
 - [Application mode](./application-mode.md)

--- a/docs/groovy/how-to-guides/local-development.md
+++ b/docs/groovy/how-to-guides/local-development.md
@@ -39,7 +39,7 @@ Add dependencies to your `pom.xml`:
 
 ```xml
 <properties>
-    <dhc.version>0.37.0</dhc.version>
+    <dhc.version>0.37.0</dhc.version> <!-- Use the version that matches your Deephaven server -->
 </properties>
 
 <dependencies>
@@ -51,6 +51,21 @@ Add dependencies to your `pom.xml`:
     <dependency>
         <groupId>io.deephaven</groupId>
         <artifactId>deephaven-engine-table</artifactId>
+        <version>${dhc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.deephaven</groupId>
+        <artifactId>deephaven-Configuration</artifactId>
+        <version>${dhc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.deephaven</groupId>
+        <artifactId>deephaven-engine-time</artifactId>
+        <version>${dhc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.deephaven</groupId>
+        <artifactId>deephaven-log-factory</artifactId>
         <version>${dhc.version}</version>
     </dependency>
 </dependencies>
@@ -69,7 +84,7 @@ The dependencies you need depend on what your project does. Here are common patt
 | Date/time utilities                    | `deephaven-engine-time`                          |
 | Logging                                | `deephaven-log-factory`                          |
 
-Browse all available modules on [Maven Central](https://mvnrepository.com/artifact/io.deephaven).
+Browse all available modules on [Maven Central](https://central.sonatype.com/namespace/io.deephaven).
 
 ## Local unit testing
 
@@ -104,6 +119,12 @@ Or in Maven:
 ```
 
 ### Example test setup
+
+Add `deephaven-engine-test-utils` as a test dependency to use `TestExecutionContext`:
+
+```groovy skip-test
+testImplementation "io.deephaven:deephaven-engine-test-utils:$dhcVersion"
+```
 
 Use JUnit with an `ExecutionContext` to test table operations:
 
@@ -142,6 +163,13 @@ public class MyTableUtilsTest {
 ```
 
 ### Reading test data
+
+Add the appropriate extensions as dependencies:
+
+```groovy skip-test
+implementation "io.deephaven:deephaven-extensions-csv:$dhcVersion"
+implementation "io.deephaven:deephaven-extensions-parquet-table:$dhcVersion"
+```
 
 Load test data from CSV or Parquet files in your test resources:
 

--- a/docs/groovy/how-to-guides/local-development.md
+++ b/docs/groovy/how-to-guides/local-development.md
@@ -14,6 +14,10 @@ Deephaven artifacts are published to Maven Central, so no credentials are requir
 Add the Maven Central repository and Deephaven dependencies to your `build.gradle`:
 
 ```groovy skip-test
+plugins {
+    id 'java'
+}
+
 repositories {
     mavenCentral()
 }
@@ -21,10 +25,10 @@ repositories {
 def dhcVersion = '0.37.0' // Use the version that matches your Deephaven server
 
 dependencies {
-    api "io.deephaven:deephaven-engine-api:$dhcVersion"
-    api "io.deephaven:deephaven-engine-table:$dhcVersion"
-    api "io.deephaven:deephaven-Configuration:$dhcVersion"
-    api "io.deephaven:deephaven-FishUtil:$dhcVersion"
+    implementation "io.deephaven:deephaven-engine-api:$dhcVersion"
+    implementation "io.deephaven:deephaven-engine-table:$dhcVersion"
+    implementation "io.deephaven:deephaven-Configuration:$dhcVersion"
+    implementation "io.deephaven:deephaven-engine-time:$dhcVersion"
     implementation "io.deephaven:deephaven-log-factory:$dhcVersion"
 }
 ```
@@ -62,14 +66,14 @@ The dependencies you need depend on what your project does. Here are common patt
 | Read/write CSV files                   | `deephaven-extensions-csv`                       |
 | Read/write Parquet files               | `deephaven-extensions-parquet-table`             |
 | Configuration utilities                | `deephaven-Configuration`                        |
-| Date/time utilities                    | `deephaven-FishUtil`                             |
+| Date/time utilities                    | `deephaven-engine-time`                          |
 | Logging                                | `deephaven-log-factory`                          |
 
 Browse all available modules on [Maven Central](https://mvnrepository.com/artifact/io.deephaven).
 
 ## Local unit testing
 
-To use Deephaven table operations in unit tests, you need to open an [`ExecutionContext`](../../conceptual/execution-context.md).
+To use Deephaven table operations in unit tests, you need to open an [`ExecutionContext`](../conceptual/execution-context.md).
 
 ### JVM configuration
 
@@ -101,12 +105,13 @@ Or in Maven:
 
 ### Example test setup
 
-Use JUnit with an ExecutionContext to test table operations:
+Use JUnit with an `ExecutionContext` to test table operations:
 
 ```java skip-test
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.context.TestExecutionContext;
 import io.deephaven.engine.table.Table;
+import io.deephaven.util.SafeCloseable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -116,16 +121,17 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MyTableUtilsTest {
 
     private static ExecutionContext executionContext;
+    private static SafeCloseable executionContextCloseable;
 
     @BeforeAll
     public static void setUp() {
         executionContext = TestExecutionContext.createForUnitTests();
-        executionContext.open();
+        executionContextCloseable = executionContext.open();
     }
 
     @AfterAll
     public static void tearDown() {
-        executionContext.close();
+        executionContextCloseable.close();
     }
 
     @Test
@@ -143,11 +149,14 @@ Load test data from CSV or Parquet files in your test resources:
 import io.deephaven.csv.CsvTools;
 import io.deephaven.parquet.table.ParquetTools;
 
+import java.nio.file.Paths;
+
 // Read CSV from test resources
 Table csvTable = CsvTools.readCsv(getClass().getResourceAsStream("/test-data.csv"));
 
 // Read Parquet from test resources
-Table parquetTable = ParquetTools.readTable(getClass().getResource("/test-data.parquet").getPath());
+String parquetPath = Paths.get(getClass().getResource("/test-data.parquet").toURI()).toString();
+Table parquetTable = ParquetTools.readTable(parquetPath);
 ```
 
 ## Related documentation

--- a/docs/groovy/how-to-guides/local-development.md
+++ b/docs/groovy/how-to-guides/local-development.md
@@ -1,0 +1,157 @@
+---
+title: Local development with Deephaven libraries
+sidebar_label: Local development
+---
+
+This guide explains how to build Java or Groovy projects that depend on Deephaven Community libraries. This is useful for creating utilities, custom functions, or extensions that work with Deephaven tables.
+
+## Set up your project
+
+Deephaven artifacts are published to Maven Central, so no credentials are required.
+
+### Gradle
+
+Add the Maven Central repository and Deephaven dependencies to your `build.gradle`:
+
+```groovy
+repositories {
+    mavenCentral()
+}
+
+def dhcVersion = '0.37.0' // Use the version that matches your Deephaven server
+
+dependencies {
+    api "io.deephaven:deephaven-engine-api:$dhcVersion"
+    api "io.deephaven:deephaven-engine-table:$dhcVersion"
+    api "io.deephaven:deephaven-Configuration:$dhcVersion"
+    api "io.deephaven:deephaven-FishUtil:$dhcVersion"
+    implementation "io.deephaven:deephaven-log-factory:$dhcVersion"
+}
+```
+
+### Maven
+
+Add dependencies to your `pom.xml`:
+
+```xml
+<properties>
+    <dhc.version>0.37.0</dhc.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>io.deephaven</groupId>
+        <artifactId>deephaven-engine-api</artifactId>
+        <version>${dhc.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.deephaven</groupId>
+        <artifactId>deephaven-engine-table</artifactId>
+        <version>${dhc.version}</version>
+    </dependency>
+</dependencies>
+```
+
+## Common dependencies by use case
+
+The dependencies you need depend on what your project does. Here are common patterns:
+
+| Use case                               | Dependencies                                     |
+| -------------------------------------- | ------------------------------------------------ |
+| Table operations (select, where, join) | `deephaven-engine-api`, `deephaven-engine-table` |
+| Read/write CSV files                   | `deephaven-extensions-csv`                       |
+| Read/write Parquet files               | `deephaven-extensions-parquet-table`             |
+| Configuration utilities                | `deephaven-Configuration`                        |
+| Date/time utilities                    | `deephaven-FishUtil`                             |
+| Logging                                | `deephaven-log-factory`                          |
+
+Browse all available modules on [Maven Central](https://mvnrepository.com/artifact/io.deephaven).
+
+## Local unit testing
+
+To use Deephaven table operations in unit tests, you need to open an [ExecutionContext](../../conceptual/execution-context.md).
+
+### JVM configuration
+
+Deephaven logs JVM internal stats that require the following JVM argument:
+
+```
+--add-exports=java.management/sun.management=ALL-UNNAMED
+```
+
+Add this to your Gradle test task:
+
+```groovy
+test {
+    jvmArgs '--add-exports=java.management/sun.management=ALL-UNNAMED'
+}
+```
+
+Or in Maven:
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <configuration>
+        <argLine>--add-exports=java.management/sun.management=ALL-UNNAMED</argLine>
+    </configuration>
+</plugin>
+```
+
+### Example test setup
+
+Use JUnit with an ExecutionContext to test table operations:
+
+```java
+import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.context.TestExecutionContext;
+import io.deephaven.engine.table.Table;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MyTableUtilsTest {
+
+    private static ExecutionContext executionContext;
+
+    @BeforeAll
+    public static void setUp() {
+        executionContext = TestExecutionContext.createForUnitTests();
+        executionContext.open();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        executionContext.close();
+    }
+
+    @Test
+    public void testTableOperation() {
+        // Your test code here
+    }
+}
+```
+
+### Reading test data
+
+Load test data from CSV or Parquet files in your test resources:
+
+```java
+import io.deephaven.csv.CsvTools;
+import io.deephaven.parquet.table.ParquetTools;
+
+// Read CSV from test resources
+Table csvTable = CsvTools.readCsv(getClass().getResourceAsStream("/test-data.csv"));
+
+// Read Parquet from test resources
+Table parquetTable = ParquetTools.readTable(getClass().getResource("/test-data.parquet").getPath());
+```
+
+## Related documentation
+
+- [Execution context](../../conceptual/execution-context.md)
+- [Extract table values](./extract-table-value.md)
+- [Application mode](./application-mode.md)

--- a/docs/groovy/how-to-guides/local-development.md
+++ b/docs/groovy/how-to-guides/local-development.md
@@ -7,7 +7,7 @@ This guide explains how to build Java or Groovy projects that depend on Deephave
 
 ## Set up your project
 
-Deephaven artifacts are published to Maven Central, so no credentials are required.
+Deephaven publishes artifacts to Maven Central, so no credentials are required.
 
 ### Gradle
 
@@ -75,14 +75,14 @@ Add dependencies to your `pom.xml`:
 
 The dependencies you need depend on what your project does. Here are common patterns:
 
-| Use case                               | Dependencies                                     |
-| -------------------------------------- | ------------------------------------------------ |
+| Use case                                     | Dependencies                                     |
+| -------------------------------------------- | ------------------------------------------------ |
 | Table operations (`select`, `where`, `join`) | `deephaven-engine-api`, `deephaven-engine-table` |
-| Read/write CSV files                   | `deephaven-extensions-csv`                       |
-| Read/write Parquet files               | `deephaven-extensions-parquet-table`             |
-| Configuration utilities                | `deephaven-Configuration`                        |
-| Date/time utilities                    | `deephaven-engine-time`                          |
-| Logging                                | `deephaven-log-factory`                          |
+| Read/write CSV files                         | `deephaven-extensions-csv`                       |
+| Read/write Parquet files                     | `deephaven-extensions-parquet-table`             |
+| Configuration utilities                      | `deephaven-Configuration`                        |
+| Date/time utilities                          | `deephaven-engine-time`                          |
+| Logging                                      | `deephaven-log-factory`                          |
 
 Browse all available modules on [Maven Central](https://central.sonatype.com/namespace/io.deephaven).
 
@@ -118,12 +118,39 @@ Or in Maven:
 </plugin>
 ```
 
+> **Note:** Advanced use cases like the Barrage Java client may require additional JVM arguments: `--add-opens=java.base/java.lang=ALL-UNNAMED`, `--add-opens=java.management/sun.management=ALL-UNNAMED`, and `--add-opens=java.base/java.nio=ALL-UNNAMED`.
+
 ### Example test setup
 
-Add `deephaven-engine-test-utils` as a test dependency to use `TestExecutionContext`:
+Add `deephaven-engine-test-utils` as a test dependency to use `TestExecutionContext`. You also need a logging implementation at runtime:
 
 ```groovy skip-test
 testImplementation "io.deephaven:deephaven-engine-test-utils:$dhcVersion"
+testRuntimeOnly "io.deephaven:deephaven-log-to-slf4j:$dhcVersion"
+testRuntimeOnly 'org.slf4j:slf4j-simple:2.0.9'
+```
+
+Or in Maven:
+
+```xml
+<dependency>
+    <groupId>io.deephaven</groupId>
+    <artifactId>deephaven-engine-test-utils</artifactId>
+    <version>${dhc.version}</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>io.deephaven</groupId>
+    <artifactId>deephaven-log-to-slf4j</artifactId>
+    <version>${dhc.version}</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-simple</artifactId>
+    <version>2.0.9</version>
+    <scope>test</scope>
+</dependency>
 ```
 
 Use JUnit with an `ExecutionContext` to test table operations:
@@ -186,6 +213,8 @@ Table csvTable = CsvTools.readCsv(getClass().getResourceAsStream("/test-data.csv
 String parquetPath = Paths.get(getClass().getResource("/test-data.parquet").toURI()).toString();
 Table parquetTable = ParquetTools.readTable(parquetPath);
 ```
+
+See [`CsvTools.readCsv`](../reference/data-import-export/CSV/readCsv.md) and [`ParquetTools.readTable`](../reference/data-import-export/Parquet/readTable.md) for more options.
 
 ## Related documentation
 

--- a/docs/groovy/how-to-guides/local-development.md
+++ b/docs/groovy/how-to-guides/local-development.md
@@ -77,7 +77,7 @@ The dependencies you need depend on what your project does. Here are common patt
 
 | Use case                               | Dependencies                                     |
 | -------------------------------------- | ------------------------------------------------ |
-| Table operations (select, where, join) | `deephaven-engine-api`, `deephaven-engine-table` |
+| Table operations (`select`, `where`, `join`) | `deephaven-engine-api`, `deephaven-engine-table` |
 | Read/write CSV files                   | `deephaven-extensions-csv`                       |
 | Read/write Parquet files               | `deephaven-extensions-parquet-table`             |
 | Configuration utilities                | `deephaven-Configuration`                        |

--- a/docs/groovy/sidebar.json
+++ b/docs/groovy/sidebar.json
@@ -962,6 +962,10 @@
                     "path": "how-to-guides/install-and-use-java-packages.md"
                   },
                   {
+                    "label": "Local development",
+                    "path": "how-to-guides/local-development.md"
+                  },
+                  {
                     "label": "Production application",
                     "path": "how-to-guides/configuration/configure-production-application.md"
                   },

--- a/docs/python/how-to-guides/local-development.md
+++ b/docs/python/how-to-guides/local-development.md
@@ -1,0 +1,16 @@
+---
+title: Local development with Deephaven libraries
+sidebar_label: Local development
+---
+
+This guide covers building Java or Groovy projects that depend on Deephaven Community libraries. This is useful for creating utilities, custom functions, or extensions that work with Deephaven tables.
+
+Since this involves Java/Groovy development with Gradle or Maven, see the full guide in the Groovy documentation:
+
+**[Local development with Deephaven libraries](/core/groovy/docs/how-to-guides/local-development)**
+
+The guide covers:
+
+- Setting up Gradle or Maven with Deephaven dependencies.
+- Common dependencies by use case.
+- Local unit testing with `ExecutionContext`.

--- a/docs/python/how-to-guides/local-development.md
+++ b/docs/python/how-to-guides/local-development.md
@@ -7,7 +7,7 @@ This guide covers building Java or Groovy projects that depend on Deephaven Comm
 
 Since this involves Java/Groovy development with Gradle or Maven, see the full guide in the Groovy documentation:
 
-**[Local development with Deephaven libraries](/core/groovy/docs/how-to-guides/local-development)**
+- [Local development with Deephaven libraries](/core/groovy/docs/how-to-guides/local-development)
 
 The guide covers:
 

--- a/docs/python/how-to-guides/local-development.md
+++ b/docs/python/how-to-guides/local-development.md
@@ -3,14 +3,210 @@ title: Local development with Deephaven libraries
 sidebar_label: Local development
 ---
 
-This guide covers building Java or Groovy projects that depend on Deephaven Community libraries. This is useful for creating utilities, custom functions, or extensions that work with Deephaven tables.
+This guide explains how to build Python projects that use Deephaven tables locally. This is useful for creating utilities, custom functions, or data pipelines that work with Deephaven tables outside of the Deephaven IDE.
 
-Since this involves Java/Groovy development with Gradle or Maven, see the full guide in the Groovy documentation:
+## Set up your project
 
-- [Local development with Deephaven libraries](/core/groovy/docs/how-to-guides/local-development)
+Install `deephaven-server` to use Deephaven tables in your Python project:
 
-The guide covers:
+```bash
+pip install deephaven-server
+```
 
-- Setting up Gradle or Maven with Deephaven dependencies.
-- Common dependencies by use case.
-- Local unit testing with `ExecutionContext`.
+> **Note:** `deephaven-server` requires Java 17+ and sets up an embedded Deephaven server. Set your `JAVA_HOME` environment variable before running.
+
+### Optional dependencies
+
+| Use case                             | Package                                      |
+| ------------------------------------ | -------------------------------------------- |
+| Connect to a remote Deephaven server | `pydeephaven`                                |
+| Read/write Parquet files             | `pyarrow` (included with `deephaven-server`) |
+| NumPy integration                    | `numpy` (included with `deephaven-server`)   |
+| Pandas integration                   | `pandas` (included with `deephaven-server`)  |
+
+## Local unit testing
+
+To use Deephaven table operations in unit tests, start an embedded server before importing Deephaven modules.
+
+### pytest setup
+
+Create a `conftest.py` file in your test directory to start the server once for all tests:
+
+```python skip-test
+# conftest.py
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def deephaven_server():
+    """Start Deephaven server before any tests run."""
+    from deephaven_server import Server
+
+    server = Server(port=10000, jvm_args=["-Xmx2g"])
+    server.start()
+
+    yield server
+
+    # Server stops automatically when the process ends
+```
+
+> **Note:** You must start the server before importing any `deephaven` modules. The `deephaven_server` import initializes the JVM, and subsequent `deephaven` imports depend on it.
+
+## Example tests
+
+```python skip-test
+# test_my_utils.py
+from deephaven import empty_table, new_table
+from deephaven.column import int_col, string_col
+
+
+def test_table_creation():
+    """Test that we can create a table."""
+    t = empty_table(10).update("X = i", "Y = X * 2")
+
+    assert t.size == 10
+    assert "X" in [col.name for col in t.columns]
+    assert "Y" in [col.name for col in t.columns]
+
+
+def test_table_operations():
+    """Test filtering and aggregation."""
+    t = new_table(
+        [
+            string_col("Category", ["A", "B", "A", "B", "A"]),
+            int_col("Value", [10, 20, 30, 40, 50]),
+        ]
+    )
+
+    # Filter
+    filtered = t.where("Category = `A`")
+    assert filtered.size == 3
+
+    # Aggregate
+    summed = t.sum_by("Category")
+    assert summed.size == 2
+```
+
+Run tests with:
+
+```bash
+pytest tests/ -v
+```
+
+## Testing ticking tables
+
+When testing with [`time_table`](../reference/table-operations/create/timeTable.md) or other ticking tables, use [`await_update`](../reference/table-operations/table-listeners/await-update.md) to wait for updates:
+
+```python skip-test
+from deephaven import time_table
+from deephaven.update_graph import exclusive_lock
+
+
+def test_ticking_table():
+    """Test a ticking table."""
+    t = time_table("PT1S").update("X = ii")
+
+    # Wait for the table to have at least 3 rows
+    with exclusive_lock(t):
+        while t.size < 3:
+            t.await_update(1000)  # Wait up to 1 second
+
+    assert t.size >= 3
+```
+
+## Testing with a remote server
+
+If your code connects to a remote Deephaven server, use `pydeephaven`:
+
+```bash
+pip install pydeephaven
+```
+
+See [Python Client Quickstart](../getting-started/pyclient-quickstart.md) for full setup instructions.
+
+```python skip-test
+# test_client.py
+import pytest
+from pydeephaven import Session
+
+
+@pytest.fixture(scope="module")
+def session():
+    """Connect to a running Deephaven server."""
+    session = Session(host="localhost", port=10000)
+    yield session
+    session.close()
+
+
+def test_fetch_table(session):
+    """Test fetching a table from the server."""
+    # Assumes 'my_table' exists on the server
+    table = session.open_table("my_table")
+    assert table.size > 0
+```
+
+## Project structure
+
+A typical project structure:
+
+```
+my_project/
+├── src/
+│   └── my_utils.py
+├── tests/
+│   ├── conftest.py      # Server setup
+│   ├── test_my_utils.py
+│   └── data/
+│       └── test_data.csv
+├── pyproject.toml
+└── README.md
+```
+
+### Example pyproject.toml
+
+```toml skip-test
+[project]
+name = "my-deephaven-project"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+  "deephaven-server>=0.37.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=7.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+## Reading test data
+
+Load test data from CSV or Parquet files:
+
+```python skip-test
+from deephaven import read_csv
+from deephaven.parquet import read
+
+
+def test_csv_data():
+    """Test with CSV data."""
+    t = read_csv("tests/data/test_data.csv")
+    assert t.size > 0
+
+
+def test_parquet_data():
+    """Test with Parquet data."""
+    t = read("tests/data/test_data.parquet")
+    assert t.size > 0
+```
+
+See [`read_csv`](../reference/data-import-export/CSV/readCsv.md) and [`read`](../reference/data-import-export/Parquet/readTable.md) for more options.
+
+## Related documentation
+
+- [Install with pip](../getting-started/pip-install.md)
+- [Python client quickstart](../getting-started/pyclient-quickstart.md)
+- [Create tables](./new-and-empty-table.md)

--- a/docs/python/how-to-guides/local-development.md
+++ b/docs/python/how-to-guides/local-development.md
@@ -34,23 +34,16 @@ Create a `conftest.py` file in your test directory to start the server once for 
 
 ```python skip-test
 # conftest.py
-import pytest
+from deephaven_server import Server
 
-
-@pytest.fixture(scope="session", autouse=True)
-def deephaven_server():
-    """Start Deephaven server before any tests run."""
-    from deephaven_server import Server
-
-    server = Server(port=10000, jvm_args=["-Xmx2g"])
-    server.start()
-
-    yield server
-
-    # Server stops automatically when the process ends
+# Start the server at module load time.
+# pytest loads conftest.py before collecting test modules, so this runs
+# before any test file imports deephaven.
+_server = Server(port=10000, jvm_args=["-Xmx2g"])
+_server.start()
 ```
 
-> **Note:** You must start the server before importing any `deephaven` modules. The `deephaven_server` import initializes the JVM, and subsequent `deephaven` imports depend on it.
+> **Note:** The server must start before any `deephaven` imports. Since pytest loads `conftest.py` before collecting test modules, starting the server at module level ensures the JVM is ready when test files import `deephaven`.
 
 ## Example tests
 

--- a/docs/python/sidebar.json
+++ b/docs/python/sidebar.json
@@ -1106,6 +1106,10 @@
                     "path": "how-to-guides/install-and-use-java-packages.md"
                   },
                   {
+                    "label": "Local development",
+                    "path": "how-to-guides/local-development.md"
+                  },
+                  {
                     "label": "Production application",
                     "path": "how-to-guides/configuration/configure-production-application.md"
                   },


### PR DESCRIPTION
Add comprehensive guide for building Java/Groovy projects with Deephaven dependencies, covering Gradle/Maven setup, common dependencies by use case, and local unit testing with ExecutionContext. Include cross-reference from Python docs.