### PR TITLE
feat: DH-19747: JS TreeTable save/restore expanded state

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/Column.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/Column.java
@@ -12,7 +12,6 @@ import jsinterop.annotations.JsOptional;
 import jsinterop.annotations.JsProperty;
 import jsinterop.base.Any;
 
-import java.util.Objects;
 import java.util.stream.IntStream;
 import java.util.stream.IntStream.Builder;
 
@@ -79,12 +78,11 @@ public class Column {
         return new CustomColumn(name, CustomColumn.TYPE_NEW, expression, options);
     }
 
-    public Column(int jsIndex, int index, Integer formatColumnIndex, Integer styleColumnIndex, String type, String name,
+    public Column(int jsIndex, int index, Integer styleColumnIndex, String type, String name,
             boolean isPartitionColumn, Integer formatStringColumnIndex, String description,
             boolean inputTableKeyColumn, boolean inputTableValueColumn, boolean isSortable) {
         this.jsIndex = jsIndex;
         this.index = index;
-        assert Objects.equals(formatColumnIndex, styleColumnIndex);
         this.styleColumnIndex = styleColumnIndex;
         this.type = type;
         this.name = name;
@@ -319,12 +317,12 @@ public class Column {
     }
 
     public Column withFormatStringColumnIndex(int formatStringColumnIndex) {
-        return new Column(jsIndex, index, styleColumnIndex, styleColumnIndex, type, name, isPartitionColumn,
+        return new Column(jsIndex, index, styleColumnIndex, type, name, isPartitionColumn,
                 formatStringColumnIndex, description, isInputTableKeyColumn, isInputTableValueColumn, isSortable);
     }
 
     public Column withStyleColumnIndex(int styleColumnIndex) {
-        return new Column(jsIndex, index, styleColumnIndex, styleColumnIndex, type, name, isPartitionColumn,
+        return new Column(jsIndex, index, styleColumnIndex, type, name, isPartitionColumn,
                 formatStringColumnIndex, description, isInputTableKeyColumn, isInputTableValueColumn, isSortable);
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -899,8 +899,7 @@ public class JsTable extends HasLifecycle implements HasTableBinding, JoinableTa
             doExchange.onData(data -> {
                 WebBarrageMessage message;
                 try {
-                    message = reader.parseFrom(barrageSnapshotOptions, cts.columnTypes(),
-                            cts.componentTypes(), data);
+                    message = reader.parseFrom(barrageSnapshotOptions, data);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/Sort.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/Sort.java
@@ -21,7 +21,7 @@ public class Sort {
             REVERSE = "REVERSE";
 
     private static final Column REVERSE_COLUMN =
-            new Column(-1, -1, null, null, "", "__REVERSE_COLUMN", false, null, null, false, false, false);
+            new Column(-1, -1, null, "", "__REVERSE_COLUMN", false, null, null, false, false, false);
 
     private final Column column;
     private String direction;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -22,7 +22,6 @@ import io.deephaven.engine.table.impl.util.BarrageMessage;
 import io.deephaven.extensions.barrage.BarrageMessageWriter;
 import io.deephaven.extensions.barrage.BarrageMessageWriterImpl;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
-import io.deephaven.extensions.barrage.BarrageTypeInfo;
 import io.deephaven.extensions.barrage.chunk.ChunkWriter;
 import io.deephaven.flightjs.protocol.BrowserFlightServiceGrpc;
 import io.deephaven.proto.backplane.grpc.ApplicationServiceGrpc;
@@ -63,8 +62,8 @@ import io.deephaven.proto.backplane.grpc.TypedTicket;
 import io.deephaven.proto.backplane.script.grpc.ConsoleServiceGrpc;
 import io.deephaven.proto.backplane.script.grpc.LogSubscriptionData;
 import io.deephaven.proto.backplane.script.grpc.LogSubscriptionRequest;
-import io.deephaven.web.client.api.barrage.WebBarrageUtils;
 import io.deephaven.web.client.api.barrage.WebChunkWriterFactory;
+import io.deephaven.web.client.api.barrage.data.BarrageColumnType;
 import io.deephaven.web.client.api.barrage.def.InitialTableDefinition;
 import io.deephaven.web.client.api.barrage.stream.AuthenticationInterceptor;
 import io.deephaven.web.client.api.barrage.stream.BiDiStream;
@@ -106,15 +105,14 @@ import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOptional;
 import jsinterop.annotations.JsNullable;
 import jsinterop.base.JsPropertyMap;
-import org.apache.arrow.flatbuf.Field;
-import org.apache.arrow.flatbuf.KeyValue;
 import org.apache.arrow.flatbuf.Message;
 import org.apache.arrow.flatbuf.MessageHeader;
 import org.apache.arrow.flatbuf.Schema;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.FlightServiceGrpc;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -129,11 +127,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -1086,32 +1084,21 @@ public class WorkerConnection {
             context.timeZone = JsTimeZone.getTimeZone(userTimeZone);
         }
 
-        BarrageTypeInfo<Field>[] typeInfos = new BarrageTypeInfo[types.length];
+        List<BarrageColumnType> columnTypes = new ArrayList<>();
         Chunk<Values>[] chunks = new Chunk[types.length];
         for (int i = 0; i < types.length; i++) {
             JsDataHandler handler = JsDataHandler.getHandler(types[i]);
-            Class<?> type = WebBarrageUtils.stringToClass(handler.deephavenType());
-            FlatBufferBuilder b = new FlatBufferBuilder();
-            int typeOffset = handler.writeType(b);
-            Field.startField(b);
-            Field.addType(b, typeOffset);
-            Field.addTypeType(b, handler.typeType());
-            b.finish(Field.endField(b));
-            Field field = Field.getRootAsField(b.dataBuffer());
-            Class<?> componentType = null;
-            if (types[i].endsWith("[]")) {
-                componentType = WebBarrageUtils
-                        .stringToClass(handler.deephavenType().substring(0, handler.deephavenType().length() - 2));
+            columnTypes.add(BarrageColumnType.fromString(columnNames[i], types[i]));
+            if (handler != null) {
+                chunks[i] = ObjectChunk.chunkWrap(handler.process(data[i], context));
+            } else {
+                chunks[i] = ObjectChunk.chunkWrap(data[i]);
             }
-            typeInfos[i] = BarrageTypeInfo.make(type, componentType, field);
-
-            chunks[i] = ObjectChunk.chunkWrap(handler.process(data[i], context));
         }
-        return newTable(columnNames, types, typeInfos, chunks);
+        return newTable(columnTypes, chunks);
     }
 
-    public Promise<JsTable> newTable(String[] columnNames, String[] types, BarrageTypeInfo<Field>[] typeInfos,
-            Chunk<Values>[] data) {
+    public Promise<JsTable> newTable(List<BarrageColumnType> columnTypes, Chunk<Values>[] data) {
         // Store the data using a reference we can clear out, so the data is garbage collected later
         // This means the table can only be created once, but that's probably what we want in this case anyway
         AtomicReference<Chunk<Values>[]> chunkRef = new AtomicReference<>(data);
@@ -1124,53 +1111,91 @@ public class WorkerConnection {
             }
             chunkRef.set(null);
 
-            StreamObserver<BarrageMessageWriter.MessageView> listener = doPutStream(columnNames, types, c, cts.getHandle().makeTicket(), d[0].size());
-            ChunkWriter.Factory f = new WebChunkWriterFactory();
-
+            StreamObserver<BarrageMessageWriter.MessageView> listener = doPutStream(columnTypes, c, cts.getHandle().makeTicket(), d[0].size());
             Flight.FlightDescriptor flightDescriptor = cts.getHandle().makeFlightDescriptor();
-            listener.onNext(bmwFactory.getSchemaView(fb -> writeSimpleSchema(columnNames, types, fb), flightDescriptor));
 
-            ChunkWriter<Chunk<Values>>[] chunkWriters = new ChunkWriter[columnNames.length];
-            for (int i = 0; i < typeInfos.length; i++) {
-                chunkWriters[i] = f.newWriter(typeInfos[i]);
-            }
-
-            BarrageMessage msg = new BarrageMessage();
-            msg.rowsAdded = RowSetFactory.fromRange(0, d[0].size() - 1);
-            msg.rowsIncluded = msg.rowsAdded;
-            msg.rowsRemoved = RowSetFactory.empty();
-            msg.length = d[0].size();
-            msg.addColumnData = new BarrageMessage.AddColumnData[columnNames.length];
-            for (int i = 0; i < columnNames.length; i++) {
-                BarrageMessage.AddColumnData acd = new BarrageMessage.AddColumnData();
-                acd.data = Collections.singletonList(d[i]);
-                msg.addColumnData[i] = acd;
-            }
-            msg.modColumnData = BarrageMessage.ZERO_MOD_COLUMNS;
-            msg.shifted = RowSetShiftData.EMPTY;
-
-            BarrageMessageWriter barrageMessageWriter =
-                    bmwFactory.newMessageWriter(msg, chunkWriters, BarrageMessageWriter.WriteMetricsConsumer.NO_OP);
-            listener.onNext(barrageMessageWriter.getSnapshotView(BarrageSnapshotOptions.builder()
-                    .useDeephavenNulls(true).build()));
-
-            listener.onCompleted();
+            writeTableToStream(columnTypes, listener, flightDescriptor, d);
         }, "creating new table")
                 .refetch()
                 .then(cts -> Promise.resolve(new JsTable(this, cts)));
     }
 
+    private void writeTableToStream(List<BarrageColumnType> columnTypes, StreamObserver<BarrageMessageWriter.MessageView> listener, Flight.@Nullable FlightDescriptor flightDescriptor, Chunk<Values>[] d) {
+        ChunkWriter.Factory f = new WebChunkWriterFactory();
+        listener.onNext(bmwFactory.getSchemaView(fb -> writeSimpleSchema(columnTypes, fb), flightDescriptor));
+
+        ChunkWriter<Chunk<Values>>[] chunkWriters = new ChunkWriter[columnTypes.size()];
+        for (int i = 0; i < columnTypes.size(); i++) {
+            chunkWriters[i] = f.newWriter(columnTypes.get(i).typeInfo());
+        }
+
+        BarrageMessage msg = new BarrageMessage();
+        msg.rowsAdded = RowSetFactory.fromRange(0, d[0].size() - 1);
+        msg.rowsIncluded = msg.rowsAdded;
+        msg.rowsRemoved = RowSetFactory.empty();
+        msg.length = d[0].size();
+        msg.addColumnData = new BarrageMessage.AddColumnData[columnTypes.size()];
+        for (int i = 0; i < columnTypes.size(); i++) {
+            BarrageMessage.AddColumnData acd = new BarrageMessage.AddColumnData();
+            acd.data = Collections.singletonList(d[i]);
+            msg.addColumnData[i] = acd;
+        }
+        msg.modColumnData = BarrageMessage.ZERO_MOD_COLUMNS;
+        msg.shifted = RowSetShiftData.EMPTY;
+
+        BarrageMessageWriter barrageMessageWriter =
+                bmwFactory.newMessageWriter(msg, chunkWriters, BarrageMessageWriter.WriteMetricsConsumer.NO_OP);
+        listener.onNext(barrageMessageWriter.getSnapshotView(BarrageSnapshotOptions.builder()
+                .useDeephavenNulls(true).build()));
+
+        listener.onCompleted();
+    }
+
+    public byte[] newTableToBytes(List<BarrageColumnType> columnTypes, Chunk<Values>[] data) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        AtomicBoolean finished = new AtomicBoolean(false);
+        StreamObserver<BarrageMessageWriter.MessageView> listener = new StreamObserver<>() {
+            @Override
+            public void onNext(BarrageMessageWriter.MessageView value) {
+                try {
+                    value.forEachStream(drainable -> {
+                        try {
+                            drainable.drainTo(out);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+
+            }
+
+            @Override
+            public void onCompleted() {
+                finished.set(true);
+            }
+        };
+        writeTableToStream(columnTypes, listener, null, data);
+        assert out.size() > 0;
+        assert finished.get();
+        return out.toByteArray();
+    }
+
     /**
      * Adapts a table schema and a unary response to a MessageView bidi stream that calls FlightService/DoPut.
      *
-     * @param columnNames the names of the columns to send
-     * @param types the types of the columns to send
+     * @param columnTypes the schema of the table
      * @param unaryObserver a unary observer to receive the final ETCR response or any error that occurs during the stream
      * @param resultTicket the ticket that will contain the table after upload
      * @param size the size of the table being uploaded
      * @return a stream observer which can be given MessageViews from a BarrageMessageWriter
      */
-    private StreamObserver<BarrageMessageWriter.MessageView> doPutStream(String[] columnNames, String[] types, StreamObserver<ExportedTableCreationResponse> unaryObserver, Ticket resultTicket, int size) {
+    private StreamObserver<BarrageMessageWriter.MessageView> doPutStream(List<BarrageColumnType> columnTypes, StreamObserver<ExportedTableCreationResponse> unaryObserver, Ticket resultTicket, int size) {
         // to doPut(), but need to filter out the messages and wait for onComplete
         final StreamObserver<InputStream> observer;
         try {
@@ -1190,7 +1215,7 @@ public class WorkerConnection {
                 public void onCompleted() {
                     // All done, notify caller with a synthetic ETCR
                     FlatBufferBuilder schemaMessageBuilder = new FlatBufferBuilder();
-                    int schemaOffset = writeSimpleSchema(columnNames, types, schemaMessageBuilder);
+                    int schemaOffset = writeSimpleSchema(columnTypes, schemaMessageBuilder);
                     Message.startMessage(schemaMessageBuilder);
                     Message.addHeaderType(schemaMessageBuilder, MessageHeader.Schema);
                     Message.addHeader(schemaMessageBuilder, schemaOffset);
@@ -1241,35 +1266,14 @@ public class WorkerConnection {
     /**
      * Writes a simple schema with the given column names and types.
      *
-     * @param columnNames
-     * @param types
+     * @param columnTypes the schema of the table
      * @param fb
      * @return
      */
-    private static int writeSimpleSchema(String[] columnNames, String[] types, FlatBufferBuilder fb) {
-        int[] fields = new int[columnNames.length];
-        int dhTypeOffset = fb.createString("deephaven:type");
-        for (int i = 0; i < columnNames.length; i++) {
-            String columnName = columnNames[i];
-
-            JsDataHandler writer = JsDataHandler.getHandler(types[i]);
-
-            int nameOffset = fb.createString(columnName);
-            int typeOffset = writer.writeType(fb);
-            int metadataOffset = Field.createCustomMetadataVector(fb, new int[] {
-                    KeyValue.createKeyValue(fb, dhTypeOffset,
-                            fb.createString(writer.deephavenType()))
-            });
-
-            Field.startField(fb);
-            Field.addName(fb, nameOffset);
-            Field.addNullable(fb, true);
-
-            Field.addTypeType(fb, writer.typeType());
-            Field.addType(fb, typeOffset);
-            Field.addCustomMetadata(fb, metadataOffset);
-
-            fields[i] = Field.endField(fb);
+    private static int writeSimpleSchema(List<BarrageColumnType> columnTypes, FlatBufferBuilder fb) {
+        int[] fields = new int[columnTypes.size()];
+        for (int i = 0; i < columnTypes.size(); i++) {
+            fields[i] = columnTypes.get(i).writeField(fb);
         }
         int fieldsOffset = Schema.createFieldsVector(fb, fields);
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -23,7 +23,9 @@ import io.deephaven.extensions.barrage.BarrageMessageWriter;
 import io.deephaven.extensions.barrage.BarrageMessageWriterImpl;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
 import io.deephaven.extensions.barrage.chunk.ChunkWriter;
+import io.deephaven.extensions.barrage.util.ExposedByteArrayOutputStream;
 import io.deephaven.flightjs.protocol.BrowserFlightServiceGrpc;
+import io.deephaven.io.streams.ByteBufferOutputStream;
 import io.deephaven.proto.backplane.grpc.ApplicationServiceGrpc;
 import io.deephaven.proto.backplane.grpc.ApplyPreviewColumnsRequest;
 import io.deephaven.proto.backplane.grpc.ConfigServiceGrpc;
@@ -1111,7 +1113,8 @@ public class WorkerConnection {
             }
             chunkRef.set(null);
 
-            StreamObserver<BarrageMessageWriter.MessageView> listener = doPutStream(columnTypes, c, cts.getHandle().makeTicket(), d[0].size());
+            StreamObserver<BarrageMessageWriter.MessageView> listener =
+                    doPutStream(columnTypes, c, cts.getHandle().makeTicket(), d[0].size());
             Flight.FlightDescriptor flightDescriptor = cts.getHandle().makeFlightDescriptor();
 
             writeTableToStream(columnTypes, listener, flightDescriptor, d);
@@ -1120,7 +1123,9 @@ public class WorkerConnection {
                 .then(cts -> Promise.resolve(new JsTable(this, cts)));
     }
 
-    private void writeTableToStream(List<BarrageColumnType> columnTypes, StreamObserver<BarrageMessageWriter.MessageView> listener, Flight.@Nullable FlightDescriptor flightDescriptor, Chunk<Values>[] d) {
+    private void writeTableToStream(List<BarrageColumnType> columnTypes,
+            StreamObserver<BarrageMessageWriter.MessageView> listener,
+            Flight.@Nullable FlightDescriptor flightDescriptor, Chunk<Values>[] d) {
         ChunkWriter.Factory f = new WebChunkWriterFactory();
         listener.onNext(bmwFactory.getSchemaView(fb -> writeSimpleSchema(columnTypes, fb), flightDescriptor));
 
@@ -1130,15 +1135,22 @@ public class WorkerConnection {
         }
 
         BarrageMessage msg = new BarrageMessage();
-        msg.rowsAdded = RowSetFactory.fromRange(0, d[0].size() - 1);
+        if (d[0].size() > 0) {
+            msg.rowsAdded = RowSetFactory.fromRange(0, d[0].size() - 1);
+        } else {
+            msg.rowsAdded = RowSetFactory.empty();
+        }
+        DomGlobal.console.log(msg.rowsAdded.size() + " rows added");
         msg.rowsIncluded = msg.rowsAdded;
         msg.rowsRemoved = RowSetFactory.empty();
         msg.length = d[0].size();
+        DomGlobal.console.log(msg.length + " length");
         msg.addColumnData = new BarrageMessage.AddColumnData[columnTypes.size()];
         for (int i = 0; i < columnTypes.size(); i++) {
             BarrageMessage.AddColumnData acd = new BarrageMessage.AddColumnData();
             acd.data = Collections.singletonList(d[i]);
             msg.addColumnData[i] = acd;
+            DomGlobal.console.log(acd.data.stream().mapToInt(Chunk::size).sum() + " rows in col");
         }
         msg.modColumnData = BarrageMessage.ZERO_MOD_COLUMNS;
         msg.shifted = RowSetShiftData.EMPTY;
@@ -1151,20 +1163,41 @@ public class WorkerConnection {
         listener.onCompleted();
     }
 
+    /**
+     * Internal API to write a table to a byte array, prefixed with each FlightData message size as a 32bit LE int.
+     * <p>
+     * Note that this is _not_ the IPC format, also used as arrow flight feather v2, as this has no support for app
+     * metadata nor the rest of the surrounding FlightData protobuf. Technically we don't need that metadata for this
+     * use case, but without the rest of the wrapping we cannot reuse the rest of our usual reading/writing code.
+     *
+     * @param columnTypes the types of each column
+     * @param data the chunks to write
+     * @return an array of bytes in the specified internal format
+     */
     public byte[] newTableToBytes(List<BarrageColumnType> columnTypes, Chunk<Values>[] data) {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ExposedByteArrayOutputStream out = new ExposedByteArrayOutputStream();
         AtomicBoolean finished = new AtomicBoolean(false);
+        AtomicReference<Throwable> error = new AtomicReference<>();
         StreamObserver<BarrageMessageWriter.MessageView> listener = new StreamObserver<>() {
             @Override
             public void onNext(BarrageMessageWriter.MessageView value) {
                 try {
+                    AtomicInteger bytesWritten = new AtomicInteger();
+                    int pos = out.size();
+                    // reserve space for the length
+                    out.writeBytes(new byte[4]);
                     value.forEachStream(drainable -> {
                         try {
-                            drainable.drainTo(out);
+                            bytesWritten.addAndGet(drainable.drainTo(out));
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }
                     });
+                    // write the length at the reserved space
+                    for (int i = 0; i < 4; i++) {
+                        out.peekBuffer()[pos + i] = (byte) (0xff & bytesWritten.get() >>> (i * 8));
+                    }
+
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -1172,7 +1205,7 @@ public class WorkerConnection {
 
             @Override
             public void onError(Throwable t) {
-
+                error.set(t);
             }
 
             @Override
@@ -1181,6 +1214,9 @@ public class WorkerConnection {
             }
         };
         writeTableToStream(columnTypes, listener, null, data);
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
         assert out.size() > 0;
         assert finished.get();
         return out.toByteArray();
@@ -1190,12 +1226,14 @@ public class WorkerConnection {
      * Adapts a table schema and a unary response to a MessageView bidi stream that calls FlightService/DoPut.
      *
      * @param columnTypes the schema of the table
-     * @param unaryObserver a unary observer to receive the final ETCR response or any error that occurs during the stream
+     * @param unaryObserver a unary observer to receive the final ETCR response or any error that occurs during the
+     *        stream
      * @param resultTicket the ticket that will contain the table after upload
      * @param size the size of the table being uploaded
      * @return a stream observer which can be given MessageViews from a BarrageMessageWriter
      */
-    private StreamObserver<BarrageMessageWriter.MessageView> doPutStream(List<BarrageColumnType> columnTypes, StreamObserver<ExportedTableCreationResponse> unaryObserver, Ticket resultTicket, int size) {
+    private StreamObserver<BarrageMessageWriter.MessageView> doPutStream(List<BarrageColumnType> columnTypes,
+            StreamObserver<ExportedTableCreationResponse> unaryObserver, Ticket resultTicket, int size) {
         // to doPut(), but need to filter out the messages and wait for onComplete
         final StreamObserver<InputStream> observer;
         try {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1112,7 +1112,7 @@ public class WorkerConnection {
 
     public Promise<JsTable> newTable(String[] columnNames, String[] types, BarrageTypeInfo<Field>[] typeInfos,
             Chunk<Values>[] data) {
-        // Store the data using a refernce we can clear out, so the data is garbage collected later
+        // Store the data using a reference we can clear out, so the data is garbage collected later
         // This means the table can only be created once, but that's probably what we want in this case anyway
         AtomicReference<Chunk<Values>[]> chunkRef = new AtomicReference<>(data);
 
@@ -1124,107 +1124,11 @@ public class WorkerConnection {
             }
             chunkRef.set(null);
 
-            ToIntFunction<FlatBufferBuilder> schemaWriter = fb -> {
-                int[] fields = new int[columnNames.length];
-                for (int i = 0; i < columnNames.length; i++) {
-                    String columnName = columnNames[i];
-
-                    JsDataHandler writer = JsDataHandler.getHandler(types[i]);
-
-                    int nameOffset = fb.createString(columnName);
-                    int typeOffset = writer.writeType(fb);
-                    int metadataOffset = Field.createCustomMetadataVector(fb, new int[] {
-                            KeyValue.createKeyValue(fb, fb.createString("deephaven:type"),
-                                    fb.createString(writer.deephavenType()))
-                    });
-
-                    Field.startField(fb);
-                    Field.addName(fb, nameOffset);
-                    Field.addNullable(fb, true);
-
-                    Field.addTypeType(fb, writer.typeType());
-                    Field.addType(fb, typeOffset);
-                    Field.addCustomMetadata(fb, metadataOffset);
-
-                    fields[i] = Field.endField(fb);
-                }
-                int fieldsOffset = Schema.createFieldsVector(fb, fields);
-
-                Schema.startSchema(fb);
-                Schema.addFields(fb, fieldsOffset);
-                return Schema.endSchema(fb);
-            };
-
-            // The "StreamObserver c" here is for a unary, so we can't just pass it directly
-            // to doPut(), but need to filter out the messages and wait for onComplete
-            final StreamObserver<InputStream> observer;
-            try {
-                observer = doPut(new StreamObserver<>() {
-                    @Override
-                    public void onNext(InputStream value) {
-                        // ignore these, we'll get an ack for each message sent, but nothing for us to act on
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        // Table creation failed, notify caller
-                        c.onError(t);
-                    }
-
-                    @Override
-                    public void onCompleted() {
-                        // All done, notify caller with a synthetic ETCR
-                        FlatBufferBuilder schemaMessageBuilder = new FlatBufferBuilder();
-                        int schemaOffset = schemaWriter.applyAsInt(schemaMessageBuilder);
-                        Message.startMessage(schemaMessageBuilder);
-                        Message.addHeaderType(schemaMessageBuilder, MessageHeader.Schema);
-                        Message.addHeader(schemaMessageBuilder, schemaOffset);
-                        schemaMessageBuilder.finish(Message.endMessage(schemaMessageBuilder));
-                        ByteBuffer schemaMessagePayload = schemaMessageBuilder.dataBuffer();
-                        ByteBuffer schemaPlusHeader = ByteBuffer.allocate(schemaMessagePayload.remaining() + 8);
-                        schemaPlusHeader.order(ByteOrder.LITTLE_ENDIAN);
-                        schemaPlusHeader.putInt(-1);
-                        schemaPlusHeader.putInt(schemaMessagePayload.remaining());
-                        schemaPlusHeader.put(schemaMessagePayload);
-                        schemaPlusHeader.flip();
-                        ExportedTableCreationResponse syntheticResponse = ExportedTableCreationResponse.newBuilder()
-                                .setSchemaHeader(ByteStringAccess.wrap(schemaPlusHeader))
-                                .setSize(data[0].size())
-                                .setIsStatic(true)
-                                .setSuccess(true)
-                                .setResultId(cts.getHandle().makeTableReference())
-                                .build();
-                        c.onNext(syntheticResponse);
-                        c.onCompleted();
-                    }
-                });
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            StreamObserver<BarrageMessageWriter.MessageView> listener = new StreamObserver<>() {
-                @Override
-                public void onNext(BarrageMessageWriter.MessageView value) {
-                    try {
-                        value.forEachStream(observer::onNext);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-
-                @Override
-                public void onError(Throwable t) {
-                    observer.onError(t);
-                }
-
-                @Override
-                public void onCompleted() {
-                    observer.onCompleted();
-                }
-            };
+            StreamObserver<BarrageMessageWriter.MessageView> listener = doPutStream(columnNames, types, c, cts.getHandle().makeTicket(), d[0].size());
             ChunkWriter.Factory f = new WebChunkWriterFactory();
 
             Flight.FlightDescriptor flightDescriptor = cts.getHandle().makeFlightDescriptor();
-            listener.onNext(bmwFactory.getSchemaView(schemaWriter, flightDescriptor));
+            listener.onNext(bmwFactory.getSchemaView(fb -> writeSimpleSchema(columnNames, types, fb), flightDescriptor));
 
             ChunkWriter<Chunk<Values>>[] chunkWriters = new ChunkWriter[columnNames.length];
             for (int i = 0; i < typeInfos.length; i++) {
@@ -1232,10 +1136,10 @@ public class WorkerConnection {
             }
 
             BarrageMessage msg = new BarrageMessage();
-            msg.rowsAdded = RowSetFactory.fromRange(0, data[0].size() - 1);
+            msg.rowsAdded = RowSetFactory.fromRange(0, d[0].size() - 1);
             msg.rowsIncluded = msg.rowsAdded;
             msg.rowsRemoved = RowSetFactory.empty();
-            msg.length = data[0].size();
+            msg.length = d[0].size();
             msg.addColumnData = new BarrageMessage.AddColumnData[columnNames.length];
             for (int i = 0; i < columnNames.length; i++) {
                 BarrageMessage.AddColumnData acd = new BarrageMessage.AddColumnData();
@@ -1254,6 +1158,124 @@ public class WorkerConnection {
         }, "creating new table")
                 .refetch()
                 .then(cts -> Promise.resolve(new JsTable(this, cts)));
+    }
+
+    /**
+     * Adapts a table schema and a unary response to a MessageView bidi stream that calls FlightService/DoPut.
+     *
+     * @param columnNames the names of the columns to send
+     * @param types the types of the columns to send
+     * @param unaryObserver a unary observer to receive the final ETCR response or any error that occurs during the stream
+     * @param resultTicket the ticket that will contain the table after upload
+     * @param size the size of the table being uploaded
+     * @return a stream observer which can be given MessageViews from a BarrageMessageWriter
+     */
+    private StreamObserver<BarrageMessageWriter.MessageView> doPutStream(String[] columnNames, String[] types, StreamObserver<ExportedTableCreationResponse> unaryObserver, Ticket resultTicket, int size) {
+        // to doPut(), but need to filter out the messages and wait for onComplete
+        final StreamObserver<InputStream> observer;
+        try {
+            observer = doPut(new StreamObserver<>() {
+                @Override
+                public void onNext(InputStream value) {
+                    // ignore these, we'll get an ack for each message sent, but nothing for us to act on
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    // Table creation failed, notify caller
+                    unaryObserver.onError(t);
+                }
+
+                @Override
+                public void onCompleted() {
+                    // All done, notify caller with a synthetic ETCR
+                    FlatBufferBuilder schemaMessageBuilder = new FlatBufferBuilder();
+                    int schemaOffset = writeSimpleSchema(columnNames, types, schemaMessageBuilder);
+                    Message.startMessage(schemaMessageBuilder);
+                    Message.addHeaderType(schemaMessageBuilder, MessageHeader.Schema);
+                    Message.addHeader(schemaMessageBuilder, schemaOffset);
+                    schemaMessageBuilder.finish(Message.endMessage(schemaMessageBuilder));
+                    ByteBuffer schemaMessagePayload = schemaMessageBuilder.dataBuffer();
+                    ByteBuffer schemaPlusHeader = ByteBuffer.allocate(schemaMessagePayload.remaining() + 8);
+                    schemaPlusHeader.order(ByteOrder.LITTLE_ENDIAN);
+                    schemaPlusHeader.putInt(-1);
+                    schemaPlusHeader.putInt(schemaMessagePayload.remaining());
+                    schemaPlusHeader.put(schemaMessagePayload);
+                    schemaPlusHeader.flip();
+                    ExportedTableCreationResponse syntheticResponse = ExportedTableCreationResponse.newBuilder()
+                            .setSchemaHeader(ByteStringAccess.wrap(schemaPlusHeader))
+                            .setSize(size)
+                            .setIsStatic(true)
+                            .setSuccess(true)
+                            .setResultId(TableReference.newBuilder().setTicket(resultTicket))
+                            .build();
+                    unaryObserver.onNext(syntheticResponse);
+                    unaryObserver.onCompleted();
+                }
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(BarrageMessageWriter.MessageView value) {
+                try {
+                    value.forEachStream(observer::onNext);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                observer.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                observer.onCompleted();
+            }
+        };
+    }
+
+    /**
+     * Writes a simple schema with the given column names and types.
+     *
+     * @param columnNames
+     * @param types
+     * @param fb
+     * @return
+     */
+    private static int writeSimpleSchema(String[] columnNames, String[] types, FlatBufferBuilder fb) {
+        int[] fields = new int[columnNames.length];
+        int dhTypeOffset = fb.createString("deephaven:type");
+        for (int i = 0; i < columnNames.length; i++) {
+            String columnName = columnNames[i];
+
+            JsDataHandler writer = JsDataHandler.getHandler(types[i]);
+
+            int nameOffset = fb.createString(columnName);
+            int typeOffset = writer.writeType(fb);
+            int metadataOffset = Field.createCustomMetadataVector(fb, new int[] {
+                    KeyValue.createKeyValue(fb, dhTypeOffset,
+                            fb.createString(writer.deephavenType()))
+            });
+
+            Field.startField(fb);
+            Field.addName(fb, nameOffset);
+            Field.addNullable(fb, true);
+
+            Field.addTypeType(fb, writer.typeType());
+            Field.addType(fb, typeOffset);
+            Field.addCustomMetadata(fb, metadataOffset);
+
+            fields[i] = Field.endField(fb);
+        }
+        int fieldsOffset = Schema.createFieldsVector(fb, fields);
+
+        Schema.startSchema(fb);
+        Schema.addFields(fb, fieldsOffset);
+        return Schema.endSchema(fb);
     }
 
     private StreamObserver<InputStream> doPut(StreamObserver<InputStream> observer) throws Exception {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1140,17 +1140,14 @@ public class WorkerConnection {
         } else {
             msg.rowsAdded = RowSetFactory.empty();
         }
-        DomGlobal.console.log(msg.rowsAdded.size() + " rows added");
         msg.rowsIncluded = msg.rowsAdded;
         msg.rowsRemoved = RowSetFactory.empty();
         msg.length = d[0].size();
-        DomGlobal.console.log(msg.length + " length");
         msg.addColumnData = new BarrageMessage.AddColumnData[columnTypes.size()];
         for (int i = 0; i < columnTypes.size(); i++) {
             BarrageMessage.AddColumnData acd = new BarrageMessage.AddColumnData();
             acd.data = Collections.singletonList(d[i]);
             msg.addColumnData[i] = acd;
-            DomGlobal.console.log(acd.data.stream().mapToInt(Chunk::size).sum() + " rows in col");
         }
         msg.modColumnData = BarrageMessage.ZERO_MOD_COLUMNS;
         msg.shifted = RowSetShiftData.EMPTY;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageMessageReader.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageMessageReader.java
@@ -12,12 +12,12 @@ import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableObjectChunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.extensions.barrage.BarrageOptions;
-import io.deephaven.extensions.barrage.BarrageTypeInfo;
 import io.deephaven.extensions.barrage.chunk.ChunkWriter;
 import io.deephaven.extensions.barrage.chunk.ChunkReader;
 import io.deephaven.extensions.barrage.util.FlatBufferIteratorAdapter;
 import io.deephaven.io.streams.ByteBufferInputStream;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
+import io.deephaven.web.client.api.barrage.data.BarrageColumnType;
 import io.deephaven.web.client.fu.JsLog;
 import io.deephaven.web.shared.data.RangeSet;
 import io.deephaven.web.shared.data.ShiftedRange;
@@ -27,7 +27,6 @@ import org.apache.arrow.flatbuf.MessageHeader;
 import org.apache.arrow.flatbuf.RecordBatch;
 import org.apache.arrow.flatbuf.Schema;
 import org.apache.arrow.flight.impl.Flight;
-import org.gwtproject.nio.TypedArrayHelper;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -59,8 +58,6 @@ public class WebBarrageMessageReader {
 
     public WebBarrageMessage parseFrom(
             final BarrageOptions options,
-            Class<?>[] columnTypes,
-            Class<?>[] componentTypes,
             Flight.FlightData flightData) throws IOException {
         ByteBuffer headerAsBB = flightData.getDataHeader().asReadOnlyByteBuffer();
         Message header = headerAsBB.hasRemaining() ? Message.getRootAsMessage(headerAsBB) : null;
@@ -111,7 +108,7 @@ public class WebBarrageMessageReader {
 
                 final ByteBuffer rowsIncluded = metadata.addedRowsIncludedAsByteBuffer();
                 msg.rowsIncluded = rowsIncluded != null ? extractIndex(rowsIncluded) : msg.rowsAdded;
-                msg.addColumnData = new WebBarrageMessage.AddColumnData[columnTypes.length];
+                msg.addColumnData = new WebBarrageMessage.AddColumnData[readers.size()];
                 for (int ci = 0; ci < msg.addColumnData.length; ++ci) {
                     msg.addColumnData[ci] = new WebBarrageMessage.AddColumnData();
                     // msg.addColumnData[ci].type = columnTypes[ci];
@@ -157,15 +154,14 @@ public class WebBarrageMessageReader {
             header.header(schema);
             for (int i = 0; i < schema.fieldsLength(); i++) {
                 Field field = schema.fields(i);
-                readers.add(chunkReaderFactory.newReader(
-                        BarrageTypeInfo.make(columnTypes[i], componentTypes[i], field), options));
+                BarrageColumnType barrageColumnType = BarrageColumnType.fromArrowField(field);
+                readers.add(chunkReaderFactory.newReader(barrageColumnType.typeInfo(), options));
             }
             return null;
         }
         if (headerType != MessageHeader.RecordBatch) {
             throw new IllegalStateException("Only know how to decode Schema/RecordBatch messages");
         }
-
 
         // throw an error when no app metadata (snapshots now provide by default)
         if (msg == null) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
@@ -137,6 +137,14 @@ public class WebBarrageUtils {
         return CompressedRangeSetReader.writeRange(s);
     }
 
+    /**
+     * Maps server-side "deephaven:type" class names to their client side equivalent Class instance for use in
+     * {@link io.deephaven.extensions.barrage.BarrageTypeInfo} construction, and comparison
+     * in readers/writers.
+     *
+     * @param t the deephaven:type string
+     * @return a client side class literal
+     */
     public static Class<?> stringToClass(String t) {
         return switch (t) {
             case "boolean", "java.lang.Boolean" -> boolean.class;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
@@ -6,9 +6,6 @@ package io.deephaven.web.client.api.barrage;
 import com.google.flatbuffers.FlatBufferBuilder;
 import io.deephaven.barrage.flatbuf.BarrageMessageType;
 import io.deephaven.barrage.flatbuf.BarrageMessageWrapper;
-import io.deephaven.web.client.api.BigDecimalWrapper;
-import io.deephaven.web.client.api.BigIntegerWrapper;
-import io.deephaven.web.client.api.DateWrapper;
 import io.deephaven.web.client.api.barrage.def.ColumnDefinition;
 import io.deephaven.web.client.api.barrage.def.InitialTableDefinition;
 import io.deephaven.web.client.api.barrage.def.TableAttributesDefinition;
@@ -106,7 +103,7 @@ public class WebBarrageUtils {
         return schema;
     }
 
-    public static Map<String, String> keyValuePairs(String filterPrefix, double count,
+    public static Map<String, String> keyValuePairs(String filterPrefix, int count,
             IntFunction<KeyValue> accessor) {
         Map<String, String> map = new HashMap<>();
         for (int i = 0; i < count; i++) {
@@ -135,30 +132,5 @@ public class WebBarrageUtils {
         }
 
         return CompressedRangeSetReader.writeRange(s);
-    }
-
-    /**
-     * Maps server-side "deephaven:type" class names to their client side equivalent Class instance for use in
-     * {@link io.deephaven.extensions.barrage.BarrageTypeInfo} construction, and comparison
-     * in readers/writers.
-     *
-     * @param t the deephaven:type string
-     * @return a client side class literal
-     */
-    public static Class<?> stringToClass(String t) {
-        return switch (t) {
-            case "boolean", "java.lang.Boolean" -> boolean.class;
-            case "char", "java.lang.Character" -> char.class;
-            case "byte", "java.lang.Byte" -> byte.class;
-            case "int", "java.lang.Integer" -> int.class;
-            case "short", "java.lang.Short" -> short.class;
-            case "long", "java.lang.Long" -> long.class;
-            case "java.lang.Float", "float" -> float.class;
-            case "java.lang.Double", "double" -> double.class;
-            case "java.time.Instant" -> DateWrapper.class;
-            case "java.math.BigInteger" -> BigIntegerWrapper.class;
-            case "java.math.BigDecimal" -> BigDecimalWrapper.class;
-            default -> Object.class;
-        };
     }
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebBarrageUtils.java
@@ -6,6 +6,7 @@ package io.deephaven.web.client.api.barrage;
 import com.google.flatbuffers.FlatBufferBuilder;
 import io.deephaven.barrage.flatbuf.BarrageMessageType;
 import io.deephaven.barrage.flatbuf.BarrageMessageWrapper;
+import io.deephaven.web.client.api.barrage.data.BarrageColumnType;
 import io.deephaven.web.client.api.barrage.def.ColumnDefinition;
 import io.deephaven.web.client.api.barrage.def.InitialTableDefinition;
 import io.deephaven.web.client.api.barrage.def.TableAttributesDefinition;

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
@@ -281,7 +281,7 @@ public class WebChunkReaderFactory implements ChunkReader.Factory {
 
                 // Disregard the actual component type and request one that can hold Object, as all transformers
                 // will yield some kind of reference type since this is JS.
-                final BarrageTypeInfo<Field> componentTypeInfo = new BarrageTypeInfo<>(
+                final BarrageTypeInfo<Field> componentTypeInfo = BarrageTypeInfo.make(
                         Object.class,
                         null,
                         typeInfo.arrowField().children(0));

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkReaderFactory.java
@@ -279,10 +279,11 @@ public class WebChunkReaderFactory implements ChunkReader.Factory {
                                     outChunk, outOffset, totalRows);
                 }
 
-                // noinspection DataFlowIssue,ConstantValue
+                // Disregard the actual component type and request one that can hold Object, as all transformers
+                // will yield some kind of reference type since this is JS.
                 final BarrageTypeInfo<Field> componentTypeInfo = new BarrageTypeInfo<>(
-                        componentType,
-                        componentType == null ? null : componentType.getComponentType(),
+                        Object.class,
+                        null,
                         typeInfo.arrowField().children(0));
                 final ChunkType chunkType = ListChunkReader.getChunkTypeFor(componentTypeInfo.type());
                 final ExpansionKernel<?> kernel =

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkWriterFactory.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/WebChunkWriterFactory.java
@@ -359,15 +359,17 @@ public class WebChunkWriterFactory implements ChunkWriter.Factory {
                 Class<?> componentType = typeInfo.componentType();
                 // TODO special case for byte[]?
 
-                final BarrageTypeInfo<Field> componentTypeInfo = new BarrageTypeInfo<>(
+                assert componentType != null;
+                final BarrageTypeInfo<Field> componentTypeInfo = BarrageTypeInfo.make(
                         componentType,
-                        componentType == null ? null : componentType.getComponentType(),
+                        componentType.getComponentType(),
                         typeInfo.arrowField().children(0));
                 final ChunkType chunkType = ListChunkReader.getChunkTypeFor(componentTypeInfo.type());
                 final ExpansionKernel<?> kernel =
                         ArrayExpansionKernel.makeExpansionKernel(chunkType, componentTypeInfo.type());
                 final ChunkWriter<?> componentWriter = newWriter(componentTypeInfo);
 
+                // noinspection unchecked
                 return (ChunkWriter<T>) new ListChunkWriter<>(listMode, fixedSizeLength, kernel, componentWriter, true);
             }
             default:

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -288,7 +288,7 @@ public abstract sealed class BarrageColumnType
 
     /**
      * Returns a Class instance to use when constructing a local BarrageTypeInfo. This is presently specific to the JS
-     * client, and would need to generalized if we shared this clas.
+     * client, and would need to generalized if we shared this class.
      */
     protected abstract Class<?> type();
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -334,23 +334,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.Null.startNull(builder);
             return org.apache.arrow.flatbuf.Null.endNull(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Null;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.Object";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
     }
@@ -373,17 +373,17 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Int.createInt(builder, bitWidth, isSigned);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Int;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             if (isSigned) {
                 switch (bitWidth) {
                     case 8:
@@ -408,7 +408,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             if (isSigned) {
                 switch (bitWidth) {
                     case 8:
@@ -448,17 +448,17 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.FloatingPoint.createFloatingPoint(builder, precision);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.FloatingPoint;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             switch (precision) {
                 case org.apache.arrow.flatbuf.Precision.SINGLE:
                     return "float";
@@ -470,7 +470,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             switch (precision) {
                 case org.apache.arrow.flatbuf.Precision.SINGLE:
                     return float.class;
@@ -496,23 +496,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.Binary.startBinary(builder);
             return org.apache.arrow.flatbuf.Binary.endBinary(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Binary;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return deephavenType;
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             // Only two types are explicitly supported as Binary by deephaven, interpret the rest as object
             if (deephavenType.equals("java.math.BigDecimal")) {
                 return BigDecimalWrapper.class;
@@ -534,23 +534,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.Utf8.startUtf8(builder);
             return org.apache.arrow.flatbuf.Utf8.endUtf8(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Utf8;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.String";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return String.class;
         }
     }
@@ -565,23 +565,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.Bool.startBool(builder);
             return org.apache.arrow.flatbuf.Bool.endBool(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Bool;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.Boolean";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return boolean.class;
         }
     }
@@ -600,22 +600,22 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Decimal.createDecimal(builder, precision, scale, bitWidth);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Decimal;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.math.BigDecimal";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return BigDecimalWrapper.class;
         }
     }
@@ -634,22 +634,22 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Date.createDate(builder, unit);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Date;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.time.LocalDate";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return LocalDateWrapper.class;
         }
     }
@@ -672,22 +672,22 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Time.createTime(builder, unit, bitWidth);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Time;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.time.LocalTime";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return LocalTimeWrapper.class;
         }
     }
@@ -711,23 +711,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             int tzOffset = timezone != null ? builder.createString(timezone) : 0;
             return org.apache.arrow.flatbuf.Timestamp.createTimestamp(builder, unit, tzOffset);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Timestamp;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.time.Instant";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return DateWrapper.class;
         }
     }
@@ -741,22 +741,22 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Interval.createInterval(builder, unit);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Interval;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.time.Duration";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
     }
@@ -776,18 +776,18 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.List.startList(builder);
             return org.apache.arrow.flatbuf.List.endList(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.List;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -797,12 +797,12 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
 
         @Override
-        public Class<?> componentType() {
+        protected Class<?> componentType() {
             return componentType.type();
         }
     }
@@ -821,18 +821,18 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.Struct_.startStruct_(builder);
             return org.apache.arrow.flatbuf.Struct_.endStruct_(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Struct_;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.Object";
         }
 
@@ -846,7 +846,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
     }
@@ -865,18 +865,18 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             int typeIdsOffset = org.apache.arrow.flatbuf.Union.createTypeIdsVector(builder, typeIds);
             return org.apache.arrow.flatbuf.Union.createUnion(builder, mode, typeIdsOffset);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Union;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.Object";
         }
 
@@ -890,7 +890,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
     }
@@ -905,27 +905,27 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.FixedSizeBinary.createFixedSizeBinary(builder, byteWidth);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.FixedSizeBinary;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "byte[]";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
 
         @Override
-        public Class<?> componentType() {
+        protected Class<?> componentType() {
             return byte.class;
         }
     }
@@ -942,17 +942,17 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.FixedSizeList.createFixedSizeList(builder, listSize);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.FixedSizeList;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -962,12 +962,12 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
 
         @Override
-        public Class<?> componentType() {
+        protected Class<?> componentType() {
             return componentType.type();
         }
     }
@@ -986,17 +986,17 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Map.createMap(builder, keysSorted);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Map;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.Object";
         }
 
@@ -1025,7 +1025,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
     }
@@ -1039,22 +1039,22 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Duration.createDuration(builder, unit);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Duration;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.time.Duration";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
     }
@@ -1065,23 +1065,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.LargeBinary.startLargeBinary(builder);
             return org.apache.arrow.flatbuf.LargeBinary.endLargeBinary(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.LargeBinary;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.Object";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
     }
@@ -1092,23 +1092,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.LargeUtf8.startLargeUtf8(builder);
             return org.apache.arrow.flatbuf.LargeUtf8.endLargeUtf8(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.LargeUtf8;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.String";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return String.class;
         }
     }
@@ -1123,18 +1123,18 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.LargeList.startLargeList(builder);
             return org.apache.arrow.flatbuf.LargeList.endLargeList(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.LargeList;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -1144,12 +1144,12 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
 
         @Override
-        public Class<?> componentType() {
+        protected Class<?> componentType() {
             return componentType.type();
         }
     }
@@ -1166,18 +1166,18 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.RunEndEncoded.startRunEndEncoded(builder);
             return org.apache.arrow.flatbuf.RunEndEncoded.endRunEndEncoded(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.RunEndEncoded;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return valuesType.deephavenType();
         }
 
@@ -1187,7 +1187,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return valuesType.type();
         }
     }
@@ -1198,28 +1198,28 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.BinaryView.startBinaryView(builder);
             return org.apache.arrow.flatbuf.BinaryView.endBinaryView(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.BinaryView;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "byte[]";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
 
         @Override
-        public Class<?> componentType() {
+        protected Class<?> componentType() {
             return byte.class;
         }
     }
@@ -1230,23 +1230,23 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.Utf8View.startUtf8View(builder);
             return org.apache.arrow.flatbuf.Utf8View.endUtf8View(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.Utf8View;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return "java.lang.String";
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return String.class;
         }
     }
@@ -1261,18 +1261,18 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.ListView.startListView(builder);
             return org.apache.arrow.flatbuf.ListView.endListView(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.ListView;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -1282,12 +1282,12 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
 
         @Override
-        public @Nullable Class<?> componentType() {
+        protected @Nullable Class<?> componentType() {
             return componentType.type();
         }
     }
@@ -1302,18 +1302,18 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
+        protected int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.LargeListView.startLargeListView(builder);
             return org.apache.arrow.flatbuf.LargeListView.endLargeListView(builder);
         }
 
         @Override
-        public byte typeType() {
+        protected byte typeType() {
             return Type.LargeListView;
         }
 
         @Override
-        public String inferDeephavenType() {
+        protected String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -1323,12 +1323,12 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public Class<?> type() {
+        protected Class<?> type() {
             return Object.class;
         }
 
         @Override
-        public @Nullable Class<?> componentType() {
+        protected @Nullable Class<?> componentType() {
             return componentType.type();
         }
     }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -39,7 +39,7 @@ public abstract sealed class BarrageColumnType
      * Best effort mapping from string type info to supported Flight/Deephaven types.
      * 
      * @param deephavenType supports deephaven:type strings, as well as some specific JS shorthand
-     * @return
+     * @return a type with the provided name based on the given type
      */
     public static BarrageColumnType fromString(String columnName, String deephavenType) {
         if (deephavenType.endsWith("[]")) {
@@ -89,6 +89,12 @@ public abstract sealed class BarrageColumnType
         }
     }
 
+    /**
+     * Creates an instance from the provided arrow field, reading both from the type info it contains and metadata.
+     *
+     * @param field the arrow field to read
+     * @return a type with the same name and type as the argument
+     */
     public static BarrageColumnType fromArrowField(Field field) {
         java.util.Map<String, String> customMetadata =
                 WebBarrageUtils.keyValuePairs("", field.customMetadataLength(), field::customMetadata);
@@ -220,17 +226,16 @@ public abstract sealed class BarrageColumnType
         this(columnName, java.util.Map.of());
     }
 
+    /**
+     * Gets the name for the column. Never null for actual columns, only for nested arrow "fields" within columns.
+     */
     public @Nullable String getColumnName() {
         return columnName;
     }
 
-    public java.util.Map<String, String> customMetadata() {
-        return customMetadata;
-    }
+    protected abstract byte typeType();
 
-    public abstract byte typeType();
-
-    public abstract int writeType(FlatBufferBuilder builder);
+    protected abstract int writeType(FlatBufferBuilder builder);
 
     public int writeField(FlatBufferBuilder builder) {
         int typeOffset = writeType(builder);
@@ -281,13 +286,35 @@ public abstract sealed class BarrageColumnType
         return null;
     }
 
-    public abstract Class<?> type();
+    /**
+     * Returns a Class instance to use when constructing a local BarrageTypeInfo. This is presently specific to the JS
+     * client, and would need to generalized if we shared this clas.
+     */
+    protected abstract Class<?> type();
 
-    public @Nullable Class<?> componentType() {
+    /**
+     * Returns a Class instance to use if this column will be a list/array/vector as the component type, otherwise null.
+     */
+    protected @Nullable Class<?> componentType() {
         return null;
     }
 
-    public abstract String deephavenType();
+    /**
+     * Returns the type that this column represents in terms that deephaven servers/clients will recognize.
+     */
+    public final String deephavenType() {
+        // If explicitly set, read that before guessing
+        if (customMetadata.containsKey("deephaven:type")) {
+            return customMetadata.get("deephaven:type");
+        }
+        return inferDeephavenType();
+    }
+
+    /**
+     * Infer a best effort deephaven type string based on the column type information. This is only used when the
+     * metadata isn't set.
+     */
+    protected abstract String inferDeephavenType();
 
     public BarrageTypeInfo<Field> typeInfo() {
         FlatBufferBuilder builder = new FlatBufferBuilder();
@@ -318,7 +345,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.Object";
         }
 
@@ -345,14 +372,6 @@ public abstract sealed class BarrageColumnType
             this.isSigned = isSigned;
         }
 
-        public int bitWidth() {
-            return bitWidth;
-        }
-
-        public boolean isSigned() {
-            return isSigned;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Int.createInt(builder, bitWidth, isSigned);
@@ -364,7 +383,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             if (isSigned) {
                 switch (bitWidth) {
                     case 8:
@@ -428,13 +447,6 @@ public abstract sealed class BarrageColumnType
             this.precision = precision;
         }
 
-        /**
-         * @return precision value from {@link org.apache.arrow.flatbuf.Precision}
-         */
-        public short precision() {
-            return precision;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.FloatingPoint.createFloatingPoint(builder, precision);
@@ -446,7 +458,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             switch (precision) {
                 case org.apache.arrow.flatbuf.Precision.SINGLE:
                     return "float";
@@ -495,7 +507,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return deephavenType;
         }
 
@@ -533,7 +545,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.String";
         }
 
@@ -564,7 +576,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.Boolean";
         }
 
@@ -579,31 +591,12 @@ public abstract sealed class BarrageColumnType
         private final int scale;
         private final int bitWidth;
 
-        public Decimal(@Nullable String columnName, int precision, int scale, int bitWidth) {
-            super(columnName);
-            this.precision = precision;
-            this.scale = scale;
-            this.bitWidth = bitWidth;
-        }
-
         public Decimal(@Nullable String columnName, int precision, int scale, int bitWidth,
                 java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.precision = precision;
             this.scale = scale;
             this.bitWidth = bitWidth;
-        }
-
-        public int precision() {
-            return precision;
-        }
-
-        public int scale() {
-            return scale;
-        }
-
-        public int bitWidth() {
-            return bitWidth;
         }
 
         @Override
@@ -617,7 +610,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.math.BigDecimal";
         }
 
@@ -640,13 +633,6 @@ public abstract sealed class BarrageColumnType
             this.unit = unit;
         }
 
-        /**
-         * @return unit value from {@link org.apache.arrow.flatbuf.DateUnit}
-         */
-        public short unit() {
-            return unit;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Date.createDate(builder, unit);
@@ -658,7 +644,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.time.LocalDate";
         }
 
@@ -685,17 +671,6 @@ public abstract sealed class BarrageColumnType
             this.bitWidth = bitWidth;
         }
 
-        /**
-         * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
-         */
-        public short unit() {
-            return unit;
-        }
-
-        public int bitWidth() {
-            return bitWidth;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Time.createTime(builder, unit, bitWidth);
@@ -707,7 +682,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.time.LocalTime";
         }
 
@@ -735,18 +710,6 @@ public abstract sealed class BarrageColumnType
             this.timezone = timezone;
         }
 
-        /**
-         * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
-         */
-        public short unit() {
-            return unit;
-        }
-
-        @Nullable
-        public String timezone() {
-            return timezone;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             int tzOffset = timezone != null ? builder.createString(timezone) : 0;
@@ -759,7 +722,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.time.Instant";
         }
 
@@ -777,13 +740,6 @@ public abstract sealed class BarrageColumnType
             this.unit = unit;
         }
 
-        /**
-         * @return unit value from {@link org.apache.arrow.flatbuf.IntervalUnit}
-         */
-        public short unit() {
-            return unit;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Interval.createInterval(builder, unit);
@@ -795,7 +751,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.time.Duration";
         }
 
@@ -819,10 +775,6 @@ public abstract sealed class BarrageColumnType
             this.componentType = componentType;
         }
 
-        public BarrageColumnType arrayComponentType() {
-            return componentType;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.List.startList(builder);
@@ -835,7 +787,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -880,7 +832,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.Object";
         }
 
@@ -912,21 +864,6 @@ public abstract sealed class BarrageColumnType
             this.fields = fields;
         }
 
-        /**
-         * @return mode value from {@link org.apache.arrow.flatbuf.UnionMode}
-         */
-        public short mode() {
-            return mode;
-        }
-
-        public int[] typeIds() {
-            return typeIds;
-        }
-
-        public java.util.List<BarrageColumnType> fields() {
-            return fields;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             int typeIdsOffset = org.apache.arrow.flatbuf.Union.createTypeIdsVector(builder, typeIds);
@@ -939,7 +876,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.Object";
         }
 
@@ -967,10 +904,6 @@ public abstract sealed class BarrageColumnType
             this.byteWidth = byteWidth;
         }
 
-        public int byteWidth() {
-            return byteWidth;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.FixedSizeBinary.createFixedSizeBinary(builder, byteWidth);
@@ -982,7 +915,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "byte[]";
         }
 
@@ -1008,14 +941,6 @@ public abstract sealed class BarrageColumnType
             this.componentType = componentType;
         }
 
-        public int listSize() {
-            return listSize;
-        }
-
-        public BarrageColumnType listComponentType() {
-            return componentType;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.FixedSizeList.createFixedSizeList(builder, listSize);
@@ -1027,7 +952,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -1060,18 +985,6 @@ public abstract sealed class BarrageColumnType
             this.valueType = valueType;
         }
 
-        public boolean keysSorted() {
-            return keysSorted;
-        }
-
-        public BarrageColumnType keyType() {
-            return keyType;
-        }
-
-        public BarrageColumnType valueType() {
-            return valueType;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Map.createMap(builder, keysSorted);
@@ -1083,7 +996,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.Object";
         }
 
@@ -1125,13 +1038,6 @@ public abstract sealed class BarrageColumnType
             this.unit = unit;
         }
 
-        /**
-         * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
-         */
-        public short unit() {
-            return unit;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             return org.apache.arrow.flatbuf.Duration.createDuration(builder, unit);
@@ -1143,7 +1049,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.time.Duration";
         }
 
@@ -1170,13 +1076,13 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
-            return "java.math.BigInteger";
+        public String inferDeephavenType() {
+            return "java.lang.Object";
         }
 
         @Override
         public Class<?> type() {
-            return BigIntegerWrapper.class;
+            return Object.class;
         }
     }
 
@@ -1197,7 +1103,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.String";
         }
 
@@ -1216,10 +1122,6 @@ public abstract sealed class BarrageColumnType
             this.componentType = componentType;
         }
 
-        public BarrageColumnType listComponentType() {
-            return componentType;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.LargeList.startLargeList(builder);
@@ -1232,7 +1134,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -1263,14 +1165,6 @@ public abstract sealed class BarrageColumnType
             this.valuesType = valuesType;
         }
 
-        public BarrageColumnType runEndsType() {
-            return runEndsType;
-        }
-
-        public BarrageColumnType valuesType() {
-            return valuesType;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.RunEndEncoded.startRunEndEncoded(builder);
@@ -1283,7 +1177,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return valuesType.deephavenType();
         }
 
@@ -1299,10 +1193,6 @@ public abstract sealed class BarrageColumnType
     }
 
     public static final class BinaryView extends BarrageColumnType {
-        public BinaryView(@Nullable String columnName) {
-            super(columnName);
-        }
-
         public BinaryView(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
         }
@@ -1319,7 +1209,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "byte[]";
         }
 
@@ -1335,10 +1225,6 @@ public abstract sealed class BarrageColumnType
     }
 
     public static final class Utf8View extends BarrageColumnType {
-        public Utf8View(@Nullable String columnName) {
-            super(columnName);
-        }
-
         public Utf8View(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
         }
@@ -1355,7 +1241,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return "java.lang.String";
         }
 
@@ -1368,19 +1254,10 @@ public abstract sealed class BarrageColumnType
     public static final class ListView extends BarrageColumnType {
         private final BarrageColumnType componentType;
 
-        public ListView(@Nullable String columnName, BarrageColumnType componentType) {
-            super(columnName);
-            this.componentType = componentType;
-        }
-
         public ListView(@Nullable String columnName, BarrageColumnType componentType,
                 java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.componentType = componentType;
-        }
-
-        public BarrageColumnType listComponentType() {
-            return componentType;
         }
 
         @Override
@@ -1395,7 +1272,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 
@@ -1424,10 +1301,6 @@ public abstract sealed class BarrageColumnType
             this.componentType = componentType;
         }
 
-        public BarrageColumnType listComponentType() {
-            return componentType;
-        }
-
         @Override
         public int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.LargeListView.startLargeListView(builder);
@@ -1440,7 +1313,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public String deephavenType() {
+        public String inferDeephavenType() {
             return componentType.deephavenType() + "[]";
         }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -45,7 +45,7 @@ public abstract sealed class BarrageColumnType
         if (deephavenType.endsWith("[]")) {
             String componentType = deephavenType.substring(0, deephavenType.length() - 2);
             BarrageColumnType componentColumnType = fromString(null, componentType);
-            return new List(deephavenType, componentColumnType);
+            return new List(columnName, componentColumnType);
         }
 
         switch (deephavenType) {
@@ -256,15 +256,16 @@ public abstract sealed class BarrageColumnType
             childrenVector = Field.createChildrenVector(builder, childrenOffsets);
         }
 
-        int nameOffset = Integer.MAX_VALUE;
+        final int nameOffset;
         if (columnName != null) {
             nameOffset = builder.createString(columnName);
+        } else {
+            // A name is required for nested fields by the server implementation
+            nameOffset = builder.createString("");
         }
         Field.startField(builder);
         Field.addNullable(builder, true);
-        if (columnName != null) {
-            Field.addName(builder, nameOffset);
-        }
+        Field.addName(builder, nameOffset);
         Field.addTypeType(builder, typeType());
         Field.addType(builder, typeOffset);
         Field.addCustomMetadata(builder, metadataOffset);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -1,0 +1,1302 @@
+package io.deephaven.web.client.api.barrage.data;
+
+import com.google.flatbuffers.FlatBufferBuilder;
+import io.deephaven.extensions.barrage.BarrageTypeInfo;
+import io.deephaven.web.client.api.BigDecimalWrapper;
+import io.deephaven.web.client.api.BigIntegerWrapper;
+import io.deephaven.web.client.api.DateWrapper;
+import io.deephaven.web.client.api.LocalDateWrapper;
+import io.deephaven.web.client.api.LocalTimeWrapper;
+import org.apache.arrow.flatbuf.Field;
+import org.apache.arrow.flatbuf.Type;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Type model that represents all Arrow field types and supported deephaven type metadata.
+ */
+public abstract sealed class BarrageColumnType
+        permits BarrageColumnType.Null, BarrageColumnType.IntType, BarrageColumnType.FloatingPoint,
+        BarrageColumnType.Binary, BarrageColumnType.Utf8, BarrageColumnType.Bool,
+        BarrageColumnType.Decimal, BarrageColumnType.Date, BarrageColumnType.Time,
+        BarrageColumnType.Timestamp, BarrageColumnType.Interval, BarrageColumnType.Array,
+        BarrageColumnType.Struct, BarrageColumnType.Union, BarrageColumnType.FixedSizeBinary,
+        BarrageColumnType.FixedSizeList, BarrageColumnType.Map, BarrageColumnType.Duration,
+        BarrageColumnType.LargeBinary, BarrageColumnType.LargeUtf8, BarrageColumnType.LargeList,
+        BarrageColumnType.RunEndEncoded, BarrageColumnType.BinaryView, BarrageColumnType.Utf8View,
+        BarrageColumnType.ListView, BarrageColumnType.LargeListView {
+
+    /**
+     * Best effort mapping from string type info to supported Flight/Deephaven types.
+     * @param deephavenType supports deephaven:type strings, as well as some specific JS shorthand
+     * @return
+     */
+    public static BarrageColumnType fromString(String columnName, String deephavenType) {
+        if (deephavenType.endsWith("[]")) {
+            String componentType = deephavenType.substring(0, deephavenType.length() - 2);
+            BarrageColumnType componentColumnType = fromString(null, componentType);
+            return new Array(deephavenType, componentColumnType);
+        }
+
+        switch (deephavenType) {
+            case "string":
+            case "java.lang.String":
+                return new Utf8(columnName);
+            case "java.time.Instant":
+            case "datetime":
+            case "java.time.ZonedDateTime":
+                return new Timestamp(columnName, org.apache.arrow.flatbuf.TimeUnit.NANOSECOND, "UTC");
+            case "int":
+                return new IntType(columnName, 32, true);
+            case "short":
+                return new IntType(columnName, 16, true);
+            case "long":
+                return new IntType(columnName, 64, true);
+            case "byte":
+                return new IntType(columnName, 8, true);
+            case "char":
+                return new IntType(columnName, 16, false);
+            case "float":
+                return new FloatingPoint(columnName, org.apache.arrow.flatbuf.Precision.SINGLE);
+            case "double":
+                return new FloatingPoint(columnName, org.apache.arrow.flatbuf.Precision.DOUBLE);
+            case "java.lang.Boolean":
+            case "boolean":
+            case "bool":
+                return new Bool(columnName);
+            case "java.math.BigDecimal":
+                return new Decimal(columnName, 128, 0, 128);
+            case "java.math.BigInteger":
+                return new Binary(columnName);
+            case "java.time.LocalDate":
+            case "localdate":
+                return new Date(columnName, org.apache.arrow.flatbuf.DateUnit.DAY);
+            case "java.time.LocalTime":
+            case "localtime":
+                return new Time(columnName, org.apache.arrow.flatbuf.TimeUnit.NANOSECOND, 64);
+            default:
+                throw new IllegalArgumentException("Unsupported deephaven type: " + deephavenType);
+        }
+    }
+
+    public static BarrageColumnType fromArrowField(Field field) {
+        String columnName = field.name();
+        switch (field.typeType()) {
+            case Type.Null:
+                return new Null(columnName);
+            case Type.Int: {
+                org.apache.arrow.flatbuf.Int intType = new org.apache.arrow.flatbuf.Int();
+                field.type(intType);
+                return new IntType(columnName, intType.bitWidth(), intType.isSigned());
+            }
+            case Type.FloatingPoint: {
+                org.apache.arrow.flatbuf.FloatingPoint fpType = new org.apache.arrow.flatbuf.FloatingPoint();
+                field.type(fpType);
+                return new FloatingPoint(columnName, fpType.precision());
+            }
+            case Type.Binary:
+                return new Binary(columnName);
+            case Type.Utf8:
+                return new Utf8(columnName);
+            case Type.Bool:
+                return new Bool(columnName);
+            case Type.Decimal: {
+                org.apache.arrow.flatbuf.Decimal decType = new org.apache.arrow.flatbuf.Decimal();
+                field.type(decType);
+                return new Decimal(columnName, decType.precision(), decType.scale(), decType.bitWidth());
+            }
+            case Type.Date: {
+                org.apache.arrow.flatbuf.Date dateType = new org.apache.arrow.flatbuf.Date();
+                field.type(dateType);
+                return new Date(columnName, dateType.unit());
+            }
+            case Type.Time: {
+                org.apache.arrow.flatbuf.Time timeType = new org.apache.arrow.flatbuf.Time();
+                field.type(timeType);
+                return new Time(columnName, timeType.unit(), timeType.bitWidth());
+            }
+            case Type.Timestamp: {
+                org.apache.arrow.flatbuf.Timestamp tsType = new org.apache.arrow.flatbuf.Timestamp();
+                field.type(tsType);
+                return new Timestamp(columnName, tsType.unit(), tsType.timezone());
+            }
+            case Type.Interval: {
+                org.apache.arrow.flatbuf.Interval intervalType = new org.apache.arrow.flatbuf.Interval();
+                field.type(intervalType);
+                return new Interval(columnName, intervalType.unit());
+            }
+            case Type.List:
+                return new Array(columnName, fromArrowField(field.children(0)));
+            case Type.Struct_: {
+                List<BarrageColumnType> fields = new ArrayList<>(field.childrenLength());
+                for (int i = 0; i < field.childrenLength(); i++) {
+                    fields.add(fromArrowField(field.children(i)));
+                }
+                return new Struct(columnName, Collections.unmodifiableList(fields));
+            }
+            case Type.Union: {
+                org.apache.arrow.flatbuf.Union unionType = new org.apache.arrow.flatbuf.Union();
+                field.type(unionType);
+                int[] typeIds = new int[unionType.typeIdsLength()];
+                for (int i = 0; i < typeIds.length; i++) {
+                    typeIds[i] = unionType.typeIds(i);
+                }
+                List<BarrageColumnType> fields = new ArrayList<>(field.childrenLength());
+                for (int i = 0; i < field.childrenLength(); i++) {
+                    fields.add(fromArrowField(field.children(i)));
+                }
+                return new Union(columnName, unionType.mode(), typeIds, Collections.unmodifiableList(fields));
+            }
+            case Type.FixedSizeBinary: {
+                org.apache.arrow.flatbuf.FixedSizeBinary fsbType = new org.apache.arrow.flatbuf.FixedSizeBinary();
+                field.type(fsbType);
+                return new FixedSizeBinary(columnName, fsbType.byteWidth());
+            }
+            case Type.FixedSizeList: {
+                org.apache.arrow.flatbuf.FixedSizeList fslType = new org.apache.arrow.flatbuf.FixedSizeList();
+                field.type(fslType);
+                return new FixedSizeList(columnName, fslType.listSize(), fromArrowField(field.children(0)));
+            }
+            case Type.Map: {
+                org.apache.arrow.flatbuf.Map mapType = new org.apache.arrow.flatbuf.Map();
+                field.type(mapType);
+                Field entriesField = field.children(0);
+                return new Map(columnName, mapType.keysSorted(), fromArrowField(entriesField.children(0)), fromArrowField(entriesField.children(1)));
+            }
+            case Type.Duration: {
+                org.apache.arrow.flatbuf.Duration durType = new org.apache.arrow.flatbuf.Duration();
+                field.type(durType);
+                return new Duration(columnName, durType.unit());
+            }
+            case Type.LargeBinary:
+                return new LargeBinary(columnName);
+            case Type.LargeUtf8:
+                return new LargeUtf8(columnName);
+            case Type.LargeList:
+                return new LargeList(columnName, fromArrowField(field.children(0)));
+            case Type.RunEndEncoded:
+                return new RunEndEncoded(columnName, fromArrowField(field.children(0)), fromArrowField(field.children(1)));
+            case Type.BinaryView:
+                return new BinaryView(columnName);
+            case Type.Utf8View:
+                return new Utf8View(columnName);
+            case Type.ListView:
+                return new ListView(columnName, fromArrowField(field.children(0)));
+            case Type.LargeListView:
+                return new LargeListView(columnName, fromArrowField(field.children(0)));
+            default:
+                throw new IllegalArgumentException("Unsupported Arrow type: " + Type.name(field.typeType()));
+        }
+    }
+
+    @Nullable
+    private final String columnName;
+
+    protected BarrageColumnType(@Nullable String columnName) {
+        this.columnName = columnName;
+    }
+
+    public @Nullable String getColumnName() {
+        return columnName;
+    }
+
+    public abstract byte typeType();
+
+    public abstract int writeType(FlatBufferBuilder builder);
+
+    public int writeField(FlatBufferBuilder builder) {
+        int typeOffset = writeType(builder);
+
+        int[] childrenOffsets = writeChildren(builder);
+        int childrenVector = Integer.MAX_VALUE;
+        if (childrenOffsets != null) {
+            childrenVector = Field.createChildrenVector(builder, childrenOffsets);
+        }
+
+        int nameOffset = Integer.MAX_VALUE;
+        if (columnName != null) {
+            nameOffset = builder.createString(columnName);
+        }
+        Field.startField(builder);
+        Field.addNullable(builder, true);
+        if (columnName != null) {
+            Field.addName(builder, nameOffset);
+        }
+        Field.addTypeType(builder, typeType());
+        Field.addType(builder, typeOffset);
+        // TODO custom metadata, including deephaven:type
+
+        if (childrenOffsets != null) {
+            Field.addChildren(builder, childrenVector);
+        }
+
+        return Field.endField(builder);
+    }
+    protected int[] writeChildren(FlatBufferBuilder builder) {
+        return null;
+    }
+
+    public abstract Class<?> type();
+    public @Nullable Class<?> componentType() {
+        return null;
+    }
+    public abstract String deephavenType();
+
+    public BarrageTypeInfo<Field> typeInfo() {
+        FlatBufferBuilder builder = new FlatBufferBuilder();
+        builder.finish(writeField(builder));
+        Field f = new Field();
+        Field.getRootAsField(builder.dataBuffer(), f);
+        return BarrageTypeInfo.make(type(), componentType(), f);
+    }
+
+    public static final class Null extends BarrageColumnType {
+        public Null(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.Null.startNull(builder);
+            return org.apache.arrow.flatbuf.Null.endNull(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Null;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.Object";
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+    }
+
+    public static final class IntType extends BarrageColumnType {
+        private final int bitWidth;
+        private final boolean isSigned;
+
+        public IntType(@Nullable String columnName, int bitWidth, boolean isSigned) {
+            super(columnName);
+            this.bitWidth = bitWidth;
+            this.isSigned = isSigned;
+        }
+
+        public int bitWidth() {
+            return bitWidth;
+        }
+
+        public boolean isSigned() {
+            return isSigned;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.Int.createInt(builder, bitWidth, isSigned);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Int;
+        }
+
+        @Override
+        public String deephavenType() {
+            if (isSigned) {
+                switch (bitWidth) {
+                    case 8: return "byte";
+                    case 16: return "short";
+                    case 32: return "int";
+                    case 64: return "long";
+                    default: throw new IllegalStateException("Unsupported signed int bitWidth: " + bitWidth);
+                }
+            } else {
+                switch (bitWidth) {
+                    case 16: return "char";
+                    default: throw new IllegalStateException("Unsupported unsigned int bitWidth: " + bitWidth);
+                }
+            }
+        }
+
+        @Override
+        public Class<?> type() {
+            if (isSigned) {
+                switch (bitWidth) {
+                    case 8: return byte.class;
+                    case 16: return short.class;
+                    case 32: return int.class;
+                    case 64: return long.class;
+                    default: throw new IllegalStateException("Unsupported signed int bitWidth: " + bitWidth);
+                }
+            } else {
+                switch (bitWidth) {
+                    case 16: return char.class;
+                    default: throw new IllegalStateException("Unsupported unsigned int bitWidth: " + bitWidth);
+                }
+            }
+        }
+    }
+
+    public static final class FloatingPoint extends BarrageColumnType {
+        private final short precision;
+
+        public FloatingPoint(@Nullable String columnName, short precision) {
+            super(columnName);
+            this.precision = precision;
+        }
+
+        /**
+         * @return precision value from {@link org.apache.arrow.flatbuf.Precision}
+         */
+        public short precision() {
+            return precision;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.FloatingPoint.createFloatingPoint(builder, precision);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.FloatingPoint;
+        }
+
+        @Override
+        public String deephavenType() {
+            switch (precision) {
+                case org.apache.arrow.flatbuf.Precision.SINGLE: return "float";
+                case org.apache.arrow.flatbuf.Precision.DOUBLE: return "double";
+                default: throw new IllegalStateException("Unsupported floating point precision: " + precision);
+            }
+        }
+
+        @Override
+        public Class<?> type() {
+            switch (precision) {
+                case org.apache.arrow.flatbuf.Precision.SINGLE: return float.class;
+                case org.apache.arrow.flatbuf.Precision.DOUBLE: return double.class;
+                default: throw new IllegalStateException("Unsupported floating point precision: " + precision);
+            }
+        }
+    }
+
+    public static final class Binary extends BarrageColumnType {
+        public Binary(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.Binary.startBinary(builder);
+            return org.apache.arrow.flatbuf.Binary.endBinary(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Binary;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.math.BigInteger";
+        }
+
+        @Override
+        public Class<?> type() {
+            return BigIntegerWrapper.class;
+        }
+    }
+
+    public static final class Utf8 extends BarrageColumnType {
+        public Utf8(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.Utf8.startUtf8(builder);
+            return org.apache.arrow.flatbuf.Utf8.endUtf8(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Utf8;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.String";
+        }
+
+        @Override
+        public Class<?> type() {
+            return String.class;
+        }
+    }
+
+    public static final class Bool extends BarrageColumnType {
+        public Bool(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.Bool.startBool(builder);
+            return org.apache.arrow.flatbuf.Bool.endBool(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Bool;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.Boolean";
+        }
+
+        @Override
+        public Class<?> type() {
+            return boolean.class;
+        }
+    }
+
+    public static final class Decimal extends BarrageColumnType {
+        private final int precision;
+        private final int scale;
+        private final int bitWidth;
+
+        public Decimal(@Nullable String columnName, int precision, int scale, int bitWidth) {
+            super(columnName);
+            this.precision = precision;
+            this.scale = scale;
+            this.bitWidth = bitWidth;
+        }
+
+        public int precision() {
+            return precision;
+        }
+
+        public int scale() {
+            return scale;
+        }
+
+        public int bitWidth() {
+            return bitWidth;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.Decimal.createDecimal(builder, precision, scale, bitWidth);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Decimal;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.math.BigDecimal";
+        }
+
+        @Override
+        public Class<?> type() {
+            return BigDecimalWrapper.class;
+        }
+    }
+
+    public static final class Date extends BarrageColumnType {
+        private final short unit;
+
+        public Date(@Nullable String columnName, short unit) {
+            super(columnName);
+            this.unit = unit;
+        }
+
+        /**
+         * @return unit value from {@link org.apache.arrow.flatbuf.DateUnit}
+         */
+        public short unit() {
+            return unit;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.Date.createDate(builder, unit);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Date;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.time.LocalDate";
+        }
+
+        @Override
+        public Class<?> type() {
+            return LocalDateWrapper.class;
+        }
+    }
+
+    public static final class Time extends BarrageColumnType {
+        private final short unit;
+        private final int bitWidth;
+
+        public Time(@Nullable String columnName, short unit, int bitWidth) {
+            super(columnName);
+            this.unit = unit;
+            this.bitWidth = bitWidth;
+        }
+
+        /**
+         * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
+         */
+        public short unit() {
+            return unit;
+        }
+
+        public int bitWidth() {
+            return bitWidth;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.Time.createTime(builder, unit, bitWidth);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Time;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.time.LocalTime";
+        }
+
+        @Override
+        public Class<?> type() {
+            return LocalTimeWrapper.class;
+        }
+    }
+
+    public static final class Timestamp extends BarrageColumnType {
+        private final short unit;
+        @Nullable
+        private final String timezone;
+
+        public Timestamp(@Nullable String columnName, short unit, @Nullable String timezone) {
+            super(columnName);
+            this.unit = unit;
+            this.timezone = timezone;
+        }
+
+        /**
+         * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
+         */
+        public short unit() {
+            return unit;
+        }
+
+        @Nullable
+        public String timezone() {
+            return timezone;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            int tzOffset = timezone != null ? builder.createString(timezone) : 0;
+            return org.apache.arrow.flatbuf.Timestamp.createTimestamp(builder, unit, tzOffset);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Timestamp;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.time.Instant";
+        }
+
+        @Override
+        public Class<?> type() {
+            return DateWrapper.class;
+        }
+    }
+
+    public static final class Interval extends BarrageColumnType {
+        private final short unit;
+
+        public Interval(@Nullable String columnName, short unit) {
+            super(columnName);
+            this.unit = unit;
+        }
+
+        /**
+         * @return unit value from {@link org.apache.arrow.flatbuf.IntervalUnit}
+         */
+        public short unit() {
+            return unit;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.Interval.createInterval(builder, unit);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Interval;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.time.Duration";
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+    }
+
+    public static final class Array extends BarrageColumnType {
+        private final BarrageColumnType componentType;
+
+        public Array(@Nullable String columnName, BarrageColumnType componentType) {
+            super(columnName);
+            this.componentType = componentType;
+        }
+
+        public BarrageColumnType arrayComponentType() {
+            return componentType;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.List.startList(builder);
+            return org.apache.arrow.flatbuf.List.endList(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.List;
+        }
+
+        @Override
+        public String deephavenType() {
+            return componentType.deephavenType() + "[]";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            return new int[] { componentType.writeField(builder) };
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+
+        @Override
+        public @Nullable Class<?> componentType() {
+            return componentType.type();
+        }
+    }
+
+    public static final class Struct extends BarrageColumnType {
+        private final List<BarrageColumnType> fields;
+
+        public Struct(@Nullable String columnName, List<BarrageColumnType> fields) {
+            super(columnName);
+            this.fields = fields;
+        }
+
+        public List<BarrageColumnType> fields() {
+            return fields;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.Struct_.startStruct_(builder);
+            return org.apache.arrow.flatbuf.Struct_.endStruct_(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Struct_;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.Object";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            int[] offsets = new int[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                offsets[i] = fields.get(i).writeField(builder);
+            }
+            return offsets;
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+    }
+
+    public static final class Union extends BarrageColumnType {
+        private final short mode;
+        private final int[] typeIds;
+        private final List<BarrageColumnType> fields;
+
+        public Union(@Nullable String columnName, short mode, int[] typeIds, List<BarrageColumnType> fields) {
+            super(columnName);
+            this.mode = mode;
+            this.typeIds = typeIds;
+            this.fields = fields;
+        }
+
+        /**
+         * @return mode value from {@link org.apache.arrow.flatbuf.UnionMode}
+         */
+        public short mode() {
+            return mode;
+        }
+
+        public int[] typeIds() {
+            return typeIds;
+        }
+
+        public List<BarrageColumnType> fields() {
+            return fields;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            int typeIdsOffset = org.apache.arrow.flatbuf.Union.createTypeIdsVector(builder, typeIds);
+            return org.apache.arrow.flatbuf.Union.createUnion(builder, mode, typeIdsOffset);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Union;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.Object";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            int[] offsets = new int[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                offsets[i] = fields.get(i).writeField(builder);
+            }
+            return offsets;
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+    }
+
+    public static final class FixedSizeBinary extends BarrageColumnType {
+        private final int byteWidth;
+
+        public FixedSizeBinary(@Nullable String columnName, int byteWidth) {
+            super(columnName);
+            this.byteWidth = byteWidth;
+        }
+
+        public int byteWidth() {
+            return byteWidth;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.FixedSizeBinary.createFixedSizeBinary(builder, byteWidth);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.FixedSizeBinary;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "byte[]";
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+
+        @Override
+        public @Nullable Class<?> componentType() {
+            return byte.class;
+        }
+    }
+
+    public static final class FixedSizeList extends BarrageColumnType {
+        private final int listSize;
+        private final BarrageColumnType componentType;
+
+        public FixedSizeList(@Nullable String columnName, int listSize, BarrageColumnType componentType) {
+            super(columnName);
+            this.listSize = listSize;
+            this.componentType = componentType;
+        }
+
+        public int listSize() {
+            return listSize;
+        }
+
+        public BarrageColumnType listComponentType() {
+            return componentType;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.FixedSizeList.createFixedSizeList(builder, listSize);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.FixedSizeList;
+        }
+
+        @Override
+        public String deephavenType() {
+            return componentType.deephavenType() + "[]";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            return new int[] { componentType.writeField(builder) };
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+
+        @Override
+        public @Nullable Class<?> componentType() {
+            return componentType.type();
+        }
+    }
+
+    public static final class Map extends BarrageColumnType {
+        private final boolean keysSorted;
+        private final BarrageColumnType keyType;
+        private final BarrageColumnType valueType;
+
+        public Map(@Nullable String columnName, boolean keysSorted, BarrageColumnType keyType, BarrageColumnType valueType) {
+            super(columnName);
+            this.keysSorted = keysSorted;
+            this.keyType = keyType;
+            this.valueType = valueType;
+        }
+
+        public boolean keysSorted() {
+            return keysSorted;
+        }
+
+        public BarrageColumnType keyType() {
+            return keyType;
+        }
+
+        public BarrageColumnType valueType() {
+            return valueType;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.Map.createMap(builder, keysSorted);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Map;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.Object";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            // Map has a single "entries" child which is a Struct with key and value children
+            int keyFieldOffset = keyType.writeField(builder);
+            int valueFieldOffset = valueType.writeField(builder);
+            int entriesChildrenVector = Field.createChildrenVector(builder, new int[] { keyFieldOffset, valueFieldOffset });
+
+            // Write the Struct_ type for the entries field
+            org.apache.arrow.flatbuf.Struct_.startStruct_(builder);
+            int entriesTypeOffset = org.apache.arrow.flatbuf.Struct_.endStruct_(builder);
+
+            int entriesNameOffset = builder.createString("entries");
+            Field.startField(builder);
+            Field.addName(builder, entriesNameOffset);
+            Field.addNullable(builder, false);
+            Field.addTypeType(builder, Type.Struct_);
+            Field.addType(builder, entriesTypeOffset);
+            Field.addChildren(builder, entriesChildrenVector);
+            int entriesFieldOffset = Field.endField(builder);
+
+            return new int[] { entriesFieldOffset };
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+    }
+
+    public static final class Duration extends BarrageColumnType {
+        private final short unit;
+
+        public Duration(@Nullable String columnName, short unit) {
+            super(columnName);
+            this.unit = unit;
+        }
+
+        /**
+         * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
+         */
+        public short unit() {
+            return unit;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            return org.apache.arrow.flatbuf.Duration.createDuration(builder, unit);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Duration;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.time.Duration";
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+    }
+
+    public static final class LargeBinary extends BarrageColumnType {
+        public LargeBinary(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.LargeBinary.startLargeBinary(builder);
+            return org.apache.arrow.flatbuf.LargeBinary.endLargeBinary(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.LargeBinary;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.math.BigInteger";
+        }
+
+        @Override
+        public Class<?> type() {
+            return BigIntegerWrapper.class;
+        }
+    }
+
+    public static final class LargeUtf8 extends BarrageColumnType {
+        public LargeUtf8(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.LargeUtf8.startLargeUtf8(builder);
+            return org.apache.arrow.flatbuf.LargeUtf8.endLargeUtf8(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.LargeUtf8;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.String";
+        }
+
+        @Override
+        public Class<?> type() {
+            return String.class;
+        }
+    }
+
+    public static final class LargeList extends BarrageColumnType {
+        private final BarrageColumnType componentType;
+
+        public LargeList(@Nullable String columnName, BarrageColumnType componentType) {
+            super(columnName);
+            this.componentType = componentType;
+        }
+
+        public BarrageColumnType listComponentType() {
+            return componentType;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.LargeList.startLargeList(builder);
+            return org.apache.arrow.flatbuf.LargeList.endLargeList(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.LargeList;
+        }
+
+        @Override
+        public String deephavenType() {
+            return componentType.deephavenType() + "[]";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            return new int[] { componentType.writeField(builder) };
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+
+        @Override
+        public @Nullable Class<?> componentType() {
+            return componentType.type();
+        }
+    }
+
+    public static final class RunEndEncoded extends BarrageColumnType {
+        private final BarrageColumnType runEndsType;
+        private final BarrageColumnType valuesType;
+
+        public RunEndEncoded(@Nullable String columnName, BarrageColumnType runEndsType, BarrageColumnType valuesType) {
+            super(columnName);
+            this.runEndsType = runEndsType;
+            this.valuesType = valuesType;
+        }
+
+        public BarrageColumnType runEndsType() {
+            return runEndsType;
+        }
+
+        public BarrageColumnType valuesType() {
+            return valuesType;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.RunEndEncoded.startRunEndEncoded(builder);
+            return org.apache.arrow.flatbuf.RunEndEncoded.endRunEndEncoded(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.RunEndEncoded;
+        }
+
+        @Override
+        public String deephavenType() {
+            return valuesType.deephavenType();
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            return new int[] { runEndsType.writeField(builder), valuesType.writeField(builder) };
+        }
+
+        @Override
+        public Class<?> type() {
+            return valuesType.type();
+        }
+    }
+
+    public static final class BinaryView extends BarrageColumnType {
+        public BinaryView(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.BinaryView.startBinaryView(builder);
+            return org.apache.arrow.flatbuf.BinaryView.endBinaryView(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.BinaryView;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "byte[]";
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+
+        @Override
+        public @Nullable Class<?> componentType() {
+            return byte.class;
+        }
+    }
+
+    public static final class Utf8View extends BarrageColumnType {
+        public Utf8View(@Nullable String columnName) {
+            super(columnName);
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.Utf8View.startUtf8View(builder);
+            return org.apache.arrow.flatbuf.Utf8View.endUtf8View(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.Utf8View;
+        }
+
+        @Override
+        public String deephavenType() {
+            return "java.lang.String";
+        }
+
+        @Override
+        public Class<?> type() {
+            return String.class;
+        }
+    }
+
+    public static final class ListView extends BarrageColumnType {
+        private final BarrageColumnType componentType;
+
+        public ListView(@Nullable String columnName, BarrageColumnType componentType) {
+            super(columnName);
+            this.componentType = componentType;
+        }
+
+        public BarrageColumnType listComponentType() {
+            return componentType;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.ListView.startListView(builder);
+            return org.apache.arrow.flatbuf.ListView.endListView(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.ListView;
+        }
+
+        @Override
+        public String deephavenType() {
+            return componentType.deephavenType() + "[]";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            return new int[] { componentType.writeField(builder) };
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+
+        @Override
+        public @Nullable Class<?> componentType() {
+            return componentType.type();
+        }
+    }
+
+    public static final class LargeListView extends BarrageColumnType {
+        private final BarrageColumnType componentType;
+
+        public LargeListView(@Nullable String columnName, BarrageColumnType componentType) {
+            super(columnName);
+            this.componentType = componentType;
+        }
+
+        public BarrageColumnType listComponentType() {
+            return componentType;
+        }
+
+        @Override
+        public int writeType(FlatBufferBuilder builder) {
+            org.apache.arrow.flatbuf.LargeListView.startLargeListView(builder);
+            return org.apache.arrow.flatbuf.LargeListView.endLargeListView(builder);
+        }
+
+        @Override
+        public byte typeType() {
+            return Type.LargeListView;
+        }
+
+        @Override
+        public String deephavenType() {
+            return componentType.deephavenType() + "[]";
+        }
+
+        @Override
+        protected int[] writeChildren(FlatBufferBuilder builder) {
+            return new int[] { componentType.writeField(builder) };
+        }
+
+        @Override
+        public Class<?> type() {
+            return Object.class;
+        }
+
+        @Override
+        public @Nullable Class<?> componentType() {
+            return componentType.type();
+        }
+    }
+}

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -7,13 +7,16 @@ import io.deephaven.web.client.api.BigIntegerWrapper;
 import io.deephaven.web.client.api.DateWrapper;
 import io.deephaven.web.client.api.LocalDateWrapper;
 import io.deephaven.web.client.api.LocalTimeWrapper;
+import io.deephaven.web.client.api.LongWrapper;
+import io.deephaven.web.client.api.barrage.WebBarrageUtils;
 import org.apache.arrow.flatbuf.Field;
+import org.apache.arrow.flatbuf.KeyValue;
 import org.apache.arrow.flatbuf.Type;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashMap;
 
 /**
  * Type model that represents all Arrow field types and supported deephaven type metadata.
@@ -22,7 +25,7 @@ public abstract sealed class BarrageColumnType
         permits BarrageColumnType.Null, BarrageColumnType.IntType, BarrageColumnType.FloatingPoint,
         BarrageColumnType.Binary, BarrageColumnType.Utf8, BarrageColumnType.Bool,
         BarrageColumnType.Decimal, BarrageColumnType.Date, BarrageColumnType.Time,
-        BarrageColumnType.Timestamp, BarrageColumnType.Interval, BarrageColumnType.Array,
+        BarrageColumnType.Timestamp, BarrageColumnType.Interval, BarrageColumnType.List,
         BarrageColumnType.Struct, BarrageColumnType.Union, BarrageColumnType.FixedSizeBinary,
         BarrageColumnType.FixedSizeList, BarrageColumnType.Map, BarrageColumnType.Duration,
         BarrageColumnType.LargeBinary, BarrageColumnType.LargeUtf8, BarrageColumnType.LargeList,
@@ -38,7 +41,7 @@ public abstract sealed class BarrageColumnType
         if (deephavenType.endsWith("[]")) {
             String componentType = deephavenType.substring(0, deephavenType.length() - 2);
             BarrageColumnType componentColumnType = fromString(null, componentType);
-            return new Array(deephavenType, componentColumnType);
+            return new List(deephavenType, componentColumnType);
         }
 
         switch (deephavenType) {
@@ -68,9 +71,9 @@ public abstract sealed class BarrageColumnType
             case "bool":
                 return new Bool(columnName);
             case "java.math.BigDecimal":
-                return new Decimal(columnName, 128, 0, 128);
+                return new Binary(columnName, "java.math.BigDecimal");
             case "java.math.BigInteger":
-                return new Binary(columnName);
+                return new Binary(columnName, "java.math.BigInteger");
             case "java.time.LocalDate":
             case "localdate":
                 return new Date(columnName, org.apache.arrow.flatbuf.DateUnit.DAY);
@@ -83,59 +86,60 @@ public abstract sealed class BarrageColumnType
     }
 
     public static BarrageColumnType fromArrowField(Field field) {
+        java.util.Map<String, String> customMetadata = WebBarrageUtils.keyValuePairs("", field.customMetadataLength(), field::customMetadata);
         String columnName = field.name();
         switch (field.typeType()) {
             case Type.Null:
-                return new Null(columnName);
+                return new Null(columnName, customMetadata);
             case Type.Int: {
                 org.apache.arrow.flatbuf.Int intType = new org.apache.arrow.flatbuf.Int();
                 field.type(intType);
-                return new IntType(columnName, intType.bitWidth(), intType.isSigned());
+                return new IntType(columnName, intType.bitWidth(), intType.isSigned(), customMetadata);
             }
             case Type.FloatingPoint: {
                 org.apache.arrow.flatbuf.FloatingPoint fpType = new org.apache.arrow.flatbuf.FloatingPoint();
                 field.type(fpType);
-                return new FloatingPoint(columnName, fpType.precision());
+                return new FloatingPoint(columnName, fpType.precision(), customMetadata);
             }
             case Type.Binary:
-                return new Binary(columnName);
+                return new Binary(columnName, customMetadata.getOrDefault("deephaven:type", "java.lang.Object"), customMetadata);
             case Type.Utf8:
-                return new Utf8(columnName);
+                return new Utf8(columnName, customMetadata);
             case Type.Bool:
-                return new Bool(columnName);
+                return new Bool(columnName, customMetadata);
             case Type.Decimal: {
                 org.apache.arrow.flatbuf.Decimal decType = new org.apache.arrow.flatbuf.Decimal();
                 field.type(decType);
-                return new Decimal(columnName, decType.precision(), decType.scale(), decType.bitWidth());
+                return new Decimal(columnName, decType.precision(), decType.scale(), decType.bitWidth(), customMetadata);
             }
             case Type.Date: {
                 org.apache.arrow.flatbuf.Date dateType = new org.apache.arrow.flatbuf.Date();
                 field.type(dateType);
-                return new Date(columnName, dateType.unit());
+                return new Date(columnName, dateType.unit(), customMetadata);
             }
             case Type.Time: {
                 org.apache.arrow.flatbuf.Time timeType = new org.apache.arrow.flatbuf.Time();
                 field.type(timeType);
-                return new Time(columnName, timeType.unit(), timeType.bitWidth());
+                return new Time(columnName, timeType.unit(), timeType.bitWidth(), customMetadata);
             }
             case Type.Timestamp: {
                 org.apache.arrow.flatbuf.Timestamp tsType = new org.apache.arrow.flatbuf.Timestamp();
                 field.type(tsType);
-                return new Timestamp(columnName, tsType.unit(), tsType.timezone());
+                return new Timestamp(columnName, tsType.unit(), tsType.timezone(), customMetadata);
             }
             case Type.Interval: {
                 org.apache.arrow.flatbuf.Interval intervalType = new org.apache.arrow.flatbuf.Interval();
                 field.type(intervalType);
-                return new Interval(columnName, intervalType.unit());
+                return new Interval(columnName, intervalType.unit(), customMetadata);
             }
             case Type.List:
-                return new Array(columnName, fromArrowField(field.children(0)));
+                return new List(columnName, fromArrowField(field.children(0)), customMetadata);
             case Type.Struct_: {
-                List<BarrageColumnType> fields = new ArrayList<>(field.childrenLength());
+                java.util.List<BarrageColumnType> fields = new ArrayList<>(field.childrenLength());
                 for (int i = 0; i < field.childrenLength(); i++) {
                     fields.add(fromArrowField(field.children(i)));
                 }
-                return new Struct(columnName, Collections.unmodifiableList(fields));
+                return new Struct(columnName, Collections.unmodifiableList(fields), customMetadata);
             }
             case Type.Union: {
                 org.apache.arrow.flatbuf.Union unionType = new org.apache.arrow.flatbuf.Union();
@@ -144,49 +148,49 @@ public abstract sealed class BarrageColumnType
                 for (int i = 0; i < typeIds.length; i++) {
                     typeIds[i] = unionType.typeIds(i);
                 }
-                List<BarrageColumnType> fields = new ArrayList<>(field.childrenLength());
+                java.util.List<BarrageColumnType> fields = new ArrayList<>(field.childrenLength());
                 for (int i = 0; i < field.childrenLength(); i++) {
                     fields.add(fromArrowField(field.children(i)));
                 }
-                return new Union(columnName, unionType.mode(), typeIds, Collections.unmodifiableList(fields));
+                return new Union(columnName, unionType.mode(), typeIds, Collections.unmodifiableList(fields), customMetadata);
             }
             case Type.FixedSizeBinary: {
                 org.apache.arrow.flatbuf.FixedSizeBinary fsbType = new org.apache.arrow.flatbuf.FixedSizeBinary();
                 field.type(fsbType);
-                return new FixedSizeBinary(columnName, fsbType.byteWidth());
+                return new FixedSizeBinary(columnName, fsbType.byteWidth(), customMetadata);
             }
             case Type.FixedSizeList: {
                 org.apache.arrow.flatbuf.FixedSizeList fslType = new org.apache.arrow.flatbuf.FixedSizeList();
                 field.type(fslType);
-                return new FixedSizeList(columnName, fslType.listSize(), fromArrowField(field.children(0)));
+                return new FixedSizeList(columnName, fslType.listSize(), fromArrowField(field.children(0)), customMetadata);
             }
             case Type.Map: {
                 org.apache.arrow.flatbuf.Map mapType = new org.apache.arrow.flatbuf.Map();
                 field.type(mapType);
                 Field entriesField = field.children(0);
-                return new Map(columnName, mapType.keysSorted(), fromArrowField(entriesField.children(0)), fromArrowField(entriesField.children(1)));
+                return new Map(columnName, mapType.keysSorted(), fromArrowField(entriesField.children(0)), fromArrowField(entriesField.children(1)), customMetadata);
             }
             case Type.Duration: {
                 org.apache.arrow.flatbuf.Duration durType = new org.apache.arrow.flatbuf.Duration();
                 field.type(durType);
-                return new Duration(columnName, durType.unit());
+                return new Duration(columnName, durType.unit(), customMetadata);
             }
             case Type.LargeBinary:
-                return new LargeBinary(columnName);
+                return new LargeBinary(columnName, customMetadata);
             case Type.LargeUtf8:
-                return new LargeUtf8(columnName);
+                return new LargeUtf8(columnName, customMetadata);
             case Type.LargeList:
-                return new LargeList(columnName, fromArrowField(field.children(0)));
+                return new LargeList(columnName, fromArrowField(field.children(0)), customMetadata);
             case Type.RunEndEncoded:
-                return new RunEndEncoded(columnName, fromArrowField(field.children(0)), fromArrowField(field.children(1)));
+                return new RunEndEncoded(columnName, fromArrowField(field.children(0)), fromArrowField(field.children(1)), customMetadata);
             case Type.BinaryView:
-                return new BinaryView(columnName);
+                return new BinaryView(columnName, customMetadata);
             case Type.Utf8View:
-                return new Utf8View(columnName);
+                return new Utf8View(columnName, customMetadata);
             case Type.ListView:
-                return new ListView(columnName, fromArrowField(field.children(0)));
+                return new ListView(columnName, fromArrowField(field.children(0)), customMetadata);
             case Type.LargeListView:
-                return new LargeListView(columnName, fromArrowField(field.children(0)));
+                return new LargeListView(columnName, fromArrowField(field.children(0)), customMetadata);
             default:
                 throw new IllegalArgumentException("Unsupported Arrow type: " + Type.name(field.typeType()));
         }
@@ -194,13 +198,23 @@ public abstract sealed class BarrageColumnType
 
     @Nullable
     private final String columnName;
+    private final java.util.Map<String, String> customMetadata;
+
+    protected BarrageColumnType(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+        this.columnName = columnName;
+        this.customMetadata = Collections.unmodifiableMap(customMetadata);
+    }
 
     protected BarrageColumnType(@Nullable String columnName) {
-        this.columnName = columnName;
+        this(columnName, java.util.Map.of());
     }
 
     public @Nullable String getColumnName() {
         return columnName;
+    }
+
+    public java.util.Map<String, String> customMetadata() {
+        return customMetadata;
     }
 
     public abstract byte typeType();
@@ -209,6 +223,21 @@ public abstract sealed class BarrageColumnType
 
     public int writeField(FlatBufferBuilder builder) {
         int typeOffset = writeType(builder);
+
+        // Merge stored custom metadata with deephaven:type (stored metadata takes precedence)
+        java.util.LinkedHashMap<String, String> mergedMetadata = new LinkedHashMap<>(customMetadata);
+        if (!deephavenType().equals("java.lang.Object") && !mergedMetadata.containsKey("deephaven:type")) {
+            mergedMetadata.put("deephaven:type", deephavenType());
+        }
+
+        int[] kvOffsets = new int[mergedMetadata.size()];
+        int idx = 0;
+        for (java.util.Map.Entry<String, String> entry : mergedMetadata.entrySet()) {
+            kvOffsets[idx++] = KeyValue.createKeyValue(builder,
+                    builder.createString(entry.getKey()),
+                    builder.createString(entry.getValue()));
+        }
+        int metadataOffset = Field.createCustomMetadataVector(builder, kvOffsets);
 
         int[] childrenOffsets = writeChildren(builder);
         int childrenVector = Integer.MAX_VALUE;
@@ -227,7 +256,7 @@ public abstract sealed class BarrageColumnType
         }
         Field.addTypeType(builder, typeType());
         Field.addType(builder, typeOffset);
-        // TODO custom metadata, including deephaven:type
+        Field.addCustomMetadata(builder, metadataOffset);
 
         if (childrenOffsets != null) {
             Field.addChildren(builder, childrenVector);
@@ -254,8 +283,8 @@ public abstract sealed class BarrageColumnType
     }
 
     public static final class Null extends BarrageColumnType {
-        public Null(@Nullable String columnName) {
-            super(columnName);
+        public Null(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
         }
 
         @Override
@@ -286,6 +315,12 @@ public abstract sealed class BarrageColumnType
 
         public IntType(@Nullable String columnName, int bitWidth, boolean isSigned) {
             super(columnName);
+            this.bitWidth = bitWidth;
+            this.isSigned = isSigned;
+        }
+
+        public IntType(@Nullable String columnName, int bitWidth, boolean isSigned, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.bitWidth = bitWidth;
             this.isSigned = isSigned;
         }
@@ -333,7 +368,7 @@ public abstract sealed class BarrageColumnType
                     case 8: return byte.class;
                     case 16: return short.class;
                     case 32: return int.class;
-                    case 64: return long.class;
+                    case 64: return LongWrapper.class;
                     default: throw new IllegalStateException("Unsupported signed int bitWidth: " + bitWidth);
                 }
             } else {
@@ -350,6 +385,11 @@ public abstract sealed class BarrageColumnType
 
         public FloatingPoint(@Nullable String columnName, short precision) {
             super(columnName);
+            this.precision = precision;
+        }
+
+        public FloatingPoint(@Nullable String columnName, short precision, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.precision = precision;
         }
 
@@ -390,8 +430,15 @@ public abstract sealed class BarrageColumnType
     }
 
     public static final class Binary extends BarrageColumnType {
-        public Binary(@Nullable String columnName) {
+        private final String deephavenType;
+        public Binary(@Nullable String columnName, String deephavenType) {
             super(columnName);
+            this.deephavenType = deephavenType;
+        }
+
+        public Binary(@Nullable String columnName, String deephavenType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+            this.deephavenType = deephavenType;
         }
 
         @Override
@@ -407,18 +454,29 @@ public abstract sealed class BarrageColumnType
 
         @Override
         public String deephavenType() {
-            return "java.math.BigInteger";
+            return deephavenType;
         }
 
         @Override
         public Class<?> type() {
-            return BigIntegerWrapper.class;
+            // Only two types are explicitly supported as Binary by deephaven, interpret the rest as object
+            if (deephavenType.equals("java.math.BigDecimal")) {
+                return BigDecimalWrapper.class;
+            }
+            if (deephavenType.equals("java.math.BigInteger")) {
+                return BigIntegerWrapper.class;
+            }
+            return Object.class;
         }
     }
 
     public static final class Utf8 extends BarrageColumnType {
         public Utf8(@Nullable String columnName) {
             super(columnName);
+        }
+
+        public Utf8(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
         }
 
         @Override
@@ -446,6 +504,10 @@ public abstract sealed class BarrageColumnType
     public static final class Bool extends BarrageColumnType {
         public Bool(@Nullable String columnName) {
             super(columnName);
+        }
+
+        public Bool(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
         }
 
         @Override
@@ -477,6 +539,13 @@ public abstract sealed class BarrageColumnType
 
         public Decimal(@Nullable String columnName, int precision, int scale, int bitWidth) {
             super(columnName);
+            this.precision = precision;
+            this.scale = scale;
+            this.bitWidth = bitWidth;
+        }
+
+        public Decimal(@Nullable String columnName, int precision, int scale, int bitWidth, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.precision = precision;
             this.scale = scale;
             this.bitWidth = bitWidth;
@@ -523,6 +592,11 @@ public abstract sealed class BarrageColumnType
             this.unit = unit;
         }
 
+        public Date(@Nullable String columnName, short unit, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+            this.unit = unit;
+        }
+
         /**
          * @return unit value from {@link org.apache.arrow.flatbuf.DateUnit}
          */
@@ -557,6 +631,12 @@ public abstract sealed class BarrageColumnType
 
         public Time(@Nullable String columnName, short unit, int bitWidth) {
             super(columnName);
+            this.unit = unit;
+            this.bitWidth = bitWidth;
+        }
+
+        public Time(@Nullable String columnName, short unit, int bitWidth, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.unit = unit;
             this.bitWidth = bitWidth;
         }
@@ -604,6 +684,12 @@ public abstract sealed class BarrageColumnType
             this.timezone = timezone;
         }
 
+        public Timestamp(@Nullable String columnName, short unit, @Nullable String timezone, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+            this.unit = unit;
+            this.timezone = timezone;
+        }
+
         /**
          * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
          */
@@ -641,8 +727,8 @@ public abstract sealed class BarrageColumnType
     public static final class Interval extends BarrageColumnType {
         private final short unit;
 
-        public Interval(@Nullable String columnName, short unit) {
-            super(columnName);
+        public Interval(@Nullable String columnName, short unit, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.unit = unit;
         }
 
@@ -674,11 +760,16 @@ public abstract sealed class BarrageColumnType
         }
     }
 
-    public static final class Array extends BarrageColumnType {
+    public static final class List extends BarrageColumnType {
         private final BarrageColumnType componentType;
 
-        public Array(@Nullable String columnName, BarrageColumnType componentType) {
+        public List(@Nullable String columnName, BarrageColumnType componentType) {
             super(columnName);
+            this.componentType = componentType;
+        }
+
+        public List(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.componentType = componentType;
         }
 
@@ -714,19 +805,20 @@ public abstract sealed class BarrageColumnType
 
         @Override
         public @Nullable Class<?> componentType() {
-            return componentType.type();
+//            return componentType.type();
+            return Object.class;
         }
     }
 
     public static final class Struct extends BarrageColumnType {
-        private final List<BarrageColumnType> fields;
+        private final java.util.List<BarrageColumnType> fields;
 
-        public Struct(@Nullable String columnName, List<BarrageColumnType> fields) {
-            super(columnName);
+        public Struct(@Nullable String columnName, java.util.List<BarrageColumnType> fields, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.fields = fields;
         }
 
-        public List<BarrageColumnType> fields() {
+        public java.util.List<BarrageColumnType> fields() {
             return fields;
         }
 
@@ -764,10 +856,17 @@ public abstract sealed class BarrageColumnType
     public static final class Union extends BarrageColumnType {
         private final short mode;
         private final int[] typeIds;
-        private final List<BarrageColumnType> fields;
+        private final java.util.List<BarrageColumnType> fields;
 
-        public Union(@Nullable String columnName, short mode, int[] typeIds, List<BarrageColumnType> fields) {
+        public Union(@Nullable String columnName, short mode, int[] typeIds, java.util.List<BarrageColumnType> fields) {
             super(columnName);
+            this.mode = mode;
+            this.typeIds = typeIds;
+            this.fields = fields;
+        }
+
+        public Union(@Nullable String columnName, short mode, int[] typeIds, java.util.List<BarrageColumnType> fields, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.mode = mode;
             this.typeIds = typeIds;
             this.fields = fields;
@@ -784,7 +883,7 @@ public abstract sealed class BarrageColumnType
             return typeIds;
         }
 
-        public List<BarrageColumnType> fields() {
+        public java.util.List<BarrageColumnType> fields() {
             return fields;
         }
 
@@ -822,8 +921,8 @@ public abstract sealed class BarrageColumnType
     public static final class FixedSizeBinary extends BarrageColumnType {
         private final int byteWidth;
 
-        public FixedSizeBinary(@Nullable String columnName, int byteWidth) {
-            super(columnName);
+        public FixedSizeBinary(@Nullable String columnName, int byteWidth, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.byteWidth = byteWidth;
         }
 
@@ -861,8 +960,8 @@ public abstract sealed class BarrageColumnType
         private final int listSize;
         private final BarrageColumnType componentType;
 
-        public FixedSizeList(@Nullable String columnName, int listSize, BarrageColumnType componentType) {
-            super(columnName);
+        public FixedSizeList(@Nullable String columnName, int listSize, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.listSize = listSize;
             this.componentType = componentType;
         }
@@ -911,8 +1010,8 @@ public abstract sealed class BarrageColumnType
         private final BarrageColumnType keyType;
         private final BarrageColumnType valueType;
 
-        public Map(@Nullable String columnName, boolean keysSorted, BarrageColumnType keyType, BarrageColumnType valueType) {
-            super(columnName);
+        public Map(@Nullable String columnName, boolean keysSorted, BarrageColumnType keyType, BarrageColumnType valueType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.keysSorted = keysSorted;
             this.keyType = keyType;
             this.valueType = valueType;
@@ -982,6 +1081,11 @@ public abstract sealed class BarrageColumnType
             this.unit = unit;
         }
 
+        public Duration(@Nullable String columnName, short unit, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+            this.unit = unit;
+        }
+
         /**
          * @return unit value from {@link org.apache.arrow.flatbuf.TimeUnit}
          */
@@ -1015,6 +1119,10 @@ public abstract sealed class BarrageColumnType
             super(columnName);
         }
 
+        public LargeBinary(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+        }
+
         @Override
         public int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.LargeBinary.startLargeBinary(builder);
@@ -1040,6 +1148,10 @@ public abstract sealed class BarrageColumnType
     public static final class LargeUtf8 extends BarrageColumnType {
         public LargeUtf8(@Nullable String columnName) {
             super(columnName);
+        }
+
+        public LargeUtf8(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
         }
 
         @Override
@@ -1069,6 +1181,11 @@ public abstract sealed class BarrageColumnType
 
         public LargeList(@Nullable String columnName, BarrageColumnType componentType) {
             super(columnName);
+            this.componentType = componentType;
+        }
+
+        public LargeList(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.componentType = componentType;
         }
 
@@ -1118,6 +1235,12 @@ public abstract sealed class BarrageColumnType
             this.valuesType = valuesType;
         }
 
+        public RunEndEncoded(@Nullable String columnName, BarrageColumnType runEndsType, BarrageColumnType valuesType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+            this.runEndsType = runEndsType;
+            this.valuesType = valuesType;
+        }
+
         public BarrageColumnType runEndsType() {
             return runEndsType;
         }
@@ -1158,6 +1281,10 @@ public abstract sealed class BarrageColumnType
             super(columnName);
         }
 
+        public BinaryView(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+        }
+
         @Override
         public int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.BinaryView.startBinaryView(builder);
@@ -1190,6 +1317,10 @@ public abstract sealed class BarrageColumnType
             super(columnName);
         }
 
+        public Utf8View(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
+        }
+
         @Override
         public int writeType(FlatBufferBuilder builder) {
             org.apache.arrow.flatbuf.Utf8View.startUtf8View(builder);
@@ -1217,6 +1348,11 @@ public abstract sealed class BarrageColumnType
 
         public ListView(@Nullable String columnName, BarrageColumnType componentType) {
             super(columnName);
+            this.componentType = componentType;
+        }
+
+        public ListView(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.componentType = componentType;
         }
 
@@ -1261,6 +1397,11 @@ public abstract sealed class BarrageColumnType
 
         public LargeListView(@Nullable String columnName, BarrageColumnType componentType) {
             super(columnName);
+            this.componentType = componentType;
+        }
+
+        public LargeListView(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+            super(columnName, customMetadata);
             this.componentType = componentType;
         }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -1,3 +1,6 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
 package io.deephaven.web.client.api.barrage.data;
 
 import com.google.flatbuffers.FlatBufferBuilder;
@@ -34,6 +37,7 @@ public abstract sealed class BarrageColumnType
 
     /**
      * Best effort mapping from string type info to supported Flight/Deephaven types.
+     * 
      * @param deephavenType supports deephaven:type strings, as well as some specific JS shorthand
      * @return
      */
@@ -86,7 +90,8 @@ public abstract sealed class BarrageColumnType
     }
 
     public static BarrageColumnType fromArrowField(Field field) {
-        java.util.Map<String, String> customMetadata = WebBarrageUtils.keyValuePairs("", field.customMetadataLength(), field::customMetadata);
+        java.util.Map<String, String> customMetadata =
+                WebBarrageUtils.keyValuePairs("", field.customMetadataLength(), field::customMetadata);
         String columnName = field.name();
         switch (field.typeType()) {
             case Type.Null:
@@ -102,7 +107,8 @@ public abstract sealed class BarrageColumnType
                 return new FloatingPoint(columnName, fpType.precision(), customMetadata);
             }
             case Type.Binary:
-                return new Binary(columnName, customMetadata.getOrDefault("deephaven:type", "java.lang.Object"), customMetadata);
+                return new Binary(columnName, customMetadata.getOrDefault("deephaven:type", "java.lang.Object"),
+                        customMetadata);
             case Type.Utf8:
                 return new Utf8(columnName, customMetadata);
             case Type.Bool:
@@ -110,7 +116,8 @@ public abstract sealed class BarrageColumnType
             case Type.Decimal: {
                 org.apache.arrow.flatbuf.Decimal decType = new org.apache.arrow.flatbuf.Decimal();
                 field.type(decType);
-                return new Decimal(columnName, decType.precision(), decType.scale(), decType.bitWidth(), customMetadata);
+                return new Decimal(columnName, decType.precision(), decType.scale(), decType.bitWidth(),
+                        customMetadata);
             }
             case Type.Date: {
                 org.apache.arrow.flatbuf.Date dateType = new org.apache.arrow.flatbuf.Date();
@@ -152,7 +159,8 @@ public abstract sealed class BarrageColumnType
                 for (int i = 0; i < field.childrenLength(); i++) {
                     fields.add(fromArrowField(field.children(i)));
                 }
-                return new Union(columnName, unionType.mode(), typeIds, Collections.unmodifiableList(fields), customMetadata);
+                return new Union(columnName, unionType.mode(), typeIds, Collections.unmodifiableList(fields),
+                        customMetadata);
             }
             case Type.FixedSizeBinary: {
                 org.apache.arrow.flatbuf.FixedSizeBinary fsbType = new org.apache.arrow.flatbuf.FixedSizeBinary();
@@ -162,13 +170,15 @@ public abstract sealed class BarrageColumnType
             case Type.FixedSizeList: {
                 org.apache.arrow.flatbuf.FixedSizeList fslType = new org.apache.arrow.flatbuf.FixedSizeList();
                 field.type(fslType);
-                return new FixedSizeList(columnName, fslType.listSize(), fromArrowField(field.children(0)), customMetadata);
+                return new FixedSizeList(columnName, fslType.listSize(), fromArrowField(field.children(0)),
+                        customMetadata);
             }
             case Type.Map: {
                 org.apache.arrow.flatbuf.Map mapType = new org.apache.arrow.flatbuf.Map();
                 field.type(mapType);
                 Field entriesField = field.children(0);
-                return new Map(columnName, mapType.keysSorted(), fromArrowField(entriesField.children(0)), fromArrowField(entriesField.children(1)), customMetadata);
+                return new Map(columnName, mapType.keysSorted(), fromArrowField(entriesField.children(0)),
+                        fromArrowField(entriesField.children(1)), customMetadata);
             }
             case Type.Duration: {
                 org.apache.arrow.flatbuf.Duration durType = new org.apache.arrow.flatbuf.Duration();
@@ -182,7 +192,8 @@ public abstract sealed class BarrageColumnType
             case Type.LargeList:
                 return new LargeList(columnName, fromArrowField(field.children(0)), customMetadata);
             case Type.RunEndEncoded:
-                return new RunEndEncoded(columnName, fromArrowField(field.children(0)), fromArrowField(field.children(1)), customMetadata);
+                return new RunEndEncoded(columnName, fromArrowField(field.children(0)),
+                        fromArrowField(field.children(1)), customMetadata);
             case Type.BinaryView:
                 return new BinaryView(columnName, customMetadata);
             case Type.Utf8View:
@@ -264,14 +275,17 @@ public abstract sealed class BarrageColumnType
 
         return Field.endField(builder);
     }
+
     protected int[] writeChildren(FlatBufferBuilder builder) {
         return null;
     }
 
     public abstract Class<?> type();
+
     public @Nullable Class<?> componentType() {
         return null;
     }
+
     public abstract String deephavenType();
 
     public BarrageTypeInfo<Field> typeInfo() {
@@ -280,6 +294,10 @@ public abstract sealed class BarrageColumnType
         Field f = new Field();
         Field.getRootAsField(builder.dataBuffer(), f);
         return BarrageTypeInfo.make(type(), componentType(), f);
+    }
+
+    public String getDeephavenColumnAttr(String string) {
+        return customMetadata.get("deephaven:" + string);
     }
 
     public static final class Null extends BarrageColumnType {
@@ -319,7 +337,8 @@ public abstract sealed class BarrageColumnType
             this.isSigned = isSigned;
         }
 
-        public IntType(@Nullable String columnName, int bitWidth, boolean isSigned, java.util.Map<String, String> customMetadata) {
+        public IntType(@Nullable String columnName, int bitWidth, boolean isSigned,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.bitWidth = bitWidth;
             this.isSigned = isSigned;
@@ -347,16 +366,23 @@ public abstract sealed class BarrageColumnType
         public String deephavenType() {
             if (isSigned) {
                 switch (bitWidth) {
-                    case 8: return "byte";
-                    case 16: return "short";
-                    case 32: return "int";
-                    case 64: return "long";
-                    default: throw new IllegalStateException("Unsupported signed int bitWidth: " + bitWidth);
+                    case 8:
+                        return "byte";
+                    case 16:
+                        return "short";
+                    case 32:
+                        return "int";
+                    case 64:
+                        return "long";
+                    default:
+                        throw new IllegalStateException("Unsupported signed int bitWidth: " + bitWidth);
                 }
             } else {
                 switch (bitWidth) {
-                    case 16: return "char";
-                    default: throw new IllegalStateException("Unsupported unsigned int bitWidth: " + bitWidth);
+                    case 16:
+                        return "char";
+                    default:
+                        throw new IllegalStateException("Unsupported unsigned int bitWidth: " + bitWidth);
                 }
             }
         }
@@ -365,16 +391,23 @@ public abstract sealed class BarrageColumnType
         public Class<?> type() {
             if (isSigned) {
                 switch (bitWidth) {
-                    case 8: return byte.class;
-                    case 16: return short.class;
-                    case 32: return int.class;
-                    case 64: return LongWrapper.class;
-                    default: throw new IllegalStateException("Unsupported signed int bitWidth: " + bitWidth);
+                    case 8:
+                        return byte.class;
+                    case 16:
+                        return short.class;
+                    case 32:
+                        return int.class;
+                    case 64:
+                        return LongWrapper.class;
+                    default:
+                        throw new IllegalStateException("Unsupported signed int bitWidth: " + bitWidth);
                 }
             } else {
                 switch (bitWidth) {
-                    case 16: return char.class;
-                    default: throw new IllegalStateException("Unsupported unsigned int bitWidth: " + bitWidth);
+                    case 16:
+                        return char.class;
+                    default:
+                        throw new IllegalStateException("Unsupported unsigned int bitWidth: " + bitWidth);
                 }
             }
         }
@@ -388,7 +421,8 @@ public abstract sealed class BarrageColumnType
             this.precision = precision;
         }
 
-        public FloatingPoint(@Nullable String columnName, short precision, java.util.Map<String, String> customMetadata) {
+        public FloatingPoint(@Nullable String columnName, short precision,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.precision = precision;
         }
@@ -413,24 +447,31 @@ public abstract sealed class BarrageColumnType
         @Override
         public String deephavenType() {
             switch (precision) {
-                case org.apache.arrow.flatbuf.Precision.SINGLE: return "float";
-                case org.apache.arrow.flatbuf.Precision.DOUBLE: return "double";
-                default: throw new IllegalStateException("Unsupported floating point precision: " + precision);
+                case org.apache.arrow.flatbuf.Precision.SINGLE:
+                    return "float";
+                case org.apache.arrow.flatbuf.Precision.DOUBLE:
+                    return "double";
+                default:
+                    throw new IllegalStateException("Unsupported floating point precision: " + precision);
             }
         }
 
         @Override
         public Class<?> type() {
             switch (precision) {
-                case org.apache.arrow.flatbuf.Precision.SINGLE: return float.class;
-                case org.apache.arrow.flatbuf.Precision.DOUBLE: return double.class;
-                default: throw new IllegalStateException("Unsupported floating point precision: " + precision);
+                case org.apache.arrow.flatbuf.Precision.SINGLE:
+                    return float.class;
+                case org.apache.arrow.flatbuf.Precision.DOUBLE:
+                    return double.class;
+                default:
+                    throw new IllegalStateException("Unsupported floating point precision: " + precision);
             }
         }
     }
 
     public static final class Binary extends BarrageColumnType {
         private final String deephavenType;
+
         public Binary(@Nullable String columnName, String deephavenType) {
             super(columnName);
             this.deephavenType = deephavenType;
@@ -544,7 +585,8 @@ public abstract sealed class BarrageColumnType
             this.bitWidth = bitWidth;
         }
 
-        public Decimal(@Nullable String columnName, int precision, int scale, int bitWidth, java.util.Map<String, String> customMetadata) {
+        public Decimal(@Nullable String columnName, int precision, int scale, int bitWidth,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.precision = precision;
             this.scale = scale;
@@ -635,7 +677,8 @@ public abstract sealed class BarrageColumnType
             this.bitWidth = bitWidth;
         }
 
-        public Time(@Nullable String columnName, short unit, int bitWidth, java.util.Map<String, String> customMetadata) {
+        public Time(@Nullable String columnName, short unit, int bitWidth,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.unit = unit;
             this.bitWidth = bitWidth;
@@ -684,7 +727,8 @@ public abstract sealed class BarrageColumnType
             this.timezone = timezone;
         }
 
-        public Timestamp(@Nullable String columnName, short unit, @Nullable String timezone, java.util.Map<String, String> customMetadata) {
+        public Timestamp(@Nullable String columnName, short unit, @Nullable String timezone,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.unit = unit;
             this.timezone = timezone;
@@ -768,7 +812,8 @@ public abstract sealed class BarrageColumnType
             this.componentType = componentType;
         }
 
-        public List(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+        public List(@Nullable String columnName, BarrageColumnType componentType,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.componentType = componentType;
         }
@@ -795,7 +840,7 @@ public abstract sealed class BarrageColumnType
 
         @Override
         protected int[] writeChildren(FlatBufferBuilder builder) {
-            return new int[] { componentType.writeField(builder) };
+            return new int[] {componentType.writeField(builder)};
         }
 
         @Override
@@ -812,7 +857,8 @@ public abstract sealed class BarrageColumnType
     public static final class Struct extends BarrageColumnType {
         private final java.util.List<BarrageColumnType> fields;
 
-        public Struct(@Nullable String columnName, java.util.List<BarrageColumnType> fields, java.util.Map<String, String> customMetadata) {
+        public Struct(@Nullable String columnName, java.util.List<BarrageColumnType> fields,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.fields = fields;
         }
@@ -857,7 +903,8 @@ public abstract sealed class BarrageColumnType
         private final int[] typeIds;
         private final java.util.List<BarrageColumnType> fields;
 
-        public Union(@Nullable String columnName, short mode, int[] typeIds, java.util.List<BarrageColumnType> fields, java.util.Map<String, String> customMetadata) {
+        public Union(@Nullable String columnName, short mode, int[] typeIds, java.util.List<BarrageColumnType> fields,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.mode = mode;
             this.typeIds = typeIds;
@@ -913,7 +960,8 @@ public abstract sealed class BarrageColumnType
     public static final class FixedSizeBinary extends BarrageColumnType {
         private final int byteWidth;
 
-        public FixedSizeBinary(@Nullable String columnName, int byteWidth, java.util.Map<String, String> customMetadata) {
+        public FixedSizeBinary(@Nullable String columnName, int byteWidth,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.byteWidth = byteWidth;
         }
@@ -943,7 +991,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public  Class<?> componentType() {
+        public Class<?> componentType() {
             return byte.class;
         }
     }
@@ -952,7 +1000,8 @@ public abstract sealed class BarrageColumnType
         private final int listSize;
         private final BarrageColumnType componentType;
 
-        public FixedSizeList(@Nullable String columnName, int listSize, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+        public FixedSizeList(@Nullable String columnName, int listSize, BarrageColumnType componentType,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.listSize = listSize;
             this.componentType = componentType;
@@ -983,7 +1032,7 @@ public abstract sealed class BarrageColumnType
 
         @Override
         protected int[] writeChildren(FlatBufferBuilder builder) {
-            return new int[] { componentType.writeField(builder) };
+            return new int[] {componentType.writeField(builder)};
         }
 
         @Override
@@ -1002,7 +1051,8 @@ public abstract sealed class BarrageColumnType
         private final BarrageColumnType keyType;
         private final BarrageColumnType valueType;
 
-        public Map(@Nullable String columnName, boolean keysSorted, BarrageColumnType keyType, BarrageColumnType valueType, java.util.Map<String, String> customMetadata) {
+        public Map(@Nullable String columnName, boolean keysSorted, BarrageColumnType keyType,
+                BarrageColumnType valueType, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.keysSorted = keysSorted;
             this.keyType = keyType;
@@ -1041,7 +1091,8 @@ public abstract sealed class BarrageColumnType
             // Map has a single "entries" child which is a Struct with key and value children
             int keyFieldOffset = keyType.writeField(builder);
             int valueFieldOffset = valueType.writeField(builder);
-            int entriesChildrenVector = Field.createChildrenVector(builder, new int[] { keyFieldOffset, valueFieldOffset });
+            int entriesChildrenVector =
+                    Field.createChildrenVector(builder, new int[] {keyFieldOffset, valueFieldOffset});
 
             // Write the Struct_ type for the entries field
             org.apache.arrow.flatbuf.Struct_.startStruct_(builder);
@@ -1056,7 +1107,7 @@ public abstract sealed class BarrageColumnType
             Field.addChildren(builder, entriesChildrenVector);
             int entriesFieldOffset = Field.endField(builder);
 
-            return new int[] { entriesFieldOffset };
+            return new int[] {entriesFieldOffset};
         }
 
         @Override
@@ -1158,7 +1209,8 @@ public abstract sealed class BarrageColumnType
     public static final class LargeList extends BarrageColumnType {
         private final BarrageColumnType componentType;
 
-        public LargeList(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+        public LargeList(@Nullable String columnName, BarrageColumnType componentType,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.componentType = componentType;
         }
@@ -1185,7 +1237,7 @@ public abstract sealed class BarrageColumnType
 
         @Override
         protected int[] writeChildren(FlatBufferBuilder builder) {
-            return new int[] { componentType.writeField(builder) };
+            return new int[] {componentType.writeField(builder)};
         }
 
         @Override
@@ -1203,7 +1255,8 @@ public abstract sealed class BarrageColumnType
         private final BarrageColumnType runEndsType;
         private final BarrageColumnType valuesType;
 
-        public RunEndEncoded(@Nullable String columnName, BarrageColumnType runEndsType, BarrageColumnType valuesType, java.util.Map<String, String> customMetadata) {
+        public RunEndEncoded(@Nullable String columnName, BarrageColumnType runEndsType, BarrageColumnType valuesType,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.runEndsType = runEndsType;
             this.valuesType = valuesType;
@@ -1235,7 +1288,7 @@ public abstract sealed class BarrageColumnType
 
         @Override
         protected int[] writeChildren(FlatBufferBuilder builder) {
-            return new int[] { runEndsType.writeField(builder), valuesType.writeField(builder) };
+            return new int[] {runEndsType.writeField(builder), valuesType.writeField(builder)};
         }
 
         @Override
@@ -1319,7 +1372,8 @@ public abstract sealed class BarrageColumnType
             this.componentType = componentType;
         }
 
-        public ListView(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+        public ListView(@Nullable String columnName, BarrageColumnType componentType,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.componentType = componentType;
         }
@@ -1346,7 +1400,7 @@ public abstract sealed class BarrageColumnType
 
         @Override
         protected int[] writeChildren(FlatBufferBuilder builder) {
-            return new int[] { componentType.writeField(builder) };
+            return new int[] {componentType.writeField(builder)};
         }
 
         @Override
@@ -1363,7 +1417,8 @@ public abstract sealed class BarrageColumnType
     public static final class LargeListView extends BarrageColumnType {
         private final BarrageColumnType componentType;
 
-        public LargeListView(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
+        public LargeListView(@Nullable String columnName, BarrageColumnType componentType,
+                java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.componentType = componentType;
         }
@@ -1390,7 +1445,7 @@ public abstract sealed class BarrageColumnType
 
         @Override
         protected int[] writeChildren(FlatBufferBuilder builder) {
-            return new int[] { componentType.writeField(builder) };
+            return new int[] {componentType.writeField(builder)};
         }
 
         @Override

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/BarrageColumnType.java
@@ -804,9 +804,8 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public @Nullable Class<?> componentType() {
-//            return componentType.type();
-            return Object.class;
+        public Class<?> componentType() {
+            return componentType.type();
         }
     }
 
@@ -857,13 +856,6 @@ public abstract sealed class BarrageColumnType
         private final short mode;
         private final int[] typeIds;
         private final java.util.List<BarrageColumnType> fields;
-
-        public Union(@Nullable String columnName, short mode, int[] typeIds, java.util.List<BarrageColumnType> fields) {
-            super(columnName);
-            this.mode = mode;
-            this.typeIds = typeIds;
-            this.fields = fields;
-        }
 
         public Union(@Nullable String columnName, short mode, int[] typeIds, java.util.List<BarrageColumnType> fields, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
@@ -951,7 +943,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public @Nullable Class<?> componentType() {
+        public  Class<?> componentType() {
             return byte.class;
         }
     }
@@ -1000,7 +992,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public @Nullable Class<?> componentType() {
+        public Class<?> componentType() {
             return componentType.type();
         }
     }
@@ -1076,11 +1068,6 @@ public abstract sealed class BarrageColumnType
     public static final class Duration extends BarrageColumnType {
         private final short unit;
 
-        public Duration(@Nullable String columnName, short unit) {
-            super(columnName);
-            this.unit = unit;
-        }
-
         public Duration(@Nullable String columnName, short unit, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
             this.unit = unit;
@@ -1115,10 +1102,6 @@ public abstract sealed class BarrageColumnType
     }
 
     public static final class LargeBinary extends BarrageColumnType {
-        public LargeBinary(@Nullable String columnName) {
-            super(columnName);
-        }
-
         public LargeBinary(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
         }
@@ -1146,10 +1129,6 @@ public abstract sealed class BarrageColumnType
     }
 
     public static final class LargeUtf8 extends BarrageColumnType {
-        public LargeUtf8(@Nullable String columnName) {
-            super(columnName);
-        }
-
         public LargeUtf8(@Nullable String columnName, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
         }
@@ -1178,11 +1157,6 @@ public abstract sealed class BarrageColumnType
 
     public static final class LargeList extends BarrageColumnType {
         private final BarrageColumnType componentType;
-
-        public LargeList(@Nullable String columnName, BarrageColumnType componentType) {
-            super(columnName);
-            this.componentType = componentType;
-        }
 
         public LargeList(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
@@ -1220,7 +1194,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public @Nullable Class<?> componentType() {
+        public Class<?> componentType() {
             return componentType.type();
         }
     }
@@ -1228,12 +1202,6 @@ public abstract sealed class BarrageColumnType
     public static final class RunEndEncoded extends BarrageColumnType {
         private final BarrageColumnType runEndsType;
         private final BarrageColumnType valuesType;
-
-        public RunEndEncoded(@Nullable String columnName, BarrageColumnType runEndsType, BarrageColumnType valuesType) {
-            super(columnName);
-            this.runEndsType = runEndsType;
-            this.valuesType = valuesType;
-        }
 
         public RunEndEncoded(@Nullable String columnName, BarrageColumnType runEndsType, BarrageColumnType valuesType, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);
@@ -1307,7 +1275,7 @@ public abstract sealed class BarrageColumnType
         }
 
         @Override
-        public @Nullable Class<?> componentType() {
+        public Class<?> componentType() {
             return byte.class;
         }
     }
@@ -1394,11 +1362,6 @@ public abstract sealed class BarrageColumnType
 
     public static final class LargeListView extends BarrageColumnType {
         private final BarrageColumnType componentType;
-
-        public LargeListView(@Nullable String columnName, BarrageColumnType componentType) {
-            super(columnName);
-            this.componentType = componentType;
-        }
 
         public LargeListView(@Nullable String columnName, BarrageColumnType componentType, java.util.Map<String, String> customMetadata) {
             super(columnName, customMetadata);

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/WebBarrageSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/data/WebBarrageSubscription.java
@@ -43,7 +43,7 @@ public abstract class WebBarrageSubscription {
             final ViewportChangedHandler viewportChangedHandler,
             final DataChangedHandler dataChangedHandler) {
 
-        WebColumnData[] dataSinks = new WebColumnData[cts.columnTypes().length];
+        WebColumnData[] dataSinks = new WebColumnData[cts.getTableDef().getColumns().length];
         for (int i = 0; i < dataSinks.length; i++) {
             dataSinks[i] = new WebColumnData();
         }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/def/ColumnDefinition.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/barrage/def/ColumnDefinition.java
@@ -4,77 +4,22 @@
 package io.deephaven.web.client.api.barrage.def;
 
 import io.deephaven.web.client.api.Column;
+import io.deephaven.web.client.api.barrage.data.BarrageColumnType;
 import org.apache.arrow.flatbuf.Field;
 
 import java.util.Map;
 
-import static io.deephaven.web.client.api.barrage.WebBarrageUtils.keyValuePairs;
-
 public class ColumnDefinition {
-    private final Field field;
+    private final BarrageColumnType columnType;
     private final int columnIndex;
-    private final String type;
-
-    private final boolean isSortable;
-
-    private final String styleColumn;
-    private final String formatColumn;
-
-    private final boolean isStyleColumn;
-    private final boolean isFormatColumn;
-    private final boolean isPartitionColumn;
-    private final boolean isHierarchicalExpandByColumn;
-    private final boolean isHierarchicalRowDepthColumn;
-    private final boolean isHierarchicalRowExpandedColumn;
-    private final boolean isRollupAggregatedNodeColumn;
-    private final boolean isRollupConstituentNodeColumn;
-    private final boolean isRollupGroupByColumn;
-    private final String rollupAggregationInputColumn;
-
-    // Indicates that this is a style column for the whole row
-    private final boolean forRow;
-    private final boolean isInputTableKeyColumn;
-    private final boolean isInputTableValueColumn;
-    private final String description;
 
     public ColumnDefinition(int index, Field field) {
-        Map<String, String> fieldMetadata =
-                keyValuePairs("deephaven:", field.customMetadataLength(), field::customMetadata);
-        this.field = field;
+        this.columnType = BarrageColumnType.fromArrowField(field);
         columnIndex = index;
-        type = fieldMetadata.get("type");
-        isSortable = "true".equals(fieldMetadata.get("isSortable"));
-        isStyleColumn = "true".equals(fieldMetadata.get("isStyle"));
-        isFormatColumn = "true".equals(fieldMetadata.get("isDateFormat"))
-                || "true".equals(fieldMetadata.get("isNumberFormat"));
-        forRow = "true".equals(fieldMetadata.get("isRowStyle"));
-
-        String formatColumnName = fieldMetadata.get("dateFormatColumn");
-        if (formatColumnName == null) {
-            formatColumnName = fieldMetadata.get("numberFormatColumn");
-        }
-        formatColumn = formatColumnName;
-
-        styleColumn = fieldMetadata.get("styleColumn");
-
-        isInputTableKeyColumn = "true".equals(fieldMetadata.get("inputtable.isKey"));
-        isInputTableValueColumn = "true".equals(fieldMetadata.get("inputtable.isValue"));
-
-        this.description = fieldMetadata.get("description");
-
-        isPartitionColumn = "true".equals(fieldMetadata.get("isPartitioning"));
-
-        isHierarchicalExpandByColumn = "true".equals(fieldMetadata.get("hierarchicalTable.isExpandByColumn"));
-        isHierarchicalRowDepthColumn = "true".equals(fieldMetadata.get("hierarchicalTable.isRowDepthColumn"));
-        isHierarchicalRowExpandedColumn = "true".equals(fieldMetadata.get("hierarchicalTable.isRowExpandedColumn"));
-        isRollupAggregatedNodeColumn = "true".equals(fieldMetadata.get("rollupTable.isAggregatedNodeColumn"));
-        isRollupConstituentNodeColumn = "true".equals(fieldMetadata.get("rollupTable.isConstituentNodeColumn"));
-        isRollupGroupByColumn = "true".equals(fieldMetadata.get("rollupTable.isGroupByColumn"));
-        rollupAggregationInputColumn = fieldMetadata.get("rollupTable.aggregationInputColumnName");
     }
 
     public String getName() {
-        return field.name();
+        return columnType.getColumnName();
     }
 
     public int getColumnIndex() {
@@ -82,23 +27,24 @@ public class ColumnDefinition {
     }
 
     public String getType() {
-        return type;
+        return columnType.deephavenType();
     }
 
     public boolean isSortable() {
-        return isSortable;
+        return "true".equals(columnType.getDeephavenColumnAttr("isSortable"));
     }
 
     public boolean isStyleColumn() {
-        return isStyleColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("isStyle"));
     }
 
     public boolean isFormatColumn() {
-        return isFormatColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("isDateFormat"))
+                || "true".equals(columnType.getDeephavenColumnAttr("isNumberFormat"));
     }
 
     public boolean isPartitionColumn() {
-        return isPartitionColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("isPartitioning"));
     }
 
     public boolean isVisible() {
@@ -107,32 +53,36 @@ public class ColumnDefinition {
     }
 
     public boolean isForRow() {
-        return forRow;
+        return "true".equals(columnType.getDeephavenColumnAttr("isRowStyle"));
     }
 
     public String getFormatColumnName() {
-        return formatColumn;
+        String formatColumnName = columnType.getDeephavenColumnAttr("dateFormatColumn");
+        if (formatColumnName == null) {
+            formatColumnName = columnType.getDeephavenColumnAttr("numberFormatColumn");
+        }
+        return formatColumnName;
     }
 
     public String getStyleColumnName() {
-        return styleColumn;
+        return columnType.getDeephavenColumnAttr("styleColumn");
     }
 
     public boolean isInputTableKeyColumn() {
-        return isInputTableKeyColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("inputtable.isKey"));
     }
 
     public boolean isInputTableValueColumn() {
-        return isInputTableValueColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("inputtable.isValue"));
     }
 
     public String getDescription() {
-        return description;
+        return columnType.getDeephavenColumnAttr("description");
     }
 
     public Column makeJsColumn(int index, Map<Boolean, Map<String, ColumnDefinition>> map) {
         if (isForRow()) {
-            return makeColumn(-1, this, null, null, false, null, null, false, false);
+            return makeColumn(-1, this, null, false, null, null, false, false);
         }
         Map<String, ColumnDefinition> byNameMap = map.get(isRollupConstituentNodeColumn());
         ColumnDefinition format = byNameMap.get(getFormatColumnName());
@@ -141,7 +91,6 @@ public class ColumnDefinition {
         return makeColumn(index,
                 this,
                 style == null ? null : style.getColumnIndex(),
-                style == null ? null : style.getColumnIndex(),
                 isPartitionColumn(),
                 format == null ? null : format.getColumnIndex(),
                 getDescription(),
@@ -149,41 +98,40 @@ public class ColumnDefinition {
                 isInputTableValueColumn());
     }
 
-    private static Column makeColumn(int jsIndex, ColumnDefinition definition, Integer numberFormatIndex,
+    private static Column makeColumn(int jsIndex, ColumnDefinition definition,
             Integer styleIndex, boolean isPartitionColumn, Integer formatStringIndex, String description,
             boolean inputTableKeyColumn, boolean inputTableValueColumn) {
-        return new Column(jsIndex, definition.getColumnIndex(), numberFormatIndex, styleIndex, definition.getType(),
+        return new Column(jsIndex, definition.getColumnIndex(), styleIndex, definition.getType(),
                 definition.getName(), isPartitionColumn, formatStringIndex, description, inputTableKeyColumn,
                 inputTableValueColumn,
                 definition.isSortable());
     }
 
     public boolean isHierarchicalExpandByColumn() {
-        return isHierarchicalExpandByColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("hierarchicalTable.isExpandByColumn"));
     }
 
     public boolean isHierarchicalRowDepthColumn() {
-        return isHierarchicalRowDepthColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("hierarchicalTable.isRowDepthColumn"));
     }
 
     public boolean isHierarchicalRowExpandedColumn() {
-        return isHierarchicalRowExpandedColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("hierarchicalTable.isRowExpandedColumn"));
     }
 
     public boolean isRollupAggregatedNodeColumn() {
-        return isRollupAggregatedNodeColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("rollupTable.isAggregatedNodeColumn"));
     }
 
     public boolean isRollupConstituentNodeColumn() {
-        return isRollupConstituentNodeColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("rollupTable.isConstituentNodeColumn"));
     }
 
     public boolean isRollupGroupByColumn() {
-        return isRollupGroupByColumn;
+        return "true".equals(columnType.getDeephavenColumnAttr("rollupTable.isGroupByColumn"));
     }
 
     public String getRollupAggregationInputColumn() {
-        return rollupAggregationInputColumn;
+        return columnType.getDeephavenColumnAttr("rollupTable.aggregationInputColumnName");
     }
-
 }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
@@ -3,7 +3,6 @@
 //
 package io.deephaven.web.client.api.parse;
 
-import com.google.flatbuffers.FlatBufferBuilder;
 import com.google.gwt.i18n.client.TimeZone;
 import elemental2.core.JsDate;
 import io.deephaven.util.BooleanUtils;
@@ -11,33 +10,15 @@ import io.deephaven.web.client.api.LongWrapper;
 import io.deephaven.web.client.api.i18n.JsDateTimeFormat;
 import io.deephaven.web.client.api.i18n.JsTimeZone;
 import jsinterop.base.Js;
-import org.apache.arrow.flatbuf.Binary;
-import org.apache.arrow.flatbuf.Date;
-import org.apache.arrow.flatbuf.DateUnit;
-import org.apache.arrow.flatbuf.FloatingPoint;
-import org.apache.arrow.flatbuf.Int;
-import org.apache.arrow.flatbuf.Precision;
-import org.apache.arrow.flatbuf.Time;
-import org.apache.arrow.flatbuf.TimeUnit;
-import org.apache.arrow.flatbuf.Timestamp;
-import org.apache.arrow.flatbuf.Type;
-import org.apache.arrow.flatbuf.Utf8;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Given the expected type of a column, pick one of the enum entries and use that to read the data into arrow buffers.
+ * Given the expected type of a column, ensure consistency in the data array
  */
 public enum JsDataHandler {
-    STRING(Type.Utf8, "java.lang.String", "string") {
-
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            Utf8.startUtf8(builder);
-            return Utf8.endUtf8(builder);
-        }
-
+    STRING("java.lang.String", "string") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             // Scan until we find an element that needs conversion
@@ -65,7 +46,7 @@ public enum JsDataHandler {
             return result;
         }
     },
-    DATE_TIME(Type.Timestamp, "java.time.Instant", "datetime", "java.time.ZonedDateTime") {
+    DATE_TIME("java.time.Instant", "datetime", "java.time.ZonedDateTime") {
         // Ensures that the 'T' separator character is in the date time
         private String ensureSeparator(String s) {
             if (s.charAt(SEPARATOR_INDEX) == ' ') {
@@ -129,12 +110,6 @@ public enum JsDataHandler {
         }
 
         @Override
-        public int writeType(FlatBufferBuilder builder) {
-            int utc = builder.createString("UTC");
-            return Timestamp.createTimestamp(builder, TimeUnit.NANOSECOND, utc);
-        }
-
-        @Override
         public Object[] process(Object[] data, ParseContext context) {
             // Scan until we find a non-LongWrapper (and non-null) instance
             int firstNonLong = 0;
@@ -169,34 +144,19 @@ public enum JsDataHandler {
             return result;
         }
     },
-    INTEGER(Type.Int, "int") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Int.createInt(builder, 32, true);
-        }
-
+    INTEGER("int") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             return writeSimpleNumbers(data);
         }
     },
-    SHORT(Type.Int, "short") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Int.createInt(builder, 16, true);
-        }
-
+    SHORT("short") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             return writeSimpleNumbers(data);
         }
     },
-    LONG(Type.Int, "long") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Int.createInt(builder, 64, true);
-        }
-
+    LONG("long") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             // Scan until we find a non-LongWrapper (and non-null) instance
@@ -231,56 +191,31 @@ public enum JsDataHandler {
             return result;
         }
     },
-    BYTE(Type.Int, "byte") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Int.createInt(builder, 8, true);
-        }
-
+    BYTE("byte") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             return writeSimpleNumbers(data);
         }
     },
-    CHAR(Type.Int, "char") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Int.createInt(builder, 16, false);
-        }
-
+    CHAR("char") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             return writeSimpleNumbers(data);
         }
     },
-    FLOAT(Type.FloatingPoint, "float") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return FloatingPoint.createFloatingPoint(builder, Precision.SINGLE);
-        }
-
+    FLOAT("float") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             return writeSimpleNumbers(data);
         }
     },
-    DOUBLE(Type.FloatingPoint, "double") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return FloatingPoint.createFloatingPoint(builder, Precision.DOUBLE);
-        }
-
+    DOUBLE("double") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             return writeSimpleNumbers(data);
         }
     },
-    BOOLEAN(Type.Bool, "java.lang.Boolean", "boolean", "bool") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Int.createInt(builder, 8, true);
-        }
-
+    BOOLEAN("java.lang.Boolean", "boolean", "bool") {
         @Override
         public Object[] process(Object[] data, ParseContext context) {
             // Scan until we find a non-Boolean (and non-null) instance
@@ -338,31 +273,13 @@ public enum JsDataHandler {
             return result;
         }
     },
-    BIG_DECIMAL(Type.Binary, "java.math.BigDecimal") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            Binary.startBinary(builder);
-            return Binary.endBinary(builder);
-        }
+    BIG_DECIMAL("java.math.BigDecimal") {
     },
-    BIG_INTEGER(Type.Binary, "java.math.BigInteger") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            Binary.startBinary(builder);
-            return Binary.endBinary(builder);
-        }
+    BIG_INTEGER("java.math.BigInteger") {
     },
-    LOCAL_DATE(Type.Date, "java.time.LocalDate", "localdate") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Date.createDate(builder, DateUnit.DAY);
-        }
+    LOCAL_DATE("java.time.LocalDate", "localdate") {
     },
-    LOCAL_TIME(Type.Time, "java.time.LocalTime", "localtime") {
-        @Override
-        public int writeType(FlatBufferBuilder builder) {
-            return Time.createTime(builder, TimeUnit.NANOSECOND, 64);
-        }
+    LOCAL_TIME("java.time.LocalTime", "localtime") {
     },
     // LIST(),
     ;
@@ -437,28 +354,13 @@ public enum JsDataHandler {
 
     private static final int SEPARATOR_INDEX = DEFAULT_DATE_TIME_PATTERN.indexOf('T');
 
-    private final byte arrowTypeType;
-    private final String deephavenType;
-
-    JsDataHandler(byte arrowTypeType, String... typeNames) {
-        this.arrowTypeType = arrowTypeType;
+    JsDataHandler(String... typeNames) {
         assert typeNames.length > 0 : "Must have at least one name";
-        this.deephavenType = typeNames[0];
         for (int i = 0; i < typeNames.length; i++) {
             JsDataHandler existing = HandlersHolder.HANDLERS.put(typeNames[i], this);
             assert existing == null : "Handler already registered for type " + typeNames[i] + ": " + name();
         }
     }
-
-    public byte typeType() {
-        return arrowTypeType;
-    }
-
-    public String deephavenType() {
-        return deephavenType;
-    }
-
-    public abstract int writeType(FlatBufferBuilder builder);
 
     /**
      * Normalizes data of the given type to be wrapped in chunks and sent to the server, performing any required type

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
@@ -273,14 +273,10 @@ public enum JsDataHandler {
             return result;
         }
     },
-    BIG_DECIMAL("java.math.BigDecimal") {
-    },
-    BIG_INTEGER("java.math.BigInteger") {
-    },
-    LOCAL_DATE("java.time.LocalDate", "localdate") {
-    },
-    LOCAL_TIME("java.time.LocalTime", "localtime") {
-    },
+    BIG_DECIMAL("java.math.BigDecimal") {},
+    BIG_INTEGER("java.math.BigInteger") {},
+    LOCAL_DATE("java.time.LocalDate", "localdate") {},
+    LOCAL_TIME("java.time.LocalTime", "localtime") {},
     // LIST(),
     ;
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/parse/JsDataHandler.java
@@ -281,9 +281,7 @@ public enum JsDataHandler {
     ;
 
     public static JsDataHandler getHandler(String deephavenType) {
-        return HandlersHolder.HANDLERS.computeIfAbsent(deephavenType, type -> {
-            throw new IllegalStateException("No handler registered for type " + type);
-        });
+        return HandlersHolder.HANDLERS.get(deephavenType);
     }
 
     /**

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/AbstractTableSubscription.java
@@ -577,7 +577,7 @@ public abstract class AbstractTableSubscription extends HasEventHandling {
     private void onFlightData(Flight.FlightData data) {
         WebBarrageMessage message;
         try {
-            message = reader.parseFrom(options, state.columnTypes(), state.componentTypes(), data);
+            message = reader.parseFrom(options, data);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -1563,7 +1563,8 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
 
         assert keyTableData.length == keyColumns.length + 2;
         if (schema.fieldsLength() != keyTableData.length) {
-            throw new RuntimeException("Expected " + keyTableData.length + " columns, but got " + schema.fieldsLength());
+            throw new RuntimeException(
+                    "Expected " + keyTableData.length + " columns, but got " + schema.fieldsLength());
         }
 
         List<BarrageColumnType> providedTypes = new ArrayList<>();
@@ -1572,17 +1573,20 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
         }
         for (int i = 0; i < keyColumns.length; i++) {
             if (!providedTypes.get(i).deephavenType().equals(keyColumns.getAt(i).getType())) {
-                throw new RuntimeException("Column " + i + " expected type " + keyColumns.getAt(i).getType() + " but got "
-                        + providedTypes.get(i).deephavenType());
+                throw new RuntimeException(
+                        "Column " + i + " expected type " + keyColumns.getAt(i).getType() + " but got "
+                                + providedTypes.get(i).deephavenType());
             }
         }
         if (!providedTypes.get(keyColumns.length).deephavenType().equals(rowDepthCol.getType())) {
-            throw new RuntimeException("Column " + keyColumns.length + " expected type " + rowDepthCol.getType() + " but got "
-                    + providedTypes.get(keyColumns.length).deephavenType());
+            throw new RuntimeException(
+                    "Column " + keyColumns.length + " expected type " + rowDepthCol.getType() + " but got "
+                            + providedTypes.get(keyColumns.length).deephavenType());
         }
         if (!providedTypes.get(keyColumns.length + 1).deephavenType().equals(actionCol.getType())) {
-            throw new RuntimeException("Column " + (keyColumns.length + 1) + " expected type " + actionCol.getType() + " but got "
-                    + providedTypes.get(keyColumns.length + 1).deephavenType());
+            throw new RuntimeException(
+                    "Column " + (keyColumns.length + 1) + " expected type " + actionCol.getType() + " but got "
+                            + providedTypes.get(keyColumns.length + 1).deephavenType());
         }
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -15,6 +15,9 @@ import elemental2.dom.AbortController;
 import elemental2.dom.DomGlobal;
 import elemental2.promise.IThenable;
 import elemental2.promise.Promise;
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.ObjectChunk;
+import io.deephaven.chunk.attributes.Values;
 import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
 import io.deephaven.proto.backplane.grpc.HierarchicalTableApplyRequest;
 import io.deephaven.proto.backplane.grpc.HierarchicalTableApplyResponse;
@@ -30,6 +33,7 @@ import io.deephaven.proto.backplane.grpc.TypedTicket;
 import io.deephaven.proto.backplane.grpc.UpdateViewRequest;
 import io.deephaven.web.client.api.*;
 import io.deephaven.web.client.api.barrage.WebBarrageUtils;
+import io.deephaven.web.client.api.barrage.data.BarrageColumnType;
 import io.deephaven.web.client.api.barrage.data.WebBarrageSubscription;
 import io.deephaven.web.client.api.barrage.def.ColumnDefinition;
 import io.deephaven.web.client.api.barrage.def.InitialTableDefinition;
@@ -1457,8 +1461,14 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
     @JsMethod
     public String saveExpandedState() {
         // Serialize the key table to a flight stream, then base64 it to a string
-
-        byte[] bytes = new byte[0];
+        List<BarrageColumnType> columnTypes = new ArrayList<>();
+        Chunk<Values>[] chunks = new Chunk[keyColumns.length];
+        for (int i = 0; i < keyColumns.length; i++) {
+            Column c = keyColumns.getAt(i);
+            columnTypes.add(BarrageColumnType.fromString(c.getName(), c.getType()));
+            chunks[i] = ObjectChunk.chunkWrap(keyTableData[i]);
+        }
+        byte[] bytes = connection.newTableToBytes(columnTypes, chunks);
         return BaseEncoding.base64().encode(bytes);
     }
 
@@ -1466,10 +1476,10 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
     public void restoreExpandedState(String nodesToRestore) {
         // Transform string to base64, and read length-prefixed payloads. Validate the schema matches, then overwrite
         // our key table and trigger replacing it.
-
-
-
         byte[] bytes = BaseEncoding.base64().decode(nodesToRestore);
+
+
+
      }
 
     /**

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -4,6 +4,7 @@
 package io.deephaven.web.client.api.tree;
 
 import com.google.common.io.BaseEncoding;
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.vertispan.tsdefs.annotations.TsIgnore;
 import com.vertispan.tsdefs.annotations.TsTypeRef;
@@ -18,6 +19,7 @@ import elemental2.promise.Promise;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.ObjectChunk;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
 import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
 import io.deephaven.proto.backplane.grpc.HierarchicalTableApplyRequest;
 import io.deephaven.proto.backplane.grpc.HierarchicalTableApplyResponse;
@@ -32,6 +34,8 @@ import io.deephaven.proto.backplane.grpc.Ticket;
 import io.deephaven.proto.backplane.grpc.TypedTicket;
 import io.deephaven.proto.backplane.grpc.UpdateViewRequest;
 import io.deephaven.web.client.api.*;
+import io.deephaven.web.client.api.barrage.WebBarrageMessage;
+import io.deephaven.web.client.api.barrage.WebBarrageMessageReader;
 import io.deephaven.web.client.api.barrage.WebBarrageUtils;
 import io.deephaven.web.client.api.barrage.data.BarrageColumnType;
 import io.deephaven.web.client.api.barrage.data.WebBarrageSubscription;
@@ -64,6 +68,9 @@ import jsinterop.annotations.JsMethod;
 import jsinterop.base.Any;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
+import org.apache.arrow.flatbuf.Message;
+import org.apache.arrow.flatbuf.Schema;
+import org.apache.arrow.flight.impl.Flight;
 
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -235,7 +242,7 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
         // Load the table and column definitions from the descriptor
         extractDefinition(treeDescriptor);
 
-        actionCol = new Column(-1, -1, null, null, "byte", "__action__", false, null, null, false, false, false);
+        actionCol = new Column(-1, -1, null, "byte", "__action__", false, null, null, false, false, false);
 
         keyTableData = new Object[keyColumns.length + 2][0];
 
@@ -1458,9 +1465,14 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
         return sourceTable.get().then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
     }
 
+    /**
+     * Serializes the current expand
+     * 
+     * @return
+     */
     @JsMethod
     public String saveExpandedState() {
-        // Serialize the key table to a flight stream, then base64 it to a string
+        // Serialize the key table to a length-prefixed flight stream, then base64 it to a string.
         List<BarrageColumnType> columnTypes = new ArrayList<>();
         Chunk<Values>[] chunks = new Chunk[keyColumns.length];
         for (int i = 0; i < keyColumns.length; i++) {
@@ -1468,19 +1480,93 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
             columnTypes.add(BarrageColumnType.fromString(c.getName(), c.getType()));
             chunks[i] = ObjectChunk.chunkWrap(keyTableData[i]);
         }
+        columnTypes.add(BarrageColumnType.fromString(rowDepthCol.getName(), rowDepthCol.getType()));
+        columnTypes.add(BarrageColumnType.fromString(actionCol.getName(), actionCol.getType()));
+
+        chunks[keyColumns.length] = ObjectChunk.chunkWrap(keyTableData[keyColumns.length]);
+        chunks[keyColumns.length + 1] = ObjectChunk.chunkWrap(keyTableData[keyColumns.length + 1]);
+
         byte[] bytes = connection.newTableToBytes(columnTypes, chunks);
         return BaseEncoding.base64().encode(bytes);
     }
 
+    /**
+     * Given a compatible expanded state string from {@link #saveExpandedState()}, replaces this table's expanded state
+     * with that state. This is a best-effort operation, and on error will have no effect except to log a diagnostic
+     * warning. With that said it is possible for the expand operation to fail
+     *
+     * @param nodesToRestore serialized string payload to restore
+     */
     @JsMethod
     public void restoreExpandedState(String nodesToRestore) {
-        // Transform string to base64, and read length-prefixed payloads. Validate the schema matches, then overwrite
+        // Transform string from base64, and read length-prefixed payloads. Validate the schema matches, then overwrite
         // our key table and trigger replacing it.
-        byte[] bytes = BaseEncoding.base64().decode(nodesToRestore);
+        final WebBarrageMessage payloadMessage;
+        try {
+            WebBarrageMessageReader reader = new WebBarrageMessageReader();
+            byte[] bytes = BaseEncoding.base64().decode(nodesToRestore);
+            CodedInputStream codedStream = CodedInputStream.newInstance(bytes);
+            int schemaSize = codedStream.readRawLittleEndian32();
+            int oldSchemaLimit = codedStream.pushLimit(schemaSize);
+            Flight.FlightData schema = Flight.FlightData.parseFrom(codedStream);
+            codedStream.popLimit(oldSchemaLimit);
+            WebBarrageMessage schemaMessage = reader.parseFrom(BarrageSnapshotOptions.builder().build(), schema);
+            if (schemaMessage != null) {
+                JsLog.warn("First payload unexpected provided full message, cannot restore expanded state");
+                return;
+            }
+            // Validate the schema matches expected
+//            Message message = Message.getRootAsMessage(schema.getDataHeader().asReadOnlyByteBuffer());
+//            Schema schema = new Schema();
+//            message.header(schema);
 
+//            BarrageColumnType.fromArrowField()
 
+            int dataSize = codedStream.readRawLittleEndian32();
+            int oldDataLimit = codedStream.pushLimit(dataSize);
+            Flight.FlightData data = Flight.FlightData.parseFrom(codedStream);
+            codedStream.popLimit(oldDataLimit);
+            payloadMessage = reader.parseFrom(BarrageSnapshotOptions.builder().build(), data);
+            if (payloadMessage == null) {
+                JsLog.warn("Record batch was incomplete, failed to restore expanded state");
+                return;
+            }
+            if (!codedStream.isAtEnd()) {
+                JsLog.warn("Unexpected trailing bytes in expand payload, aborting restore");
+                return;
+            }
 
-     }
+            // Validate the payload's schema
+            if (keyTableData.length != payloadMessage.addColumnData.length) {
+                JsLog.warn("Wrong number of columns in expanded state payload, expected " + keyTableData.length + " but got " + payloadMessage.addColumnData.length);
+                return;
+            }
+//            for (int i = 0; i < payloadMessage.addColumnData; i++) {
+//
+//            }
+            
+        } catch (Exception e) {
+            JsLog.warn("Failed to read expanded state", e);
+            return;
+        }
+
+        Object[][] oldKeyTableData = keyTableData;
+        try {
+            keyTableData = new Object[oldKeyTableData.length][];
+            for (int i = 0; i < payloadMessage.addColumnData.length; i++) {
+                ObjectChunk<?, ?> colData = payloadMessage.addColumnData[i].data.get(0).asObjectChunk();
+                keyTableData[i] = new Object[colData.size()];
+                for (int j = 0; j < colData.size(); j++) {
+                    keyTableData[i][j] = colData.get(j);
+                }
+            }
+        } catch (Exception e) {
+            keyTableData = oldKeyTableData;
+            JsLog.warn("Failed to replace expanded state", e);
+            return;
+        }
+        replaceKeyTable();
+    }
 
     /**
      * a new copy of this treetable, so it can be sorted and filtered separately, and maintain a different viewport.

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -4,6 +4,7 @@
 package io.deephaven.web.client.api.tree;
 
 import com.google.common.io.BaseEncoding;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.vertispan.tsdefs.annotations.TsIgnore;
@@ -1515,12 +1516,9 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
                 JsLog.warn("First payload unexpected provided full message, cannot restore expanded state");
                 return;
             }
-            // Validate the schema matches expected
-//            Message message = Message.getRootAsMessage(schema.getDataHeader().asReadOnlyByteBuffer());
-//            Schema schema = new Schema();
-//            message.header(schema);
 
-//            BarrageColumnType.fromArrowField()
+            // Validate the schema matches expected
+            validateSchemaMatchesKeyTypes(schema.getDataHeader());
 
             int dataSize = codedStream.readRawLittleEndian32();
             int oldDataLimit = codedStream.pushLimit(dataSize);
@@ -1535,16 +1533,6 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
                 JsLog.warn("Unexpected trailing bytes in expand payload, aborting restore");
                 return;
             }
-
-            // Validate the payload's schema
-            if (keyTableData.length != payloadMessage.addColumnData.length) {
-                JsLog.warn("Wrong number of columns in expanded state payload, expected " + keyTableData.length + " but got " + payloadMessage.addColumnData.length);
-                return;
-            }
-//            for (int i = 0; i < payloadMessage.addColumnData; i++) {
-//
-//            }
-            
         } catch (Exception e) {
             JsLog.warn("Failed to read expanded state", e);
             return;
@@ -1566,6 +1554,36 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
             return;
         }
         replaceKeyTable();
+    }
+
+    private void validateSchemaMatchesKeyTypes(ByteString dataHeader) {
+        Message message = Message.getRootAsMessage(dataHeader.asReadOnlyByteBuffer());
+        Schema schema = new Schema();
+        message.header(schema);
+
+        assert keyTableData.length == keyColumns.length + 2;
+        if (schema.fieldsLength() != keyTableData.length) {
+            throw new RuntimeException("Expected " + keyTableData.length + " columns, but got " + schema.fieldsLength());
+        }
+
+        List<BarrageColumnType> providedTypes = new ArrayList<>();
+        for (int i = 0; i < schema.fieldsLength(); i++) {
+            providedTypes.add(BarrageColumnType.fromArrowField(schema.fields(i)));
+        }
+        for (int i = 0; i < keyColumns.length; i++) {
+            if (!providedTypes.get(i).deephavenType().equals(keyColumns.getAt(i).getType())) {
+                throw new RuntimeException("Column " + i + " expected type " + keyColumns.getAt(i).getType() + " but got "
+                        + providedTypes.get(i).deephavenType());
+            }
+        }
+        if (!providedTypes.get(keyColumns.length).deephavenType().equals(rowDepthCol.getType())) {
+            throw new RuntimeException("Column " + keyColumns.length + " expected type " + rowDepthCol.getType() + " but got "
+                    + providedTypes.get(keyColumns.length).deephavenType());
+        }
+        if (!providedTypes.get(keyColumns.length + 1).deephavenType().equals(actionCol.getType())) {
+            throw new RuntimeException("Column " + (keyColumns.length + 1) + " expected type " + actionCol.getType() + " but got "
+                    + providedTypes.get(keyColumns.length + 1).deephavenType());
+        }
     }
 
     /**

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/tree/JsTreeTable.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.web.client.api.tree;
 
+import com.google.common.io.BaseEncoding;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.vertispan.tsdefs.annotations.TsIgnore;
 import com.vertispan.tsdefs.annotations.TsTypeRef;
@@ -1453,85 +1454,23 @@ public class JsTreeTable extends HasLifecycle implements ServerObject {
         return sourceTable.get().then(t -> Promise.resolve(t.getGrandTotalsTable(config)));
     }
 
-    // TODO core#279 restore this with protobuf once smartkey has some pb-based analog
-    // private static final int SERIALIZED_VERSION = 1;
-    //
-    // @JsMethod
-    // public String saveExpandedState() {
-    // if (expandedMap.get(Key.root()).expandedChildren.isEmpty()) {
-    // return "";//empty string means nothing expanded, don't bother with preamble
-    // }
-    // KeySerializer serializer = new KeySerializer_Impl();
-    // TypeSerializer typeSerializer = serializer.createSerializer();
-    // final StringSerializationStreamWriter writer = new StringSerializationStreamWriter(typeSerializer);
-    // writer.prepareToWrite();
-    // writer.writeInt(SERIALIZED_VERSION);
-    // writer.writeString(typeSerializer.getChecksum());
-    //
-    // // Starting from the root node, write a node, its child count, then call this recursively.
-    // // Normally we would write the key first, but the root key is a special case where we don't
-    // // do this.
-    // try {
-    // writeTreeNode(serializer, writer, Key.root());
-    // } catch (SerializationException e) {
-    // throw new IllegalStateException("Failed to serialize content: " + e.getMessage(), e);
-    // }
-    //
-    // return writer.toString();
-    // }
-    //
-    // private void writeTreeNode(KeySerializer serializer, SerializationStreamWriter writer, Key key) throws
-    // SerializationException {
-    // TreeNodeState node = expandedMap.get(key);
-    // if (node == null) {
-    // writer.writeInt(0);
-    // return;
-    // }
-    // writer.writeInt(node.expandedChildren.size());
-    // for (Key child : node.expandedChildren) {
-    // serializer.write(child, writer);
-    // writeTreeNode(serializer, writer, child);
-    // }
-    // }
-    //
-    // @JsMethod
-    // public void restoreExpandedState(String nodesToRestore) throws SerializationException {
-    // // sanity check that nothing has been expanded yet so we can safely do this
-    // if (!expandedMap.get(Key.root()).expandedChildren.isEmpty()) {
-    // throw new IllegalArgumentException("Tree already has expanded children, ignoring restoreExpandedState call");
-    // }
-    // if (nodesToRestore.isEmpty()) {
-    // // no work to do, empty set of items expanded
-    // return;
-    // }
-    // KeySerializer serializer = new KeySerializer_Impl();
-    // TypeSerializer typeSerializer = serializer.createSerializer();
-    // StringSerializationStreamReader reader = new StringSerializationStreamReader(typeSerializer, nodesToRestore);
-    // int vers = reader.readInt();
-    // if (vers != SERIALIZED_VERSION) {
-    // throw new IllegalArgumentException("Failed to deserialize, current version doesn't match the serialized data.
-    // Expected version " + SERIALIZED_VERSION + ", actual version " + vers);
-    // }
-    // String checksum = reader.readString();
-    // if (!checksum.equals(typeSerializer.getChecksum())) {
-    // throw new IllegalArgumentException("Failed to deserialize, current type definition doesn't match the serialized
-    // data. Expected: " + typeSerializer.getChecksum() + ", actual: " + checksum);
-    // }
-    //
-    // // read each key, assuming root as the first key
-    // readTreeNode(serializer, reader, Key.root());
-    // }
-    //
-    // private void readTreeNode(KeySerializer serializer, SerializationStreamReader reader, Key key) throws
-    // SerializationException {
-    // TreeNodeState node = expandedMap.get(key);
-    // int count = reader.readInt();
-    // for (int i = 0; i < count; i++) {
-    // Key child = serializer.read(reader);
-    // node.expand(child);
-    // readTreeNode(serializer, reader, child);
-    // }
-    // }
+    @JsMethod
+    public String saveExpandedState() {
+        // Serialize the key table to a flight stream, then base64 it to a string
+
+        byte[] bytes = new byte[0];
+        return BaseEncoding.base64().encode(bytes);
+    }
+
+    @JsMethod
+    public void restoreExpandedState(String nodesToRestore) {
+        // Transform string to base64, and read length-prefixed payloads. Validate the schema matches, then overwrite
+        // our key table and trigger replacing it.
+
+
+
+        byte[] bytes = BaseEncoding.base64().decode(nodesToRestore);
+     }
 
     /**
      * a new copy of this treetable, so it can be sorted and filtered separately, and maintain a different viewport.

--- a/web/client-api/src/main/java/io/deephaven/web/client/state/ClientTableState.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/state/ClientTableState.java
@@ -7,7 +7,6 @@ import elemental2.core.JsMap;
 import elemental2.core.JsObject;
 import elemental2.core.JsSet;
 import elemental2.promise.Promise;
-import io.deephaven.extensions.barrage.BarrageTypeInfo;
 import io.deephaven.proto.backplane.grpc.ExportedTableCreationResponse;
 import io.deephaven.web.client.api.*;
 import io.deephaven.web.client.api.barrage.WebBarrageUtils;
@@ -231,33 +230,6 @@ public final class ClientTableState extends TableConfig {
 
     public TableTicket getHandle() {
         return handle;
-    }
-
-    /**
-     * Returns the Java Class to represent each column in the table. This lets the client replace certain JVM-only
-     * classes with alternative implementations, but still use the simple {@link BarrageTypeInfo} wrapper.
-     */
-    public Class<?>[] columnTypes() {
-        return Arrays.stream(tableDef.getColumns())
-                .map(ColumnDefinition::getType)
-                .map(WebBarrageUtils::stringToClass)
-                .toArray(Class<?>[]::new);
-    }
-
-    /**
-     * Returns the Java Class to represent the component type in any list/array type. At this time, this value is not
-     * used by the chunk reading implementation.
-     */
-    public Class<?>[] componentTypes() {
-        return Arrays.stream(tableDef.getColumns()).map(ColumnDefinition::getType).map(t -> {
-            // All arrays and vectors will be handled as objects for now.
-            // TODO (deephaven-core#2102) clarify if we need to handle these cases at all
-            if (t.endsWith("[]") || t.endsWith("Vector")) {
-                return Object.class;
-            }
-            // Non-arrays or vectors should return null
-            return null;
-        }).toArray(Class[]::new);
     }
 
     public ClientTableState newState(TableTicket newHandle, TableConfig config) {

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/HierarchicalTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/HierarchicalTableTestGwt.java
@@ -1064,14 +1064,14 @@ public class HierarchicalTableTestGwt extends AbstractAsyncGwtTestCase {
                                 return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1902d);
                             }).then(e -> {
                                 // Now that we're expanded, restore the initial state
-                                assertEquals(10, (int)e.getDetail().getTreeSize());
+                                assertEquals(10, (int) e.getDetail().getTreeSize());
                                 rootExpanded.set(tree.saveExpandedState());
 
                                 tree.restoreExpandedState(empty);
                                 return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1903d);
                             }).then(e -> {
                                 // Confirm we're back to the initial state, re-expand the root node
-                                assertEquals(startingSize, (int)e.getDetail().getTreeSize());
+                                assertEquals(startingSize, (int) e.getDetail().getTreeSize());
 
                                 tree.restoreExpandedState(rootExpanded.get());
                                 return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1904d);
@@ -1084,12 +1084,13 @@ public class HierarchicalTableTestGwt extends AbstractAsyncGwtTestCase {
                                 outOfViewExpanded.set(tree.saveExpandedState());
                                 return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1905d);
                             }).then(e -> {
-                                assertEquals(20, (int)e.getDetail().getTreeSize());
-                                // Restore original state again, let it load, then use the saved state to expand things we can't se
+                                assertEquals(20, (int) e.getDetail().getTreeSize());
+                                // Restore original state again, let it load, then use the saved state to expand things
+                                // we can't se
                                 tree.collapseAll();
                                 return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1906d);
                             }).then(e -> {
-                                assertEquals(1, (int)e.getDetail().getTreeSize());
+                                assertEquals(1, (int) e.getDetail().getTreeSize());
                                 for (TableData.Row row : e.getDetail().getRows().asList()) {
                                     assertFalse(((TreeViewportData.TreeRow) row).isExpanded());
                                 }
@@ -1099,7 +1100,7 @@ public class HierarchicalTableTestGwt extends AbstractAsyncGwtTestCase {
                                 tree.setViewport(0, 5, null, null);
                                 return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1907d);
                             }).then(e -> {
-                                assertEquals(20, (int)e.getDetail().getTreeSize());
+                                assertEquals(20, (int) e.getDetail().getTreeSize());
 
                                 JsArray<TreeViewportData.TreeRow> rows = Js.cast(e.getDetail().getRows());
                                 assertTrue(rows.getAt(0).isExpanded());
@@ -1107,7 +1108,7 @@ public class HierarchicalTableTestGwt extends AbstractAsyncGwtTestCase {
                                 assertFalse(rows.getAt(2).isExpanded());
                                 return null;
                             });
-                    })
-                    .then(this::finish).catch_(this::report);
+                })
+                .then(this::finish).catch_(this::report);
     }
 }

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/HierarchicalTableTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/HierarchicalTableTestGwt.java
@@ -15,6 +15,7 @@ import jsinterop.base.JsPropertyMap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -1040,5 +1041,73 @@ public class HierarchicalTableTestGwt extends AbstractAsyncGwtTestCase {
                             });
                 })
                 .then(this::finish).catch_(this::report);
+    }
+
+
+    public void testSaveRestoreState() {
+        connect(tables)
+                .then(treeTable("static_tree"))
+                .then(tree -> {
+                    delayTestFinish(5000);
+                    String empty = tree.saveExpandedState();
+                    AtomicReference<String> rootExpanded = new AtomicReference<>();
+                    AtomicReference<String> outOfViewExpanded = new AtomicReference<>();
+                    int startingSize = 1;
+
+                    tree.setViewport(0, 5, null, null);
+                    return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1901d)
+                            .then(e -> {
+                                // Confirm initial state is just one node, expand root and save it to use later
+                                assertEquals(startingSize, (int) e.getDetail().getTreeSize());
+                                tree.expand(JsTreeTable.RowReferenceUnion.of(0), null);
+                                rootExpanded.set(tree.saveExpandedState());
+                                return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1902d);
+                            }).then(e -> {
+                                // Now that we're expanded, restore the initial state
+                                assertEquals(10, (int)e.getDetail().getTreeSize());
+                                rootExpanded.set(tree.saveExpandedState());
+
+                                tree.restoreExpandedState(empty);
+                                return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1903d);
+                            }).then(e -> {
+                                // Confirm we're back to the initial state, re-expand the root node
+                                assertEquals(startingSize, (int)e.getDetail().getTreeSize());
+
+                                tree.restoreExpandedState(rootExpanded.get());
+                                return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1904d);
+                            }).then(e -> {
+                                assertEquals(10, (int) e.getDetail().getTreeSize());
+
+                                // With the root node expanded again, expand some other child and save the state
+                                tree.expand(JsTreeTable.RowReferenceUnion.of(1), null);
+                                tree.setViewport(6, 100, null, null);
+                                outOfViewExpanded.set(tree.saveExpandedState());
+                                return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1905d);
+                            }).then(e -> {
+                                assertEquals(20, (int)e.getDetail().getTreeSize());
+                                // Restore original state again, let it load, then use the saved state to expand things we can't se
+                                tree.collapseAll();
+                                return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1906d);
+                            }).then(e -> {
+                                assertEquals(1, (int)e.getDetail().getTreeSize());
+                                for (TableData.Row row : e.getDetail().getRows().asList()) {
+                                    assertFalse(((TreeViewportData.TreeRow) row).isExpanded());
+                                }
+                                tree.restoreExpandedState(outOfViewExpanded.get());
+
+                                // Scroll back up and ensure rows 0 and 1 are expanded
+                                tree.setViewport(0, 5, null, null);
+                                return tree.<TreeViewportData>nextEvent(JsTreeTable.EVENT_UPDATED, 1907d);
+                            }).then(e -> {
+                                assertEquals(20, (int)e.getDetail().getTreeSize());
+
+                                JsArray<TreeViewportData.TreeRow> rows = Js.cast(e.getDetail().getRows());
+                                assertTrue(rows.getAt(0).isExpanded());
+                                assertTrue(rows.getAt(1).isExpanded());
+                                assertFalse(rows.getAt(2).isExpanded());
+                                return null;
+                            });
+                    })
+                    .then(this::finish).catch_(this::report);
     }
 }

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/NullValueTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/NullValueTestGwt.java
@@ -74,7 +74,7 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                     return Promise.resolve(table);
                 })
                 .then(table -> {
-                    validateTypes(table, true);
+                    validateTypes(table);
 
                     return Promise.resolve(table);
                 })
@@ -84,7 +84,7 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                     options.columns = table.getColumns();
                     TableSubscription sub = table.createSubscription(options);
                     return assertUpdateReceived(sub, data -> {
-                        validateSomeNulls(table, data, true);
+                        validateSomeNulls(table, data);
                     }, 1000).then(ignore -> Promise.resolve(table));
                 })
 
@@ -235,7 +235,7 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                 .then(this::finish).catch_(this::report);
     }
 
-    private static void validateSomeNulls(JsTable table, ViewportData data, boolean checkArrays) {
+    private static void validateSomeNulls(JsTable table, ViewportData data) {
         JsArray<? extends TableData.Row> rows = data.getRows();
         TableData.Row nullRow = rows.getAt(0);
 
@@ -261,10 +261,8 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                 valueRow.get(table.findColumn("MyBigInteger")).<BigIntegerWrapper>cast().getWrapped());
         assertEquals(BigDecimal.valueOf(1, 4),
                 valueRow.get(table.findColumn("MyBigDecimal")).<BigDecimalWrapper>cast().getWrapped());
-        if (checkArrays) {
-            assertArrayEquals(new String[] {"A", "B", "C"},
-                    valueRow.get(table.findColumn("MyStringArray1")).<String[]>cast());
-        }
+        assertArrayEquals(new String[] {"A", "B", "C"},
+                valueRow.get(table.findColumn("MyStringArray1")).<String[]>cast());
 
         LocalDateWrapper localDate =
                 valueRow.get(table.findColumn("MyLocalDate")).<LocalDateWrapper>cast();
@@ -280,7 +278,7 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
         assertEquals(0, localTime.getNano());
     }
 
-    private static void validateTypes(JsTable table, boolean checkArrays) {
+    private static void validateTypes(JsTable table) {
         assertEquals("int", table.findColumn("MyInt").getType());
         assertEquals("long", table.findColumn("MyLong").getType());
         assertEquals("double", table.findColumn("MyDouble").getType());
@@ -293,9 +291,7 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
         assertEquals("java.time.Instant", table.findColumn("MyDate").getType());
         assertEquals("java.math.BigInteger", table.findColumn("MyBigInteger").getType());
         assertEquals("java.math.BigDecimal", table.findColumn("MyBigDecimal").getType());
-        if (checkArrays) {
-            assertEquals("java.lang.String[]", table.findColumn("MyStringArray1").getType());
-        }
+        assertEquals("java.lang.String[]", table.findColumn("MyStringArray1").getType());
         assertEquals("java.time.LocalDate", table.findColumn("MyLocalDate").getType());
         assertEquals("java.time.LocalTime", table.findColumn("MyLocalTime").getType());
     }
@@ -333,7 +329,7 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                     return Promise.resolve(table);
                 })
                 .then(table -> {
-                    validateTypes(table, true);
+                    validateTypes(table);
 
                     return Promise.resolve(table);
                 })
@@ -368,11 +364,9 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                     return table.createSnapshot(snapshotOptions)
                             .then(s -> {
                                 // Copy all data, send it back to the server using WorkerConnection.newTable
-                                String[] columnNames =
-                                        table.getColumns().asList().stream().filter(c -> !c.getType().endsWith("[]"))
+                                String[] columnNames = table.getColumns().asList().stream()
                                                 .map(Column::getName).toArray(String[]::new);
-                                String[] types =
-                                        table.getColumns().asList().stream().filter(c -> !c.getType().endsWith("[]"))
+                                String[] types = table.getColumns().asList().stream()
                                                 .map(Column::getType).toArray(String[]::new);
                                 Object[][] data = new Object[columnNames.length][];
                                 for (int i = 0; i < data.length; i++) {
@@ -386,12 +380,12 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                             })
                             .then(newTable -> {
                                 // subscribe to the new table, verify it matches the existing one
-                                validateTypes(newTable, false);
+                                validateTypes(newTable);
                                 DataOptions.SubscriptionOptions options2 = new DataOptions.SubscriptionOptions();
                                 options2.columns = newTable.getColumns();
                                 TableSubscription sub = newTable.createSubscription(options2);
                                 return assertUpdateReceived(sub, data -> {
-                                    validateSomeNulls(newTable, data, false);
+                                    validateSomeNulls(newTable, data);
                                 }, 1000).then(ignore -> Promise.resolve(table));
                             });
                 })

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/NullValueTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/NullValueTestGwt.java
@@ -365,9 +365,9 @@ public class NullValueTestGwt extends AbstractAsyncGwtTestCase {
                             .then(s -> {
                                 // Copy all data, send it back to the server using WorkerConnection.newTable
                                 String[] columnNames = table.getColumns().asList().stream()
-                                                .map(Column::getName).toArray(String[]::new);
+                                        .map(Column::getName).toArray(String[]::new);
                                 String[] types = table.getColumns().asList().stream()
-                                                .map(Column::getType).toArray(String[]::new);
+                                        .map(Column::getType).toArray(String[]::new);
                                 Object[][] data = new Object[columnNames.length][];
                                 for (int i = 0; i < data.length; i++) {
                                     Column column = table.findColumn(columnNames[i]);

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/filter/FilterConditionTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/filter/FilterConditionTestGwt.java
@@ -18,7 +18,7 @@ public class FilterConditionTestGwt extends AbstractAsyncGwtTestCase {
     }
 
     private Column getColumn() {
-        return new Column(0, 0, -1, -1, "int", "ColumnName", false, -1, null, false, false, false);
+        return new Column(0, 0, -1, "int", "ColumnName", false, -1, null, false, false, false);
     }
 
     private FilterValue[] arr(FilterValue filterValue) {


### PR DESCRIPTION
Implemented by writing something close to the DoPut stream to a byte[], with the ability to read it back when provided.

Simplifies how we handle column types in the JS client by providing a generalized column type class that can compose types, in theory supporting all Arrow types.