### PR TITLE
fix: DH-22657: Use array instead of chunks for Jackson repeated processors

### DIFF
--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ByteMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ByteMixin.java
@@ -5,12 +5,10 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
-import io.deephaven.chunk.sized.SizedByteChunk;
 import io.deephaven.json.ByteValue;
-import io.deephaven.json.Value;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
 
@@ -69,7 +67,7 @@ final class ByteMixin extends Mixin<ByteValue> {
     }
 
     final class ByteRepeaterImpl extends RepeaterProcessorBase<byte[]> {
-        private final SizedByteChunk<?> chunk = new SizedByteChunk<>(0);
+        private byte[] buffer = new byte[0];
 
         public ByteRepeaterImpl() {
             super(null, null, Type.byteType().arrayType());
@@ -77,24 +75,17 @@ final class ByteMixin extends Mixin<ByteValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableByteChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ByteMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableByteChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ByteMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public byte[] doneImpl(JsonParser parser, int length) {
-            final WritableByteChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/CharMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/CharMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
-import io.deephaven.chunk.sized.SizedCharChunk;
 import io.deephaven.json.CharValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -64,7 +63,7 @@ final class CharMixin extends Mixin<CharValue> {
     }
 
     final class CharRepeaterImpl extends RepeaterProcessorBase<char[]> {
-        private final SizedCharChunk<?> chunk = new SizedCharChunk<>(0);
+        private char[] buffer = new char[0];
 
         public CharRepeaterImpl() {
             super(null, null, Type.charType().arrayType());
@@ -72,24 +71,17 @@ final class CharMixin extends Mixin<CharValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableCharChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, CharMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableCharChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, CharMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public char[] doneImpl(JsonParser parser, int length) {
-            final WritableCharChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/DoubleMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/DoubleMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
-import io.deephaven.chunk.sized.SizedDoubleChunk;
 import io.deephaven.json.DoubleValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -68,7 +67,7 @@ final class DoubleMixin extends Mixin<DoubleValue> {
     }
 
     final class DoubleRepeaterImpl extends RepeaterProcessorBase<double[]> {
-        private final SizedDoubleChunk<?> chunk = new SizedDoubleChunk<>(0);
+        private double[] buffer = new double[0];
 
         public DoubleRepeaterImpl() {
             super(null, null, Type.doubleType().arrayType());
@@ -76,24 +75,17 @@ final class DoubleMixin extends Mixin<DoubleValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableDoubleChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, DoubleMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableDoubleChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, DoubleMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public double[] doneImpl(JsonParser parser, int length) {
-            final WritableDoubleChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/FloatMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/FloatMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableFloatChunk;
-import io.deephaven.chunk.sized.SizedFloatChunk;
 import io.deephaven.json.FloatValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -68,7 +67,7 @@ final class FloatMixin extends Mixin<FloatValue> {
     }
 
     final class FloatRepeaterImpl extends RepeaterProcessorBase<float[]> {
-        private final SizedFloatChunk<?> chunk = new SizedFloatChunk<>(0);
+        private float[] buffer = new float[0];
 
         public FloatRepeaterImpl() {
             super(null, null, Type.floatType().arrayType());
@@ -76,24 +75,17 @@ final class FloatMixin extends Mixin<FloatValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableFloatChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, FloatMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableFloatChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, FloatMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public float[] doneImpl(JsonParser parser, int length) {
-            final WritableFloatChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/IntMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/IntMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableIntChunk;
-import io.deephaven.chunk.sized.SizedIntChunk;
 import io.deephaven.json.IntValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -69,7 +68,7 @@ final class IntMixin extends Mixin<IntValue> {
     }
 
     final class IntRepeaterImpl extends RepeaterProcessorBase<int[]> {
-        private final SizedIntChunk<?> chunk = new SizedIntChunk<>(0);
+        private int[] buffer = new int[0];
 
         public IntRepeaterImpl() {
             super(null, null, Type.intType().arrayType());
@@ -77,24 +76,17 @@ final class IntMixin extends Mixin<IntValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableIntChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, IntMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableIntChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, IntMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public int[] doneImpl(JsonParser parser, int length) {
-            final WritableIntChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/LongMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/LongMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableLongChunk;
-import io.deephaven.chunk.sized.SizedLongChunk;
 import io.deephaven.json.LongValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -69,7 +68,7 @@ final class LongMixin extends Mixin<LongValue> {
     }
 
     final class LongRepeaterImpl extends RepeaterProcessorBase<long[]> {
-        private final SizedLongChunk<?> chunk = new SizedLongChunk<>(0);
+        private long[] buffer = new long[0];
 
         public LongRepeaterImpl() {
             super(null, null, Type.longType().arrayType());
@@ -77,24 +76,17 @@ final class LongMixin extends Mixin<LongValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableLongChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, LongMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableLongChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, LongMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public long[] doneImpl(JsonParser parser, int length) {
-            final WritableLongChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/RepeaterGenericImpl.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/RepeaterGenericImpl.java
@@ -4,46 +4,41 @@
 package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
-import io.deephaven.chunk.WritableObjectChunk;
-import io.deephaven.chunk.sized.SizedObjectChunk;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.qst.type.NativeArrayType;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
 
 final class RepeaterGenericImpl<T> extends RepeaterProcessorBase<T[]> {
     private final ToObject<T> toObject;
-    private final SizedObjectChunk<T, ?> chunk;
+    private final Class<T[]> bufferClass;
+    private final Class<T> componentClass;
+    private T[] buffer;
 
     public RepeaterGenericImpl(ToObject<T> toObject, T[] onMissing, T[] onNull, NativeArrayType<T[], T> arrayType) {
         super(onMissing, onNull, arrayType);
         this.toObject = Objects.requireNonNull(toObject);
-        chunk = new SizedObjectChunk<>(0);
+        this.bufferClass = arrayType.clazz();
+        this.componentClass = arrayType.componentType().clazz();
+        // noinspection unchecked
+        this.buffer = (T[]) Array.newInstance(componentClass, 0);
     }
 
     @Override
     public void processElementImpl(JsonParser parser, int index) throws IOException {
-        final int newSize = index + 1;
-        final WritableObjectChunk<T, ?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-        chunk.set(index, toObject.parseValue(parser));
-        chunk.setSize(newSize);
+        buffer = ArrayUtil.put(buffer, index, toObject.parseValue(parser), componentClass);
     }
 
     @Override
     public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-        final int newSize = index + 1;
-        final WritableObjectChunk<T, ?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-        chunk.set(index, toObject.parseMissing(parser));
-        chunk.setSize(newSize);
+        buffer = ArrayUtil.put(buffer, index, toObject.parseMissing(parser), componentClass);
     }
 
     @Override
     public T[] doneImpl(JsonParser parser, int length) {
-        final WritableObjectChunk<T, ?> chunk = this.chunk.get();
-        final T[] result = Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
-        chunk.fillWithNullValue(0, length);
-        return result;
+        return Arrays.copyOfRange(buffer, 0, length, bufferClass);
     }
 }

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/RepeaterGenericImpl.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/RepeaterGenericImpl.java
@@ -39,6 +39,8 @@ final class RepeaterGenericImpl<T> extends RepeaterProcessorBase<T[]> {
 
     @Override
     public T[] doneImpl(JsonParser parser, int length) {
-        return Arrays.copyOfRange(buffer, 0, length, bufferClass);
+        final T[] result = Arrays.copyOfRange(buffer, 0, length, bufferClass);
+        Arrays.fill(buffer, 0, length, null);
+        return result;
     }
 }

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ShortMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ShortMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableShortChunk;
-import io.deephaven.chunk.sized.SizedShortChunk;
 import io.deephaven.json.ShortValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -68,7 +67,7 @@ final class ShortMixin extends Mixin<ShortValue> {
     }
 
     final class ShortRepeaterImpl extends RepeaterProcessorBase<short[]> {
-        private final SizedShortChunk<?> chunk = new SizedShortChunk<>(0);
+        private short[] buffer = new short[0];
 
         public ShortRepeaterImpl() {
             super(null, null, Type.shortType().arrayType());
@@ -76,24 +75,17 @@ final class ShortMixin extends Mixin<ShortValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableShortChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ShortMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableShortChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ShortMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public short[] doneImpl(JsonParser parser, int length) {
-            final WritableShortChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/kafka/src/test/java/io/deephaven/kafka/KafkaToolsIntegrationTest.java
+++ b/extensions/kafka/src/test/java/io/deephaven/kafka/KafkaToolsIntegrationTest.java
@@ -7,20 +7,31 @@ import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.ColumnDefinition;
 import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.engine.table.impl.util.ColumnHolder;
 import io.deephaven.engine.testutil.ControlledUpdateGraph;
 import io.deephaven.engine.testutil.TstUtils;
 import io.deephaven.engine.testutil.junit4.EngineCleanup;
 import io.deephaven.engine.util.TableTools;
+import io.deephaven.json.ArrayValue;
+import io.deephaven.json.ByteValue;
+import io.deephaven.json.CharValue;
+import io.deephaven.json.DoubleValue;
+import io.deephaven.json.FloatValue;
+import io.deephaven.json.IntValue;
+import io.deephaven.json.LongValue;
 import io.deephaven.json.ObjectValue;
+import io.deephaven.json.ShortValue;
 import io.deephaven.json.StringValue;
 import io.deephaven.json.jackson.JacksonProvider;
 import io.deephaven.kafka.KafkaTools.TableType;
 import io.deephaven.kafka.testcontainers.KafkaService;
+import io.deephaven.qst.type.Type;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.serialization.VoidSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -278,6 +289,104 @@ class KafkaToolsIntegrationTest {
             producer.flush();
 
             awaitEquals(e3, taa);
+        }
+    }
+
+    @ParameterizedTest(name = "jsonArrayTest_DH22657 {0}")
+    @EnumSource
+    @Timeout(TIMEOUT_SECONDS)
+    void jsonArrayTest_DH22657(final KafkaService kafkaService, final TestInfo testInfo) throws Exception {
+        Assumptions.assumeTrue(kafkaService.isEnabled());
+        kafkaService.init();
+        final String topic = sanitizedTopicName(testInfo);
+        final String byteArrayName = "ByteArray";
+        final String charArrayName = "CharArray";
+        final String shortArrayName = "ShortArray";
+        final String intArrayName = "IntArray";
+        final String longArrayName = "LongArray";
+        final String floatArrayName = "FloatArray";
+        final String doubleArrayName = "DoubleArray";
+        final String stringArrayName = "StringArray";
+
+        final TableDefinition td;
+        final Table e1;
+        final Table e2;
+        {
+            td = TableDefinition.of(
+                    PARTITION_COLUMN,
+                    OFFSET_COLUMN,
+                    TIMESTAMP_COLUMN,
+                    ColumnDefinition.of(byteArrayName, Type.byteType().arrayType()),
+                    ColumnDefinition.of(charArrayName, Type.charType().arrayType()),
+                    ColumnDefinition.of(shortArrayName, Type.shortType().arrayType()),
+                    ColumnDefinition.of(intArrayName, Type.intType().arrayType()),
+                    ColumnDefinition.of(longArrayName, Type.longType().arrayType()),
+                    ColumnDefinition.of(floatArrayName, Type.floatType().arrayType()),
+                    ColumnDefinition.of(doubleArrayName, Type.doubleType().arrayType()),
+                    ColumnDefinition.of(stringArrayName, Type.stringType().arrayType()));
+            e1 = TableTools.newTable(td);
+            e2 = TableTools.newTable(td,
+                    intCol(PARTITION_COLUMN.getName(), 0, 0),
+                    longCol(OFFSET_COLUMN.getName(), 0, 1),
+                    instantCol(TIMESTAMP_COLUMN.getName(), Instant.ofEpochMilli(42L), Instant.ofEpochMilli(43L)),
+                    new ColumnHolder<>(byteArrayName, byte[].class, byte.class, false,
+                            new byte[] {1, 2, 3},
+                            new byte[] {3, 2, 1}),
+                    new ColumnHolder<>(charArrayName, char[].class, char.class, false,
+                            new char[] {'a', 'b', 'c'},
+                            new char[] {'d', 'e', 'f'}),
+                    new ColumnHolder<>(shortArrayName, short[].class, short.class, false,
+                            new short[] {1, 2, 3},
+                            new short[] {3, 2, 1}),
+                    new ColumnHolder<>(intArrayName, int[].class, int.class, false,
+                            new int[] {1, 2, 3},
+                            new int[] {3, 2, 1}),
+                    new ColumnHolder<>(longArrayName, long[].class, long.class, false,
+                            new long[] {1, 2, 3},
+                            new long[] {3, 2, 1}),
+                    new ColumnHolder<>(floatArrayName, float[].class, float.class, false,
+                            new float[] {1, 2, 3},
+                            new float[] {3, 2, 1}),
+                    new ColumnHolder<>(doubleArrayName, double[].class, double.class, false,
+                            new double[] {1, 2, 3},
+                            new double[] {3, 2, 1}),
+                    new ColumnHolder<>(stringArrayName, String[].class, String.class, false,
+                            new String[] {"foo", "bar", "baz"},
+                            new String[] {"baz", "bar", "foo"}));
+        }
+
+        createTopic(kafkaService, topic);
+
+        final KafkaTools.TableAndAdapter taa = KafkaTools.consumeToTableAndAdapter(
+                kafkaService.properties(),
+                topic,
+                ALL_PARTITIONS,
+                ALL_PARTITIONS_SEEK_TO_BEGINNING,
+                KafkaTools.Consume.IGNORE,
+                KafkaTools.Consume.objectProcessorSpec(
+                        JacksonProvider.of(ObjectValue.builder()
+                                .putFields(byteArrayName, ArrayValue.strict(ByteValue.standard()))
+                                .putFields(charArrayName, ArrayValue.strict(CharValue.standard()))
+                                .putFields(shortArrayName, ArrayValue.strict(ShortValue.standard()))
+                                .putFields(intArrayName, ArrayValue.strict(IntValue.standard()))
+                                .putFields(longArrayName, ArrayValue.strict(LongValue.standard()))
+                                .putFields(floatArrayName, ArrayValue.strict(FloatValue.standard()))
+                                .putFields(doubleArrayName, ArrayValue.strict(DoubleValue.standard()))
+                                .putFields(stringArrayName, ArrayValue.strict(StringValue.standard()))
+                                .build())),
+                TableType.append());
+
+        try (final KafkaProducer<Void, String> producer =
+                kafkaService.producer(new VoidSerializer(), new StringSerializer())) {
+            awaitEquals(e1, taa);
+
+            producer.send(new ProducerRecord<>(topic, null, 42L, null,
+                    "{ \"ByteArray\": [1, 2, 3], \"CharArray\": [\"a\", \"b\", \"c\"], \"ShortArray\": [1, 2, 3], \"IntArray\": [1, 2, 3], \"LongArray\": [1, 2, 3], \"FloatArray\": [1, 2, 3], \"DoubleArray\": [1, 2, 3], \"StringArray\": [\"foo\", \"bar\", \"baz\"] }"));
+            producer.send(new ProducerRecord<>(topic, null, 43L, null,
+                    "{ \"ByteArray\": [3, 2, 1], \"CharArray\": [\"d\", \"e\", \"f\"], \"ShortArray\": [3, 2, 1], \"IntArray\": [3, 2, 1], \"LongArray\": [3, 2, 1], \"FloatArray\": [3, 2, 1], \"DoubleArray\": [3, 2, 1], \"StringArray\": [\"baz\", \"bar\", \"foo\"] }"));
+            producer.flush();
+
+            awaitEquals(e2, taa);
         }
     }
 


### PR DESCRIPTION
This solves a leak as reported via ReleaseTracker by using arrays instead of chunks. As it was in the previous impl, this does mean that the buffer size will grow to the largest array seen while processing JSON events, and will remain until the processor is GCd. An alternative design could consider taking and releasing a chunk every single iteration (startImpl / doneImpl).