### PR TITLE
fix: DH-22657: Use array instead of chunks for Jackson repeated processors

### DIFF
--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ByteMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ByteMixin.java
@@ -5,12 +5,10 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableByteChunk;
 import io.deephaven.chunk.WritableChunk;
-import io.deephaven.chunk.sized.SizedByteChunk;
 import io.deephaven.json.ByteValue;
-import io.deephaven.json.Value;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
 
@@ -69,7 +67,7 @@ final class ByteMixin extends Mixin<ByteValue> {
     }
 
     final class ByteRepeaterImpl extends RepeaterProcessorBase<byte[]> {
-        private final SizedByteChunk<?> chunk = new SizedByteChunk<>(0);
+        private byte[] buffer = new byte[0];
 
         public ByteRepeaterImpl() {
             super(null, null, Type.byteType().arrayType());
@@ -77,24 +75,17 @@ final class ByteMixin extends Mixin<ByteValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableByteChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ByteMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableByteChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ByteMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public byte[] doneImpl(JsonParser parser, int length) {
-            final WritableByteChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/CharMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/CharMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableCharChunk;
 import io.deephaven.chunk.WritableChunk;
-import io.deephaven.chunk.sized.SizedCharChunk;
 import io.deephaven.json.CharValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -64,7 +63,7 @@ final class CharMixin extends Mixin<CharValue> {
     }
 
     final class CharRepeaterImpl extends RepeaterProcessorBase<char[]> {
-        private final SizedCharChunk<?> chunk = new SizedCharChunk<>(0);
+        private char[] buffer = new char[0];
 
         public CharRepeaterImpl() {
             super(null, null, Type.charType().arrayType());
@@ -72,24 +71,17 @@ final class CharMixin extends Mixin<CharValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableCharChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, CharMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableCharChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, CharMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public char[] doneImpl(JsonParser parser, int length) {
-            final WritableCharChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/DoubleMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/DoubleMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableDoubleChunk;
-import io.deephaven.chunk.sized.SizedDoubleChunk;
 import io.deephaven.json.DoubleValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -68,7 +67,7 @@ final class DoubleMixin extends Mixin<DoubleValue> {
     }
 
     final class DoubleRepeaterImpl extends RepeaterProcessorBase<double[]> {
-        private final SizedDoubleChunk<?> chunk = new SizedDoubleChunk<>(0);
+        private double[] buffer = new double[0];
 
         public DoubleRepeaterImpl() {
             super(null, null, Type.doubleType().arrayType());
@@ -76,24 +75,17 @@ final class DoubleMixin extends Mixin<DoubleValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableDoubleChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, DoubleMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableDoubleChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, DoubleMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public double[] doneImpl(JsonParser parser, int length) {
-            final WritableDoubleChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/FloatMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/FloatMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableFloatChunk;
-import io.deephaven.chunk.sized.SizedFloatChunk;
 import io.deephaven.json.FloatValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -68,7 +67,7 @@ final class FloatMixin extends Mixin<FloatValue> {
     }
 
     final class FloatRepeaterImpl extends RepeaterProcessorBase<float[]> {
-        private final SizedFloatChunk<?> chunk = new SizedFloatChunk<>(0);
+        private float[] buffer = new float[0];
 
         public FloatRepeaterImpl() {
             super(null, null, Type.floatType().arrayType());
@@ -76,24 +75,17 @@ final class FloatMixin extends Mixin<FloatValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableFloatChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, FloatMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableFloatChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, FloatMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public float[] doneImpl(JsonParser parser, int length) {
-            final WritableFloatChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/IntMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/IntMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableIntChunk;
-import io.deephaven.chunk.sized.SizedIntChunk;
 import io.deephaven.json.IntValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -69,7 +68,7 @@ final class IntMixin extends Mixin<IntValue> {
     }
 
     final class IntRepeaterImpl extends RepeaterProcessorBase<int[]> {
-        private final SizedIntChunk<?> chunk = new SizedIntChunk<>(0);
+        private int[] buffer = new int[0];
 
         public IntRepeaterImpl() {
             super(null, null, Type.intType().arrayType());
@@ -77,24 +76,17 @@ final class IntMixin extends Mixin<IntValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableIntChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, IntMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableIntChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, IntMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public int[] doneImpl(JsonParser parser, int length) {
-            final WritableIntChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/LongMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/LongMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableLongChunk;
-import io.deephaven.chunk.sized.SizedLongChunk;
 import io.deephaven.json.LongValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -69,7 +68,7 @@ final class LongMixin extends Mixin<LongValue> {
     }
 
     final class LongRepeaterImpl extends RepeaterProcessorBase<long[]> {
-        private final SizedLongChunk<?> chunk = new SizedLongChunk<>(0);
+        private long[] buffer = new long[0];
 
         public LongRepeaterImpl() {
             super(null, null, Type.longType().arrayType());
@@ -77,24 +76,17 @@ final class LongMixin extends Mixin<LongValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableLongChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, LongMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableLongChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, LongMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public long[] doneImpl(JsonParser parser, int length) {
-            final WritableLongChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/RepeaterGenericImpl.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/RepeaterGenericImpl.java
@@ -4,46 +4,43 @@
 package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
-import io.deephaven.chunk.WritableObjectChunk;
-import io.deephaven.chunk.sized.SizedObjectChunk;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.qst.type.NativeArrayType;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
 
 final class RepeaterGenericImpl<T> extends RepeaterProcessorBase<T[]> {
     private final ToObject<T> toObject;
-    private final SizedObjectChunk<T, ?> chunk;
+    private final Class<T[]> bufferClass;
+    private final Class<T> componentClass;
+    private T[] buffer;
 
     public RepeaterGenericImpl(ToObject<T> toObject, T[] onMissing, T[] onNull, NativeArrayType<T[], T> arrayType) {
         super(onMissing, onNull, arrayType);
         this.toObject = Objects.requireNonNull(toObject);
-        chunk = new SizedObjectChunk<>(0);
+        this.bufferClass = arrayType.clazz();
+        this.componentClass = arrayType.componentType().clazz();
+        // noinspection unchecked
+        this.buffer = (T[]) Array.newInstance(componentClass, 0);
     }
 
     @Override
     public void processElementImpl(JsonParser parser, int index) throws IOException {
-        final int newSize = index + 1;
-        final WritableObjectChunk<T, ?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-        chunk.set(index, toObject.parseValue(parser));
-        chunk.setSize(newSize);
+        buffer = ArrayUtil.put(buffer, index, toObject.parseValue(parser), componentClass);
     }
 
     @Override
     public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-        final int newSize = index + 1;
-        final WritableObjectChunk<T, ?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-        chunk.set(index, toObject.parseMissing(parser));
-        chunk.setSize(newSize);
+        buffer = ArrayUtil.put(buffer, index, toObject.parseMissing(parser), componentClass);
     }
 
     @Override
     public T[] doneImpl(JsonParser parser, int length) {
-        final WritableObjectChunk<T, ?> chunk = this.chunk.get();
-        final T[] result = Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
-        chunk.fillWithNullValue(0, length);
+        final T[] result = Arrays.copyOfRange(buffer, 0, length, bufferClass);
+        Arrays.fill(buffer, 0, length, null);
         return result;
     }
 }

--- a/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ShortMixin.java
+++ b/extensions/json-jackson/src/main/java/io/deephaven/json/jackson/ShortMixin.java
@@ -5,10 +5,9 @@ package io.deephaven.json.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import io.deephaven.base.MathUtil;
+import io.deephaven.base.ArrayUtil;
 import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableShortChunk;
-import io.deephaven.chunk.sized.SizedShortChunk;
 import io.deephaven.json.ShortValue;
 import io.deephaven.qst.type.Type;
 import io.deephaven.util.QueryConstants;
@@ -68,7 +67,7 @@ final class ShortMixin extends Mixin<ShortValue> {
     }
 
     final class ShortRepeaterImpl extends RepeaterProcessorBase<short[]> {
-        private final SizedShortChunk<?> chunk = new SizedShortChunk<>(0);
+        private short[] buffer = new short[0];
 
         public ShortRepeaterImpl() {
             super(null, null, Type.shortType().arrayType());
@@ -76,24 +75,17 @@ final class ShortMixin extends Mixin<ShortValue> {
 
         @Override
         public void processElementImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableShortChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ShortMixin.this.parseValue(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseValue(parser));
         }
 
         @Override
         public void processElementMissingImpl(JsonParser parser, int index) throws IOException {
-            final int newSize = index + 1;
-            final WritableShortChunk<?> chunk = this.chunk.ensureCapacityPreserve(MathUtil.roundUpArraySize(newSize));
-            chunk.set(index, ShortMixin.this.parseMissing(parser));
-            chunk.setSize(newSize);
+            buffer = ArrayUtil.put(buffer, index, parseMissing(parser));
         }
 
         @Override
         public short[] doneImpl(JsonParser parser, int length) {
-            final WritableShortChunk<?> chunk = this.chunk.get();
-            return Arrays.copyOfRange(chunk.array(), chunk.arrayOffset(), chunk.arrayOffset() + length);
+            return Arrays.copyOfRange(buffer, 0, length);
         }
     }
 


### PR DESCRIPTION
This solves a leak as reported via ReleaseTracker by using arrays instead of chunks. As it was in the previous impl, this does mean that the buffer size will grow to the largest array seen while processing JSON events, and will remain until the processor is GCd. An alternative design could consider taking and releasing a chunk every single iteration (startImpl / doneImpl).

Cherry-pick of #8035 (and #8050 in spirit).

Note: this fixes https://deephaven.atlassian.net/browse/DH-22418, https://deephaven.atlassian.net/browse/DH-21741, and https://deephaven.atlassian.net/browse/DH-22657. The cherry-pick does not include the tests that are in main because the kafka integration testing is not part of the rc/v41.x branch at this time.