### PR TITLE
fix: DH-22693: Update pushdown disable flag.

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -286,8 +286,8 @@ public class QueryTable extends BaseTable<QueryTable> {
     /**
      * Disable the usage of parquet row group dictionaries during push-down filtering.
      */
-    public static boolean DISABLE_WHERE_PUSHDOWN_PARQUET_DICTIONARY =
-            Configuration.getInstance().getBooleanWithDefault("QueryTable.disableWherePushdownParquetDictionary",
+    public static boolean DISABLE_WHERE_PUSHDOWN_DICTIONARY =
+            Configuration.getInstance().getBooleanWithDefault("QueryTable.disableWherePushdownDictionary",
                     false);
 
     /**

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -470,7 +470,7 @@ public class ParquetTableLocation extends AbstractTableLocation {
 
     private static final RegionedPushdownAction.Location PARQUET_DICTIONARY =
             new RegionedPushdownAction.Location(
-                    () -> QueryTable.DISABLE_WHERE_PUSHDOWN_PARQUET_DICTIONARY,
+                    () -> QueryTable.DISABLE_WHERE_PUSHDOWN_DICTIONARY,
                     PushdownResult.REGION_DICTIONARY_DATA_COST,
                     BasePushdownFilterContext::supportsChunkFiltering,
                     (tl, cr) -> ((ParquetTableLocation) tl).supportsDictionaryFiltering());


### PR DESCRIPTION
Updates the configuration flag used to disable dictionary-based predicate pushdown during Parquet table filtering (DH-22693), aligning the Parquet pushdown code to reference the newly named `QueryTable` toggle.

**Changes:**
- Renamed the `QueryTable` dictionary pushdown disable flag and its backing configuration property key.
- Updated Parquet pushdown action wiring to use the renamed flag.