### PR TITLE
ci: DH-22709: Fix paths-filter base for release branch

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -22,8 +22,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
+          # Ignored by the action if it is a pull_request event
+          base: ${{ github.ref }}
           filters: |
             non-docs:
               - '!docs/**'

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Detect docs changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -22,8 +22,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
+          # Ignored by the action if it is a pull_request event
+          base: ${{ github.ref }}
           filters: |
             non-docs:
               - '!docs/**'

--- a/.github/workflows/quick-ci.yml
+++ b/.github/workflows/quick-ci.yml
@@ -22,8 +22,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Check for non-docs changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
+          # Ignored by the action if it is a pull_request event
+          base: ${{ github.ref }}
           filters: |
             non-docs:
               - '!docs/**'


### PR DESCRIPTION
paths-filter defaults to base of the default branch for `pull` triggers. Change to the branch itself and it will just check the last commit

My only concern was the publish process creates a new `release/v*` branch which when compared to its last commit, could have only changed docs. But this was already handled because the `publish-ci` step right after that checks if non-docs had changed also has `|| startsWith(ref, 'release/v*')` so publish should work fine even if the last commit was docs only.