### PR TITLE
fix: DH-15773: Fix non-string one click key comparison

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/OneClick.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/plot/OneClick.java
@@ -208,14 +208,13 @@ public class OneClick {
         } else if (key1 == null || key2 == null) {
             return false;
         }
-        if (key1 instanceof String) {
-            return key1.equals(key2);
+        if (key1 instanceof String[]) {
+            if (key2 instanceof String[]) {
+                return Arrays.equals((String[]) key1, (String[]) key2);
+            }
+            return false;
         }
-        assert key1 instanceof String[];
-        if (key2 instanceof String[]) {
-            return Arrays.equals((String[]) key1, (String[]) key2);
-        }
-        return false;// key2 isn't String[], so fail
+        return key1.equals(key2);
     }
 
     private static boolean anyKeyMatches(Object[] keys, Object key) {


### PR DESCRIPTION
Currently, if using the linker tool with a numeric one click, the first filter works, but subsequent ones error because an internal key comparison fails.

Using linker now works as expected for this code:
```
from deephaven import empty_table
from deephaven.plot.selectable_dataset import one_click
from deephaven.plot.figure import Figure
source = empty_table(10).update(["X = i", "Y = Math.random()", "Z = i % 2"])
oc = one_click(t=source, by=["Z"])
plot = Figure().plot_xy(series_name="Plot", t=oc, x="X", y="Y").show()
```