### PR TITLE
feat!: DH-20878: Default PartitionedTableProxy sanity check joins to False.

### DIFF
--- a/docs/groovy/how-to-guides/partitioned-tables.md
+++ b/docs/groovy/how-to-guides/partitioned-tables.md
@@ -303,7 +303,7 @@ resultViaProxy = ptJoined.merge()
 ```
 
 > [!CAUTION]
-> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., `naturalJoin`), `whereIn`, or `whereNotIn` when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
 > When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 

--- a/docs/groovy/how-to-guides/partitioned-tables.md
+++ b/docs/groovy/how-to-guides/partitioned-tables.md
@@ -303,9 +303,9 @@ resultViaProxy = ptJoined.merge()
 ```
 
 > [!CAUTION]
-> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
-> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
+> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 
 ## Why use partitioned tables?
 

--- a/docs/groovy/how-to-guides/partitioned-tables.md
+++ b/docs/groovy/how-to-guides/partitioned-tables.md
@@ -302,6 +302,11 @@ ptJoined = ptProxyJoined.target()
 resultViaProxy = ptJoined.merge()
 ```
 
+> [!CAUTION]
+> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+>
+> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
+
 ## Why use partitioned tables?
 
 So far this guide has shown how you can use partitioned tables in your queries. But it doesn't cover why you may want to use them. Initially, we discussed that partitioned tables are useful for:

--- a/docs/groovy/reference/table-operations/partitioned-tables/proxy.md
+++ b/docs/groovy/reference/table-operations/partitioned-tables/proxy.md
@@ -32,9 +32,9 @@ Whether to check that proxied join operations will only find a given join key in
 </ParamTable>
 
 > [!CAUTION]
-> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
-> When `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
+> When `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 
 ## Returns
 

--- a/docs/groovy/reference/table-operations/partitioned-tables/proxy.md
+++ b/docs/groovy/reference/table-operations/partitioned-tables/proxy.md
@@ -32,7 +32,7 @@ Whether to check that proxied join operations will only find a given join key in
 </ParamTable>
 
 > [!CAUTION]
-> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., `naturalJoin`), `whereIn`, or `whereNotIn` when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
 > When `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 

--- a/docs/groovy/reference/table-operations/partitioned-tables/proxy.md
+++ b/docs/groovy/reference/table-operations/partitioned-tables/proxy.md
@@ -2,12 +2,12 @@
 title: proxy
 ---
 
-The `proxy` method creates a `PartitionedTable.Proxy` that allows table operations to be applied to the constituent tables of the source `PartitionedTable`.
+The [`proxy`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/PartitionedTable.html#proxy()) method creates a `PartitionedTable.Proxy` that allows table operations to be applied to the constituent tables of the source `PartitionedTable`.
 
 Each operation thus applied will produce a new `PartitionedTable` with the results, as in `transform(UnaryOperator, Dependency...)` or [`partitionedTransform(PartitionedTable, BinaryOperator, Dependency...)`](./partitionedTransform.md), and return a new proxy to that `PartitionedTable`.
 
 > [!NOTE]
-> If the `proxy` overload with no parameters is used, the result is the same as `proxy(true, true)`.
+> If the `proxy` overload with no parameters is used, the result is the same as `proxy(true, false)`.
 
 ## Syntax
 
@@ -30,6 +30,11 @@ Whether to check that proxied join operations will only find a given join key in
 
 </Param>
 </ParamTable>
+
+> [!CAUTION]
+> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+>
+> When `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
 
 ## Returns
 

--- a/docs/python/how-to-guides/partitioned-tables.md
+++ b/docs/python/how-to-guides/partitioned-tables.md
@@ -329,9 +329,9 @@ result_via_proxy = pt_joined.merge()
 ```
 
 > [!CAUTION]
-> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
-> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
+> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 
 ## Why use partitioned tables?
 

--- a/docs/python/how-to-guides/partitioned-tables.md
+++ b/docs/python/how-to-guides/partitioned-tables.md
@@ -329,7 +329,7 @@ result_via_proxy = pt_joined.merge()
 ```
 
 > [!CAUTION]
-> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., `natural_join`), `where_in`, or `where_not_in` when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
 > When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 

--- a/docs/python/how-to-guides/partitioned-tables.md
+++ b/docs/python/how-to-guides/partitioned-tables.md
@@ -328,6 +328,11 @@ pt_joined = pt_proxy_joined.target
 result_via_proxy = pt_joined.merge()
 ```
 
+> [!CAUTION]
+> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+>
+> When the second argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
+
 ## Why use partitioned tables?
 
 So far this guide has shown how you can use partitioned tables in your queries. But it doesn't cover why you may want to use them. Initially, we discussed that partitioned tables are useful for:

--- a/docs/python/reference/table-operations/partitioned-tables/proxy.md
+++ b/docs/python/reference/table-operations/partitioned-tables/proxy.md
@@ -34,9 +34,9 @@ Whether to check that for proxied join operations, a given join key only occurs 
 
 
 > [!CAUTION]
-> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
-> When the argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
+> When the argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 
 
 ## Returns

--- a/docs/python/reference/table-operations/partitioned-tables/proxy.md
+++ b/docs/python/reference/table-operations/partitioned-tables/proxy.md
@@ -33,7 +33,7 @@ Whether to check that for proxied join operations, a given join key only occurs 
 </ParamTable>
 
 > [!CAUTION]
-> `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
+> `PartitionedTable` transforms and proxies produce different results than on a single-table join (e.g., `natural_join`), `where_in`, or `where_not_in` when the filter or join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
 > When the argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
 

--- a/docs/python/reference/table-operations/partitioned-tables/proxy.md
+++ b/docs/python/reference/table-operations/partitioned-tables/proxy.md
@@ -2,7 +2,7 @@
 title: proxy
 ---
 
-The `proxy` method creates a new `PartitionedTableProxy` from the provided `PartitionedTable`.
+The [`proxy`](https://docs.deephaven.io/core/pydoc/code/deephaven.table.html#deephaven.table.PartitionedTable.proxy) method creates a new [`PartitionedTableProxy`](https://docs.deephaven.io/core/pydoc/code/deephaven.table.html#deephaven.table.PartitionedTableProxy) from the provided `PartitionedTable`.
 
 A `PartitionedTableProxy` is a table operation proxy object for the underlying `PartitionedTable`. The `PartitionedTableProxy` gives users access to a variety of Deephaven table operations that are not available to a `PartitionedTable`. When a user has made all the desired changes to the `PartitionedTableProxy`, they can use the `target` attribute to return the underlying `PartitionedTable` with the changes applied.
 
@@ -13,7 +13,7 @@ A query can achieve the same results by using either [`transform`](./transform.m
 ```python syntax
 PartitionedTable.proxy(
   require_matching_keys: bool = True,
-  sanity_check_joins: bool = True
+  sanity_check_joins: bool = False
 ) -> PartitionedTableProxy
 ```
 
@@ -31,6 +31,13 @@ Whether to check that for proxied join operations, a given join key only occurs 
 
 </Param>
 </ParamTable>
+
+
+> [!CAUTION]
+> PartitionedTable transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must take care to ensure that your data's keys map to appropriate partitions to enable correct answers.
+>
+> When the argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition; but it does not validate that a key exists in the same partition in both the left and right table.
+
 
 ## Returns
 

--- a/docs/python/reference/table-operations/partitioned-tables/proxy.md
+++ b/docs/python/reference/table-operations/partitioned-tables/proxy.md
@@ -32,12 +32,10 @@ Whether to check that for proxied join operations, a given join key only occurs 
 </Param>
 </ParamTable>
 
-
 > [!CAUTION]
 > `PartitionedTable` transforms and proxies produce different results than on a single-table `join` when the join keys span partitions. You must ensure that your data's keys map to appropriate partitions to enable correct answers.
 >
 > When the argument `sanityCheckJoins` to the `proxy` method is true, the engine validates that join keys exist only in a single partition, but it does not validate that a key exists in the same partition in both the left and right table.
-
 
 ## Returns
 

--- a/engine/api/src/main/java/io/deephaven/engine/table/PartitionedTable.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/PartitionedTable.java
@@ -138,7 +138,10 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      *
      * <p>
      * Note that as of Deephaven Core 42.0, proxies do not sanity check join operations by default. You must manually
-     * call {@code proxy(true, true)} to get pre-42.0 behavior.
+     * call {@code proxy(true, true)} to get pre-42.0 behavior. The sanity check requires examining every row of all
+     * constituent tables and updating a shared data structure, increasing the total amount of work required and
+     * reducing the potential parallelism of the join operation. However, the sanity check may catch data errors in the
+     * query that would produce otherwise unexpected results.
      * </p>
      *
      * @return A proxy that allows {@link TableOperations table operations} to be applied to the constituent tables of
@@ -167,7 +170,10 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      * @param sanityCheckJoinOperations Whether to check that proxied join operations will only find a given join key in
      *        one constituent table for {@code this} and the {@link Table table} argument if it is also a
      *        {@link PartitionedTable.Proxy proxy}. If a join key exists in more than one constituent table, the results
-     *        of the proxy are inconsistent with the result on a non-partitioned table.
+     *        of the proxy are inconsistent with the result on a non-partitioned table. Although the argument is named
+     *        "sanityCheckJoinOperations", it applies to any operation that combines results from a left-hand-side table
+     *        and a right-hand-side table that correlates keys between the tables which also includes
+     *        {@link Table#whereIn(Object, String...)} and {@link Table#whereNotIn(Object, String...)}.
      * @return A proxy that allows {@link TableOperations table operations} to be applied to the constituent tables of
      *         this PartitionedTable
      */

--- a/engine/api/src/main/java/io/deephaven/engine/table/PartitionedTable.java
+++ b/engine/api/src/main/java/io/deephaven/engine/table/PartitionedTable.java
@@ -134,7 +134,12 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
     boolean constituentChangesPermitted();
 
     /**
-     * Same as {@code proxy(true, true)}.
+     * Same as {@code proxy(true, false)}.
+     *
+     * <p>
+     * Note that as of Deephaven Core 42.0, proxies do not sanity check join operations by default. You must manually
+     * call {@code proxy(true, true)} to get pre-42.0 behavior.
+     * </p>
      *
      * @return A proxy that allows {@link TableOperations table operations} to be applied to the constituent tables of
      *         this PartitionedTable
@@ -143,7 +148,7 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
     @FinalDefault
     @ConcurrentMethod
     default Proxy proxy() {
-        return proxy(true, true);
+        return proxy(true, false);
     }
 
     /**
@@ -161,7 +166,8 @@ public interface PartitionedTable extends LivenessNode, LogOutputAppendable {
      *        {@link #partitionedTransform(PartitionedTable, BinaryOperator, Dependency...) partitioned transform}
      * @param sanityCheckJoinOperations Whether to check that proxied join operations will only find a given join key in
      *        one constituent table for {@code this} and the {@link Table table} argument if it is also a
-     *        {@link PartitionedTable.Proxy proxy}
+     *        {@link PartitionedTable.Proxy proxy}. If a join key exists in more than one constituent table, the results
+     *        of the proxy are inconsistent with the result on a non-partitioned table.
      * @return A proxy that allows {@link TableOperations table operations} to be applied to the constituent tables of
      *         this PartitionedTable
      */


### PR DESCRIPTION
BREAKING CHANGE: Queries that previously would have failed because join keys span two constituents no longer fail.  To restore prior behavior, you must explicitly set sanity checking to true when creating the proxy.