### PR TITLE
fix: DH-20800: Allow JS subscriptions to outlive their tables

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/JsTable.java
@@ -845,7 +845,13 @@ public class JsTable extends HasLifecycle implements HasTableBinding, JoinableTa
         if (copy.columns == null) {
             throw new IllegalArgumentException("Missing 'columns' property in viewport subscription options");
         }
-        return TableViewportSubscription.make(copy, this);
+        TableViewportSubscription subscription = TableViewportSubscription.make(copy, this);
+
+        // Sever any connection between this table and the subscription
+        subscription.retainForExternalUse();
+        subscription.internalClose();
+
+        return subscription;
     }
 
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/subscription/TableViewportSubscription.java
@@ -212,7 +212,7 @@ public class TableViewportSubscription extends AbstractTableSubscription {
         }
     }
 
-    private void retainForExternalUse() {
+    public void retainForExternalUse() {
         retained = true;
     }
 

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/AbstractAsyncGwtTestCase.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/AbstractAsyncGwtTestCase.java
@@ -19,8 +19,8 @@ import io.deephaven.web.client.fu.CancellablePromise;
 import io.deephaven.web.client.ide.IdeSession;
 import io.deephaven.web.shared.fu.JsRunnable;
 import io.deephaven.web.shared.fu.RemoverFn;
-import jsinterop.annotations.JsMethod;
-import jsinterop.annotations.JsPackage;
+import javaemul.internal.annotations.DoNotAutobox;
+import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsProperty;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
@@ -36,11 +36,43 @@ import java.util.function.Predicate;
 import static elemental2.dom.DomGlobal.console;
 
 public abstract class AbstractAsyncGwtTestCase extends GWTTestCase {
-    @JsMethod(namespace = JsPackage.GLOBAL)
-    private static native Object eval(String code);
+    private boolean errorLogsFailTests = true;
+    private LogMethod originalConsoleError;
+    protected final List<Object[]> errorLogsSeen = new ArrayList<>();
 
-    private static Promise<JsPropertyMap<Object>> importScript(String moduleName) {
-        return (Promise<JsPropertyMap<Object>>) eval("import('" + moduleName + "')");
+    @JsFunction
+    interface LogMethod {
+        void write(@DoNotAutobox Object... msgs);
+    }
+
+    @Override
+    protected void gwtSetUp() throws Exception {
+        super.gwtSetUp();
+        originalConsoleError = ((LogMethod) Js.asPropertyMap(console).get("error"));
+        LogMethod replacementConsoleError = (args) -> {
+            originalConsoleError.write("The following error was captured by test handler:");
+            originalConsoleError.write(args);
+            errorLogsSeen.add(args);
+            if (errorLogsFailTests) {
+                report("console.error called: " + Arrays.toString(args));
+            }
+        };
+        Js.asPropertyMap(console).set("error", replacementConsoleError);
+    }
+
+    @Override
+    protected void gwtTearDown() throws Exception {
+        super.gwtTearDown();
+        errorLogsSeen.clear();
+        Js.asPropertyMap(console).set("error", originalConsoleError);
+    }
+
+    /**
+     * Disarms the test from failing on the first error log it encounters. Either ignore error logs after calling this,
+     * or read the protected {@link #errorLogsSeen} list of messages.
+     */
+    protected void errorLogsDontFail() {
+        errorLogsFailTests = false;
     }
 
     private static Promise<Void> importDhInternal() {

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.web.client.api.subscription;
 
+import com.google.gwt.core.client.GWT;
 import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.promise.IThenable;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1032,6 +1034,40 @@ public class ViewportTestGwt extends AbstractAsyncGwtTestCase {
                         }
                         return Promise.resolve(snapshot);
                     });
+                })
+                .then(this::finish).catch_(this::report);
+    }
+
+    public void testSubscriptionsOutlivingTables() {
+        AtomicBoolean seenUnhandledError = new AtomicBoolean(false);
+        DomGlobal.self.addEventListener("unhandledrejection", e -> {
+            seenUnhandledError.set(true);
+        });
+        GWT.setUncaughtExceptionHandler(e -> seenUnhandledError.set(true));
+        connect(tables)
+                .then(table("growingForward"))
+                .then(t -> {
+                    delayTestFinish(9001);
+
+                    DataOptions.ViewportSubscriptionOptions options = new DataOptions.ViewportSubscriptionOptions();
+                    options.columns = t.getColumns();
+                    options.rows = Js.uncheckedCast(JsRangeSet.ofRange(0, 1));
+                    TableViewportSubscription sub = t.createViewportSubscription(options);
+                    return waitForEvent(sub, TableSubscription.EVENT_UPDATED, 2000).onInvoke(sub)
+                            .then(s -> {
+                                t.close();
+                                // even though the table is closed, we should still get updates without errors
+                                return waitForEvent(s, TableSubscription.EVENT_UPDATED, 2000).onInvoke(sub);
+                            }).then(s -> {
+                                // The next event isn't quite sufficient, because handlers could go off out of order,
+                                // wait one more.
+                                return waitForEvent(s, TableSubscription.EVENT_UPDATED, 2000).onInvoke(sub);
+                            }).then(s -> {
+                                // close the subscription and end the test
+                                s.close();
+                                assertFalse(seenUnhandledError.get());
+                                return null;
+                            });
                 })
                 .then(this::finish).catch_(this::report);
     }

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
@@ -3,6 +3,7 @@
 //
 package io.deephaven.web.client.api.subscription;
 
+import com.google.common.cache.RemovalListener;
 import com.google.gwt.core.client.GWT;
 import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
@@ -24,6 +25,8 @@ import io.deephaven.web.client.api.filter.FilterCondition;
 import io.deephaven.web.client.api.filter.FilterValue;
 import io.deephaven.web.shared.fu.JsConsumer;
 import io.deephaven.web.shared.fu.RemoverFn;
+import javaemul.internal.annotations.DoNotAutobox;
+import jsinterop.annotations.JsFunction;
 import jsinterop.base.Any;
 import jsinterop.base.Js;
 
@@ -32,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1038,12 +1042,22 @@ public class ViewportTestGwt extends AbstractAsyncGwtTestCase {
                 .then(this::finish).catch_(this::report);
     }
 
+    @JsFunction
+    interface LogMethod {
+        void write(@DoNotAutobox Object... msgs);
+    }
+
     public void testSubscriptionsOutlivingTables() {
+        // DH-20800 resulted in a logged error, but no exception. This test instruments the browser's log functionality
+        // so we can detect that an error was written out, and confirm through its absence that the bug was fixed.
+        LogMethod originalConsoleError = console::error;
         AtomicBoolean seenUnhandledError = new AtomicBoolean(false);
-        DomGlobal.self.addEventListener("unhandledrejection", e -> {
+        LogMethod replacementConsoleError = (args) -> {
             seenUnhandledError.set(true);
-        });
-        GWT.setUncaughtExceptionHandler(e -> seenUnhandledError.set(true));
+            originalConsoleError.write("The following error was captured by test handler");
+            originalConsoleError.write(args);
+        };
+        Js.asPropertyMap(DomGlobal.console).set("error", replacementConsoleError);
         connect(tables)
                 .then(table("growingForward"))
                 .then(t -> {

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/subscription/ViewportTestGwt.java
@@ -3,8 +3,6 @@
 //
 package io.deephaven.web.client.api.subscription;
 
-import com.google.common.cache.RemovalListener;
-import com.google.gwt.core.client.GWT;
 import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.promise.IThenable;
@@ -25,8 +23,6 @@ import io.deephaven.web.client.api.filter.FilterCondition;
 import io.deephaven.web.client.api.filter.FilterValue;
 import io.deephaven.web.shared.fu.JsConsumer;
 import io.deephaven.web.shared.fu.RemoverFn;
-import javaemul.internal.annotations.DoNotAutobox;
-import jsinterop.annotations.JsFunction;
 import jsinterop.base.Any;
 import jsinterop.base.Js;
 
@@ -34,8 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1042,22 +1036,13 @@ public class ViewportTestGwt extends AbstractAsyncGwtTestCase {
                 .then(this::finish).catch_(this::report);
     }
 
-    @JsFunction
-    interface LogMethod {
-        void write(@DoNotAutobox Object... msgs);
-    }
+
 
     public void testSubscriptionsOutlivingTables() {
         // DH-20800 resulted in a logged error, but no exception. This test instruments the browser's log functionality
         // so we can detect that an error was written out, and confirm through its absence that the bug was fixed.
-        LogMethod originalConsoleError = console::error;
-        AtomicBoolean seenUnhandledError = new AtomicBoolean(false);
-        LogMethod replacementConsoleError = (args) -> {
-            seenUnhandledError.set(true);
-            originalConsoleError.write("The following error was captured by test handler");
-            originalConsoleError.write(args);
-        };
-        Js.asPropertyMap(DomGlobal.console).set("error", replacementConsoleError);
+        errorLogsDontFail();
+
         connect(tables)
                 .then(table("growingForward"))
                 .then(t -> {
@@ -1077,9 +1062,10 @@ public class ViewportTestGwt extends AbstractAsyncGwtTestCase {
                                 // wait one more.
                                 return waitForEvent(s, TableSubscription.EVENT_UPDATED, 2000).onInvoke(sub);
                             }).then(s -> {
-                                // close the subscription and end the test
+                                // close the subscription and end the test, confirming explicitly that we did not see
+                                // an error message
                                 s.close();
-                                assertFalse(seenUnhandledError.get());
+                                assertTrue(errorLogsSeen.toString(), errorLogsSeen.isEmpty());
                                 return null;
                             });
                 })


### PR DESCRIPTION
This fix only applies to the new viewport subscription API, as the table wasn't correctly marking the subscription instance as exclusively owned by calling code.

The test works by checking for the logged error message, as no actual exception occurs with this bug.