### PR TITLE
fix(csharp/client): DH-22925: Migrate unit tests to TUnit

### DIFF
--- a/csharp/client/Dh_NetClientTests/AddDropTest.cs
+++ b/csharp/client/Dh_NetClientTests/AddDropTest.cs
@@ -2,25 +2,24 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class AddDropTest(ITestOutputHelper output) {
-  [Fact]
-  public void TestDropSomeColumns() {
+public class AddDropTest {
+  [Test]
+  public async Task TestDropSomeColumns() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
     var t = table.Update("II = ii").Where("Ticker == `AAPL`");
     var cn = ctx.ColumnNames;
     var t2 = t.DropColumns(cn.ImportDate, cn.Ticker, cn.Open, cn.Close);
-    output.WriteLine(t2.ToString(true));
+    Console.WriteLine(t2.ToString(true));
 
     var expected = new TableMaker();
     expected.AddColumn("Volume", [(Int64)100000, 250000, 19000]);
     expected.AddColumn("II", [(Int64)5, 6, 7]);
 
-    TableComparer.AssertSame(expected, t2);
+    await Assert.That(() => TableComparer.AssertSame(expected, t2)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/AggregatesTest.cs
+++ b/csharp/client/Dh_NetClientTests/AggregatesTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class AggregatesTest {
-  [Fact]
-  public void TestVariousAggregates() {
+  [Test]
+  public async Task TestVariousAggregates() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
@@ -30,6 +30,6 @@ public class AggregatesTest {
     expected.AddColumn("MaxClose", [544.9]);
     expected.AddColumn("Count", [(Int64)2]);
 
-    TableComparer.AssertSame(expected, aggTable);
+    await Assert.That(() => TableComparer.AssertSame(expected, aggTable)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/Dh_NetClientTests.csproj
+++ b/csharp/client/Dh_NetClientTests/Dh_NetClientTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -13,18 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="TUnit" Version="1.56.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Dh_NetClient\Dh_NetClient.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/csharp/client/Dh_NetClientTests/FilterTest.cs
+++ b/csharp/client/Dh_NetClientTests/FilterTest.cs
@@ -2,19 +2,18 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class FilterTest(ITestOutputHelper output) {
-  [Fact]
-  public void TestFilterATable() {
+public class FilterTest {
+  [Test]
+  public async Task TestFilterATable() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
     var t1 = table.Where(
       "ImportDate == `2017-11-01` && Ticker == `AAPL` && (Close <= 120.0 || isNull(Close))");
-    output.WriteLine(t1.ToString(true));
+    Console.WriteLine(t1.ToString(true));
 
     var expected = new TableMaker();
     expected.AddColumn("ImportDate", ["2017-11-01", "2017-11-01", "2017-11-01"]);
@@ -23,6 +22,6 @@ public class FilterTest(ITestOutputHelper output) {
     expected.AddColumn("Close", [23.5, 24.2, 26.7]);
     expected.AddColumn("Volume", [(Int64)100000, 250000, 19000]);
 
-    TableComparer.AssertSame(expected, t1);
+    await Assert.That(() => TableComparer.AssertSame(expected, t1)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/GlobalUsings.cs
+++ b/csharp/client/Dh_NetClientTests/GlobalUsings.cs
@@ -1,4 +1,3 @@
 ﻿//
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
-global using Xunit;

--- a/csharp/client/Dh_NetClientTests/GroupTest.cs
+++ b/csharp/client/Dh_NetClientTests/GroupTest.cs
@@ -2,13 +2,12 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class GroupTest(ITestOutputHelper output) {
-  [Fact]
-  public void GroupATable() {
+public class GroupTest {
+  [Test]
+  public async Task GroupATable() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var maker = new TableMaker();
@@ -32,7 +31,7 @@ public class GroupTest(ITestOutputHelper output) {
     using var t1 = maker.MakeTable(ctx.Client.Manager);
 
     using var grouped = t1.By("Type");
-    output.WriteLine(grouped.ToString(true, true));
+    Console.WriteLine(grouped.ToString(true, true));
 
     var expected = new TableMaker();
     expected.AddColumn("Type", ["Granny Smith", "Gala", "Golden Delicious"]);
@@ -40,11 +39,11 @@ public class GroupTest(ITestOutputHelper output) {
       [["Green", "Green"], ["Red-Green", "Orange-Green"], ["Yellow", "Yellow"]]);
     expected.AddColumn<List<Int32>>("Weight", [[102, 85], [79, 92], [78, 99]]);
     expected.AddColumn<List<Int32>>("Calories", [[53, 48], [51, 61], [46, 57]]);
-    TableComparer.AssertSame(expected, grouped);
+    await Assert.That(() => TableComparer.AssertSame(expected, grouped)).ThrowsNothing();
   }
 
-  [Fact]
-  public void NestedListsNotSupported() {
+  [Test]
+  public async Task NestedListsNotSupported() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var maker = new TableMaker();
@@ -53,6 +52,6 @@ public class GroupTest(ITestOutputHelper output) {
       [[4, 5]]
     ]);
     using var t = maker.MakeTable(ctx.Client.Manager);
-    Assert.Throws<Exception>(t.ToClientTable);
+    await Assert.That(() => t.ToClientTable()).Throws<Exception>();
   }
 }

--- a/csharp/client/Dh_NetClientTests/HeadAndTailTest.cs
+++ b/csharp/client/Dh_NetClientTests/HeadAndTailTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class HeadAndTailTest {
-  [Fact]
-  public void TestHeadAndTail() {
+  [Test]
+  public async Task TestHeadAndTail() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
@@ -21,7 +21,7 @@ public class HeadAndTailTest {
 
       expected.AddColumn("Ticker", ["XRX", "XRX"]);
       expected.AddColumn("Volume", [(Int64)345000, 87000]);
-      TableComparer.AssertSame(expected, th);
+      await Assert.That(() => TableComparer.AssertSame(expected, th)).ThrowsNothing();
     }
 
     {
@@ -29,7 +29,7 @@ public class HeadAndTailTest {
 
       expected.AddColumn("Ticker", ["ZNGA", "ZNGA"]);
       expected.AddColumn("Volume", [(Int64)46123, 48300]);
-      TableComparer.AssertSame(expected, tt);
+      await Assert.That(() => TableComparer.AssertSame(expected, tt)).ThrowsNothing();
     }
   }
 }

--- a/csharp/client/Dh_NetClientTests/InputTableTest.cs
+++ b/csharp/client/Dh_NetClientTests/InputTableTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class InputTableTest {
-  [Fact]
-  public void TestInputTableAppend() {
+  [Test]
+  public async Task TestInputTableAppend() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -20,7 +20,7 @@ public class InputTableTest {
       var expected = new TableMaker();
       expected.AddColumn("A", [(Int64)0, 1, 2]);
       expected.AddColumn("B", [(Int64)100, 101, 102]);
-      TableComparer.AssertSame(expected, inputTable);
+      await Assert.That(() => TableComparer.AssertSame(expected, inputTable)).ThrowsNothing();
     }
 
     var tableToAdd = tm.EmptyTable(2).Update("A = ii", "B = ii + 200");
@@ -33,13 +33,13 @@ public class InputTableTest {
       var expected = new TableMaker();
       expected.AddColumn("A", aData);
       expected.AddColumn("B", bData);
-      TableComparer.AssertSame(expected, inputTable);
+      await Assert.That(() => TableComparer.AssertSame(expected, inputTable)).ThrowsNothing();
     }
   }
 
 
-  [Fact]
-  public void TestInputTableKeyed() {
+  [Test]
+  public async Task TestInputTableKeyed() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -48,28 +48,27 @@ public class InputTableTest {
     var inputTable = tm.InputTable(source, "A");
 
 
-    // expect input_table to be {0, 100}, {1, 101}, {2, 102}
+    // expect inputTable to be {0, 100}, {1, 101}, {2, 102}
     {
       var aData = new Int64[] { 0, 1, 2 };
       var bData = new Int64[] { 100, 101, 102 };
       var expected = new TableMaker();
       expected.AddColumn("A", aData);
       expected.AddColumn("B", bData);
-      TableComparer.AssertSame(expected, inputTable);
+      await Assert.That(() => TableComparer.AssertSame(expected, inputTable)).ThrowsNothing();
     }
-
 
     var tableToAdd = tm.EmptyTable(2).Update("A = ii", "B = ii + 200");
     inputTable.AddTable(tableToAdd);
 
-    // Because key is "A", expect input_table to be {0, 200}, {1, 201}, {2, 102}
+    // Because key is "A", expect inputTable to be {0, 200}, {1, 201}, {2, 102}
     {
       var aData = new Int64[] { 0, 1, 2 };
       var bData = new Int64[] { 200, 201, 102 };
       var expected = new TableMaker();
       expected.AddColumn("A", aData);
       expected.AddColumn("B", bData);
-      TableComparer.AssertSame(expected, inputTable);
+      await Assert.That(() => TableComparer.AssertSame(expected, inputTable)).ThrowsNothing();
     }
   }
 }

--- a/csharp/client/Dh_NetClientTests/JoinTest.cs
+++ b/csharp/client/Dh_NetClientTests/JoinTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class JoinTest {
-  [Fact]
-  public void TestJoin() {
+  [Test]
+  public async Task TestJoin() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var testTable = ctx.TestTable;
 
@@ -23,11 +23,11 @@ public class JoinTest {
     expected.AddColumn("Close", [53.8, 88.5, 38.7, 453, 26.7, 544.9]);
     expected.AddColumn("ADV", [216000, 6060842, 138000, 138000000, 123000, 47211.50]);
 
-    TableComparer.AssertSame(expected, filtered);
+    await Assert.That(() => TableComparer.AssertSame(expected, filtered)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestAj() {
+  [Test]
+  public async Task TestAj() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -84,12 +84,12 @@ public class JoinTest {
       expected.AddColumn("BidSize", [(int?)null, 20, 20, 5, 13]);
       expected.AddColumn("Ask", [(double?)null, 3.4, 3.4, 105, 110]);
       expected.AddColumn("AskSize", [(int?)null, 33, 33, 47, 15]);
-      TableComparer.AssertSame(expected, result);
+      await Assert.That(() => TableComparer.AssertSame(expected, result)).ThrowsNothing();
     }
   }
 
-  [Fact]
-  public void TestRaj() {
+  [Test]
+  public async Task TestRaj() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -147,7 +147,7 @@ public class JoinTest {
       expected.AddColumn("Ask", [(double?)2.5, null, null, 105, 110]);
       expected.AddColumn("AskSize", [(int?)83, null, null, 47, 15]);
 
-      TableComparer.AssertSame(expected, result);
+      await Assert.That(() => TableComparer.AssertSame(expected, result)).ThrowsNothing();
     }
   }
 }

--- a/csharp/client/Dh_NetClientTests/LastByTest.cs
+++ b/csharp/client/Dh_NetClientTests/LastByTest.cs
@@ -2,15 +2,12 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class LastByTest(ITestOutputHelper output) {
-  private readonly ITestOutputHelper _output = output;
-
-  [Fact]
-  public void TestLastBy() {
+public class LastByTest {
+  [Test]
+  public async Task TestLastBy() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var testTable = ctx.TestTable;
 
@@ -29,6 +26,6 @@ public class LastByTest(ITestOutputHelper output) {
     expected.AddColumn("Open", openData);
     expected.AddColumn("Close", closeData);
 
-    TableComparer.AssertSame(expected, lb);
+    await Assert.That(() => TableComparer.AssertSame(expected, lb)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/MergeTest.cs
+++ b/csharp/client/Dh_NetClientTests/MergeTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class MergeTest {
-  [Fact]
-  public void TestMerge() {
+  [Test]
+  public async Task TestMerge() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var testTable = ctx.TestTable;
 
@@ -29,6 +29,6 @@ public class MergeTest {
     expected.AddColumn("Close", [23.5, 24.2, 26.7, 538.2, 544.9]);
     expected.AddColumn("Volume", [(Int64)100000, 250000, 19000, 46123, 48300]);
 
-    TableComparer.AssertSame(expected, merged);
+    await Assert.That(() => TableComparer.AssertSame(expected, merged)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/NullSentinelPassthroughTest.cs
+++ b/csharp/client/Dh_NetClientTests/NullSentinelPassthroughTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class NullSentinelPassthroughTest {
-  [Fact]
-  public void SentinelsVisible() {
+  [Test]
+  public async Task SentinelsVisible() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var manager = ctx.Client.Manager;
     using var t = manager.EmptyTable(1)
@@ -22,13 +22,13 @@ public class NullSentinelPassthroughTest {
       );
 
     var ct = t.ToClientTable();
-    AssertHasSentinel(ct, 0, DeephavenConstants.NullChar);
-    AssertHasSentinel(ct, 1, DeephavenConstants.NullByte);
-    AssertHasSentinel(ct, 2, DeephavenConstants.NullShort);
-    AssertHasSentinel(ct, 3, DeephavenConstants.NullInt);
-    AssertHasSentinel(ct, 4, DeephavenConstants.NullLong);
-    AssertHasSentinel(ct, 5, DeephavenConstants.NullFloat);
-    AssertHasSentinel(ct, 6, DeephavenConstants.NullDouble);
+    await Assert.That(() => AssertHasSentinel(ct, 0, DeephavenConstants.NullChar)).ThrowsNothing();
+    await Assert.That(() => AssertHasSentinel(ct, 1, DeephavenConstants.NullByte)).ThrowsNothing();
+    await Assert.That(() => AssertHasSentinel(ct, 2, DeephavenConstants.NullShort)).ThrowsNothing();
+    await Assert.That(() => AssertHasSentinel(ct, 3, DeephavenConstants.NullInt)).ThrowsNothing();
+    await Assert.That(() => AssertHasSentinel(ct, 4, DeephavenConstants.NullLong)).ThrowsNothing();
+    await Assert.That(() => AssertHasSentinel(ct, 5, DeephavenConstants.NullFloat)).ThrowsNothing();
+    await Assert.That(() => AssertHasSentinel(ct, 6, DeephavenConstants.NullDouble)).ThrowsNothing();
   }
 
   private static void AssertHasSentinel<T>(IClientTable ct, int columnIndex, T sentinel) where T : struct, IEquatable<T> {

--- a/csharp/client/Dh_NetClientTests/ReadOnlyListAdapterTest.cs
+++ b/csharp/client/Dh_NetClientTests/ReadOnlyListAdapterTest.cs
@@ -8,89 +8,81 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class ReadOnlyListAdaptersTest {
-  [Fact]
-  public void AsIList() {
+  [Test]
+  public async Task AsIList() {
     IList list = MakeReadOnlyListAdapterForValueTypes();
-    Assert.Equal(4, list.Count);
-    Assert.True(list.IsFixedSize);
-    Assert.True(list.IsReadOnly);
+    await Assert.That(list.Count).IsEqualTo(4);
+    await Assert.That(list.IsFixedSize).IsTrue();
+    await Assert.That(list.IsReadOnly).IsTrue();
     object?[] expected = [1, 2, null, 4];
-    Assert.Equivalent(expected, list);
-    Assert.Equal(1, list[0]);
-    Assert.True(list.Contains(2));
-    Assert.True(list.Contains(null));
-    Assert.False(list.Contains(3));
+    await Assert.That(list).IsEquivalentTo(expected);
+    await Assert.That(list[0]).IsEqualTo(1);
+    await Assert.That(list.Contains(2)).IsTrue();
+    await Assert.That(list.Contains(null)).IsTrue();
+    await Assert.That(list.Contains(3)).IsFalse();
     var dest = new object?[5];
     list.CopyTo(dest, 1);
-    Assert.Equivalent(new object?[]{null, 1, 2, null, 4}, dest);
+    await Assert.That(dest).IsEquivalentTo(new object?[] { null, 1, 2, null, 4 });
 
     // test enumeration
     var copy = list.Cast<object>().ToArray();
-    Assert.Equivalent(copy, list);
+    await Assert.That(list).IsEquivalentTo(copy);
 
-    Assert.Throws<NotImplementedException>(() => list.Clear());
-    Assert.Throws<NotImplementedException>(() => list.Add(5));
-    Assert.Throws<NotImplementedException>(() => list.Remove(1));
-    Assert.Throws<NotImplementedException>(() => list.Insert(0, 1));
-    Assert.Throws<NotImplementedException>(() => list.RemoveAt(0));
+    await Assert.That(() => list.Clear()).Throws<NotImplementedException>();
+    await Assert.That(() => list.Add(5)).Throws<NotImplementedException>();
+    await Assert.That(() => list.Remove(1)).Throws<NotImplementedException>();
+    await Assert.That(() => list.Insert(0, 1)).Throws<NotImplementedException>();
+    await Assert.That(() => list.RemoveAt(0)).Throws<NotImplementedException>();
   }
 
-  [Fact]
-  public void AsIListOfT() {
+  [Test]
+  public async Task AsIListOfT() {
     IList<Int32> list = MakeReadOnlyListAdapterForValueTypes();
-    Assert.Equal(4, list.Count);
-    Assert.True(list.IsReadOnly);
+    await Assert.That(list.Count).IsEqualTo(4);
+    await Assert.That(list.IsReadOnly).IsTrue();
     Int32[] expected = [1, 2, DeephavenConstants.NullInt, 4];
-    // Comparing expected and list directly doesn't work because of something
-    // in the way XUnit works. Probably because my Enumerable, Enumerable<int>
-    // and Enumerable<int?> all give different answers. To be investigated.
-    var listAsArray = list.ToArray();
-    Assert.Equal(expected.ToArray(), listAsArray);
-    Assert.Equal(1, list[0]);
-    Assert.True(list.Contains(2));
-    Assert.False(list.Contains(3));
+    await Assert.That(list).IsEquivalentTo(expected.ToArray());
+    await Assert.That(list[0]).IsEqualTo(1);
+    await Assert.That(list.Contains(2)).IsTrue();
+    await Assert.That(list.Contains(3)).IsFalse();
     var dest = new int[5];
     list.CopyTo(dest, 1);
-    Assert.Equal(new Int32[] { 0, 1, 2, DeephavenConstants.NullInt, 4 }, dest);
+    await Assert.That(dest).IsEquivalentTo(new Int32[] { 0, 1, 2, DeephavenConstants.NullInt, 4 });
 
     // test enumeration
     var copy = list.Select(x => x).ToArray();
-    Assert.Equal(copy, listAsArray);
+    await Assert.That(list).IsEquivalentTo(copy);
 
-    Assert.Throws<NotImplementedException>(() => list.Clear());
-    Assert.Throws<NotImplementedException>(() => list.Add(5));
-    Assert.Throws<NotImplementedException>(() => list.Remove(1));
-    Assert.Throws<NotImplementedException>(() => list.Insert(0, 1));
-    Assert.Throws<NotImplementedException>(() => list.RemoveAt(0));
+    await Assert.That(() => list.Clear()).Throws<NotImplementedException>();
+    await Assert.That(() => list.Add(5)).Throws<NotImplementedException>();
+    await Assert.That(() => list.Remove(1)).Throws<NotImplementedException>();
+    await Assert.That(() => list.Insert(0, 1)).Throws<NotImplementedException>();
+    await Assert.That(() => list.RemoveAt(0)).Throws<NotImplementedException>();
   }
 
-  [Fact]
-  public void AsIListOfNullableT() {
+  [Test]
+  public async Task AsIListOfNullableT() {
     IList<Int32?> list = MakeReadOnlyListAdapterForValueTypes();
-    Assert.Equal(4, list.Count);
-    Assert.True(list.IsReadOnly);
+    await Assert.That(list.Count).IsEqualTo(4);
+    await Assert.That(list.IsReadOnly).IsTrue();
     Int32?[] expected = [1, 2, null, 4];
-    // Comparing expected and list directly doesn't work because of something
-    // in the way XUnit works. Probably because my Enumerable, Enumerable<int>
-    // and Enumerable<int?> all give different answers. To be investigated.
-    var listAsArray = list.ToArray();
-    Assert.Equal(expected, listAsArray);
-    Assert.Equal(1, list[0]);
-    Assert.True(list.Contains(2));
-    Assert.False(list.Contains(3));
+    await Assert.That(list).IsEquivalentTo(expected);
+    await Assert.That(list[0]).IsEqualTo(1);
+    await Assert.That(list.Contains(2)).IsTrue();
+    await Assert.That(list.Contains(3)).IsFalse();
     var dest = new Int32?[5];
     list.CopyTo(dest, 1);
-    Assert.Equal(new Int32?[] { null, 1, 2, null, 4 }, dest);
+    await Assert.That(dest).IsEquivalentTo(new Int32?[] { null, 1, 2, null, 4 });
 
     // test enumeration
     var copy = list.Select(x => x).ToArray();
-    Assert.Equal(copy, listAsArray);
+    await Assert.That(list).IsEquivalentTo(copy);
 
-    Assert.Throws<NotImplementedException>(() => list.Clear());
-    Assert.Throws<NotImplementedException>(() => list.Add(5));
-    Assert.Throws<NotImplementedException>(() => list.Remove(1));
-    Assert.Throws<NotImplementedException>(() => list.Insert(0, 1));
-    Assert.Throws<NotImplementedException>(() => list.RemoveAt(0));
+    await Assert.That(() => list.Clear()).Throws<NotImplementedException>();
+    await Assert.That(() => list.Add(5)).Throws<NotImplementedException>();
+    await Assert.That(() => list.Remove(1)).Throws<NotImplementedException>();
+    await Assert.That(() => list.Insert(0, 1)).Throws<NotImplementedException>();
+    await Assert.That(() => list.RemoveAt(0)).Throws<NotImplementedException>();
   }
 
   private static ReadOnlyListAdapterForValueTypes<Int32> MakeReadOnlyListAdapterForValueTypes() {

--- a/csharp/client/Dh_NetClientTests/RoundTripTest.cs
+++ b/csharp/client/Dh_NetClientTests/RoundTripTest.cs
@@ -3,8 +3,8 @@
 namespace Deephaven.Dh_NetClientTests;
 
 public class RoundTripTest {
-  [Fact]
-  public void Elements() {
+  [Test]
+  public async Task Elements() {
     var tm = new TableMaker();
     tm.AddColumn("Col1", [0, 1, 2, 3, 4, 5]);
     tm.AddColumn("Col2", ["a", "b", "c", "d", "e", "f"]);
@@ -12,11 +12,11 @@ public class RoundTripTest {
     var at = tm.ToArrowTable();
     var ct = ArrowUtil.ToClientTable(at);
     var at2 = ct.ToArrowTable();
-    TableComparer.AssertSame(at, at2);
+    await Assert.That(() => TableComparer.AssertSame(at, at2)).ThrowsNothing();
   }
 
-  [Fact]
-  public void Nested() {
+  [Test]
+  public async Task Nested() {
     var tm = new TableMaker();
     var dto1 = new DateTimeOffset(1966, 3, 1, 12, 34, 56, TimeSpan.Zero);
     var dto2 = new DateTimeOffset(1999, 12, 31, 3, 44, 55, TimeSpan.Zero);
@@ -46,6 +46,6 @@ public class RoundTripTest {
 
     var ct = ArrowUtil.ToClientTable(at);
     var at2 = ct.ToArrowTable();
-    TableComparer.AssertSame(at, at2);
+    await Assert.That(() => TableComparer.AssertSame(at, at2)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/ScriptTest.cs
+++ b/csharp/client/Dh_NetClientTests/ScriptTest.cs
@@ -6,18 +6,18 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class ScriptTest {
-  [Fact]
-  public void TestScriptSessionError() {
+  [Test]
+  public async Task TestScriptSessionError() {
     using var ctx = CommonContextForTests.Create(new ClientOptions().SetSessionType(""));
     var m = ctx.Client.Manager;
     const string script = "from deephaven import empty_table";
-    var ex = Record.Exception(() => m.RunScript(script));
-    Assert.NotNull(ex);
-    Assert.Contains("Client was created without specifying a script language", ex.Message);
+    await Assert.That(() => m.RunScript(script))
+      .Throws<Exception>()
+      .WithMessageContaining("Client was created without specifying a script language");
   }
 
-  [Fact]
-  public void TestScriptExecution() {
+  [Test]
+  public async Task TestScriptExecution() {
     var intData = new List<Int32>();
     var longData = new List<Int64>();
 
@@ -42,6 +42,6 @@ public class ScriptTest {
     var expected = new TableMaker();
     expected.AddColumn("intData", intData);
     expected.AddColumn("longData", longData);
-    TableComparer.AssertSame(expected, t);
+    await Assert.That(() => TableComparer.AssertSame(expected, t)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/SelectTest.cs
+++ b/csharp/client/Dh_NetClientTests/SelectTest.cs
@@ -2,19 +2,12 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
 public class SelectTest {
-  private readonly ITestOutputHelper _output;
-
-  public SelectTest(ITestOutputHelper output) {
-    _output = output;
-  }
-
-  [Fact]
-  public void TestSupportAllTypes() {
+  [Test]
+  public async Task TestSupportAllTypes() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var boolData = new List<bool>();
@@ -62,13 +55,13 @@ public class SelectTest {
     tm.AddColumn("timeOnlyData", timeOnlyData);
 
     var th = tm.MakeTable(ctx.Client.Manager);
-    _output.WriteLine(th.ToString(true));
+    Console.WriteLine(th.ToString(true));
 
-    TableComparer.AssertSame(tm, th);
+    await Assert.That(() => TableComparer.AssertSame(tm, th)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestCreateUpdateFetchATable() {
+  [Test]
+  public async Task TestCreateUpdateFetchATable() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var tm = new TableMaker();
@@ -86,11 +79,11 @@ public class SelectTest {
     tm.AddColumn("Q2", [0, 100, 200, 300, 400, 500, 600, 700, 800, 900]);
     tm.AddColumn("Q3", [10, 110, 210, 310, 410, 510, 610, 710, 810, 910]);
     tm.AddColumn("Q4", [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]);
-    TableComparer.AssertSame(tm, t4);
+    await Assert.That(() => TableComparer.AssertSame(tm, t4)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestSelectAFewColumns() {
+  [Test]
+  public async Task TestSelectAFewColumns() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
@@ -102,29 +95,28 @@ public class SelectTest {
     tm.AddColumn("Ticker", ["AAPL", "AAPL"]);
     tm.AddColumn("Close", [23.5, 24.2]);
     tm.AddColumn("Volume", [(Int64)100000, 250000]);
-    TableComparer.AssertSame(tm, t1);
+    await Assert.That(() => TableComparer.AssertSame(tm, t1)).ThrowsNothing();
   }
 
-
-  [Fact]
-  public void TestLastByAndSelect() {
+  [Test]
+  public async Task TestLastByAndSelect() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
     var t1 = table.Where("ImportDate == `2017-11-01` && Ticker == `AAPL`")
       .LastBy("Ticker")
       .Select("Ticker", "Close", "Volume");
-    _output.WriteLine(t1.ToString(true));
+    Console.WriteLine(t1.ToString(true));
 
     var tm = new TableMaker();
     tm.AddColumn("Ticker", ["AAPL"]);
     tm.AddColumn("Close", [26.7]);
     tm.AddColumn("Volume", [(Int64)19000]);
-    TableComparer.AssertSame(tm, t1);
+    await Assert.That(() => TableComparer.AssertSame(tm, t1)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestNewColumns() {
+  [Test]
+  public async Task TestNewColumns() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
@@ -135,23 +127,21 @@ public class SelectTest {
     var tm = new TableMaker();
     tm.AddColumn("MV1", [(double)2350000, 6050000, 507300]);
     tm.AddColumn("V_plus_12", [(Int64)100012, 250012, 19012]);
-    TableComparer.AssertSame(tm, t1);
+    await Assert.That(() => TableComparer.AssertSame(tm, t1)).ThrowsNothing();
   }
 
-
-  [Fact]
-  public void TestDropColumns() {
+  [Test]
+  public async Task TestDropColumns() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
     var t1 = table.DropColumns("ImportDate", "Open", "Close");
-    Assert.Equal(5, table.Schema.FieldsList.Count);
-    Assert.Equal(2, t1.Schema.FieldsList.Count);
+    await Assert.That(table.Schema.FieldsList.Count).IsEqualTo(5);
+    await Assert.That(t1.Schema.FieldsList.Count).IsEqualTo(2);
   }
 
-
-  [Fact]
-  public void TestSimpleWhere() {
+  [Test]
+  public async Task TestSimpleWhere() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
     var updated = table.Update("QQQ = i");
@@ -162,38 +152,38 @@ public class SelectTest {
     var tm = new TableMaker();
     tm.AddColumn("Ticker", ["IBM"]);
     tm.AddColumn("Volume", [(Int64)138000]);
-    TableComparer.AssertSame(tm, t1);
+    await Assert.That(() => TableComparer.AssertSame(tm, t1)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestFormulaInTheWhereClause() {
+  [Test]
+  public async Task TestFormulaInTheWhereClause() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
     var t1 = table.Where(
         "ImportDate == `2017-11-01` && Ticker == `AAPL` && Volume % 10 == Volume % 100")
       .Select("Ticker", "Volume");
-    _output.WriteLine(t1.ToString(true));
+    Console.WriteLine(t1.ToString(true));
 
     var tm = new TableMaker();
     tm.AddColumn("Ticker", ["AAPL", "AAPL", "AAPL"]);
     tm.AddColumn("Volume", [(Int64)100000, 250000, 19000]);
-    TableComparer.AssertSame(tm, t1);
+    await Assert.That(() => TableComparer.AssertSame(tm, t1)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestSimpleWhereWithSyntaxError() {
+  [Test]
+  public async Task TestSimpleWhereWithSyntaxError() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
-    Assert.Throws<AggregateException>(() => {
+    await Assert.That(() => {
       var t1 = table.Where(")))))");
-      _output.WriteLine(t1.ToString(true));
-    });
+      Console.WriteLine(t1.ToString(true));
+    }).Throws<AggregateException>();
   }
 
-  [Fact]
-  public void TestWhereIn() {
+  [Test]
+  public async Task TestWhereIn() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var sourceMaker = new TableMaker();
@@ -215,11 +205,11 @@ public class SelectTest {
     expected.AddColumn("Number", [(Int32?)null, 2, null, 3]);
     expected.AddColumn("Color", ["red", "blue", "purple", "blue"]);
     expected.AddColumn("Code", [(Int32?)12, 13, null, null]);
-    TableComparer.AssertSame(expected, result);
+    await Assert.That(() => TableComparer.AssertSame(expected, result)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestLazyUpdate() {
+  [Test]
+  public async Task TestLazyUpdate() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var sourceMaker = new TableMaker();
@@ -235,11 +225,11 @@ public class SelectTest {
     expected.AddColumn("B", [1, 2, 3, 4]);
     expected.AddColumn("C", [5, 2, 5, 5]);
     expected.AddColumn("Y", [Math.Sqrt(5), Math.Sqrt(2), Math.Sqrt(5), Math.Sqrt(5)]);
-    TableComparer.AssertSame(expected, result);
+    await Assert.That(() => TableComparer.AssertSame(expected, result)).ThrowsNothing();
   }
 
-  [Fact]
-  public void TestSelectDistinct() {
+  [Test]
+  public async Task TestSelectDistinct() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var sourceMaker = new TableMaker();
@@ -248,10 +238,10 @@ public class SelectTest {
     var source = sourceMaker.MakeTable(ctx.Client.Manager);
 
     var result = source.SelectDistinct("A");
-    _output.WriteLine(result.ToString(true));
+    Console.WriteLine(result.ToString(true));
 
     var expected = new TableMaker();
     expected.AddColumn("A", ["apple", "orange", "plum", "grape"]);
-    TableComparer.AssertSame(expected, result);
+    await Assert.That(() => TableComparer.AssertSame(expected, result)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/SharableDictTest.cs
+++ b/csharp/client/Dh_NetClientTests/SharableDictTest.cs
@@ -52,7 +52,7 @@ public class SharableDictTest {
       new(10, 2000)
     };
 
-    await Assert.That(list).IsEquivalentTo(expected);
+    await Assert.That(list.SequenceEqual(expected)).IsTrue();
   }
 
   [Test]

--- a/csharp/client/Dh_NetClientTests/SharableDictTest.cs
+++ b/csharp/client/Dh_NetClientTests/SharableDictTest.cs
@@ -7,37 +7,37 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class SharableDictTest {
-  [Fact]
-  public void Simple() {
+  [Test]
+  public async Task Simple() {
     var d = SharableDict<string>.Empty;
     var dict = d.With(10, "hello")
       .With(11, "world")
       .With(1000, "Deephaven");
 
-    Assert.True(ContainsEntry(dict, 10, "hello"));
-    Assert.True(ContainsEntry(dict, 11, "world"));
-    Assert.True(ContainsEntry(dict, 1000, "Deephaven"));
-    Assert.False(dict.TryGetValue(1001, out _));
-    Assert.Equal(3, dict.Count);
+    await Assert.That(ContainsEntry(dict, 10, "hello")).IsTrue();
+    await Assert.That(ContainsEntry(dict, 11, "world")).IsTrue();
+    await Assert.That(ContainsEntry(dict, 1000, "Deephaven")).IsTrue();
+    await Assert.That(dict.TryGetValue(1001, out _)).IsFalse();
+    await Assert.That(dict.Count).IsEqualTo(3);
 
     var dict2 = dict.With(11, "world v2")
       .With(1000, "Deephaven v2");
 
     // dict2 has some new values
-    Assert.True(ContainsEntry(dict2, 10, "hello"));
-    Assert.True(ContainsEntry(dict2, 11, "world v2"));
-    Assert.True(ContainsEntry(dict2, 1000, "Deephaven v2"));
-    Assert.Equal(3, dict2.Count);
+    await Assert.That(ContainsEntry(dict2, 10, "hello")).IsTrue();
+    await Assert.That(ContainsEntry(dict2, 11, "world v2")).IsTrue();
+    await Assert.That(ContainsEntry(dict2, 1000, "Deephaven v2")).IsTrue();
+    await Assert.That(dict2.Count).IsEqualTo(3);
 
     // Initial dict unchanged
-    Assert.True(ContainsEntry(dict, 10, "hello"));
-    Assert.True(ContainsEntry(dict, 11, "world"));
-    Assert.True(ContainsEntry(dict, 1000, "Deephaven"));
-    Assert.Equal(3, dict.Count);
+    await Assert.That(ContainsEntry(dict, 10, "hello")).IsTrue();
+    await Assert.That(ContainsEntry(dict, 11, "world")).IsTrue();
+    await Assert.That(ContainsEntry(dict, 1000, "Deephaven")).IsTrue();
+    await Assert.That(dict.Count).IsEqualTo(3);
   }
 
-  [Fact]
-  public void Ordering() {
+  [Test]
+  public async Task Ordering() {
     var dict = SharableDict<int>.Empty;
     dict = dict.With(3, 1000)
       .With(10, 2000)
@@ -52,30 +52,30 @@ public class SharableDictTest {
       new(10, 2000)
     };
 
-    Assert.Equal(expected, list);
+    await Assert.That(list).IsEquivalentTo(expected);
   }
 
-  [Fact]
-  public void Canonicalizes() {
+  [Test]
+  public async Task Canonicalizes() {
     var d0 = SharableDict<string>.Empty;
     var d1 = d0.With(1_000, "hello");
     var d2 = d1.With(1_000_000, "there");
     var d3 = d2.With(1_000_000_000, "Deephaven");
 
-    Assert.Equal(0, d0.Count);
-    Assert.Equal(1, d1.Count);
-    Assert.Equal(2, d2.Count);
-    Assert.Equal(3, d3.Count);
+    await Assert.That(d0.Count).IsEqualTo(0);
+    await Assert.That(d1.Count).IsEqualTo(1);
+    await Assert.That(d2.Count).IsEqualTo(2);
+    await Assert.That(d3.Count).IsEqualTo(3);
 
     var newd2 = d3.Without(1_000);
     var newd1 = newd2.Without(1_000_000);
     var newd0 = newd1.Without(1_000_000_000);
 
-    Assert.True(ReferenceEquals(newd0.RootForUnitTests, d0.RootForUnitTests));
+    await Assert.That(ReferenceEquals(newd0.RootForUnitTests, d0.RootForUnitTests)).IsTrue();
   }
 
-  [Fact]
-  public void NonexistentRemoveIsNoop() {
+  [Test]
+  public async Task NonexistentRemoveIsNoop() {
     var dict = SharableDict<string>.Empty
       .With(10, "hello")
       .With(11, "world")
@@ -83,11 +83,11 @@ public class SharableDictTest {
 
     var d2 = dict.Without(999); // nonexistent key
 
-    Assert.True(ReferenceEquals(dict, d2));
+    await Assert.That(ReferenceEquals(dict, d2)).IsTrue();
   }
 
-  [Fact]
-  public void Iterates() {
+  [Test]
+  public async Task Iterates() {
     var dict = SharableDict<string>.Empty;
     for (var i = 0; i != 10000; ++i) {
       dict = dict.With(i * 37, "hello" + i);
@@ -95,26 +95,26 @@ public class SharableDictTest {
 
     var nextIndex = 0;
     foreach (var (k, v) in dict) {
-      Assert.Equal(nextIndex * 37, k);
-      Assert.Equal("hello" + nextIndex, v);
+      await Assert.That(k).IsEqualTo(nextIndex * 37);
+      await Assert.That(v).IsEqualTo("hello" + nextIndex);
       ++nextIndex;
     }
   }
 
-  [Fact]
-  public void Difference() {
+  [Test]
+  public async Task Difference() {
     var dict1 = SharableDict<int>.Empty;
     for (var i = 0; i != 10; ++i) {
       dict1 = dict1.With(i, i * 37);
     }
 
     var dict2 = dict1
-      .With(100, 999)  // add
-      .With(1000, 9999)  // add
-      .Without(3)  // remove
-      .Without(5)  // remove
-      .With(7, 12345)  // modify
-      .With(-1, 999);  // add
+      .With(100, 999) // add
+      .With(1000, 9999) // add
+      .Without(3) // remove
+      .Without(5) // remove
+      .With(7, 12345) // modify
+      .With(-1, 999); // add
 
     var (a, r, m) = dict1.CalcDifference(dict2);
 
@@ -133,50 +133,50 @@ public class SharableDictTest {
       new(7, 12345)
     };
 
-    Assert.Equal(aExpected, a);
-    Assert.Equal(rExpected, r);
-    Assert.Equal(mExpected, m);
+    await Assert.That(a).IsEquivalentTo(aExpected);
+    await Assert.That(r).IsEquivalentTo(rExpected);
+    await Assert.That(m).IsEquivalentTo(mExpected);
 
-    Assert.Equal(32, a.CountNodesForUnitTesting());
-    Assert.Equal(21, r.CountNodesForUnitTesting());
-    Assert.Equal(21, m.CountNodesForUnitTesting());
+    await Assert.That(a.CountNodesForUnitTesting()).IsEqualTo(32);
+    await Assert.That(r.CountNodesForUnitTesting()).IsEqualTo(21);
+    await Assert.That(m.CountNodesForUnitTesting()).IsEqualTo(21);
   }
 
-  [Fact]
-  public void DictIsEfficientForLargeDenseSets() {
+  [Test]
+  public async Task DictIsEfficientForLargeDenseSets() {
     // These should asymptote towards 64 elements per node.
 
     // An empty dict costs 11 nodes
-    TestDenseEfficiency(0, 11);
+    await TestDenseEfficiency(0, 11);
 
     // A dict densely packed with the first 64 integers costs 21 nodes
     // Efficency: 21 nodes per 64 elements
     // 0.328 nodes per element, 3.048 elements per node
-    TestDenseEfficiency(64, 21);
+    await TestDenseEfficiency(64, 21);
 
     // A dict densely packed with the first 4096 integers costs 84 nodes
     // Efficency: 84 nodes per 4096 elements
     // 0.021 nodes per element, 48.76 elements per node
-    TestDenseEfficiency(4096, 84);
+    await TestDenseEfficiency(4096, 84);
 
     // A dict densely packed with the first 65536 integers costs 1059 nodes
     // Efficency: 84 nodes per 4096 elements
     // 0.016 nodes per element, 61.88 elements per node
-    TestDenseEfficiency(65536, 1059);
+    await TestDenseEfficiency(65536, 1059);
   }
 
-  private static void TestDenseEfficiency(int count, int expectedNodeCount) {
+  private static async Task TestDenseEfficiency(int count, int expectedNodeCount) {
     var dict = SharableDict<int>.Empty;
     for (var i = 0; i != count; ++i) {
       dict = dict.With(i, i * 1111);
     }
     for (var i = 0; i != count; ++i) {
-      Assert.True(dict.TryGetValue(i, out var value));
-      Assert.Equal(i * 1111, value);
+      await Assert.That(dict.TryGetValue(i, out var value)).IsTrue();
+      await Assert.That(value).IsEqualTo(i * 1111);
     }
 
-    Assert.Equal(count, dict.Count);
-    Assert.Equal(expectedNodeCount, dict.CountNodesForUnitTesting());
+    await Assert.That(dict.Count).IsEqualTo(count);
+    await Assert.That(dict.CountNodesForUnitTesting()).IsEqualTo(expectedNodeCount);
   }
 
   private static bool ContainsEntry<T>(SharableDict<T> dict, Int64 key, T expected) {

--- a/csharp/client/Dh_NetClientTests/SortTest.cs
+++ b/csharp/client/Dh_NetClientTests/SortTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class SortTest {
-  [Fact]
-  public void SortDemoTable() {
+  [Test]
+  public async Task SortDemoTable() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var testTable = ctx.TestTable;
 
@@ -23,11 +23,11 @@ public class SortTest {
     expected.AddColumn("Open", [541.2, 685.3, 92.3, 50.5, 83.1]);
     expected.AddColumn("Volume", [(Int64)46123, 48300, 6060842, 87000, 345000]);
 
-    TableComparer.AssertSame(expected, table1);
+    await Assert.That(() => TableComparer.AssertSame(expected, table1)).ThrowsNothing();
   }
 
-  [Fact]
-  public void SortTempTable() {
+  [Test]
+  public async Task SortTempTable() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
 
     var maker = new TableMaker();
@@ -46,6 +46,6 @@ public class SortTest {
     expected.AddColumn("IntValue2", [2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1]);
     expected.AddColumn("IntValue3", [1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
 
-    TableComparer.AssertSame(expected, sorted);
+    await Assert.That(() => TableComparer.AssertSame(expected, sorted)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/StringFilterTest.cs
+++ b/csharp/client/Dh_NetClientTests/StringFilterTest.cs
@@ -2,11 +2,12 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
+using TUnit.Assertions.Exceptions;
 
 namespace Deephaven.Dh_NetClientTests;
 
 public class StringFilterTest {
-  [Fact]
+  [Test]
   public void StringFilter() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var testTable = ctx.TestTable;
@@ -44,7 +45,7 @@ public class StringFilterTest {
     try {
       TableComparer.AssertSame(expected, filteredTable);
     } catch (Exception e) {
-      throw new AggregateException($"While processing {description}", e);
+      throw new AssertionException($"While processing {description}: {e.Message}", e);
     }
   }
 }

--- a/csharp/client/Dh_NetClientTests/TableHandleAttributesTest.cs
+++ b/csharp/client/Dh_NetClientTests/TableHandleAttributesTest.cs
@@ -6,31 +6,31 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class TableHandleAttributesTest {
-  [Fact]
-  public void TableHandleAttributes() {
+  [Test]
+  public async Task TableHandleAttributes() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
     const Int64 numRows = 37;
     var t = thm.EmptyTable(numRows).Update("II = ii");
-    Assert.Equal(numRows, t.NumRows);
-    Assert.True(t.IsStatic);
+    await Assert.That(t.NumRows).IsEqualTo(numRows);
+    await Assert.That(t.IsStatic).IsTrue();
   }
 
-  [Fact]
-  public void TableHandleDynamicAttributes() {
+  [Test]
+  public async Task TableHandleDynamicAttributes() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
     var t = thm.TimeTable(1_000_000_000).Update("II = ii");
-    Assert.False(t.IsStatic);
+    await Assert.That(t.IsStatic).IsFalse();
   }
 
-  [Fact]
-  public void TableHandleCreatedByDoPut() {
+  [Test]
+  public async Task TableHandleCreatedByDoPut() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
-    Assert.True(table.IsStatic);
+    await Assert.That(table.IsStatic).IsTrue();
     // The columns all have the same size, so look at the source data for any one of them and get its size
     var expectedSize = ctx.ColumnData.ImportDate.Length;
-    Assert.Equal(expectedSize, table.NumRows);
+    await Assert.That(table.NumRows).IsEqualTo(expectedSize);
   }
 }

--- a/csharp/client/Dh_NetClientTests/TableTest.cs
+++ b/csharp/client/Dh_NetClientTests/TableTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class TableTest {
-  [Fact]
-  public void FetchTheWholeTable() {
+  [Test]
+  public async Task FetchTheWholeTable() {
     const int target = 10;
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
@@ -76,6 +76,6 @@ public class TableTest {
     expected.AddColumn("Strings", strings);
     expected.AddColumn("DateTimes", dateTimes);
 
-    TableComparer.AssertSame(expected, th);
+    await Assert.That(() => TableComparer.AssertSame(expected, th)).ThrowsNothing();
   }
 }

--- a/csharp/client/Dh_NetClientTests/TickingTest.cs
+++ b/csharp/client/Dh_NetClientTests/TickingTest.cs
@@ -1,25 +1,26 @@
 ﻿//
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
+
+using System.Threading.Channels;
 using Apache.Arrow;
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class TickingTest(ITestOutputHelper output) {
-  [Fact]
-  public void EventuallyReaches10Rows() {
+public class TickingTest {
+  [Test]
+  public async Task EventuallyReaches10Rows() {
     const Int64 maxRows = 10;
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
 
     using var table = thm.TimeTable(TimeSpan.FromMilliseconds(500)).Update("II = ii");
-    var callback = new ReachesNRowsCallback(output, maxRows);
+    var callback = new ReachesNRowsCallback(maxRows);
     using var cookie = table.Subscribe(callback);
 
     while (true) {
-      var (done, exception) = callback.WaitForUpdate();
+      var (done, exception) = await callback.WaitForUpdateAsync();
       if (done) {
         break;
       }
@@ -29,8 +30,8 @@ public class TickingTest(ITestOutputHelper output) {
     }
   }
 
-  [Fact]
-  public void AllEventuallyGreaterThan10() {
+  [Test]
+  public async Task AllEventuallyGreaterThan10() {
     const Int64 maxRows = 10;
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
@@ -39,11 +40,11 @@ public class TickingTest(ITestOutputHelper output) {
       .View("Key = (long)(ii % 10)", "Value = ii")
       .LastBy("Key");
 
-    var callback = new AllValuesGreaterThanNCallback(output, maxRows);
+    var callback = new AllValuesGreaterThanNCallback(maxRows);
     using var cookie = table.Subscribe(callback);
 
     while (true) {
-      var (done, exception) = callback.WaitForUpdate();
+      var (done, exception) = await callback.WaitForUpdateAsync();
       if (done) {
         break;
       }
@@ -53,8 +54,8 @@ public class TickingTest(ITestOutputHelper output) {
     }
   }
 
-  [Fact]
-  public void AllDataEventuallyPresent() {
+  [Test]
+  public async Task AllDataEventuallyPresent() {
     const Int64 maxRows = 10;
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
@@ -76,11 +77,11 @@ public class TickingTest(ITestOutputHelper output) {
       .Sort(SortPair.Ascending("II"))
       .DropColumns("Timestamp", "II");
 
-    var callback = new WaitForPopulatedTableCallback(output, maxRows);
+    var callback = new WaitForPopulatedTableCallback(maxRows);
     using var cookie = table.Subscribe(callback);
 
     while (true) {
-      var (done, exception) = callback.WaitForUpdate();
+      var (done, exception) = await callback.WaitForUpdateAsync();
       if (done) {
         break;
       }
@@ -92,58 +93,36 @@ public class TickingTest(ITestOutputHelper output) {
 }
 
 public abstract class CommonBase : IObserver<TickingUpdate> {
-  protected readonly ITestOutputHelper Output;
-
-  protected CommonBase(ITestOutputHelper output) { 
-    Output = output;
-  }
-
-  private readonly object _sync = new();
-  private bool _done = false;
-  private Exception? _exception = null;
+  private readonly Channel<(bool, Exception?)> _channel = Channel.CreateUnbounded<(bool, Exception?)>();
 
   public void OnError(Exception error) {
-    lock (_sync) {
-      _exception = error;
-      Monitor.PulseAll(_sync);
-    }
+    _channel.Writer.TryWrite((false, error));
   }
 
-  public (bool, Exception?) WaitForUpdate() {
-    lock (_sync) {
-      while (true) {
-        if (_done || _exception != null) {
-          return (_done, _exception);
-        }
-
-        Monitor.Wait(_sync);
-      }
-    }
+  public async Task<(bool, Exception?)> WaitForUpdateAsync() {
+    return await _channel.Reader.ReadAsync();
   }
 
   public void OnCompleted() {
-    Output.WriteLine("Subscription complete");
+    Console.WriteLine("Subscription complete");
   }
 
   public abstract void OnNext(TickingUpdate value);
 
   protected void NotifyDone() {
-    lock (_sync) {
-      _done = true;
-      Monitor.PulseAll(_sync);
-    }
+    _channel.Writer.TryWrite((true, null));
   }
 }
 
 public sealed class ReachesNRowsCallback: CommonBase {
   private readonly Int64 _target;
 
-  public ReachesNRowsCallback(ITestOutputHelper output, Int64 target) : base(output) {
+  public ReachesNRowsCallback(Int64 target) {
     _target = target;
   }
 
   public override void OnNext(TickingUpdate update) {
-    Output.WriteLine($"=== The Full Table ===\n{update.Current.ToString(true, true)}");
+    Console.WriteLine($"=== The Full Table ===\n{update.Current.ToString(true, true)}");
     if (update.Current.NumRows >= _target) {
       NotifyDone();
     }
@@ -153,12 +132,12 @@ public sealed class ReachesNRowsCallback: CommonBase {
 public sealed class WaitForPopulatedTableCallback : CommonBase {
   private readonly Int64 _target;
 
-  public WaitForPopulatedTableCallback(ITestOutputHelper output, Int64 target) : base(output) {
+  public WaitForPopulatedTableCallback(Int64 target) {
     _target = target;
   }
 
   public override void OnNext(TickingUpdate update) {
-    Output.WriteLine($"=== The Full Table ===\n{update.Current.ToString(true, true)}");
+    Console.WriteLine($"=== The Full Table ===\n{update.Current.ToString(true, true)}");
 
     var current = update.Current;
 
@@ -236,14 +215,14 @@ public sealed class WaitForPopulatedTableCallback : CommonBase {
 public sealed class AllValuesGreaterThanNCallback : CommonBase {
   private readonly Int64 _target;
 
-  public AllValuesGreaterThanNCallback(ITestOutputHelper output, Int64 target) : base(output) {
+  public AllValuesGreaterThanNCallback(Int64 target) {
     _target = target;
   }
 
   public override void OnNext(TickingUpdate update) {
     var current = update.Current;
 
-    Output.WriteLine($"=== The Full Table ===\n{current.ToString(true, true)}");
+    Console.WriteLine($"=== The Full Table ===\n{current.ToString(true, true)}");
 
     if (current.NumRows == 0) {
       return;

--- a/csharp/client/Dh_NetClientTests/UngroupTest.cs
+++ b/csharp/client/Dh_NetClientTests/UngroupTest.cs
@@ -2,35 +2,34 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class UngroupTest(ITestOutputHelper output) {
-  [Fact]
-  public void UngroupColumns() {
+public class UngroupTest {
+  [Test]
+  public async Task UngroupColumns() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
     table = table.Where("ImportDate == `2017-11-01`");
 
     var byTable = table.Where("Ticker == `AAPL`").View("Ticker", "Close").By("Ticker");
-    output.WriteLine(byTable.ToString(true, true));
+    Console.WriteLine(byTable.ToString(true, true));
     var ungrouped = byTable.Ungroup("Close");
-    output.WriteLine(ungrouped.ToString(true, true));
+    Console.WriteLine(ungrouped.ToString(true, true));
 
     {
       var expected = new TableMaker();
       expected.AddColumn("Ticker", ["AAPL"]);
       expected.AddColumn<double[]>("Close", [[23.5, 24.2, 26.7]]);
-      TableComparer.AssertSame(expected, byTable);
+      await Assert.That(() => TableComparer.AssertSame(expected, byTable)).ThrowsNothing();
     }
 
     {
       var expected = new TableMaker();
       expected.AddColumn("Ticker", ["AAPL", "AAPL", "AAPL"]);
       expected.AddColumn("Close", [23.5, 24.2, 26.7]);
-      TableComparer.AssertSame(expected, ungrouped);
+      await Assert.That(() => TableComparer.AssertSame(expected, ungrouped)).ThrowsNothing();
     }
   }
 }

--- a/csharp/client/Dh_NetClientTests/UpdateByTest.cs
+++ b/csharp/client/Dh_NetClientTests/UpdateByTest.cs
@@ -2,17 +2,16 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 using static Deephaven.Dh_NetClient.UpdateByOperation;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class UpdateByTest(ITestOutputHelper output) {
+public class UpdateByTest() {
   const int NumCols = 5;
   const int NumRows = 1000;
 
-  [Fact]
-  public void SimpleCumSum() {
+  [Test]
+  public async Task SimpleCumSum() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -22,11 +21,11 @@ public class UpdateByTest(ITestOutputHelper output) {
 
     var expected = new TableMaker();
     expected.AddColumn("SumX", new Int64[] { 0, 1, 2, 4, 6, 9, 12, 16, 20, 25 });
-    TableComparer.AssertSame(expected, filtered);
+    await Assert.That(() => TableComparer.AssertSame(expected, filtered)).ThrowsNothing();
   }
 
-  [Fact]
-  public void SimpleOps() {
+  [Test]
+  public async Task SimpleOps() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -37,17 +36,17 @@ public class UpdateByTest(ITestOutputHelper output) {
       var op = simpleOps[opIndex];
       for (var tableIndex = 0; tableIndex != tables.Length; ++tableIndex) {
         var table = tables[tableIndex];
-        output.WriteLine($"Processing op {opIndex} on Table {tableIndex}");
+        Console.WriteLine($"Processing op {opIndex} on Table {tableIndex}");
         using var result = table.UpdateBy([op], "e");
-        Assert.Equal(table.IsStatic, result.IsStatic);
-        Assert.Equal(2 + table.NumCols, result.NumCols);
-        Assert.True(result.NumRows >= table.NumRows);
+        await Assert.That(result.IsStatic).IsEqualTo(table.IsStatic);
+        await Assert.That(result.NumCols).IsEqualTo(2 + table.NumCols);
+        await Assert.That(result.NumRows >= table.NumRows).IsTrue();
       }
     }
   }
 
-  [Fact]
-  public void EmOps() {
+  [Test]
+  public async Task EmOps() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -58,19 +57,19 @@ public class UpdateByTest(ITestOutputHelper output) {
       var op = emOps[opIndex];
       for (var tableIndex = 0; tableIndex != tables.Length; ++tableIndex) {
         var table = tables[tableIndex];
-        output.WriteLine($"Processing op {opIndex} on Table {tableIndex}");
+        Console.WriteLine($"Processing op {opIndex} on Table {tableIndex}");
         using var result = table.UpdateBy([op], "b");
-        Assert.Equal(table.IsStatic, result.IsStatic);
-        Assert.Equal(1 + table.NumCols, result.NumCols);
+        await Assert.That(result.IsStatic).IsEqualTo(table.IsStatic);
+        await Assert.That(result.NumCols).IsEqualTo(1 + table.NumCols);
         if (result.IsStatic) {
-          Assert.Equal(result.NumRows, table.NumRows);
+          await Assert.That(table.NumRows).IsEqualTo(result.NumRows);
         }
       }
     }
   }
 
-  [Fact]
-  public void RollingOps() {
+  [Test]
+  public async Task RollingOps() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -81,17 +80,17 @@ public class UpdateByTest(ITestOutputHelper output) {
       var op = rollingOps[opIndex];
       for (var tableIndex = 0; tableIndex != tables.Length; ++tableIndex) {
         var table = tables[tableIndex];
-        output.WriteLine($"Processing op {opIndex} on Table {tableIndex}");
+        Console.WriteLine($"Processing op {opIndex} on Table {tableIndex}");
         using var result = table.UpdateBy([op], "c");
-        Assert.Equal(table.IsStatic, result.IsStatic);
-        Assert.Equal(2 + table.NumCols, result.NumCols);
-        Assert.True(result.NumRows >= table.NumRows);
+        await Assert.That(result.IsStatic).IsEqualTo(table.IsStatic);
+        await Assert.That(result.NumCols).IsEqualTo(2 + table.NumCols);
+        await Assert.That(result.NumRows >= table.NumRows).IsTrue();
       }
     }
   }
 
-  [Fact]
-  public void MultipleOps() {
+  [Test]
+  public async Task MultipleOps() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var tm = ctx.Client.Manager;
 
@@ -106,12 +105,12 @@ public class UpdateByTest(ITestOutputHelper output) {
 
     for (var tableIndex = 0; tableIndex != tables.Length; ++tableIndex) {
       var table = tables[tableIndex];
-      output.WriteLine($"Processing table {tableIndex}");
+      Console.WriteLine($"Processing table {tableIndex}");
       using var result = table.UpdateBy(multipleOps, "c");
-      Assert.Equal(table.IsStatic, result.IsStatic);
-      Assert.Equal(10 + table.NumCols, result.NumCols);
+      await Assert.That(result.IsStatic).IsEqualTo(table.IsStatic);
+      await Assert.That(result.NumCols).IsEqualTo(10 + table.NumCols);
       if (result.IsStatic) {
-        Assert.Equal(result.NumRows, table.NumRows);
+        await Assert.That(table.NumRows).IsEqualTo(result.NumRows);
       }
     }
   }

--- a/csharp/client/Dh_NetClientTests/ValidationTest.cs
+++ b/csharp/client/Dh_NetClientTests/ValidationTest.cs
@@ -2,30 +2,29 @@
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
 using Deephaven.Dh_NetClient;
-using Xunit.Abstractions;
 
 namespace Deephaven.Dh_NetClientTests;
 
-public class ValidationTest(ITestOutputHelper output) {
-  [Theory]
-  [InlineData("X = 3)")]  // Syntax error
-  [InlineData("S = `hello`", "T = java.util.regex.Pattern.quote(S)")]  // Pattern.quote not on whitelist
-  [InlineData("X = Math.min(3, 4)")]  // Math.min not on whitelist
-  public void BadSelect(params string[] selections) {
+public class ValidationTest {
+  [Test]
+  [Arguments("X = 3)")] // Syntax error
+  [Arguments("S = `hello`", "T = java.util.regex.Pattern.quote(S)")] // Pattern.quote not on whitelist
+  [Arguments("X = Math.min(3, 4)")] // Math.min not on whitelist
+  public async Task BadSelect(params string[] selections) {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
     using var staticTable = thm.EmptyTable(10);
-    Assert.Throws<AggregateException>(() => {
-      using var temp = staticTable.Select(selections);
-    });
+    await Assert.That(() => {
+      using var _ = staticTable.Select(selections);
+    }).Throws<AggregateException>();
   }
 
 
-  [Theory]
-  [InlineData("X = 3")]
-  [InlineData("S = `hello`", "T = S.length()")]  // instance methods of String ok
-  [InlineData("X = min(3, 4)")]  // builtin from GroovyStaticImports
-  [InlineData("X = isFinite(3)")]  // another builtin from GroovyStaticImports
+  [Test]
+  [Arguments("X = 3")]
+  [Arguments("S = `hello`", "T = S.length()")]  // instance methods of String ok
+  [Arguments("X = min(3, 4)")]  // builtin from GroovyStaticImports
+  [Arguments("X = isFinite(3)")]  // another builtin from GroovyStaticImports
   public void GoodSelect(params string[] selections) {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
@@ -33,28 +32,28 @@ public class ValidationTest(ITestOutputHelper output) {
       .Select(selections);
   }
 
-  [Theory]
-  [InlineData("X > 3)")]  // syntax error
-  [InlineData("S = java.util.regex.Pattern.quote(S)")]  // Pattern.quote not on whitelist
-  [InlineData("X = Math.min(3, 4)")]  // Math.min not on whitelist
-  public void BadWhere(string condition) {
+  [Test]
+  [Arguments("X > 3)")] // syntax error
+  [Arguments("S = java.util.regex.Pattern.quote(S)")] // Pattern.quote not on whitelist
+  [Arguments("X = Math.min(3, 4)")] // Math.min not on whitelist
+  public async Task BadWhere(string condition) {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;
     using var staticTable = thm.EmptyTable(10)
       .Update("X = 12", "S = `hello`");
 
-    Assert.Throws<AggregateException>(() => {
-      using var temp = staticTable.Where(condition);
-    });
+    await Assert.That(() => {
+      using var _ = staticTable.Where(condition);
+    }).Throws<AggregateException>();
   }
 
-  [Theory]
-  [InlineData("X = 3")]
-  [InlineData("S = `hello`")]
-  [InlineData("S.length() = 17")] // instance methods of String ok
-  [InlineData("X = min(3, 4)")] // "builtin" from GroovyStaticImports
-  [InlineData("X = isFinite(3)")] // another builtin from GroovyStaticImports
-  [InlineData("X in 3, 4, 5")]
+  [Test]
+  [Arguments("X = 3")]
+  [Arguments("S = `hello`")]
+  [Arguments("S.length() = 17")] // instance methods of String ok
+  [Arguments("X = min(3, 4)")] // "builtin" from GroovyStaticImports
+  [Arguments("X = isFinite(3)")] // another builtin from GroovyStaticImports
+  [Arguments("X in 3, 4, 5")]
   public void GoodWhere(string condition) {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var thm = ctx.Client.Manager;

--- a/csharp/client/Dh_NetClientTests/ViewTest.cs
+++ b/csharp/client/Dh_NetClientTests/ViewTest.cs
@@ -6,8 +6,8 @@ using Deephaven.Dh_NetClient;
 namespace Deephaven.Dh_NetClientTests;
 
 public class ViewTest {
-  [Fact]
-  public void View() {
+  [Test]
+  public async Task View() {
     using var ctx = CommonContextForTests.Create(new ClientOptions());
     var table = ctx.TestTable;
 
@@ -19,6 +19,6 @@ public class ViewTest {
     expected.AddColumn("Close", [53.8, 88.5, 38.7, 453, 26.7, 544.9, 13.4]);
     expected.AddColumn("Volume", [(Int64)87000, 6060842, 138000, 138000000, 19000, 48300, 1500]);
 
-    TableComparer.AssertSame(expected, t1);
+    await Assert.That(() => TableComparer.AssertSame(expected, t1)).ThrowsNothing();
   }
 }


### PR DESCRIPTION
This PR changes the unit test framework used from XUnit to TUnit. It will have a bunch of superficial changes to most of the unit tests.
