### PR TITLE
fix: DH-22863: Mark leaf listener adapters as SystemicObjects

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableListenerBase.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableListenerBase.java
@@ -188,9 +188,11 @@ public abstract class InstrumentedTableListenerBase extends LivenessArtifact
                 AsyncClientErrorNotifier.reportError(originalException);
             }
         } catch (IOException e) {
-            throw new UncheckedTableException(
+            final UncheckedTableException uncheckedTableException = new UncheckedTableException(
                     "Exception while delivering async client error notification for " + sourceEntry.toString(),
                     originalException);
+            uncheckedTableException.addSuppressed(e);
+            throw uncheckedTableException;
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
@@ -12,6 +12,8 @@ import io.deephaven.time.DateTimeUtils;
 import io.deephaven.engine.liveness.Liveness;
 import io.deephaven.engine.table.impl.util.AsyncErrorLogger;
 import io.deephaven.engine.table.impl.util.AsyncClientErrorNotifier;
+import io.deephaven.engine.util.systemicmarking.SystemicObject;
+import io.deephaven.engine.util.systemicmarking.SystemicObjectTracker;
 import io.deephaven.util.Utils;
 import io.deephaven.util.annotations.ReferentialIntegrity;
 import org.jetbrains.annotations.NotNull;
@@ -28,12 +30,20 @@ import java.util.stream.LongStream;
  *
  * For creating internally ticking table nodes, instead use {@link BaseTable.ListenerImpl}
  */
-public abstract class InstrumentedTableUpdateListenerAdapter extends InstrumentedTableUpdateListener {
+public abstract class InstrumentedTableUpdateListenerAdapter extends InstrumentedTableUpdateListener
+        implements SystemicObject<InstrumentedTableUpdateListenerAdapter> {
 
     private static final RetentionCache<InstrumentedTableUpdateListenerAdapter> RETENTION_CACHE =
             new RetentionCache<>();
 
     private final boolean retain;
+
+    /**
+     * Whether this listener is systemically important. As a leaf of the update propagation tree there is no downstream
+     * object to consult, so we capture the systemic state of the thread that created us (see
+     * {@link SystemicObjectTracker}).
+     */
+    private boolean systemic = SystemicObjectTracker.isSystemicThread();
 
     @ReferentialIntegrity
     protected final Table source;
@@ -87,11 +97,26 @@ public abstract class InstrumentedTableUpdateListenerAdapter extends Instrumente
     @Override
     public void onFailureInternal(Throwable originalException, Entry sourceEntry) {
         AsyncErrorLogger.log(DateTimeUtils.nowMillisResolution(), sourceEntry, sourceEntry, originalException);
-        try {
-            AsyncClientErrorNotifier.reportError(originalException);
-        } catch (IOException e) {
-            throw new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+
+        // Secondary notification to client error monitoring, only for systemic listeners
+        if (SystemicObjectTracker.isSystemic(this)) {
+            try {
+                AsyncClientErrorNotifier.reportError(originalException);
+            } catch (IOException e) {
+                throw new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+            }
         }
+    }
+
+    @Override
+    public boolean isSystemicObject() {
+        return systemic;
+    }
+
+    @Override
+    public InstrumentedTableUpdateListenerAdapter markSystemic() {
+        systemic = true;
+        return this;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
@@ -104,7 +104,8 @@ public abstract class InstrumentedTableUpdateListenerAdapter extends Instrumente
             } catch (IOException e) {
                 final UncheckedTableException uncheckedTableException =
                         new UncheckedTableException(
-                                "Exception while delivering async client error notification for " + sourceEntry.toString(),
+                                "Exception while delivering async client error notification for "
+                                        + sourceEntry.toString(),
                                 originalException);
                 uncheckedTableException.addSuppressed(e);
                 throw uncheckedTableException;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
@@ -103,7 +103,9 @@ public abstract class InstrumentedTableUpdateListenerAdapter extends Instrumente
                 AsyncClientErrorNotifier.reportError(originalException);
             } catch (IOException e) {
                 final UncheckedTableException uncheckedTableException =
-                        new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+                        new UncheckedTableException(
+                                "Exception while delivering async client error notification for " + sourceEntry.toString(),
+                                originalException);
                 uncheckedTableException.addSuppressed(e);
                 throw uncheckedTableException;
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/InstrumentedTableUpdateListenerAdapter.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import java.io.IOException;
-import java.util.stream.LongStream;
 
 /**
  * This class is used for ShiftAwareListeners that represent "leaf" nodes in the update propagation tree.
@@ -43,7 +42,7 @@ public abstract class InstrumentedTableUpdateListenerAdapter extends Instrumente
      * object to consult, so we capture the systemic state of the thread that created us (see
      * {@link SystemicObjectTracker}).
      */
-    private boolean systemic = SystemicObjectTracker.isSystemicThread();
+    private volatile boolean systemic = SystemicObjectTracker.isSystemicThread();
 
     @ReferentialIntegrity
     protected final Table source;
@@ -103,7 +102,10 @@ public abstract class InstrumentedTableUpdateListenerAdapter extends Instrumente
             try {
                 AsyncClientErrorNotifier.reportError(originalException);
             } catch (IOException e) {
-                throw new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+                final UncheckedTableException uncheckedTableException =
+                        new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+                uncheckedTableException.addSuppressed(e);
+                throw uncheckedTableException;
             }
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/MergedListener.java
@@ -201,7 +201,10 @@ public abstract class MergedListener extends LivenessArtifact implements Notific
                 AsyncClientErrorNotifier.reportError(error);
             }
         } catch (IOException ioe) {
-            throw new UncheckedTableException("Exception while reporting async error for " + entry, ioe);
+            final UncheckedTableException uncheckedTableException =
+                    new UncheckedTableException("Exception while reporting async error for " + entry, error);
+            uncheckedTableException.addSuppressed(ioe);
+            throw uncheckedTableException;
         }
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
@@ -11,6 +11,8 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.engine.liveness.Liveness;
 import io.deephaven.engine.table.impl.util.*;
+import io.deephaven.engine.util.systemicmarking.SystemicObject;
+import io.deephaven.engine.util.systemicmarking.SystemicObjectTracker;
 import io.deephaven.util.Utils;
 import io.deephaven.util.annotations.ReferentialIntegrity;
 import org.jetbrains.annotations.NotNull;
@@ -26,12 +28,20 @@ import java.io.IOException;
  *
  * For creating internally ticking table nodes, instead use {@link BaseTable.ShiftObliviousListenerImpl}
  */
-public abstract class ShiftObliviousInstrumentedListenerAdapter extends ShiftObliviousInstrumentedListener {
+public abstract class ShiftObliviousInstrumentedListenerAdapter extends ShiftObliviousInstrumentedListener
+        implements SystemicObject<ShiftObliviousInstrumentedListenerAdapter> {
 
     private static final RetentionCache<ShiftObliviousInstrumentedListenerAdapter> RETENTION_CACHE =
             new RetentionCache<>();
 
     private final boolean retain;
+
+    /**
+     * Whether this listener is systemically important. As a leaf of the update propagation tree there is no downstream
+     * object to consult, so we capture the systemic state of the thread that created us (see
+     * {@link SystemicObjectTracker}).
+     */
+    private boolean systemic = SystemicObjectTracker.isSystemicThread();
 
     @ReferentialIntegrity
     protected final Table source;
@@ -79,11 +89,26 @@ public abstract class ShiftObliviousInstrumentedListenerAdapter extends ShiftObl
     @Override
     public void onFailureInternal(Throwable originalException, Entry sourceEntry) {
         AsyncErrorLogger.log(DateTimeUtils.nowMillisResolution(), sourceEntry, sourceEntry, originalException);
-        try {
-            AsyncClientErrorNotifier.reportError(originalException);
-        } catch (IOException e) {
-            throw new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+
+        // Secondary notification to client error monitoring, only for systemic listeners
+        if (SystemicObjectTracker.isSystemic(this)) {
+            try {
+                AsyncClientErrorNotifier.reportError(originalException);
+            } catch (IOException e) {
+                throw new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+            }
         }
+    }
+
+    @Override
+    public boolean isSystemicObject() {
+        return systemic;
+    }
+
+    @Override
+    public ShiftObliviousInstrumentedListenerAdapter markSystemic() {
+        systemic = true;
+        return this;
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
@@ -41,7 +41,7 @@ public abstract class ShiftObliviousInstrumentedListenerAdapter extends ShiftObl
      * object to consult, so we capture the systemic state of the thread that created us (see
      * {@link SystemicObjectTracker}).
      */
-    private boolean systemic = SystemicObjectTracker.isSystemicThread();
+    private volatile boolean systemic = SystemicObjectTracker.isSystemicThread();
 
     @ReferentialIntegrity
     protected final Table source;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
@@ -95,7 +95,10 @@ public abstract class ShiftObliviousInstrumentedListenerAdapter extends ShiftObl
             try {
                 AsyncClientErrorNotifier.reportError(originalException);
             } catch (IOException e) {
-                throw new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+                final UncheckedTableException uncheckedTableException =
+                        new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+                uncheckedTableException.addSuppressed(e);
+                throw uncheckedTableException;
             }
         }
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
@@ -96,7 +96,9 @@ public abstract class ShiftObliviousInstrumentedListenerAdapter extends ShiftObl
                 AsyncClientErrorNotifier.reportError(originalException);
             } catch (IOException e) {
                 final UncheckedTableException uncheckedTableException =
-                        new UncheckedTableException("Exception in " + sourceEntry.toString(), originalException);
+                        new UncheckedTableException(
+                                "Exception while delivering async client error notification for " + sourceEntry.toString(),
+                                originalException);
                 uncheckedTableException.addSuppressed(e);
                 throw uncheckedTableException;
             }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ShiftObliviousInstrumentedListenerAdapter.java
@@ -97,7 +97,8 @@ public abstract class ShiftObliviousInstrumentedListenerAdapter extends ShiftObl
             } catch (IOException e) {
                 final UncheckedTableException uncheckedTableException =
                         new UncheckedTableException(
-                                "Exception while delivering async client error notification for " + sourceEntry.toString(),
+                                "Exception while delivering async client error notification for "
+                                        + sourceEntry.toString(),
                                 originalException);
                 uncheckedTableException.addSuppressed(e);
                 throw uncheckedTableException;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -1071,8 +1071,10 @@ public abstract class UpdateBy {
                 AsyncClientErrorNotifier.reportError(error);
             }
         } catch (IOException e) {
-            throw new UncheckedTableException(
+            final UncheckedTableException uncheckedTableException = new UncheckedTableException(
                     "Exception while delivering async client error notification for " + sourceEntry, error);
+            uncheckedTableException.addSuppressed(e);
+            throw uncheckedTableException;
         }
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestListenerFailure.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestListenerFailure.java
@@ -6,15 +6,19 @@ package io.deephaven.engine.table.impl;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.exceptions.TableAlreadyFailedException;
 import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.TableUpdate;
 import io.deephaven.engine.testutil.ControlledUpdateGraph;
 import io.deephaven.engine.testutil.TstUtils;
 import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
 import io.deephaven.engine.util.TableTools;
 import io.deephaven.engine.table.impl.select.FormulaEvaluationException;
+import io.deephaven.engine.table.impl.util.AsyncClientErrorNotifier;
 import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.util.systemicmarking.SystemicObjectTracker;
 import junit.framework.TestCase;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.deephaven.engine.testutil.TstUtils.assertTableEquals;
 import static io.deephaven.engine.testutil.TstUtils.i;
@@ -76,6 +80,113 @@ public class TestListenerFailure extends RefreshingTableTestCase {
             return false;
         }
         return throwables.get(0).getCause().getClass().equals(NullPointerException.class);
+    }
+
+    /**
+     * Verify that a leaf {@link InstrumentedTableUpdateListenerAdapter} captures its systemic state at construction
+     * time and that {@link io.deephaven.engine.util.systemicmarking.SystemicObject#markSystemic} mutates it.
+     */
+    public void testLeafListenerSystemicMarking() {
+        // dh-tests.prop sets SystemicObjectTracker.enabled=true; without it there is nothing to differentiate.
+        assertTrue("Systemic object marking must be enabled for this test",
+                SystemicObjectTracker.isSystemicObjectMarkingEnabled());
+        final QueryTable source = TstUtils.testRefreshingTable(col("Str", "A", "B"));
+
+        final InstrumentedTableUpdateListenerAdapter systemic = SystemicObjectTracker.executeSystemically(true,
+                () -> new InstrumentedTableUpdateListenerAdapter("Systemic", source, false) {
+                    @Override
+                    public void onUpdate(final TableUpdate upstream) {}
+                });
+        assertTrue(systemic.isSystemicObject());
+
+        final InstrumentedTableUpdateListenerAdapter nonSystemic = SystemicObjectTracker.executeSystemically(false,
+                () -> new InstrumentedTableUpdateListenerAdapter("NonSystemic", source, false) {
+                    @Override
+                    public void onUpdate(final TableUpdate upstream) {}
+                });
+        assertFalse(nonSystemic.isSystemicObject());
+
+        // markSystemic returns this and flips the flag
+        assertSame(nonSystemic, nonSystemic.markSystemic());
+        assertTrue(nonSystemic.isSystemicObject());
+    }
+
+    /**
+     * A systemic leaf listener that fails should deliver a secondary client error notification, while a non-systemic
+     * one should not. The error is always logged regardless.
+     */
+    public void testLeafListenerFailureNotifiesWhenSystemic() {
+        // dh-tests.prop sets SystemicObjectTracker.enabled=true; without it every object is systemic and a
+        // non-systemic listener could not be distinguished.
+        assertTrue("Systemic object marking must be enabled for this test",
+                SystemicObjectTracker.isSystemicObjectMarkingEnabled());
+
+        // A systemic listener always reports.
+        assertEquals(1, reportsFromFailingUpdateListener(true, false));
+        assertEquals(1, reportsFromFailingShiftObliviousListener(true, false));
+
+        // A non-systemic listener reports only its log, not the secondary client error notification.
+        assertEquals(0, reportsFromFailingUpdateListener(false, false));
+        assertEquals(0, reportsFromFailingShiftObliviousListener(false, false));
+
+        // ... unless it has been explicitly marked systemic after construction.
+        assertEquals(1, reportsFromFailingUpdateListener(false, true));
+        assertEquals(1, reportsFromFailingShiftObliviousListener(false, true));
+    }
+
+    private static int reportsFromFailingUpdateListener(final boolean constructSystemic, final boolean markAfter) {
+        final QueryTable source = TstUtils.testRefreshingTable(col("Str", "A", "B"));
+        final InstrumentedTableUpdateListenerAdapter listener = SystemicObjectTracker.executeSystemically(
+                constructSystemic,
+                () -> new InstrumentedTableUpdateListenerAdapter("Failing Update Listener", source, false) {
+                    @Override
+                    public void onUpdate(final TableUpdate upstream) {
+                        throw new RuntimeException("Test-induced update listener failure");
+                    }
+                });
+        if (markAfter) {
+            listener.markSystemic();
+        }
+        source.addUpdateListener(listener);
+        return countReportsFromFailingCycle(source);
+    }
+
+    private static int reportsFromFailingShiftObliviousListener(
+            final boolean constructSystemic, final boolean markAfter) {
+        final QueryTable source = TstUtils.testRefreshingTable(col("Str", "A", "B"));
+        final ShiftObliviousInstrumentedListenerAdapter listener = SystemicObjectTracker.executeSystemically(
+                constructSystemic,
+                () -> new ShiftObliviousInstrumentedListenerAdapter("Failing ShiftOblivious Listener", source, false) {
+                    @Override
+                    public void onUpdate(final RowSet added, final RowSet removed, final RowSet modified) {
+                        throw new RuntimeException("Test-induced shift-oblivious listener failure");
+                    }
+                });
+        if (markAfter) {
+            listener.markSystemic();
+        }
+        source.addUpdateListener(listener, false);
+        return countReportsFromFailingCycle(source);
+    }
+
+    /**
+     * Install a counting {@link UpdateErrorReporter}, run a cycle that drives {@code source} to fail its listener, and
+     * return the number of secondary client error notifications that were delivered.
+     */
+    private static int countReportsFromFailingCycle(final QueryTable source) {
+        final AtomicInteger reportCount = new AtomicInteger();
+        final UpdateErrorReporter oldReporter =
+                AsyncClientErrorNotifier.setReporter(t -> reportCount.incrementAndGet());
+        try {
+            final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+            updateGraph.runWithinUnitTestCycle(() -> {
+                TstUtils.addToTable(source, i(3), col("Str", "C"));
+                source.notifyListeners(i(3), i(), i());
+            });
+        } finally {
+            AsyncClientErrorNotifier.setReporter(oldReporter);
+        }
+        return reportCount.get();
     }
 
     public void testMemoCheck() {


### PR DESCRIPTION
InstrumentedTableUpdateListenerAdapter and
ShiftObliviousInstrumentedListenerAdapter are leaves of the update propagation tree with no downstream object to consult when deciding whether a failure should escalate to client error monitoring. Make them SystemicObjects that capture their systemic state from the creating thread at construction time, and gate the secondary AsyncClientErrorNotifier.reportError notification in onFailureInternal on that systemic state.