### PR TITLE
fix: DH-22949: race condition/work duplication in UpdateBy caching

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -727,7 +727,7 @@ public abstract class UpdateBy {
 
             // Operations with multiple column inputs like WeightedAvg/WeightedSum may have duplicate source indices
             // (when the value and weight columns are the same, e.g.). This isn't an error, but will break our caching
-            // strategy if we don't filter for duplicates,
+            // strategy if we don't filter for duplicates.
             final int[] uniqueSrcIndices = IntStream.of(srcIndices).distinct().toArray();
 
             jobScheduler.iterateParallel(executionContext,

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/updateby/UpdateBy.java
@@ -725,11 +725,16 @@ public abstract class UpdateBy {
                 return;
             }
 
+            // Operations with multiple column inputs like WeightedAvg/WeightedSum may have duplicate source indices
+            // (when the value and weight columns are the same, e.g.). This isn't an error, but will break our caching
+            // strategy if we don't filter for duplicates,
+            final int[] uniqueSrcIndices = IntStream.of(srcIndices).distinct().toArray();
+
             jobScheduler.iterateParallel(executionContext,
                     chainAppendables(this, stringAndIndexToAppendable("-cacheOperatorInputSources", winIdx)),
-                    JobScheduler.DEFAULT_CONTEXT_FACTORY, 0, srcIndices.length,
+                    JobScheduler.DEFAULT_CONTEXT_FACTORY, 0, uniqueSrcIndices.length,
                     (context, idx, nestedErrorConsumer, sourceComplete) -> createCachedColumnSource(
-                            srcIndices[idx], sourceComplete, nestedErrorConsumer),
+                            uniqueSrcIndices[idx], sourceComplete, nestedErrorConsumer),
                     onCachingComplete,
                     () -> {
                     },

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
@@ -22,7 +22,6 @@ import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.annotations.TestUseOnly;
 import io.deephaven.util.annotations.VisibleForTesting;
 import io.deephaven.util.SafeCloseable;
-import io.deephaven.util.mutable.MutableInt;
 import io.deephaven.vector.DoubleVector;
 import io.deephaven.vector.ObjectVector;
 import io.deephaven.vector.ShortVector;
@@ -724,18 +723,16 @@ public class TestRollingWAvg extends BaseUpdateByTest {
                         new DoubleGenerator(30.1, 40.1, 0.0)
                 }).t;
 
-        // Without the fix, local testing failed 20/20 runs with NPE with maximum of 5 seconds before failure.
-        // 30 seconds anticipated to be sufficient to repro even on slower hardware (without delaying overall testing)
+        // This is a probabilistic test, not guaranteed to fail on every run without the fix. Local testing failed
+        // 20/20 runs with NPE with a maximum of 5 seconds before failure. 30 seconds is anticipated to be sufficient
+        // to repro even on slower hardware (without delaying overall testing).
         final int SECONDS_TO_RUN = 30;
 
         final boolean restoreValue = QueryTable.setMemoizeResults(false);
         try (final SafeCloseable ignored = () -> QueryTable.setMemoizeResults(restoreValue)) {
             final long deadlineNanos =
                     System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(SECONDS_TO_RUN);
-            final MutableInt iteration = new MutableInt(0);
             do {
-                System.out.println("iteration " + iteration.getAndIncrement() + ", "
-                        + (deadlineNanos - System.nanoTime()) / 1_000_000_000.0 + "s remaining");
                 final Table result = table.updateBy(
                         UpdateByOperation.RollingWAvg(10, "x", "rwx = x", "rwy = y"), "Sym");
                 Assert.eq(result.size(), "result.size()", table.size());

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
@@ -726,7 +726,7 @@ public class TestRollingWAvg extends BaseUpdateByTest {
         // This is a probabilistic test, not guaranteed to fail on every run without the fix. Local testing failed
         // 20/20 runs with NPE with a maximum of 5 seconds before failure. 30 seconds is anticipated to be sufficient
         // to repro even on slower hardware (without delaying overall testing).
-        final int SECONDS_TO_RUN = 30;
+        final int SECONDS_TO_RUN = 10;
 
         final boolean restoreValue = QueryTable.setMemoizeResults(false);
         try (final SafeCloseable ignored = () -> QueryTable.setMemoizeResults(restoreValue)) {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
@@ -21,6 +21,8 @@ import io.deephaven.test.types.OutOfBandTest;
 import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.annotations.TestUseOnly;
 import io.deephaven.util.annotations.VisibleForTesting;
+import io.deephaven.util.SafeCloseable;
+import io.deephaven.util.mutable.MutableInt;
 import io.deephaven.vector.DoubleVector;
 import io.deephaven.vector.ObjectVector;
 import io.deephaven.vector.ShortVector;
@@ -707,6 +709,38 @@ public class TestRollingWAvg extends BaseUpdateByTest {
         final Table result = t.updateBy(
                 UpdateByOperation.RollingWAvg(10, "x", "rwx = x", "rwy = y"));
         Assert.eq(result.size(), "result.size()", t.size());
+    }
+
+    /**
+     * Repro for DH-22949, where getting NPE when single operator has duplicate input columns (e.g. value==weight for
+     * RollingWAvg).
+     */
+    @Test
+    public void testDH22949() {
+        final QueryTable table = createTestTable(100, true, false, false, 0xABCDEF,
+                new String[] {"x", "y"},
+                new TestDataGenerator[] {
+                        new DoubleGenerator(10.1, 20.1, 0.0),
+                        new DoubleGenerator(30.1, 40.1, 0.0)
+                }).t;
+
+        // Without the fix, local testing failed 20/20 runs with NPE with maximum of 5 seconds before failure.
+        // 30 seconds anticipated to be sufficient to repro even on slower hardware (without delaying overall testing)
+        final int SECONDS_TO_RUN = 30;
+
+        final boolean restoreValue = QueryTable.setMemoizeResults(false);
+        try (final SafeCloseable ignored = () -> QueryTable.setMemoizeResults(restoreValue)) {
+            final long deadlineNanos =
+                    System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(SECONDS_TO_RUN);
+            final MutableInt iteration = new MutableInt(0);
+            do {
+                System.out.println("iteration " + iteration.getAndIncrement() + ", "
+                        + (deadlineNanos - System.nanoTime()) / 1_000_000_000.0 + "s remaining");
+                final Table result = table.updateBy(
+                        UpdateByOperation.RollingWAvg(10, "x", "rwx = x", "rwy = y"), "Sym");
+                Assert.eq(result.size(), "result.size()", table.size());
+            } while (System.nanoTime() < deadlineNanos);
+        }
     }
 
     @Test

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/updateby/TestRollingWAvg.java
@@ -724,7 +724,7 @@ public class TestRollingWAvg extends BaseUpdateByTest {
                 }).t;
 
         // This is a probabilistic test, not guaranteed to fail on every run without the fix. Local testing failed
-        // 20/20 runs with NPE with a maximum of 5 seconds before failure. 30 seconds is anticipated to be sufficient
+        // 20/20 runs with NPE with a maximum of 5 seconds before failure. 10 seconds is anticipated to be sufficient
         // to repro even on slower hardware (without delaying overall testing).
         final int SECONDS_TO_RUN = 10;
 


### PR DESCRIPTION
Fixes DH-22949 by preventing duplicate work (and resulting race/NPE) when UpdateBy operators have duplicate input columns (e.g., value column equals weight column for rolling weighted average), and adds a regression test intended to reproduce the issue.

**Changes:**
- De-duplicate operator input source indices before caching to avoid parallel caching tasks operating on the same source index.
- Add a DH-22949 reproduction/regression test for bucketed `RollingWAvg` with duplicate inputs.