### PR TITLE
fix: DH-22921: Repro and fix for remote table column bitset mismatch

### DIFF
--- a/java-client/barrage-dagger/build.gradle
+++ b/java-client/barrage-dagger/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 }
 
 test {
+    systemProperty "PeriodicUpdateGraph.allowUnitTestMode", false
 }
 
 apply plugin: 'io.deephaven.java-open-nio'

--- a/java-client/barrage-dagger/src/test/java/io/deephaven/client/impl/BarrageSnapshotTest.java
+++ b/java-client/barrage-dagger/src/test/java/io/deephaven/client/impl/BarrageSnapshotTest.java
@@ -8,6 +8,8 @@ package io.deephaven.client.impl;//
 
 import io.deephaven.engine.table.Table;
 
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.table.impl.InMemoryTable;
 import io.deephaven.engine.testutil.TstUtils;
 import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
@@ -23,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.BitSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -128,6 +131,49 @@ public class BarrageSnapshotTest extends DeephavenApiServerTestBase {
             final Table result = snapshot.entireTable().get();
             assertThat(result.size()).isEqualTo(3);
             TstUtils.assertTableEquals(inMemoryTable, result);
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void subscriptionSnapshotPartialTableWithExplicitAllColumnsCompletes() throws Exception {
+        final Table sourceTable = InMemoryTable.from(TestDataUtil.getTestDataNewTable());
+
+        final ExportObject<Table> export = serverSessionState.newServerSideExport(sourceTable);
+        final io.deephaven.qst.table.TableSpec tableSpec = io.deephaven.qst.table.TableSpec
+                .ticket(export.getExportId().getTicket().toByteArray());
+
+        try (final TableHandle handle = barrageSession.session().serial().execute(tableSpec)) {
+            assertThat(handle.isSuccessful()).isTrue();
+
+            final BarrageSubscription subscription = barrageSession.subscribe(handle);
+            final BitSet allColumns = new BitSet(sourceTable.numColumns());
+            allColumns.set(0, sourceTable.numColumns());
+
+            final Table result = subscription.snapshotPartialTable(null, allColumns).get(5, TimeUnit.SECONDS);
+            TstUtils.assertTableEquals(sourceTable, result);
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void subscriptionPartialTableWithExplicitAllColumnsCompletes() throws Exception {
+        final Table sourceTable = InMemoryTable.from(TestDataUtil.getTestDataNewTable());
+
+        final ExportObject<Table> export = serverSessionState.newServerSideExport(sourceTable);
+        final io.deephaven.qst.table.TableSpec tableSpec = io.deephaven.qst.table.TableSpec
+                .ticket(export.getExportId().getTicket().toByteArray());
+
+        try (final TableHandle handle = barrageSession.session().serial().execute(tableSpec)) {
+            assertThat(handle.isSuccessful()).isTrue();
+
+            final BarrageSubscription subscription = barrageSession.subscribe(handle);
+            final BitSet allColumns = new BitSet(sourceTable.numColumns());
+            allColumns.set(0, sourceTable.numColumns());
+            final Table expected = sourceTable.head(2);
+
+            try (final RowSet viewport = RowSetFactory.flat(2)) {
+                final Table result = subscription.snapshotPartialTable(viewport, allColumns).get(5, TimeUnit.SECONDS);
+                TstUtils.assertTableEquals(expected, result);
+            }
         }
     }
 

--- a/java-client/barrage-dagger/src/test/java/io/deephaven/client/impl/BarrageSnapshotTest.java
+++ b/java-client/barrage-dagger/src/test/java/io/deephaven/client/impl/BarrageSnapshotTest.java
@@ -1,10 +1,7 @@
 //
 // Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
 //
-package io.deephaven.client.impl;//
-
-// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
-//
+package io.deephaven.client.impl;
 
 import io.deephaven.engine.table.Table;
 
@@ -19,6 +16,7 @@ import io.deephaven.server.session.SessionState;
 import io.deephaven.server.session.SessionState.ExportObject;
 import io.deephaven.server.util.TestDataUtil;
 import io.grpc.ManagedChannel;
+import io.deephaven.util.SafeCloseable;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.After;
@@ -135,7 +133,58 @@ public class BarrageSnapshotTest extends DeephavenApiServerTestBase {
     }
 
     @Test(timeout = 10000)
-    public void subscriptionSnapshotPartialTableWithExplicitAllColumnsCompletes() throws Exception {
+    public void subscribeFullViewportWithExplicitAllColumnsCompletes() throws Exception {
+        final Table sourceTable = InMemoryTable.from(TestDataUtil.getTestDataNewTable());
+
+        final ExportObject<Table> export = serverSessionState.newServerSideExport(sourceTable);
+        final io.deephaven.qst.table.TableSpec tableSpec = io.deephaven.qst.table.TableSpec
+                .ticket(export.getExportId().getTicket().toByteArray());
+
+        try (final TableHandle handle = barrageSession.session().serial().execute(tableSpec)) {
+            assertThat(handle.isSuccessful()).isTrue();
+
+            // @Test(timeout) runs the body on a new thread; open the execution context so BarrageTable
+            // picks up a refreshing-capable UpdateGraph instead of PoisonedUpdateGraph.
+            try (final SafeCloseable ignored = getExecutionContext().open()) {
+                final BarrageSubscription subscription = barrageSession.subscribe(handle);
+                final BitSet allColumns = new BitSet(sourceTable.numColumns());
+                allColumns.set(0, sourceTable.numColumns());
+
+                final Table result = subscription.partialTable(null, allColumns).get(5, TimeUnit.SECONDS);
+                TstUtils.assertTableEquals(sourceTable, result);
+            }
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void subscribePartialViewportWithExplicitAllColumnsCompletes() throws Exception {
+        final Table sourceTable = InMemoryTable.from(TestDataUtil.getTestDataNewTable());
+
+        final ExportObject<Table> export = serverSessionState.newServerSideExport(sourceTable);
+        final io.deephaven.qst.table.TableSpec tableSpec = io.deephaven.qst.table.TableSpec
+                .ticket(export.getExportId().getTicket().toByteArray());
+
+        try (final TableHandle handle = barrageSession.session().serial().execute(tableSpec)) {
+            assertThat(handle.isSuccessful()).isTrue();
+
+            // @Test(timeout) runs the body on a new thread; open the execution context so BarrageTable
+            // picks up a refreshing-capable UpdateGraph instead of PoisonedUpdateGraph.
+            try (final SafeCloseable ignored = getExecutionContext().open()) {
+                final BarrageSubscription subscription = barrageSession.subscribe(handle);
+                final BitSet allColumns = new BitSet(sourceTable.numColumns());
+                allColumns.set(0, sourceTable.numColumns());
+                final Table expected = sourceTable.head(2);
+
+                try (final RowSet viewport = RowSetFactory.flat(2)) {
+                    final Table result = subscription.partialTable(viewport, allColumns).get(5, TimeUnit.SECONDS);
+                    TstUtils.assertTableEquals(expected, result);
+                }
+            }
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void snapshotPartialTableFullViewportWithExplicitAllColumnsCompletes() throws Exception {
         final Table sourceTable = InMemoryTable.from(TestDataUtil.getTestDataNewTable());
 
         final ExportObject<Table> export = serverSessionState.newServerSideExport(sourceTable);
@@ -155,7 +204,7 @@ public class BarrageSnapshotTest extends DeephavenApiServerTestBase {
     }
 
     @Test(timeout = 10000)
-    public void subscriptionPartialTableWithExplicitAllColumnsCompletes() throws Exception {
+    public void snapshotPartialTablePartialViewportWithExplicitAllColumnsCompletes() throws Exception {
         final Table sourceTable = InMemoryTable.from(TestDataUtil.getTestDataNewTable());
 
         final ExportObject<Table> export = serverSessionState.newServerSideExport(sourceTable);

--- a/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
+++ b/java-client/barrage/src/main/java/io/deephaven/client/impl/BarrageSubscriptionImpl.java
@@ -409,12 +409,14 @@ public class BarrageSubscriptionImpl extends ReferenceCountedLivenessNode implem
 
             final BarrageTable localResultTable = resultTable;
             // @formatter:off
+            final int numColumns = localResultTable.numColumns();
+            final boolean allColumnsExpected = expectedColumns == null || expectedColumns.cardinality() == numColumns;
             final boolean correctColumns =
-                    // all columns are expected
-                    (expectedColumns == null
-                        && (serverColumns == null || serverColumns.cardinality() == localResultTable.numColumns()))
-                    // only specific set of columns are expected
-                    || (expectedColumns != null && expectedColumns.equals(serverColumns));
+                    // all columns are expected (null or explicit full set)
+                    (allColumnsExpected
+                            && (serverColumns == null || serverColumns.cardinality() == numColumns))
+                            // only a specific subset of columns is expected
+                            || (!allColumnsExpected && expectedColumns.equals(serverColumns));
 
             final boolean isComplete =
                     // Full subscription is completed


### PR DESCRIPTION
Fixes a Barrage client subscription completion edge case where an explicit “all columns” `BitSet` from the client can fail to match the server’s column descriptor (e.g., server sends `null` to indicate all columns), preventing partial snapshots/subscriptions from completing.

**Changes:**
- Updates `BarrageSubscriptionImpl.CheckForCompletion#viewportChanged` to treat an explicit full-column `BitSet` as equivalent to “all columns expected”.
- Adds end-to-end snapshot tests to reproduce and validate completion when explicit all-columns are requested (with and without a viewport).