### PR TITLE
feat: DH-22670: Add codec-mapping ability for Parquet reading

### DIFF
--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -186,9 +186,9 @@ public class ParquetSchemaReader {
             colDef.name = colName;
             colDef.dhSpecialType = columnTypeInfo.flatMap(ColumnTypeInfo::specialType).orElse(null);
             final Optional<CodecInfo> codecInfo = columnTypeInfo.flatMap(ColumnTypeInfo::codec);
-            String codecName = codecInfo.map(CodecInfo::codecName).orElse(null);
+            String codecName = maybeMapClassName(codecInfo.map(CodecInfo::codecName).orElse(null));
             String codecArgs = codecInfo.flatMap(CodecInfo::codecArg).orElse(null);
-            colDef.codecType = codecInfo.map(CodecInfo::dataType).orElse(null);
+            colDef.codecType = maybeMapClassName(codecInfo.map(CodecInfo::dataType).orElse(null));
             if (codecName != null && !codecName.isEmpty()) {
                 builderSupplier.get().addColumnCodec(colName, codecName, codecArgs);
             }
@@ -268,6 +268,31 @@ public class ParquetSchemaReader {
         return (instructionsBuilder.getValue() == null)
                 ? readInstructions
                 : instructionsBuilder.getValue().build();
+    }
+
+    private final static Map<String, String> CLASS_NAME_MAP = new HashMap<>();
+
+    /**
+     * Add a class name mapping to use when reading from parquet metadata
+     *
+     * @param from the name of the class as identified in the metadata
+     * @param to the name of the class that should be used as a 1:1 basis from the written metadata class
+     * @return the previous value associates with the {@code from}, if any, or null
+     */
+    public static String addClassNameMap(@NotNull final String from, @NotNull final String to) {
+        synchronized (CLASS_NAME_MAP) {
+            return CLASS_NAME_MAP.put(from, to);
+        }
+    }
+
+    private static String maybeMapClassName(final String input) {
+        if (input == null) {
+            return null;
+        }
+
+        synchronized (CLASS_NAME_MAP) {
+            return CLASS_NAME_MAP.getOrDefault(input, input);
+        }
     }
 
     /**

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/ParquetSchemaReader.java
@@ -194,7 +194,7 @@ public class ParquetSchemaReader {
             }
             colDef.isArray = column.getMaxRepetitionLevel() > 0;
             if (colDef.codecType != null && !colDef.codecType.isEmpty()) {
-                colDef.codecComponentType = codecInfo.flatMap(CodecInfo::componentType).orElse(null);
+                colDef.codecComponentType = maybeMapClassName(codecInfo.flatMap(CodecInfo::componentType).orElse(null));
                 consumer.accept(colDef);
                 continue;
             }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -46,11 +46,15 @@ import org.apache.parquet.schema.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.*;
 
+import io.deephaven.util.codec.ObjectCodec;
+import io.deephaven.util.codec.ObjectDecoder;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Proxy;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.DigestOutputStream;
@@ -1376,6 +1380,172 @@ public class TestParquetTools {
             final Table actual = ParquetTools.readTable(f.getPath(), instructions);
             assertEquals(td, actual.getDefinition());
             assertTableEquals(expected, actual);
+        }
+    }
+
+    /**
+     * Verify functionality of {@link ParquetSchemaReader#addClassNameMap(String, String)}. In this test, we are
+     * serializing a column as an array of integers, and "mapping" the codec and column-type so that they are read back
+     * as negated longs
+     */
+    @Test
+    public void testClassNameMap() {
+        final String writeCodecName = WriteCodec.class.getName();
+        final String writeTypeName = WriteType.class.getName();
+
+        final Path parquetFile = Path.of(testRoot, "testClassNameMap.parquet");
+
+        final WriteType row0 = new WriteType(1, 2, 3);
+        final WriteType row1 = new WriteType(4, 5);
+
+        final TableDefinition writeDef = TableDefinition.of(
+                ColumnDefinition.fromGenericType("Values", WriteType.class));
+        final Table writeTable = TableTools.newTable(writeDef,
+                new ColumnHolder<>("Values", WriteType.class, null, false, row0, row1));
+
+        // @formatter:off
+        // parquet metadata should contain the following:
+        // "columnTypes": [{
+        //   "columnName": "Values",
+        //   "codec": {
+        //     "codecName" :"io.deephaven.parquet.table.TestParquetTools$WriteCodec",
+        //     "dataType" :"io.deephaven.parquet.table.TestParquetTools$WriteType"
+        //   }
+        // }]
+        // @formatter:on
+        final ParquetInstructions writeInstructions = ParquetInstructions.builder()
+                .addColumnCodec("Values", writeCodecName)
+                .build();
+
+        ParquetTools.writeTable(writeTable, parquetFile.toString(), writeInstructions);
+
+        final String readCodecName = ReadCodec.class.getName();
+        final String readTypeName = "long[]";
+
+        // add class mappings so that we use a different codec for reading, and expect a different column-type back
+        ParquetSchemaReader.addClassNameMap(writeCodecName, readCodecName);
+        ParquetSchemaReader.addClassNameMap(writeTypeName, readTypeName);
+
+        final Table readTable = ParquetTools.readTable(parquetFile.toString());
+
+        assertEquals(long[].class, readTable.getDefinition().getColumn("Values").getDataType());
+
+        final ObjectVector<long[]> values = ColumnVectors.ofObject(readTable, "Values", long[].class);
+        assertThat(values.get(0)).containsExactly(-1L, -2L, -3L);
+        assertThat(values.get(1)).containsExactly(-4L, -5L);
+    }
+
+    /**
+     * An example non-standard column-type which simply wraps an array of int
+     */
+    public static class WriteType {
+        public final int[] values;
+
+        public WriteType(int... values) {
+            this.values = values;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("WT: %s", Arrays.toString(values));
+        }
+    }
+
+    /**
+     * An example codec used to persist an array of int to a parquet file
+     */
+    public static class WriteCodec implements ObjectCodec<WriteType> {
+
+        @SuppressWarnings("unused")
+        public WriteCodec(final String args) {}
+
+        @Override
+        public byte[] encode(final WriteType input) {
+            if (input == null || input.values.length == 0) {
+                return new byte[0];
+            }
+            final ByteBuffer buf = ByteBuffer.allocate(input.values.length * Integer.BYTES);
+            for (final int v : input.values) {
+                buf.putInt(v);
+            }
+            return buf.array();
+        }
+
+        @Override
+        public boolean isNullable() {
+            return true;
+        }
+
+        @Override
+        public int getPrecision() {
+            return 0;
+        }
+
+        @Override
+        public int getScale() {
+            return 0;
+        }
+
+        @Override
+        public WriteType decode(final byte[] input, final int offset, final int length) {
+            if (length == 0) {
+                return null;
+            }
+            final ByteBuffer buf = ByteBuffer.wrap(input, offset, length);
+            final int[] values = new int[length / Integer.BYTES];
+            for (int i = 0; i < values.length; i++) {
+                values[i] = buf.getInt();
+            }
+            return new WriteType(values);
+        }
+
+        @Override
+        public int expectedObjectWidth() {
+            return ObjectDecoder.VARIABLE_WIDTH_SENTINEL;
+        }
+    }
+
+    public static class ReadCodec implements ObjectCodec<long[]> {
+
+        @SuppressWarnings("unused")
+        public ReadCodec(final String args) {}
+
+        @Override
+        public byte[] encode(final long[] input) {
+            throw new IllegalStateException("Not intended for writing");
+        }
+
+        @Override
+        public boolean isNullable() {
+            return true;
+        }
+
+        @Override
+        public int getPrecision() {
+            return 0;
+        }
+
+        @Override
+        public int getScale() {
+            return 0;
+        }
+
+        @Override
+        public long[] decode(final byte[] input, final int offset, final int length) {
+            if (length == 0) {
+                return null;
+            }
+            final ByteBuffer buf = ByteBuffer.wrap(input, offset, length);
+            final long[] values = new long[length / Integer.BYTES];
+            for (int i = 0; i < values.length; i++) {
+                values[i] = -(long) buf.getInt();
+            }
+            return values;
+        }
+
+        @Override
+        public int expectedObjectWidth() {
+            return ObjectDecoder.VARIABLE_WIDTH_SENTINEL;
         }
     }
 

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -1387,6 +1387,11 @@ public class TestParquetTools {
      * Verify functionality of {@link ParquetSchemaReader#addClassNameMap(String, String)}. In this test, we are
      * serializing a column as an array of integers, and "mapping" the codec and column-type so that they are read back
      * as negated longs
+     * <p>
+     * Note that this test leaves the static CLASS_NAME_MAP (in {@link ParquetSchemaReader}) in an altered state. This
+     * should not impact any other unit tests executed in the same JVM because only this particular test is using the
+     * "mapped from" classes ({@link WriteType} and {@link WriteCodec}). If the existence of those DOES alter the
+     * outcome of any other tests, it indicates a problem
      */
     @Test
     public void testClassNameMap() {

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -1428,6 +1428,7 @@ public class TestParquetTools {
         final String readTypeName = "long[]";
 
         // add class mappings so that we use a different codec for reading, and expect a different column-type back.
+        // NOTE that these mappings will not be removed, and may be used by other unit-tests that run in this JVM.
         // NOTE that these mappings will not be removed, and may be used by other unit-tests that run in this JVM
         ParquetSchemaReader.addClassNameMap(writeCodecName, readCodecName);
         ParquetSchemaReader.addClassNameMap(writeTypeName, readTypeName);

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -37,6 +37,8 @@ import io.deephaven.time.DateTimeUtils;
 import io.deephaven.util.QueryConstants;
 import io.deephaven.util.channel.SeekableChannelsProvider;
 import io.deephaven.util.channel.SeekableChannelsProviderLoader;
+import io.deephaven.util.codec.ObjectCodec;
+import io.deephaven.util.codec.ObjectDecoder;
 import io.deephaven.vector.*;
 import junit.framework.TestCase;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -45,9 +47,6 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.*;
-
-import io.deephaven.util.codec.ObjectCodec;
-import io.deephaven.util.codec.ObjectDecoder;
 
 import java.io.File;
 import java.io.IOException;

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -1427,7 +1427,8 @@ public class TestParquetTools {
         final String readCodecName = ReadCodec.class.getName();
         final String readTypeName = "long[]";
 
-        // add class mappings so that we use a different codec for reading, and expect a different column-type back
+        // add class mappings so that we use a different codec for reading, and expect a different column-type back.
+        // NOTE that these mappings will not be removed, and may be used by other unit-tests that run in this JVM
         ParquetSchemaReader.addClassNameMap(writeCodecName, readCodecName);
         ParquetSchemaReader.addClassNameMap(writeTypeName, readTypeName);
 

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -1429,7 +1429,6 @@ public class TestParquetTools {
 
         // add class mappings so that we use a different codec for reading, and expect a different column-type back.
         // NOTE that these mappings will not be removed, and may be used by other unit-tests that run in this JVM.
-        // NOTE that these mappings will not be removed, and may be used by other unit-tests that run in this JVM
         ParquetSchemaReader.addClassNameMap(writeCodecName, readCodecName);
         ParquetSchemaReader.addClassNameMap(writeTypeName, readTypeName);
 


### PR DESCRIPTION
adds the ability for Parquet reading to map specific codec and column-types