### PR TITLE
ci: Fix docs nightlies potentially running some examples against latest

### DIFF
--- a/docs/snapshotter/docker/python/docker-compose.numba.yml
+++ b/docs/snapshotter/docker/python/docker-compose.numba.yml
@@ -2,6 +2,7 @@ services:
   # Build the server image with NumPy pinned below 2.5 so the Numba examples
   # can import and run (Numba does not support NumPy 2.5).
   server:
+    image: deephaven-server-numba
     build:
       context: .
       dockerfile: ./numba.Dockerfile

--- a/docs/snapshotter/docker/python/docker-compose.pyclient.yml
+++ b/docs/snapshotter/docker/python/docker-compose.pyclient.yml
@@ -7,10 +7,13 @@ services:
       dockerfile: ./pyclient.Dockerfile
       no_cache: true
       target: pypi-version
+      args:
+        - DEEPHAVEN_SERVER_IMAGE=${DEEPHAVEN_SERVER_IMAGE}
   # This is the server the snapshot tool uses
   # It is really used to run the pydeephaven client from the server Python environment
   server:
-    build: 
+    image: deephaven-server-pyclient
+    build:
       context: .
       dockerfile: ./pyclient.Dockerfile # Installs pydeephaven to the server
       target: server

--- a/docs/snapshotter/docker/python/numba.Dockerfile
+++ b/docs/snapshotter/docker/python/numba.Dockerfile
@@ -1,4 +1,5 @@
-ARG DEEPHAVEN_SERVER_IMAGE=ghcr.io/deephaven/server:latest
+# check InvalidDefaultArgInFrom=skip
+ARG DEEPHAVEN_SERVER_IMAGE
 FROM ${DEEPHAVEN_SERVER_IMAGE}
 
 # Numba does not yet support NumPy 2.5, but the base server image ships NumPy 2.5.

--- a/docs/snapshotter/docker/python/pyclient.Dockerfile
+++ b/docs/snapshotter/docker/python/pyclient.Dockerfile
@@ -1,7 +1,8 @@
+# check=skip=InvalidDefaultArgInFrom
 # Should be run with --no-cache to ensure the latest pydeephaven is installed
 # This arg must go first otherwise Docker thinks it is part of pypi-version
 # if it is above the server FROM line
-ARG DEEPHAVEN_SERVER_IMAGE=ghcr.io/deephaven/server:latest
+ARG DEEPHAVEN_SERVER_IMAGE
 FROM alpine/curl AS pypi-version
 WORKDIR /src
 RUN curl https://pypi.org/pypi/pydeephaven/json > ./plugin-version.json


### PR DESCRIPTION
Basically when the pyclient-version build step ran, it didn't pass the server tag, so it set it to latest and I think this could accidentally write a new image to `ghcr.io/deephaven/server:edge` in the local Docker repo when the server ran. That server may have actually been latest tag and thus cause other snapshots to run against latest, not edge. The snapshot tool only pulls images once, so I think if it ran the non-pyclient tests after pyclient, it would be using the pyclient-server and could use the wrong image for `edge`.

Remove the default so it will fail entirely on pyclient instead of pulling a default image. Also updates `IMAGE` so the inherited `server` config doesn't write to `ghcr.io/deephaven/server:edge` locally after the build.