### PR TITLE
chore: no-ticket: fix nightly check job name

### DIFF
--- a/.github/workflows/nightly-check-ci.yml
+++ b/.github/workflows/nightly-check-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   nightly:
-    name: nightly (${{ matrix.gradle-task }}, Java ${{ matrix.test-jvm-version }}
+    name: nightly (${{ matrix.gradle-task }}, Java ${{ matrix.test-jvm-version }})
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This job name was mis-edited in https://github.com/deephaven/deephaven-core/pull/8182; this fixes the naming by re-adding the trailing `)`.