### PR TITLE
fix: DH-23028: Don't freeze protobuf message

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/JsBusinessCalendar.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/calendar/JsBusinessCalendar.java
@@ -6,10 +6,8 @@ package io.deephaven.web.client.api.widget.calendar;
 import com.vertispan.tsdefs.annotations.TsInterface;
 import com.vertispan.tsdefs.annotations.TsName;
 import elemental2.core.JsArray;
-import elemental2.core.JsObject;
 import io.deephaven.proto.backplane.script.grpc.FigureDescriptor;
 import io.deephaven.web.client.api.i18n.JsTimeZone;
-import io.deephaven.web.client.api.widget.calendar.enums.JsDayOfWeek;
 import io.deephaven.web.client.fu.JsCollectors;
 import jsinterop.annotations.JsProperty;
 import jsinterop.base.Js;
@@ -27,7 +25,6 @@ public class JsBusinessCalendar {
 
     public JsBusinessCalendar(FigureDescriptor.BusinessCalendarDescriptor businessCalendarDescriptor) {
         this.businessCalendarDescriptor = businessCalendarDescriptor;
-        JsObject.freeze(this.businessCalendarDescriptor);
         timeZone = JsTimeZone.getTimeZone(businessCalendarDescriptor.getTimeZone());
         businessPeriods = businessCalendarDescriptor.getBusinessPeriodsList().stream()
                 .map(JsBusinessPeriod::new)

--- a/web/client-api/src/test/java/io/deephaven/web/ClientIntegrationTestSuite.java
+++ b/web/client-api/src/test/java/io/deephaven/web/ClientIntegrationTestSuite.java
@@ -10,6 +10,7 @@ import io.deephaven.web.client.api.storage.JsStorageServiceTestGwt;
 import io.deephaven.web.client.api.subscription.ConcurrentTableTestGwt;
 import io.deephaven.web.client.api.subscription.ViewportTestGwt;
 import io.deephaven.web.client.api.widget.plot.ChartDataTestGwt;
+import io.deephaven.web.client.api.widget.plot.JsFigureTestGwt;
 import io.deephaven.web.client.fu.LazyPromiseTestGwt;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -34,6 +35,7 @@ public class ClientIntegrationTestSuite extends GWTTestSuite {
         suite.addTestSuite(ColumnStatisticsTestGwt.class);
         suite.addTestSuite(GrpcTransportTestGwt.class);
         suite.addTestSuite(ChartDataTestGwt.class);
+        suite.addTestSuite(JsFigureTestGwt.class);
         suite.addTestSuite(SharedObjectTestGwt.class);
         suite.addTestSuite(RunEndEncodedTestGwt.class);
 

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/AbstractAsyncGwtTestCase.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/AbstractAsyncGwtTestCase.java
@@ -15,6 +15,7 @@ import io.deephaven.web.client.api.event.Event;
 import io.deephaven.web.client.api.event.HasEventHandling;
 import io.deephaven.web.client.api.subscription.ViewportData;
 import io.deephaven.web.client.api.tree.JsTreeTable;
+import io.deephaven.web.client.api.widget.plot.JsFigure;
 import io.deephaven.web.client.fu.CancellablePromise;
 import io.deephaven.web.client.ide.IdeSession;
 import io.deephaven.web.shared.fu.JsRunnable;
@@ -189,6 +190,11 @@ public abstract class AbstractAsyncGwtTestCase extends GWTTestCase {
 
     public IThenable.ThenOnFulfilledCallbackFn<IdeSession, JsPartitionedTable> partitionedTable(String tableName) {
         return session -> session.getPartitionedTable(tableName);
+    }
+
+
+    public IThenable.ThenOnFulfilledCallbackFn<IdeSession, JsFigure> figure(String figureName) {
+        return session -> session.getFigure(figureName);
     }
 
     /**

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/JsFigureTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/widget/plot/JsFigureTestGwt.java
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.web.client.api.widget.plot;
+
+import io.deephaven.web.client.api.AbstractAsyncGwtTestCase;
+
+public class JsFigureTestGwt extends AbstractAsyncGwtTestCase {
+    private static final TableSourceBuilder tables = new TableSourceBuilder()
+            .script("""
+                    from deephaven import empty_table
+                    from deephaven.calendar import calendar
+                    from deephaven.plot.figure import Figure
+
+                    nyse_cal = calendar("USNYSE_EXAMPLE")""")
+            .script("source = empty_table(100).update([\"Timestamp = '2024-01-01T00:00:00 ET' + i * HOUR\", \"Value = i\"])")
+            .script("""
+                    bizday_plot = (
+                        Figure()
+                        .axis(dim=0, business_time=True, calendar=nyse_cal)
+                        .plot_xy(series_name="Business day data", t=source, x="Timestamp", y="Value")
+                        .show()
+                    )""");
+
+    public void testBusinessTime() {
+        connect(tables).then(figure("bizday_plot"))
+                .then(figure -> {
+                    for (int i = 0; i < figure.getCharts().length; i++) {
+                        JsChart chart = figure.getCharts()[i];
+                        for (int j = 0; j < chart.getAxes().length; j++) {
+                            JsAxis axis = chart.getAxes()[j];
+                            axis.range(200.0, null, null);
+                        }
+                    }
+                    figure.subscribe();
+                    return waitForEvent(figure, JsFigure.EVENT_UPDATED, 4321).onInvoke(figure);
+                })
+                .then(this::finish, this::report);
+    }
+
+    @Override
+    public String getModuleName() {
+        return "io.deephaven.web.DeephavenIntegrationTest";
+    }
+}


### PR DESCRIPTION
The added test doesn't actually fail at this time, as the tests aren't run in "strict" mode, but the UI and doc tool are, which triggers the bug when a frozen object has new properties assigned to it.

Backport #8194