### PR TITLE
fix: DH-23039: Detect cyclical protobuf message descriptors

### DIFF
--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParser.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParser.java
@@ -18,7 +18,7 @@ public final class ProtobufDescriptorParser {
      *
      * <p>
      * Parsing proceeds through each {@link Descriptor#getFields() descriptor field} that matches
-     * {@link FieldOptions#include()}}. By default, this is {@code true} for all fields.
+     * {@link FieldOptions#include()}. By default, this is {@code true} for all fields.
      *
      * <p>
      * For simple types, the fields are parsed as:
@@ -161,6 +161,11 @@ public final class ProtobufDescriptorParser {
      * <p>
      * The {@link FieldPath} context is kept during traversal and is an important part of the returned message
      * functions. Callers will typically use the returned field path to assign appropriate names to the functions.
+     *
+     * <p>
+     * Descriptors which are cyclic, or have descendant that are cyclic, are not currently supported; any cycles must be
+     * broken by {@link FieldOptions#exclude() excluding} one of the fields that leads to, or is part of, the cycle. If
+     * a cycle is detected, an {@link IllegalArgumentException} with a descriptive error message will be thrown.
      *
      * @param descriptor the descriptor
      * @param options the options

--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
@@ -35,12 +35,10 @@ import io.deephaven.function.TypedFunction.Visitor;
 
 import java.lang.reflect.Array;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -81,25 +79,19 @@ class ProtobufDescriptorParserImpl {
     private class DescriptorContext {
         private final FieldPath fieldPath;
         private final Descriptor descriptor;
-        private final Set<String> ancestorFullNames;
 
         public DescriptorContext(FieldPath fieldPath, Descriptor descriptor) {
-            this(fieldPath, descriptor, Set.of());
-        }
-
-        private DescriptorContext(FieldPath fieldPath, Descriptor descriptor, Set<String> ancestorFullNames) {
             this.fieldPath = Objects.requireNonNull(fieldPath);
             this.descriptor = Objects.requireNonNull(descriptor);
             final String fullName = descriptor.getFullName();
-            if (ancestorFullNames.contains(fullName)) {
-                throw new IllegalArgumentException(String.format(
-                        "Cyclical protobuf message descriptor detected at [%s]. Cyclic protobuf message descriptors are not supported; use `%s` fieldOptions to exclude one of the fields to work around this.",
-                        describeCycle(fieldPath, descriptor),
-                        ProtobufDescriptorParserOptions.class.getName()));
+            for (FieldDescriptor fd : fieldPath.path()) {
+                if (fullName.equals(fd.getContainingType().getFullName())) {
+                    throw new IllegalArgumentException(String.format(
+                            "Cyclical protobuf message descriptor detected at [%s]. Cyclic protobuf message descriptors are not supported; use `%s` fieldOptions to exclude one of the fields to work around this.",
+                            describeCycle(fieldPath, descriptor),
+                            ProtobufDescriptorParserOptions.class.getName()));
+                }
             }
-            final Set<String> next = new HashSet<>(ancestorFullNames);
-            next.add(fullName);
-            this.ancestorFullNames = next;
         }
 
         private static String describeCycle(FieldPath path, Descriptor descriptor) {
@@ -110,13 +102,6 @@ class ProtobufDescriptorParserImpl {
             }
             sb.append('`').append(descriptor.getFullName()).append('`');
             return sb.toString();
-        }
-
-        /**
-         * Creates a child descriptor context, inheriting this context's ancestry for cycle detection.
-         */
-        private DescriptorContext child(FieldPath fieldPath, Descriptor descriptor) {
-            return new DescriptorContext(fieldPath, descriptor, ancestorFullNames);
         }
 
         private ProtobufFunctions functions() {
@@ -188,7 +173,7 @@ class ProtobufDescriptorParserImpl {
             if (fd.getJavaType() != JavaType.MESSAGE) {
                 throw new IllegalStateException();
             }
-            return parent.child(fieldPath, fd.getMessageType());
+            return new DescriptorContext(fieldPath, fd.getMessageType());
         }
 
         private class FieldObject implements ToObjectFunction<Message, Object> {
@@ -301,7 +286,7 @@ class ProtobufDescriptorParserImpl {
                 if (valueFd == null) {
                     throw new IllegalStateException("Expected map to have field descriptor number 2 (value)");
                 }
-                final DescriptorContext dc = parent.child(append(parent.fieldPath, fd), fd.getMessageType());
+                final DescriptorContext dc = new DescriptorContext(append(parent.fieldPath, fd), fd.getMessageType());
 
                 // Note: maps are a "special" case, where even though we don't include the key / value FDs as a return
                 // io.deephaven.protobuf.ProtobufFunction#path, it's important that we force their inclusion if we've

--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
@@ -93,14 +93,22 @@ class ProtobufDescriptorParserImpl {
             final String fullName = descriptor.getFullName();
             if (ancestorFullNames.contains(fullName)) {
                 throw new IllegalArgumentException(String.format(
-                        "Cyclical protobuf message descriptor detected at field path %s: message type '%s' is " +
-                                "self-referential (directly or indirectly). Recursive message schemas are not " +
-                                "supported; use FieldOptions to exclude the field that closes the cycle.",
-                        fieldPath.namePath(), fullName));
+                        "Cyclical protobuf message descriptor detected at [%s]. Recursive message schemas are not supported; use FieldOptions to exclude the field that closes the cycle.",
+                        describeCycle(fieldPath, descriptor)));
             }
             final Set<String> next = new HashSet<>(ancestorFullNames);
             next.add(fullName);
             this.ancestorFullNames = next;
+        }
+
+        private static String describeCycle(FieldPath path, Descriptor descriptor) {
+            final StringBuilder sb = new StringBuilder();
+            for (FieldDescriptor fd : path.path()) {
+                sb.append('`').append(fd.getContainingType().getFullName()).append("` \"").append(fd.getName())
+                        .append("\" -> ");
+            }
+            sb.append('`').append(descriptor.getFullName()).append('`');
+            return sb.toString();
         }
 
         /**

--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
@@ -35,10 +35,12 @@ import io.deephaven.function.TypedFunction.Visitor;
 
 import java.lang.reflect.Array;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -79,10 +81,33 @@ class ProtobufDescriptorParserImpl {
     private class DescriptorContext {
         private final FieldPath fieldPath;
         private final Descriptor descriptor;
+        private final Set<String> ancestorFullNames;
 
         public DescriptorContext(FieldPath fieldPath, Descriptor descriptor) {
+            this(fieldPath, descriptor, Set.of());
+        }
+
+        private DescriptorContext(FieldPath fieldPath, Descriptor descriptor, Set<String> ancestorFullNames) {
             this.fieldPath = Objects.requireNonNull(fieldPath);
             this.descriptor = Objects.requireNonNull(descriptor);
+            final String fullName = descriptor.getFullName();
+            if (ancestorFullNames.contains(fullName)) {
+                throw new IllegalArgumentException(String.format(
+                        "Cyclical protobuf message descriptor detected at field path %s: message type '%s' is " +
+                                "self-referential (directly or indirectly). Recursive message schemas are not " +
+                                "supported; use FieldOptions to exclude the field that closes the cycle.",
+                        fieldPath.namePath(), fullName));
+            }
+            final Set<String> next = new HashSet<>(ancestorFullNames);
+            next.add(fullName);
+            this.ancestorFullNames = next;
+        }
+
+        /**
+         * Creates a child descriptor context, inheriting this context's ancestry for cycle detection.
+         */
+        private DescriptorContext child(FieldPath fieldPath, Descriptor descriptor) {
+            return new DescriptorContext(fieldPath, descriptor, ancestorFullNames);
         }
 
         private ProtobufFunctions functions() {
@@ -154,7 +179,7 @@ class ProtobufDescriptorParserImpl {
             if (fd.getJavaType() != JavaType.MESSAGE) {
                 throw new IllegalStateException();
             }
-            return new DescriptorContext(fieldPath, fd.getMessageType());
+            return parent.child(fieldPath, fd.getMessageType());
         }
 
         private class FieldObject implements ToObjectFunction<Message, Object> {
@@ -267,7 +292,7 @@ class ProtobufDescriptorParserImpl {
                 if (valueFd == null) {
                     throw new IllegalStateException("Expected map to have field descriptor number 2 (value)");
                 }
-                final DescriptorContext dc = new DescriptorContext(append(parent.fieldPath, fd), fd.getMessageType());
+                final DescriptorContext dc = parent.child(append(parent.fieldPath, fd), fd.getMessageType());
 
                 // Note: maps are a "special" case, where even though we don't include the key / value FDs as a return
                 // io.deephaven.protobuf.ProtobufFunction#path, it's important that we force their inclusion if we've

--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
@@ -93,8 +93,9 @@ class ProtobufDescriptorParserImpl {
             final String fullName = descriptor.getFullName();
             if (ancestorFullNames.contains(fullName)) {
                 throw new IllegalArgumentException(String.format(
-                        "Cyclical protobuf message descriptor detected at [%s]. Recursive message schemas are not supported; use FieldOptions to exclude the field that closes the cycle.",
-                        describeCycle(fieldPath, descriptor)));
+                        "Cyclical protobuf message descriptor detected at [%s]. Cyclic protobuf message descriptors are not supported; use `%s` fieldOptions to exclude one of the fields to work around this.",
+                        describeCycle(fieldPath, descriptor),
+                        ProtobufDescriptorParserOptions.class.getName()));
             }
             final Set<String> next = new HashSet<>(ancestorFullNames);
             next.add(fullName);

--- a/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
+++ b/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
@@ -1583,17 +1583,17 @@ public class ProtobufDescriptorParserTest {
     void selfReferentialMessageThrows() {
         assertThatThrownBy(() -> ProtobufDescriptorParser.parse(SelfReferential.getDescriptor(),
                 ProtobufDescriptorParserOptions.defaults()))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("Cyclical protobuf message descriptor detected")
-                        .hasMessageContaining(SelfReferential.getDescriptor().getFullName());
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cyclical protobuf message descriptor detected")
+                .hasMessageContaining(SelfReferential.getDescriptor().getFullName());
     }
 
     @Test
     void indirectCycleMessageThrows() {
         assertThatThrownBy(() -> ProtobufDescriptorParser.parse(CycleA.getDescriptor(),
                 ProtobufDescriptorParserOptions.defaults()))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("Cyclical protobuf message descriptor detected");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cyclical protobuf message descriptor detected");
     }
 
     private static Map<List<String>, TypedFunction<Message>> nf(Descriptor descriptor) {

--- a/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
+++ b/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
@@ -43,6 +43,7 @@ import io.deephaven.protobuf.test.AnIntIntMap;
 import io.deephaven.protobuf.test.AnyWrapper;
 import io.deephaven.protobuf.test.ByteWrapper;
 import io.deephaven.protobuf.test.ByteWrapperRepeated;
+import io.deephaven.protobuf.test.CycleA;
 import io.deephaven.protobuf.test.FieldMaskWrapper;
 import io.deephaven.protobuf.test.MultiRepeated;
 import io.deephaven.protobuf.test.NestedArrays;
@@ -56,6 +57,7 @@ import io.deephaven.protobuf.test.RepeatedMessage;
 import io.deephaven.protobuf.test.RepeatedMessage.Person;
 import io.deephaven.protobuf.test.RepeatedTimestamp;
 import io.deephaven.protobuf.test.RepeatedWrappers;
+import io.deephaven.protobuf.test.SelfReferential;
 import io.deephaven.protobuf.test.TheWrappers;
 import io.deephaven.protobuf.test.TwoTs;
 import io.deephaven.protobuf.test.UnionType;
@@ -81,6 +83,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ProtobufDescriptorParserTest {
 
@@ -1574,6 +1577,23 @@ public class ProtobufDescriptorParserTest {
                                 .build(), new String[][] {new String[0], new String[] {"Foo", "Bar"}});
                     }
                 });
+    }
+
+    @Test
+    void selfReferentialMessageThrows() {
+        assertThatThrownBy(() -> ProtobufDescriptorParser.parse(SelfReferential.getDescriptor(),
+                ProtobufDescriptorParserOptions.defaults()))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("Cyclical protobuf message descriptor detected")
+                        .hasMessageContaining(SelfReferential.getDescriptor().getFullName());
+    }
+
+    @Test
+    void indirectCycleMessageThrows() {
+        assertThatThrownBy(() -> ProtobufDescriptorParser.parse(CycleA.getDescriptor(),
+                ProtobufDescriptorParserOptions.defaults()))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("Cyclical protobuf message descriptor detected");
     }
 
     private static Map<List<String>, TypedFunction<Message>> nf(Descriptor descriptor) {

--- a/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
+++ b/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
@@ -45,6 +45,7 @@ import io.deephaven.protobuf.test.ByteWrapper;
 import io.deephaven.protobuf.test.ByteWrapperRepeated;
 import io.deephaven.protobuf.test.CycleA;
 import io.deephaven.protobuf.test.FieldMaskWrapper;
+import io.deephaven.protobuf.test.LollypopCycle;
 import io.deephaven.protobuf.test.MultiRepeated;
 import io.deephaven.protobuf.test.NestedArrays;
 import io.deephaven.protobuf.test.NestedByteWrapper;
@@ -1585,7 +1586,8 @@ public class ProtobufDescriptorParserTest {
                 ProtobufDescriptorParserOptions.defaults()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Cyclical protobuf message descriptor detected")
-                .hasMessageContaining(SelfReferential.getDescriptor().getFullName());
+                .hasMessageContaining(
+                        "[`io.deephaven.protobuf.test.SelfReferential` \"child\" -> `io.deephaven.protobuf.test.SelfReferential`]");
     }
 
     @Test
@@ -1594,7 +1596,18 @@ public class ProtobufDescriptorParserTest {
                 ProtobufDescriptorParserOptions.defaults()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Cyclical protobuf message descriptor detected")
-                .hasMessageContaining(CycleA.getDescriptor().getFullName());
+                .hasMessageContaining(
+                        "[`io.deephaven.protobuf.test.CycleA` \"b\" -> `io.deephaven.protobuf.test.CycleB` \"a\" -> `io.deephaven.protobuf.test.CycleA`]");
+    }
+
+    @Test
+    void lollypopCycleMessageThrows() {
+        assertThatThrownBy(() -> ProtobufDescriptorParser.parse(LollypopCycle.getDescriptor(),
+                ProtobufDescriptorParserOptions.defaults()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cyclical protobuf message descriptor detected")
+                .hasMessageContaining(
+                        "[`io.deephaven.protobuf.test.LollypopCycle` \"child\" -> `io.deephaven.protobuf.test.CycleA` \"b\" -> `io.deephaven.protobuf.test.CycleB` \"a\" -> `io.deephaven.protobuf.test.CycleA`]");
     }
 
     private static Map<List<String>, TypedFunction<Message>> nf(Descriptor descriptor) {

--- a/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
+++ b/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
@@ -1593,7 +1593,8 @@ public class ProtobufDescriptorParserTest {
         assertThatThrownBy(() -> ProtobufDescriptorParser.parse(CycleA.getDescriptor(),
                 ProtobufDescriptorParserOptions.defaults()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Cyclical protobuf message descriptor detected");
+                .hasMessageContaining("Cyclical protobuf message descriptor detected")
+                .hasMessageContaining(CycleA.getDescriptor().getFullName());
     }
 
     private static Map<List<String>, TypedFunction<Message>> nf(Descriptor descriptor) {

--- a/extensions/protobuf/src/test/proto/mytest.proto
+++ b/extensions/protobuf/src/test/proto/mytest.proto
@@ -235,3 +235,16 @@ message FieldPathTesting {
   }
   Foo foo = 1;
 }
+
+message SelfReferential {
+  int32 value = 1;
+  SelfReferential child = 2;
+}
+
+message CycleA {
+  CycleB b = 1;
+}
+
+message CycleB {
+  CycleA a = 1;
+}

--- a/extensions/protobuf/src/test/proto/mytest.proto
+++ b/extensions/protobuf/src/test/proto/mytest.proto
@@ -236,15 +236,22 @@ message FieldPathTesting {
   Foo foo = 1;
 }
 
+// A message that is self-cyclic
 message SelfReferential {
   int32 value = 1;
   SelfReferential child = 2;
 }
 
+// A message that has a indirect cycle
 message CycleA {
   CycleB b = 1;
 }
 
 message CycleB {
   CycleA a = 1;
+}
+
+// A message whose children have a cycle (this message itself is not part of the cycle)
+message LollypopCycle {
+  CycleA child = 1;
 }


### PR DESCRIPTION
Detect cyclical protobuf message descriptors and throw a useful exception message instead of StackOverflowError.