### PR TITLE
fix: DH-23039: Detect cyclical protobuf message descriptors

### DIFF
--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParser.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParser.java
@@ -18,7 +18,7 @@ public final class ProtobufDescriptorParser {
      *
      * <p>
      * Parsing proceeds through each {@link Descriptor#getFields() descriptor field} that matches
-     * {@link FieldOptions#include()}}. By default, this is {@code true} for all fields.
+     * {@link FieldOptions#include()}. By default, this is {@code true} for all fields.
      *
      * <p>
      * For simple types, the fields are parsed as:
@@ -161,6 +161,11 @@ public final class ProtobufDescriptorParser {
      * <p>
      * The {@link FieldPath} context is kept during traversal and is an important part of the returned message
      * functions. Callers will typically use the returned field path to assign appropriate names to the functions.
+     *
+     * <p>
+     * Descriptors which are cyclic, or have descendant that are cyclic, are not currently supported; any cycles must be
+     * broken by {@link FieldOptions#exclude() excluding} one of the fields that leads to, or is part of, the cycle. If
+     * a cycle is detected, an {@link IllegalArgumentException} with a descriptive error message will be thrown.
      *
      * @param descriptor the descriptor
      * @param options the options

--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
@@ -76,6 +76,16 @@ class ProtobufDescriptorParserImpl {
         return new DescriptorContext(FieldPath.empty(), descriptor).functions();
     }
 
+    private static String describeCycle(FieldPath path, Descriptor descriptor) {
+        final StringBuilder sb = new StringBuilder();
+        for (FieldDescriptor fd : path.path()) {
+            sb.append('`').append(fd.getContainingType().getFullName()).append("` \"").append(fd.getName())
+                    .append("\" -> ");
+        }
+        sb.append('`').append(descriptor.getFullName()).append('`');
+        return sb.toString();
+    }
+
     private class DescriptorContext {
         private final FieldPath fieldPath;
         private final Descriptor descriptor;
@@ -92,16 +102,6 @@ class ProtobufDescriptorParserImpl {
                             ProtobufDescriptorParserOptions.class.getName()));
                 }
             }
-        }
-
-        private static String describeCycle(FieldPath path, Descriptor descriptor) {
-            final StringBuilder sb = new StringBuilder();
-            for (FieldDescriptor fd : path.path()) {
-                sb.append('`').append(fd.getContainingType().getFullName()).append("` \"").append(fd.getName())
-                        .append("\" -> ");
-            }
-            sb.append('`').append(descriptor.getFullName()).append('`');
-            return sb.toString();
         }
 
         private ProtobufFunctions functions() {

--- a/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
+++ b/extensions/protobuf/src/main/java/io/deephaven/protobuf/ProtobufDescriptorParserImpl.java
@@ -83,6 +83,25 @@ class ProtobufDescriptorParserImpl {
         public DescriptorContext(FieldPath fieldPath, Descriptor descriptor) {
             this.fieldPath = Objects.requireNonNull(fieldPath);
             this.descriptor = Objects.requireNonNull(descriptor);
+            final String fullName = descriptor.getFullName();
+            for (FieldDescriptor fd : fieldPath.path()) {
+                if (fullName.equals(fd.getContainingType().getFullName())) {
+                    throw new IllegalArgumentException(String.format(
+                            "Cyclical protobuf message descriptor detected at [%s]. Cyclic protobuf message descriptors are not supported; use `%s` fieldOptions to exclude one of the fields to work around this.",
+                            describeCycle(fieldPath, descriptor),
+                            ProtobufDescriptorParserOptions.class.getName()));
+                }
+            }
+        }
+
+        private static String describeCycle(FieldPath path, Descriptor descriptor) {
+            final StringBuilder sb = new StringBuilder();
+            for (FieldDescriptor fd : path.path()) {
+                sb.append('`').append(fd.getContainingType().getFullName()).append("` \"").append(fd.getName())
+                        .append("\" -> ");
+            }
+            sb.append('`').append(descriptor.getFullName()).append('`');
+            return sb.toString();
         }
 
         private ProtobufFunctions functions() {

--- a/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
+++ b/extensions/protobuf/src/test/java/io/deephaven/protobuf/ProtobufDescriptorParserTest.java
@@ -43,7 +43,9 @@ import io.deephaven.protobuf.test.AnIntIntMap;
 import io.deephaven.protobuf.test.AnyWrapper;
 import io.deephaven.protobuf.test.ByteWrapper;
 import io.deephaven.protobuf.test.ByteWrapperRepeated;
+import io.deephaven.protobuf.test.CycleA;
 import io.deephaven.protobuf.test.FieldMaskWrapper;
+import io.deephaven.protobuf.test.LollypopCycle;
 import io.deephaven.protobuf.test.MultiRepeated;
 import io.deephaven.protobuf.test.NestedArrays;
 import io.deephaven.protobuf.test.NestedByteWrapper;
@@ -56,6 +58,7 @@ import io.deephaven.protobuf.test.RepeatedMessage;
 import io.deephaven.protobuf.test.RepeatedMessage.Person;
 import io.deephaven.protobuf.test.RepeatedTimestamp;
 import io.deephaven.protobuf.test.RepeatedWrappers;
+import io.deephaven.protobuf.test.SelfReferential;
 import io.deephaven.protobuf.test.TheWrappers;
 import io.deephaven.protobuf.test.TwoTs;
 import io.deephaven.protobuf.test.UnionType;
@@ -81,6 +84,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ProtobufDescriptorParserTest {
 
@@ -1574,6 +1578,36 @@ public class ProtobufDescriptorParserTest {
                                 .build(), new String[][] {new String[0], new String[] {"Foo", "Bar"}});
                     }
                 });
+    }
+
+    @Test
+    void selfReferentialMessageThrows() {
+        assertThatThrownBy(() -> ProtobufDescriptorParser.parse(SelfReferential.getDescriptor(),
+                ProtobufDescriptorParserOptions.defaults()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cyclical protobuf message descriptor detected")
+                .hasMessageContaining(
+                        "[`io.deephaven.protobuf.test.SelfReferential` \"child\" -> `io.deephaven.protobuf.test.SelfReferential`]");
+    }
+
+    @Test
+    void indirectCycleMessageThrows() {
+        assertThatThrownBy(() -> ProtobufDescriptorParser.parse(CycleA.getDescriptor(),
+                ProtobufDescriptorParserOptions.defaults()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cyclical protobuf message descriptor detected")
+                .hasMessageContaining(
+                        "[`io.deephaven.protobuf.test.CycleA` \"b\" -> `io.deephaven.protobuf.test.CycleB` \"a\" -> `io.deephaven.protobuf.test.CycleA`]");
+    }
+
+    @Test
+    void lollypopCycleMessageThrows() {
+        assertThatThrownBy(() -> ProtobufDescriptorParser.parse(LollypopCycle.getDescriptor(),
+                ProtobufDescriptorParserOptions.defaults()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cyclical protobuf message descriptor detected")
+                .hasMessageContaining(
+                        "[`io.deephaven.protobuf.test.LollypopCycle` \"child\" -> `io.deephaven.protobuf.test.CycleA` \"b\" -> `io.deephaven.protobuf.test.CycleB` \"a\" -> `io.deephaven.protobuf.test.CycleA`]");
     }
 
     private static Map<List<String>, TypedFunction<Message>> nf(Descriptor descriptor) {

--- a/extensions/protobuf/src/test/proto/mytest.proto
+++ b/extensions/protobuf/src/test/proto/mytest.proto
@@ -235,3 +235,23 @@ message FieldPathTesting {
   }
   Foo foo = 1;
 }
+
+// A message that is self-cyclic
+message SelfReferential {
+  int32 value = 1;
+  SelfReferential child = 2;
+}
+
+// A message that has a indirect cycle
+message CycleA {
+  CycleB b = 1;
+}
+
+message CycleB {
+  CycleA a = 1;
+}
+
+// A message whose children have a cycle (this message itself is not part of the cycle)
+message LollypopCycle {
+  CycleA child = 1;
+}


### PR DESCRIPTION
Detect cyclical protobuf message descriptors and throw a useful exception message instead of StackOverflowError.

Cherry-pick of #8210