### PR TITLE
fix(py/jpy-integration): DH-23071, DH-21041: Make ReferenceCountingTest less flaky

### DIFF
--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
@@ -136,19 +136,17 @@ public class ReferenceCounting implements AutoCloseable {
                 // settle and do their thing or whatever
                 TimeUnit.SECONDS.sleep(2);
 
-                if (didFinalizationHappen.getAsBoolean()) {
-                    return CleanupResult.SUCCESS;
-                } else {
-                    return CleanupResult.GC_HAPPENED_BUT_CLIENT_OBJECT_WASNT_FINALIZED;
-                }
+                return didFinalizationHappen.getAsBoolean() ? CleanupResult.SUCCESS
+                        : CleanupResult.SENTINELS_WERE_FINALIZED_BUT_CLIENT_OBJECT_WAS_NOT;
             }
         }
 
-        return CleanupResult.GC_DIDNT_HAPPEN;
+        return didFinalizationHappen.getAsBoolean() ? CleanupResult.CLIENT_OBJECT_WAS_FINALIZED_BUT_SENTINELS_WERE_NOT
+                : CleanupResult.FINALIZATION_DIDNT_HAPPEN;
     }
 
     public enum CleanupResult {
-        SUCCESS, GC_DIDNT_HAPPEN, GC_HAPPENED_BUT_CLIENT_OBJECT_WASNT_FINALIZED
+        SUCCESS, SENTINELS_WERE_FINALIZED_BUT_CLIENT_OBJECT_WAS_NOT, CLIENT_OBJECT_WAS_FINALIZED_BUT_SENTINELS_WERE_NOT, FINALIZATION_DIDNT_HAPPEN
     }
 
     /**

--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
@@ -11,6 +11,8 @@ import org.junit.Assert;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 public class ReferenceCounting implements AutoCloseable {
 
@@ -73,53 +75,80 @@ public class ReferenceCounting implements AutoCloseable {
     /**
      * This is a fragile method, whose aspiration is to ensure that garbage collection happens.
      *
-     * Usage:
+     * The strategy is to make three objects: a sentinel object, the caller object under test, and then another sentinel
+     * object. The trick here is to create the caller object under test after the first sentinel but before the second
+     * sentinel. The underlying assumption is that "surely" the garbage collector won't collect both sentinels without
+     * also collecting the caller object.
      *
-     * ReferenceCounting.GarbageSentinel gs = ref.makeGarbageSentinel(); // make your object under test
-     * Assert.assertTrue(gs.tryCollectGarbage()) // now test that your object got gc'ed
+     * Then we try to induce garbage collection.
      *
-     * There are some shortcomings: 1. There is no guarantee that GC will actually be invoked. 2. Even if our sentinel
-     * object is collected, this doesn't guarantee that the object under test has been collected.
+     * Then we ask the caller if it looks like their object was finalized.
      *
-     * That said - this seems to work for at least some VM implementations.
+     * There are three possible outcomes: 1. If the two sentinel objects were not both finalized, return
+     * GC_DIDNT_HAPPEN. 2. If the two sentinel objects were finalized but the caller object under test was not, return
+     * GC_HAPPENED_BUT_CLIENT_OBJECT_WASNT_FINALIZED. 3. Otherwise, if all three objects were finalized, return SUCCESS.
+     *
+     * @param makeObject Create the caller object under test and supply it to us. We will set our reference to null at
+     *        the appropriate time. The caller should not try to hold a reference to it
+     * @param didFinalizationHappen Return true if the caller determines that finalization happened on its object.
+     *        Otherwise, return false.
      */
-    public GarbageSentinel makeGarbageSentinel() {
-        return new GarbageSentinel(gc);
-    }
+    public <T> CleanupResult doesCleanupHappenAtFinalizerTime(
+            Supplier<T> makeObject, BooleanSupplier didFinalizationHappen) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(2);
+        Object beforeSentinel = new Object() {
+            @Override
+            protected void finalize() throws Throwable {
+                super.finalize();
+                latch.countDown();
+            }
+        };
 
-    public static class GarbageSentinel {
-        private final GcModule gc;
-        private final CountDownLatch latch = new CountDownLatch(1);
-        private Object trackedObject;
+        T callerObject = makeObject.get();
 
-        public GarbageSentinel(GcModule gc) {
-            this.gc = gc;
-            trackedObject = new Object() {
-                @Override
-                protected void finalize() throws Throwable {
-                    super.finalize();
-                    latch.countDown();
-                }
-            };
-        }
+        Object afterSentinel = new Object() {
+            @Override
+            protected void finalize() throws Throwable {
+                super.finalize();
+                latch.countDown();
+            }
+        };
 
-        public boolean tryCollectGarbage() throws InterruptedException {
-            trackedObject = null;
+        blackhole(beforeSentinel, callerObject, afterSentinel);
 
-            // Will try 10 times, for a total of 2.5 seconds, to collect the garbage.
-            for (int i = 0; i < 10; i++) {
-                System.gc();
-                System.runFinalization();
+        beforeSentinel = null;
+        callerObject = null;
+        afterSentinel = null;
 
-                if (latch.await(250, TimeUnit.MILLISECONDS)) {
-                    PyObject.cleanup();
-                    gc.collect();
-                    return true;
+        // Will try 20 times, for a total of 5 seconds, to collect the garbage
+        // and wait for both sentinels to be finalized.
+        for (int i = 0; i < 20; i++) {
+            System.gc();
+            System.runFinalization();
+
+            if (latch.await(250, TimeUnit.MILLISECONDS)) {
+                // Both sentinels are finalized. Now see if the caller's
+                // state was finalized.
+                PyObject.cleanup();
+                gc.collect();
+
+                // Wait two more seconds for good luck and to let the above methods
+                // settle and do their thing or whatever
+                TimeUnit.SECONDS.sleep(2);
+
+                if (didFinalizationHappen.getAsBoolean()) {
+                    return CleanupResult.SUCCESS;
+                } else {
+                    return CleanupResult.GC_HAPPENED_BUT_CLIENT_OBJECT_WASNT_FINALIZED;
                 }
             }
-
-            return false;
         }
+
+        return CleanupResult.GC_DIDNT_HAPPEN;
+    }
+
+    public enum CleanupResult {
+        SUCCESS, GC_DIDNT_HAPPEN, GC_HAPPENED_BUT_CLIENT_OBJECT_WASNT_FINALIZED
     }
 
     /**

--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
@@ -71,29 +71,55 @@ public class ReferenceCounting implements AutoCloseable {
     }
 
     /**
-     * This is a fragile method, meant to ensure that GC gets invoked. There are a couple of shortcomings:
+     * This is a fragile method, whose aspiration is to ensure that garbage collection happens.
      *
-     * 1) There is no guarantee that GC will actually be invoked. 2) Even if our dummy object is collected, it doesn't
-     * guarantee that any other objects we care about have been GCd.
+     * Usage:
+     *
+     * ReferenceCounting.GarbageSentinel gs = ref.makeGarbageSentinel(); // make your object under test
+     * Assert.assertTrue(gs.tryCollectGarbage()) // now test that your object got gc'ed
+     *
+     * There are some shortcomings: 1. There is no guarantee that GC will actually be invoked. 2. Even if our sentinel
+     * object is collected, this doesn't guarantee that the object under test has been collected.
      *
      * That said - this seems to work for at least some VM implementations.
      */
-    public void gc() throws InterruptedException {
-        final CountDownLatch latch = new CountDownLatch(1);
-        // noinspection unused
-        Object obj = new Object() {
-            @Override
-            protected void finalize() throws Throwable {
-                super.finalize();
-                latch.countDown();
+    public GarbageSentinel makeGarbageSentinel() {
+        return new GarbageSentinel(gc);
+    }
+
+    public static class GarbageSentinel {
+        private final GcModule gc;
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private Object trackedObject;
+
+        public GarbageSentinel(GcModule gc) {
+            this.gc = gc;
+            trackedObject = new Object() {
+                @Override
+                protected void finalize() throws Throwable {
+                    super.finalize();
+                    latch.countDown();
+                }
+            };
+        }
+
+        public boolean tryCollectGarbage() throws InterruptedException {
+            trackedObject = null;
+
+            // Will try 10 times, for a total of 2.5 seconds, to collect the garbage.
+            for (int i = 0; i < 10; i++) {
+                System.gc();
+                System.runFinalization();
+
+                if (latch.await(250, TimeUnit.MILLISECONDS)) {
+                    PyObject.cleanup();
+                    gc.collect();
+                    return true;
+                }
             }
-        };
-        // noinspection UnusedAssignment
-        obj = null;
-        System.gc();
-        Assert.assertTrue("GC did not happen within 1 second", latch.await(1, TimeUnit.SECONDS));
-        PyObject.cleanup();
-        gc.collect();
+
+            return false;
+        }
     }
 
     /**

--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCountingTest.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCountingTest.java
@@ -7,6 +7,8 @@ import io.deephaven.jpy.BuiltinsModule;
 import io.deephaven.jpy.JpyModule;
 import io.deephaven.jpy.PythonTest;
 import io.deephaven.jpy.integration.DestructorModuleParent.OnDelete;
+
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -73,20 +75,29 @@ public class ReferenceCountingTest extends PythonTest {
 
     @Test
     public void viaPython() throws InterruptedException {
-        final ReferenceCounting.GarbageSentinel gs = ref.makeGarbageSentinel();
-        PyObject.executeCode("import sys", PyInputMode.STATEMENT);
-        PyObject.executeCode("x = dict()", PyInputMode.STATEMENT);
-        // the extra ref counts here are due to the reference that getrefcount itself is imposing
-        PyObject.executeCode("assert sys.getrefcount(x) == 2", PyInputMode.STATEMENT);
-        {
-            PyObject javaRef = PyObject.executeCode("x", PyInputMode.EXPRESSION);
-            PyObject.executeCode("assert sys.getrefcount(x) == 3", PyInputMode.STATEMENT);
-            ReferenceCounting.blackhole(javaRef);
-            javaRef = null;
-        }
-        // let's hope GC will kick in...
-        Assert.assertTrue("Could not force garbage collection", gs.tryCollectGarbage());
-        PyObject.executeCode("assert sys.getrefcount(x) == 2", PyInputMode.STATEMENT);
+        final ReferenceCounting.CleanupResult result = ref.doesCleanupHappenAtFinalizerTime(
+                () -> {
+                    PyObject.executeCode("import sys", PyInputMode.STATEMENT);
+                    PyObject.executeCode("x = dict()", PyInputMode.STATEMENT);
+                    // the extra ref counts here are due to the reference that getrefcount itself is imposing
+                    PyObject.executeCode("assert sys.getrefcount(x) == 2", PyInputMode.STATEMENT);
+                    PyObject javaRef = PyObject.executeCode("x", PyInputMode.EXPRESSION);
+                    PyObject.executeCode("assert sys.getrefcount(x) == 3", PyInputMode.STATEMENT);
+                    return javaRef;
+                },
+
+                () -> {
+                    try {
+                        PyObject.executeCode("assert sys.getrefcount(x) == 2", PyInputMode.STATEMENT);
+                        return true;
+                    } catch (Throwable t) {
+                        return false;
+                    }
+                });
+
+        Assert.assertTrue(
+                "Cleanup didn't happen. Reason: " + result,
+                result == ReferenceCounting.CleanupResult.SUCCESS);
     }
 
     @Test
@@ -176,19 +187,22 @@ public class ReferenceCountingTest extends PythonTest {
         // this tests fails in python 2, but I haven't spent time debugging
         assumePython3();
 
-        final ReferenceCounting.GarbageSentinel gs = ref.makeGarbageSentinel();
-
         final CountDownLatch latch = new CountDownLatch(1);
-        {
-            PyObject child = destructor.create_child(new OnDelete(latch));
-            ref.check(1, child);
-            ReferenceCounting.blackhole(child);
-            child = null;
-        }
-        // let's hope GC will kick in...
-        Assert.assertTrue("Could not force garbage collection", gs.tryCollectGarbage());
-        Assert.assertTrue(latch.await(1, TimeUnit.SECONDS));
+        final ReferenceCounting.CleanupResult result = ref.doesCleanupHappenAtFinalizerTime(
+                () -> {
+                    PyObject child = destructor.create_child(new OnDelete(latch));
+                    ref.check(1, child);
+                    return child;
+                },
+
+                () -> latch.getCount() == 0);
+
+        Assert.assertTrue(
+                "Cleanup didn't happen. Reason: " + result,
+                result == ReferenceCounting.CleanupResult.SUCCESS);
     }
+
+
 
     @Test
     public void pythonObjectInJavaWillDestructAfterClosure() throws InterruptedException {

--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCountingTest.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCountingTest.java
@@ -73,6 +73,7 @@ public class ReferenceCountingTest extends PythonTest {
 
     @Test
     public void viaPython() throws InterruptedException {
+        final ReferenceCounting.GarbageSentinel gs = ref.makeGarbageSentinel();
         PyObject.executeCode("import sys", PyInputMode.STATEMENT);
         PyObject.executeCode("x = dict()", PyInputMode.STATEMENT);
         // the extra ref counts here are due to the reference that getrefcount itself is imposing
@@ -84,7 +85,7 @@ public class ReferenceCountingTest extends PythonTest {
             javaRef = null;
         }
         // let's hope GC will kick in...
-        ref.gc();
+        Assert.assertTrue("Could not force garbage collection", gs.tryCollectGarbage());
         PyObject.executeCode("assert sys.getrefcount(x) == 2", PyInputMode.STATEMENT);
     }
 
@@ -175,6 +176,8 @@ public class ReferenceCountingTest extends PythonTest {
         // this tests fails in python 2, but I haven't spent time debugging
         assumePython3();
 
+        final ReferenceCounting.GarbageSentinel gs = ref.makeGarbageSentinel();
+
         final CountDownLatch latch = new CountDownLatch(1);
         {
             PyObject child = destructor.create_child(new OnDelete(latch));
@@ -183,7 +186,7 @@ public class ReferenceCountingTest extends PythonTest {
             child = null;
         }
         // let's hope GC will kick in...
-        ref.gc();
+        Assert.assertTrue("Could not force garbage collection", gs.tryCollectGarbage());
         Assert.assertTrue(latch.await(1, TimeUnit.SECONDS));
     }
 


### PR DESCRIPTION
We try to improve the robustness of the GC test:

1. Create two "sentinel" objects: one is created before the object under test and one is created after. 
2. The "force GC logic" won't consider itself successful until both sentinel objects have been GC'ed.
3.  Since one was created before the object under test, and one was created after, "hopefully" this means the object under test will also be GC'ed.
4. Try more aggressively to make GC happen.
