### PR TITLE
fix: recover reconnect when a gRPC stream fails before headers

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/grpc/CustomTransportChannel.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/grpc/CustomTransportChannel.java
@@ -32,10 +32,15 @@ public class CustomTransportChannel extends AbstractGrpcWebChannel {
 
     @Override
     protected Transport createTransport(final String method, final URL url, final TransportCallbacks callbacks) {
+        // The channel expects headers to arrive before the stream ends. If the server is never reached, the stream
+        // ends with no headers and the channel throws while deriving a status from them. Uphold the contract:
+        // guarantee the channel always sees headers first.
+        final ConnectionFailureAwareCallbacks safeCallbacks = new ConnectionFailureAwareCallbacks(callbacks);
+
         final GrpcTransportOptions options = new GrpcTransportOptions();
         options.url = url;
-        options.onChunk = callbacks::onChunk;
-        options.onEnd = callbacks::onEnd;
+        options.onChunk = safeCallbacks::onChunk;
+        options.onEnd = safeCallbacks::onEnd;
         options.onHeaders = (headers, status) -> {
             // normalize the headers union values to a string
             final JsPropertyMap<String> h = JsPropertyMap.of();
@@ -53,7 +58,7 @@ public class CustomTransportChannel extends AbstractGrpcWebChannel {
                 h.set(key, value);
             }
 
-            callbacks.onHeaders(status, h);
+            safeCallbacks.onHeaders(status, h);
         };
         final GrpcTransport transport = transportFactory.create(options);
         return new Transport() {
@@ -77,5 +82,41 @@ public class CustomTransportChannel extends AbstractGrpcWebChannel {
                 transport.cancel();
             }
         };
+    }
+
+    /**
+     * Decorates the channel's callbacks to uphold its expectation that headers are delivered before the stream ends. If
+     * a stream ends before any headers arrive - i.e. the server was never reached - this first reports a synthetic "503
+     * Service Unavailable" with empty headers, so the channel closes the call cleanly as UNAVAILABLE instead of
+     * throwing while reading a status out of headers it never received.
+     */
+    private static final class ConnectionFailureAwareCallbacks implements TransportCallbacks {
+        private static final int SERVICE_UNAVAILABLE = 503;
+
+        private final TransportCallbacks delegate;
+        private boolean headersReceived;
+
+        ConnectionFailureAwareCallbacks(final TransportCallbacks delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onHeaders(final int status, final JsPropertyMap<String> headers) {
+            headersReceived = true;
+            delegate.onHeaders(status, headers);
+        }
+
+        @Override
+        public void onChunk(final Uint8Array chunk) {
+            delegate.onChunk(chunk);
+        }
+
+        @Override
+        public void onEnd(final Object error) {
+            if (!headersReceived) {
+                delegate.onHeaders(SERVICE_UNAVAILABLE, Js.uncheckedCast(JsPropertyMap.of()));
+            }
+            delegate.onEnd(error);
+        }
     }
 }

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/grpc/GrpcTransportTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/grpc/GrpcTransportTestGwt.java
@@ -141,4 +141,58 @@ public class GrpcTransportTestGwt extends AbstractAsyncGwtTestCase {
                     .then(ignore2 -> Promise.resolve(coreClient));
         }).then(this::finish).catch_(this::report);
     }
+
+    /**
+     * Dummy transport that never delivers headers and simply ends the stream, as happens when the server is unreachable
+     * during a (re)connect attempt - the socket closes before any response is received.
+     */
+    private native GrpcTransportFactory makeEndsBeforeHeadersTransportFactory() /*-{
+        return {
+            create: function(options) {
+                return {
+                    start: function(metadata) {
+                        // never call onHeaders; end the stream as if the server was never reached
+                        $wnd.setTimeout(function() { options.onEnd(); }, 0);
+                    },
+                    sendMessage: function(msgBytes) {
+                        // no-op
+                    },
+                    finishSend: function() {
+                        // no-op
+                    },
+                    cancel: function() {
+                        // no-op
+                    }
+                };
+            },
+            supportsClientStreaming: true
+        };
+    }-*/;
+
+    /**
+     * Regression test: when a transport's stream ends before any headers arrive, the channel must report a clean
+     * failure rather than throwing while computing the closing status. Previously the status was derived from the
+     * (never received) headers, throwing a TypeError before the failure was delivered - so callers such as the
+     * reconnect logic never learned the attempt failed and hung indefinitely.
+     */
+    public void testTransportEndsBeforeHeaders() {
+        // The failure path logs the resulting error; judge the test on whether login rejects, not on the logs.
+        errorLogsDontFail();
+        setupDhInternal().then(ignore -> {
+            delayTestFinish(7103);
+            ConnectOptions connectOptions = new ConnectOptions();
+            connectOptions.transportFactory = makeEndsBeforeHeadersTransportFactory();
+            CoreClient coreClient = new CoreClient(localServer, connectOptions);
+            return coreClient.login(JsPropertyMap.of("type", CoreClient.LOGIN_TYPE_ANONYMOUS));
+        }).then(success -> {
+            // The stream ended before headers, so login must not succeed.
+            reportUncaughtException(new AssertionError(
+                    "Expected login to fail when the transport ends before headers, but it succeeded"));
+            return Promise.resolve((Object) success);
+        }, failure -> {
+            // Expected: a clean rejection instead of an uncaught error or an indefinite hang.
+            finishTest();
+            return Promise.resolve((Object) failure);
+        });
+    }
 }


### PR DESCRIPTION
Fixes  https://github.com/deephaven/deephaven-core/issues/8235

When a gRPC stream ends before any response headers arrive (e.g. the server is unreachable during a reconnect attempt), the channel derived its closing status from the never-received headers and threw a TypeError before the failure was delivered. Callers such as the reconnect logic never learned the attempt failed and hung indefinitely.

`CustomTransportChannel` now reports a headers-less stream end as a clean UNAVAILABLE failure, so the reconnect logic is notified and recovers instead of hanging. Adds a regression test covering the case.