### PR TITLE
fix: add reconnect support to JsWidget so deephaven.ui widgets revive

### DIFF
--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -1018,8 +1018,7 @@ public class WorkerConnection {
                             .setType(varDef.getType())
                             .setTicket(ticket)
                             .build();
-                    return whenServerReady("get a widget")
-                            .then(response -> Promise.resolve(new JsWidget(this, typedTicket)));
+                    return getWidget(typedTicket);
                 }).promise();
     }
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -730,12 +730,9 @@ public class WorkerConnection {
             return getHierarchicalTable(definition);
         } else {
             warnLegacyTicketTypes(definition.getType());
-            return getWidget(definition, () -> reexportScopeTicket(definition))
+            return getWidget(definition)
                     .then(JsWidget::refetch)
-                    .then(widget -> {
-                        registerSimpleReconnectable(widget);
-                        return Promise.resolve(widget);
-                    });
+                    .then(JsWidget::markReconnectable);
         }
     }
 
@@ -788,10 +785,7 @@ public class WorkerConnection {
             warnLegacyTicketTypes(typedTicket.getType());
             return getWidget(typedTicket)
                     .then(JsWidget::refetch)
-                    .then(widget -> {
-                        registerSimpleReconnectable(widget);
-                        return Promise.resolve(widget);
-                    });
+                    .then(JsWidget::markReconnectable);
         }
     }
 
@@ -1018,11 +1012,6 @@ public class WorkerConnection {
     }
 
     public Promise<JsWidget> getWidget(JsVariableDefinition varDef) {
-        return getWidget(varDef, null);
-    }
-
-    private Promise<JsWidget> getWidget(JsVariableDefinition varDef,
-            Supplier<Promise<TypedTicket>> reexportTicket) {
         return exportScopeTicket(varDef)
                 .race(ticket -> {
                     TypedTicket typedTicket = TypedTicket.newBuilder()
@@ -1030,19 +1019,8 @@ public class WorkerConnection {
                             .setTicket(ticket)
                             .build();
                     return whenServerReady("get a widget")
-                            .then(response -> Promise.resolve(new JsWidget(this, typedTicket, reexportTicket)));
+                            .then(response -> Promise.resolve(new JsWidget(this, typedTicket)));
                 }).promise();
-    }
-
-    /**
-     * Exports the variable again with a fresh ticket, to revive a widget after a new session was created.
-     */
-    private Promise<TypedTicket> reexportScopeTicket(JsVariableDefinition varDef) {
-        TicketAndPromise<?> exported = exportScopeTicket(varDef);
-        return exported.promise().then(ignore -> Promise.resolve(TypedTicket.newBuilder()
-                .setType(varDef.getType())
-                .setTicket(exported.ticket())
-                .build()));
     }
 
     public Promise<JsWidget> getWidget(TypedTicket typedTicket) {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/WorkerConnection.java
@@ -134,6 +134,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -559,7 +560,6 @@ public class WorkerConnection {
 
     public void connectionLost() {
         // notify all active tables and widgets that the connection is closed
-        // TODO(deephaven-core#3604) when a new session is created, refetch all widgets and use that to drive reconnect
         simpleReconnectableInstances.forEach((item, index, array) -> {
             try {
                 item.disconnected();
@@ -730,7 +730,12 @@ public class WorkerConnection {
             return getHierarchicalTable(definition);
         } else {
             warnLegacyTicketTypes(definition.getType());
-            return getWidget(definition).then(JsWidget::refetch);
+            return getWidget(definition, () -> reexportScopeTicket(definition))
+                    .then(JsWidget::refetch)
+                    .then(widget -> {
+                        registerSimpleReconnectable(widget);
+                        return Promise.resolve(widget);
+                    });
         }
     }
 
@@ -781,7 +786,12 @@ public class WorkerConnection {
             return new JsWidget(this, typedTicket).refetch().then(w -> Promise.resolve(new JsTreeTable(this, w)));
         } else {
             warnLegacyTicketTypes(typedTicket.getType());
-            return getWidget(typedTicket).then(JsWidget::refetch);
+            return getWidget(typedTicket)
+                    .then(JsWidget::refetch)
+                    .then(widget -> {
+                        registerSimpleReconnectable(widget);
+                        return Promise.resolve(widget);
+                    });
         }
     }
 
@@ -1008,14 +1018,31 @@ public class WorkerConnection {
     }
 
     public Promise<JsWidget> getWidget(JsVariableDefinition varDef) {
+        return getWidget(varDef, null);
+    }
+
+    private Promise<JsWidget> getWidget(JsVariableDefinition varDef,
+            Supplier<Promise<TypedTicket>> reexportTicket) {
         return exportScopeTicket(varDef)
                 .race(ticket -> {
                     TypedTicket typedTicket = TypedTicket.newBuilder()
                             .setType(varDef.getType())
                             .setTicket(ticket)
                             .build();
-                    return getWidget(typedTicket);
+                    return whenServerReady("get a widget")
+                            .then(response -> Promise.resolve(new JsWidget(this, typedTicket, reexportTicket)));
                 }).promise();
+    }
+
+    /**
+     * Exports the variable again with a fresh ticket, to revive a widget after a new session was created.
+     */
+    private Promise<TypedTicket> reexportScopeTicket(JsVariableDefinition varDef) {
+        TicketAndPromise<?> exported = exportScopeTicket(varDef);
+        return exported.promise().then(ignore -> Promise.resolve(TypedTicket.newBuilder()
+                .setType(varDef.getType())
+                .setTicket(exported.ticket())
+                .build()));
     }
 
     public Promise<JsWidget> getWidget(TypedTicket typedTicket) {
@@ -1029,6 +1056,10 @@ public class WorkerConnection {
 
     public void unregisterSimpleReconnectable(HasLifecycle figure) {
         this.simpleReconnectableInstances.delete(figure);
+    }
+
+    public boolean isConnected() {
+        return state == State.Connected;
     }
 
 

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -117,20 +117,13 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
     public static final String EVENT_CLOSE = "close";
 
     private final WorkerConnection connection;
-    private TypedTicket typedTicket;
-
-    /**
-     * If non-null, allows the widget to be re-exported from its underlying server-side object after a new session was
-     * created, so that the widget can be revived. Widgets fetched from a raw ticket cannot be re-exported, and can only
-     * be revived while the session that exported them is still alive.
-     */
-    private final Supplier<Promise<TypedTicket>> reexportTicket;
+    private final TypedTicket typedTicket;
 
     private boolean hasFetched;
 
     /**
-     * Set when the connection reports this widget as disconnected, cleared when a revive (via {@link #reconnect()} or
-     * {@link #refetch()}) succeeds. While set, {@link #refetch()} re-announces the widget to consumers on success.
+     * Set when the connection reports this widget as disconnected, cleared when a same-session revive (via
+     * {@link #reconnect()}) succeeds. While set, the next initial response re-announces the widget to consumers.
      */
     private boolean awaitingRevive;
 
@@ -142,14 +135,8 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
     private JsArray<JsWidgetExportedObject> exportedObjects;
 
     public JsWidget(WorkerConnection connection, TypedTicket typedTicket) {
-        this(connection, typedTicket, null);
-    }
-
-    public JsWidget(WorkerConnection connection, TypedTicket typedTicket,
-            Supplier<Promise<TypedTicket>> reexportTicket) {
         this.connection = connection;
         this.typedTicket = typedTicket;
-        this.reexportTicket = reexportTicket;
         hasFetched = false;
         BiDiStream.Factory<StreamRequest, StreamResponse> factory = connection.streamFactory();
         streamFactory = () -> factory.<BrowserNextResponse>create(
@@ -162,6 +149,16 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
     @Override
     public WorkerConnection getConnection() {
         return connection;
+    }
+
+    /**
+     * Marks this as a standalone, independently-reconnectable widget and registers it with the connection so it is
+     * revived on reconnect. Called only for widgets handed directly to the caller - widgets wrapped by a figure / tree
+     * / partitioned-table are revived by their owner and must not be registered here (that would double-revive them).
+     */
+    public Promise<JsWidget> markReconnectable() {
+        connection.registerSimpleReconnectable(this);
+        return Promise.resolve(this);
     }
 
     private void closeStream() {
@@ -184,9 +181,9 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
     }
 
     /**
-     * Opens (or reopens) the message stream to the server using the widget's current ticket. If the widget was
-     * disconnected and a new session was created on the server, the old export is gone - when possible, the underlying
-     * object is re-exported with a fresh ticket before the stream is reopened.
+     * Opens (or reopens) the message stream using the widget's current ticket. Used for the initial fetch. When invoked
+     * as the connection's new-session revive hook, the export ticket is no longer valid and the server-side object may
+     * differ, so we cannot safely reconnect - the revive fails.
      */
     @Override
     public Promise<JsWidget> refetch() {
@@ -194,21 +191,16 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
             // initial fetch, or an internal caller deliberately rebinding the stream
             return openStream();
         }
-        if (reexportTicket == null) {
-            // No way to re-export the underlying object - attempt to reattach to the existing export, which only
-            // works if the server kept it alive.
-            return announceAfter(openStream());
-        }
-        return announceAfter(reexportTicket.get()
-                .then(freshTicket -> {
-                    typedTicket = freshTicket;
-                    return openStream();
-                }));
+        // A new session was created: the old export ticket is invalid and the object may differ. Fail the revive
+        // rather than silently reconnect to a different object.
+        IllegalStateException failure = new IllegalStateException("Cannot revive widget: a new session was created");
+        die(failure);
+        return (Promise<JsWidget>) (Promise) Promise.reject(failure);
     }
 
     /**
-     * The session survived the disconnect, so the export should still be alive - reopen the message stream with the
-     * same ticket. If that fails, fall back to a full refetch when possible.
+     * Same-session reconnect: the export ticket is still valid, so reopen the message stream with the same ticket and
+     * re-announce to consumers on success. If the stream cannot be reopened, fail the revive.
      */
     @Override
     public void reconnect() {
@@ -216,10 +208,6 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
             announceReconnect();
             return Promise.resolve(widget);
         }, failure -> {
-            if (reexportTicket != null) {
-                // the export may have expired after all - retry with a fresh export
-                return refetch();
-            }
             die(failure);
             return (Promise<JsWidget>) (Promise) Promise.reject(failure);
         }).catch_(ignore -> {
@@ -233,16 +221,6 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
         awaitingRevive = true;
         closeStream();
         super.disconnected();
-    }
-
-    private Promise<JsWidget> announceAfter(Promise<JsWidget> reviveAttempt) {
-        return reviveAttempt.then(widget -> {
-            announceReconnect();
-            return Promise.resolve(widget);
-        }, failure -> {
-            die(failure);
-            return (Promise<JsWidget>) (Promise) Promise.reject(failure);
-        });
     }
 
     private void announceReconnect() {

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -28,7 +28,7 @@ import io.deephaven.web.client.api.Callbacks;
 import io.deephaven.web.client.api.ServerObject;
 import io.deephaven.web.client.api.WorkerConnection;
 import io.deephaven.web.client.api.barrage.stream.BiDiStream;
-import io.deephaven.web.client.api.event.HasEventHandling;
+import io.deephaven.web.client.api.lifecycle.HasLifecycle;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsOptional;
 import jsinterop.annotations.JsNullable;
@@ -97,9 +97,8 @@ import java.util.function.Supplier;
  * without the server somehow signaling that it will never reference that export again.</li>
  * </ul>
  */
-// TODO consider reconnect support? This is somewhat tricky without understanding the semantics of the widget
 @TsName(namespace = "dh", name = "Widget")
-public class JsWidget extends HasEventHandling implements ServerObject, WidgetMessageDetails {
+public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessageDetails {
     /**
      * Fired when a new message is received from the server.
      * <p>
@@ -118,9 +117,22 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
     public static final String EVENT_CLOSE = "close";
 
     private final WorkerConnection connection;
-    private final TypedTicket typedTicket;
+    private TypedTicket typedTicket;
+
+    /**
+     * If non-null, allows the widget to be re-exported from its underlying server-side object after a new session was
+     * created, so that the widget can be revived. Widgets fetched from a raw ticket cannot be re-exported, and can only
+     * be revived while the session that exported them is still alive.
+     */
+    private final Supplier<Promise<TypedTicket>> reexportTicket;
 
     private boolean hasFetched;
+
+    /**
+     * Set when the connection reports this widget as disconnected, cleared when a revive (via {@link #reconnect()} or
+     * {@link #refetch()}) succeeds. While set, {@link #refetch()} re-announces the widget to consumers on success.
+     */
+    private boolean awaitingRevive;
 
     private final Supplier<BiDiStream<StreamRequest, StreamResponse>> streamFactory;
     private BiDiStream<StreamRequest, StreamResponse> messageStream;
@@ -130,8 +142,14 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
     private JsArray<JsWidgetExportedObject> exportedObjects;
 
     public JsWidget(WorkerConnection connection, TypedTicket typedTicket) {
+        this(connection, typedTicket, null);
+    }
+
+    public JsWidget(WorkerConnection connection, TypedTicket typedTicket,
+            Supplier<Promise<TypedTicket>> reexportTicket) {
         this.connection = connection;
         this.typedTicket = typedTicket;
+        this.reexportTicket = reexportTicket;
         hasFetched = false;
         BiDiStream.Factory<StreamRequest, StreamResponse> factory = connection.streamFactory();
         streamFactory = () -> factory.<BrowserNextResponse>create(
@@ -160,11 +178,82 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
     @JsMethod
     public void close() {
         suppressEvents();
+        connection.unregisterSimpleReconnectable(this);
         closeStream();
         connection.releaseTicket(getTicket());
     }
 
+    /**
+     * Opens (or reopens) the message stream to the server using the widget's current ticket. If the widget was
+     * disconnected and a new session was created on the server, the old export is gone - when possible, the underlying
+     * object is re-exported with a fresh ticket before the stream is reopened.
+     */
+    @Override
     public Promise<JsWidget> refetch() {
+        if (!awaitingRevive) {
+            // initial fetch, or an internal caller deliberately rebinding the stream
+            return openStream();
+        }
+        if (reexportTicket == null) {
+            // No way to re-export the underlying object - attempt to reattach to the existing export, which only
+            // works if the server kept it alive.
+            return announceAfter(openStream());
+        }
+        return announceAfter(reexportTicket.get()
+                .then(freshTicket -> {
+                    typedTicket = freshTicket;
+                    return openStream();
+                }));
+    }
+
+    /**
+     * The session survived the disconnect, so the export should still be alive - reopen the message stream with the
+     * same ticket. If that fails, fall back to a full refetch when possible.
+     */
+    @Override
+    public void reconnect() {
+        openStream().then(widget -> {
+            announceReconnect();
+            return Promise.resolve(widget);
+        }, failure -> {
+            if (reexportTicket != null) {
+                // the export may have expired after all - retry with a fresh export
+                return refetch();
+            }
+            die(failure);
+            return (Promise<JsWidget>) (Promise) Promise.reject(failure);
+        }).catch_(ignore -> {
+            // failure was already reported via die()
+            return null;
+        });
+    }
+
+    @Override
+    public void disconnected() {
+        awaitingRevive = true;
+        closeStream();
+        super.disconnected();
+    }
+
+    private Promise<JsWidget> announceAfter(Promise<JsWidget> reviveAttempt) {
+        return reviveAttempt.then(widget -> {
+            announceReconnect();
+            return Promise.resolve(widget);
+        }, failure -> {
+            die(failure);
+            return (Promise<JsWidget>) (Promise) Promise.reject(failure);
+        });
+    }
+
+    private void announceReconnect() {
+        awaitingRevive = false;
+        // unsuppress events and fire the reconnect event first, then re-deliver the fresh initial response as a
+        // message so that consumers re-render from the server's current state
+        super.reconnect();
+        fireEvent(EVENT_MESSAGE, new EventDetails(response.getData(), exportedObjects));
+    }
+
+    private Promise<JsWidget> openStream() {
         closeStream();
         return new Promise<>((resolve, reject) -> {
             exportedObjects = new JsArray<>();
@@ -194,7 +283,11 @@ public class JsWidget extends HasEventHandling implements ServerObject, WidgetMe
                     reject.onInvoke(status.getDescription());
                 }
                 DomGlobal.setTimeout(ignore -> {
-                    fireEvent(EVENT_CLOSE);
+                    // Skip the close event on a transport failure while the whole connection is down - the
+                    // connection's lifecycle (disconnected/reconnect/refetch) owns this widget's state instead.
+                    if (status.isOk() || connection.isConnected()) {
+                        fireEvent(EVENT_CLOSE);
+                    }
                 }, 0);
                 closeStream();
             });

--- a/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
+++ b/web/client-api/src/main/java/io/deephaven/web/client/api/widget/JsWidget.java
@@ -161,6 +161,16 @@ public class JsWidget extends HasLifecycle implements ServerObject, WidgetMessag
         return Promise.resolve(this);
     }
 
+    /**
+     * A failed revive means this widget will never reconnect, so stop tracking it as reconnectable (mirroring
+     * {@link #close()}); otherwise it keeps receiving disconnect/refetch calls on every future reconnect.
+     */
+    @Override
+    public void die(Object error) {
+        connection.unregisterSimpleReconnectable(this);
+        super.die(error);
+    }
+
     private void closeStream() {
         if (messageStream != null) {
             messageStream.end();


### PR DESCRIPTION
JsWidget extended HasEventHandling and was never registered as reconnectable, so after a disconnect its message stream was nulled and never reopened - every subsequent message became a silent no-op, leaving deephaven.ui components (e.g. a ui.button) dead until page reload.

Make JsWidget lifecycle-aware (extend HasLifecycle) and register plain widgets as reconnectable, so on reconnect it reopens its stream, emits disconnect/ reconnect events, and re-delivers the current document.

Fixes #8240