### PR TITLE
chore: Update web v1.26.0

### DIFF
--- a/web/client-ui/Dockerfile
+++ b/web/client-ui/Dockerfile
@@ -2,10 +2,10 @@ FROM deephaven/node:local-build
 WORKDIR /usr/src/app
 
 # Most of the time, these versions are the same, except in cases where a patch only affects one of the packages
-ARG WEB_VERSION=1.24.0
+ARG WEB_VERSION=1.26.0
 ARG GRID_VERSION=1.1.0
 ARG CHART_VERSION=1.1.0
-ARG WIDGET_VERSION=1.24.0
+ARG WIDGET_VERSION=1.26.0
 
 # Pull in the published code-studio package from npmjs and extract is
 RUN set -eux; \


### PR DESCRIPTION
Release notes: https://github.com/deephaven/web-client-ui/releases/tag/v1.26.0

- DH-22030: Add event handler prereqs to chart

Release notes: https://github.com/deephaven/web-client-ui/releases/tag/v1.25.0
Features
- DH-21344: Dropdown for input table enums

Bug Fixes
- DH-22961: Content toolbar buttons overflow
- DH-23020: Fix input table delete exceeds max stack
- DH-23038: Fix extraneous characters from input table context menu paste
