### PR TITLE
fix: DH-23105: Correct SourceTable sorted attribute assignment

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/SourceTable.java
@@ -307,18 +307,6 @@ public abstract class SourceTable<IMPL_TYPE extends SourceTable<IMPL_TYPE>> exte
     protected final QueryTable doCoalesce() {
         initialize();
 
-        if (!isRefreshing()) {
-            final Collection<TableLocation> includedLocations = columnSourceManager.includedLocations();
-            if (includedLocations.size() == 1) {
-                for (final SortColumn sc : includedLocations.iterator().next().getSortedColumns()) {
-                    final SortingOrder order = sc.order() == SortColumn.Order.ASCENDING
-                            ? SortingOrder.Ascending
-                            : SortingOrder.Descending;
-                    SortedColumnsAttribute.setOrderForColumn(this, sc.column().name(), order);
-                }
-            }
-        }
-
         final OperationSnapshotControl snapshotControl =
                 createSnapshotControlIfRefreshing((final BaseTable<?> parent) -> new OperationSnapshotControl(parent) {
 
@@ -336,6 +324,19 @@ public abstract class SourceTable<IMPL_TYPE extends SourceTable<IMPL_TYPE>> exte
             copyAttributes(resultTable, CopyAttributeOperation.Coalesce);
             if (rowSet.isEmpty()) {
                 resultTable.setAttribute(INITIALLY_EMPTY_COALESCED_SOURCE_TABLE_ATTRIBUTE, true);
+            }
+            if (!isRefreshing()) {
+                // (Maybe) set the sorted attribute on the result table (not on the uncoalesced table).
+                // Its attributes may already have been published and frozen.
+                final Collection<TableLocation> includedLocations = columnSourceManager.includedLocations();
+                if (includedLocations.size() == 1) {
+                    for (final SortColumn sc : includedLocations.iterator().next().getSortedColumns()) {
+                        final SortingOrder order = sc.order() == SortColumn.Order.ASCENDING
+                                ? SortingOrder.Ascending
+                                : SortingOrder.Descending;
+                        SortedColumnsAttribute.setOrderForColumn(resultTable, sc.column().name(), order);
+                    }
+                }
             }
 
             if (snapshotControl != null) {

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableReadWriteTest.java
@@ -623,9 +623,9 @@ public final class ParquetTableReadWriteTest {
         final File dest = new File(rootFile, "ParquetTest_sortedColumnsAttribute_test.parquet");
         writeTable(sorted, dest.getPath());
 
-        // Coalescing populates the sort attribute from parquet metadata onto the SourceTable
-        final Table fromDisk = readTable(dest.getPath());
-        fromDisk.coalesce();
+        // Coalescing populates the sort attribute from parquet metadata onto the coalesced result table; the
+        // uncoalesced SourceTable's attributes are never mutated (they may already have been published)
+        final Table fromDisk = readTable(dest.getPath()).coalesce();
         assertEquals(Optional.of(SortingOrder.Ascending),
                 SortedColumnsAttribute.getOrderForColumn(fromDisk, "x"));
         assertEquals(Optional.empty(),
@@ -636,8 +636,7 @@ public final class ParquetTableReadWriteTest {
         final File dest2 = new File(rootFile, "ParquetTest_sortedColumnsAttribute_test2.parquet");
         writeTable(sorted2, dest2.getPath());
 
-        final Table fromDisk2 = readTable(dest2.getPath());
-        fromDisk2.coalesce();
+        final Table fromDisk2 = readTable(dest2.getPath()).coalesce();
         assertEquals(Optional.of(SortingOrder.Ascending),
                 SortedColumnsAttribute.getOrderForColumn(fromDisk2, "x"));
 
@@ -646,8 +645,7 @@ public final class ParquetTableReadWriteTest {
         final File dest3 = new File(rootFile, "ParquetTest_sortedColumnsAttribute_desc_test.parquet");
         writeTable(sortedDesc, dest3.getPath());
 
-        final Table fromDisk3 = readTable(dest3.getPath());
-        fromDisk3.coalesce();
+        final Table fromDisk3 = readTable(dest3.getPath()).coalesce();
         assertEquals(Optional.of(SortingOrder.Descending),
                 SortedColumnsAttribute.getOrderForColumn(fromDisk3, "x"));
     }

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/TestParquetTools.java
@@ -16,6 +16,8 @@ import io.deephaven.engine.table.Table;
 import io.deephaven.engine.table.TableDefinition;
 import io.deephaven.engine.table.impl.InMemoryTable;
 import io.deephaven.engine.table.impl.QueryTable;
+import io.deephaven.engine.table.impl.SortedColumnsAttribute;
+import io.deephaven.engine.table.impl.SortingOrder;
 import io.deephaven.engine.table.impl.UncoalescedTable;
 import io.deephaven.engine.table.impl.indexer.DataIndexer;
 import io.deephaven.engine.table.impl.locations.TableDataException;
@@ -1446,6 +1448,26 @@ public class TestParquetTools {
             }
             return Optional.empty();
         }
+    }
+
+    /**
+     * Regression test for publishing a source table's attributes before its first coalesce. Reading a parquet file with
+     * sorting metadata, publishing the uncoalesced table's attributes (as the server's export path does when sending
+     * table metadata to clients), and then coalescing must not throw, and the coalesced result must still carry the
+     * sorted-columns attribute.
+     */
+    @Test
+    public void testPublishAttributesBeforeCoalesce() {
+        final Path parquetFile = Path.of(testRoot, "testPublishAttributesBeforeCoalesce.parquet");
+        final Table sorted = emptyTable(100).update("A = ii % 10").sort("A");
+        ParquetTools.writeTable(sorted, parquetFile.toString());
+
+        final Table fromDisk = ParquetTools.readTable(parquetFile.toString());
+        // Publish the (uncoalesced) table's attributes before the first coalesce
+        fromDisk.getAttributes();
+        final Table coalesced = fromDisk.coalesce();
+        assertEquals(Optional.of(SortingOrder.Ascending), SortedColumnsAttribute.getOrderForColumn(coalesced, "A"));
+        assertTableEquals(sorted, coalesced);
     }
 
     /**


### PR DESCRIPTION
Corrects sorted-column metadata assignment during `SourceTable` coalescing.

**Changes:**
- Applies sorting metadata to the coalesced result instead of the published source table.
- Updates round-trip tests and adds regression coverage.
