### PR TITLE
fix: DH-23111: ensure recursive protobuf checking is done correctly

### DIFF
--- a/extensions/protobuf/build.gradle
+++ b/extensions/protobuf/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'io.deephaven.project.register'
-    id 'com.google.protobuf' version '0.9.6'
+    alias(libs.plugins.protobuf)
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -364,3 +364,6 @@ testcontainers-localstack = { module = "org.testcontainers:localstack", version.
 testcontainers-minio = { module = "org.testcontainers:minio", version.ref = "testcontainers" }
 testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers" }
 testcontainers-redpanda = { module = "org.testcontainers:redpanda", version.ref = "testcontainers" }
+
+[plugins]
+protobuf = { id = "com.google.protobuf", version = "0.9.6" }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'io.deephaven.project.register'
+    alias(libs.plugins.protobuf)
 }
 
 dependencies {
@@ -127,4 +128,10 @@ TestTools.addEngineOutOfBandTest(project)
 
 test {
     systemProperty 'ApplicationConfigs.testAppDir', layout.projectDirectory.dir('src/test/app.d/').toString()
+}
+
+protobuf {
+    protoc {
+        artifact = libs.protoc.get().toString()
+    }
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -135,3 +135,11 @@ protobuf {
         artifact = libs.protoc.get().toString()
     }
 }
+
+spotless {
+    java {
+        targetExclude(
+                'build/generated/sources/proto/test/java/**',
+        )
+    }
+}

--- a/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
+++ b/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 
@@ -85,7 +86,14 @@ public class GrpcErrorHelper {
                 continue;
             }
             fds.push(fd);
-            checkHasNoUnknownFieldsRecursiveImpl(topLevel, fds, (Message) e.getValue());
+            if (!fd.isRepeated()) {
+                checkHasNoUnknownFieldsRecursiveImpl(topLevel, fds, (Message) e.getValue());
+            } else {
+                final List<?> values = (List<?>) e.getValue();
+                for (Object value : values) {
+                    checkHasNoUnknownFieldsRecursiveImpl(topLevel, fds, (Message) value);
+                }
+            }
             if (fds.pop() != fd) {
                 throw new IllegalStateException("pop did not produce the expected result");
             }

--- a/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
+++ b/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
@@ -7,6 +7,7 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.UnknownFieldSet;
 import com.google.rpc.Code;
 import io.deephaven.proto.util.Exceptions;
 import io.grpc.StatusRuntimeException;
@@ -67,9 +68,12 @@ public class GrpcErrorHelper {
     }
 
     public static void checkHasNoUnknownFields(Message message) {
-        if (!message.getUnknownFields().isEmpty()) {
-            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
-                    String.format("%s has unknown field(s)", message.getDescriptorForType().getFullName()));
+        final UnknownFieldSet unknownFields = message.getUnknownFields();
+        if (!unknownFields.isEmpty()) {
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT, String.format(
+                    "%s has unknown field(s) with id %s",
+                    message.getDescriptorForType().getFullName(),
+                    unknownFields.asMap().keySet()));
         }
     }
 
@@ -103,7 +107,10 @@ public class GrpcErrorHelper {
     private static void checkHasNoUnknownFieldsAtPath(Message topLevel, Deque<FieldDescriptor> path, Message message) {
         if (path.isEmpty()) {
             checkHasNoUnknownFields(message);
-        } else if (!message.getUnknownFields().isEmpty()) {
+            return;
+        }
+        final UnknownFieldSet unknownFields = message.getUnknownFields();
+        if (!unknownFields.isEmpty()) {
             // In Java 21+, we can simplify pathString construction.
             // final String pathString = path.reversed().toString()
             final String pathString;
@@ -117,8 +124,10 @@ public class GrpcErrorHelper {
                 pathString = sb.toString();
             }
             throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
-                    String.format("%s has unknown field(s), topLevel=%s, path=[%s]",
-                            message.getDescriptorForType().getFullName(), topLevel.getDescriptorForType().getFullName(),
+                    String.format("%s has unknown field(s) with id %s, topLevel=%s, path=[%s]",
+                            message.getDescriptorForType().getFullName(),
+                            unknownFields.asMap().keySet(),
+                            topLevel.getDescriptorForType().getFullName(),
                             pathString));
         }
     }

--- a/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
+++ b/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
@@ -13,6 +13,9 @@ import io.grpc.StatusRuntimeException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Objects;
 
@@ -63,18 +66,53 @@ public class GrpcErrorHelper {
     }
 
     public static void checkHasNoUnknownFields(Message message) {
-        if (!message.getUnknownFields().asMap().isEmpty()) {
+        if (!message.getUnknownFields().isEmpty()) {
             throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
                     String.format("%s has unknown field(s)", message.getDescriptorForType().getFullName()));
         }
     }
 
     public static void checkHasNoUnknownFieldsRecursive(Message message) {
-        checkHasNoUnknownFields(message);
+        checkHasNoUnknownFieldsRecursiveImpl(message, new ArrayDeque<>(), message);
+    }
+
+    private static void checkHasNoUnknownFieldsRecursiveImpl(Message topLevel, Deque<FieldDescriptor> fds,
+            Message message) {
+        checkHasNoUnknownFieldsAtPath(topLevel, fds, message);
         for (Entry<FieldDescriptor, Object> e : message.getAllFields().entrySet()) {
-            if (e instanceof Message) {
-                checkHasNoUnknownFieldsRecursive((Message) e);
+            final FieldDescriptor fd = e.getKey();
+            if (fd.getJavaType() != FieldDescriptor.JavaType.MESSAGE) {
+                continue;
             }
+            fds.push(fd);
+            checkHasNoUnknownFieldsRecursiveImpl(topLevel, fds, (Message) e.getValue());
+            if (fds.pop() != fd) {
+                throw new IllegalStateException("pop did not produce the expected result");
+            }
+        }
+    }
+
+    private static void checkHasNoUnknownFieldsAtPath(Message topLevel, Deque<FieldDescriptor> path, Message message) {
+        if (path.isEmpty()) {
+            checkHasNoUnknownFields(message);
+        } else if (!message.getUnknownFields().isEmpty()) {
+            // In Java 21+, we can simplify pathString construction.
+            // final String pathString = path.reversed().toString()
+            final String pathString;
+            {
+                final StringBuilder sb = new StringBuilder();
+                final Iterator<FieldDescriptor> it = path.descendingIterator();
+                sb.append('[').append(it.next());
+                while (it.hasNext()) {
+                    sb.append(',').append(it.next());
+                }
+                sb.append(']');
+                pathString = sb.toString();
+            }
+            throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
+                    String.format("%s has unknown field(s), topLevel=%s, path=%s",
+                            message.getDefaultInstanceForType().getDescriptorForType().getFullName(),
+                            topLevel.getDescriptorForType().getFullName(), pathString));
         }
     }
 

--- a/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
+++ b/server/src/main/java/io/deephaven/server/grpc/GrpcErrorHelper.java
@@ -102,17 +102,16 @@ public class GrpcErrorHelper {
             {
                 final StringBuilder sb = new StringBuilder();
                 final Iterator<FieldDescriptor> it = path.descendingIterator();
-                sb.append('[').append(it.next());
+                sb.append(it.next());
                 while (it.hasNext()) {
                     sb.append(',').append(it.next());
                 }
-                sb.append(']');
                 pathString = sb.toString();
             }
             throw Exceptions.statusRuntimeException(Code.INVALID_ARGUMENT,
-                    String.format("%s has unknown field(s), topLevel=%s, path=%s",
-                            message.getDefaultInstanceForType().getDescriptorForType().getFullName(),
-                            topLevel.getDescriptorForType().getFullName(), pathString));
+                    String.format("%s has unknown field(s), topLevel=%s, path=[%s]",
+                            message.getDescriptorForType().getFullName(), topLevel.getDescriptorForType().getFullName(),
+                            pathString));
         }
     }
 

--- a/server/src/test/java/io/deephaven/server/grpc/GrpcErrorHelperTest.java
+++ b/server/src/test/java/io/deephaven/server/grpc/GrpcErrorHelperTest.java
@@ -10,6 +10,8 @@ import io.deephaven.protobuf.test.Message2v1;
 import io.deephaven.protobuf.test.Message2v2;
 import io.deephaven.protobuf.test.OuterV1;
 import io.deephaven.protobuf.test.OuterV2;
+import io.deephaven.protobuf.test.RepeatedFieldv1;
+import io.deephaven.protobuf.test.RepeatedFieldv2;
 import io.grpc.StatusRuntimeException;
 import org.junit.Test;
 
@@ -151,6 +153,50 @@ public class GrpcErrorHelperTest {
             } catch (final StatusRuntimeException e) {
                 assertThat(e).hasMessageContaining(
                         "io.deephaven.protobuf.test.Message1v1 has unknown field(s), topLevel=io.deephaven.protobuf.test.OuterV1, path=[io.deephaven.protobuf.test.OuterV1.inner,io.deephaven.protobuf.test.Message2v1.message]");
+            }
+        }
+    }
+
+    @Test
+    public void unknownFieldsRepeatedMessage() throws InvalidProtocolBufferException {
+        {
+            // establishing a precondition that we can decode just an id
+            final RepeatedFieldv2 v2OnlyId = RepeatedFieldv2.newBuilder()
+                    .addMessage(Message1v2.newBuilder().setId(42).build())
+                    .build();
+            final RepeatedFieldv1 expected = RepeatedFieldv1.newBuilder()
+                    .addMessage(Message1v1.newBuilder().setId(42).build())
+                    .build();
+            assertThat(RepeatedFieldv1.parseFrom(v2OnlyId.toByteString())).isEqualTo(expected);
+        }
+
+        {
+            final RepeatedFieldv2 v2 = RepeatedFieldv2.newBuilder()
+                    .addMessage(Message1v2.newBuilder()
+                            .setId(42)
+                            .setName("Foo Bar")
+                            .build())
+                    .build();
+
+            final RepeatedFieldv1 v1 = RepeatedFieldv1.parseFrom(v2.toByteString());
+            assertThat(v1.getUnknownFields().isEmpty()).isTrue();
+            for (Message1v1 message1v1 : v1.getMessageList()) {
+                assertThat(message1v1.getUnknownFields().isEmpty()).isFalse();
+                assertThat(message1v1.getUnknownFields().hasField(Message1v2.NAME_FIELD_NUMBER)).isTrue();
+            }
+            // v2 is fine
+            GrpcErrorHelper.checkHasNoUnknownFields(v2);
+            GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v2);
+
+            // v1 no has unknown fields _itself_
+            GrpcErrorHelper.checkHasNoUnknownFields(v1);
+            // but, recursively, it does have known fields
+            try {
+                GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v1);
+                failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+            } catch (final StatusRuntimeException e) {
+                assertThat(e).hasMessageContaining(
+                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s), topLevel=io.deephaven.protobuf.test.RepeatedFieldv1, path=[io.deephaven.protobuf.test.RepeatedFieldv1.message]");
             }
         }
     }

--- a/server/src/test/java/io/deephaven/server/grpc/GrpcErrorHelperTest.java
+++ b/server/src/test/java/io/deephaven/server/grpc/GrpcErrorHelperTest.java
@@ -1,0 +1,157 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.server.grpc;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.deephaven.protobuf.test.Message1v1;
+import io.deephaven.protobuf.test.Message1v2;
+import io.deephaven.protobuf.test.Message2v1;
+import io.deephaven.protobuf.test.Message2v2;
+import io.deephaven.protobuf.test.OuterV1;
+import io.deephaven.protobuf.test.OuterV2;
+import io.grpc.StatusRuntimeException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class GrpcErrorHelperTest {
+
+    @Test
+    public void unknownFieldsFlatMessage() throws InvalidProtocolBufferException {
+        {
+            // establishing a precondition that we can decode just an id
+            final Message1v2 v2OnlyId = Message1v2.newBuilder().setId(42).build();
+            final Message1v1 expected = Message1v1.newBuilder().setId(42).build();
+            assertThat(Message1v1.parseFrom(v2OnlyId.toByteString())).isEqualTo(expected);
+        }
+
+        {
+            final Message1v2 v2 = Message1v2.newBuilder().setId(42).setName("Foo Bar").build();
+            final Message1v1 v1 = Message1v1.parseFrom(v2.toByteString());
+            assertThat(v1.getUnknownFields().isEmpty()).isFalse();
+            assertThat(v1.getUnknownFields().hasField(Message1v2.NAME_FIELD_NUMBER));
+
+            // v2 is fine
+            GrpcErrorHelper.checkHasNoUnknownFields(v2);
+            GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v2);
+
+            // v1 has unknown fields
+            try {
+                GrpcErrorHelper.checkHasNoUnknownFields(v1);
+                failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+            } catch (final StatusRuntimeException e) {
+                assertThat(e).hasMessageContaining("io.deephaven.protobuf.test.Message1v1 has unknown field(s)");
+            }
+            try {
+                GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v1);
+                failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+            } catch (final StatusRuntimeException e) {
+                assertThat(e).hasMessageContaining("io.deephaven.protobuf.test.Message1v1 has unknown field(s)");
+            }
+        }
+    }
+
+    @Test
+    public void unknownFieldsNestedMessage() throws InvalidProtocolBufferException {
+        {
+
+            // establishing a precondition that we can decode just an id
+            final Message2v2 v2OnlyId = Message2v2.newBuilder()
+                    .setId(42)
+                    .setMessage(Message1v2.newBuilder().setId(42).build())
+                    .build();
+            final Message2v1 expected = Message2v1.newBuilder()
+                    .setId(42)
+                    .setMessage(Message1v1.newBuilder().setId(42).build())
+                    .build();
+            assertThat(Message2v1.parseFrom(v2OnlyId.toByteString())).isEqualTo(expected);
+        }
+
+        {
+            final Message2v2 v2 = Message2v2.newBuilder()
+                    .setId(42)
+                    .setMessage(Message1v2.newBuilder()
+                            .setId(42)
+                            .setName("Foo Bar")
+                            .build())
+                    .build();
+
+            final Message2v1 v1 = Message2v1.parseFrom(v2.toByteString());
+            assertThat(v1.getUnknownFields().isEmpty()).isTrue();
+            assertThat(v1.getMessage().getUnknownFields().isEmpty()).isFalse();
+            assertThat(v1.getMessage().getUnknownFields().hasField(Message1v2.NAME_FIELD_NUMBER)).isTrue();
+
+
+            // v2 is fine
+            GrpcErrorHelper.checkHasNoUnknownFields(v2);
+            GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v2);
+
+            // v1 no has unknown fields _itself_
+            GrpcErrorHelper.checkHasNoUnknownFields(v1);
+            // but, recursively, it does have known fields
+            try {
+                GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v1);
+                failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+            } catch (final StatusRuntimeException e) {
+                assertThat(e).hasMessageContaining(
+                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s), topLevel=io.deephaven.protobuf.test.Message2v1, path=[io.deephaven.protobuf.test.Message2v1.message]");
+            }
+        }
+    }
+
+    @Test
+    public void unknownFieldsDoubleNestedMessage() throws InvalidProtocolBufferException {
+        {
+
+            // establishing a precondition that we can decode just an id
+            final OuterV2 v2OnlyId = OuterV2.newBuilder().setInner(Message2v2.newBuilder()
+                    .setId(42)
+                    .setMessage(Message1v2.newBuilder().setId(42).build())
+                    .build())
+                    .build();
+            final OuterV1 expected = OuterV1.newBuilder().setInner(Message2v1.newBuilder()
+                    .setId(42)
+                    .setMessage(Message1v1.newBuilder().setId(42).build())
+                    .build())
+                    .build();
+            assertThat(OuterV1.parseFrom(v2OnlyId.toByteString())).isEqualTo(expected);
+        }
+
+        {
+            final OuterV2 v2 = OuterV2.newBuilder().setInner(Message2v2.newBuilder()
+                    .setId(42)
+                    .setMessage(Message1v2.newBuilder()
+                            .setId(42)
+                            .setName("Foo Bar")
+                            .build())
+                    .build())
+                    .build();
+
+            final OuterV1 v1 = OuterV1.parseFrom(v2.toByteString());
+            assertThat(v1.getUnknownFields().isEmpty()).isTrue();
+            assertThat(v1.getInner().getUnknownFields().isEmpty()).isTrue();
+            assertThat(v1.getInner().getMessage().getUnknownFields().isEmpty()).isFalse();
+            assertThat(v1.getInner().getMessage().getUnknownFields().hasField(Message1v2.NAME_FIELD_NUMBER)).isTrue();
+
+            // v2 is fine
+            GrpcErrorHelper.checkHasNoUnknownFields(v2);
+            GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v2);
+
+            // v1 has no unknown fields _itself_
+            GrpcErrorHelper.checkHasNoUnknownFields(v1);
+            // v1.inner has no known fields _itself_
+            GrpcErrorHelper.checkHasNoUnknownFields(v1.getInner());
+
+            // but, recursively, it does have known fields
+            try {
+                GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v1);
+                failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
+            } catch (final StatusRuntimeException e) {
+                assertThat(e).hasMessageContaining(
+                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s), topLevel=io.deephaven.protobuf.test.OuterV1, path=[io.deephaven.protobuf.test.OuterV1.inner,io.deephaven.protobuf.test.Message2v1.message]");
+            }
+        }
+    }
+}

--- a/server/src/test/java/io/deephaven/server/grpc/GrpcErrorHelperTest.java
+++ b/server/src/test/java/io/deephaven/server/grpc/GrpcErrorHelperTest.java
@@ -44,13 +44,15 @@ public class GrpcErrorHelperTest {
                 GrpcErrorHelper.checkHasNoUnknownFields(v1);
                 failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
             } catch (final StatusRuntimeException e) {
-                assertThat(e).hasMessageContaining("io.deephaven.protobuf.test.Message1v1 has unknown field(s)");
+                assertThat(e)
+                        .hasMessageContaining("io.deephaven.protobuf.test.Message1v1 has unknown field(s) with id [2]");
             }
             try {
                 GrpcErrorHelper.checkHasNoUnknownFieldsRecursive(v1);
                 failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
             } catch (final StatusRuntimeException e) {
-                assertThat(e).hasMessageContaining("io.deephaven.protobuf.test.Message1v1 has unknown field(s)");
+                assertThat(e)
+                        .hasMessageContaining("io.deephaven.protobuf.test.Message1v1 has unknown field(s) with id [2]");
             }
         }
     }
@@ -98,7 +100,7 @@ public class GrpcErrorHelperTest {
                 failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
             } catch (final StatusRuntimeException e) {
                 assertThat(e).hasMessageContaining(
-                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s), topLevel=io.deephaven.protobuf.test.Message2v1, path=[io.deephaven.protobuf.test.Message2v1.message]");
+                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s) with id [2], topLevel=io.deephaven.protobuf.test.Message2v1, path=[io.deephaven.protobuf.test.Message2v1.message]");
             }
         }
     }
@@ -152,7 +154,7 @@ public class GrpcErrorHelperTest {
                 failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
             } catch (final StatusRuntimeException e) {
                 assertThat(e).hasMessageContaining(
-                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s), topLevel=io.deephaven.protobuf.test.OuterV1, path=[io.deephaven.protobuf.test.OuterV1.inner,io.deephaven.protobuf.test.Message2v1.message]");
+                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s) with id [2], topLevel=io.deephaven.protobuf.test.OuterV1, path=[io.deephaven.protobuf.test.OuterV1.inner,io.deephaven.protobuf.test.Message2v1.message]");
             }
         }
     }
@@ -196,7 +198,7 @@ public class GrpcErrorHelperTest {
                 failBecauseExceptionWasNotThrown(StatusRuntimeException.class);
             } catch (final StatusRuntimeException e) {
                 assertThat(e).hasMessageContaining(
-                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s), topLevel=io.deephaven.protobuf.test.RepeatedFieldv1, path=[io.deephaven.protobuf.test.RepeatedFieldv1.message]");
+                        "io.deephaven.protobuf.test.Message1v1 has unknown field(s) with id [2], topLevel=io.deephaven.protobuf.test.RepeatedFieldv1, path=[io.deephaven.protobuf.test.RepeatedFieldv1.message]");
             }
         }
     }

--- a/server/src/test/proto/example_messages.proto
+++ b/server/src/test/proto/example_messages.proto
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-2022 Deephaven Data Labs and Patent Pending
+ */
+syntax = "proto3";
+
+
+package io.deephaven.protobuf.test;
+
+option java_multiple_files = true;
+option optimize_for = SPEED;
+
+message Message1v1 {
+  int32 id = 1;
+}
+
+// Note: for ease of testing purposes, this is meant to be an evolution of Message1v1 (ie, it must be an "extension"
+// of Message1v1, with the same initial fields).
+message Message1v2 {
+  int32 id = 1;
+  string name = 2;
+}
+
+message Message2v1 {
+  int64 id = 1;
+  Message1v1 message = 2;
+}
+
+// Note: for ease of testing purposes, this is meant to be an evolution of Message2v1 (ie, it must be an "extension"
+// of Message2v1, with the same initial fields).
+message Message2v2 {
+  int64 id = 1;
+  Message1v2 message = 2;
+}
+
+// one more layer of nested
+
+message OuterV1 {
+  Message2v1 inner = 1;
+}
+
+message OuterV2 {
+  Message2v2 inner = 1;
+}

--- a/server/src/test/proto/example_messages.proto
+++ b/server/src/test/proto/example_messages.proto
@@ -41,3 +41,13 @@ message OuterV1 {
 message OuterV2 {
   Message2v2 inner = 1;
 }
+
+message RepeatedFieldv1 {
+  repeated Message1v1 message = 1;
+}
+
+// Note: for ease of testing purposes, this is meant to be an evolution of RepeatedFieldv1 (ie, it must be an "extension"
+// of RepeatedFieldv1, with the same initial fields).
+message RepeatedFieldv2 {
+  repeated Message1v2 message = 1;
+}


### PR DESCRIPTION
This fixes the recursive protobuf unknown field detection, while also providing a more detailed error message when the unknown field is nested.