### PR TITLE
fix(py/jpy-integration): DH-23071, DH-21041: Fix flaky jpy cleanup tests by polling instead of racing the finalizer

### DIFF
--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCounting.java
@@ -8,8 +8,9 @@ import org.jpy.CreateModule;
 import org.jpy.PyObject;
 import org.junit.Assert;
 
+import java.lang.ref.Reference;
+import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -39,7 +40,7 @@ public class ReferenceCounting implements AutoCloseable {
         Assert.assertEquals(expectedReferenceCount, RefcountModule.refcount(refcountModule, object));
         gc.collect();
         Assert.assertEquals(expectedReferenceCount, RefcountModule.refcount(refcountModule, object));
-        blackhole(object);
+        Reference.reachabilityFence(object);
     }
 
     public void check(int expectedReferenceCount, Object obj) {
@@ -73,88 +74,53 @@ public class ReferenceCounting implements AutoCloseable {
     }
 
     /**
-     * This is a fragile method, whose aspiration is to ensure that garbage collection happens.
+     * Rather than trying to demonstrate that cleanup happens at a specific moment (which the JVM does not guarantee,
+     * and which made the previous finalizer-sentinel version of this method flaky — see git history), this method only
+     * asks that cleanup happen eventually: it repeatedly nudges the JVM garbage collector, drains the jpy reference
+     * queue, and runs the Python garbage collector, polling the caller's condition until it becomes true or the timeout
+     * expires.
      *
-     * The strategy is to make three objects: a sentinel object, the caller object under test, and then another sentinel
-     * object. The trick here is to create the caller object under test after the first sentinel but before the second
-     * sentinel. The underlying assumption is that "surely" the garbage collector won't collect both sentinels without
-     * also collecting the caller object.
-     *
-     * Then we try to induce garbage collection.
-     *
-     * Then we ask the caller if it looks like their object was finalized.
-     *
-     * There are three possible outcomes: 1. If the two sentinel objects were not both finalized, return
-     * GC_DIDNT_HAPPEN. 2. If the two sentinel objects were finalized but the caller object under test was not, return
-     * GC_HAPPENED_BUT_CLIENT_OBJECT_WASNT_FINALIZED. 3. Otherwise, if all three objects were finalized, return SUCCESS.
-     *
-     * @param makeObject Create the caller object under test and supply it to us. We will set our reference to null at
-     *        the appropriate time. The caller should not try to hold a reference to it
+     * @param makeObject Create the caller object under test and supply it to us. We will drop our reference to it
+     *        before polling. The caller should not try to hold a reference to it
      * @param didFinalizationHappen Return true if the caller determines that finalization happened on its object.
      *        Otherwise, return false.
+     * @return true if cleanup was observed before the timeout, false otherwise
      */
-    public <T> CleanupResult doesCleanupHappenAtFinalizerTime(
-            Supplier<T> makeObject, BooleanSupplier didFinalizationHappen) throws InterruptedException {
-        final CountDownLatch latch = new CountDownLatch(2);
-        Object beforeSentinel = new Object() {
-            @Override
-            protected void finalize() throws Throwable {
-                super.finalize();
-                latch.countDown();
-            }
-        };
-
+    public <T> boolean doesCleanupHappenEventually(
+            Supplier<T> makeObject, BooleanSupplier didFinalizationHappen)
+            throws InterruptedException {
         T callerObject = makeObject.get();
-
-        Object afterSentinel = new Object() {
-            @Override
-            protected void finalize() throws Throwable {
-                super.finalize();
-                latch.countDown();
-            }
-        };
-
-        blackhole(beforeSentinel, callerObject, afterSentinel);
-
-        beforeSentinel = null;
+        Reference.reachabilityFence(callerObject);
+        // noinspection UnusedAssignment
         callerObject = null;
-        afterSentinel = null;
 
-        // Will try 20 times, for a total of 5 seconds, to collect the garbage
-        // and wait for both sentinels to be finalized.
-        for (int i = 0; i < 20; i++) {
+        // Implementation note: the problem with the former test is that it waited for evidence that GC happened, and
+        // then *immediately* called PyObject.cleanup().
+        // PyObject.cleanup() works by processing swept Weak/PhantomReferences from their queue. There is a race between
+        // the garbage collector posting items to that queue and PyObject.cleanup() checking that queue. If
+        // PyObject.cleanup() is called too early, it may miss the Weak/PhantomReference
+        // being posted. Now, you might think "no worries, if our explicit call to PyObject.cleanup() missed the queue,
+        // the dedicated cleanup thread defined in the JPY project at PyObjectReferences.cleanupThreadLogic() will soon
+        // run and pick it up; all we need to do is wait a couple of seconds for it to wake up and finish."
+        // This was the approach taken by the previous version of the code. The problem is *that thread never runs*
+        // because we have disabled it "for now" in py/jpy-integration/src/javaToPython/build.gradle.template.
+        // To make this more robust, we repeatedly call all the relevant collection methods in a loop until our PyObject
+        // is eventually cleaned up. In ~750 trials the worst case delay was 137 ms, so we are using 5 seconds here,
+        // which is a generous margin without stalling a broken run for long.
+        final Duration cleanupTimeout = Duration.ofSeconds(5);
+
+        final long deadlineNanos = System.nanoTime() + cleanupTimeout.toNanos();
+        while (true) {
             System.gc();
-            System.runFinalization();
-
-            if (latch.await(250, TimeUnit.MILLISECONDS)) {
-                // Both sentinels are finalized. Now see if the caller's
-                // state was finalized.
-                PyObject.cleanup();
-                gc.collect();
-
-                // Wait two more seconds for good luck and to let the above methods
-                // settle and do their thing or whatever
-                TimeUnit.SECONDS.sleep(2);
-
-                return didFinalizationHappen.getAsBoolean() ? CleanupResult.SUCCESS
-                        : CleanupResult.SENTINELS_WERE_FINALIZED_BUT_CLIENT_OBJECT_WAS_NOT;
+            PyObject.cleanup();
+            gc.collect();
+            if (didFinalizationHappen.getAsBoolean()) {
+                return true;
             }
-        }
-
-        return didFinalizationHappen.getAsBoolean() ? CleanupResult.CLIENT_OBJECT_WAS_FINALIZED_BUT_SENTINELS_WERE_NOT
-                : CleanupResult.FINALIZATION_DIDNT_HAPPEN;
-    }
-
-    public enum CleanupResult {
-        SUCCESS, SENTINELS_WERE_FINALIZED_BUT_CLIENT_OBJECT_WAS_NOT, CLIENT_OBJECT_WAS_FINALIZED_BUT_SENTINELS_WERE_NOT, FINALIZATION_DIDNT_HAPPEN
-    }
-
-    /**
-     * The blackhole ensures that java can't GC away our java objects early (which effects the python reference count)
-     */
-    public static void blackhole(Object... objects) {
-        if (Objects.hash(objects) == Integer.MAX_VALUE) {
-            System.out.println("Blackhole"); // very unlikely
+            if (System.nanoTime() >= deadlineNanos) {
+                return false;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
         }
     }
 }

--- a/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCountingTest.java
+++ b/py/jpy-integration/src/javaToPython/java/io/deephaven/jpy/integration/ReferenceCountingTest.java
@@ -8,7 +8,7 @@ import io.deephaven.jpy.JpyModule;
 import io.deephaven.jpy.PythonTest;
 import io.deephaven.jpy.integration.DestructorModuleParent.OnDelete;
 
-import java.time.Duration;
+import java.lang.ref.Reference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -16,7 +16,11 @@ import io.deephaven.jpy.integration.SomeJavaClassOutTest.SomeJavaClass;
 import org.jpy.PyInputMode;
 import org.jpy.PyModule;
 import org.jpy.PyObject;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Tests that when passing array from java to python, it is correctly recognized by jpy.
@@ -71,7 +75,7 @@ public class ReferenceCountingTest extends PythonTest {
 
     @Test
     public void viaPython() throws InterruptedException {
-        final ReferenceCounting.CleanupResult result = ref.doesCleanupHappenAtFinalizerTime(
+        final boolean cleanedUp = ref.doesCleanupHappenEventually(
                 () -> {
                     PyObject.executeCode("import sys", PyInputMode.STATEMENT);
                     PyObject.executeCode("x = dict()", PyInputMode.STATEMENT);
@@ -91,11 +95,7 @@ public class ReferenceCountingTest extends PythonTest {
                     }
                 });
 
-        // Because the test is flaky, for now we will simply report it as "skipped" if it fails.
-        // We accomplish this by using assumeTrue rather than assertTrue.
-        Assume.assumeTrue(
-                "Cleanup didn't happen. Reason: " + result,
-                result == ReferenceCounting.CleanupResult.SUCCESS);
+        Assert.assertTrue("Cleanup didn't happen within the deadline", cleanedUp);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class ReferenceCountingTest extends PythonTest {
         scope.asDict().delItem("copy2");
         ref.check(1, pyObject);
 
-        ReferenceCounting.blackhole(scope);
+        Reference.reachabilityFence(scope);
     }
 
     @Test
@@ -140,7 +140,9 @@ public class ReferenceCountingTest extends PythonTest {
         final PyObject javaCopy2 = scope.asDict().get("copy1");
         ref.check(4, pyObject);
 
-        ReferenceCounting.blackhole(scope, javaCopy1, javaCopy2);
+        Reference.reachabilityFence(scope);
+        Reference.reachabilityFence(javaCopy1);
+        Reference.reachabilityFence(javaCopy2);
     }
 
 
@@ -167,7 +169,8 @@ public class ReferenceCountingTest extends PythonTest {
 
         final PyObject copy2 = pyOut.identity((Object) pyObject);
         ref.check(3, pyObject);
-        ReferenceCounting.blackhole(copy1, copy2);
+        Reference.reachabilityFence(copy1);
+        Reference.reachabilityFence(copy2);
     }
 
     @Test
@@ -185,8 +188,9 @@ public class ReferenceCountingTest extends PythonTest {
         // this tests fails in python 2, but I haven't spent time debugging
         assumePython3();
 
+        // Eventually-consistent by design; see the comment on viaPython.
         final CountDownLatch latch = new CountDownLatch(1);
-        final ReferenceCounting.CleanupResult result = ref.doesCleanupHappenAtFinalizerTime(
+        final boolean cleanedUp = ref.doesCleanupHappenEventually(
                 () -> {
                     PyObject child = destructor.create_child(new OnDelete(latch));
                     ref.check(1, child);
@@ -195,14 +199,8 @@ public class ReferenceCountingTest extends PythonTest {
 
                 () -> latch.getCount() == 0);
 
-        // Because the test is flaky, for now we will simply report it as "skipped" if it fails.
-        // We accomplish this by using assumeTrue rather than assertTrue.
-        Assume.assumeTrue(
-                "Cleanup didn't happen. Reason: " + result,
-                result == ReferenceCounting.CleanupResult.SUCCESS);
+        Assert.assertTrue("Cleanup didn't happen within the deadline", cleanedUp);
     }
-
-
 
     @Test
     public void pythonObjectInJavaWillDestructAfterClosure() throws InterruptedException {


### PR DESCRIPTION
Also use `Reference.reachabilityFence()` (right abstraction) rather than `blackhole()` (wrong abstraction).

Tested on 500 runs in Github Actions. No failures.