### PR TITLE
fix: DH-23106: Column handling for pushdown filters (#8250)

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/AbstractFilterExecution.java
@@ -494,17 +494,19 @@ abstract class AbstractFilterExecution {
         // declares the barrier to any filter that respects it.
         final Map<Object, Collection<Object>> barrierDependencies = new HashMap<>();
 
+        final Map<String, ColumnSource<?>> columnSourceMap = sourceTable.getColumnSourceMap();
+
         try {
             for (int ii = 0; ii < filters.size(); ii++) {
                 final WhereFilter filter = filters.get(ii);
-                if (!PushdownFilterMatcher.canPushdownFilter(filter)) {
+                // Pushdown requires a column source for every filter column; a filter may reference a column that is
+                // not present in the source table (e.g. a ClockFilter after the column was narrowed away), in which
+                // case we skip pushdown and let regular filter execution handle (and report) the missing column.
+                if (!PushdownFilterMatcher.canPushdownFilter(filter)
+                        || !columnSourceMap.keySet().containsAll(filter.getColumns())) {
                     statelessFilters[ii] = new StatelessFilter(ii, filter, null, null, barrierDependencies);
                 } else {
-                    // Only consider column sources that are actually present in the source table,because filters may
-                    // refer to columns like "i" or "ii" that are not actually in the table.
-                    final Map<String, ColumnSource<?>> columnSourceMap = sourceTable.getColumnSourceMap();
                     final List<ColumnSource<?>> filterSources = filter.getColumns().stream()
-                            .filter(columnSourceMap::containsKey)
                             .map(sourceTable::getColumnSource)
                             .collect(Collectors.toList());
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownFilterMatcher.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/PushdownFilterMatcher.java
@@ -4,6 +4,7 @@
 package io.deephaven.engine.table.impl;
 
 import io.deephaven.api.filter.Filter;
+import io.deephaven.base.verify.Assert;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.impl.select.NoPredicatePushdown;
@@ -111,13 +112,16 @@ public interface PushdownFilterMatcher {
      * pushing down the filter (or {@code null} when pushdown is not supported).
      *
      * @param filter The {@link WhereFilter filter} to match.
-     * @param filterSources The list of {@link ColumnSource column sources} that match the filter columns.
+     * @param filterSources The list of {@link ColumnSource column sources} for the filter columns; must be parallel to
+     *        {@link WhereFilter#getColumns() filter.getColumns()}.
      * @return The {@link PushdownFilterMatcher} to use for pushing down the filter, or {@code null} if pushdown is not
      *         supported.
      */
     static PushdownFilterMatcher getPushdownFilterMatcher(
             final WhereFilter filter,
             final List<ColumnSource<?>> filterSources) {
+        Assert.eq(filterSources.size(), "filterSources.size()",
+                filter.getColumns().size(), "filter.getColumns().size()");
         // Select the executor to use for this filter (or assign null if pushdown is not supported).
         if (!PushdownFilterMatcher.canPushdownFilter(filter)) {
             return null;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/PushdownFilterMatcherTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/PushdownFilterMatcherTest.java
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl;
+
+import io.deephaven.base.verify.AssertionFailure;
+import io.deephaven.engine.table.ColumnSource;
+import io.deephaven.engine.table.MatchOptions;
+import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.select.ConjunctiveFilter;
+import io.deephaven.engine.table.impl.select.MatchFilter;
+import io.deephaven.engine.table.impl.select.WhereFilter;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.engine.util.TableTools;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.deephaven.engine.util.TableTools.stringCol;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Tests for {@link PushdownFilterMatcher#getPushdownFilterMatcher(WhereFilter, List)}, in particular the requirement
+ * that {@code filterSources} be parallel to {@code filter.getColumns()} (DH-23106).
+ */
+public class PushdownFilterMatcherTest {
+
+    @Rule
+    public final EngineCleanup cleanup = new EngineCleanup();
+
+    private Table table;
+    private WhereFilter singleColumnFilter;
+    private WhereFilter multiColumnFilter;
+
+    @Before
+    public void setUp() {
+        table = TableTools.newTable(
+                stringCol("X", "A", "B", "C"),
+                stringCol("Y", "D", "E", "F"));
+        singleColumnFilter = new MatchFilter(MatchOptions.REGULAR, "X", "A");
+        multiColumnFilter = ConjunctiveFilter.of(
+                new MatchFilter(MatchOptions.REGULAR, "X", "A"),
+                new MatchFilter(MatchOptions.REGULAR, "Y", "D"));
+        singleColumnFilter.init(table.getDefinition());
+        multiColumnFilter.init(table.getDefinition());
+    }
+
+    @Test
+    public void testParallelSourcesAccepted() {
+        final ColumnSource<?> csX = table.getColumnSource("X");
+        final ColumnSource<?> csY = table.getColumnSource("Y");
+        // Correctly-parallel lists must not throw, whatever matcher (or null) they resolve to.
+        PushdownFilterMatcher.getPushdownFilterMatcher(singleColumnFilter, List.of(csX));
+        PushdownFilterMatcher.getPushdownFilterMatcher(multiColumnFilter, List.of(csX, csY));
+    }
+
+    @Test
+    public void testSingleColumnFilterWithEmptySourcesThrows() {
+        // Before DH-23106 this threw IndexOutOfBoundsException from filterSources.get(0)
+        assertThrows(AssertionFailure.class, () -> PushdownFilterMatcher.getPushdownFilterMatcher(
+                singleColumnFilter, Collections.emptyList()));
+    }
+
+    @Test
+    public void testMultiColumnFilterWithPartialSourcesThrows() {
+        // Before DH-23106 a partial source list was silently passed to PushdownPredicateManager.getSharedPPM,
+        // potentially selecting a shared PPM that does not cover all of the filter's columns
+        final ColumnSource<?> csX = table.getColumnSource("X");
+        assertThrows(AssertionFailure.class, () -> PushdownFilterMatcher.getPushdownFilterMatcher(
+                multiColumnFilter, List.of(csX)));
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableWhereTest.java
@@ -50,6 +50,7 @@ import io.deephaven.util.datastructures.CachingSupplier;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableObject;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -3048,5 +3049,70 @@ public abstract class QueryTableWhereTest {
         }
         final VectorComponentFilterWrapper vectorComponentFilterWrapper = (VectorComponentFilterWrapper) filters[0];
         return new WhereFilter[] {vectorComponentFilterWrapper.breakChunkType()};
+    }
+
+    /**
+     * A filter that declares columns that need not exist in the table being filtered, accepting all rows regardless.
+     * Models filters (like ClockFilter) whose {@code init} does not validate column presence.
+     */
+    private static final class DeclaredColumnsFilter extends WhereFilterImpl {
+        private final List<String> declaredColumns;
+
+        private DeclaredColumnsFilter(final String... declaredColumns) {
+            this.declaredColumns = List.of(declaredColumns);
+        }
+
+        @Override
+        public List<String> getColumns() {
+            return declaredColumns;
+        }
+
+        @Override
+        public List<String> getColumnArrays() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void init(@NotNull final TableDefinition tableDefinition) {}
+
+        @NotNull
+        @Override
+        public WritableRowSet filter(
+                @NotNull final RowSet selection, @NotNull final RowSet fullSet, @NotNull final Table table,
+                final boolean usePrev) {
+            return selection.copy();
+        }
+
+        @Override
+        public boolean isSimpleFilter() {
+            return true;
+        }
+
+        @Override
+        public void setRecomputeListener(final RecomputeListener result) {}
+
+        @Override
+        public WhereFilter copy() {
+            return this;
+        }
+    }
+
+    @Test
+    public void testPushdownFilterColumnMissingFromTable() {
+        // Regression test for DH-23106: a pushdown-eligible filter whose declared column is not present in the
+        // source table must not crash pushdown matcher selection (previously IndexOutOfBoundsException from
+        // PushdownFilterMatcher.getPushdownFilterMatcher indexing an empty source list).
+        final Table source = emptyTable(100).update("X = ii");
+        final Table result = source.where(new DeclaredColumnsFilter("Phantom"));
+        assertTableEquals(source, result);
+    }
+
+    @Test
+    public void testPushdownFilterSomeColumnsMissingFromTable() {
+        // Regression test for DH-23106: a multi-column filter with only some columns present must skip pushdown
+        // entirely rather than hand a partial source list to PushdownPredicateManager.getSharedPPM.
+        final Table source = emptyTable(100).update("X = ii");
+        final Table result = source.where(new DeclaredColumnsFilter("X", "Phantom"));
+        assertTableEquals(source, result);
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestClockFilters.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/select/TestClockFilters.java
@@ -12,6 +12,7 @@ import io.deephaven.api.literal.Literal;
 import io.deephaven.base.Factory;
 import io.deephaven.engine.context.ExecutionContext;
 import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.impl.NoSuchColumnException;
 import io.deephaven.engine.table.vectors.ColumnVectors;
 import io.deephaven.engine.testutil.ControlledUpdateGraph;
 import io.deephaven.engine.testutil.filters.RowSetCapturingFilter;
@@ -881,5 +882,27 @@ public class TestClockFilters {
             expected = expected.sort("Timestamp");
         }
         assertTableEquals(expected, result);
+    }
+
+    @Test
+    public void testUnsortedNarrowedTable() {
+        // Regression test for DH-23106: ClockFilter.init does not validate column presence, so an UnsortedClockFilter
+        // on a column that was narrowed away used to crash pushdown matcher selection with IndexOutOfBoundsException.
+        // The correct failure is a clear NoSuchColumnException from the filter's execution.
+        clock.reset();
+        final UnsortedClockFilter filter = new UnsortedClockFilter("Timestamp", clock, true);
+        final Table narrowed = testInput1.view("Int");
+        try {
+            narrowed.where(filter);
+            fail("expected NoSuchColumnException");
+        } catch (Exception expected) {
+            final StringBuilder chain = new StringBuilder();
+            Throwable cause = expected;
+            while (cause != null && !(cause instanceof NoSuchColumnException)) {
+                chain.append(cause).append("; caused by ");
+                cause = cause.getCause();
+            }
+            assertNotNull("expected NoSuchColumnException in failure chain, but was: " + chain + "null", cause);
+        }
     }
 }


### PR DESCRIPTION
## Pull request overview

Fixes pushdown filter handling when referenced columns are absent.

**Changes:**
- Skips pushdown unless every filter column exists.
- Adds matcher contract validation.
- Adds regression and contract tests.

Cherry pick of #8250