### PR TITLE
fix!: DH-22774: Bump to Calcite 1.42.0 (#8241)

### DIFF
--- a/extensions/flight-sql/build.gradle
+++ b/extensions/flight-sql/build.gradle
@@ -32,11 +32,6 @@ dependencies {
     // :sql does not expose calcite as a dependency (maybe it should?); in the meantime, we want to make sure we can
     // provide reasonable error messages to the client
     implementation libs.calcite.core
-    constraints {
-        implementation(libs.json.smart) {
-            because 'CVE-2024-57699'
-        }
-    }
 
     implementation libs.dagger
     implementation libs.arrow.flight.sql

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,7 @@ avro = "1.12.1"
 awssdk = "2.29.52"
 aws-s3-tables-catalog-for-iceberg = "0.1.8"
 
-# Note: when bumping Calcite version, see if we still need the version constraint for json-smart
-calcite = "1.41.0"
-json-smart = "2.5.2"
+calcite = "1.42.0"
 
 classgraph = "4.8.184"
 commons-compress = "1.28.0"
@@ -140,7 +138,6 @@ awssdk-netty-nio = { module = "software.amazon.awssdk:netty-nio-client" }
 s3-tables-catalog-for-iceberg = { module = "software.amazon.s3tables:s3-tables-catalog-for-iceberg", version.ref = "aws-s3-tables-catalog-for-iceberg" }
 
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }
-json-smart = { module = "net.minidev:json-smart", version.ref = "json-smart" }
 
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -9,11 +9,6 @@ description = 'The Deephaven SQL parser'
 dependencies {
     api project(':qst')
     implementation libs.calcite.core
-    constraints {
-        implementation(libs.json.smart) {
-            because 'CVE-2024-57699'
-        }
-    }
 
     compileOnly project(':util-immutables')
     annotationProcessor libs.immutables.value

--- a/sql/src/main/java/io/deephaven/sql/AggregateCallAdapterImpl.java
+++ b/sql/src/main/java/io/deephaven/sql/AggregateCallAdapterImpl.java
@@ -24,8 +24,14 @@ final class AggregateCallAdapterImpl {
             Map.entry(SqlStdOperatorTable.AVG, aggSpecFunction(AggSpec.avg())),
             Map.entry(SqlStdOperatorTable.SUM, aggSpecFunction(AggSpec.sum())),
             Map.entry(SqlStdOperatorTable.ANY_VALUE, aggSpecFunction(AggSpec.first())),
-            Map.entry(SqlStdOperatorTable.FIRST_VALUE, aggSpecFunction(AggSpec.first())),
-            Map.entry(SqlStdOperatorTable.LAST_VALUE, aggSpecFunction(AggSpec.last())),
+            // SQLTODO(window-functions): FIRST_VALUE / LAST_VALUE are window-only functions in the SQL standard
+            // (they require an OVER clause); their bare-aggregate form was a non-standard extension. As of Calcite
+            // 1.42, the validator enforces conformance and rejects the bare form, so it can no longer be mapped
+            // here. Windowed usage (OVER ...) produces a LogicalWindow RelNode that is not yet translated (see
+            // RelNodeVisitorAdapter); supporting it would map to Table#updateBy (QST UpdateByTable). Until then,
+            // these are unsupported.
+            // Map.entry(SqlStdOperatorTable.FIRST_VALUE, aggSpecFunction(AggSpec.first())),
+            // Map.entry(SqlStdOperatorTable.LAST_VALUE, aggSpecFunction(AggSpec.last())),
             Map.entry(SqlStdOperatorTable.STDDEV, aggSpecFunction(AggSpec.std())),
             Map.entry(SqlStdOperatorTable.VARIANCE, aggSpecFunction(AggSpec.var())),
             Map.entry(SqlStdOperatorTable.COUNT, AggregateCallAdapterImpl::count),

--- a/sql/src/test/resources/io/deephaven/sql/qst-12.dot
+++ b/sql/src/test/resources/io/deephaven/sql/qst-12.dot
@@ -2,8 +2,8 @@ digraph {
 "op_0" ["label"="ticketTable(scan/books)"]
 "op_1" ["label"="view(__p_2_0=Id,__p_2_1=Title,__p_2_2=AuthorId)"]
 "op_2" ["label"="view(__a_1_0=__p_2_2,__a_1_1=__p_2_0)"]
-"op_3" ["label"="aggBy([],[__p_0_0 = count, __p_0_1 = __a_1_0 aggregated with max, __p_0_2 = __a_1_1 aggregated with min, __p_0_3 = __a_1_1 aggregated with first, __p_0_4 = __a_1_1 aggregated with last, __p_0_5 = __a_1_1 aggregated with average])"]
-"op_4" ["label"="view(my_count=__p_0_0,max_author_id=__p_0_1,min_id=__p_0_2,first_id=__p_0_3,last_id=__p_0_4,avg_id=__p_0_5,avg_id0=__p_0_5)"]
+"op_3" ["label"="aggBy([],[__p_0_0 = count, __p_0_1 = __a_1_0 aggregated with max, __p_0_2 = __a_1_1 aggregated with min, __p_0_3 = __a_1_1 aggregated with average])"]
+"op_4" ["label"="view(my_count=__p_0_0,max_author_id=__p_0_1,min_id=__p_0_2,avg_id=__p_0_3,avg_id0=__p_0_3)"]
 "op_1" -> "op_0"
 "op_2" -> "op_1"
 "op_3" -> "op_2"

--- a/sql/src/test/resources/io/deephaven/sql/query-12.sql
+++ b/sql/src/test/resources/io/deephaven/sql/query-12.sql
@@ -2,8 +2,6 @@ SELECT
   count(*) as my_count,
   max(AuthorId) as max_author_id,
   min(Id) as min_id,
-  FIRST_VALUE(Id) as first_id,
-  LAST_VALUE(Id) as last_id,
   avg(Id) as avg_id,
   avg(Id) as avg_id
 FROM


### PR DESCRIPTION
BREAKING CHANGE: SQL window functions (including FIRST_VALUE and LAST_VALUE) are no longer supported. This is due to stricter validation that makes the OVER clause mandatory for these functions; because our current SQL engine does not support evaluating the OVER clause, all window functions have been disabled.