### PR TITLE
fix: DH-23170: Fixed ruff formatting caused by upgrade

### DIFF
--- a/py/embedded-server/README.md
+++ b/py/embedded-server/README.md
@@ -22,9 +22,11 @@ $ pip install py/embedded-server/build/wheel/deephaven_server-0.12.0-py3-none-an
 
 ```python
 from deephaven_server import Server
+
 server = Server()
 server.start()
 
 from deephaven import time_table
-ticking_table = time_table('PT1s').update_view(formulas=["Col1 = i % 2"])
+
+ticking_table = time_table("PT1s").update_view(formulas=["Col1 = i % 2"])
 ```

--- a/py/embedded-server/README_PyPi.md
+++ b/py/embedded-server/README_PyPi.md
@@ -21,9 +21,11 @@ pip3 install deephaven-server
 
 ```python
 from deephaven_server import Server
+
 server = Server()
 server.start()
 
 from deephaven import time_table
-ticking_table = time_table('PT1s').update_view(formulas=["Col1 = i % 2"])
+
+ticking_table = time_table("PT1s").update_view(formulas=["Col1 = i % 2"])
 ```


### PR DESCRIPTION
Fixed the formatting of two files after the unpinned ruff dep upgrade to 0.16.0 failed them.  Publish CI now works.