### PR TITLE
fix: DH-23174: pushdown estimation region indexes used incorrectly (#8275)

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/RegionedColumnSourceManager.java
@@ -762,34 +762,45 @@ public class RegionedColumnSourceManager
             return Integer.compare(regionIndex, other.regionIndex);
         }
 
-        private WritableRowSet subsetAndShiftIntoLocationSpace(final RowSet selection) {
-            final long locationStartKey = firstRowKey();
-            // Extract the portion of selection that overlaps this region.
-            final WritableRowSet overlappingRows = selection.subSetByKeyRange(locationStartKey, lastRowKey());
-            // Shift to the region's key space
-            overlappingRows.shiftInPlace(-locationStartKey);
-            return overlappingRows;
-        }
-
-        private void unshiftIntoRegionSpace(final WritableRowSet rowSet) {
-            rowSet.shiftInPlace(firstRowKey());
-        }
-
-        void unshiftIntoRegionSpace(final PushdownResult result) {
-            if (result.match().isNonempty()) {
-                unshiftIntoRegionSpace(result.match());
-            }
-            if (result.maybeMatch().isNonempty()) {
-                unshiftIntoRegionSpace(result.maybeMatch());
-            }
-        }
-
         private long firstRowKey() {
             return getFirstRowKey(regionIndex);
         }
 
         private long lastRowKey() {
             return getLastRowKey(regionIndex);
+        }
+    }
+
+    /**
+     * Extract the portion of {@code selection} that overlaps the region with the given {@code regionIndex}, and shift
+     * it into that region's own key space. Pure region-id arithmetic; does not require an
+     * {@link IncludedTableLocationEntry} instance, so it may be applied to any currently-included region index
+     * (notably, by the pushdown helpers below, which must not assume that {@code regionIndex} is a valid position in
+     * {@link #orderedIncludedTableLocations}, since that list is compacted on removal while region indices are not
+     * reused).
+     * <p>
+     * Declared {@code static} on the enclosing manager rather than on {@link IncludedTableLocationEntry} because that
+     * inner class is non-static, and this project's Java 11 language level does not permit static methods in non-static
+     * inner classes.
+     */
+    private static WritableRowSet subsetAndShiftIntoLocationSpace(final int regionIndex, final RowSet selection) {
+        final long locationStartKey = getFirstRowKey(regionIndex);
+        final WritableRowSet overlappingRows =
+                selection.subSetByKeyRange(locationStartKey, getLastRowKey(regionIndex));
+        overlappingRows.shiftInPlace(-locationStartKey);
+        return overlappingRows;
+    }
+
+    private static void unshiftIntoRegionSpace(final int regionIndex, final WritableRowSet rowSet) {
+        rowSet.shiftInPlace(getFirstRowKey(regionIndex));
+    }
+
+    private static void unshiftIntoRegionSpace(final int regionIndex, final PushdownResult result) {
+        if (result.match().isNonempty()) {
+            unshiftIntoRegionSpace(regionIndex, result.match());
+        }
+        if (result.maybeMatch().isNonempty()) {
+            unshiftIntoRegionSpace(regionIndex, result.maybeMatch());
         }
     }
 
@@ -870,10 +881,12 @@ public class RegionedColumnSourceManager
                     ctx.reset();
                     final int regionIndex = regionIndices[idx];
 
-                    final IncludedTableLocationEntry tle = orderedIncludedTableLocations.get(regionIndex);
-                    ctx.shiftedRowSet = tle.subsetAndShiftIntoLocationSpace(selection);
+                    // NB: Resolve the location via locationSource, which is keyed by the stable regionIndex and is
+                    // never compacted on removal, rather than orderedIncludedTableLocations, which is compacted on
+                    // removal and so cannot be indexed by regionIndex.
+                    ctx.shiftedRowSet = subsetAndShiftIntoLocationSpace(regionIndex, selection);
 
-                    estimator.estimate(regionIndex, tle.location, ctx.shiftedRowSet,
+                    estimator.estimate(regionIndex, locationSource.get(regionIndex), ctx.shiftedRowSet,
                             cost -> {
                                 AtomicUtil.setIfGreaterThan(minCost, cost, cost);
                                 resume.run();
@@ -947,12 +960,14 @@ public class RegionedColumnSourceManager
                     ctx.reset();
                     final int regionIndex = regionIndices[idx];
 
-                    final IncludedTableLocationEntry tle = orderedIncludedTableLocations.get(regionIndex);
-                    ctx.shiftedRowSet = tle.subsetAndShiftIntoLocationSpace(selection);
+                    // NB: Resolve the location via locationSource, which is keyed by the stable regionIndex and is
+                    // never compacted on removal, rather than orderedIncludedTableLocations, which is compacted on
+                    // removal and so cannot be indexed by regionIndex.
+                    ctx.shiftedRowSet = subsetAndShiftIntoLocationSpace(regionIndex, selection);
 
-                    action.pushdown(regionIndex, tle.location, ctx.shiftedRowSet,
+                    action.pushdown(regionIndex, locationSource.get(regionIndex), ctx.shiftedRowSet,
                             result -> {
-                                tle.unshiftIntoRegionSpace(result);
+                                unshiftIntoRegionSpace(regionIndex, result);
                                 matches[idx] = result.match();
                                 maybeMatches[idx] = result.maybeMatch();
                                 resume.run();

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/TestRegionedColumnSourceManager.java
@@ -13,6 +13,8 @@ import io.deephaven.engine.rowset.RowSetFactory;
 import io.deephaven.engine.rowset.WritableRowSet;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.ColumnToCodecMappings;
+import io.deephaven.engine.table.impl.PushdownFilterContext;
+import io.deephaven.engine.table.impl.PushdownResult;
 import io.deephaven.engine.table.impl.indexer.DataIndexer;
 import io.deephaven.engine.table.impl.locations.ColumnLocation;
 import io.deephaven.engine.table.impl.locations.ImmutableTableLocationKey;
@@ -20,6 +22,10 @@ import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.TableLocation;
 import io.deephaven.engine.table.impl.locations.impl.SimpleTableLocationKey;
 import io.deephaven.engine.table.impl.locations.impl.TableLocationUpdateSubscriptionBuffer;
+import io.deephaven.engine.table.impl.select.WhereFilter;
+import io.deephaven.engine.table.impl.select.WhereFilterFactory;
+import io.deephaven.engine.table.impl.util.ImmediateJobScheduler;
+import io.deephaven.engine.table.impl.util.JobScheduler;
 import io.deephaven.engine.testutil.ControlledUpdateGraph;
 import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
 import io.deephaven.qst.column.Column;
@@ -32,6 +38,10 @@ import org.junit.Test;
 
 import java.lang.ref.WeakReference;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -271,11 +281,15 @@ public class TestRegionedColumnSourceManager extends RefreshingTableTestCase {
     }
 
     private void expectPoison() {
+        expectPoison(3);
+    }
+
+    private void expectPoison(final int regionIndex) {
         checking(new Expectations() {
             {
-                exactly(1).of(partitioningColumnSource).invalidateRegion(3);
-                exactly(1).of(groupingColumnSource).invalidateRegion(3);
-                exactly(1).of(normalColumnSource).invalidateRegion(3);
+                exactly(1).of(partitioningColumnSource).invalidateRegion(regionIndex);
+                exactly(1).of(groupingColumnSource).invalidateRegion(regionIndex);
+                exactly(1).of(normalColumnSource).invalidateRegion(regionIndex);
             }
         });
     }
@@ -740,6 +754,169 @@ public class TestRegionedColumnSourceManager extends RefreshingTableTestCase {
 
         // expect table locations to be cleaned up via LivenessScope release as the test exits
         IntStream.range(0, tableLocations.length).forEachOrdered(li -> {
+            final TableLocation tl = tableLocations[li];
+            checking(new Expectations() {
+                {
+                    oneOf(tl).supportsSubscriptions();
+                    if (li % 2 == 0) {
+                        // Even locations don't support subscriptions
+                        will(returnValue(false));
+                    } else {
+                        will(returnValue(true));
+                        oneOf(tl).unsubscribe(with(subscriptionBuffers[li]));
+                    }
+                }
+            });
+        });
+    }
+
+    /**
+     * Regression test for a bug where the pushdown-filter helpers resolved a region's {@link TableLocation} by indexing
+     * {@code orderedIncludedTableLocations} with the region's stable, monotonically-increasing region index rather than
+     * a list position. Since that list is compacted whenever a location is removed, but region indices are never
+     * reused, an included location's region index can outgrow the list's size (yielding an
+     * {@link IndexOutOfBoundsException}) or land on the wrong entry (yielding a silently incorrect result).
+     */
+    @Test
+    public void testPushdownAfterLocationRemoval() {
+        SUT = new RegionedColumnSourceManager(true, true, componentFactory, ColumnToCodecMappings.EMPTY,
+                tableDefinition);
+
+        // Check run with no locations. This establishes capturedPartitioningColumnIndex/capturedGroupingColumnIndex
+        // against the manager's persistent, tracking master RowSet, which checkIndexes() relies on for every
+        // subsequent refresh() (whose TableUpdate#added() is a plain, non-tracking per-cycle delta).
+        captureIndexes(SUT.initialize());
+        checkIndexes();
+
+        // Add and include all 4 locations: region indices 0, 1, 2, 3 in insertion order.
+        Arrays.stream(tableLocations).forEach(SUT::addLocation);
+        setSizeExpectations(true, true, 5, 1000, 5003, 2);
+        updateGraph.runWithinUnitTestCycle(() -> captureIndexes(SUT.refresh().added()));
+        checkIndexes();
+        assertEquals(Arrays.asList(tableLocation0A, tableLocation1A, tableLocation0B, tableLocation1B),
+                SUT.includedLocations());
+
+        // Remove tableLocation0A (region index 0). orderedIncludedTableLocations compacts to size 3 (holding, in
+        // order, the entries for region indices 1, 2, and 3), but region index 0 is never reused. (Not using
+        // setSizeExpectations/checkIndexes here, since that harness has no notion of removal: re-supplying the
+        // unchanged sizes would incorrectly re-include region 0's rows in the expected row set/data index.)
+        expectPoison(0);
+        updateGraph.runWithinUnitTestCycle(() -> {
+            SUT.removeLocationKey(tableLocation0A.getKey());
+            SUT.refresh();
+        });
+        assertIsSatisfied();
+        assertEquals(Arrays.asList(tableLocation1A, tableLocation0B, tableLocation1B), SUT.includedLocations());
+
+        final WhereFilter filter = WhereFilterFactory.getExpression("RCS_2 = `x`");
+        final PushdownFilterContext context = PushdownFilterContext.NO_PUSHDOWN_CONTEXT;
+        final JobScheduler jobScheduler = new ImmediateJobScheduler();
+
+        // Region 3 (tableLocation1B, size 2) has the highest region index. Before the fix, resolving it via
+        // orderedIncludedTableLocations.get(3) throws IndexOutOfBoundsException, because that list was compacted to
+        // size 3 by the removal above.
+        try (final RowSet region3Selection = RowSetFactory.fromRange(
+                RegionedColumnSource.getFirstRowKey(3), RegionedColumnSource.getFirstRowKey(3) + 1)) {
+            checking(new Expectations() {
+                {
+                    oneOf(tableLocation1B).estimatePushdownFilterCost(
+                            with(same(filter)), with(any(RowSet.class)), with(false), with(same(context)),
+                            with(same(jobScheduler)), with(any(LongConsumer.class)), with(any(Consumer.class)));
+                    will(new CustomAction("complete cost") {
+                        @Override
+                        public Object invoke(final Invocation invocation) {
+                            ((LongConsumer) invocation.getParameter(5))
+                                    .accept(PushdownResult.REGION_METADATA_STATS_COST);
+                            return null;
+                        }
+                    });
+                }
+            });
+
+            final AtomicLong cost = new AtomicLong(-1);
+            final AtomicReference<Exception> error = new AtomicReference<>();
+            SUT.estimatePushdownFilterCost(filter, region3Selection, false, context, jobScheduler, cost::set,
+                    error::set);
+
+            assertNull("estimatePushdownFilterCost for the highest-indexed region must not throw", error.get());
+            assertEquals(PushdownResult.REGION_METADATA_STATS_COST, cost.get());
+            assertIsSatisfied();
+        }
+
+        try (final RowSet region3Selection = RowSetFactory.fromRange(
+                RegionedColumnSource.getFirstRowKey(3), RegionedColumnSource.getFirstRowKey(3) + 1)) {
+            checking(new Expectations() {
+                {
+                    oneOf(tableLocation1B).pushdownFilter(
+                            with(same(filter)), with(any(RowSet.class)), with(false), with(same(context)),
+                            with(any(Long.class)), with(same(jobScheduler)), with(any(Consumer.class)),
+                            with(any(Consumer.class)));
+                    will(new CustomAction("complete pushdown") {
+                        @Override
+                        public Object invoke(final Invocation invocation) {
+                            final RowSet shiftedSelection = (RowSet) invocation.getParameter(1);
+                            // noinspection unchecked
+                            ((Consumer<PushdownResult>) invocation.getParameter(6))
+                                    .accept(PushdownResult.allMaybeMatch(shiftedSelection));
+                            return null;
+                        }
+                    });
+                }
+            });
+
+            final AtomicReference<PushdownResult> result = new AtomicReference<>();
+            final AtomicReference<Exception> error = new AtomicReference<>();
+            SUT.pushdownFilter(filter, region3Selection, false, context, Long.MAX_VALUE, jobScheduler, result::set,
+                    error::set);
+
+            assertNull("pushdownFilter for the highest-indexed region must not throw", error.get());
+            assertNotNull(result.get());
+            assertRowSetEquals(region3Selection, result.get().maybeMatch());
+            result.get().close();
+            assertIsSatisfied();
+        }
+
+        // Region 1 (tableLocation1A, size 1000) sits at list position 0 in the post-removal
+        // orderedIncludedTableLocations, but list position 1 -- what its region index would incorrectly select --
+        // now holds tableLocation0B's entry. Before the fix, this silently queries the wrong location.
+        try (final RowSet region1Selection = RowSetFactory.fromRange(
+                RegionedColumnSource.getFirstRowKey(1), RegionedColumnSource.getFirstRowKey(1) + 999)) {
+            checking(new Expectations() {
+                {
+                    oneOf(tableLocation1A).pushdownFilter(
+                            with(same(filter)), with(any(RowSet.class)), with(false), with(same(context)),
+                            with(any(Long.class)), with(same(jobScheduler)), with(any(Consumer.class)),
+                            with(any(Consumer.class)));
+                    will(new CustomAction("complete pushdown") {
+                        @Override
+                        public Object invoke(final Invocation invocation) {
+                            final RowSet shiftedSelection = (RowSet) invocation.getParameter(1);
+                            // noinspection unchecked
+                            ((Consumer<PushdownResult>) invocation.getParameter(6))
+                                    .accept(PushdownResult.allMaybeMatch(shiftedSelection));
+                            return null;
+                        }
+                    });
+                }
+            });
+
+            final AtomicReference<PushdownResult> result = new AtomicReference<>();
+            final AtomicReference<Exception> error = new AtomicReference<>();
+            SUT.pushdownFilter(filter, region1Selection, false, context, Long.MAX_VALUE, jobScheduler, result::set,
+                    error::set);
+
+            assertNull("pushdownFilter must query the location that actually owns the requested region",
+                    error.get());
+            assertNotNull(result.get());
+            assertRowSetEquals(region1Selection, result.get().maybeMatch());
+            result.get().close();
+            assertIsSatisfied();
+        }
+
+        // expect the still-included table locations to be cleaned up via LivenessScope release as the test exits.
+        // tableLocation0A (li=0) was removed above, so it is no longer tracked by the manager and does not go
+        // through this cleanup path.
+        IntStream.range(1, tableLocations.length).forEachOrdered(li -> {
             final TableLocation tl = tableLocations[li];
             checking(new Expectations() {
                 {

--- a/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
+++ b/extensions/iceberg/src/test/java/io/deephaven/iceberg/junit5/SqliteCatalogBase.java
@@ -2399,6 +2399,73 @@ public abstract class SqliteCatalogBase {
         assertTableEquals(expected2, fromIcebergRefreshing.select());
     }
 
+    /**
+     * Regression test for a bug where a refreshing Iceberg table with a filtered child crashed with an
+     * {@link IndexOutOfBoundsException} when a commit replaced a partition's data file (remove + add). The
+     * pushdown-filter helpers in {@code RegionedColumnSourceManager} resolved locations by indexing the
+     * included-locations list (which is compacted on removal) with the region index (which is never reused), so after a
+     * removal the newly-added region's index exceeded the list size.
+     */
+    @Test
+    void testManualRefreshingFilteredPartitionReplace() {
+        final Table part1 = TableTools.emptyTable(10)
+                .update("intCol = (int) i");
+        final Table part2 = TableTools.emptyTable(10)
+                .update("intCol = (int) 100 + i");
+        final TableIdentifier tableIdentifier = TableIdentifier.parse("MyNamespace.MyTable");
+
+        final TableDefinition tableDefinition = TableDefinition.of(
+                ColumnDefinition.ofInt("intCol"),
+                ColumnDefinition.ofString("PC").withPartitioning());
+        final IcebergTableAdapter tableAdapter = catalogAdapter.createTable(tableIdentifier, tableDefinition);
+        final IcebergTableWriter tableWriter = tableAdapter.tableWriter(writerOptionsBuilder()
+                .tableDefinition(tableDefinition)
+                .build());
+        tableWriter.append(IcebergWriteInstructions.builder()
+                .addTables(part1, part2)
+                .addAllPartitionPaths(List.of("PC=apple", "PC=boy"))
+                .build());
+
+        final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+        final IcebergTableImpl fromIcebergRefreshing =
+                (IcebergTableImpl) tableAdapter.table(IcebergReadInstructions.builder()
+                        .updateMode(IcebergUpdateMode.manualRefreshingMode())
+                        .build());
+
+        // Filter on a non-partitioning column, so it executes (with pushdown) against the regioned column sources
+        // rather than being satisfied from partition values. The filter window must cover rows in both the
+        // replacement data file and the surviving one.
+        final Table filtered = fromIcebergRefreshing.where("intCol >= 5");
+        final Table expected = TableTools.merge(
+                part1.update("PC = `apple`"),
+                part2.update("PC = `boy`"))
+                .where("intCol >= 5");
+        assertTableEquals(expected, filtered.sort("intCol"));
+
+        // Replace partition PC=apple: one commit removes its data file, another adds a replacement, and a single
+        // refresh observes both. The reader drops the removed file's region (index 0) -- compacting the
+        // included-locations list -- and assigns the replacement file the next region index (2), so region indices
+        // no longer correspond to positions in that list.
+        tableAdapter.icebergTable().newDelete()
+                .deleteFromRowFilter(Expressions.equal("PC", "apple"))
+                .commit();
+        final Table part1Replacement = TableTools.emptyTable(10)
+                .update("intCol = (int) 50 + i");
+        tableWriter.append(IcebergWriteInstructions.builder()
+                .addTables(part1Replacement)
+                .addPartitionPaths("PC=apple")
+                .build());
+
+        fromIcebergRefreshing.update();
+        updateGraph.runWithinUnitTestCycle(fromIcebergRefreshing::refresh);
+
+        final Table expected2 = TableTools.merge(
+                part1Replacement.update("PC = `apple`"),
+                part2.update("PC = `boy`"))
+                .where("intCol >= 5");
+        assertTableEquals(expected2, filtered.sort("intCol"));
+    }
+
     @Test
     void testAutoRefreshingPartitionedAppend() throws InterruptedException {
         final Table part1 = TableTools.emptyTable(10)


### PR DESCRIPTION
## Pull request overview

Fixes region-to-location resolution after location removal, preventing incorrect pushdown results and index errors.

**Changes:**
- Resolves locations through stable region indexes.
- Adds regression coverage for compacted location lists.