### PR TITLE
fix: DH-23194: Implement RowSet.intersect for JS API

### DIFF
--- a/web/client-api/src/main/resources/io/deephaven/web/super/io/deephaven/engine/rowset/WebRowSetImpl.java
+++ b/web/client-api/src/main/resources/io/deephaven/web/super/io/deephaven/engine/rowset/WebRowSetImpl.java
@@ -65,10 +65,7 @@ final class WebRowSetImpl implements RowSet, WritableRowSet {
         if (this.isEmpty() || rowSet.isEmpty()) {
             return RowSetFactory.empty();
         }
-        if (rowSet.equals(this)) {
-            return copy();
-        }
-        throw new UnsupportedOperationException("intersect");
+        return new WebRowSetImpl(rangeSet.intersect(((WebRowSetImpl) rowSet).rangeSet));
     }
 
     @Override

--- a/web/client-api/src/test/java/io/deephaven/web/ClientIntegrationTestSuite.java
+++ b/web/client-api/src/test/java/io/deephaven/web/ClientIntegrationTestSuite.java
@@ -39,6 +39,7 @@ public class ClientIntegrationTestSuite extends GWTTestSuite {
         suite.addTestSuite(SharedObjectTestGwt.class);
         suite.addTestSuite(RunEndEncodedTestGwt.class);
         suite.addTestSuite(DictionaryEncodedTestGwt.class);
+        suite.addTestSuite(DoPutTestGwt.class);
 
         // This should be a unit test, but it requires a browser environment to run on GWT 2.9
         // GWT 2.9 doesn't have proper bindings for Promises in HtmlUnit, so we need to use the IntegrationTest suite

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/DoPutTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/DoPutTestGwt.java
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.web.client.api;
+
+import com.google.gwt.junit.DoNotRunWith;
+import com.google.gwt.junit.Platform;
+
+@DoNotRunWith(Platform.HtmlUnitBug)
+public class DoPutTestGwt extends AbstractAsyncGwtTestCase {
+
+    private final TableSourceBuilder tables = new TableSourceBuilder();
+
+    /**
+     * Creates arrays of 0-100k of ints, doubles, longs, strings, and string arrays (arrays of one element), pushes to
+     * server via DoPut (WorkerConnection.newTable), and sets a viewport to confirm the row count is correct.
+     */
+    public void testLargeTable() {
+        final int rowCount = 100_000;
+
+        // Build column-oriented data (Object[][] for WorkerConnection.newTable)
+        Object[] intCol = new Object[rowCount];
+        Object[] doubleCol = new Object[rowCount];
+        Object[] longCol = new Object[rowCount];
+        Object[] stringCol = new Object[rowCount];
+        Object[] stringArrayCol = new Object[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            intCol[i] = (double) i; // JS numbers are doubles
+            doubleCol[i] = (double) i * 1.5;
+            longCol[i] = LongWrapper.of((long) i * 1000L);
+            stringCol[i] = "str_" + i;
+            stringArrayCol[i] = new String[] {"item_" + i};
+        }
+
+        String[] columnNames = {"MyInt", "MyDouble", "MyLong", "MyString", "MyStringArray"};
+        String[] types = {"int", "double", "long", "java.lang.String", "java.lang.String[]"};
+        Object[][] data = {intCol, doubleCol, longCol, stringCol, stringArrayCol};
+
+        connect(tables)
+                .then(session -> {
+                    delayTestFinish(30_000);
+                    // Use emptyTable to obtain the WorkerConnection so we can use the underlying newTable api
+                    return session.emptyTable(1);
+                })
+                .then(table -> {
+                    WorkerConnection connection = table.getConnection();
+                    table.close();
+                    return connection.newTable(columnNames, types, data, null);
+                })
+                .then(table -> {
+                    assertEquals(rowCount, table.getSize(), 0);
+
+                    // Set a viewport covering the full table and verify we get the expected row count
+                    table.setViewport(0, rowCount - 1, null);
+                    return assertUpdateReceived(table, rowCount, 10_000);
+                })
+                .then(this::finish).catch_(this::report);
+    }
+
+    @Override
+    public String getModuleName() {
+        return "io.deephaven.web.DeephavenIntegrationTest";
+    }
+}

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/DoPutTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/DoPutTestGwt.java
@@ -12,11 +12,11 @@ public class DoPutTestGwt extends AbstractAsyncGwtTestCase {
     private final TableSourceBuilder tables = new TableSourceBuilder();
 
     /**
-     * Creates arrays of 0-100k of ints, doubles, longs, strings, and string arrays (arrays of one element), pushes to
+     * Creates large arrays of ints, doubles, longs, strings, and string arrays (arrays of one element), pushes to
      * server via DoPut (WorkerConnection.newTable), and sets a viewport to confirm the row count is correct.
      */
     public void testLargeTable() {
-        final int rowCount = 100_000;
+        final int rowCount = 25_000;
 
         // Build column-oriented data (Object[][] for WorkerConnection.newTable)
         Object[] intCol = new Object[rowCount];

--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
@@ -793,6 +793,60 @@ public class RangeSet {
     }
 
     /**
+     * Returns a new {@code RangeSet} representing the intersection of this set with the provided set. The result
+     * contains only keys that are present in both {@code this} and {@code other}. Neither this set nor the argument
+     * is modified.
+     *
+     * @param other the set to intersect with
+     * @return a new {@code RangeSet} containing only keys present in both sets; empty if there is no overlap
+     */
+    public RangeSet intersect(RangeSet other) {
+        if (isEmpty() || other.isEmpty()) {
+            return empty();
+        }
+
+        List<Range> result = new ArrayList<>();
+        Iterator<Range> thisIter = sortedRanges.iterator();
+        Iterator<Range> otherIter = other.sortedRanges.iterator();
+
+        Range a = thisIter.next();
+        Range b = otherIter.next();
+        while (true) {
+            // Compute the intersection of the two current ranges
+            long start = Math.max(a.getFirst(), b.getFirst());
+            long end = Math.min(a.getLast(), b.getLast());
+            if (start <= end) {
+                result.add(new Range(start, end));
+            }
+
+            // Advance the iterator whose current range ends first
+            if (a.getLast() < b.getLast()) {
+                if (!thisIter.hasNext()) {
+                    break;
+                }
+                a = thisIter.next();
+            } else if (b.getLast() < a.getLast()) {
+                if (!otherIter.hasNext()) {
+                    break;
+                }
+                b = otherIter.next();
+            } else {
+                // Both end at the same point, advance both
+                if (!thisIter.hasNext() || !otherIter.hasNext()) {
+                    break;
+                }
+                a = thisIter.next();
+                b = otherIter.next();
+            }
+        }
+
+        if (result.isEmpty()) {
+            return empty();
+        }
+        return fromSortedRanges(result);
+    }
+
+    /**
      * Removes all keys in the provided rangeset that are present in this.
      *
      * @param other the rows to remove

--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
@@ -805,6 +805,10 @@ public class RangeSet {
             return empty();
         }
 
+        if (this == other) {
+            return this;
+        }
+
         List<Range> result = new ArrayList<>();
         Iterator<Range> thisIter = sortedRanges.iterator();
         Iterator<Range> otherIter = other.sortedRanges.iterator();

--- a/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
+++ b/web/shared-beans/src/main/java/io/deephaven/web/shared/data/RangeSet.java
@@ -794,8 +794,8 @@ public class RangeSet {
 
     /**
      * Returns a new {@code RangeSet} representing the intersection of this set with the provided set. The result
-     * contains only keys that are present in both {@code this} and {@code other}. Neither this set nor the argument
-     * is modified.
+     * contains only keys that are present in both {@code this} and {@code other}. Neither this set nor the argument is
+     * modified.
      *
      * @param other the set to intersect with
      * @return a new {@code RangeSet} containing only keys present in both sets; empty if there is no overlap

--- a/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
+++ b/web/shared-beans/src/test/java/io/deephaven/web/shared/data/RangeSetTest.java
@@ -683,4 +683,68 @@ public class RangeSetTest {
         assert !positionsIter.hasNext();
         assertEquals(positions, keys.invert(selected));
     }
+
+
+    @Test
+    public void testIntersect() {
+        // Empty intersect anything => empty
+        assertEquals(RangeSet.empty(), RangeSet.empty().intersect(RangeSet.empty()));
+        assertEquals(RangeSet.empty(), RangeSet.empty().intersect(RangeSet.ofRange(0, 10)));
+        assertEquals(RangeSet.empty(), RangeSet.ofRange(0, 10).intersect(RangeSet.empty()));
+
+        // Identical sets
+        assertEquals(RangeSet.ofRange(5, 10), RangeSet.ofRange(5, 10).intersect(RangeSet.ofRange(5, 10)));
+
+        // One is a subset of the other
+        assertEquals(RangeSet.ofRange(5, 10), RangeSet.ofRange(0, 20).intersect(RangeSet.ofRange(5, 10)));
+        assertEquals(RangeSet.ofRange(5, 10), RangeSet.ofRange(5, 10).intersect(RangeSet.ofRange(0, 20)));
+
+        // Partial overlap — single ranges
+        assertEquals(RangeSet.ofRange(5, 10), RangeSet.ofRange(0, 10).intersect(RangeSet.ofRange(5, 15)));
+        assertEquals(RangeSet.ofRange(5, 10), RangeSet.ofRange(5, 15).intersect(RangeSet.ofRange(0, 10)));
+
+        // No overlap
+        assertEquals(RangeSet.empty(), RangeSet.ofRange(0, 5).intersect(RangeSet.ofRange(10, 15)));
+        assertEquals(RangeSet.empty(), RangeSet.ofRange(10, 15).intersect(RangeSet.ofRange(0, 5)));
+        // Adjacent but not overlapping
+        assertEquals(RangeSet.empty(), RangeSet.ofRange(0, 5).intersect(RangeSet.ofRange(6, 10)));
+
+        // Multiple ranges in both sets
+        RangeSet a = of(new Range(0, 10), new Range(20, 30), new Range(40, 50));
+        RangeSet b = of(new Range(5, 25), new Range(45, 55));
+        RangeSet expected = of(new Range(5, 10), new Range(20, 25), new Range(45, 50));
+        assertEquals(expected, a.intersect(b));
+        assertEquals(expected, b.intersect(a));
+
+        // Multiple ranges — no overlap in some regions
+        a = of(new Range(0, 5), new Range(10, 15), new Range(20, 25));
+        b = of(new Range(3, 12), new Range(22, 30));
+        expected = of(new Range(3, 5), new Range(10, 12), new Range(22, 25));
+        assertEquals(expected, a.intersect(b));
+        assertEquals(expected, b.intersect(a));
+
+        // Single-element intersections
+        assertEquals(RangeSet.ofItems(5), RangeSet.ofRange(0, 5).intersect(RangeSet.ofRange(5, 10)));
+        assertEquals(RangeSet.ofItems(10), RangeSet.ofRange(5, 10).intersect(RangeSet.ofRange(10, 15)));
+
+        // Discrete items
+        a = RangeSet.ofItems(1, 3, 5, 7, 9);
+        b = RangeSet.ofItems(2, 3, 6, 7, 8);
+        assertEquals(RangeSet.ofItems(3, 7), a.intersect(b));
+
+        // Non-mutation: original sets unchanged
+        a = RangeSet.ofRange(0, 10);
+        b = RangeSet.ofRange(5, 15);
+        RangeSet result = a.intersect(b);
+        assertEquals(RangeSet.ofRange(5, 10), result);
+        assertEquals(RangeSet.ofRange(0, 10), a);
+        assertEquals(RangeSet.ofRange(5, 15), b);
+
+        // Large values
+        long largeA = (long) Integer.MAX_VALUE + 10L;
+        long largeB = (long) Integer.MAX_VALUE + 100L;
+        a = RangeSet.ofRange(largeA, largeB);
+        b = RangeSet.ofRange(largeA + 20, largeB + 50);
+        assertEquals(RangeSet.ofRange(largeA + 20, largeB), a.intersect(b));
+    }
 }


### PR DESCRIPTION
Tables smaller than 4096 had no problem uploading, but our barrage stream wriiter limits the first RecordBatch to 4096 by default.