### PR TITLE
fix: DH-21193: Tie location key filter to table key

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
@@ -32,12 +32,47 @@ public class FilteredTableDataService extends AbstractTableDataService {
     public interface LocationKeyFilter {
 
         /**
+         * Accepts every location of every table.
+         */
+        LocationKeyFilter ALL = locationKey -> true;
+
+        /**
+         * Accepts no location of any table. Returning this from {@link #forTable(TableKey)} lets the caller skip the
+         * filtered service entirely for that table.
+         */
+        LocationKeyFilter NONE = locationKey -> false;
+
+        /**
          * Determine whether a {@link TableLocationKey} should be visible via this service.
+         *
+         * <p>
+         * A {@link TableLocationKey} holds partition values and no table identity, so it identifies a location only
+         * relative to its table. This method must therefore be asked only of a filter that has already been bound to a
+         * table with {@link #forTable(TableKey)}. A table-blind filter is its own binding, so for such a filter the
+         * distinction does not arise.
          *
          * @param locationKey The location key
          * @return True if the location key should be visible, false otherwise
          */
         boolean accept(@NotNull TableLocationKey locationKey);
+
+        /**
+         * Bind this filter to a table, returning the filter that applies to that table's locations.
+         *
+         * <p>
+         * {@link FilteredTableDataService} binds once, when it builds the {@link TableLocationProvider} for a table,
+         * and asks only the bound filter about locations. A filter whose decision depends on both the table and the
+         * location - one that does not factor into an independent table test and location test - overrides this to
+         * capture the table. A filter that does not discriminate on the table inherits the default and binds to itself.
+         *
+         * @param tableKey The table to bind to
+         * @return The filter for locations of {@code tableKey}; {@link #NONE} if no location of that table can be
+         *         accepted, which lets the caller avoid consulting the filtered service at all
+         */
+        @NotNull
+        default LocationKeyFilter forTable(@NotNull TableKey tableKey) {
+            return this;
+        }
     }
 
     /**
@@ -55,7 +90,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     @Nullable
     public TableLocationProvider getRawTableLocationProvider(@NotNull final TableKey tableKey,
             @NotNull final TableLocationKey tableLocationKey) {
-        if (!locationKeyFilter.accept(tableLocationKey)) {
+        if (!locationKeyFilter.forTable(tableKey).accept(tableLocationKey)) {
             return null;
         }
 
@@ -77,18 +112,29 @@ public class FilteredTableDataService extends AbstractTableDataService {
     @Override
     @NotNull
     protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
-        return new TableLocationProviderImpl(serviceToFilter.getTableLocationProvider(tableKey));
+        final LocationKeyFilter filterForTable = locationKeyFilter.forTable(tableKey);
+        if (filterForTable == LocationKeyFilter.NONE) {
+            // No location of this table can be accepted, so don't consult the filtered service at all. That service is
+            // frequently remote, and consulting it would open a subscription whose every result would be discarded.
+            return new NullTableLocationProvider(tableKey);
+        }
+        return new TableLocationProviderImpl(serviceToFilter.getTableLocationProvider(tableKey), filterForTable);
     }
 
     private class TableLocationProviderImpl implements TableLocationProvider {
 
         private final TableLocationProvider inputProvider;
 
+        /** The service's filter, bound to this provider's table. */
+        private final LocationKeyFilter filterForTable;
+
         private final String implementationName;
         private final Map<Listener, FilteringListener> listeners = new WeakHashMap<>();
 
-        private TableLocationProviderImpl(@NotNull final TableLocationProvider inputProvider) {
+        private TableLocationProviderImpl(@NotNull final TableLocationProvider inputProvider,
+                @NotNull final LocationKeyFilter filterForTable) {
             this.inputProvider = inputProvider;
+            this.filterForTable = filterForTable;
             implementationName = "Filtered-" + inputProvider.getImplementationName();
         }
 
@@ -109,7 +155,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
 
         @Override
         public void subscribe(@NotNull final Listener listener) {
-            final FilteringListener filteringListener = new FilteringListener(listener);
+            final FilteringListener filteringListener = new FilteringListener(filterForTable, listener);
             synchronized (listeners) {
                 listeners.put(listener, filteringListener);
             }
@@ -144,18 +190,18 @@ public class FilteredTableDataService extends AbstractTableDataService {
                 final Predicate<ImmutableTableLocationKey> filter) {
             // Apply this service's locationKeyFilter alongside the caller's, so that enumeration exposes the same
             // set as hasTableLocationKey, getTableLocationIfPresent, and subscription delivery.
-            inputProvider.getTableLocationKeys(consumer, filter.and(locationKeyFilter::accept));
+            inputProvider.getTableLocationKeys(consumer, filter.and(filterForTable::accept));
         }
 
         @Override
         public boolean hasTableLocationKey(@NotNull final TableLocationKey tableLocationKey) {
-            return locationKeyFilter.accept(tableLocationKey) && inputProvider.hasTableLocationKey(tableLocationKey);
+            return filterForTable.accept(tableLocationKey) && inputProvider.hasTableLocationKey(tableLocationKey);
         }
 
         @Nullable
         @Override
         public TableLocation getTableLocationIfPresent(@NotNull final TableLocationKey tableLocationKey) {
-            if (!locationKeyFilter.accept(tableLocationKey)) {
+            if (!filterForTable.accept(tableLocationKey)) {
                 return null;
             }
             return inputProvider.getTableLocationIfPresent(tableLocationKey);
@@ -182,8 +228,13 @@ public class FilteredTableDataService extends AbstractTableDataService {
     private class FilteringListener extends WeakReferenceWrapper<TableLocationProvider.Listener>
             implements TableLocationProvider.Listener {
 
-        private FilteringListener(@NotNull final TableLocationProvider.Listener outputListener) {
+        /** The service's filter, bound to the table of the provider this listener was subscribed to. */
+        private final LocationKeyFilter filterForTable;
+
+        private FilteringListener(@NotNull final LocationKeyFilter filterForTable,
+                @NotNull final TableLocationProvider.Listener outputListener) {
             super(outputListener);
+            this.filterForTable = filterForTable;
         }
 
         @Override
@@ -192,7 +243,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
             final TableLocationProvider.Listener outputListener = getWrapped();
             // We can't try to clean up null listeners here, the underlying implementation may not allow concurrent
             // unsubscribe operations.
-            if (outputListener != null && locationKeyFilter.accept(tableLocationKey.get())) {
+            if (outputListener != null && filterForTable.accept(tableLocationKey.get())) {
                 outputListener.handleTableLocationKeyAdded(tableLocationKey);
             }
         }
@@ -201,7 +252,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
         public void handleTableLocationKeyRemoved(
                 @NotNull final LiveSupplier<ImmutableTableLocationKey> tableLocationKey) {
             final TableLocationProvider.Listener outputListener = getWrapped();
-            if (outputListener != null && locationKeyFilter.accept(tableLocationKey.get())) {
+            if (outputListener != null && filterForTable.accept(tableLocationKey.get())) {
                 outputListener.handleTableLocationKeyRemoved(tableLocationKey);
             }
         }
@@ -216,9 +267,9 @@ public class FilteredTableDataService extends AbstractTableDataService {
             if (outputListener != null) {
                 // Produce filtered lists of added and removed keys.
                 final Collection<LiveSupplier<ImmutableTableLocationKey>> filteredAddedKeys = addedKeys.stream()
-                        .filter(key -> locationKeyFilter.accept(key.get())).collect(Collectors.toList());
+                        .filter(key -> filterForTable.accept(key.get())).collect(Collectors.toList());
                 final Collection<LiveSupplier<ImmutableTableLocationKey>> filteredRemovedKeys = removedKeys.stream()
-                        .filter(key -> locationKeyFilter.accept(key.get())).collect(Collectors.toList());
+                        .filter(key -> filterForTable.accept(key.get())).collect(Collectors.toList());
 
                 if (filteredAddedKeys.isEmpty() && filteredRemovedKeys.isEmpty()) {
                     return;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
@@ -142,7 +142,9 @@ public class FilteredTableDataService extends AbstractTableDataService {
         public void getTableLocationKeys(
                 final Consumer<LiveSupplier<ImmutableTableLocationKey>> consumer,
                 final Predicate<ImmutableTableLocationKey> filter) {
-            inputProvider.getTableLocationKeys(consumer, filter);
+            // Apply this service's locationKeyFilter alongside the caller's, so that enumeration exposes the same
+            // set as hasTableLocationKey, getTableLocationIfPresent, and subscription delivery.
+            inputProvider.getTableLocationKeys(consumer, filter.and(locationKeyFilter::accept));
         }
 
         @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
@@ -62,6 +62,9 @@ public class FilteredTableDataService extends AbstractTableDataService {
 
         /**
          * Produce the filter that decides the locations of {@code tableKey}.
+         * <p>
+         * This may be called more than once for the same table, so it must be a deterministic function of its argument:
+         * equal table keys must yield filters that accept the same locations.
          *
          * @param tableKey The table to filter the locations of
          * @return The filter for locations of {@code tableKey}; {@link LocationKeyFilter#NONE} if no location of that

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
@@ -29,7 +29,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     private final LocationKeyFilterProvider locationKeyFilterProvider;
 
     /**
-     * A filter that has been bound to a table, and so can decide that table's locations.
+     * A filter that has been bound to a table, and so can decide whether to accept that table's locations.
      */
     @FunctionalInterface
     public interface LocationKeyFilter {
@@ -46,7 +46,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
         /**
          * Determine whether one location of the bound table should be visible via this service.
          *
-         * @param locationKey The location key, whose partition values are meaningful only within the bound table
+         * @param locationKey The location key, implicitly part of the table this LocationKeyFilter was created for
          * @return True if the location key should be visible, false otherwise
          */
         boolean accept(@NotNull TableLocationKey locationKey);
@@ -55,21 +55,18 @@ public class FilteredTableDataService extends AbstractTableDataService {
     /**
      * Supplies the {@link LocationKeyFilter} for a table.
      * <p>
-     * A filter that does not discriminate on the table is a provider that ignores its argument.
+     * Implementations ignore the {@code tableKey} argument if they don't discriminate by table.
      */
     @FunctionalInterface
     public interface LocationKeyFilterProvider {
 
         /**
-         * Produce the filter that decides the locations of {@code tableKey}.
+         * Produce a filter that applies to locations belonging to the table specified by {@code tableKey}.
          * <p>
          * An implementation that accepts no location of {@code tableKey} <em>must</em> return the
          * {@link LocationKeyFilter#NONE} instance itself, and one that accepts every location <em>should</em> return
          * {@link LocationKeyFilter#ALL}. The sentinels are recognized by reference identity, so an equivalent lambda is
          * not a substitute.
-         * <p>
-         * This may be called more than once for the same table, so it must be a deterministic function of its argument:
-         * equal table keys must yield filters that accept the same locations.
          *
          * @param tableKey The table to filter the locations of
          * @return The filter for locations of {@code tableKey}; {@link LocationKeyFilter#NONE} if no location of that
@@ -119,8 +116,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
         final LocationKeyFilter filterForTable = locationKeyFilterProvider.forTable(tableKey);
         if (filterForTable == LocationKeyFilter.NONE) {
-            // No location of this table can be accepted, so don't consult the filtered service at all. That service is
-            // frequently remote, and consulting it would open a subscription whose every result would be discarded.
+            // No location of this table can be accepted, so don't consult the filtered service at all.
             return new NullTableLocationProvider(tableKey);
         }
         return new TableLocationProviderImpl(serviceToFilter.getTableLocationProvider(tableKey), filterForTable);
@@ -193,8 +189,6 @@ public class FilteredTableDataService extends AbstractTableDataService {
         public void getTableLocationKeys(
                 final Consumer<LiveSupplier<ImmutableTableLocationKey>> consumer,
                 final Predicate<ImmutableTableLocationKey> filter) {
-            // Apply this table's bound filter alongside the caller's, so that enumeration exposes the same
-            // set as hasTableLocationKey, getTableLocationIfPresent, and subscription delivery.
             inputProvider.getTableLocationKeys(consumer, filter.and(filterForTable::accept));
         }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
@@ -63,6 +63,11 @@ public class FilteredTableDataService extends AbstractTableDataService {
         /**
          * Produce the filter that decides the locations of {@code tableKey}.
          * <p>
+         * An implementation that accepts no location of {@code tableKey} <em>must</em> return the
+         * {@link LocationKeyFilter#NONE} instance itself, and one that accepts every location <em>should</em> return
+         * {@link LocationKeyFilter#ALL}. The sentinels are recognized by reference identity, so an equivalent lambda is
+         * not a substitute.
+         * <p>
          * This may be called more than once for the same table, so it must be a deterministic function of its argument:
          * equal table keys must yield filters that accept the same locations.
          *

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
@@ -26,71 +26,68 @@ public class FilteredTableDataService extends AbstractTableDataService {
     private static final String IMPLEMENTATION_NAME = FilteredTableDataService.class.getSimpleName();
 
     private final TableDataService serviceToFilter;
-    private final LocationKeyFilter locationKeyFilter;
+    private final LocationKeyFilterProvider locationKeyFilterProvider;
 
+    /**
+     * A filter that has been bound to a table, and so can decide that table's locations.
+     */
     @FunctionalInterface
     public interface LocationKeyFilter {
 
-        /**
-         * Accepts every location of every table.
-         */
+        /** Accepts every location of the table. */
         LocationKeyFilter ALL = locationKey -> true;
 
         /**
-         * Accepts no location of any table. Returning this from {@link #forTable(TableKey)} lets the caller skip the
-         * filtered service entirely for that table.
+         * Accepts no location of the table. A provider that returns this is saying the table is entirely excluded,
+         * which lets the caller skip the filtered service for it.
          */
         LocationKeyFilter NONE = locationKey -> false;
 
         /**
-         * Determine whether a {@link TableLocationKey} should be visible via this service.
+         * Determine whether one location of the bound table should be visible via this service.
          *
-         * <p>
-         * A {@link TableLocationKey} holds partition values and no table identity, so it identifies a location only
-         * relative to its table. This method must therefore be asked only of a filter that has already been bound to a
-         * table with {@link #forTable(TableKey)}. A table-blind filter is its own binding, so for such a filter the
-         * distinction does not arise.
-         *
-         * @param locationKey The location key
+         * @param locationKey The location key, whose partition values are meaningful only within the bound table
          * @return True if the location key should be visible, false otherwise
          */
         boolean accept(@NotNull TableLocationKey locationKey);
+    }
+
+    /**
+     * Supplies the {@link LocationKeyFilter} for a table.
+     * <p>
+     * A filter that does not discriminate on the table is a provider that ignores its argument.
+     */
+    @FunctionalInterface
+    public interface LocationKeyFilterProvider {
 
         /**
-         * Bind this filter to a table, returning the filter that applies to that table's locations.
+         * Produce the filter that decides the locations of {@code tableKey}.
          *
-         * <p>
-         * {@link FilteredTableDataService} binds once, when it builds the {@link TableLocationProvider} for a table,
-         * and asks only the bound filter about locations. A filter whose decision depends on both the table and the
-         * location - one that does not factor into an independent table test and location test - overrides this to
-         * capture the table. A filter that does not discriminate on the table inherits the default and binds to itself.
-         *
-         * @param tableKey The table to bind to
-         * @return The filter for locations of {@code tableKey}; {@link #NONE} if no location of that table can be
-         *         accepted, which lets the caller avoid consulting the filtered service at all
+         * @param tableKey The table to filter the locations of
+         * @return The filter for locations of {@code tableKey}; {@link LocationKeyFilter#NONE} if no location of that
+         *         table can be accepted, which lets the caller avoid consulting the filtered service at all
          */
         @NotNull
-        default LocationKeyFilter forTable(@NotNull TableKey tableKey) {
-            return this;
-        }
+        LocationKeyFilter forTable(@NotNull TableKey tableKey);
     }
 
     /**
      * @param serviceToFilter The service that's being filtered
-     * @param locationKeyFilter The filter function
+     * @param locationKeyFilterProvider Supplies the filter for each table's locations
      */
     public FilteredTableDataService(@NotNull final TableDataService serviceToFilter,
-            @NotNull final LocationKeyFilter locationKeyFilter) {
+            @NotNull final LocationKeyFilterProvider locationKeyFilterProvider) {
         super("Filtered-" + Require.neqNull(serviceToFilter, "serviceToFilter").getName());
         this.serviceToFilter = Require.neqNull(serviceToFilter, "serviceToFilter");
-        this.locationKeyFilter = Require.neqNull(locationKeyFilter, "locationKeyFilter");
+        this.locationKeyFilterProvider =
+                Require.neqNull(locationKeyFilterProvider, "locationKeyFilterProvider");
     }
 
     @Override
     @Nullable
     public TableLocationProvider getRawTableLocationProvider(@NotNull final TableKey tableKey,
             @NotNull final TableLocationKey tableLocationKey) {
-        if (!locationKeyFilter.forTable(tableKey).accept(tableLocationKey)) {
+        if (!locationKeyFilterProvider.forTable(tableKey).accept(tableLocationKey)) {
             return null;
         }
 
@@ -112,7 +109,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     @Override
     @NotNull
     protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
-        final LocationKeyFilter filterForTable = locationKeyFilter.forTable(tableKey);
+        final LocationKeyFilter filterForTable = locationKeyFilterProvider.forTable(tableKey);
         if (filterForTable == LocationKeyFilter.NONE) {
             // No location of this table can be accepted, so don't consult the filtered service at all. That service is
             // frequently remote, and consulting it would open a subscription whose every result would be discarded.
@@ -188,7 +185,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
         public void getTableLocationKeys(
                 final Consumer<LiveSupplier<ImmutableTableLocationKey>> consumer,
                 final Predicate<ImmutableTableLocationKey> filter) {
-            // Apply this service's locationKeyFilter alongside the caller's, so that enumeration exposes the same
+            // Apply this table's bound filter alongside the caller's, so that enumeration exposes the same
             // set as hasTableLocationKey, getTableLocationIfPresent, and subscription delivery.
             inputProvider.getTableLocationKeys(consumer, filter.and(filterForTable::accept));
         }
@@ -302,7 +299,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     public String toString() {
         return getImplementationName() + '{' +
                 (getName() != null ? "name=" + getName() + ", " : "") +
-                "locationKeyFilter=" + locationKeyFilter +
+                "locationKeyFilterProvider=" + locationKeyFilterProvider +
                 ", serviceToFilter=" + serviceToFilter +
                 '}';
     }
@@ -311,7 +308,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     public String describe() {
         return getImplementationName() + '{' +
                 (getName() != null ? "name=" + getName() + ", " : "") +
-                "locationKeyFilter=" + locationKeyFilter +
+                "locationKeyFilterProvider=" + locationKeyFilterProvider +
                 ", serviceToFilter=" + serviceToFilter.describe() +
                 '}';
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
@@ -15,17 +15,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
  * A {@link TableLocationProvider} that provides no locations, for a table that is known to have none visible.
- *
- * <p>
- * This exists so that a service which has already decided a table is entirely excluded can say so without consulting
- * the service it would otherwise delegate to. That delegate is frequently remote, so the alternative is a subscription
- * whose every result would be discarded.
  */
 public class NullTableLocationProvider implements TableLocationProvider {
 
@@ -34,7 +29,7 @@ public class NullTableLocationProvider implements TableLocationProvider {
     /**
      * Constructs a provider with no locations for the given table.
      *
-     * @param tableKey the table this provider stands in for
+     * @param tableKey the key for the table with no locations
      */
     public NullTableLocationProvider(@NotNull final TableKey tableKey) {
         this.tableKey = tableKey.makeImmutable();
@@ -62,22 +57,11 @@ public class NullTableLocationProvider implements TableLocationProvider {
         return false;
     }
 
-    /**
-     * Always throws: this provider never ticks, so reaching here means a caller subscribed without first checking
-     * {@link #supportsSubscriptions()}.
-     *
-     * @param listener the listener that would have been subscribed
-     */
     @Override
     public void subscribe(@NotNull final Listener listener) {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * Always throws, for the same reason as {@link #subscribe(Listener)}: no subscription can exist to cancel.
-     *
-     * @param listener the listener that would have been unsubscribed
-     */
     @Override
     public void unsubscribe(@NotNull final Listener listener) {
         throw new UnsupportedOperationException();
@@ -94,7 +78,7 @@ public class NullTableLocationProvider implements TableLocationProvider {
     @Override
     @NotNull
     public Collection<ImmutableTableLocationKey> getTableLocationKeys() {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.locations.impl;
+
+import io.deephaven.engine.liveness.LiveSupplier;
+import io.deephaven.engine.table.impl.TableUpdateMode;
+import io.deephaven.engine.table.impl.locations.ImmutableTableKey;
+import io.deephaven.engine.table.impl.locations.ImmutableTableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableKey;
+import io.deephaven.engine.table.impl.locations.TableLocation;
+import io.deephaven.engine.table.impl.locations.TableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableLocationProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * A {@link TableLocationProvider} that provides no locations, for a table that is known to have none visible.
+ *
+ * <p>
+ * This exists so that a service which has already decided a table is entirely excluded can say so without consulting
+ * the service it would otherwise delegate to. That delegate is frequently remote, so the alternative is a subscription
+ * whose every result would be discarded.
+ */
+public class NullTableLocationProvider implements TableLocationProvider {
+
+    private final ImmutableTableKey tableKey;
+
+    /**
+     * Constructs a provider with no locations for the given table.
+     *
+     * @param tableKey the table this provider stands in for
+     */
+    public NullTableLocationProvider(@NotNull final TableKey tableKey) {
+        this.tableKey = tableKey.makeImmutable();
+    }
+
+    @Override
+    public ImmutableTableKey getKey() {
+        return tableKey;
+    }
+
+    @Override
+    @NotNull
+    public TableUpdateMode getUpdateMode() {
+        return TableUpdateMode.STATIC;
+    }
+
+    @Override
+    @NotNull
+    public TableUpdateMode getLocationUpdateMode() {
+        return TableUpdateMode.STATIC;
+    }
+
+    @Override
+    public boolean supportsSubscriptions() {
+        return false;
+    }
+
+    @Override
+    public void subscribe(@NotNull final Listener listener) {}
+
+    @Override
+    public void unsubscribe(@NotNull final Listener listener) {}
+
+    @Override
+    public void refresh() {}
+
+    @Override
+    public TableLocationProvider ensureInitialized() {
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public Collection<ImmutableTableLocationKey> getTableLocationKeys() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void getTableLocationKeys(
+            final Consumer<LiveSupplier<ImmutableTableLocationKey>> consumer,
+            final Predicate<ImmutableTableLocationKey> filter) {}
+
+    @Override
+    public boolean hasTableLocationKey(@NotNull final TableLocationKey tableLocationKey) {
+        return false;
+    }
+
+    @Override
+    @Nullable
+    public TableLocation getTableLocationIfPresent(@NotNull final TableLocationKey tableLocationKey) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return getImplementationName() + '{' + tableKey + '}';
+    }
+}

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
@@ -62,11 +62,26 @@ public class NullTableLocationProvider implements TableLocationProvider {
         return false;
     }
 
+    /**
+     * Always throws: this provider never ticks, so reaching here means a caller subscribed without first checking
+     * {@link #supportsSubscriptions()}.
+     *
+     * @param listener the listener that would have been subscribed
+     */
     @Override
-    public void subscribe(@NotNull final Listener listener) {}
+    public void subscribe(@NotNull final Listener listener) {
+        throw new UnsupportedOperationException();
+    }
 
+    /**
+     * Always throws, for the same reason as {@link #subscribe(Listener)}: no subscription can exist to cancel.
+     *
+     * @param listener the listener that would have been unsubscribed
+     */
     @Override
-    public void unsubscribe(@NotNull final Listener listener) {}
+    public void unsubscribe(@NotNull final Listener listener) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public void refresh() {}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
@@ -11,6 +11,7 @@ import io.deephaven.engine.table.impl.locations.TableKey;
 import io.deephaven.engine.table.impl.locations.TableLocation;
 import io.deephaven.engine.table.impl.locations.TableLocationKey;
 import io.deephaven.engine.table.impl.locations.TableLocationProvider;
+import io.deephaven.engine.table.impl.locations.impl.FilteredTableDataService.LocationKeyFilter;
 import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -102,6 +103,138 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
                 .getTableLocationKeys(trackedKey -> visible.add(trackedKey.get()), key -> !key.equals(b));
 
         Assert.assertEquals(Set.of(a), visible);
+    }
+
+    /**
+     * The filter is bound to a table exactly once per table, when the provider is built, and not again per location or
+     * per discovery call.
+     */
+    @Test
+    public void testFilterIsBoundOncePerTable() {
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(keyFor("A"));
+        underlying.addKey(keyFor("B"));
+        underlying.addKey(keyFor("C"));
+
+        final CountingFilter counting = new CountingFilter(LocationKeyFilter.ALL);
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), counting);
+
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+        Assert.assertEquals(3, provider.getTableLocationKeys().size());
+        Assert.assertTrue(provider.hasTableLocationKey(keyFor("A")));
+        Assert.assertEquals(3, filtered.getTableLocationProvider(TABLE).getTableLocationKeys().size());
+
+        Assert.assertEquals("forTable calls", 1, counting.bindCount);
+    }
+
+    /**
+     * The bound filter, not the unbound one, decides each location, so a filter that discriminates on the table takes
+     * effect per table rather than per service.
+     */
+    @Test
+    public void testBoundFilterDecidesLocations() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+
+        // Unbound accept() is never consulted; binding to TABLE yields a filter that keeps only A.
+        final LocationKeyFilter perTable = new LocationKeyFilter() {
+            @Override
+            public boolean accept(@NotNull final TableLocationKey locationKey) {
+                throw new UnsupportedOperationException("must be bound to a table first");
+            }
+
+            @Override
+            @NotNull
+            public LocationKeyFilter forTable(@NotNull final TableKey tableKey) {
+                return TABLE.equals(tableKey) ? key -> key.equals(a) : LocationKeyFilter.NONE;
+            }
+        };
+
+        final TableLocationProvider provider =
+                new FilteredTableDataService(new FixedProviderService(underlying), perTable)
+                        .getTableLocationProvider(TABLE);
+
+        Assert.assertEquals(Set.of(a), new HashSet<>(provider.getTableLocationKeys()));
+        Assert.assertTrue(provider.hasTableLocationKey(a));
+        Assert.assertFalse(provider.hasTableLocationKey(b));
+    }
+
+    /**
+     * Binding to {@link LocationKeyFilter#NONE} yields an empty provider without the filtered service being consulted
+     * at all. That service is frequently remote, so avoiding it is the point of the {@code NONE} answer.
+     */
+    @Test
+    public void testNoneAvoidsTheFilteredService() {
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(keyFor("A"));
+
+        final RecordingProviderService service = new RecordingProviderService(underlying);
+        final FilteredTableDataService filtered = new FilteredTableDataService(service, LocationKeyFilter.NONE);
+
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+
+        Assert.assertTrue(provider.getTableLocationKeys().isEmpty());
+        Assert.assertFalse(provider.hasTableLocationKey(keyFor("A")));
+        Assert.assertEquals(TABLE, provider.getKey());
+        Assert.assertFalse("the filtered service was consulted", service.consulted);
+    }
+
+    /**
+     * A table-blind filter binds to itself, so an existing single-method filter keeps working unchanged.
+     */
+    @Test
+    public void testTableBlindFilterBindsToItself() {
+        final LocationKeyFilter blind = key -> true;
+        Assert.assertSame(blind, blind.forTable(TABLE));
+        Assert.assertSame(LocationKeyFilter.ALL, LocationKeyFilter.ALL.forTable(TABLE));
+        Assert.assertSame(LocationKeyFilter.NONE, LocationKeyFilter.NONE.forTable(TABLE));
+    }
+
+    /**
+     * A {@link LocationKeyFilter} that counts how often it is bound to a table, delegating the location decision.
+     */
+    private static final class CountingFilter implements LocationKeyFilter {
+
+        private final LocationKeyFilter delegate;
+        private int bindCount;
+
+        /**
+         * Creates a counting filter over the given delegate.
+         *
+         * @param delegate the filter that decides locations once bound
+         */
+        private CountingFilter(@NotNull final LocationKeyFilter delegate) {
+            this.delegate = delegate;
+        }
+
+        /**
+         * Delegates the location decision.
+         *
+         * @param locationKey the location key
+         * @return the delegate's answer
+         */
+        @Override
+        public boolean accept(@NotNull final TableLocationKey locationKey) {
+            return delegate.accept(locationKey);
+        }
+
+        /**
+         * Records the binding and returns the delegate.
+         *
+         * @param tableKey the table being bound to
+         * @return the delegate
+         */
+        @Override
+        @NotNull
+        public LocationKeyFilter forTable(@NotNull final TableKey tableKey) {
+            ++bindCount;
+            return delegate;
+        }
     }
 
     /**
@@ -252,6 +385,38 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         @Override
         @NotNull
         protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
+            return provider;
+        }
+    }
+
+    /**
+     * A {@link FixedProviderService} that records whether it was ever asked for a provider.
+     */
+    private static final class RecordingProviderService extends AbstractTableDataService {
+
+        private final TableLocationProvider provider;
+        private boolean consulted;
+
+        /**
+         * Creates a service backed by a single provider.
+         *
+         * @param provider the provider to return for every table
+         */
+        private RecordingProviderService(@NotNull final TableLocationProvider provider) {
+            super("recordingProviderService");
+            this.provider = provider;
+        }
+
+        /**
+         * Records the request and returns the fixed provider.
+         *
+         * @param tableKey ignored
+         * @return the fixed provider
+         */
+        @Override
+        @NotNull
+        protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
+            consulted = true;
             return provider;
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
@@ -1,0 +1,258 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.locations.impl;
+
+import io.deephaven.base.log.LogOutput;
+import io.deephaven.engine.table.impl.TableUpdateMode;
+import io.deephaven.engine.table.impl.locations.ImmutableTableKey;
+import io.deephaven.engine.table.impl.locations.ImmutableTableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableKey;
+import io.deephaven.engine.table.impl.locations.TableLocation;
+import io.deephaven.engine.table.impl.locations.TableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableLocationProvider;
+import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Verifies that {@link FilteredTableDataService} applies its {@code locationKeyFilter} consistently across every way a
+ * caller can discover a location.
+ */
+public class TestFilteredTableDataService extends RefreshingTableTestCase {
+
+    /** The table whose locations are filtered throughout. */
+    private static final TableKey TABLE = new NamedTableKey("Market.Quotes");
+
+    /**
+     * Enumerating locations through the filtered provider hides the keys the {@code locationKeyFilter} rejects, rather
+     * than passing the underlying provider's unfiltered set through.
+     */
+    @Test
+    public void testGetTableLocationKeysAppliesFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey c = keyFor("C");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+        underlying.addKey(c);
+
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), key -> !key.equals(c));
+
+        final Set<ImmutableTableLocationKey> visible =
+                new HashSet<>(filtered.getTableLocationProvider(TABLE).getTableLocationKeys());
+
+        Assert.assertEquals(Set.of(a, b), visible);
+    }
+
+    /**
+     * Enumeration and {@code hasTableLocationKey} report the same set. These are the two discovery paths a caller can
+     * take, and a location visible through one but not the other is the defect this fixes.
+     */
+    @Test
+    public void testEnumerationAgreesWithHasTableLocationKey() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey c = keyFor("C");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+        underlying.addKey(c);
+
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), key -> !key.equals(c));
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+
+        final Set<ImmutableTableLocationKey> enumerated = new HashSet<>(provider.getTableLocationKeys());
+        for (final TableLocationKey key : new TableLocationKey[] {a, b, c}) {
+            Assert.assertEquals("agreement for " + key,
+                    provider.hasTableLocationKey(key), enumerated.contains(key));
+        }
+    }
+
+    /**
+     * The caller's own predicate still applies, and is combined with the service's filter rather than replacing it.
+     */
+    @Test
+    public void testCallerPredicateIsCombinedWithTheServiceFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey c = keyFor("C");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+        underlying.addKey(c);
+
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), key -> !key.equals(c));
+
+        final Set<ImmutableTableLocationKey> visible = new HashSet<>();
+        filtered.getTableLocationProvider(TABLE)
+                .getTableLocationKeys(trackedKey -> visible.add(trackedKey.get()), key -> !key.equals(b));
+
+        Assert.assertEquals(Set.of(a), visible);
+    }
+
+    /**
+     * A named {@link TableKey}, distinct from every other key, so a test cannot pass by accident on a key the
+     * implementation supplied by default.
+     */
+    private static final class NamedTableKey implements ImmutableTableKey {
+
+        private final String name;
+
+        /**
+         * Creates a key with the given name.
+         *
+         * @param name the name, used for identity and display
+         */
+        private NamedTableKey(@NotNull final String name) {
+            this.name = name;
+        }
+
+        /**
+         * Returns the implementation name used in diagnostic output.
+         *
+         * @return the implementation name
+         */
+        @Override
+        public String getImplementationName() {
+            return "NamedTableKey";
+        }
+
+        /**
+         * Appends this key's name to the given log output.
+         *
+         * @param logOutput the output to append to
+         * @return the output, for chaining
+         */
+        @Override
+        public LogOutput append(final LogOutput logOutput) {
+            return logOutput.append(name);
+        }
+
+        /**
+         * Returns this key's name.
+         *
+         * @return the name
+         */
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        /**
+         * Hashes on the name.
+         *
+         * @return the hash code
+         */
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        /**
+         * Compares on the name.
+         *
+         * @param other the object to compare to
+         * @return true if the other object is a NamedTableKey with the same name
+         */
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof NamedTableKey && name.equals(((NamedTableKey) other).name);
+        }
+    }
+
+    /**
+     * Creates a single-partition location key for the given value.
+     *
+     * @param value the value of the {@code Part} partition
+     * @return the key
+     */
+    private static TableLocationKey keyFor(@NotNull final String value) {
+        final Map<String, Comparable<?>> partitions = new HashMap<>();
+        partitions.put("Part", value);
+        return new SimpleTableLocationKey(partitions);
+    }
+
+    /**
+     * A subscription-free provider populated with a fixed set of keys via {@link #addKey(TableLocationKey)}.
+     */
+    private static final class PopulatedProvider extends AbstractTableLocationProvider {
+
+        /**
+         * Creates an empty provider for the given table.
+         *
+         * @param tableKey the table this provider serves
+         */
+        private PopulatedProvider(@NotNull final TableKey tableKey) {
+            super(tableKey, false, TableUpdateMode.ADD_REMOVE, TableUpdateMode.ADD_REMOVE);
+        }
+
+        /**
+         * Adds a key to this provider's set.
+         *
+         * @param locationKey the key to add
+         */
+        private void addKey(@NotNull final TableLocationKey locationKey) {
+            handleTableLocationKeyAdded(locationKey);
+        }
+
+        /**
+         * Never called: this provider is enumerated, not read.
+         *
+         * @param locationKey the key that would be built
+         * @return never returns
+         */
+        @Override
+        @NotNull
+        protected TableLocation makeTableLocation(@NotNull final TableLocationKey locationKey) {
+            throw new UnsupportedOperationException("test provider is enumerated only");
+        }
+
+        /** Does nothing: the key set is fixed at construction. */
+        @Override
+        public void refresh() {}
+    }
+
+    /**
+     * A minimal {@link AbstractTableDataService} that always hands back one fixed provider.
+     */
+    private static final class FixedProviderService extends AbstractTableDataService {
+
+        private final TableLocationProvider provider;
+
+        /**
+         * Creates a service backed by a single provider.
+         *
+         * @param provider the provider to return for every table
+         */
+        private FixedProviderService(@NotNull final TableLocationProvider provider) {
+            super("fixedProviderService");
+            this.provider = provider;
+        }
+
+        /**
+         * Returns the fixed provider, regardless of the requested table.
+         *
+         * @param tableKey ignored
+         * @return the fixed provider
+         */
+        @Override
+        @NotNull
+        protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
+            return provider;
+        }
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
@@ -12,6 +12,7 @@ import io.deephaven.engine.table.impl.locations.TableLocation;
 import io.deephaven.engine.table.impl.locations.TableLocationKey;
 import io.deephaven.engine.table.impl.locations.TableLocationProvider;
 import io.deephaven.engine.table.impl.locations.impl.FilteredTableDataService.LocationKeyFilter;
+import io.deephaven.engine.table.impl.locations.impl.FilteredTableDataService.LocationKeyFilterProvider;
 import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -47,7 +48,7 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         underlying.addKey(c);
 
         final FilteredTableDataService filtered =
-                new FilteredTableDataService(new FixedProviderService(underlying), key -> !key.equals(c));
+                new FilteredTableDataService(new FixedProviderService(underlying), tableKey -> key -> !key.equals(c));
 
         final Set<ImmutableTableLocationKey> visible =
                 new HashSet<>(filtered.getTableLocationProvider(TABLE).getTableLocationKeys());
@@ -71,7 +72,7 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         underlying.addKey(c);
 
         final FilteredTableDataService filtered =
-                new FilteredTableDataService(new FixedProviderService(underlying), key -> !key.equals(c));
+                new FilteredTableDataService(new FixedProviderService(underlying), tableKey -> key -> !key.equals(c));
         final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
 
         final Set<ImmutableTableLocationKey> enumerated = new HashSet<>(provider.getTableLocationKeys());
@@ -96,7 +97,7 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         underlying.addKey(c);
 
         final FilteredTableDataService filtered =
-                new FilteredTableDataService(new FixedProviderService(underlying), key -> !key.equals(c));
+                new FilteredTableDataService(new FixedProviderService(underlying), tableKey -> key -> !key.equals(c));
 
         final Set<ImmutableTableLocationKey> visible = new HashSet<>();
         filtered.getTableLocationProvider(TABLE)
@@ -116,7 +117,7 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         underlying.addKey(keyFor("B"));
         underlying.addKey(keyFor("C"));
 
-        final CountingFilter counting = new CountingFilter(LocationKeyFilter.ALL);
+        final CountingProvider counting = new CountingProvider(LocationKeyFilter.ALL);
         final FilteredTableDataService filtered =
                 new FilteredTableDataService(new FixedProviderService(underlying), counting);
 
@@ -141,19 +142,9 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         underlying.addKey(a);
         underlying.addKey(b);
 
-        // Unbound accept() is never consulted; binding to TABLE yields a filter that keeps only A.
-        final LocationKeyFilter perTable = new LocationKeyFilter() {
-            @Override
-            public boolean accept(@NotNull final TableLocationKey locationKey) {
-                throw new UnsupportedOperationException("must be bound to a table first");
-            }
-
-            @Override
-            @NotNull
-            public LocationKeyFilter forTable(@NotNull final TableKey tableKey) {
-                return TABLE.equals(tableKey) ? key -> key.equals(a) : LocationKeyFilter.NONE;
-            }
-        };
+        // Binding to TABLE yields a filter that keeps only A; any other table is excluded outright.
+        final LocationKeyFilterProvider perTable =
+                tableKey -> TABLE.equals(tableKey) ? key -> key.equals(a) : LocationKeyFilter.NONE;
 
         final TableLocationProvider provider =
                 new FilteredTableDataService(new FixedProviderService(underlying), perTable)
@@ -174,7 +165,8 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         underlying.addKey(keyFor("A"));
 
         final RecordingProviderService service = new RecordingProviderService(underlying);
-        final FilteredTableDataService filtered = new FilteredTableDataService(service, LocationKeyFilter.NONE);
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(service, tableKey -> LocationKeyFilter.NONE);
 
         final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
 
@@ -185,42 +177,32 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
     }
 
     /**
-     * A table-blind filter binds to itself, so an existing single-method filter keeps working unchanged.
+     * A provider that ignores its argument supplies the same filter for every table, which is how a filter that does
+     * not discriminate on the table is expressed.
      */
     @Test
-    public void testTableBlindFilterBindsToItself() {
+    public void testTableBlindProviderSuppliesOneFilter() {
         final LocationKeyFilter blind = key -> true;
-        Assert.assertSame(blind, blind.forTable(TABLE));
-        Assert.assertSame(LocationKeyFilter.ALL, LocationKeyFilter.ALL.forTable(TABLE));
-        Assert.assertSame(LocationKeyFilter.NONE, LocationKeyFilter.NONE.forTable(TABLE));
+        final LocationKeyFilterProvider provider = tableKey -> blind;
+        Assert.assertSame(blind, provider.forTable(TABLE));
+        Assert.assertSame(blind, provider.forTable(new NamedTableKey("Other.Table")));
     }
 
     /**
-     * A {@link LocationKeyFilter} that counts how often it is bound to a table, delegating the location decision.
+     * A {@link LocationKeyFilterProvider} that counts how often it is asked to bind, supplying a fixed filter.
      */
-    private static final class CountingFilter implements LocationKeyFilter {
+    private static final class CountingProvider implements LocationKeyFilterProvider {
 
         private final LocationKeyFilter delegate;
         private int bindCount;
 
         /**
-         * Creates a counting filter over the given delegate.
+         * Creates a counting provider that always supplies the given filter.
          *
          * @param delegate the filter that decides locations once bound
          */
-        private CountingFilter(@NotNull final LocationKeyFilter delegate) {
+        private CountingProvider(@NotNull final LocationKeyFilter delegate) {
             this.delegate = delegate;
-        }
-
-        /**
-         * Delegates the location decision.
-         *
-         * @param locationKey the location key
-         * @return the delegate's answer
-         */
-        @Override
-        public boolean accept(@NotNull final TableLocationKey locationKey) {
-            return delegate.accept(locationKey);
         }
 
         /**

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
@@ -4,10 +4,12 @@
 package io.deephaven.engine.table.impl.locations.impl;
 
 import io.deephaven.base.log.LogOutput;
+import io.deephaven.engine.liveness.LiveSupplier;
 import io.deephaven.engine.table.impl.TableUpdateMode;
 import io.deephaven.engine.table.impl.locations.ImmutableTableKey;
 import io.deephaven.engine.table.impl.locations.ImmutableTableLocationKey;
 import io.deephaven.engine.table.impl.locations.TableKey;
+import io.deephaven.engine.table.impl.locations.TableDataException;
 import io.deephaven.engine.table.impl.locations.TableLocation;
 import io.deephaven.engine.table.impl.locations.TableLocationKey;
 import io.deephaven.engine.table.impl.locations.TableLocationProvider;
@@ -186,16 +188,23 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
         final TableLocationKey a = keyFor("A");
         final TableKey other = new NamedTableKey("Market.Trades");
 
+        // The delegate holds the same location under BOTH tables, so it can answer for either. Without that, the
+        // negative assertion below would pass even if the filter were never consulted - the delegate would return
+        // null for an unknown table anyway, which is what made an earlier version of this test vacuous.
         final PopulatedProvider underlying = new PopulatedProvider(TABLE);
         underlying.addKey(a);
+        final PopulatedProvider otherUnderlying = new PopulatedProvider(other);
+        otherUnderlying.addKey(a);
+        final PerTableProviderService delegate = new PerTableProviderService(Map.of(
+                TABLE, underlying, other, otherUnderlying));
+        delegate.getTableLocationProvider(TABLE);
+        delegate.getTableLocationProvider(other);
+        Assert.assertSame("the delegate must be able to answer for the excluded table, or this test proves nothing",
+                otherUnderlying, delegate.getRawTableLocationProvider(other, a));
 
         // Accepts every location of TABLE and no location of any other table.
         final LocationKeyFilterProvider perTable =
                 tableKey -> TABLE.equals(tableKey) ? LocationKeyFilter.ALL : LocationKeyFilter.NONE;
-
-        final FixedProviderService delegate = new FixedProviderService(underlying);
-        // The delegate's raw lookup consults its own provider cache, so make it create the provider for TABLE first.
-        delegate.getTableLocationProvider(TABLE);
         final FilteredTableDataService filtered = new FilteredTableDataService(delegate, perTable);
 
         Assert.assertSame(underlying, filtered.getRawTableLocationProvider(TABLE, a));
@@ -429,4 +438,153 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
             return provider;
         }
     }
+
+
+    /**
+     * Subscription delivery applies the table-bound filter, so a listener sees only the keys the filter accepts - both
+     * the initial snapshot and keys pushed afterwards. This is the one discovery path a caller can take that
+     * enumeration and {@code hasTableLocationKey} do not cover.
+     */
+    @Test
+    public void testSubscriptionDeliveryAppliesTheFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey pushed = keyFor("pushedAccepted");
+        final TableLocationKey pushedRejected = keyFor("C");
+
+        final SubscribableProvider underlying = new SubscribableProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+
+        // Reject exactly the keys named "C"; everything else is visible.
+        final FilteredTableDataService filtered = new FilteredTableDataService(
+                new FixedProviderService(underlying), tableKey -> key -> !key.equals(pushedRejected));
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+        Assert.assertTrue("the provider must be subscribable for this test to mean anything",
+                provider.supportsSubscriptions());
+
+        final Set<ImmutableTableLocationKey> delivered = new HashSet<>();
+        provider.subscribe(new TableLocationProvider.Listener() {
+            @Override
+            public void handleTableLocationKeyAdded(@NotNull final LiveSupplier<ImmutableTableLocationKey> key) {
+                delivered.add(key.get());
+            }
+
+            @Override
+            public void handleTableLocationKeyRemoved(@NotNull final LiveSupplier<ImmutableTableLocationKey> key) {
+                delivered.remove(key.get());
+            }
+
+            @Override
+            public void handleException(@NotNull final TableDataException exception) {
+                throw exception;
+            }
+        });
+
+        // The initial snapshot is filtered.
+        Assert.assertEquals(Set.of(a, b), delivered);
+
+        // ... and so is everything pushed afterwards.
+        underlying.addKey(pushed);
+        underlying.addKey(pushedRejected);
+        Assert.assertEquals(Set.of(a, b, pushed), delivered);
+    }
+
+    /**
+     * A {@link TableDataService} holding a distinct provider per table. The provider cache is keyed by each provider's
+     * own table key, so a single provider instance cannot serve two different tables.
+     */
+    private static final class PerTableProviderService extends AbstractTableDataService {
+
+        private final Map<TableKey, TableLocationProvider> providers;
+
+        /**
+         * Creates a service backed by one provider per table.
+         *
+         * @param providers the provider to return for each table
+         */
+        private PerTableProviderService(@NotNull final Map<TableKey, TableLocationProvider> providers) {
+            super("perTableProviderService");
+            this.providers = providers;
+        }
+
+        /**
+         * Returns the provider registered for the requested table.
+         *
+         * @param tableKey the table being requested
+         * @return that table's provider
+         */
+        @Override
+        @NotNull
+        protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
+            final TableLocationProvider provider = providers.get(tableKey);
+            Assert.assertNotNull("no provider registered for " + tableKey, provider);
+            return provider;
+        }
+    }
+
+
+    /**
+     * A {@link PopulatedProvider} that supports subscriptions, so that listener delivery can be exercised. Keys added
+     * after a subscriber attaches are pushed to it.
+     */
+    private static final class SubscribableProvider extends AbstractTableLocationProvider {
+
+        /**
+         * Creates an empty subscribable provider for the given table.
+         *
+         * @param tableKey the table this provider serves
+         */
+        private SubscribableProvider(@NotNull final TableKey tableKey) {
+            super(tableKey, true, TableUpdateMode.ADD_REMOVE, TableUpdateMode.ADD_REMOVE);
+        }
+
+        /**
+         * Adds a key, pushing it to any current subscriber.
+         *
+         * @param locationKey the key to add
+         */
+        private void addKey(@NotNull final TableLocationKey locationKey) {
+            handleTableLocationKeyAdded(locationKey);
+        }
+
+        /** Activation is immediate: the key set is already in memory. */
+        @Override
+        protected void activateUnderlyingDataSource() {
+            activationSuccessful(this);
+        }
+
+        /** Nothing to tear down. */
+        @Override
+        protected void deactivateUnderlyingDataSource() {}
+
+        /**
+         * Matches the token handed to {@link #activationSuccessful}.
+         *
+         * @param token the subscription token
+         * @param <T> the token type
+         * @return whether the token is this provider
+         */
+        @Override
+        protected <T> boolean matchSubscriptionToken(final T token) {
+            return token == this;
+        }
+
+        /**
+         * Never called: this provider is enumerated, not read.
+         *
+         * @param locationKey the key that would be built
+         * @return never returns
+         */
+        @Override
+        @NotNull
+        protected TableLocation makeTableLocation(@NotNull final TableLocationKey locationKey) {
+            throw new UnsupportedOperationException("test provider is enumerated only");
+        }
+
+        /** Does nothing: keys arrive through {@link #addKey}. */
+        @Override
+        public void refresh() {}
+    }
+
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
@@ -177,6 +177,33 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
     }
 
     /**
+     * The single-location raw lookup binds the filter to the table key it was handed, so one location key is accepted
+     * for one table and rejected for another. This is the path that previously asked an unbound filter about a bare
+     * location key and so could not tell the two tables apart.
+     */
+    @Test
+    public void testRawLookupAppliesTheTableAwareFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableKey other = new NamedTableKey("Market.Trades");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+
+        // Accepts every location of TABLE and no location of any other table.
+        final LocationKeyFilterProvider perTable =
+                tableKey -> TABLE.equals(tableKey) ? LocationKeyFilter.ALL : LocationKeyFilter.NONE;
+
+        final FixedProviderService delegate = new FixedProviderService(underlying);
+        // The delegate's raw lookup consults its own provider cache, so make it create the provider for TABLE first.
+        delegate.getTableLocationProvider(TABLE);
+        final FilteredTableDataService filtered = new FilteredTableDataService(delegate, perTable);
+
+        Assert.assertSame(underlying, filtered.getRawTableLocationProvider(TABLE, a));
+        Assert.assertNull("the same location key must be rejected for a table the filter excludes",
+                filtered.getRawTableLocationProvider(other, a));
+    }
+
+    /**
      * A provider that ignores its argument supplies the same filter for every table, which is how a filter that does
      * not discriminate on the table is expressed.
      */

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
@@ -107,8 +107,8 @@ public class TestFilteredTableDataService extends RefreshingTableTestCase {
     }
 
     /**
-     * The filter is bound to a table exactly once per table, when the provider is built, and not again per location or
-     * per discovery call.
+     * Building a table's provider binds the filter once, and neither a repeated provider lookup nor per-location
+     * discovery through that provider binds it again.
      */
     @Test
     public void testFilterIsBoundOncePerTable() {

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestTableDataService.java
@@ -65,7 +65,8 @@ public class TestTableDataService {
         final TableDataService[] tableDataServices;
 
         private DummyServiceSelector(final TableLocationKey tlk1, final TableLocationKey tlk2) {
-            final FilteredTableDataService.LocationKeyFilter dummyFilter = (tlk) -> true;
+            final FilteredTableDataService.LocationKeyFilterProvider dummyFilter =
+                    tableKey -> FilteredTableDataService.LocationKeyFilter.ALL;
             tableDataServices = new TableDataService[] {
                     new FilteredTableDataService(new DummyTableDataService("dummyTds1",
                             new DummyTableLocation(StandaloneTableKey.getInstance(), tlk1)), dummyFilter),


### PR DESCRIPTION
## Summary

`FilteredTableDataService` took a `LocationKeyFilter` that was asked about a bare `TableLocationKey`. A
`TableLocationKey` carries partition values and no table identity, so it names a location only *relative to*
its table — asking whether one is acceptable without saying which table it belongs to is not a well-formed
question. This PR splits the interface so the filter is bound to a table first:

```java
LocationKeyFilterProvider.forTable(TableKey) -> LocationKeyFilter.accept(TableLocationKey)
```

Every existing decision point then uses the binding its provider already holds, so no call site has to
reconstruct the table.

The motivating consumer is Deephaven Enterprise, where a data import server's claim on a table can name an
internal partition: two services may own different locations of the same table, and a filter that is only
ever shown a bare location key cannot decide which one owns a given location without guessing.

## Behavior changes

**1. Enumeration now applies the filter.** `TableLocationProviderImpl.getTableLocationKeys(consumer, filter)`
previously delegated straight to the input provider **without applying the service's own location filter**,
so excluded locations were still enumerated even though `hasTableLocationKey`, `getTableLocationIfPresent`
and subscription delivery all excluded them. It now passes `filter.and(filterForTable::accept)`. This is a
fix independent of the interface split, and it is the change most likely to be visible to an existing user of
`FilteredTableDataService`.

**2. A fully excluded table no longer consults the wrapped service.** When `forTable` returns
`LocationKeyFilter.NONE`, `makeTableLocationProvider` returns the new public `NullTableLocationProvider`
instead of wrapping the delegate. The wrapped service is frequently remote, so the previous behavior opened a
subscription whose every result would be discarded.

## API notes

- `LocationKeyFilter` gains `ALL` and `NONE` constants. **They are recognized by reference identity**, so an
  implementation that accepts no location of a table *must* return the `NONE` instance rather than an
  equivalent lambda — returning `locationKey -> false` decides every location correctly and silently loses
  all of it, because the table still reads as servable. The `forTable` javadoc states this.
- `forTable` may be called more than once for the same table and must therefore be a deterministic function
  of its argument. It is not cached: it has no production callers on a hot path (zero in Core, one in
  Enterprise, on the partition-write path beside an ACL check, a schema lookup, an audit event and the
  parquet I/O), so a per-table cache would buy nothing and add a lifecycle to reason about.
- `NullTableLocationProvider` is new and public, adapted from a private copy that already existed downstream.
  Its `subscribe`/`unsubscribe` throw `UnsupportedOperationException`, matching `SingleTableLocationProvider`
  — the other provider in this package with `supportsSubscriptions() == false`. Every caller in the repo
  guards on `supportsSubscriptions()` before subscribing.

**Not source-compatible for implementors.** `LocationKeyFilter` no longer serves as the constructor
parameter; anyone constructing a `FilteredTableDataService` supplies a `LocationKeyFilterProvider`. A filter
that does not discriminate on the table becomes a provider that ignores its argument.

## Testing

New `TestFilteredTableDataService` (8 tests) covers the binding, both sentinels, the enumeration fix, listener
filtering, and that the raw single-location lookup applies the *table-aware* filter — the same location key
accepted for one table and rejected for another. `engine-table` `locations.impl`: 20 tests green.

Cross-repo validation against the Enterprise consumer (`EnterpriseFilterWrapper`,
`TableDataServiceFactory.AndFilter`) is in deephaven-ent/iris#3739, which depends on this PR.
