### PR TITLE
fix: DH-23250: gRPC Drainable should implement KnownLength

### DIFF
--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/DefensiveDrainable.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/util/DefensiveDrainable.java
@@ -4,6 +4,7 @@
 package io.deephaven.extensions.barrage.util;
 
 import io.grpc.Drainable;
+import io.grpc.KnownLength;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -15,7 +16,7 @@ import java.io.OutputStream;
  * should use {@link #drainTo(OutputStream)} when applicable. If handing off to external code that needs a real
  * {@link InputStream}, use {@link #capture()}.
  */
-public abstract class DefensiveDrainable extends InputStream implements Drainable {
+public abstract class DefensiveDrainable extends InputStream implements Drainable, KnownLength {
 
     private static UnsupportedOperationException unsupportedUsagePattern() {
         return new UnsupportedOperationException(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ netty = "4.1.136.Final"
 protobuf-gwt='4.33.2-2'
 grpc-gwt='1.76.2-2'
 
-grpc-web-gwt-fetch='1.2.0'
+grpc-web-gwt-fetch='1.3.0'
 
 guava = "33.6.0-jre"
 gwt = "2.13.1"

--- a/web/client-api/src/test/java/io/deephaven/web/client/api/DoPutTestGwt.java
+++ b/web/client-api/src/test/java/io/deephaven/web/client/api/DoPutTestGwt.java
@@ -16,7 +16,7 @@ public class DoPutTestGwt extends AbstractAsyncGwtTestCase {
      * server via DoPut (WorkerConnection.newTable), and sets a viewport to confirm the row count is correct.
      */
     public void testLargeTable() {
-        final int rowCount = 25_000;
+        final int rowCount = 100_000;
 
         // Build column-oriented data (Object[][] for WorkerConnection.newTable)
         Object[] intCol = new Object[rowCount];


### PR DESCRIPTION
The Drainable API also intends for an implementation to advertise that its InputSize.available() is accurate through implementing KnownLength, otherwise available() will not be called. Updated the gRPC-web implementation for GWT to read this as well.

The JS API test for DoPut locally went from 10s for 25k rows to 4s for 100k rows.