### PR TITLE
fix: DH-23310: Remove stray final continuation character

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.python-wheel.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.python-wheel.gradle
@@ -51,7 +51,7 @@ def buildWheel = Docker.registerDockerTask(project, 'buildWheel') { config ->
                       ruff format --check;\\
                       python setup.py bdist_wheel; \\
                       pip freeze | xargs pip uninstall -y; \\
-                      rm -rf .mypy_cache; \\
+                      rm -rf .mypy_cache;
                       '''
     }
     config.parentContainers = [ Docker.registryTask(project, 'python') ]


### PR DESCRIPTION
This fix addresses this warning in the logs:


```
WARNING]: Empty continuation line found in: RUN set -eux;                       test -n "${DEEPHAVEN_VERSION}";                      pip install --upgrade pip;                      pip install --root-user-action ignore -r requirements-dev.txt;                      mypy --install-types --non-interactive --config-file pyproject.toml .;                      ruff check;                      ruff format --check;                      python setup.py bdist_wheel;                       pip freeze | xargs pip uninstall -y;                       rm -rf .mypy_cache; 
[WARNING]: Empty continuation lines will become errors in a future release.

```
