### PR TITLE
perf: DH-23193: Improve Barrage Low-Level Serialization/Deserialization

### DIFF
--- a/extensions/barrage/benchmark/build.gradle
+++ b/extensions/barrage/benchmark/build.gradle
@@ -1,0 +1,59 @@
+plugins {
+    id 'java-library'
+    id 'io.deephaven.project.register'
+}
+
+description 'Barrage Benchmark: Benchmarks for Barrage message serialization/deserialization'
+
+sourceSets {
+    test {
+        java {
+            srcDir 'src/benchmark/java'
+        }
+    }
+}
+
+dependencies {
+    testImplementation project(':extensions-barrage')
+    testImplementation project(':engine-table')
+    testImplementation project(':BenchmarkSupport')
+    testImplementation libs.arrow.vector
+    testImplementation libs.flatbuffers.java
+    testImplementation platform(libs.grpc.bom)
+    testImplementation libs.grpc.api
+    testImplementation TestTools.projectDependency(project, 'engine-rowset')
+    testImplementation TestTools.projectDependency(project, 'engine-table')
+
+    testAnnotationProcessor libs.jmh.generator.annprocess
+    testCompileOnly libs.jmh.generator.annprocess
+
+    testRuntimeOnly project(':configs')
+    testRuntimeOnly project(':test-configs')
+}
+
+def createJmhTask = {
+    taskName, cliArgs, jvmAddArgs=[], heapSize='8g' -> tasks.create(taskName, JavaExec, { JavaExec task ->
+        new File("$rootDir/tmp/workspace").mkdirs()
+        new File("$rootDir/tmp/logs").mkdirs()
+
+        task.workingDir "$rootDir/tmp/workspace"
+        task.classpath = sourceSets.test.runtimeClasspath
+        task.mainClass.set 'io.deephaven.benchmarking.runner.BenchmarkRunner'
+
+        // arguments to pass to the application
+        def jvmArgs = [ '-DConfiguration.rootFile=dh-tests.prop',
+                "-Dworkspace=$rootDir/tmp/workspace",
+                '-Dconfiguration.quiet=true',
+                '-Djava.awt.headless=true',
+                '-DQueryTable.memoizeResults=false',
+                "-Xmx$heapSize"
+        ]
+        jvmArgs.addAll(jvmAddArgs)
+        task.jvmArgs jvmArgs
+        task.args cliArgs
+
+        return
+    })
+}
+
+createJmhTask('jmhRunBarrageRoundTrip', 'BarrageMessageRoundTripBenchmark')

--- a/extensions/barrage/benchmark/gradle.properties
+++ b/extensions/barrage/benchmark/gradle.properties
@@ -1,0 +1,1 @@
+io.deephaven.project.ProjectType=JAVA_LOCAL

--- a/extensions/barrage/benchmark/src/benchmark/java/io/deephaven/benchmark/barrage/BarrageMessageRoundTripBenchmark.java
+++ b/extensions/barrage/benchmark/src/benchmark/java/io/deephaven/benchmark/barrage/BarrageMessageRoundTripBenchmark.java
@@ -1,0 +1,315 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.benchmark.barrage;
+
+import io.deephaven.chunk.Chunk;
+import io.deephaven.chunk.ChunkType;
+import io.deephaven.chunk.WritableByteChunk;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.WritableDoubleChunk;
+import io.deephaven.chunk.WritableFloatChunk;
+import io.deephaven.chunk.WritableIntChunk;
+import io.deephaven.chunk.WritableLongChunk;
+import io.deephaven.chunk.WritableShortChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.context.ExecutionContext;
+import io.deephaven.engine.context.TestExecutionContext;
+import io.deephaven.engine.rowset.RowSetFactory;
+import io.deephaven.engine.rowset.RowSetShiftData;
+import io.deephaven.engine.table.ColumnDefinition;
+import io.deephaven.engine.table.TableDefinition;
+import io.deephaven.engine.table.impl.util.BarrageMessage;
+import io.deephaven.extensions.barrage.BarrageMessageWriter;
+import io.deephaven.extensions.barrage.BarrageMessageWriterImpl;
+import io.deephaven.extensions.barrage.BarrageSnapshotOptions;
+import io.deephaven.extensions.barrage.BarrageTypeInfo;
+import io.deephaven.extensions.barrage.chunk.ChunkWriter;
+import io.deephaven.extensions.barrage.chunk.DefaultChunkWriterFactory;
+import io.deephaven.extensions.barrage.util.BarrageMessageReaderImpl;
+import io.deephaven.extensions.barrage.util.BarrageUtil;
+import io.deephaven.extensions.barrage.util.ExposedByteArrayOutputStream;
+import io.deephaven.util.QueryConstants;
+import io.deephaven.util.SafeCloseable;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks the cost of serializing and deserializing a Barrage snapshot message composed of a large number of random
+ * primitive columns of a single type.
+ * <p>
+ * The write path mirrors what a Barrage producer does: a {@link BarrageMessage} is handed to a
+ * {@link BarrageMessageWriter}, and its full-snapshot {@link BarrageMessageWriter.MessageView} is drained to a byte
+ * buffer. The read path mirrors a Barrage client: {@link BarrageMessageReaderImpl#safelyParseFrom} reconstructs a
+ * {@link BarrageMessage} from those bytes. The reader is stateful and must first observe a schema message (fed once
+ * during setup) to establish its per-column {@link ChunkWriter}s before it can parse record batches.
+ * <p>
+ * The source data is held in array-backed chunks whose {@code close()} is a no-op, so the pre-built message survives
+ * repeated serialization and each invocation measures serialization only (no per-invocation data marshalling).
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 10, time = 2)
+@Fork(1)
+public class BarrageMessageRoundTripBenchmark {
+
+    private static final BarrageMessageWriter.Factory WRITER_FACTORY = new BarrageMessageWriterImpl.Factory();
+
+    /** The primitive element type of every column. */
+    @Param({"double", "float", "long", "int", "short", "byte"})
+    private String columnType;
+
+    /** Number of columns in the message. */
+    @Param({"5000"})
+    private int numColumns;
+
+    /** Number of rows per column. */
+    @Param({"2000"})
+    private int numRows;
+
+    /** Fraction of cells that are null; exercises the validity-buffer / DH-null encoding paths. */
+    @Param({"0.0", "0.1"})
+    private double nullFraction;
+
+    /** When true, nulls are encoded as the Deephaven sentinel value; when false, as an Arrow validity buffer. */
+    @Param({"false", "true"})
+    private boolean useDeephavenNulls;
+
+    private SafeCloseable executionContext;
+
+    private BarrageSnapshotOptions options;
+    private BarrageMessageReaderImpl reader;
+
+    // reader-side wire metadata (every column shares the same primitive type)
+    private ChunkType[] wireChunkTypes;
+    private Class<?>[] wireTypes;
+    private Class<?>[] wireComponentTypes;
+
+    // the reusable, pre-built message and its pre-serialized bytes
+    private BarrageMessage message;
+    private ChunkWriter<Chunk<Values>>[] chunkWriters;
+    private byte[] serialized;
+
+    @Setup(Level.Trial)
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        executionContext = TestExecutionContext.createForUnitTests().open();
+
+        options = BarrageSnapshotOptions.builder()
+                .useDeephavenNulls(useDeephavenNulls)
+                .build();
+        reader = new BarrageMessageReaderImpl();
+
+        final Class<?> dataType = primitiveClass(columnType);
+        final ChunkType chunkType = ChunkType.fromElementType(dataType);
+
+        // Build the flat table schema of numColumns columns of the chosen type.
+        final List<ColumnDefinition<?>> columns = new ArrayList<>(numColumns);
+        for (int ci = 0; ci < numColumns; ++ci) {
+            columns.add(ColumnDefinition.fromGenericType("C" + ci, dataType));
+        }
+        final TableDefinition definition = TableDefinition.of(columns);
+        final Schema schema = BarrageUtil.makeSchema(options, definition, Map.of(), true);
+
+        // Per-column wire metadata.
+        wireChunkTypes = new ChunkType[numColumns];
+        wireTypes = new Class<?>[numColumns];
+        wireComponentTypes = new Class<?>[numColumns];
+        Arrays.fill(wireChunkTypes, chunkType);
+        Arrays.fill(wireTypes, dataType);
+
+        chunkWriters = (ChunkWriter<Chunk<Values>>[]) new ChunkWriter[numColumns];
+        for (int ci = 0; ci < numColumns; ++ci) {
+            chunkWriters[ci] = DefaultChunkWriterFactory.INSTANCE.newWriterPojo(
+                    BarrageTypeInfo.make(dataType, null, schema.getFields().get(ci)));
+        }
+
+        // Generate the random column data once. The chunks are array-backed and have a no-op close(), so the message
+        // can be handed to a writer repeatedly without losing its data.
+        final Random random = new Random(0xB33FCAFEL);
+        final BarrageMessage.AddColumnData[] addColumnData = new BarrageMessage.AddColumnData[numColumns];
+        for (int ci = 0; ci < numColumns; ++ci) {
+            final BarrageMessage.AddColumnData acd = new BarrageMessage.AddColumnData();
+            acd.type = dataType;
+            acd.componentType = null;
+            acd.chunkType = chunkType;
+            acd.data = List.of(makeColumn(random));
+            addColumnData[ci] = acd;
+        }
+
+        message = new BarrageMessage();
+        message.isSnapshot = true;
+        message.firstSeq = 0;
+        message.lastSeq = 0;
+        message.rowsAdded = RowSetFactory.flat(numRows);
+        message.rowsIncluded = RowSetFactory.flat(numRows);
+        message.rowsRemoved = RowSetFactory.empty();
+        message.shifted = RowSetShiftData.EMPTY;
+        message.addColumnData = addColumnData;
+        message.modColumnData = BarrageMessage.ZERO_MOD_COLUMNS;
+
+        // Prime the stateful reader with the schema so it can construct its per-column chunk readers. This message
+        // carries no body and safelyParseFrom returns null for it.
+        final byte[] schemaBytes = drain(WRITER_FACTORY.getSchemaView(schema::getSchema));
+        deserialize(schemaBytes);
+
+        // Serialize once for the deserialize benchmark and validate a single-batch round trip.
+        serialized = serialize();
+        try (final BarrageMessage roundTrip = deserialize(serialized)) {
+            if (roundTrip == null || roundTrip.rowsAdded.size() != numRows) {
+                throw new IllegalStateException("Round trip failed to reproduce " + numRows
+                        + " rows; the message likely split into multiple record batches");
+            }
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        executionContext.close();
+    }
+
+    private static Class<?> primitiveClass(final String type) {
+        switch (type) {
+            case "double":
+                return double.class;
+            case "float":
+                return float.class;
+            case "long":
+                return long.class;
+            case "int":
+                return int.class;
+            case "short":
+                return short.class;
+            case "byte":
+                return byte.class;
+            default:
+                throw new IllegalArgumentException("Unknown column type: " + type);
+        }
+    }
+
+    private boolean nextIsNull(final Random random) {
+        return nullFraction > 0.0 && random.nextDouble() < nullFraction;
+    }
+
+    private WritableChunk<Values> makeColumn(final Random random) {
+        switch (columnType) {
+            case "double": {
+                final double[] values = new double[numRows];
+                for (int ri = 0; ri < numRows; ++ri) {
+                    values[ri] = nextIsNull(random) ? QueryConstants.NULL_DOUBLE : random.nextDouble();
+                }
+                return WritableDoubleChunk.writableChunkWrap(values);
+            }
+            case "float": {
+                final float[] values = new float[numRows];
+                for (int ri = 0; ri < numRows; ++ri) {
+                    values[ri] = nextIsNull(random) ? QueryConstants.NULL_FLOAT : random.nextFloat();
+                }
+                return WritableFloatChunk.writableChunkWrap(values);
+            }
+            case "long": {
+                final long[] values = new long[numRows];
+                for (int ri = 0; ri < numRows; ++ri) {
+                    values[ri] = nextIsNull(random) ? QueryConstants.NULL_LONG : random.nextLong();
+                }
+                return WritableLongChunk.writableChunkWrap(values);
+            }
+            case "int": {
+                final int[] values = new int[numRows];
+                for (int ri = 0; ri < numRows; ++ri) {
+                    values[ri] = nextIsNull(random) ? QueryConstants.NULL_INT : random.nextInt();
+                }
+                return WritableIntChunk.writableChunkWrap(values);
+            }
+            case "short": {
+                final short[] values = new short[numRows];
+                for (int ri = 0; ri < numRows; ++ri) {
+                    values[ri] = nextIsNull(random) ? QueryConstants.NULL_SHORT : (short) random.nextInt();
+                }
+                return WritableShortChunk.writableChunkWrap(values);
+            }
+            case "byte": {
+                final byte[] values = new byte[numRows];
+                for (int ri = 0; ri < numRows; ++ri) {
+                    values[ri] = nextIsNull(random) ? QueryConstants.NULL_BYTE : (byte) random.nextInt();
+                }
+                return WritableByteChunk.writableChunkWrap(values);
+            }
+            default:
+                throw new IllegalArgumentException("Unknown column type: " + columnType);
+        }
+    }
+
+    private static byte[] drain(final BarrageMessageWriter.MessageView view) {
+        try (final ExposedByteArrayOutputStream out = new ExposedByteArrayOutputStream()) {
+            view.forEachStream(stream -> {
+                try {
+                    stream.drainTo(out);
+                    stream.close();
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            return out.toByteArray();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private byte[] serialize() {
+        try (final BarrageMessageWriter writer =
+                WRITER_FACTORY.newMessageWriter(message, chunkWriters,
+                        BarrageMessageWriter.WriteMetricsConsumer.NO_OP)) {
+            return drain(writer.getSnapshotView(options));
+        }
+    }
+
+    private BarrageMessage deserialize(final byte[] bytes) {
+        return reader.safelyParseFrom(options, wireChunkTypes, wireTypes, wireComponentTypes,
+                new ByteArrayInputStream(bytes));
+    }
+
+    @Benchmark
+    public void serialize(final Blackhole bh) {
+        bh.consume(serialize());
+    }
+
+    @Benchmark
+    public void deserialize(final Blackhole bh) {
+        try (final BarrageMessage msg = deserialize(serialized)) {
+            bh.consume(msg);
+        }
+    }
+
+    @Benchmark
+    public void roundTrip(final Blackhole bh) {
+        try (final BarrageMessage msg = deserialize(serialize())) {
+            bh.consume(msg);
+        }
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkReader.java
@@ -9,6 +9,7 @@ import io.deephaven.chunk.WritableChunk;
 import io.deephaven.chunk.WritableLongChunk;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.chunk.attributes.Values;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.util.datastructures.LongSizedDataStructure;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,6 +20,15 @@ import java.util.function.IntFunction;
 
 public abstract class BaseChunkReader<READ_CHUNK_TYPE extends WritableChunk<Values>>
         implements ChunkReader<READ_CHUNK_TYPE> {
+
+    /**
+     * Upper bound (in bytes) on a single bulk payload read shared by the fixed-width primitive readers. Wide columns
+     * are decoded in windows of this size rather than materializing the entire payload at once. Configure once here
+     * (rather than per type) via {@code BaseChunkReader.bulkReadBufferBytes}.
+     */
+    protected static final int BULK_READ_BUFFER_BYTES = Configuration.getInstance()
+            .getIntegerForClassWithDefault(BaseChunkReader.class, "bulkReadBufferBytes", 4096);
+
     @FunctionalInterface
     public interface ChunkTransformer<READ_CHUNK_TYPE extends Chunk<Values>, DEST_CHUNK_TYPE extends WritableChunk<Values>> {
         void transform(READ_CHUNK_TYPE source, DEST_CHUNK_TYPE dest, int destOffset);

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkWriter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/BaseChunkWriter.java
@@ -7,6 +7,7 @@ import io.deephaven.UncheckedDeephavenException;
 import io.deephaven.chunk.Chunk;
 import io.deephaven.chunk.attributes.Values;
 import io.deephaven.chunk.util.pools.PoolableChunk;
+import io.deephaven.configuration.Configuration;
 import io.deephaven.engine.rowset.RowSequence;
 import io.deephaven.engine.rowset.RowSet;
 import io.deephaven.engine.rowset.RowSetFactory;
@@ -29,6 +30,15 @@ public abstract class BaseChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>>
 
     public static final byte[] PADDING_BUFFER = new byte[8];
     public static final int REMAINDER_MOD_8_MASK = 0x7;
+
+    /**
+     * Upper bound (in bytes) on a single bulk payload write shared by the fixed-width primitive writers. Wide columns
+     * are encoded into little-endian bytes and flushed in windows of this size rather than writing one value (and its
+     * individual bytes) at a time. Configure once here (rather than per type) via
+     * {@code BaseChunkWriter.bulkWriteBufferBytes}.
+     */
+    protected static final int BULK_WRITE_BUFFER_BYTES = Configuration.getInstance()
+            .getIntegerForClassWithDefault(BaseChunkWriter.class, "bulkWriteBufferBytes", 4096);
 
     private final ChunkTransformer<SOURCE_CHUNK_TYPE> transformer;
     private final Supplier<SOURCE_CHUNK_TYPE> emptyChunkSupplier;

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkReader.java
@@ -92,8 +92,12 @@ public class ByteChunkReader extends BaseChunkReader<WritableByteChunk<Values>> 
             final ChunkWriter.FieldNodeInfo nodeInfo,
             final WritableByteChunk<Values> chunk,
             final int offset) throws IOException {
-        for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-            chunk.set(offset + ii, is.readByte());
+        // Bytes have no endianness, so transfer the payload directly into the chunk's backing array in bounded windows
+        // rather than one DataInput#readByte call per element (and without materializing the whole payload at once).
+        for (int ei = 0; ei < nodeInfo.numElements;) {
+            final int length = Math.min(Math.max(1, BULK_READ_BUFFER_BYTES), nodeInfo.numElements - ei);
+            is.readFully(chunk.array(), chunk.arrayOffset() + offset + ei, length);
+            ei += length;
         }
     }
 
@@ -106,35 +110,33 @@ public class ByteChunkReader extends BaseChunkReader<WritableByteChunk<Values>> 
         final int numElements = nodeInfo.numElements;
         final int numValidityWords = (numElements + 63) / 64;
 
-        int ei = 0;
-        int pendingSkips = 0;
+        // The payload carries a value slot for every element, including nulls; transfer it directly into the chunk's
+        // backing array in bounded windows, then overwrite the invalid positions with the null value.
+        for (int ei = 0; ei < numElements;) {
+            final int length = Math.min(Math.max(1, BULK_READ_BUFFER_BYTES), numElements - ei);
+            is.readFully(chunk.array(), chunk.arrayOffset() + offset + ei, length);
+            ei += length;
+        }
 
+        int ei = 0;
         for (int vi = 0; vi < numValidityWords; ++vi) {
             int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
             long validityWord = isValid.get(vi);
             do {
                 if ((validityWord & 1) == 1) {
-                    if (pendingSkips > 0) {
-                        is.skipBytes(pendingSkips * Byte.BYTES);
-                        chunk.fillWithNullValue(offset + ei, pendingSkips);
-                        ei += pendingSkips;
-                        pendingSkips = 0;
-                    }
-                    chunk.set(offset + ei++, is.readByte());
-                    validityWord >>= 1;
-                    bitsLeftInThisWord--;
+                    // Skip the run of valid slots (already read) to the next null.
+                    final int valids = Math.min(Long.numberOfTrailingZeros(~validityWord), bitsLeftInThisWord);
+                    ei += valids;
+                    validityWord >>= valids;
+                    bitsLeftInThisWord -= valids;
                 } else {
-                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
-                    pendingSkips += skips;
-                    validityWord >>= skips;
-                    bitsLeftInThisWord -= skips;
+                    final int nulls = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    chunk.fillWithNullValue(offset + ei, nulls);
+                    ei += nulls;
+                    validityWord >>= nulls;
+                    bitsLeftInThisWord -= nulls;
                 }
             } while (bitsLeftInThisWord > 0);
-        }
-
-        if (pendingSkips > 0) {
-            is.skipBytes(pendingSkips * Byte.BYTES);
-            chunk.fillWithNullValue(offset + ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkWriter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ByteChunkWriter.java
@@ -29,6 +29,9 @@ import java.util.function.Supplier;
 
 public class ByteChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends BaseChunkWriter<SOURCE_CHUNK_TYPE> {
     private static final String DEBUG_NAME = "ByteChunkWriter";
+
+    // Number of elements encoded per bounded bulk-write window (see BaseChunkWriter#BULK_WRITE_BUFFER_BYTES).
+    private static final int BULK_WRITE_ELEMENTS = Math.max(1, BULK_WRITE_BUFFER_BYTES / Byte.BYTES);
     private static final ByteChunkWriter<ByteChunk<Values>> NULLABLE_IDENTITY_INSTANCE = new ByteChunkWriter<>(
             null, ByteChunk::getEmptyChunk, true);
     private static final ByteChunkWriter<ByteChunk<Values>> NON_NULLABLE_IDENTITY_INSTANCE = new ByteChunkWriter<>(
@@ -145,16 +148,27 @@ public class ByteChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends Ba
             // write the validity buffer
             bytesWritten += writeValidityBuffer(dos);
 
-            // write the payload buffer
+            // write the payload buffer in bounded windows, gathering values into a byte[] and flushing a full window
+            // with a single bulk write rather than one DataOutput value at a time
             final ByteChunk<Values> byteChunk = context.getChunk().asByteChunk();
+            final byte[] buffer = new byte[BULK_WRITE_ELEMENTS * Byte.BYTES];
+            final MutableInt bufferPos = new MutableInt(0);
             subset.forAllRowKeys(row -> {
-                try {
-                    dos.writeByte(byteChunk.get((int) row));
-                } catch (final IOException e) {
-                    throw new UncheckedDeephavenException(
-                            "Unexpected exception while draining data to OutputStream: ", e);
+                buffer[bufferPos.get()] = byteChunk.get((int) row);
+                bufferPos.add(Byte.BYTES);
+                if (bufferPos.get() == buffer.length) {
+                    try {
+                        outputStream.write(buffer, 0, buffer.length);
+                    } catch (final IOException e) {
+                        throw new UncheckedDeephavenException(
+                                "Unexpected exception while draining data to OutputStream: ", e);
+                    }
+                    bufferPos.set(0);
                 }
             });
+            if (bufferPos.get() > 0) {
+                outputStream.write(buffer, 0, bufferPos.get());
+            }
 
             bytesWritten += elementSize * subset.size();
             bytesWritten += writePadBuffer(dos, bytesWritten);

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkReader.java
@@ -25,6 +25,9 @@ import java.util.PrimitiveIterator;
 public class DoubleChunkReader extends BaseChunkReader<WritableDoubleChunk<Values>> {
     private static final String DEBUG_NAME = "DoubleChunkReader";
 
+    // Number of elements decoded per bounded bulk-read window (see BaseChunkReader#BULK_READ_BUFFER_BYTES).
+    private static final int BULK_READ_ELEMENTS = Math.max(1, BULK_READ_BUFFER_BYTES / Double.BYTES);
+
     public static <WIRE_CHUNK_TYPE extends WritableChunk<Values>, T extends ChunkReader<WIRE_CHUNK_TYPE>> ChunkReader<WritableDoubleChunk<Values>> transformFrom(
             final T wireReader,
             final ChunkTransformer<WIRE_CHUNK_TYPE, WritableDoubleChunk<Values>> wireTransform) {
@@ -92,8 +95,17 @@ public class DoubleChunkReader extends BaseChunkReader<WritableDoubleChunk<Value
             final ChunkWriter.FieldNodeInfo nodeInfo,
             final WritableDoubleChunk<Values> chunk,
             final int offset) throws IOException {
-        for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-            chunk.set(offset + ii, is.readDouble());
+        final int numElements = nodeInfo.numElements;
+        // Read the payload in bounded windows into a reused buffer and decode each value from its little-endian bytes
+        // via LittleEndianCodec (VarHandle on the JVM, GWT-safe arithmetic in the web client's super-source).
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Double.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Double.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getDouble(buffer, jj * Double.BYTES));
+            }
+            ei += n;
         }
     }
 
@@ -106,35 +118,37 @@ public class DoubleChunkReader extends BaseChunkReader<WritableDoubleChunk<Value
         final int numElements = nodeInfo.numElements;
         final int numValidityWords = (numElements + 63) / 64;
 
-        int ei = 0;
-        int pendingSkips = 0;
+        // The payload carries a value slot for every element, including nulls; read it in bounded windows into a
+        // reused buffer and decode each value, then overwrite the invalid positions with the null value.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Double.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Double.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getDouble(buffer, jj * Double.BYTES));
+            }
+            ei += n;
+        }
 
+        int ei = 0;
         for (int vi = 0; vi < numValidityWords; ++vi) {
             int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
             long validityWord = isValid.get(vi);
             do {
                 if ((validityWord & 1) == 1) {
-                    if (pendingSkips > 0) {
-                        is.skipBytes(pendingSkips * Double.BYTES);
-                        chunk.fillWithNullValue(offset + ei, pendingSkips);
-                        ei += pendingSkips;
-                        pendingSkips = 0;
-                    }
-                    chunk.set(offset + ei++, is.readDouble());
-                    validityWord >>= 1;
-                    bitsLeftInThisWord--;
+                    // Skip the run of valid slots (already decoded) to the next null.
+                    final int valids = Math.min(Long.numberOfTrailingZeros(~validityWord), bitsLeftInThisWord);
+                    ei += valids;
+                    validityWord >>= valids;
+                    bitsLeftInThisWord -= valids;
                 } else {
-                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
-                    pendingSkips += skips;
-                    validityWord >>= skips;
-                    bitsLeftInThisWord -= skips;
+                    final int nulls = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    chunk.fillWithNullValue(offset + ei, nulls);
+                    ei += nulls;
+                    validityWord >>= nulls;
+                    bitsLeftInThisWord -= nulls;
                 }
             } while (bitsLeftInThisWord > 0);
-        }
-
-        if (pendingSkips > 0) {
-            is.skipBytes(pendingSkips * Double.BYTES);
-            chunk.fillWithNullValue(offset + ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkWriter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/DoubleChunkWriter.java
@@ -29,6 +29,9 @@ import java.util.function.Supplier;
 
 public class DoubleChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends BaseChunkWriter<SOURCE_CHUNK_TYPE> {
     private static final String DEBUG_NAME = "DoubleChunkWriter";
+
+    // Number of elements encoded per bounded bulk-write window (see BaseChunkWriter#BULK_WRITE_BUFFER_BYTES).
+    private static final int BULK_WRITE_ELEMENTS = Math.max(1, BULK_WRITE_BUFFER_BYTES / Double.BYTES);
     private static final DoubleChunkWriter<DoubleChunk<Values>> NULLABLE_IDENTITY_INSTANCE = new DoubleChunkWriter<>(
             null, DoubleChunk::getEmptyChunk, true);
     private static final DoubleChunkWriter<DoubleChunk<Values>> NON_NULLABLE_IDENTITY_INSTANCE = new DoubleChunkWriter<>(
@@ -145,16 +148,28 @@ public class DoubleChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends 
             // write the validity buffer
             bytesWritten += writeValidityBuffer(dos);
 
-            // write the payload buffer
+            // write the payload buffer in bounded windows, encoding each value into little-endian bytes (via
+            // LittleEndianCodec) and flushing a full window with a single bulk write rather than one DataOutput value
+            // (eight bytes) at a time.
             final DoubleChunk<Values> doubleChunk = context.getChunk().asDoubleChunk();
+            final byte[] buffer = new byte[BULK_WRITE_ELEMENTS * Double.BYTES];
+            final MutableInt bufferPos = new MutableInt(0);
             subset.forAllRowKeys(row -> {
-                try {
-                    dos.writeDouble(doubleChunk.get((int) row));
-                } catch (final IOException e) {
-                    throw new UncheckedDeephavenException(
-                            "Unexpected exception while draining data to OutputStream: ", e);
+                LittleEndianCodec.putDouble(buffer, bufferPos.get(), doubleChunk.get((int) row));
+                bufferPos.add(Double.BYTES);
+                if (bufferPos.get() == buffer.length) {
+                    try {
+                        outputStream.write(buffer, 0, buffer.length);
+                    } catch (final IOException e) {
+                        throw new UncheckedDeephavenException(
+                                "Unexpected exception while draining data to OutputStream: ", e);
+                    }
+                    bufferPos.set(0);
                 }
             });
+            if (bufferPos.get() > 0) {
+                outputStream.write(buffer, 0, bufferPos.get());
+            }
 
             bytesWritten += elementSize * subset.size();
             bytesWritten += writePadBuffer(dos, bytesWritten);

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkReader.java
@@ -25,6 +25,9 @@ import java.util.PrimitiveIterator;
 public class FloatChunkReader extends BaseChunkReader<WritableFloatChunk<Values>> {
     private static final String DEBUG_NAME = "FloatChunkReader";
 
+    // Number of elements decoded per bounded bulk-read window (see BaseChunkReader#BULK_READ_BUFFER_BYTES).
+    private static final int BULK_READ_ELEMENTS = Math.max(1, BULK_READ_BUFFER_BYTES / Float.BYTES);
+
     public static <WIRE_CHUNK_TYPE extends WritableChunk<Values>, T extends ChunkReader<WIRE_CHUNK_TYPE>> ChunkReader<WritableFloatChunk<Values>> transformFrom(
             final T wireReader,
             final ChunkTransformer<WIRE_CHUNK_TYPE, WritableFloatChunk<Values>> wireTransform) {
@@ -92,8 +95,16 @@ public class FloatChunkReader extends BaseChunkReader<WritableFloatChunk<Values>
             final ChunkWriter.FieldNodeInfo nodeInfo,
             final WritableFloatChunk<Values> chunk,
             final int offset) throws IOException {
-        for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-            chunk.set(offset + ii, is.readFloat());
+        final int numElements = nodeInfo.numElements;
+        // Read the payload in bounded windows into a reused buffer and decode each value from its little-endian bytes.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Float.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Float.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getFloat(buffer, jj * Float.BYTES));
+            }
+            ei += n;
         }
     }
 
@@ -106,35 +117,37 @@ public class FloatChunkReader extends BaseChunkReader<WritableFloatChunk<Values>
         final int numElements = nodeInfo.numElements;
         final int numValidityWords = (numElements + 63) / 64;
 
-        int ei = 0;
-        int pendingSkips = 0;
+        // The payload carries a value slot for every element, including nulls; read it in bounded windows into a
+        // reused buffer and decode each value, then overwrite the invalid positions with the null value.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Float.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Float.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getFloat(buffer, jj * Float.BYTES));
+            }
+            ei += n;
+        }
 
+        int ei = 0;
         for (int vi = 0; vi < numValidityWords; ++vi) {
             int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
             long validityWord = isValid.get(vi);
             do {
                 if ((validityWord & 1) == 1) {
-                    if (pendingSkips > 0) {
-                        is.skipBytes(pendingSkips * Float.BYTES);
-                        chunk.fillWithNullValue(offset + ei, pendingSkips);
-                        ei += pendingSkips;
-                        pendingSkips = 0;
-                    }
-                    chunk.set(offset + ei++, is.readFloat());
-                    validityWord >>= 1;
-                    bitsLeftInThisWord--;
+                    // Skip the run of valid slots (already decoded) to the next null.
+                    final int valids = Math.min(Long.numberOfTrailingZeros(~validityWord), bitsLeftInThisWord);
+                    ei += valids;
+                    validityWord >>= valids;
+                    bitsLeftInThisWord -= valids;
                 } else {
-                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
-                    pendingSkips += skips;
-                    validityWord >>= skips;
-                    bitsLeftInThisWord -= skips;
+                    final int nulls = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    chunk.fillWithNullValue(offset + ei, nulls);
+                    ei += nulls;
+                    validityWord >>= nulls;
+                    bitsLeftInThisWord -= nulls;
                 }
             } while (bitsLeftInThisWord > 0);
-        }
-
-        if (pendingSkips > 0) {
-            is.skipBytes(pendingSkips * Float.BYTES);
-            chunk.fillWithNullValue(offset + ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkWriter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/FloatChunkWriter.java
@@ -29,6 +29,9 @@ import java.util.function.Supplier;
 
 public class FloatChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends BaseChunkWriter<SOURCE_CHUNK_TYPE> {
     private static final String DEBUG_NAME = "FloatChunkWriter";
+
+    // Number of elements encoded per bounded bulk-write window (see BaseChunkWriter#BULK_WRITE_BUFFER_BYTES).
+    private static final int BULK_WRITE_ELEMENTS = Math.max(1, BULK_WRITE_BUFFER_BYTES / Float.BYTES);
     private static final FloatChunkWriter<FloatChunk<Values>> NULLABLE_IDENTITY_INSTANCE = new FloatChunkWriter<>(
             null, FloatChunk::getEmptyChunk, true);
     private static final FloatChunkWriter<FloatChunk<Values>> NON_NULLABLE_IDENTITY_INSTANCE = new FloatChunkWriter<>(
@@ -145,16 +148,27 @@ public class FloatChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends B
             // write the validity buffer
             bytesWritten += writeValidityBuffer(dos);
 
-            // write the payload buffer
+            // write the payload buffer in bounded windows, encoding each value into little-endian bytes and flushing a
+            // full window with a single bulk write rather than one DataOutput value (four bytes) at a time
             final FloatChunk<Values> floatChunk = context.getChunk().asFloatChunk();
+            final byte[] buffer = new byte[BULK_WRITE_ELEMENTS * Float.BYTES];
+            final MutableInt bufferPos = new MutableInt(0);
             subset.forAllRowKeys(row -> {
-                try {
-                    dos.writeFloat(floatChunk.get((int) row));
-                } catch (final IOException e) {
-                    throw new UncheckedDeephavenException(
-                            "Unexpected exception while draining data to OutputStream: ", e);
+                LittleEndianCodec.putFloat(buffer, bufferPos.get(), floatChunk.get((int) row));
+                bufferPos.add(Float.BYTES);
+                if (bufferPos.get() == buffer.length) {
+                    try {
+                        outputStream.write(buffer, 0, buffer.length);
+                    } catch (final IOException e) {
+                        throw new UncheckedDeephavenException(
+                                "Unexpected exception while draining data to OutputStream: ", e);
+                    }
+                    bufferPos.set(0);
                 }
             });
+            if (bufferPos.get() > 0) {
+                outputStream.write(buffer, 0, bufferPos.get());
+            }
 
             bytesWritten += elementSize * subset.size();
             bytesWritten += writePadBuffer(dos, bytesWritten);

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkReader.java
@@ -25,6 +25,9 @@ import java.util.PrimitiveIterator;
 public class IntChunkReader extends BaseChunkReader<WritableIntChunk<Values>> {
     private static final String DEBUG_NAME = "IntChunkReader";
 
+    // Number of elements decoded per bounded bulk-read window (see BaseChunkReader#BULK_READ_BUFFER_BYTES).
+    private static final int BULK_READ_ELEMENTS = Math.max(1, BULK_READ_BUFFER_BYTES / Integer.BYTES);
+
     public static <WIRE_CHUNK_TYPE extends WritableChunk<Values>, T extends ChunkReader<WIRE_CHUNK_TYPE>> ChunkReader<WritableIntChunk<Values>> transformFrom(
             final T wireReader,
             final ChunkTransformer<WIRE_CHUNK_TYPE, WritableIntChunk<Values>> wireTransform) {
@@ -92,8 +95,16 @@ public class IntChunkReader extends BaseChunkReader<WritableIntChunk<Values>> {
             final ChunkWriter.FieldNodeInfo nodeInfo,
             final WritableIntChunk<Values> chunk,
             final int offset) throws IOException {
-        for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-            chunk.set(offset + ii, is.readInt());
+        final int numElements = nodeInfo.numElements;
+        // Read the payload in bounded windows into a reused buffer and decode each value from its little-endian bytes.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Integer.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Integer.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getInt(buffer, jj * Integer.BYTES));
+            }
+            ei += n;
         }
     }
 
@@ -106,35 +117,37 @@ public class IntChunkReader extends BaseChunkReader<WritableIntChunk<Values>> {
         final int numElements = nodeInfo.numElements;
         final int numValidityWords = (numElements + 63) / 64;
 
-        int ei = 0;
-        int pendingSkips = 0;
+        // The payload carries a value slot for every element, including nulls; read it in bounded windows into a
+        // reused buffer and decode each value, then overwrite the invalid positions with the null value.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Integer.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Integer.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getInt(buffer, jj * Integer.BYTES));
+            }
+            ei += n;
+        }
 
+        int ei = 0;
         for (int vi = 0; vi < numValidityWords; ++vi) {
             int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
             long validityWord = isValid.get(vi);
             do {
                 if ((validityWord & 1) == 1) {
-                    if (pendingSkips > 0) {
-                        is.skipBytes(pendingSkips * Integer.BYTES);
-                        chunk.fillWithNullValue(offset + ei, pendingSkips);
-                        ei += pendingSkips;
-                        pendingSkips = 0;
-                    }
-                    chunk.set(offset + ei++, is.readInt());
-                    validityWord >>= 1;
-                    bitsLeftInThisWord--;
+                    // Skip the run of valid slots (already decoded) to the next null.
+                    final int valids = Math.min(Long.numberOfTrailingZeros(~validityWord), bitsLeftInThisWord);
+                    ei += valids;
+                    validityWord >>= valids;
+                    bitsLeftInThisWord -= valids;
                 } else {
-                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
-                    pendingSkips += skips;
-                    validityWord >>= skips;
-                    bitsLeftInThisWord -= skips;
+                    final int nulls = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    chunk.fillWithNullValue(offset + ei, nulls);
+                    ei += nulls;
+                    validityWord >>= nulls;
+                    bitsLeftInThisWord -= nulls;
                 }
             } while (bitsLeftInThisWord > 0);
-        }
-
-        if (pendingSkips > 0) {
-            is.skipBytes(pendingSkips * Integer.BYTES);
-            chunk.fillWithNullValue(offset + ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkWriter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/IntChunkWriter.java
@@ -29,6 +29,9 @@ import java.util.function.Supplier;
 
 public class IntChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends BaseChunkWriter<SOURCE_CHUNK_TYPE> {
     private static final String DEBUG_NAME = "IntChunkWriter";
+
+    // Number of elements encoded per bounded bulk-write window (see BaseChunkWriter#BULK_WRITE_BUFFER_BYTES).
+    private static final int BULK_WRITE_ELEMENTS = Math.max(1, BULK_WRITE_BUFFER_BYTES / Integer.BYTES);
     private static final IntChunkWriter<IntChunk<Values>> NULLABLE_IDENTITY_INSTANCE = new IntChunkWriter<>(
             null, IntChunk::getEmptyChunk, true);
     private static final IntChunkWriter<IntChunk<Values>> NON_NULLABLE_IDENTITY_INSTANCE = new IntChunkWriter<>(
@@ -145,16 +148,27 @@ public class IntChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends Bas
             // write the validity buffer
             bytesWritten += writeValidityBuffer(dos);
 
-            // write the payload buffer
+            // write the payload buffer in bounded windows, encoding each value into little-endian bytes and flushing a
+            // full window with a single bulk write rather than one DataOutput value (four bytes) at a time
             final IntChunk<Values> intChunk = context.getChunk().asIntChunk();
+            final byte[] buffer = new byte[BULK_WRITE_ELEMENTS * Integer.BYTES];
+            final MutableInt bufferPos = new MutableInt(0);
             subset.forAllRowKeys(row -> {
-                try {
-                    dos.writeInt(intChunk.get((int) row));
-                } catch (final IOException e) {
-                    throw new UncheckedDeephavenException(
-                            "Unexpected exception while draining data to OutputStream: ", e);
+                LittleEndianCodec.putInt(buffer, bufferPos.get(), intChunk.get((int) row));
+                bufferPos.add(Integer.BYTES);
+                if (bufferPos.get() == buffer.length) {
+                    try {
+                        outputStream.write(buffer, 0, buffer.length);
+                    } catch (final IOException e) {
+                        throw new UncheckedDeephavenException(
+                                "Unexpected exception while draining data to OutputStream: ", e);
+                    }
+                    bufferPos.set(0);
                 }
             });
+            if (bufferPos.get() > 0) {
+                outputStream.write(buffer, 0, bufferPos.get());
+            }
 
             bytesWritten += elementSize * subset.size();
             bytesWritten += writePadBuffer(dos, bytesWritten);

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LittleEndianCodec.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LittleEndianCodec.java
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.extensions.barrage.chunk;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+/**
+ * Little-endian codec between fixed-width primitive values and a {@code byte[]} payload window, used by the barrage
+ * fixed-width chunk readers/writers to bulk-decode/encode a window of values.
+ * <p>
+ * This JVM implementation uses {@link VarHandle} for a single (possibly unaligned) load/store per value. These readers
+ * and writers are also cross-compiled to JavaScript for the web client, where {@code java.lang.invoke} is unavailable;
+ * a GWT super-source replacement of this class (see {@code web/client-api/.../super}) provides an equivalent
+ * implementation using only GWT-safe arithmetic. The two must be kept in sync.
+ */
+final class LittleEndianCodec {
+    private LittleEndianCodec() {}
+
+    private static final VarHandle LONG =
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle INT =
+            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle SHORT =
+            MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle DOUBLE =
+            MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.LITTLE_ENDIAN);
+    private static final VarHandle FLOAT =
+            MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.LITTLE_ENDIAN);
+
+    static long getLong(final byte[] b, final int o) {
+        return (long) LONG.get(b, o);
+    }
+
+    static int getInt(final byte[] b, final int o) {
+        return (int) INT.get(b, o);
+    }
+
+    static short getShort(final byte[] b, final int o) {
+        return (short) SHORT.get(b, o);
+    }
+
+    static double getDouble(final byte[] b, final int o) {
+        return (double) DOUBLE.get(b, o);
+    }
+
+    static float getFloat(final byte[] b, final int o) {
+        return (float) FLOAT.get(b, o);
+    }
+
+    static void putLong(final byte[] b, final int o, final long v) {
+        LONG.set(b, o, v);
+    }
+
+    static void putInt(final byte[] b, final int o, final int v) {
+        INT.set(b, o, v);
+    }
+
+    static void putShort(final byte[] b, final int o, final short v) {
+        SHORT.set(b, o, v);
+    }
+
+    static void putDouble(final byte[] b, final int o, final double v) {
+        DOUBLE.set(b, o, v);
+    }
+
+    static void putFloat(final byte[] b, final int o, final float v) {
+        FLOAT.set(b, o, v);
+    }
+}

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkReader.java
@@ -24,6 +24,9 @@ import java.util.PrimitiveIterator;
 public class LongChunkReader extends BaseChunkReader<WritableLongChunk<Values>> {
     private static final String DEBUG_NAME = "LongChunkReader";
 
+    // Number of elements decoded per bounded bulk-read window (see BaseChunkReader#BULK_READ_BUFFER_BYTES).
+    private static final int BULK_READ_ELEMENTS = Math.max(1, BULK_READ_BUFFER_BYTES / Long.BYTES);
+
     public static <WIRE_CHUNK_TYPE extends WritableChunk<Values>, T extends ChunkReader<WIRE_CHUNK_TYPE>> ChunkReader<WritableLongChunk<Values>> transformFrom(
             final T wireReader,
             final ChunkTransformer<WIRE_CHUNK_TYPE, WritableLongChunk<Values>> wireTransform) {
@@ -91,8 +94,16 @@ public class LongChunkReader extends BaseChunkReader<WritableLongChunk<Values>> 
             final ChunkWriter.FieldNodeInfo nodeInfo,
             final WritableLongChunk<Values> chunk,
             final int offset) throws IOException {
-        for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-            chunk.set(offset + ii, is.readLong());
+        final int numElements = nodeInfo.numElements;
+        // Read the payload in bounded windows into a reused buffer and decode each value from its little-endian bytes.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Long.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Long.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getLong(buffer, jj * Long.BYTES));
+            }
+            ei += n;
         }
     }
 
@@ -105,35 +116,37 @@ public class LongChunkReader extends BaseChunkReader<WritableLongChunk<Values>> 
         final int numElements = nodeInfo.numElements;
         final int numValidityWords = (numElements + 63) / 64;
 
-        int ei = 0;
-        int pendingSkips = 0;
+        // The payload carries a value slot for every element, including nulls; read it in bounded windows into a
+        // reused buffer and decode each value, then overwrite the invalid positions with the null value.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Long.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Long.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getLong(buffer, jj * Long.BYTES));
+            }
+            ei += n;
+        }
 
+        int ei = 0;
         for (int vi = 0; vi < numValidityWords; ++vi) {
             int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
             long validityWord = isValid.get(vi);
             do {
                 if ((validityWord & 1) == 1) {
-                    if (pendingSkips > 0) {
-                        is.skipBytes(pendingSkips * Long.BYTES);
-                        chunk.fillWithNullValue(offset + ei, pendingSkips);
-                        ei += pendingSkips;
-                        pendingSkips = 0;
-                    }
-                    chunk.set(offset + ei++, is.readLong());
-                    validityWord >>= 1;
-                    bitsLeftInThisWord--;
+                    // Skip the run of valid slots (already decoded) to the next null.
+                    final int valids = Math.min(Long.numberOfTrailingZeros(~validityWord), bitsLeftInThisWord);
+                    ei += valids;
+                    validityWord >>= valids;
+                    bitsLeftInThisWord -= valids;
                 } else {
-                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
-                    pendingSkips += skips;
-                    validityWord >>= skips;
-                    bitsLeftInThisWord -= skips;
+                    final int nulls = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    chunk.fillWithNullValue(offset + ei, nulls);
+                    ei += nulls;
+                    validityWord >>= nulls;
+                    bitsLeftInThisWord -= nulls;
                 }
             } while (bitsLeftInThisWord > 0);
-        }
-
-        if (pendingSkips > 0) {
-            is.skipBytes(pendingSkips * Long.BYTES);
-            chunk.fillWithNullValue(offset + ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkWriter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/LongChunkWriter.java
@@ -29,6 +29,9 @@ import java.util.function.Supplier;
 
 public class LongChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends BaseChunkWriter<SOURCE_CHUNK_TYPE> {
     private static final String DEBUG_NAME = "LongChunkWriter";
+
+    // Number of elements encoded per bounded bulk-write window (see BaseChunkWriter#BULK_WRITE_BUFFER_BYTES).
+    private static final int BULK_WRITE_ELEMENTS = Math.max(1, BULK_WRITE_BUFFER_BYTES / Long.BYTES);
     private static final LongChunkWriter<LongChunk<Values>> NULLABLE_IDENTITY_INSTANCE = new LongChunkWriter<>(
             null, LongChunk::getEmptyChunk, true);
     private static final LongChunkWriter<LongChunk<Values>> NON_NULLABLE_IDENTITY_INSTANCE = new LongChunkWriter<>(
@@ -145,16 +148,27 @@ public class LongChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends Ba
             // write the validity buffer
             bytesWritten += writeValidityBuffer(dos);
 
-            // write the payload buffer
+            // write the payload buffer in bounded windows, encoding each value into little-endian bytes and flushing a
+            // full window with a single bulk write rather than one DataOutput value (eight bytes) at a time
             final LongChunk<Values> longChunk = context.getChunk().asLongChunk();
+            final byte[] buffer = new byte[BULK_WRITE_ELEMENTS * Long.BYTES];
+            final MutableInt bufferPos = new MutableInt(0);
             subset.forAllRowKeys(row -> {
-                try {
-                    dos.writeLong(longChunk.get((int) row));
-                } catch (final IOException e) {
-                    throw new UncheckedDeephavenException(
-                            "Unexpected exception while draining data to OutputStream: ", e);
+                LittleEndianCodec.putLong(buffer, bufferPos.get(), longChunk.get((int) row));
+                bufferPos.add(Long.BYTES);
+                if (bufferPos.get() == buffer.length) {
+                    try {
+                        outputStream.write(buffer, 0, buffer.length);
+                    } catch (final IOException e) {
+                        throw new UncheckedDeephavenException(
+                                "Unexpected exception while draining data to OutputStream: ", e);
+                    }
+                    bufferPos.set(0);
                 }
             });
+            if (bufferPos.get() > 0) {
+                outputStream.write(buffer, 0, bufferPos.get());
+            }
 
             bytesWritten += elementSize * subset.size();
             bytesWritten += writePadBuffer(dos, bytesWritten);

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkReader.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkReader.java
@@ -25,6 +25,9 @@ import java.util.PrimitiveIterator;
 public class ShortChunkReader extends BaseChunkReader<WritableShortChunk<Values>> {
     private static final String DEBUG_NAME = "ShortChunkReader";
 
+    // Number of elements decoded per bounded bulk-read window (see BaseChunkReader#BULK_READ_BUFFER_BYTES).
+    private static final int BULK_READ_ELEMENTS = Math.max(1, BULK_READ_BUFFER_BYTES / Short.BYTES);
+
     public static <WIRE_CHUNK_TYPE extends WritableChunk<Values>, T extends ChunkReader<WIRE_CHUNK_TYPE>> ChunkReader<WritableShortChunk<Values>> transformFrom(
             final T wireReader,
             final ChunkTransformer<WIRE_CHUNK_TYPE, WritableShortChunk<Values>> wireTransform) {
@@ -92,8 +95,16 @@ public class ShortChunkReader extends BaseChunkReader<WritableShortChunk<Values>
             final ChunkWriter.FieldNodeInfo nodeInfo,
             final WritableShortChunk<Values> chunk,
             final int offset) throws IOException {
-        for (int ii = 0; ii < nodeInfo.numElements; ++ii) {
-            chunk.set(offset + ii, is.readShort());
+        final int numElements = nodeInfo.numElements;
+        // Read the payload in bounded windows into a reused buffer and decode each value from its little-endian bytes.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Short.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Short.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getShort(buffer, jj * Short.BYTES));
+            }
+            ei += n;
         }
     }
 
@@ -106,35 +117,37 @@ public class ShortChunkReader extends BaseChunkReader<WritableShortChunk<Values>
         final int numElements = nodeInfo.numElements;
         final int numValidityWords = (numElements + 63) / 64;
 
-        int ei = 0;
-        int pendingSkips = 0;
+        // The payload carries a value slot for every element, including nulls; read it in bounded windows into a
+        // reused buffer and decode each value, then overwrite the invalid positions with the null value.
+        final byte[] buffer = new byte[Math.min(numElements, BULK_READ_ELEMENTS) * Short.BYTES];
+        for (int ei = 0; ei < numElements;) {
+            final int n = Math.min(BULK_READ_ELEMENTS, numElements - ei);
+            is.readFully(buffer, 0, n * Short.BYTES);
+            for (int jj = 0; jj < n; ++jj) {
+                chunk.set(offset + ei + jj, LittleEndianCodec.getShort(buffer, jj * Short.BYTES));
+            }
+            ei += n;
+        }
 
+        int ei = 0;
         for (int vi = 0; vi < numValidityWords; ++vi) {
             int bitsLeftInThisWord = Math.min(64, numElements - vi * 64);
             long validityWord = isValid.get(vi);
             do {
                 if ((validityWord & 1) == 1) {
-                    if (pendingSkips > 0) {
-                        is.skipBytes(pendingSkips * Short.BYTES);
-                        chunk.fillWithNullValue(offset + ei, pendingSkips);
-                        ei += pendingSkips;
-                        pendingSkips = 0;
-                    }
-                    chunk.set(offset + ei++, is.readShort());
-                    validityWord >>= 1;
-                    bitsLeftInThisWord--;
+                    // Skip the run of valid slots (already decoded) to the next null.
+                    final int valids = Math.min(Long.numberOfTrailingZeros(~validityWord), bitsLeftInThisWord);
+                    ei += valids;
+                    validityWord >>= valids;
+                    bitsLeftInThisWord -= valids;
                 } else {
-                    final int skips = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
-                    pendingSkips += skips;
-                    validityWord >>= skips;
-                    bitsLeftInThisWord -= skips;
+                    final int nulls = Math.min(Long.numberOfTrailingZeros(validityWord), bitsLeftInThisWord);
+                    chunk.fillWithNullValue(offset + ei, nulls);
+                    ei += nulls;
+                    validityWord >>= nulls;
+                    bitsLeftInThisWord -= nulls;
                 }
             } while (bitsLeftInThisWord > 0);
-        }
-
-        if (pendingSkips > 0) {
-            is.skipBytes(pendingSkips * Short.BYTES);
-            chunk.fillWithNullValue(offset + ei, pendingSkips);
         }
     }
 }

--- a/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkWriter.java
+++ b/extensions/barrage/src/main/java/io/deephaven/extensions/barrage/chunk/ShortChunkWriter.java
@@ -29,6 +29,9 @@ import java.util.function.Supplier;
 
 public class ShortChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends BaseChunkWriter<SOURCE_CHUNK_TYPE> {
     private static final String DEBUG_NAME = "ShortChunkWriter";
+
+    // Number of elements encoded per bounded bulk-write window (see BaseChunkWriter#BULK_WRITE_BUFFER_BYTES).
+    private static final int BULK_WRITE_ELEMENTS = Math.max(1, BULK_WRITE_BUFFER_BYTES / Short.BYTES);
     private static final ShortChunkWriter<ShortChunk<Values>> NULLABLE_IDENTITY_INSTANCE = new ShortChunkWriter<>(
             null, ShortChunk::getEmptyChunk, true);
     private static final ShortChunkWriter<ShortChunk<Values>> NON_NULLABLE_IDENTITY_INSTANCE = new ShortChunkWriter<>(
@@ -145,16 +148,27 @@ public class ShortChunkWriter<SOURCE_CHUNK_TYPE extends Chunk<Values>> extends B
             // write the validity buffer
             bytesWritten += writeValidityBuffer(dos);
 
-            // write the payload buffer
+            // write the payload buffer in bounded windows, encoding each value into little-endian bytes and flushing a
+            // full window with a single bulk write rather than one DataOutput value (two bytes) at a time
             final ShortChunk<Values> shortChunk = context.getChunk().asShortChunk();
+            final byte[] buffer = new byte[BULK_WRITE_ELEMENTS * Short.BYTES];
+            final MutableInt bufferPos = new MutableInt(0);
             subset.forAllRowKeys(row -> {
-                try {
-                    dos.writeShort(shortChunk.get((int) row));
-                } catch (final IOException e) {
-                    throw new UncheckedDeephavenException(
-                            "Unexpected exception while draining data to OutputStream: ", e);
+                LittleEndianCodec.putShort(buffer, bufferPos.get(), shortChunk.get((int) row));
+                bufferPos.add(Short.BYTES);
+                if (bufferPos.get() == buffer.length) {
+                    try {
+                        outputStream.write(buffer, 0, buffer.length);
+                    } catch (final IOException e) {
+                        throw new UncheckedDeephavenException(
+                                "Unexpected exception while draining data to OutputStream: ", e);
+                    }
+                    bufferPos.set(0);
                 }
             });
+            if (bufferPos.get() > 0) {
+                outputStream.write(buffer, 0, bufferPos.get());
+            }
 
             bytesWritten += elementSize * subset.size();
             bytesWritten += writePadBuffer(dos, bytesWritten);

--- a/extensions/barrage/src/main/resources/io/deephaven/extensions/barrage/Barrage.gwt.xml
+++ b/extensions/barrage/src/main/resources/io/deephaven/extensions/barrage/Barrage.gwt.xml
@@ -22,8 +22,15 @@
     <source path="util" includes="Float16.java,FlatBufferIteratorAdapter.java,DefensiveDrainable.java,DefensiveCapture.java,ExposedByteArrayOutputStream.java" />
     <source path="chunk">
         <exclude name="vector/*" />
+        <exclude name="writermap/*" />
+        <!-- JVM implementation uses VarHandle; GWT uses the super-source replacement in web/client-api. -->
+        <exclude name="LittleEndianCodec.java" />
         <exclude name="DefaultChunkReaderFactory.java" />
         <exclude name="DefaultChunkWriterFactory.java" />
+        <exclude name="DictionaryWriterRegistryImpl.java" />
+        <exclude name="LocalDictionaryWriterState.java" />
+        <exclude name="SharedDictionaryWriterState.java" />
+        <exclude name="SharedWriterDictionary.java" />
         <exclude name="MapChunkReader.java" />
         <exclude name="MapChunkWriter.java" />
         <exclude name="RunEndEncodedChunkWriter.java" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -259,6 +259,9 @@ project(':extensions-arrow').projectDir = file('extensions/arrow')
 include(':extensions-barrage')
 project(':extensions-barrage').projectDir = file('extensions/barrage')
 
+include(':extensions-barrage-benchmark')
+project(':extensions-barrage-benchmark').projectDir = file('extensions/barrage/benchmark')
+
 include(':extensions-classgraph')
 project(':extensions-classgraph').projectDir = file('extensions/classgraph')
 

--- a/web/client-api/src/main/java/io/deephaven/web/super/io/deephaven/extensions/barrage/chunk/LittleEndianCodec.java
+++ b/web/client-api/src/main/java/io/deephaven/web/super/io/deephaven/extensions/barrage/chunk/LittleEndianCodec.java
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.extensions.barrage.chunk;
+
+/**
+ * GWT super-source replacement for {@link LittleEndianCodec}. {@code java.lang.invoke.VarHandle} is unavailable in GWT,
+ * so this implementation uses only GWT-safe arithmetic. It must stay in sync with the JVM implementation in
+ * {@code extensions/barrage/.../chunk/LittleEndianCodec.java}.
+ */
+final class LittleEndianCodec {
+    private LittleEndianCodec() {}
+
+    static long getLong(final byte[] b, final int o) {
+        return (b[o] & 0xFFL)
+                | (b[o + 1] & 0xFFL) << 8
+                | (b[o + 2] & 0xFFL) << 16
+                | (b[o + 3] & 0xFFL) << 24
+                | (b[o + 4] & 0xFFL) << 32
+                | (b[o + 5] & 0xFFL) << 40
+                | (b[o + 6] & 0xFFL) << 48
+                | (b[o + 7] & 0xFFL) << 56;
+    }
+
+    static int getInt(final byte[] b, final int o) {
+        return (b[o] & 0xFF)
+                | (b[o + 1] & 0xFF) << 8
+                | (b[o + 2] & 0xFF) << 16
+                | (b[o + 3] & 0xFF) << 24;
+    }
+
+    static short getShort(final byte[] b, final int o) {
+        return (short) ((b[o] & 0xFF) | (b[o + 1] & 0xFF) << 8);
+    }
+
+    static double getDouble(final byte[] b, final int o) {
+        return Double.longBitsToDouble(getLong(b, o));
+    }
+
+    static float getFloat(final byte[] b, final int o) {
+        return Float.intBitsToFloat(getInt(b, o));
+    }
+
+    static void putLong(final byte[] b, final int o, final long v) {
+        b[o] = (byte) v;
+        b[o + 1] = (byte) (v >> 8);
+        b[o + 2] = (byte) (v >> 16);
+        b[o + 3] = (byte) (v >> 24);
+        b[o + 4] = (byte) (v >> 32);
+        b[o + 5] = (byte) (v >> 40);
+        b[o + 6] = (byte) (v >> 48);
+        b[o + 7] = (byte) (v >> 56);
+    }
+
+    static void putInt(final byte[] b, final int o, final int v) {
+        b[o] = (byte) v;
+        b[o + 1] = (byte) (v >> 8);
+        b[o + 2] = (byte) (v >> 16);
+        b[o + 3] = (byte) (v >> 24);
+    }
+
+    static void putShort(final byte[] b, final int o, final short v) {
+        b[o] = (byte) v;
+        b[o + 1] = (byte) (v >> 8);
+    }
+
+    static void putDouble(final byte[] b, final int o, final double v) {
+        putLong(b, o, Double.doubleToLongBits(v));
+    }
+
+    static void putFloat(final byte[] b, final int o, final float v) {
+        putInt(b, o, Float.floatToIntBits(v));
+    }
+}


### PR DESCRIPTION
This improves a microbenchmark serializing and deserializing BarrageMessages significantly.

after

Speedup from the GWT-safe bulk read/write optimization for fixed-width primitive
Barrage columns (`double`/`float`/`long`/`int`/`short`/`byte`).

- **Before**: the original per-value readers/writers on `upstream/main` (one
`DataInput`/`DataOutput` call — i.e. 8/4/2/1 individual byte operations — per value).
- **After**: bulk reads/writes of a bounded window (`BaseChunkReader.bulkReadBufferBytes`
/ `BaseChunkWriter.bulkWriteBufferBytes`, default 4096) decoded/encoded with
`LittleEndianCodec` (VarHandle on the JVM, GWT-safe arithmetic in the web client).

`BarrageMessageRoundTripBenchmark`: a full-snapshot Barrage message of **5000 columns ×
2000 rows** of a single primitive type, measured with JMH (`AverageTime`, ms/op,
1 fork, 3×2s warmup, 5×2s measurement). `null encoding` distinguishes the Arrow
validity-buffer path (`useDeephavenNulls=false`) from the Deephaven-sentinel path
(`useDeephavenNulls=true`); `nullFraction` is the fraction of null cells.

Lower is better; **speedup = before / after**.

Deserialize is ~4.4–12.9× faster.

| type | nullFraction | null encoding | before (ms) | after (ms) | speedup |
|------|:---:|:---:|---:|---:|:---:|
| double | 0.0 | DH sentinel | 108.05 | 11.31 | 9.6× | | double | 0.0 | validity buffer | 116.47 | 11.61 | 10.0× | | double | 0.1 | DH sentinel | 108.03 | 11.38 | 9.5× | | double | 0.1 | validity buffer | 113.34 | 17.25 | 6.6× | | float | 0.0 | DH sentinel | 46.02 | 5.84 | 7.9× | | float | 0.0 | validity buffer | 62.14 | 6.48 | 9.6× | | float | 0.1 | DH sentinel | 46.22 | 5.60 | 8.2× | | float | 0.1 | validity buffer | 67.65 | 11.93 | 5.7× | | long | 0.0 | DH sentinel | 108.44 | 11.46 | 9.5× | | long | 0.0 | validity buffer | 118.51 | 12.13 | 9.8× | | long | 0.1 | DH sentinel | 108.29 | 11.65 | 9.3× | | long | 0.1 | validity buffer | 114.46 | 17.22 | 6.6× | | int | 0.0 | DH sentinel | 45.91 | 5.39 | 8.5× |
| int | 0.0 | validity buffer | 62.94 | 5.48 | 11.5× | | int | 0.1 | DH sentinel | 45.78 | 5.00 | 9.2× |
| int | 0.1 | validity buffer | 69.05 | 10.96 | 6.3× | | short | 0.0 | DH sentinel | 30.10 | 2.85 | 10.5× | | short | 0.0 | validity buffer | 36.26 | 3.10 | 11.7× | | short | 0.1 | DH sentinel | 30.19 | 2.88 | 10.5× | | short | 0.1 | validity buffer | 42.59 | 8.23 | 5.2× | | byte | 0.0 | DH sentinel | 12.36 | 0.96 | 12.9× | | byte | 0.0 | validity buffer | 22.90 | 3.56 | 6.4× | | byte | 0.1 | DH sentinel | 12.34 | 0.98 | 12.6× | | byte | 0.1 | validity buffer | 30.91 | 7.10 | 4.4× |

Serialize is ~1.7–38.3× faster.

| type | nullFraction | null encoding | before (ms) | after (ms) | speedup |
|------|:---:|:---:|---:|---:|:---:|
| double | 0.0 | DH sentinel | 111.90 | 27.14 | 4.1× | | double | 0.0 | validity buffer | 113.87 | 32.45 | 3.5× | | double | 0.1 | DH sentinel | 108.13 | 27.17 | 4.0× | | double | 0.1 | validity buffer | 157.01 | 92.86 | 1.7× | | float | 0.0 | DH sentinel | 640.22 | 16.90 | 37.9× | | float | 0.0 | validity buffer | 648.25 | 22.33 | 29.0× | | float | 0.1 | DH sentinel | 640.48 | 16.93 | 37.8× | | float | 0.1 | validity buffer | 679.62 | 67.24 | 10.1× | | long | 0.0 | DH sentinel | 111.83 | 27.52 | 4.1× | | long | 0.0 | validity buffer | 121.54 | 32.37 | 3.8× | | long | 0.1 | DH sentinel | 111.82 | 27.47 | 4.1× | | long | 0.1 | validity buffer | 152.01 | 72.83 | 2.1× | | int | 0.0 | DH sentinel | 645.71 | 16.84 | 38.3× | | int | 0.0 | validity buffer | 647.40 | 21.74 | 29.8× | | int | 0.1 | DH sentinel | 645.16 | 17.22 | 37.5× | | int | 0.1 | validity buffer | 677.96 | 63.49 | 10.7× | | short | 0.0 | DH sentinel | 329.86 | 9.84 | 33.5× | | short | 0.0 | validity buffer | 341.46 | 30.09 | 11.3× | | short | 0.1 | DH sentinel | 329.78 | 9.88 | 33.4× | | short | 0.1 | validity buffer | 362.17 | 57.31 | 6.3× | | byte | 0.0 | DH sentinel | 91.11 | 6.51 | 14.0× | | byte | 0.0 | validity buffer | 114.69 | 44.49 | 2.6× | | byte | 0.1 | DH sentinel | 91.18 | 6.35 | 14.3× | | byte | 0.1 | validity buffer | 126.26 | 55.74 | 2.3× |

---------

Cherry-pick of https://github.com/deephaven/deephaven-core/pull/8293