### PR TITLE
fix: DH-21193: Tie location key filter to table key

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/FilteredTableDataService.java
@@ -26,36 +26,73 @@ public class FilteredTableDataService extends AbstractTableDataService {
     private static final String IMPLEMENTATION_NAME = FilteredTableDataService.class.getSimpleName();
 
     private final TableDataService serviceToFilter;
-    private final LocationKeyFilter locationKeyFilter;
+    private final LocationKeyFilterProvider locationKeyFilterProvider;
 
+    /**
+     * A filter that has been bound to a table, and so can decide whether to accept that table's locations.
+     */
     @FunctionalInterface
     public interface LocationKeyFilter {
 
+        /** Accepts every location of the table. */
+        LocationKeyFilter ALL = locationKey -> true;
+
         /**
-         * Determine whether a {@link TableLocationKey} should be visible via this service.
+         * Accepts no location of the table. A provider that returns this is saying the table is entirely excluded,
+         * which lets the caller skip the filtered service for it.
+         */
+        LocationKeyFilter NONE = locationKey -> false;
+
+        /**
+         * Determine whether one location of the bound table should be visible via this service.
          *
-         * @param locationKey The location key
+         * @param locationKey The location key, implicitly part of the table this LocationKeyFilter was created for
          * @return True if the location key should be visible, false otherwise
          */
         boolean accept(@NotNull TableLocationKey locationKey);
     }
 
     /**
+     * Supplies the {@link LocationKeyFilter} for a table.
+     * <p>
+     * Implementations ignore the {@code tableKey} argument if they don't discriminate by table.
+     */
+    @FunctionalInterface
+    public interface LocationKeyFilterProvider {
+
+        /**
+         * Produce a filter that applies to locations belonging to the table specified by {@code tableKey}.
+         * <p>
+         * An implementation that accepts no location of {@code tableKey} <em>must</em> return the
+         * {@link LocationKeyFilter#NONE} instance itself, and one that accepts every location <em>should</em> return
+         * {@link LocationKeyFilter#ALL}. The sentinels are recognized by reference identity, so an equivalent lambda is
+         * not a substitute.
+         *
+         * @param tableKey The table to filter the locations of
+         * @return The filter for locations of {@code tableKey}; {@link LocationKeyFilter#NONE} if no location of that
+         *         table can be accepted, which lets the caller avoid consulting the filtered service at all
+         */
+        @NotNull
+        LocationKeyFilter forTable(@NotNull TableKey tableKey);
+    }
+
+    /**
      * @param serviceToFilter The service that's being filtered
-     * @param locationKeyFilter The filter function
+     * @param locationKeyFilterProvider Supplies the filter for each table's locations
      */
     public FilteredTableDataService(@NotNull final TableDataService serviceToFilter,
-            @NotNull final LocationKeyFilter locationKeyFilter) {
+            @NotNull final LocationKeyFilterProvider locationKeyFilterProvider) {
         super("Filtered-" + Require.neqNull(serviceToFilter, "serviceToFilter").getName());
         this.serviceToFilter = Require.neqNull(serviceToFilter, "serviceToFilter");
-        this.locationKeyFilter = Require.neqNull(locationKeyFilter, "locationKeyFilter");
+        this.locationKeyFilterProvider =
+                Require.neqNull(locationKeyFilterProvider, "locationKeyFilterProvider");
     }
 
     @Override
     @Nullable
     public TableLocationProvider getRawTableLocationProvider(@NotNull final TableKey tableKey,
             @NotNull final TableLocationKey tableLocationKey) {
-        if (!locationKeyFilter.accept(tableLocationKey)) {
+        if (!locationKeyFilterProvider.forTable(tableKey).accept(tableLocationKey)) {
             return null;
         }
 
@@ -77,18 +114,28 @@ public class FilteredTableDataService extends AbstractTableDataService {
     @Override
     @NotNull
     protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
-        return new TableLocationProviderImpl(serviceToFilter.getTableLocationProvider(tableKey));
+        final LocationKeyFilter filterForTable = locationKeyFilterProvider.forTable(tableKey);
+        if (filterForTable == LocationKeyFilter.NONE) {
+            // No location of this table can be accepted, so don't consult the filtered service at all.
+            return new NullTableLocationProvider(tableKey);
+        }
+        return new TableLocationProviderImpl(serviceToFilter.getTableLocationProvider(tableKey), filterForTable);
     }
 
     private class TableLocationProviderImpl implements TableLocationProvider {
 
         private final TableLocationProvider inputProvider;
 
+        /** The service's filter, bound to this provider's table. */
+        private final LocationKeyFilter filterForTable;
+
         private final String implementationName;
         private final Map<Listener, FilteringListener> listeners = new WeakHashMap<>();
 
-        private TableLocationProviderImpl(@NotNull final TableLocationProvider inputProvider) {
+        private TableLocationProviderImpl(@NotNull final TableLocationProvider inputProvider,
+                @NotNull final LocationKeyFilter filterForTable) {
             this.inputProvider = inputProvider;
+            this.filterForTable = filterForTable;
             implementationName = "Filtered-" + inputProvider.getImplementationName();
         }
 
@@ -109,7 +156,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
 
         @Override
         public void subscribe(@NotNull final Listener listener) {
-            final FilteringListener filteringListener = new FilteringListener(listener);
+            final FilteringListener filteringListener = new FilteringListener(filterForTable, listener);
             synchronized (listeners) {
                 listeners.put(listener, filteringListener);
             }
@@ -142,18 +189,18 @@ public class FilteredTableDataService extends AbstractTableDataService {
         public void getTableLocationKeys(
                 final Consumer<LiveSupplier<ImmutableTableLocationKey>> consumer,
                 final Predicate<ImmutableTableLocationKey> filter) {
-            inputProvider.getTableLocationKeys(consumer, filter);
+            inputProvider.getTableLocationKeys(consumer, filter.and(filterForTable::accept));
         }
 
         @Override
         public boolean hasTableLocationKey(@NotNull final TableLocationKey tableLocationKey) {
-            return locationKeyFilter.accept(tableLocationKey) && inputProvider.hasTableLocationKey(tableLocationKey);
+            return filterForTable.accept(tableLocationKey) && inputProvider.hasTableLocationKey(tableLocationKey);
         }
 
         @Nullable
         @Override
         public TableLocation getTableLocationIfPresent(@NotNull final TableLocationKey tableLocationKey) {
-            if (!locationKeyFilter.accept(tableLocationKey)) {
+            if (!filterForTable.accept(tableLocationKey)) {
                 return null;
             }
             return inputProvider.getTableLocationIfPresent(tableLocationKey);
@@ -180,8 +227,13 @@ public class FilteredTableDataService extends AbstractTableDataService {
     private class FilteringListener extends WeakReferenceWrapper<TableLocationProvider.Listener>
             implements TableLocationProvider.Listener {
 
-        private FilteringListener(@NotNull final TableLocationProvider.Listener outputListener) {
+        /** The service's filter, bound to the table of the provider this listener was subscribed to. */
+        private final LocationKeyFilter filterForTable;
+
+        private FilteringListener(@NotNull final LocationKeyFilter filterForTable,
+                @NotNull final TableLocationProvider.Listener outputListener) {
             super(outputListener);
+            this.filterForTable = filterForTable;
         }
 
         @Override
@@ -190,7 +242,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
             final TableLocationProvider.Listener outputListener = getWrapped();
             // We can't try to clean up null listeners here, the underlying implementation may not allow concurrent
             // unsubscribe operations.
-            if (outputListener != null && locationKeyFilter.accept(tableLocationKey.get())) {
+            if (outputListener != null && filterForTable.accept(tableLocationKey.get())) {
                 outputListener.handleTableLocationKeyAdded(tableLocationKey);
             }
         }
@@ -199,7 +251,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
         public void handleTableLocationKeyRemoved(
                 @NotNull final LiveSupplier<ImmutableTableLocationKey> tableLocationKey) {
             final TableLocationProvider.Listener outputListener = getWrapped();
-            if (outputListener != null && locationKeyFilter.accept(tableLocationKey.get())) {
+            if (outputListener != null && filterForTable.accept(tableLocationKey.get())) {
                 outputListener.handleTableLocationKeyRemoved(tableLocationKey);
             }
         }
@@ -214,9 +266,9 @@ public class FilteredTableDataService extends AbstractTableDataService {
             if (outputListener != null) {
                 // Produce filtered lists of added and removed keys.
                 final Collection<LiveSupplier<ImmutableTableLocationKey>> filteredAddedKeys = addedKeys.stream()
-                        .filter(key -> locationKeyFilter.accept(key.get())).collect(Collectors.toList());
+                        .filter(key -> filterForTable.accept(key.get())).collect(Collectors.toList());
                 final Collection<LiveSupplier<ImmutableTableLocationKey>> filteredRemovedKeys = removedKeys.stream()
-                        .filter(key -> locationKeyFilter.accept(key.get())).collect(Collectors.toList());
+                        .filter(key -> filterForTable.accept(key.get())).collect(Collectors.toList());
 
                 if (filteredAddedKeys.isEmpty() && filteredRemovedKeys.isEmpty()) {
                     return;
@@ -249,7 +301,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     public String toString() {
         return getImplementationName() + '{' +
                 (getName() != null ? "name=" + getName() + ", " : "") +
-                "locationKeyFilter=" + locationKeyFilter +
+                "locationKeyFilterProvider=" + locationKeyFilterProvider +
                 ", serviceToFilter=" + serviceToFilter +
                 '}';
     }
@@ -258,7 +310,7 @@ public class FilteredTableDataService extends AbstractTableDataService {
     public String describe() {
         return getImplementationName() + '{' +
                 (getName() != null ? "name=" + getName() + ", " : "") +
-                "locationKeyFilter=" + locationKeyFilter +
+                "locationKeyFilterProvider=" + locationKeyFilterProvider +
                 ", serviceToFilter=" + serviceToFilter.describe() +
                 '}';
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/locations/impl/NullTableLocationProvider.java
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.locations.impl;
+
+import io.deephaven.engine.liveness.LiveSupplier;
+import io.deephaven.engine.table.impl.TableUpdateMode;
+import io.deephaven.engine.table.impl.locations.ImmutableTableKey;
+import io.deephaven.engine.table.impl.locations.ImmutableTableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableKey;
+import io.deephaven.engine.table.impl.locations.TableLocation;
+import io.deephaven.engine.table.impl.locations.TableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableLocationProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * A {@link TableLocationProvider} that provides no locations, for a table that is known to have none visible.
+ */
+public class NullTableLocationProvider implements TableLocationProvider {
+
+    private final ImmutableTableKey tableKey;
+
+    /**
+     * Constructs a provider with no locations for the given table.
+     *
+     * @param tableKey the key for the table with no locations
+     */
+    public NullTableLocationProvider(@NotNull final TableKey tableKey) {
+        this.tableKey = tableKey.makeImmutable();
+    }
+
+    @Override
+    public ImmutableTableKey getKey() {
+        return tableKey;
+    }
+
+    @Override
+    @NotNull
+    public TableUpdateMode getUpdateMode() {
+        return TableUpdateMode.STATIC;
+    }
+
+    @Override
+    @NotNull
+    public TableUpdateMode getLocationUpdateMode() {
+        return TableUpdateMode.STATIC;
+    }
+
+    @Override
+    public boolean supportsSubscriptions() {
+        return false;
+    }
+
+    @Override
+    public void subscribe(@NotNull final Listener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unsubscribe(@NotNull final Listener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void refresh() {}
+
+    @Override
+    public TableLocationProvider ensureInitialized() {
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public Collection<ImmutableTableLocationKey> getTableLocationKeys() {
+        return List.of();
+    }
+
+    @Override
+    public void getTableLocationKeys(
+            final Consumer<LiveSupplier<ImmutableTableLocationKey>> consumer,
+            final Predicate<ImmutableTableLocationKey> filter) {}
+
+    @Override
+    public boolean hasTableLocationKey(@NotNull final TableLocationKey tableLocationKey) {
+        return false;
+    }
+
+    @Override
+    @Nullable
+    public TableLocation getTableLocationIfPresent(@NotNull final TableLocationKey tableLocationKey) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return getImplementationName() + '{' + tableKey + '}';
+    }
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestFilteredTableDataService.java
@@ -1,0 +1,590 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.locations.impl;
+
+import io.deephaven.base.log.LogOutput;
+import io.deephaven.engine.liveness.LiveSupplier;
+import io.deephaven.engine.table.impl.TableUpdateMode;
+import io.deephaven.engine.table.impl.locations.ImmutableTableKey;
+import io.deephaven.engine.table.impl.locations.ImmutableTableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableKey;
+import io.deephaven.engine.table.impl.locations.TableDataException;
+import io.deephaven.engine.table.impl.locations.TableLocation;
+import io.deephaven.engine.table.impl.locations.TableLocationKey;
+import io.deephaven.engine.table.impl.locations.TableLocationProvider;
+import io.deephaven.engine.table.impl.locations.impl.FilteredTableDataService.LocationKeyFilter;
+import io.deephaven.engine.table.impl.locations.impl.FilteredTableDataService.LocationKeyFilterProvider;
+import io.deephaven.engine.testutil.testcase.RefreshingTableTestCase;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Verifies that {@link FilteredTableDataService} applies its {@code locationKeyFilter} consistently across every way a
+ * caller can discover a location.
+ */
+public class TestFilteredTableDataService extends RefreshingTableTestCase {
+
+    /** The table whose locations are filtered throughout. */
+    private static final TableKey TABLE = new NamedTableKey("Market.Quotes");
+
+    /**
+     * Enumerating locations through the filtered provider hides the keys the {@code locationKeyFilter} rejects, rather
+     * than passing the underlying provider's unfiltered set through.
+     */
+    @Test
+    public void testGetTableLocationKeysAppliesFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey c = keyFor("C");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+        underlying.addKey(c);
+
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), tableKey -> key -> !key.equals(c));
+
+        final Set<ImmutableTableLocationKey> visible =
+                new HashSet<>(filtered.getTableLocationProvider(TABLE).getTableLocationKeys());
+
+        Assert.assertEquals(Set.of(a, b), visible);
+    }
+
+    /**
+     * Enumeration and {@code hasTableLocationKey} report the same set. These are the two discovery paths a caller can
+     * take, and a location visible through one but not the other is the defect this fixes.
+     */
+    @Test
+    public void testEnumerationAgreesWithHasTableLocationKey() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey c = keyFor("C");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+        underlying.addKey(c);
+
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), tableKey -> key -> !key.equals(c));
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+
+        final Set<ImmutableTableLocationKey> enumerated = new HashSet<>(provider.getTableLocationKeys());
+        for (final TableLocationKey key : new TableLocationKey[] {a, b, c}) {
+            Assert.assertEquals("agreement for " + key,
+                    provider.hasTableLocationKey(key), enumerated.contains(key));
+        }
+    }
+
+    /**
+     * The caller's own predicate still applies, and is combined with the service's filter rather than replacing it.
+     */
+    @Test
+    public void testCallerPredicateIsCombinedWithTheServiceFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey c = keyFor("C");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+        underlying.addKey(c);
+
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), tableKey -> key -> !key.equals(c));
+
+        final Set<ImmutableTableLocationKey> visible = new HashSet<>();
+        filtered.getTableLocationProvider(TABLE)
+                .getTableLocationKeys(trackedKey -> visible.add(trackedKey.get()), key -> !key.equals(b));
+
+        Assert.assertEquals(Set.of(a), visible);
+    }
+
+    /**
+     * Building a table's provider binds the filter once, and neither a repeated provider lookup nor per-location
+     * discovery through that provider binds it again.
+     */
+    @Test
+    public void testFilterIsBoundOncePerTable() {
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(keyFor("A"));
+        underlying.addKey(keyFor("B"));
+        underlying.addKey(keyFor("C"));
+
+        final CountingProvider counting = new CountingProvider(LocationKeyFilter.ALL);
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(new FixedProviderService(underlying), counting);
+
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+        Assert.assertEquals(3, provider.getTableLocationKeys().size());
+        Assert.assertTrue(provider.hasTableLocationKey(keyFor("A")));
+        Assert.assertEquals(3, filtered.getTableLocationProvider(TABLE).getTableLocationKeys().size());
+
+        Assert.assertEquals("forTable calls", 1, counting.bindCount);
+    }
+
+    /**
+     * The bound filter, not the unbound one, decides each location, so a filter that discriminates on the table takes
+     * effect per table rather than per service.
+     */
+    @Test
+    public void testBoundFilterDecidesLocations() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+
+        // Binding to TABLE yields a filter that keeps only A; any other table is excluded outright.
+        final LocationKeyFilterProvider perTable =
+                tableKey -> TABLE.equals(tableKey) ? key -> key.equals(a) : LocationKeyFilter.NONE;
+
+        final TableLocationProvider provider =
+                new FilteredTableDataService(new FixedProviderService(underlying), perTable)
+                        .getTableLocationProvider(TABLE);
+
+        Assert.assertEquals(Set.of(a), new HashSet<>(provider.getTableLocationKeys()));
+        Assert.assertTrue(provider.hasTableLocationKey(a));
+        Assert.assertFalse(provider.hasTableLocationKey(b));
+    }
+
+    /**
+     * Binding to {@link LocationKeyFilter#NONE} yields an empty provider without the filtered service being consulted
+     * at all. That service is frequently remote, so avoiding it is the point of the {@code NONE} answer.
+     */
+    @Test
+    public void testNoneAvoidsTheFilteredService() {
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(keyFor("A"));
+
+        final RecordingProviderService service = new RecordingProviderService(underlying);
+        final FilteredTableDataService filtered =
+                new FilteredTableDataService(service, tableKey -> LocationKeyFilter.NONE);
+
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+
+        Assert.assertTrue(provider.getTableLocationKeys().isEmpty());
+        Assert.assertFalse(provider.hasTableLocationKey(keyFor("A")));
+        Assert.assertEquals(TABLE, provider.getKey());
+        Assert.assertFalse("the filtered service was consulted", service.consulted);
+    }
+
+    /**
+     * The single-location raw lookup binds the filter to the table key it was handed, so one location key is accepted
+     * for one table and rejected for another. This is the path that previously asked an unbound filter about a bare
+     * location key and so could not tell the two tables apart.
+     */
+    @Test
+    public void testRawLookupAppliesTheTableAwareFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableKey other = new NamedTableKey("Market.Trades");
+
+        // The delegate holds the same location under BOTH tables, so it can answer for either. Without that, the
+        // negative assertion below would pass even if the filter were never consulted - the delegate would return
+        // null for an unknown table anyway, which is what made an earlier version of this test vacuous.
+        final PopulatedProvider underlying = new PopulatedProvider(TABLE);
+        underlying.addKey(a);
+        final PopulatedProvider otherUnderlying = new PopulatedProvider(other);
+        otherUnderlying.addKey(a);
+        final PerTableProviderService delegate = new PerTableProviderService(Map.of(
+                TABLE, underlying, other, otherUnderlying));
+        delegate.getTableLocationProvider(TABLE);
+        delegate.getTableLocationProvider(other);
+        Assert.assertSame("the delegate must be able to answer for the excluded table, or this test proves nothing",
+                otherUnderlying, delegate.getRawTableLocationProvider(other, a));
+
+        // Accepts every location of TABLE and no location of any other table.
+        final LocationKeyFilterProvider perTable =
+                tableKey -> TABLE.equals(tableKey) ? LocationKeyFilter.ALL : LocationKeyFilter.NONE;
+        final FilteredTableDataService filtered = new FilteredTableDataService(delegate, perTable);
+
+        Assert.assertSame(underlying, filtered.getRawTableLocationProvider(TABLE, a));
+        Assert.assertNull("the same location key must be rejected for a table the filter excludes",
+                filtered.getRawTableLocationProvider(other, a));
+    }
+
+    /**
+     * A provider that ignores its argument supplies the same filter for every table, which is how a filter that does
+     * not discriminate on the table is expressed.
+     */
+    @Test
+    public void testTableBlindProviderSuppliesOneFilter() {
+        final LocationKeyFilter blind = key -> true;
+        final LocationKeyFilterProvider provider = tableKey -> blind;
+        Assert.assertSame(blind, provider.forTable(TABLE));
+        Assert.assertSame(blind, provider.forTable(new NamedTableKey("Other.Table")));
+    }
+
+    /**
+     * A {@link LocationKeyFilterProvider} that counts how often it is asked to bind, supplying a fixed filter.
+     */
+    private static final class CountingProvider implements LocationKeyFilterProvider {
+
+        private final LocationKeyFilter delegate;
+        private int bindCount;
+
+        /**
+         * Creates a counting provider that always supplies the given filter.
+         *
+         * @param delegate the filter that decides locations once bound
+         */
+        private CountingProvider(@NotNull final LocationKeyFilter delegate) {
+            this.delegate = delegate;
+        }
+
+        /**
+         * Records the binding and returns the delegate.
+         *
+         * @param tableKey the table being bound to
+         * @return the delegate
+         */
+        @Override
+        @NotNull
+        public LocationKeyFilter forTable(@NotNull final TableKey tableKey) {
+            ++bindCount;
+            return delegate;
+        }
+    }
+
+    /**
+     * A named {@link TableKey}, distinct from every other key, so a test cannot pass by accident on a key the
+     * implementation supplied by default.
+     */
+    private static final class NamedTableKey implements ImmutableTableKey {
+
+        private final String name;
+
+        /**
+         * Creates a key with the given name.
+         *
+         * @param name the name, used for identity and display
+         */
+        private NamedTableKey(@NotNull final String name) {
+            this.name = name;
+        }
+
+        /**
+         * Returns the implementation name used in diagnostic output.
+         *
+         * @return the implementation name
+         */
+        @Override
+        public String getImplementationName() {
+            return "NamedTableKey";
+        }
+
+        /**
+         * Appends this key's name to the given log output.
+         *
+         * @param logOutput the output to append to
+         * @return the output, for chaining
+         */
+        @Override
+        public LogOutput append(final LogOutput logOutput) {
+            return logOutput.append(name);
+        }
+
+        /**
+         * Returns this key's name.
+         *
+         * @return the name
+         */
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        /**
+         * Hashes on the name.
+         *
+         * @return the hash code
+         */
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        /**
+         * Compares on the name.
+         *
+         * @param other the object to compare to
+         * @return true if the other object is a NamedTableKey with the same name
+         */
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof NamedTableKey && name.equals(((NamedTableKey) other).name);
+        }
+    }
+
+    /**
+     * Creates a single-partition location key for the given value.
+     *
+     * @param value the value of the {@code Part} partition
+     * @return the key
+     */
+    private static TableLocationKey keyFor(@NotNull final String value) {
+        final Map<String, Comparable<?>> partitions = new HashMap<>();
+        partitions.put("Part", value);
+        return new SimpleTableLocationKey(partitions);
+    }
+
+    /**
+     * A subscription-free provider populated with a fixed set of keys via {@link #addKey(TableLocationKey)}.
+     */
+    private static final class PopulatedProvider extends AbstractTableLocationProvider {
+
+        /**
+         * Creates an empty provider for the given table.
+         *
+         * @param tableKey the table this provider serves
+         */
+        private PopulatedProvider(@NotNull final TableKey tableKey) {
+            super(tableKey, false, TableUpdateMode.ADD_REMOVE, TableUpdateMode.ADD_REMOVE);
+        }
+
+        /**
+         * Adds a key to this provider's set.
+         *
+         * @param locationKey the key to add
+         */
+        private void addKey(@NotNull final TableLocationKey locationKey) {
+            handleTableLocationKeyAdded(locationKey);
+        }
+
+        /**
+         * Never called: this provider is enumerated, not read.
+         *
+         * @param locationKey the key that would be built
+         * @return never returns
+         */
+        @Override
+        @NotNull
+        protected TableLocation makeTableLocation(@NotNull final TableLocationKey locationKey) {
+            throw new UnsupportedOperationException("test provider is enumerated only");
+        }
+
+        /** Does nothing: the key set is fixed at construction. */
+        @Override
+        public void refresh() {}
+    }
+
+    /**
+     * A minimal {@link AbstractTableDataService} that always hands back one fixed provider.
+     */
+    private static final class FixedProviderService extends AbstractTableDataService {
+
+        private final TableLocationProvider provider;
+
+        /**
+         * Creates a service backed by a single provider.
+         *
+         * @param provider the provider to return for every table
+         */
+        private FixedProviderService(@NotNull final TableLocationProvider provider) {
+            super("fixedProviderService");
+            this.provider = provider;
+        }
+
+        /**
+         * Returns the fixed provider, regardless of the requested table.
+         *
+         * @param tableKey ignored
+         * @return the fixed provider
+         */
+        @Override
+        @NotNull
+        protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
+            return provider;
+        }
+    }
+
+    /**
+     * A {@link FixedProviderService} that records whether it was ever asked for a provider.
+     */
+    private static final class RecordingProviderService extends AbstractTableDataService {
+
+        private final TableLocationProvider provider;
+        private boolean consulted;
+
+        /**
+         * Creates a service backed by a single provider.
+         *
+         * @param provider the provider to return for every table
+         */
+        private RecordingProviderService(@NotNull final TableLocationProvider provider) {
+            super("recordingProviderService");
+            this.provider = provider;
+        }
+
+        /**
+         * Records the request and returns the fixed provider.
+         *
+         * @param tableKey ignored
+         * @return the fixed provider
+         */
+        @Override
+        @NotNull
+        protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
+            consulted = true;
+            return provider;
+        }
+    }
+
+
+    /**
+     * Subscription delivery applies the table-bound filter, so a listener sees only the keys the filter accepts - both
+     * the initial snapshot and keys pushed afterwards. This is the one discovery path a caller can take that
+     * enumeration and {@code hasTableLocationKey} do not cover.
+     */
+    @Test
+    public void testSubscriptionDeliveryAppliesTheFilter() {
+        final TableLocationKey a = keyFor("A");
+        final TableLocationKey b = keyFor("B");
+        final TableLocationKey pushed = keyFor("pushedAccepted");
+        final TableLocationKey pushedRejected = keyFor("C");
+
+        final SubscribableProvider underlying = new SubscribableProvider(TABLE);
+        underlying.addKey(a);
+        underlying.addKey(b);
+
+        // Reject exactly the keys named "C"; everything else is visible.
+        final FilteredTableDataService filtered = new FilteredTableDataService(
+                new FixedProviderService(underlying), tableKey -> key -> !key.equals(pushedRejected));
+        final TableLocationProvider provider = filtered.getTableLocationProvider(TABLE);
+        Assert.assertTrue("the provider must be subscribable for this test to mean anything",
+                provider.supportsSubscriptions());
+
+        final Set<ImmutableTableLocationKey> delivered = new HashSet<>();
+        provider.subscribe(new TableLocationProvider.Listener() {
+            @Override
+            public void handleTableLocationKeyAdded(@NotNull final LiveSupplier<ImmutableTableLocationKey> key) {
+                delivered.add(key.get());
+            }
+
+            @Override
+            public void handleTableLocationKeyRemoved(@NotNull final LiveSupplier<ImmutableTableLocationKey> key) {
+                delivered.remove(key.get());
+            }
+
+            @Override
+            public void handleException(@NotNull final TableDataException exception) {
+                throw exception;
+            }
+        });
+
+        // The initial snapshot is filtered.
+        Assert.assertEquals(Set.of(a, b), delivered);
+
+        // ... and so is everything pushed afterwards.
+        underlying.addKey(pushed);
+        underlying.addKey(pushedRejected);
+        Assert.assertEquals(Set.of(a, b, pushed), delivered);
+    }
+
+    /**
+     * A {@link TableDataService} holding a distinct provider per table. The provider cache is keyed by each provider's
+     * own table key, so a single provider instance cannot serve two different tables.
+     */
+    private static final class PerTableProviderService extends AbstractTableDataService {
+
+        private final Map<TableKey, TableLocationProvider> providers;
+
+        /**
+         * Creates a service backed by one provider per table.
+         *
+         * @param providers the provider to return for each table
+         */
+        private PerTableProviderService(@NotNull final Map<TableKey, TableLocationProvider> providers) {
+            super("perTableProviderService");
+            this.providers = providers;
+        }
+
+        /**
+         * Returns the provider registered for the requested table.
+         *
+         * @param tableKey the table being requested
+         * @return that table's provider
+         */
+        @Override
+        @NotNull
+        protected TableLocationProvider makeTableLocationProvider(@NotNull final TableKey tableKey) {
+            final TableLocationProvider provider = providers.get(tableKey);
+            Assert.assertNotNull("no provider registered for " + tableKey, provider);
+            return provider;
+        }
+    }
+
+
+    /**
+     * A {@link PopulatedProvider} that supports subscriptions, so that listener delivery can be exercised. Keys added
+     * after a subscriber attaches are pushed to it.
+     */
+    private static final class SubscribableProvider extends AbstractTableLocationProvider {
+
+        /**
+         * Creates an empty subscribable provider for the given table.
+         *
+         * @param tableKey the table this provider serves
+         */
+        private SubscribableProvider(@NotNull final TableKey tableKey) {
+            super(tableKey, true, TableUpdateMode.ADD_REMOVE, TableUpdateMode.ADD_REMOVE);
+        }
+
+        /**
+         * Adds a key, pushing it to any current subscriber.
+         *
+         * @param locationKey the key to add
+         */
+        private void addKey(@NotNull final TableLocationKey locationKey) {
+            handleTableLocationKeyAdded(locationKey);
+        }
+
+        /** Activation is immediate: the key set is already in memory. */
+        @Override
+        protected void activateUnderlyingDataSource() {
+            activationSuccessful(this);
+        }
+
+        /** Nothing to tear down. */
+        @Override
+        protected void deactivateUnderlyingDataSource() {}
+
+        /**
+         * Matches the token handed to {@link #activationSuccessful}.
+         *
+         * @param token the subscription token
+         * @param <T> the token type
+         * @return whether the token is this provider
+         */
+        @Override
+        protected <T> boolean matchSubscriptionToken(final T token) {
+            return token == this;
+        }
+
+        /**
+         * Never called: this provider is enumerated, not read.
+         *
+         * @param locationKey the key that would be built
+         * @return never returns
+         */
+        @Override
+        @NotNull
+        protected TableLocation makeTableLocation(@NotNull final TableLocationKey locationKey) {
+            throw new UnsupportedOperationException("test provider is enumerated only");
+        }
+
+        /** Does nothing: keys arrive through {@link #addKey}. */
+        @Override
+        public void refresh() {}
+    }
+
+}

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestTableDataService.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/locations/impl/TestTableDataService.java
@@ -65,7 +65,8 @@ public class TestTableDataService {
         final TableDataService[] tableDataServices;
 
         private DummyServiceSelector(final TableLocationKey tlk1, final TableLocationKey tlk2) {
-            final FilteredTableDataService.LocationKeyFilter dummyFilter = (tlk) -> true;
+            final FilteredTableDataService.LocationKeyFilterProvider dummyFilter =
+                    tableKey -> FilteredTableDataService.LocationKeyFilter.ALL;
             tableDataServices = new TableDataService[] {
                     new FilteredTableDataService(new DummyTableDataService("dummyTds1",
                             new DummyTableLocation(StandaloneTableKey.getInstance(), tlk1)), dummyFilter),


### PR DESCRIPTION
FilteredTableDataService took a LocationKeyFilter that was asked about a bare TableLocationKey. A location key carries partition values and no table identity, so it names a location only relative to its table; asking whether one is acceptable without saying which table it belongs to is not a well-formed question for a filter whose answer does not factor into an independent table test and location test.

Split the interface so the filter is bound to a table first:

    LocationKeyFilterProvider.forTable(TableKey) -> LocationKeyFilter.accept(TableLocationKey)

Every existing decision point now uses the binding its provider already holds, so no call site has to reconstruct the table. A filter that does not discriminate by table is a provider that ignores its argument.

Two behavior changes come with it:

- Enumeration now applies the service's filter. getTableLocationKeys(consumer, filter) previously delegated without applying it, so a filtered service could enumerate locations that hasTableLocationKey, getTableLocationIfPresent and subscription delivery all excluded. The four now agree.
- A fully excluded table no longer consults the wrapped service. When forTable returns LocationKeyFilter.NONE, makeTableLocationProvider returns the new public NullTableLocationProvider instead of wrapping the delegate, which is frequently remote.

LocationKeyFilter gains ALL and NONE, recognized by reference identity, so an implementation that accepts no location of a table must return the NONE instance rather than an equivalent lambda.

NullTableLocationProvider is new and public. Its subscribe/unsubscribe throw UnsupportedOperationException, matching SingleTableLocationProvider, the other provider in this package with supportsSubscriptions() == false.

Not source-compatible for implementors: anyone constructing a FilteredTableDataService now supplies a LocationKeyFilterProvider.