### PR TITLE
fix: DH-23266: Fix zero-key aggBy NPE on upstream shift when an operator shares an input slot it does not own

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/ChunkedOperatorAggregationHelper.java
@@ -2462,9 +2462,10 @@ public class ChunkedOperatorAggregationHelper {
                         previousValues = newValues = null;
                     } else {
                         if (workingPreChunks[inputSlot] == null) {
-                            workingPreChunks[inputSlot] = ac.inputColumns[ii].getPrevChunk(getContexts[ii], preChunkOk);
+                            workingPreChunks[inputSlot] =
+                                    ac.inputColumns[inputSlot].getPrevChunk(getContexts[inputSlot], preChunkOk);
                             workingPostChunks[inputSlot] =
-                                    ac.inputColumns[ii].getChunk(postGetContexts[ii], postChunkOk);
+                                    ac.inputColumns[inputSlot].getChunk(postGetContexts[inputSlot], postChunkOk);
                         }
                         previousValues = workingPreChunks[inputSlot];
                         newValues = workingPostChunks[inputSlot];

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/QueryTableAggregationTest.java
@@ -3601,6 +3601,58 @@ public class QueryTableAggregationTest {
     }
 
     @Test
+    public void testNoKeyShiftWithSharedSortedFirstInputColumn() {
+        final QueryTable table = testRefreshingTable(i(0, 1).toTracking(), intCol("Value", 10, 11));
+
+        // AggSum does not require row keys, so it owns the input slot for Value but is absent from the shift
+        // pass; AggSortedFirst requires row keys and shares that slot.
+        final Table result = table.aggBy(List.of(
+                AggSum("Sum=Value"),
+                AggSortedFirst("Value", "First=Value")));
+
+        assertTableEquals(newTable(longCol("Sum", 21), intCol("First", 10)), result);
+
+        final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+        updateGraph.runWithinUnitTestCycle(() -> {
+            // Move both keys up by 100, reported purely as a shift: the values are unchanged, only their keys moved.
+            addToTable(table, i(100, 101), intCol("Value", 10, 11));
+            removeRows(table, i(0, 1));
+            final RowSetShiftData.Builder shiftBuilder = new RowSetShiftData.Builder();
+            shiftBuilder.shiftRange(0, 1, 100);
+            table.notifyListeners(
+                    new TableUpdateImpl(i(), i(), i(), shiftBuilder.build(), ModifiedColumnSet.EMPTY));
+        });
+
+        assertTableEquals(newTable(longCol("Sum", 21), intCol("First", 10)), result);
+    }
+
+    @Test
+    public void testNoKeyShiftWithMultipleOperatorsSharingInputColumn() {
+        final QueryTable table = testRefreshingTable(i(0, 1).toTracking(), intCol("Value", 10, 11));
+
+        // Three operators share the input slot for Value: AggSum owns it but does not require row keys, while
+        // both sorted operators do. This exercises reuse of the shared chunk after it has been fetched once.
+        final Table result = table.aggBy(List.of(
+                AggSum("Sum=Value"),
+                AggSortedFirst("Value", "First=Value"),
+                AggSortedLast("Value", "Last=Value")));
+
+        assertTableEquals(newTable(longCol("Sum", 21), intCol("First", 10), intCol("Last", 11)), result);
+
+        final ControlledUpdateGraph updateGraph = ExecutionContext.getContext().getUpdateGraph().cast();
+        updateGraph.runWithinUnitTestCycle(() -> {
+            addToTable(table, i(100, 101), intCol("Value", 10, 11));
+            removeRows(table, i(0, 1));
+            final RowSetShiftData.Builder shiftBuilder = new RowSetShiftData.Builder();
+            shiftBuilder.shiftRange(0, 1, 100);
+            table.notifyListeners(
+                    new TableUpdateImpl(i(), i(), i(), shiftBuilder.build(), ModifiedColumnSet.EMPTY));
+        });
+
+        assertTableEquals(newTable(longCol("Sum", 21), intCol("First", 10), intCol("Last", 11)), result);
+    }
+
+    @Test
     public void testFirstByShift() {
         final QueryTable table = testRefreshingTable(i(1, 2, 4097).toTracking(),
                 intCol("Sentinel", 1, 2, 4097),


### PR DESCRIPTION
`AggregationContext` de-duplicates operators reading the same `ColumnSource` into a shared input slot, keyed by the index of the first operator using that source. `doProcessShiftNoKey` stored the fetched chunks at `workingPreChunks[inputSlot]` but fetched them with `getContexts[ii]` — the operator index. When an operator shares a slot it does not own (`inputSlot != ii`), `getContexts[ii]` is null, and the no-key shift pass dies with an NPE:

```
java.lang.NullPointerException: Cannot invoke "ContextWithChunk.getWritableChunk()" because "context" is null
  at ChunkedOperatorAggregationHelper.doProcessShiftNoKey(ChunkedOperatorAggregationHelper.java:2465)
```

The null is only reached when the operator owning the slot is itself absent from `operatorsToShift` (i.e. `requiresRowKeys() == false`), since otherwise the shared chunk is already populated by the time the sharing operator is processed. Reproducing conditions, all three required:

* zero-key `aggBy` (no group-by columns)
* an upstream update carrying a shift over pre-existing rows
* an `AggSortedFirst`/`AggSortedLast` whose sort column is also the input of an earlier aggregation that does not require row keys (e.g. `AggSum`)

The fix indexes by `inputSlot`, matching every other fetch site in the file — the structurally identical no-key modification path and the bucketed shift path were already correct, so only the zero-key shift path was affected. This is a hard listener failure rather than silent corruption, and it is long-standing: the line predates the 2021 repo restructuring.
