### PR TITLE
fix!: DH-23267: Drop primitive SSM equality test against boxed ObjectVector

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/ByteSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/ByteSegmentedSortedMultiset.java
@@ -12,11 +12,8 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.vector.ByteVector;
 import io.deephaven.vector.ByteVectorDirect;
-import io.deephaven.vector.ObjectVector;
 import io.deephaven.util.compare.ByteComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.util.type.TypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfByte;
 import io.deephaven.engine.primitive.value.iterator.ValueIteratorOfByte;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
@@ -3049,7 +3046,6 @@ public final class ByteSegmentedSortedMultiset implements SegmentedSortedMultiSe
     }
     // endregion
 
-    // region VectorEquals
     private boolean equalsArray(ByteVector o) {
         if (size() != o.size()) {
             return false;
@@ -3082,80 +3078,31 @@ public final class ByteSegmentedSortedMultiset implements SegmentedSortedMultiSe
             return true;
         }
     }
-    // endregion VectorEquals
-
-    // region UnboxValue
-    /**
-     * Convert an element of a boxed {@link ObjectVector} into the primitive representation this SSM stores. A
-     * {@code null} element becomes the null sentinel, which is how the SSM itself stores nulls.
-     */
-    private static byte unboxValue(final Object value) {
-        return TypeUtils.unbox((Byte) value);
-    }
-    // endregion UnboxValue
-
-    private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        if (o.getComponentType() != byte.class && o.getComponentType() != Byte.class) {
-            return false;
-        }
-        // endregion EqualsArrayTypeCheck
-
-        if (size() != o.size()) {
-            return false;
-        }
-
-        // iterate o exactly once; random access via get can be expensive for some Vector implementations
-        try (final CloseableIterator<?> oit = o.iterator()) {
-            if (size == 1) {
-                return ByteComparisons.eq(get(0), unboxValue(oit.next()));
-            }
-
-            if (leafCount == 1) {
-                for (int ii = 0; ii < size; ii++) {
-                    if (!ByteComparisons.eq(directoryValues[ii], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            for (int li = 0; li < leafCount; ++li) {
-                for (int ai = 0; ai < leafSizes[li]; ai++) {
-                    if (!ByteComparisons.eq(leafValues[li][ai], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-    }
 
     /**
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link ByteVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link ByteVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link ByteVector#equals(ByteVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link ByteVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
+
         if (o instanceof ByteVector) {
             return equalsArray((ByteVector) o);
         }
-        // endregion VectorEquals
 
-        if (o instanceof ObjectVector) {
-            return equalsArray((ObjectVector<?>) o);
-        }
         return false;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/CharSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/CharSegmentedSortedMultiset.java
@@ -8,11 +8,8 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.vector.CharVector;
 import io.deephaven.vector.CharVectorDirect;
-import io.deephaven.vector.ObjectVector;
 import io.deephaven.util.compare.CharComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.util.type.TypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfChar;
 import io.deephaven.engine.primitive.value.iterator.ValueIteratorOfChar;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
@@ -3045,7 +3042,6 @@ public final class CharSegmentedSortedMultiset implements SegmentedSortedMultiSe
     }
     // endregion
 
-    // region VectorEquals
     private boolean equalsArray(CharVector o) {
         if (size() != o.size()) {
             return false;
@@ -3078,80 +3074,31 @@ public final class CharSegmentedSortedMultiset implements SegmentedSortedMultiSe
             return true;
         }
     }
-    // endregion VectorEquals
-
-    // region UnboxValue
-    /**
-     * Convert an element of a boxed {@link ObjectVector} into the primitive representation this SSM stores. A
-     * {@code null} element becomes the null sentinel, which is how the SSM itself stores nulls.
-     */
-    private static char unboxValue(final Object value) {
-        return TypeUtils.unbox((Character) value);
-    }
-    // endregion UnboxValue
-
-    private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        if (o.getComponentType() != char.class && o.getComponentType() != Character.class) {
-            return false;
-        }
-        // endregion EqualsArrayTypeCheck
-
-        if (size() != o.size()) {
-            return false;
-        }
-
-        // iterate o exactly once; random access via get can be expensive for some Vector implementations
-        try (final CloseableIterator<?> oit = o.iterator()) {
-            if (size == 1) {
-                return CharComparisons.eq(get(0), unboxValue(oit.next()));
-            }
-
-            if (leafCount == 1) {
-                for (int ii = 0; ii < size; ii++) {
-                    if (!CharComparisons.eq(directoryValues[ii], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            for (int li = 0; li < leafCount; ++li) {
-                for (int ai = 0; ai < leafSizes[li]; ai++) {
-                    if (!CharComparisons.eq(leafValues[li][ai], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-    }
 
     /**
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link CharVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link CharVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link CharVector#equals(CharVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link CharVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
+
         if (o instanceof CharVector) {
             return equalsArray((CharVector) o);
         }
-        // endregion VectorEquals
 
-        if (o instanceof ObjectVector) {
-            return equalsArray((ObjectVector<?>) o);
-        }
         return false;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/DoubleSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/DoubleSegmentedSortedMultiset.java
@@ -12,11 +12,8 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.vector.DoubleVector;
 import io.deephaven.vector.DoubleVectorDirect;
-import io.deephaven.vector.ObjectVector;
 import io.deephaven.util.compare.DoubleComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.util.type.TypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfDouble;
 import io.deephaven.engine.primitive.value.iterator.ValueIteratorOfDouble;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
@@ -3048,7 +3045,6 @@ public final class DoubleSegmentedSortedMultiset implements SegmentedSortedMulti
     }
     // endregion
 
-    // region VectorEquals
     private boolean equalsArray(DoubleVector o) {
         if (size() != o.size()) {
             return false;
@@ -3081,80 +3077,31 @@ public final class DoubleSegmentedSortedMultiset implements SegmentedSortedMulti
             return true;
         }
     }
-    // endregion VectorEquals
-
-    // region UnboxValue
-    /**
-     * Convert an element of a boxed {@link ObjectVector} into the primitive representation this SSM stores. A
-     * {@code null} element becomes the null sentinel, which is how the SSM itself stores nulls.
-     */
-    private static double unboxValue(final Object value) {
-        return TypeUtils.unbox((Double) value);
-    }
-    // endregion UnboxValue
-
-    private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        if (o.getComponentType() != double.class && o.getComponentType() != Double.class) {
-            return false;
-        }
-        // endregion EqualsArrayTypeCheck
-
-        if (size() != o.size()) {
-            return false;
-        }
-
-        // iterate o exactly once; random access via get can be expensive for some Vector implementations
-        try (final CloseableIterator<?> oit = o.iterator()) {
-            if (size == 1) {
-                return DoubleComparisons.eq(get(0), unboxValue(oit.next()));
-            }
-
-            if (leafCount == 1) {
-                for (int ii = 0; ii < size; ii++) {
-                    if (!DoubleComparisons.eq(directoryValues[ii], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            for (int li = 0; li < leafCount; ++li) {
-                for (int ai = 0; ai < leafSizes[li]; ai++) {
-                    if (!DoubleComparisons.eq(leafValues[li][ai], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-    }
 
     /**
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link DoubleVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link DoubleVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link DoubleVector#equals(DoubleVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link DoubleVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
+
         if (o instanceof DoubleVector) {
             return equalsArray((DoubleVector) o);
         }
-        // endregion VectorEquals
 
-        if (o instanceof ObjectVector) {
-            return equalsArray((ObjectVector<?>) o);
-        }
         return false;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/FloatSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/FloatSegmentedSortedMultiset.java
@@ -12,11 +12,8 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.vector.FloatVector;
 import io.deephaven.vector.FloatVectorDirect;
-import io.deephaven.vector.ObjectVector;
 import io.deephaven.util.compare.FloatComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.util.type.TypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfFloat;
 import io.deephaven.engine.primitive.value.iterator.ValueIteratorOfFloat;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
@@ -3048,7 +3045,6 @@ public final class FloatSegmentedSortedMultiset implements SegmentedSortedMultiS
     }
     // endregion
 
-    // region VectorEquals
     private boolean equalsArray(FloatVector o) {
         if (size() != o.size()) {
             return false;
@@ -3081,80 +3077,31 @@ public final class FloatSegmentedSortedMultiset implements SegmentedSortedMultiS
             return true;
         }
     }
-    // endregion VectorEquals
-
-    // region UnboxValue
-    /**
-     * Convert an element of a boxed {@link ObjectVector} into the primitive representation this SSM stores. A
-     * {@code null} element becomes the null sentinel, which is how the SSM itself stores nulls.
-     */
-    private static float unboxValue(final Object value) {
-        return TypeUtils.unbox((Float) value);
-    }
-    // endregion UnboxValue
-
-    private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        if (o.getComponentType() != float.class && o.getComponentType() != Float.class) {
-            return false;
-        }
-        // endregion EqualsArrayTypeCheck
-
-        if (size() != o.size()) {
-            return false;
-        }
-
-        // iterate o exactly once; random access via get can be expensive for some Vector implementations
-        try (final CloseableIterator<?> oit = o.iterator()) {
-            if (size == 1) {
-                return FloatComparisons.eq(get(0), unboxValue(oit.next()));
-            }
-
-            if (leafCount == 1) {
-                for (int ii = 0; ii < size; ii++) {
-                    if (!FloatComparisons.eq(directoryValues[ii], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            for (int li = 0; li < leafCount; ++li) {
-                for (int ai = 0; ai < leafSizes[li]; ai++) {
-                    if (!FloatComparisons.eq(leafValues[li][ai], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-    }
 
     /**
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link FloatVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link FloatVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link FloatVector#equals(FloatVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link FloatVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
+
         if (o instanceof FloatVector) {
             return equalsArray((FloatVector) o);
         }
-        // endregion VectorEquals
 
-        if (o instanceof ObjectVector) {
-            return equalsArray((ObjectVector<?>) o);
-        }
         return false;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/IntSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/IntSegmentedSortedMultiset.java
@@ -12,11 +12,8 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.vector.IntVector;
 import io.deephaven.vector.IntVectorDirect;
-import io.deephaven.vector.ObjectVector;
 import io.deephaven.util.compare.IntComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.util.type.TypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfInt;
 import io.deephaven.engine.primitive.value.iterator.ValueIteratorOfInt;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
@@ -3049,7 +3046,6 @@ public final class IntSegmentedSortedMultiset implements SegmentedSortedMultiSet
     }
     // endregion
 
-    // region VectorEquals
     private boolean equalsArray(IntVector o) {
         if (size() != o.size()) {
             return false;
@@ -3082,80 +3078,31 @@ public final class IntSegmentedSortedMultiset implements SegmentedSortedMultiSet
             return true;
         }
     }
-    // endregion VectorEquals
-
-    // region UnboxValue
-    /**
-     * Convert an element of a boxed {@link ObjectVector} into the primitive representation this SSM stores. A
-     * {@code null} element becomes the null sentinel, which is how the SSM itself stores nulls.
-     */
-    private static int unboxValue(final Object value) {
-        return TypeUtils.unbox((Integer) value);
-    }
-    // endregion UnboxValue
-
-    private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        if (o.getComponentType() != int.class && o.getComponentType() != Integer.class) {
-            return false;
-        }
-        // endregion EqualsArrayTypeCheck
-
-        if (size() != o.size()) {
-            return false;
-        }
-
-        // iterate o exactly once; random access via get can be expensive for some Vector implementations
-        try (final CloseableIterator<?> oit = o.iterator()) {
-            if (size == 1) {
-                return IntComparisons.eq(get(0), unboxValue(oit.next()));
-            }
-
-            if (leafCount == 1) {
-                for (int ii = 0; ii < size; ii++) {
-                    if (!IntComparisons.eq(directoryValues[ii], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            for (int li = 0; li < leafCount; ++li) {
-                for (int ai = 0; ai < leafSizes[li]; ai++) {
-                    if (!IntComparisons.eq(leafValues[li][ai], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-    }
 
     /**
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link IntVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link IntVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link IntVector#equals(IntVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link IntVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
+
         if (o instanceof IntVector) {
             return equalsArray((IntVector) o);
         }
-        // endregion VectorEquals
 
-        if (o instanceof ObjectVector) {
-            return equalsArray((ObjectVector<?>) o);
-        }
         return false;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/LongSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/LongSegmentedSortedMultiset.java
@@ -9,6 +9,7 @@ package io.deephaven.engine.table.impl.ssms;
 
 import java.time.Instant;
 
+import io.deephaven.vector.ObjectVector;
 import io.deephaven.vector.ObjectVectorDirect;
 import io.deephaven.time.DateTimeUtils;
 
@@ -17,11 +18,8 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.vector.LongVector;
 import io.deephaven.vector.LongVectorDirect;
-import io.deephaven.vector.ObjectVector;
 import io.deephaven.util.compare.LongComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.util.type.TypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfLong;
 import io.deephaven.engine.primitive.value.iterator.ValueIteratorOfLong;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
@@ -3054,7 +3052,6 @@ public final class LongSegmentedSortedMultiset implements SegmentedSortedMultiSe
     }
     // endregion
 
-    // region VectorEquals
     private boolean equalsArray(LongVector o) {
         if (size() != o.size()) {
             return false;
@@ -3087,80 +3084,31 @@ public final class LongSegmentedSortedMultiset implements SegmentedSortedMultiSe
             return true;
         }
     }
-    // endregion VectorEquals
-
-    // region UnboxValue
-    /**
-     * Convert an element of a boxed {@link ObjectVector} into the primitive representation this SSM stores. A
-     * {@code null} element becomes the null sentinel, which is how the SSM itself stores nulls.
-     */
-    private static long unboxValue(final Object value) {
-        return TypeUtils.unbox((Long) value);
-    }
-    // endregion UnboxValue
-
-    private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        if (o.getComponentType() != long.class && o.getComponentType() != Long.class) {
-            return false;
-        }
-        // endregion EqualsArrayTypeCheck
-
-        if (size() != o.size()) {
-            return false;
-        }
-
-        // iterate o exactly once; random access via get can be expensive for some Vector implementations
-        try (final CloseableIterator<?> oit = o.iterator()) {
-            if (size == 1) {
-                return LongComparisons.eq(get(0), unboxValue(oit.next()));
-            }
-
-            if (leafCount == 1) {
-                for (int ii = 0; ii < size; ii++) {
-                    if (!LongComparisons.eq(directoryValues[ii], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            for (int li = 0; li < leafCount; ++li) {
-                for (int ai = 0; ai < leafSizes[li]; ai++) {
-                    if (!LongComparisons.eq(leafValues[li][ai], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-    }
 
     /**
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link LongVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link LongVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link LongVector#equals(LongVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link LongVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
+
         if (o instanceof LongVector) {
             return equalsArray((LongVector) o);
         }
-        // endregion VectorEquals
 
-        if (o instanceof ObjectVector) {
-            return equalsArray((ObjectVector<?>) o);
-        }
         return false;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/ObjectSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/ObjectSegmentedSortedMultiset.java
@@ -9,6 +9,8 @@ package io.deephaven.engine.table.impl.ssms;
 
 import java.lang.reflect.Array;
 
+import io.deephaven.engine.primitive.iterator.CloseableIterator;
+
 import java.util.Objects;
 import io.deephaven.util.compare.ObjectComparisons;
 
@@ -19,7 +21,6 @@ import io.deephaven.vector.ObjectVector;
 import io.deephaven.vector.ObjectVectorDirect;
 import io.deephaven.util.compare.ObjectComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.value.iterator.ValueIterator;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
 import io.deephaven.chunk.*;
@@ -3059,18 +3060,7 @@ public final class ObjectSegmentedSortedMultiset implements SegmentedSortedMulti
     }
     // endregion
 
-    // region VectorEquals
-    // endregion VectorEquals
-
-    // region UnboxValue
-    // endregion UnboxValue
-
     private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        // No component-type check: it only guards the primitive variants' unboxValue() cast, and gating
-        // on the declared type would break symmetry with ObjectVector.equals().
-        // endregion EqualsArrayTypeCheck
-
         if (size() != o.size()) {
             return false;
         }
@@ -3107,22 +3097,26 @@ public final class ObjectSegmentedSortedMultiset implements SegmentedSortedMulti
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link ObjectVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link ObjectVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link ObjectVector#equals(ObjectVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link ObjectVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
-        // endregion VectorEquals
 
         if (o instanceof ObjectVector) {
             return equalsArray((ObjectVector<?>) o);
         }
+
         return false;
     }
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/ShortSegmentedSortedMultiset.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/ssms/ShortSegmentedSortedMultiset.java
@@ -12,11 +12,8 @@ import io.deephaven.base.verify.Require;
 import io.deephaven.chunk.attributes.Any;
 import io.deephaven.vector.ShortVector;
 import io.deephaven.vector.ShortVectorDirect;
-import io.deephaven.vector.ObjectVector;
 import io.deephaven.util.compare.ShortComparisons;
 import io.deephaven.util.type.ArrayTypeUtils;
-import io.deephaven.util.type.TypeUtils;
-import io.deephaven.engine.primitive.iterator.CloseableIterator;
 import io.deephaven.engine.primitive.iterator.CloseablePrimitiveIteratorOfShort;
 import io.deephaven.engine.primitive.value.iterator.ValueIteratorOfShort;
 import io.deephaven.engine.table.impl.sort.timsort.TimsortUtils;
@@ -3049,7 +3046,6 @@ public final class ShortSegmentedSortedMultiset implements SegmentedSortedMultiS
     }
     // endregion
 
-    // region VectorEquals
     private boolean equalsArray(ShortVector o) {
         if (size() != o.size()) {
             return false;
@@ -3082,80 +3078,31 @@ public final class ShortSegmentedSortedMultiset implements SegmentedSortedMultiS
             return true;
         }
     }
-    // endregion VectorEquals
-
-    // region UnboxValue
-    /**
-     * Convert an element of a boxed {@link ObjectVector} into the primitive representation this SSM stores. A
-     * {@code null} element becomes the null sentinel, which is how the SSM itself stores nulls.
-     */
-    private static short unboxValue(final Object value) {
-        return TypeUtils.unbox((Short) value);
-    }
-    // endregion UnboxValue
-
-    private boolean equalsArray(ObjectVector<?> o) {
-        // region EqualsArrayTypeCheck
-        if (o.getComponentType() != short.class && o.getComponentType() != Short.class) {
-            return false;
-        }
-        // endregion EqualsArrayTypeCheck
-
-        if (size() != o.size()) {
-            return false;
-        }
-
-        // iterate o exactly once; random access via get can be expensive for some Vector implementations
-        try (final CloseableIterator<?> oit = o.iterator()) {
-            if (size == 1) {
-                return ShortComparisons.eq(get(0), unboxValue(oit.next()));
-            }
-
-            if (leafCount == 1) {
-                for (int ii = 0; ii < size; ii++) {
-                    if (!ShortComparisons.eq(directoryValues[ii], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            for (int li = 0; li < leafCount; ++li) {
-                for (int ai = 0; ai < leafSizes[li]; ai++) {
-                    if (!ShortComparisons.eq(leafValues[li][ai], unboxValue(oit.next()))) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-    }
 
     /**
      * {@inheritDoc}
      *
      * <p>
-     * Equal to any Vector holding the same values, including another SSM: an SSM <em>is</em> a Vector, so it takes the
-     * same element-wise path rather than a structural comparison of leaf layouts. Two SSMs can hold identical values in
-     * different layouts -- leaves need not be full, and the node sizes need not agree -- so layout is not a sound basis
-     * for equality.
+     * Equal to any {@link ShortVector} holding the same values, including another SSM: an SSM <em>is</em> a
+     * {@link ShortVector}, so it takes the same element-wise path rather than a structural comparison of leaf layouts.
+     * Two SSMs can hold identical values in different layouts -- leaves need not be full, and the node sizes need not
+     * agree -- so layout is not a sound basis for equality.
+     *
+     * <p>
+     * Nothing else is equal, exactly as {@link ShortVector#equals(ShortVector, Object)} requires: a Vector that stores
+     * its elements some other way cannot be accepted without breaking the {@link #hashCode()} contract, and would not
+     * be reciprocated in any case, since that Vector's own {@code equals} rejects a {@link ShortVector}.
      */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        // region VectorEquals
+
         if (o instanceof ShortVector) {
             return equalsArray((ShortVector) o);
         }
-        // endregion VectorEquals
 
-        if (o instanceof ObjectVector) {
-            return equalsArray((ObjectVector<?>) o);
-        }
         return false;
     }
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestByteSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestByteSegmentedSortedMultiset.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -774,21 +775,21 @@ public class TestByteSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final ByteSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Byte[] boxed = new Byte[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new ByteVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // ByteVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // a boxed Vector of the same values is not equal in either direction: it would hold a null reference wherever
+        // this SSM holds the null sentinel, so accepting it would make equal values hash differently
+        final Byte[] boxed = new Byte[valueCount];
+        for (int ii = 0; ii < valueCount; ++ii) {
+            boxed[ii] = values[ii];
+        }
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxed));
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -818,11 +819,6 @@ public class TestByteSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (byte) ('a' + ii);
         }
         assertFalse(ssm.equals(new ByteVectorDirect(longer)));
-        final Byte[] longerBoxed = new Byte[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (byte) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -831,10 +827,6 @@ public class TestByteSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final byte[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new ByteVectorDirect(modifiedValues)));
-
-                final Byte[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }
@@ -909,31 +901,33 @@ public class TestByteSegmentedSortedMultiset extends RefreshingTableTestCase {
         final ByteSegmentedSortedMultiset ssm = makeSsm(nodeSize, sortedValues);
         final byte[] stored = ssm.toArray();
 
-        // boxing the null sentinel yields a non-null element holding the sentinel value, which compares equal
+        // the null sentinel is an ordinary value to a ByteVector comparison: equal both ways, and hashing alike
+        assertEqualBothWays(ssm, new ByteVectorDirect(stored));
+
+        // boxing the sentinel yields a non-null element holding the sentinel value...
         final Byte[] boxedSentinel = new Byte[stored.length];
         for (int ii = 0; ii < stored.length; ++ii) {
             boxedSentinel[ii] = stored[ii];
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedSentinel)));
+        // ...but a boxed Vector is still not a ByteVector, so it is not equal in either direction
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxedSentinel));
 
-        // a literal null also compares equal to the stored null sentinel
+        // a boxed Vector holding a literal null where this SSM holds the sentinel is likewise not equal. This is the
+        // case that made the branch unsound: the two would have compared equal while hashing differently, since
+        // hashCode() hashes the sentinel and a boxed Vector hashes the null reference.
         final Byte[] boxedNull = boxedSentinel.clone();
         for (int ii = 0; ii < stored.length; ++ii) {
             if (stored[ii] == NULL_BYTE) {
                 boxedNull[ii] = null;
             }
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedNull)));
+        final ObjectVectorDirect<Byte> boxedNullVector = new ObjectVectorDirect<>(boxedNull);
+        assertNotEqualBothWays(ssm, boxedNullVector);
 
-        // a null at a position holding a non-null value is not equal
-        for (int ii = 0; ii < stored.length; ++ii) {
-            if (stored[ii] != NULL_BYTE) {
-                final Byte[] boxedWrongNull = boxedSentinel.clone();
-                boxedWrongNull[ii] = null;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(boxedWrongNull)));
-                break;
-            }
-        }
+        // ... and a hash lookup keyed on that boxed Vector must therefore miss rather than silently mismatch
+        final Map<Object, String> map = new HashMap<>();
+        map.put(boxedNullVector, "boxed");
+        assertNull(map.get(ssm));
     }
     // endregion NullEquals
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestCharSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestCharSegmentedSortedMultiset.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -771,21 +772,21 @@ public class TestCharSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final CharSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Character[] boxed = new Character[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new CharVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // CharVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // a boxed Vector of the same values is not equal in either direction: it would hold a null reference wherever
+        // this SSM holds the null sentinel, so accepting it would make equal values hash differently
+        final Character[] boxed = new Character[valueCount];
+        for (int ii = 0; ii < valueCount; ++ii) {
+            boxed[ii] = values[ii];
+        }
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxed));
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -815,11 +816,6 @@ public class TestCharSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (char) ('a' + ii);
         }
         assertFalse(ssm.equals(new CharVectorDirect(longer)));
-        final Character[] longerBoxed = new Character[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (char) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -828,10 +824,6 @@ public class TestCharSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final char[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new CharVectorDirect(modifiedValues)));
-
-                final Character[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }
@@ -906,31 +898,33 @@ public class TestCharSegmentedSortedMultiset extends RefreshingTableTestCase {
         final CharSegmentedSortedMultiset ssm = makeSsm(nodeSize, sortedValues);
         final char[] stored = ssm.toArray();
 
-        // boxing the null sentinel yields a non-null element holding the sentinel value, which compares equal
+        // the null sentinel is an ordinary value to a CharVector comparison: equal both ways, and hashing alike
+        assertEqualBothWays(ssm, new CharVectorDirect(stored));
+
+        // boxing the sentinel yields a non-null element holding the sentinel value...
         final Character[] boxedSentinel = new Character[stored.length];
         for (int ii = 0; ii < stored.length; ++ii) {
             boxedSentinel[ii] = stored[ii];
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedSentinel)));
+        // ...but a boxed Vector is still not a CharVector, so it is not equal in either direction
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxedSentinel));
 
-        // a literal null also compares equal to the stored null sentinel
+        // a boxed Vector holding a literal null where this SSM holds the sentinel is likewise not equal. This is the
+        // case that made the branch unsound: the two would have compared equal while hashing differently, since
+        // hashCode() hashes the sentinel and a boxed Vector hashes the null reference.
         final Character[] boxedNull = boxedSentinel.clone();
         for (int ii = 0; ii < stored.length; ++ii) {
             if (stored[ii] == NULL_CHAR) {
                 boxedNull[ii] = null;
             }
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedNull)));
+        final ObjectVectorDirect<Character> boxedNullVector = new ObjectVectorDirect<>(boxedNull);
+        assertNotEqualBothWays(ssm, boxedNullVector);
 
-        // a null at a position holding a non-null value is not equal
-        for (int ii = 0; ii < stored.length; ++ii) {
-            if (stored[ii] != NULL_CHAR) {
-                final Character[] boxedWrongNull = boxedSentinel.clone();
-                boxedWrongNull[ii] = null;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(boxedWrongNull)));
-                break;
-            }
-        }
+        // ... and a hash lookup keyed on that boxed Vector must therefore miss rather than silently mismatch
+        final Map<Object, String> map = new HashMap<>();
+        map.put(boxedNullVector, "boxed");
+        assertNull(map.get(ssm));
     }
     // endregion NullEquals
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestDoubleSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestDoubleSegmentedSortedMultiset.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -774,21 +775,21 @@ public class TestDoubleSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final DoubleSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Double[] boxed = new Double[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new DoubleVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // DoubleVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // a boxed Vector of the same values is not equal in either direction: it would hold a null reference wherever
+        // this SSM holds the null sentinel, so accepting it would make equal values hash differently
+        final Double[] boxed = new Double[valueCount];
+        for (int ii = 0; ii < valueCount; ++ii) {
+            boxed[ii] = values[ii];
+        }
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxed));
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -818,11 +819,6 @@ public class TestDoubleSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (double) ('a' + ii);
         }
         assertFalse(ssm.equals(new DoubleVectorDirect(longer)));
-        final Double[] longerBoxed = new Double[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (double) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -831,10 +827,6 @@ public class TestDoubleSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final double[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new DoubleVectorDirect(modifiedValues)));
-
-                final Double[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }
@@ -909,31 +901,33 @@ public class TestDoubleSegmentedSortedMultiset extends RefreshingTableTestCase {
         final DoubleSegmentedSortedMultiset ssm = makeSsm(nodeSize, sortedValues);
         final double[] stored = ssm.toArray();
 
-        // boxing the null sentinel yields a non-null element holding the sentinel value, which compares equal
+        // the null sentinel is an ordinary value to a DoubleVector comparison: equal both ways, and hashing alike
+        assertEqualBothWays(ssm, new DoubleVectorDirect(stored));
+
+        // boxing the sentinel yields a non-null element holding the sentinel value...
         final Double[] boxedSentinel = new Double[stored.length];
         for (int ii = 0; ii < stored.length; ++ii) {
             boxedSentinel[ii] = stored[ii];
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedSentinel)));
+        // ...but a boxed Vector is still not a DoubleVector, so it is not equal in either direction
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxedSentinel));
 
-        // a literal null also compares equal to the stored null sentinel
+        // a boxed Vector holding a literal null where this SSM holds the sentinel is likewise not equal. This is the
+        // case that made the branch unsound: the two would have compared equal while hashing differently, since
+        // hashCode() hashes the sentinel and a boxed Vector hashes the null reference.
         final Double[] boxedNull = boxedSentinel.clone();
         for (int ii = 0; ii < stored.length; ++ii) {
             if (stored[ii] == NULL_DOUBLE) {
                 boxedNull[ii] = null;
             }
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedNull)));
+        final ObjectVectorDirect<Double> boxedNullVector = new ObjectVectorDirect<>(boxedNull);
+        assertNotEqualBothWays(ssm, boxedNullVector);
 
-        // a null at a position holding a non-null value is not equal
-        for (int ii = 0; ii < stored.length; ++ii) {
-            if (stored[ii] != NULL_DOUBLE) {
-                final Double[] boxedWrongNull = boxedSentinel.clone();
-                boxedWrongNull[ii] = null;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(boxedWrongNull)));
-                break;
-            }
-        }
+        // ... and a hash lookup keyed on that boxed Vector must therefore miss rather than silently mismatch
+        final Map<Object, String> map = new HashMap<>();
+        map.put(boxedNullVector, "boxed");
+        assertNull(map.get(ssm));
     }
     // endregion NullEquals
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestDoubleSegmentedSortedMultisetSpecialValues.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestDoubleSegmentedSortedMultisetSpecialValues.java
@@ -201,14 +201,12 @@ public class TestDoubleSegmentedSortedMultisetSpecialValues extends RefreshingTa
         assertEqualBothWays(ssmA, ssmB.getDirect());
         assertEqualBothWays(ssmA, new DoubleVectorDirect(withB));
 
-        // the boxed comparison only runs in one direction: a DoubleSegmentedSortedMultiset is a DoubleVector rather
-        // than an ObjectVector, so it is not a comparand an ObjectVectorDirect will accept
+        // a boxed Vector of the same values is a different Vector type, and so not equal in either direction
         final Double[] boxedB = new Double[withB.length];
         for (int ii = 0; ii < withB.length; ++ii) {
             boxedB[ii] = withB[ii];
         }
-        assertTrue(ssmA.equals(new ObjectVectorDirect<>(boxedB)));
-        assertEquals(ssmA.hashCode(), new ObjectVectorDirect<>(boxedB).hashCode());
+        assertNotEqualBothWays(ssmA, new ObjectVectorDirect<>(boxedB));
     }
 
     /**
@@ -232,8 +230,7 @@ public class TestDoubleSegmentedSortedMultisetSpecialValues extends RefreshingTa
         for (int ii = 0; ii < withPositive.length; ++ii) {
             boxedPositive[ii] = withPositive[ii];
         }
-        assertTrue(ssmNegative.equals(new ObjectVectorDirect<>(boxedPositive)));
-        assertEquals(ssmNegative.hashCode(), new ObjectVectorDirect<>(boxedPositive).hashCode());
+        assertNotEqualBothWays(ssmNegative, new ObjectVectorDirect<>(boxedPositive));
     }
 
     /**
@@ -244,5 +241,14 @@ public class TestDoubleSegmentedSortedMultisetSpecialValues extends RefreshingTa
         assertTrue(lhs + " should equal " + rhs, lhs.equals(rhs));
         assertTrue(rhs + " should equal " + lhs, rhs.equals(lhs));
         assertEquals("equal values must hash alike", lhs.hashCode(), rhs.hashCode());
+    }
+
+    /**
+     * Assert that two Vectors agree that they are unequal no matter which is the receiver. Their hash codes are
+     * unconstrained -- unequal values are permitted to collide.
+     */
+    private void assertNotEqualBothWays(final Object lhs, final Object rhs) {
+        assertFalse(lhs + " should not equal " + rhs, lhs.equals(rhs));
+        assertFalse(rhs + " should not equal " + lhs, rhs.equals(lhs));
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestFloatSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestFloatSegmentedSortedMultiset.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -774,21 +775,21 @@ public class TestFloatSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final FloatSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Float[] boxed = new Float[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new FloatVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // FloatVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // a boxed Vector of the same values is not equal in either direction: it would hold a null reference wherever
+        // this SSM holds the null sentinel, so accepting it would make equal values hash differently
+        final Float[] boxed = new Float[valueCount];
+        for (int ii = 0; ii < valueCount; ++ii) {
+            boxed[ii] = values[ii];
+        }
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxed));
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -818,11 +819,6 @@ public class TestFloatSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (float) ('a' + ii);
         }
         assertFalse(ssm.equals(new FloatVectorDirect(longer)));
-        final Float[] longerBoxed = new Float[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (float) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -831,10 +827,6 @@ public class TestFloatSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final float[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new FloatVectorDirect(modifiedValues)));
-
-                final Float[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }
@@ -909,31 +901,33 @@ public class TestFloatSegmentedSortedMultiset extends RefreshingTableTestCase {
         final FloatSegmentedSortedMultiset ssm = makeSsm(nodeSize, sortedValues);
         final float[] stored = ssm.toArray();
 
-        // boxing the null sentinel yields a non-null element holding the sentinel value, which compares equal
+        // the null sentinel is an ordinary value to a FloatVector comparison: equal both ways, and hashing alike
+        assertEqualBothWays(ssm, new FloatVectorDirect(stored));
+
+        // boxing the sentinel yields a non-null element holding the sentinel value...
         final Float[] boxedSentinel = new Float[stored.length];
         for (int ii = 0; ii < stored.length; ++ii) {
             boxedSentinel[ii] = stored[ii];
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedSentinel)));
+        // ...but a boxed Vector is still not a FloatVector, so it is not equal in either direction
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxedSentinel));
 
-        // a literal null also compares equal to the stored null sentinel
+        // a boxed Vector holding a literal null where this SSM holds the sentinel is likewise not equal. This is the
+        // case that made the branch unsound: the two would have compared equal while hashing differently, since
+        // hashCode() hashes the sentinel and a boxed Vector hashes the null reference.
         final Float[] boxedNull = boxedSentinel.clone();
         for (int ii = 0; ii < stored.length; ++ii) {
             if (stored[ii] == NULL_FLOAT) {
                 boxedNull[ii] = null;
             }
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedNull)));
+        final ObjectVectorDirect<Float> boxedNullVector = new ObjectVectorDirect<>(boxedNull);
+        assertNotEqualBothWays(ssm, boxedNullVector);
 
-        // a null at a position holding a non-null value is not equal
-        for (int ii = 0; ii < stored.length; ++ii) {
-            if (stored[ii] != NULL_FLOAT) {
-                final Float[] boxedWrongNull = boxedSentinel.clone();
-                boxedWrongNull[ii] = null;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(boxedWrongNull)));
-                break;
-            }
-        }
+        // ... and a hash lookup keyed on that boxed Vector must therefore miss rather than silently mismatch
+        final Map<Object, String> map = new HashMap<>();
+        map.put(boxedNullVector, "boxed");
+        assertNull(map.get(ssm));
     }
     // endregion NullEquals
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestFloatSegmentedSortedMultisetSpecialValues.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestFloatSegmentedSortedMultisetSpecialValues.java
@@ -196,14 +196,12 @@ public class TestFloatSegmentedSortedMultisetSpecialValues extends RefreshingTab
         assertEqualBothWays(ssmA, ssmB.getDirect());
         assertEqualBothWays(ssmA, new FloatVectorDirect(withB));
 
-        // the boxed comparison only runs in one direction: a FloatSegmentedSortedMultiset is a FloatVector rather
-        // than an ObjectVector, so it is not a comparand an ObjectVectorDirect will accept
+        // a boxed Vector of the same values is a different Vector type, and so not equal in either direction
         final Float[] boxedB = new Float[withB.length];
         for (int ii = 0; ii < withB.length; ++ii) {
             boxedB[ii] = withB[ii];
         }
-        assertTrue(ssmA.equals(new ObjectVectorDirect<>(boxedB)));
-        assertEquals(ssmA.hashCode(), new ObjectVectorDirect<>(boxedB).hashCode());
+        assertNotEqualBothWays(ssmA, new ObjectVectorDirect<>(boxedB));
     }
 
     /**
@@ -227,8 +225,7 @@ public class TestFloatSegmentedSortedMultisetSpecialValues extends RefreshingTab
         for (int ii = 0; ii < withPositive.length; ++ii) {
             boxedPositive[ii] = withPositive[ii];
         }
-        assertTrue(ssmNegative.equals(new ObjectVectorDirect<>(boxedPositive)));
-        assertEquals(ssmNegative.hashCode(), new ObjectVectorDirect<>(boxedPositive).hashCode());
+        assertNotEqualBothWays(ssmNegative, new ObjectVectorDirect<>(boxedPositive));
     }
 
     /**
@@ -239,5 +236,14 @@ public class TestFloatSegmentedSortedMultisetSpecialValues extends RefreshingTab
         assertTrue(lhs + " should equal " + rhs, lhs.equals(rhs));
         assertTrue(rhs + " should equal " + lhs, rhs.equals(lhs));
         assertEquals("equal values must hash alike", lhs.hashCode(), rhs.hashCode());
+    }
+
+    /**
+     * Assert that two Vectors agree that they are unequal no matter which is the receiver. Their hash codes are
+     * unconstrained -- unequal values are permitted to collide.
+     */
+    private void assertNotEqualBothWays(final Object lhs, final Object rhs) {
+        assertFalse(lhs + " should not equal " + rhs, lhs.equals(rhs));
+        assertFalse(rhs + " should not equal " + lhs, rhs.equals(lhs));
     }
 }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestIntSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestIntSegmentedSortedMultiset.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -774,21 +775,21 @@ public class TestIntSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final IntSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Integer[] boxed = new Integer[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new IntVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // IntVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // a boxed Vector of the same values is not equal in either direction: it would hold a null reference wherever
+        // this SSM holds the null sentinel, so accepting it would make equal values hash differently
+        final Integer[] boxed = new Integer[valueCount];
+        for (int ii = 0; ii < valueCount; ++ii) {
+            boxed[ii] = values[ii];
+        }
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxed));
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -818,11 +819,6 @@ public class TestIntSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (int) ('a' + ii);
         }
         assertFalse(ssm.equals(new IntVectorDirect(longer)));
-        final Integer[] longerBoxed = new Integer[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (int) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -831,10 +827,6 @@ public class TestIntSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final int[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new IntVectorDirect(modifiedValues)));
-
-                final Integer[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }
@@ -909,31 +901,33 @@ public class TestIntSegmentedSortedMultiset extends RefreshingTableTestCase {
         final IntSegmentedSortedMultiset ssm = makeSsm(nodeSize, sortedValues);
         final int[] stored = ssm.toArray();
 
-        // boxing the null sentinel yields a non-null element holding the sentinel value, which compares equal
+        // the null sentinel is an ordinary value to a IntVector comparison: equal both ways, and hashing alike
+        assertEqualBothWays(ssm, new IntVectorDirect(stored));
+
+        // boxing the sentinel yields a non-null element holding the sentinel value...
         final Integer[] boxedSentinel = new Integer[stored.length];
         for (int ii = 0; ii < stored.length; ++ii) {
             boxedSentinel[ii] = stored[ii];
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedSentinel)));
+        // ...but a boxed Vector is still not a IntVector, so it is not equal in either direction
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxedSentinel));
 
-        // a literal null also compares equal to the stored null sentinel
+        // a boxed Vector holding a literal null where this SSM holds the sentinel is likewise not equal. This is the
+        // case that made the branch unsound: the two would have compared equal while hashing differently, since
+        // hashCode() hashes the sentinel and a boxed Vector hashes the null reference.
         final Integer[] boxedNull = boxedSentinel.clone();
         for (int ii = 0; ii < stored.length; ++ii) {
             if (stored[ii] == NULL_INT) {
                 boxedNull[ii] = null;
             }
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedNull)));
+        final ObjectVectorDirect<Integer> boxedNullVector = new ObjectVectorDirect<>(boxedNull);
+        assertNotEqualBothWays(ssm, boxedNullVector);
 
-        // a null at a position holding a non-null value is not equal
-        for (int ii = 0; ii < stored.length; ++ii) {
-            if (stored[ii] != NULL_INT) {
-                final Integer[] boxedWrongNull = boxedSentinel.clone();
-                boxedWrongNull[ii] = null;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(boxedWrongNull)));
-                break;
-            }
-        }
+        // ... and a hash lookup keyed on that boxed Vector must therefore miss rather than silently mismatch
+        final Map<Object, String> map = new HashMap<>();
+        map.put(boxedNullVector, "boxed");
+        assertNull(map.get(ssm));
     }
     // endregion NullEquals
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestLongSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestLongSegmentedSortedMultiset.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -774,21 +775,21 @@ public class TestLongSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final LongSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Long[] boxed = new Long[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new LongVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // LongVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // a boxed Vector of the same values is not equal in either direction: it would hold a null reference wherever
+        // this SSM holds the null sentinel, so accepting it would make equal values hash differently
+        final Long[] boxed = new Long[valueCount];
+        for (int ii = 0; ii < valueCount; ++ii) {
+            boxed[ii] = values[ii];
+        }
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxed));
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -818,11 +819,6 @@ public class TestLongSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (long) ('a' + ii);
         }
         assertFalse(ssm.equals(new LongVectorDirect(longer)));
-        final Long[] longerBoxed = new Long[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (long) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -831,10 +827,6 @@ public class TestLongSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final long[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new LongVectorDirect(modifiedValues)));
-
-                final Long[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }
@@ -909,31 +901,33 @@ public class TestLongSegmentedSortedMultiset extends RefreshingTableTestCase {
         final LongSegmentedSortedMultiset ssm = makeSsm(nodeSize, sortedValues);
         final long[] stored = ssm.toArray();
 
-        // boxing the null sentinel yields a non-null element holding the sentinel value, which compares equal
+        // the null sentinel is an ordinary value to a LongVector comparison: equal both ways, and hashing alike
+        assertEqualBothWays(ssm, new LongVectorDirect(stored));
+
+        // boxing the sentinel yields a non-null element holding the sentinel value...
         final Long[] boxedSentinel = new Long[stored.length];
         for (int ii = 0; ii < stored.length; ++ii) {
             boxedSentinel[ii] = stored[ii];
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedSentinel)));
+        // ...but a boxed Vector is still not a LongVector, so it is not equal in either direction
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxedSentinel));
 
-        // a literal null also compares equal to the stored null sentinel
+        // a boxed Vector holding a literal null where this SSM holds the sentinel is likewise not equal. This is the
+        // case that made the branch unsound: the two would have compared equal while hashing differently, since
+        // hashCode() hashes the sentinel and a boxed Vector hashes the null reference.
         final Long[] boxedNull = boxedSentinel.clone();
         for (int ii = 0; ii < stored.length; ++ii) {
             if (stored[ii] == NULL_LONG) {
                 boxedNull[ii] = null;
             }
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedNull)));
+        final ObjectVectorDirect<Long> boxedNullVector = new ObjectVectorDirect<>(boxedNull);
+        assertNotEqualBothWays(ssm, boxedNullVector);
 
-        // a null at a position holding a non-null value is not equal
-        for (int ii = 0; ii < stored.length; ++ii) {
-            if (stored[ii] != NULL_LONG) {
-                final Long[] boxedWrongNull = boxedSentinel.clone();
-                boxedWrongNull[ii] = null;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(boxedWrongNull)));
-                break;
-            }
-        }
+        // ... and a hash lookup keyed on that boxed Vector must therefore miss rather than silently mismatch
+        final Map<Object, String> map = new HashMap<>();
+        map.put(boxedNullVector, "boxed");
+        assertNull(map.get(ssm));
     }
     // endregion NullEquals
 

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestObjectSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestObjectSegmentedSortedMultiset.java
@@ -761,21 +761,14 @@ public class TestObjectSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final ObjectSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Object[] boxed = new Object[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new ObjectVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // ObjectVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -805,11 +798,6 @@ public class TestObjectSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (Object) ('a' + ii);
         }
         assertFalse(ssm.equals(new ObjectVectorDirect(longer)));
-        final Object[] longerBoxed = new Object[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (Object) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -818,10 +806,6 @@ public class TestObjectSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final Object[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new ObjectVectorDirect(modifiedValues)));
-
-                final Object[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestShortSegmentedSortedMultiset.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/ssms/TestShortSegmentedSortedMultiset.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
@@ -774,21 +775,21 @@ public class TestShortSegmentedSortedMultiset extends RefreshingTableTestCase {
         }
         final ShortSegmentedSortedMultiset ssm = makeSsm(nodeSize, values);
 
-        final Short[] boxed = new Short[valueCount];
-        for (int ii = 0; ii < valueCount; ++ii) {
-            boxed[ii] = values[ii];
-        }
-
         // a Vector with identical contents is equal, in both directions, and anything equal must hash alike -- so the
         // SSM has to use the same shared Vector helper that the *VectorDirect implementations use, and compare
         // elements the same way that helper hashes them, rather than either with a scheme of its own
         assertEqualBothWays(ssm, ssm.getDirect());
         assertEqualBothWays(ssm, new ShortVectorDirect(values));
 
-        // the boxed comparison only runs in one direction for the primitive variants, because a primitive SSM is a
-        // ShortVector rather than an ObjectVector and so is not a comparand ObjectVectorDirect will accept
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxed)));
-        assertEquals(ssm.hashCode(), new ObjectVectorDirect<>(boxed).hashCode());
+        // region BoxedEquals
+        // a boxed Vector of the same values is not equal in either direction: it would hold a null reference wherever
+        // this SSM holds the null sentinel, so accepting it would make equal values hash differently
+        final Short[] boxed = new Short[valueCount];
+        for (int ii = 0; ii < valueCount; ++ii) {
+            boxed[ii] = values[ii];
+        }
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxed));
+        // endregion BoxedEquals
 
         // another SSM holding the same values is equal however those values happen to be laid out: equality is a
         // property of the contents, and identical contents can occupy different leaf structures, since leaves need
@@ -818,11 +819,6 @@ public class TestShortSegmentedSortedMultiset extends RefreshingTableTestCase {
             longer[ii] = (short) ('a' + ii);
         }
         assertFalse(ssm.equals(new ShortVectorDirect(longer)));
-        final Short[] longerBoxed = new Short[valueCount + 1];
-        for (int ii = 0; ii < longerBoxed.length; ++ii) {
-            longerBoxed[ii] = (short) ('a' + ii);
-        }
-        assertFalse(ssm.equals(new ObjectVectorDirect<>(longerBoxed)));
 
         // a Vector that differs from the original in a single position is not equal; check the first, middle, and last
         if (valueCount > 0) {
@@ -831,10 +827,6 @@ public class TestShortSegmentedSortedMultiset extends RefreshingTableTestCase {
                 final short[] modifiedValues = values.clone();
                 modifiedValues[position] = different;
                 assertFalse(ssm.equals(new ShortVectorDirect(modifiedValues)));
-
-                final Short[] modifiedBoxed = boxed.clone();
-                modifiedBoxed[position] = different;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(modifiedBoxed)));
             }
         }
     }
@@ -909,31 +901,33 @@ public class TestShortSegmentedSortedMultiset extends RefreshingTableTestCase {
         final ShortSegmentedSortedMultiset ssm = makeSsm(nodeSize, sortedValues);
         final short[] stored = ssm.toArray();
 
-        // boxing the null sentinel yields a non-null element holding the sentinel value, which compares equal
+        // the null sentinel is an ordinary value to a ShortVector comparison: equal both ways, and hashing alike
+        assertEqualBothWays(ssm, new ShortVectorDirect(stored));
+
+        // boxing the sentinel yields a non-null element holding the sentinel value...
         final Short[] boxedSentinel = new Short[stored.length];
         for (int ii = 0; ii < stored.length; ++ii) {
             boxedSentinel[ii] = stored[ii];
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedSentinel)));
+        // ...but a boxed Vector is still not a ShortVector, so it is not equal in either direction
+        assertNotEqualBothWays(ssm, new ObjectVectorDirect<>(boxedSentinel));
 
-        // a literal null also compares equal to the stored null sentinel
+        // a boxed Vector holding a literal null where this SSM holds the sentinel is likewise not equal. This is the
+        // case that made the branch unsound: the two would have compared equal while hashing differently, since
+        // hashCode() hashes the sentinel and a boxed Vector hashes the null reference.
         final Short[] boxedNull = boxedSentinel.clone();
         for (int ii = 0; ii < stored.length; ++ii) {
             if (stored[ii] == NULL_SHORT) {
                 boxedNull[ii] = null;
             }
         }
-        assertTrue(ssm.equals(new ObjectVectorDirect<>(boxedNull)));
+        final ObjectVectorDirect<Short> boxedNullVector = new ObjectVectorDirect<>(boxedNull);
+        assertNotEqualBothWays(ssm, boxedNullVector);
 
-        // a null at a position holding a non-null value is not equal
-        for (int ii = 0; ii < stored.length; ++ii) {
-            if (stored[ii] != NULL_SHORT) {
-                final Short[] boxedWrongNull = boxedSentinel.clone();
-                boxedWrongNull[ii] = null;
-                assertFalse(ssm.equals(new ObjectVectorDirect<>(boxedWrongNull)));
-                break;
-            }
-        }
+        // ... and a hash lookup keyed on that boxed Vector must therefore miss rather than silently mismatch
+        final Map<Object, String> map = new HashMap<>();
+        map.put(boxedNullVector, "boxed");
+        assertNull(map.get(ssm));
     }
     // endregion NullEquals
 

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSegmentedSortedMultiset.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSegmentedSortedMultiset.java
@@ -410,28 +410,31 @@ public class ReplicateSegmentedSortedMultiset {
                         "    }"));
     }
 
+    /**
+     * The replicated {@code equalsArray} already takes the right parameter type -- {@code CharVector} becomes
+     * {@code ObjectVector}, which is what an Object SSM is -- so only its iteration needs adjusting: there is no
+     * {@code CloseablePrimitiveIteratorOfObject}, and the generic
+     * {@link io.deephaven.engine.primitive.iterator.CloseableIterator} that replaces it is drained with {@code next()}
+     * rather than the primitive variants' {@code nextObject()}.
+     */
     private static List<String> fixupObjectCompare(List<String> lines) {
-        // removes both the primitive-vector equalsArray overload and the branch of equals that dispatches to it;
-        // another Object SSM is an ObjectVector, so it reaches the remaining equalsArray overload
-        lines = removeRegion(lines, "VectorEquals");
-        // the primitive iterator is only used by the (now removed) primitive-vector equalsArray overload
+        lines = globalReplacements(lines,
+                "equalsArray\\(ObjectVector o\\)", "equalsArray(ObjectVector<?> o)",
+                "equalsArray\\(\\(ObjectVector\\) o\\)", "equalsArray((ObjectVector<?>) o)",
+                "final CloseablePrimitiveIteratorOfObject oit", "final CloseableIterator<?> oit",
+                "oit\\.nextObject\\(\\)", "oit.next()");
         lines = removeImport(lines, "\\s*import .*CloseablePrimitiveIteratorOfObject;");
-        lines = replaceRegion(lines, "EqualsArrayTypeCheck", Collections.singletonList(
-                "        // No component-type check: it only guards the primitive variants' unboxValue() cast, and gating\n"
-                        +
-                        "        // on the declared type would break symmetry with ObjectVector.equals()."));
-        // an Object SSM stores its elements exactly as the boxed vector supplies them -- nothing to unbox, and no null
-        // sentinel -- so drop the helper and read the iterator directly
-        lines = removeRegion(lines, "UnboxValue");
-        lines = globalReplacements(lines, "unboxValue\\(oit\\.next\\(\\)\\)", "oit.next()");
-        return removeImport(lines, "\\s*import io\\.deephaven\\.util\\.type\\.TypeUtils;");
+        return addImport(lines, "import io.deephaven.engine.primitive.iterator.CloseableIterator;");
     }
 
     private static void insertInstantExtensions(String longPath) throws IOException {
         final File longFile = new File(longPath);
         List<String> lines = FileUtils.readLines(longFile, Charset.defaultCharset());
 
+        // the Instant extensions are the only place a primitive SSM deals in ObjectVector, so the template does not
+        // import it
         lines = addImport(lines,
+                "import io.deephaven.vector.ObjectVector;",
                 "import io.deephaven.vector.ObjectVectorDirect;",
                 "import io.deephaven.time.DateTimeUtils;");
         lines = addImport(lines, Instant.class);

--- a/replication/static/src/main/java/io/deephaven/replicators/ReplicateSegmentedSortedMultisetTests.java
+++ b/replication/static/src/main/java/io/deephaven/replicators/ReplicateSegmentedSortedMultisetTests.java
@@ -86,8 +86,13 @@ public class ReplicateSegmentedSortedMultisetTests {
                 "\\.nextObject\\(\\)", ".next()");
         lines = removeImport(lines, "\\s*import static.*QueryConstants.*;");
         lines = removeRegion(lines, "SortFixupSanityCheck");
-        // the null-sentinel equality semantics are specific to the primitive types
+        // the null-sentinel equality semantics are specific to the primitive types; that region holds the only
+        // HashMap use, so its import goes with it
         lines = removeRegion(lines, "NullEquals");
+        lines = removeImport(lines, "\\s*import java\\.util\\.HashMap;");
+        // an Object SSM *is* an ObjectVector, so a boxed Vector of its values is equal -- the assertions just above,
+        // which the primitive-vector case replicates into, already cover it
+        lines = removeRegion(lines, "BoxedEquals");
         FileUtils.writeLines(objectFile, ReplicationUtils.fixupChunkAttributes(lines));
     }
 }


### PR DESCRIPTION
## Important Note

The elided functionality isn't currently being used. Verified against legacy, core+, core. However, should probably not back-port this to 42.x, would prefer it to land in a major version to support (maybe) existing users.

## Summary

For all seven primitive `SegmentedSortedMultiset` variants, `equals(ObjectVector)` treated a real Java `null` as matching the stored null sentinel (`NULL_LONG` etc.), while `hashCode()` hashes the raw sentinel. The two were `equals` but hashed differently, so hash-based lookups silently missed. `ObjectVector.equals()` never accepted a `CharVector` in return, so the relation was asymmetric too.

The branch is dropped: a primitive SSM now compares equal only to a Vector of its own primitive type, as `CharVector.equals(CharVector, Object)` defines it. It could not be repaired without breaking `hashCode()`, which must keep agreeing with `CharVector.hashCode(CharVector)`. Dating to 5c1b52c85, it has never had a consumer here.

## What this breaks

A primitive SSM is no longer equal to a boxed `ObjectVector` of the same values:

```java
ssm.equals(new ObjectVectorDirect<>(new Character[] {'a', 'b'}))   // was true, now false
ssm.equals(new ObjectVectorDirect<>(new Character[] {null, 'b'}))  // was true, now false
```

All seven primitive types, in the boxed-null case *and* the all-non-null case — not only when the SSM holds the sentinel. Still equal: another SSM in any leaf layout, any `CharVector`, `getDirect()`.

No engine path reaches it — SSM values live in `*Vector`-typed columns, engine comparisons are within a single column, and `TableDiff` gates on column type before comparing values. The reachable surface is user formula/filter code such as `where("Distincts == someObjectVector")`, which now returns `false`. That comparison was already unreliable: reversed operands returned `false` before, and hash lookups already missed. No Core+ source references these packages; the legacy `com.illumon.iris.db.v2.ssms` copy is independent and untouched.

## Object SSM

Behaviorally unchanged, but the replicator needed restructuring: the Object variant's equality came from the very overload the primitives are losing. It now derives from the surviving `equalsArray(CharVector)` — `CharVector` replicates to `ObjectVector` — with only its iteration fixed up, the pattern `fixupObjectIterator` already uses.
