### PR TITLE
fix: DH-23320: Report the formula column in a rollup AggFormula level's ModifiedColumnSet

### DIFF
--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FormulaMultiColumnChunkedOperator.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/by/FormulaMultiColumnChunkedOperator.java
@@ -325,7 +325,10 @@ class FormulaMultiColumnChunkedOperator implements IterativeChunkedAggregationOp
         }
         updateUpstreamModifiedColumnSet =
                 upstream.modified().isEmpty() ? ModifiedColumnSet.EMPTY : upstream.modifiedColumnSet();
-        return false;
+        // Without delegation our chunk callbacks are no-ops, so nothing would ever mark us modified and our result MCS
+        // factory would never be consulted. Claim the step and let the factory decide; it gates on the same condition
+        // propagateUpdates recomputes on, so we report the column exactly when we rewrite it.
+        return !delegateToBy;
     }
 
     @Override

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestAggBy.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestAggBy.java
@@ -89,15 +89,18 @@ public class TestAggBy extends RefreshingTableTestCase {
     }
 
     /**
-     * An {@code AggFormula} must name its formula column in the {@link ModifiedColumnSet} it reports whenever churn in
-     * a group makes it recompute that column.
+     * An {@code AggFormula} names its formula column in the {@link ModifiedColumnSet} it reports whenever churn in a
+     * group makes it recompute that column.
      *
      * <p>
      * The non-rollup counterpart to {@code TestRollupTable.testRollupFormulaReportsModifiedFormulaColumn}. The
-     * {@code AggGroup} here registers the shared group operator, which is what leaves the formula operator
-     * non-delegating -- the same condition every rollup level meets. Two keys means the bucketed path, where the
-     * rollup's zero-key root exercises the singleton one. The cycles cover a shift, an add, a remove, and an in-place
-     * modify, since the gap is structural rather than particular to one kind of churn.
+     * {@code AggGroup} here registers the shared group operator, which leaves the formula operator non-delegating --
+     * the same condition every rollup level meets, reached through a plain {@code aggBy}. Two keys puts this on the
+     * bucketed path, where the rollup's zero-key root covers the singleton one.
+     *
+     * <p>
+     * Reporting holds for every kind of churn, hence the add, remove, and modify cycles, and reaches no further: a
+     * plain {@code aggBy} exposes no group RowSet column, so the leading shift owes nothing downstream at all.
      */
     @Test
     public void testAggFormulaReportsModifiedFormulaColumn() {
@@ -122,8 +125,8 @@ public class TestAggBy extends RefreshingTableTestCase {
 
         final ControlledUpdateGraph cug = source.getUpdateGraph().cast();
 
-        // A pure shift of the "b" rows first, as in the reported reproducer: their keys move but their values do not,
-        // so the formula cannot change and nothing is owed downstream. The cycles after it run against shifted keys.
+        // A pure shift of the "b" rows: their keys move but their values do not, so the formula cannot change, and with
+        // no group RowSet column exposed nothing is owed downstream. The cycles after it run against shifted keys.
         cug.runWithinUnitTestCycle(() -> {
             addToTable(source, i(102, 103), stringCol("Sym", "b", "b"), intCol("Value", 20, 21));
             removeRows(source, i(2, 3));

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestAggBy.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestAggBy.java
@@ -22,6 +22,7 @@ import io.deephaven.engine.rowset.RowSetShiftData;
 import io.deephaven.engine.table.ColumnSource;
 import io.deephaven.engine.table.ModifiedColumnSet;
 import io.deephaven.engine.table.Table;
+import io.deephaven.engine.table.TableUpdate;
 import io.deephaven.engine.table.impl.select.DynamicWhereFilter;
 import io.deephaven.engine.table.impl.select.MatchPairFactory;
 import io.deephaven.engine.table.impl.util.ColumnHolder;
@@ -85,6 +86,98 @@ public class TestAggBy extends RefreshingTableTestCase {
         show(minMax);
 
         assertEquals(2, minMax.size());
+    }
+
+    /**
+     * An {@code AggFormula} must name its formula column in the {@link ModifiedColumnSet} it reports whenever churn in
+     * a group makes it recompute that column.
+     *
+     * <p>
+     * The non-rollup counterpart to {@code TestRollupTable.testRollupFormulaReportsModifiedFormulaColumn}. The
+     * {@code AggGroup} here registers the shared group operator, which is what leaves the formula operator
+     * non-delegating -- the same condition every rollup level meets. Two keys means the bucketed path, where the
+     * rollup's zero-key root exercises the singleton one. The cycles cover a shift, an add, a remove, and an in-place
+     * modify, since the gap is structural rather than particular to one kind of churn.
+     */
+    @Test
+    public void testAggFormulaReportsModifiedFormulaColumn() {
+        final QueryTable source = testRefreshingTable(
+                i(0, 1, 2, 3).toTracking(),
+                stringCol("Sym", "a", "a", "b", "b"),
+                intCol("Value", 10, 11, 20, 21));
+
+        final QueryTable agged = (QueryTable) source.aggBy(
+                List.of(AggGroup("Grp=Value"), AggFormula("FSum=sum(Value)")), "Sym");
+
+        // A direct read, correct whether or not the column is advertised, and one gated on the reported MCS.
+        final Table direct = agged.select("Sym", "FSum");
+        final Table mcsGated = agged.sort("Sym").select("Sym", "FSum");
+
+        final Table initial = newTable(stringCol("Sym", "a", "b"), longCol("FSum", 21, 41));
+        assertTableEquals(initial, direct);
+        assertTableEquals(initial, mcsGated);
+
+        final SimpleListener listener = new SimpleListener(agged);
+        agged.addUpdateListener(listener);
+
+        final ControlledUpdateGraph cug = source.getUpdateGraph().cast();
+
+        // A pure shift of the "b" rows first, as in the reported reproducer: their keys move but their values do not,
+        // so the formula cannot change and nothing is owed downstream. The cycles after it run against shifted keys.
+        cug.runWithinUnitTestCycle(() -> {
+            addToTable(source, i(102, 103), stringCol("Sym", "b", "b"), intCol("Value", 20, 21));
+            removeRows(source, i(2, 3));
+            final RowSetShiftData.Builder shiftBuilder = new RowSetShiftData.Builder();
+            shiftBuilder.shiftRange(2, 3, 100);
+            source.notifyListeners(new TableUpdateImpl(i(), i(), i(), shiftBuilder.build(), ModifiedColumnSet.EMPTY));
+        });
+        assertEquals(0, listener.getCount());
+        assertTableEquals(initial, direct);
+        assertTableEquals(initial, mcsGated);
+
+        // A row joins the "b" group.
+        cug.runWithinUnitTestCycle(() -> {
+            addToTable(source, i(4), stringCol("Sym", "b"), intCol("Value", 22));
+            source.notifyListeners(i(4), i(), i());
+        });
+        assertFormulaReported(agged, listener, direct, mcsGated,
+                newTable(stringCol("Sym", "a", "b"), longCol("FSum", 21, 63)));
+
+        // A row leaves the "a" group.
+        cug.runWithinUnitTestCycle(() -> {
+            removeRows(source, i(0));
+            source.notifyListeners(i(), i(0), i());
+        });
+        assertFormulaReported(agged, listener, direct, mcsGated,
+                newTable(stringCol("Sym", "a", "b"), longCol("FSum", 11, 63)));
+
+        // A row keeps its group but changes value, so the group's membership is untouched.
+        cug.runWithinUnitTestCycle(() -> {
+            addToTable(source, i(1), stringCol("Sym", "a"), intCol("Value", 111));
+            source.notifyListeners(new TableUpdateImpl(i(), i(), i(1), RowSetShiftData.EMPTY,
+                    source.newModifiedColumnSet("Value")));
+        });
+        assertFormulaReported(agged, listener, direct, mcsGated,
+                newTable(stringCol("Sym", "a", "b"), longCol("FSum", 111, 63)));
+
+        agged.removeUpdateListener(listener);
+        listener.close();
+    }
+
+    /**
+     * Assert that the update {@code listener} just captured off {@code agged} marks rows modified and names
+     * {@code FSum} in its {@link ModifiedColumnSet}, and that the result reads as {@code expected} both directly and
+     * through the gated consumer.
+     */
+    private static void assertFormulaReported(final QueryTable agged, final SimpleListener listener,
+            final Table direct, final Table mcsGated, final Table expected) {
+        final TableUpdate update = listener.getUpdate();
+        assertTrue(update.modified().isNonempty());
+        assertTrue("modifiedColumnSet " + update.modifiedColumnSet() + " should contain FSum",
+                update.modifiedColumnSet().containsAny(agged.newModifiedColumnSet("FSum")));
+
+        assertTableEquals(expected, direct);
+        assertTableEquals(expected, mcsGated);
     }
 
     @Test

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestRollupTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestRollupTable.java
@@ -1230,6 +1230,95 @@ public class TestRollupTable extends RefreshingTableTestCase {
     }
 
     /**
+     * A rollup {@code AggFormula} level must name its formula column in the {@link ModifiedColumnSet} it reports
+     * whenever churn in a group makes it recompute that column.
+     *
+     * <p>
+     * The value itself is recomputed correctly, so a direct read of the result {@code ColumnSource} cannot detect the
+     * missing report; each cycle below therefore also reads through a consumer that refreshes only what the reported
+     * set marks dirty (a {@code sort} feeding a {@code select}), which is left serving the pre-update value.
+     *
+     * <p>
+     * The gap is structural rather than particular to one kind of churn, hence the add, remove, and modify cycles. A
+     * shift-only cycle is excluded because it cannot change the formula's value:
+     * {@link #testRollupFormulaShiftOnlyDoesNotRecompute} covers that the column must stay <em>out</em> of the reported
+     * set there.
+     */
+    @Test
+    public void testRollupFormulaReportsModifiedFormulaColumn() {
+        final QueryTable source = TstUtils.testRefreshingTable(
+                i(0, 1, 2, 3).toTracking(),
+                stringCol("Sym", "a", "a", "b", "b"),
+                intCol("Value", 10, 11, 20, 21),
+                intCol("Unrelated", 1, 2, 3, 4));
+
+        final RollupTable rollup = source.rollup(List.of(AggFormula("FSum", "sum(Value)")), "Sym");
+        final QueryTable root = (QueryTable) rollup.getRoot();
+
+        // A direct read, correct whether or not the column is advertised, and one gated on the reported MCS.
+        final Table direct = root.select("FSum");
+        final Table mcsGated = root.sort("Sym").select("FSum");
+
+        assertTableEquals(newTable(longCol("FSum", 62)), direct);
+        assertTableEquals(newTable(longCol("FSum", 62)), mcsGated);
+
+        final SimpleListener listener = new SimpleListener(root);
+        root.addUpdateListener(listener);
+
+        final ControlledUpdateGraph cug = source.getUpdateGraph().cast();
+
+        // A row joins the "b" group.
+        cug.runWithinUnitTestCycle(() -> {
+            addToTable(source, i(4), stringCol("Sym", "b"), intCol("Value", 22), intCol("Unrelated", 5));
+            source.notifyListeners(i(4), i(), i());
+        });
+        assertFormulaReported(root, listener, direct, mcsGated, 84);
+
+        // A row leaves the "a" group.
+        cug.runWithinUnitTestCycle(() -> {
+            removeRows(source, i(0));
+            source.notifyListeners(i(), i(0), i());
+        });
+        assertFormulaReported(root, listener, direct, mcsGated, 74);
+
+        // A row keeps its group but changes value, so the group's membership is untouched.
+        cug.runWithinUnitTestCycle(() -> {
+            addToTable(source, i(1), stringCol("Sym", "a"), intCol("Value", 111), intCol("Unrelated", 2));
+            source.notifyListeners(new TableUpdateImpl(i(), i(), i(1), RowSetShiftData.EMPTY,
+                    source.newModifiedColumnSet("Value")));
+        });
+        assertFormulaReported(root, listener, direct, mcsGated, 174);
+
+        // Modifying a column the formula does not read must stay silent.
+        final int updatesBefore = listener.getCount();
+        cug.runWithinUnitTestCycle(() -> {
+            addToTable(source, i(1), stringCol("Sym", "a"), intCol("Value", 111), intCol("Unrelated", 99));
+            source.notifyListeners(new TableUpdateImpl(i(), i(), i(1), RowSetShiftData.EMPTY,
+                    source.newModifiedColumnSet("Unrelated")));
+        });
+        Assert.assertEquals(updatesBefore, listener.getCount());
+
+        root.removeUpdateListener(listener);
+        listener.close();
+    }
+
+    /**
+     * Assert that the update {@code listener} just captured off {@code root} marks its row modified and names
+     * {@code FSum} in its {@link ModifiedColumnSet}, and that {@code FSum} reads as {@code expected} both directly and
+     * through the gated consumer.
+     */
+    private static void assertFormulaReported(final QueryTable root, final SimpleListener listener, final Table direct,
+            final Table mcsGated, final long expected) {
+        final TableUpdate update = listener.getUpdate();
+        Assert.assertTrue(update.modified().isNonempty());
+        Assert.assertTrue("modifiedColumnSet " + update.modifiedColumnSet() + " should contain FSum",
+                update.modifiedColumnSet().containsAny(root.newModifiedColumnSet("FSum")));
+
+        assertTableEquals(newTable(longCol("FSum", expected)), direct);
+        assertTableEquals(newTable(longCol("FSum", expected)), mcsGated);
+    }
+
+    /**
      * {@code AggUnique} routes {@link Instant} to the primitive ({@code long}) operator, but routes
      * {@link ZonedDateTime}, {@link Boolean}, and {@link String} to the object operator, so the value-column
      * reinterpret its re-aggregation performs must apply to Instant alone -- converting every type that has a primitive

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/TestRollupTable.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/TestRollupTable.java
@@ -1230,19 +1230,19 @@ public class TestRollupTable extends RefreshingTableTestCase {
     }
 
     /**
-     * A rollup {@code AggFormula} level must name its formula column in the {@link ModifiedColumnSet} it reports
-     * whenever churn in a group makes it recompute that column.
+     * A rollup {@code AggFormula} level names its formula column in the {@link ModifiedColumnSet} it reports whenever
+     * churn in a group makes it recompute that column.
      *
      * <p>
-     * The value itself is recomputed correctly, so a direct read of the result {@code ColumnSource} cannot detect the
-     * missing report; each cycle below therefore also reads through a consumer that refreshes only what the reported
-     * set marks dirty (a {@code sort} feeding a {@code select}), which is left serving the pre-update value.
+     * A direct read of the result {@code ColumnSource} is correct whatever was reported, so on its own it says nothing
+     * about the report. Each cycle therefore also reads through a consumer that refreshes only what the reported set
+     * marks dirty (a {@code sort} feeding a {@code select}), which holds the new value only if the column was named.
      *
      * <p>
-     * The gap is structural rather than particular to one kind of churn, hence the add, remove, and modify cycles. A
-     * shift-only cycle is excluded because it cannot change the formula's value:
-     * {@link #testRollupFormulaShiftOnlyDoesNotRecompute} covers that the column must stay <em>out</em> of the reported
-     * set there.
+     * Reporting is driven by the same condition that decides to recompute, so it holds for every kind of churn -- hence
+     * the add, remove, and modify cycles -- and reaches no further: the last cycle touches a column the formula does
+     * not read and expects silence, and {@link #testRollupFormulaShiftOnlyDoesNotRecompute} covers a shift, which
+     * cannot change the formula's value.
      */
     @Test
     public void testRollupFormulaReportsModifiedFormulaColumn() {


### PR DESCRIPTION
A rollup AggFormula level registers a separate group operator for its RowSet bookkeeping, so its FormulaMultiColumnChunkedOperator is built with delegateToBy=false, making every per-chunk callback a no-op. Those callbacks are the only thing that marks an operator modified, so the aggregation never consulted the operator's result ModifiedColumnSet factory and the formula column could not reach the level's downstream ModifiedColumnSet. propagateUpdates runs regardless, so the value was recomputed correctly; only the advertisement was missing, which left any consumer gating its refresh on the reported set -- a sort feeding a select, say -- serving a stale value indefinitely. Have resetForStep claim modifications for the step when not delegating and let the existing factory decide what to report; it gates on the same condition propagateUpdates recomputes on, so the column is advertised exactly when it is rewritten.