### PR TITLE
fix: DH-23376, DH-23336: apply dictionary size thresholds to predicate pushdown, fix overflow in binsearch kernels

### DIFF
--- a/docs/groovy/conceptual/query-table-configuration.md
+++ b/docs/groovy/conceptual/query-table-configuration.md
@@ -20,8 +20,13 @@ The `QueryTable` has the following user-configurable properties:
 | [DataIndex](#dataindex)                                             | `QueryTable.useDataIndexForWhere`                        | true       |
 | [DataIndex](#dataindex)                                             | `QueryTable.useDataIndexForAggregation`                  | true       |
 | [DataIndex](#dataindex)                                             | `QueryTable.useDataIndexForJoins`                        | true       |
+| [DataIndex](#dataindex)                                             | `QueryTable.dataIndexForWhereThreshold`                  | 0.25       |
 | [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownDataIndex`               | false      |
 | [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownParquetRowGroupMetadata` | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownMergedTables`            | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownDictionary`              | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownSortedColumn`            | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.dictionaryForWhereThreshold`                 | 0.25       |
 | [Parallel processing with where](#parallel-processing-with-where)   | `QueryTable.disableParallelWhere`                        | false      |
 | [Parallel processing with where](#parallel-processing-with-where)   | `QueryTable.parallelWhereRowsPerSegment`                 | `1 << 16`  |
 | [Parallel processing with where](#parallel-processing-with-where)   | `QueryTable.parallelWhereSegments`                       | -1         |
@@ -71,15 +76,25 @@ A Deephaven [DataIndex](../how-to-guides/data-indexes.md) is an index that can i
 | `QueryTable.useDataIndexForAggregation`    | true          | Enables data index usage in `QueryTable#aggBy`, `QueryTable#selectDistinct`, within [rollup-tables](../reference/table-operations/create/rollup.md) and [tree-tables](../reference/table-operations/create/tree.md) |
 | `QueryTable.useDataIndexForJoins`          | true          | Enables data index usage in [Deephaven Joins](../how-to-guides/joins-timeseries-range.md#which-method-should-you-use)                                                                                               |
 | `QueryTable.disableWherePushdownDataIndex` | false         | Disables data index usage within [where's pushdown predicates](#pushdown-predicates-with-where)                                                                                                                     |
+| `QueryTable.dataIndexForWhereThreshold`    | 0.25 (double) | The maximum size of a data index table, as a fraction of the rows remaining to be filtered, for the index to be used by `where`                                                                                     |
 
 ## Pushdown predicates with `where`
 
 Pushdown predicates refer to the mechanism whereby filtering conditions are applied as early as possible, ideally at the data source (e.g., Parquet or other columnar formats), before loading data into the system. By annotating source reads with predicates, the engine pulls in only the rows that satisfy the conditions, significantly reducing I/O and improving performance.
 
-| Property Name                                            | Default Value | Description                                                                                           |
-| -------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------- |
-| `QueryTable.disableWherePushdownDataIndex`               | false         | Disables the use of [data index](../how-to-guides/data-indexes.md) within where's pushdown predicates |
-| `QueryTable.disableWherePushdownParquetRowGroupMetadata` | false         | Disables the usage of Parquet row group metadata during push-down filtering                           |
+| Property Name                                            | Default Value | Description                                                                                                                                    |
+| -------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `QueryTable.disableWherePushdownDataIndex`               | false         | Disables the use of [data index](../how-to-guides/data-indexes.md) within where's pushdown predicates                                          |
+| `QueryTable.disableWherePushdownParquetRowGroupMetadata` | false         | Disables the usage of Parquet row group metadata during pushdown filtering                                                                     |
+| `QueryTable.disableWherePushdownMergedTables`            | false         | Disables predicate pushdown when filtering merged tables                                                                                       |
+| `QueryTable.disableWherePushdownDictionary`              | false         | Disables dictionary-encoding predicate pushdown operations                                                                                     |
+| `QueryTable.disableWherePushdownSortedColumn`            | false         | Disables the use of sorted column binary search during pushdown filtering                                                                      |
+| `QueryTable.dataIndexForWhereThreshold`                  | 0.25 (double) | The maximum size of a data index table, as a fraction of the rows remaining to be filtered, for the index to be used by `where`                |
+| `QueryTable.dictionaryForWhereThreshold`                 | 0.25 (double) | The dictionary size, as a fraction of the rows remaining to be filtered, that the dictionary must fall below for push-down filtering to use it |
+
+The two `*ForWhereThreshold` properties are cost heuristics rather than on/off switches. Scanning a data index table or a dictionary costs time proportional to its size, so the engine only does so when that structure is small relative to the rows it can eliminate. Rows skipped by this check are not eliminated — they are filtered directly by a later stage. Raise the value toward `1.0` to apply these optimizations to columns with more distinct values, or set it to `0` to effectively disable the technique.
+
+For more details, see [Predicate pushdown filtering](../how-to-guides/predicate-pushdown.md).
 
 ## Parallel processing with `where`
 

--- a/docs/groovy/how-to-guides/predicate-pushdown.md
+++ b/docs/groovy/how-to-guides/predicate-pushdown.md
@@ -161,6 +161,8 @@ source = ParquetTools.readTable("/data/examples/ParquetExamples/grades/grades.pa
 result = source.where("Class = `Math`")
 ```
 
+Filtering the dictionary costs time proportional to the number of unique dictionary entries, so it only pays off when the dictionary is small relative to the amount of data it can eliminate. Before filtering a region's dictionary, the engine compares the dictionary size to the number of rows still to be filtered in that region. The dictionary is used only when it holds fewer entries than [`QueryTable.dictionaryForWhereThreshold`](#tuning-predicate-pushdown-features) times the remaining row count. Otherwise, the engine skips the dictionary and leaves those rows to be filtered directly. The threshold defaults to `0.25`, so the dictionary must hold fewer entries than 25% of the remaining rows for the engine to use it.
+
 If desired, you can [disable](#disabling-predicate-pushdown-features) the use of dictionary encoding during pushdown operations:
 
 ## Disabling predicate pushdown features
@@ -172,6 +174,15 @@ Under certain circumstances, you may want to disable specific predicate pushdown
 - [`QueryTable.disableWherePushdownDataIndex`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DISABLE_WHERE_PUSHDOWN_DATA_INDEX) – disables the use of file-level Deephaven data indexes when filtering.
 - [`QueryTable.disableWherePushdownDictionary`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DISABLE_WHERE_PUSHDOWN_DICTIONARY) – disables the use of dictionary encoding when filtering.
 - [`QueryTable.disableWherePushdownSortedColumn`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DISABLE_WHERE_PUSHDOWN_SORTED_COLUMN_LOCATION) – disables the use of sorted column binary search when filtering.
+
+## Tuning predicate pushdown features
+
+Some pushdown techniques must build or scan an auxiliary structure (such as a data index table or a dictionary) before they can eliminate rows. That work is only worthwhile when the structure is small relative to the data it filters, so the engine applies a size-ratio test before using it. Both properties below are doubles that bound the size of the auxiliary structure as a fraction of the remaining rows to be filtered; when the structure is too large for its threshold, the engine skips the optimization and filters the rows directly.
+
+- [`QueryTable.dataIndexForWhereThreshold`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DATA_INDEX_FOR_WHERE_THRESHOLD) (default `0.25`) – the maximum ratio of data index table size to remaining row count for the engine to use a [data index](#deephaven-data-indexes) when filtering.
+- [`QueryTable.dictionaryForWhereThreshold`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DICTIONARY_FOR_WHERE_THRESHOLD) (default `0.25`) – the ratio of dictionary size to remaining row count that the dictionary must fall below for the engine to use [dictionary encoding](#dictionary-encoding) when filtering.
+
+Raising a threshold toward `1.0` makes the engine more willing to use the optimization on columns with many distinct values; lowering it restricts the optimization to highly repetitive data. Setting a threshold to `0` effectively disables that pushdown technique.
 
 For more information, see the [Query table configuration](../conceptual/query-table-configuration.md) documentation.
 

--- a/docs/python/conceptual/query-table-configuration.md
+++ b/docs/python/conceptual/query-table-configuration.md
@@ -20,8 +20,13 @@ The `QueryTable` has the following user-configurable properties:
 | [DataIndex](#dataindex)                                             | `QueryTable.useDataIndexForWhere`                        | true       |
 | [DataIndex](#dataindex)                                             | `QueryTable.useDataIndexForAggregation`                  | true       |
 | [DataIndex](#dataindex)                                             | `QueryTable.useDataIndexForJoins`                        | true       |
+| [DataIndex](#dataindex)                                             | `QueryTable.dataIndexForWhereThreshold`                  | 0.25       |
 | [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownDataIndex`               | false      |
 | [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownParquetRowGroupMetadata` | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownMergedTables`            | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownDictionary`              | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.disableWherePushdownSortedColumn`            | false      |
+| [Pushdown predicates with where](#pushdown-predicates-with-where)   | `QueryTable.dictionaryForWhereThreshold`                 | 0.25       |
 | [Parallel processing with where](#parallel-processing-with-where)   | `QueryTable.disableParallelWhere`                        | false      |
 | [Parallel processing with where](#parallel-processing-with-where)   | `QueryTable.parallelWhereRowsPerSegment`                 | `1 << 16`  |
 | [Parallel processing with where](#parallel-processing-with-where)   | `QueryTable.parallelWhereSegments`                       | -1         |
@@ -70,18 +75,26 @@ A Deephaven [DataIndex](../how-to-guides/data-indexes.md) is an index that can i
 | `QueryTable.useDataIndexForAggregation`    | true          | Enables data index usage in `QueryTable#aggBy`, `QueryTable#selectDistinct`, within [rollup-tables](../reference/table-operations/create/rollup.md) and [tree-tables](../reference/table-operations/create/tree.md) |
 | `QueryTable.useDataIndexForJoins`          | true          | Enables data index usage in [Deephaven Joins](../how-to-guides/joins-timeseries-range.md#which-method-should-you-use)                                                                                               |
 | `QueryTable.disableWherePushdownDataIndex` | false         | Disables data index usage within [where's pushdown predicates](#pushdown-predicates-with-where)                                                                                                                     |
+| `QueryTable.dataIndexForWhereThreshold`    | 0.25 (double) | The maximum size of a data index table, as a fraction of the rows remaining to be filtered, for the index to be used by `where`                                                                                     |
 
 ## Pushdown predicates with `where`
 
 Pushdown predicates refer to the mechanism whereby filtering conditions are applied as early as possible, ideally at the data source (e.g., Parquet or other columnar formats), before loading data into the system. By annotating source reads with predicates, the engine pulls in only the rows that satisfy the conditions, significantly reducing I/O and improving performance.
 
-| Property Name                                            | Default Value | Description                                                                                               |
-| -------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------- |
-| `QueryTable.useDataIndexForWhere`                        | true          | Enables the uses of table-level [data index](../how-to-guides/data-indexes.md) during `where` operations. |
-| `QueryTable.disableWherePushdownDataIndex`               | false         | Disables the use of [data index](../how-to-guides/data-indexes.md) within `where`'s predicate pushdown.   |
-| `QueryTable.disableWherePushdownParquetRowGroupMetadata` | false         | Disables the usage of Parquet row group metadata during push-down filtering.                              |
-| `QueryTable.disableWherePushdownMergedTables`            | false         | Disable predicate pushdown when filtering merged tables.                                                  |
-| `QueryTable.disableWherePushdownParquetDictionary`       | false         | Disables dictionary-encoding predicate pushdown operations.                                               |
+| Property Name                                            | Default Value | Description                                                                                                                                     |
+| -------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `QueryTable.useDataIndexForWhere`                        | true          | Enables the uses of table-level [data index](../how-to-guides/data-indexes.md) during `where` operations.                                       |
+| `QueryTable.disableWherePushdownDataIndex`               | false         | Disables the use of [data index](../how-to-guides/data-indexes.md) within `where`'s predicate pushdown.                                         |
+| `QueryTable.disableWherePushdownParquetRowGroupMetadata` | false         | Disables the usage of Parquet row group metadata during push-down filtering.                                                                    |
+| `QueryTable.disableWherePushdownMergedTables`            | false         | Disable predicate pushdown when filtering merged tables.                                                                                        |
+| `QueryTable.disableWherePushdownDictionary`              | false         | Disables dictionary-encoding predicate pushdown operations.                                                                                     |
+| `QueryTable.disableWherePushdownSortedColumn`            | false         | Disables the use of sorted column binary search during push-down filtering.                                                                     |
+| `QueryTable.dataIndexForWhereThreshold`                  | 0.25 (double) | The maximum size of a data index table, as a fraction of the rows remaining to be filtered, for the index to be used by `where`.                |
+| `QueryTable.dictionaryForWhereThreshold`                 | 0.25 (double) | The dictionary size, as a fraction of the rows remaining to be filtered, that the dictionary must fall below for push-down filtering to use it. |
+
+The two `*ForWhereThreshold` properties are cost heuristics rather than on/off switches. Scanning a data index table or a dictionary costs time proportional to its size, so the engine only does so when that structure is small relative to the rows it can eliminate. Rows skipped by this check are not eliminated — they are filtered directly by a later stage. Raise the value toward `1.0` to apply these optimizations to columns with more distinct values, or set it to `0` to effectively disable the technique.
+
+For more details, see [Predicate pushdown filtering](../how-to-guides/predicate-pushdown.md).
 
 ## Parallel processing with `where`
 

--- a/docs/python/how-to-guides/predicate-pushdown.md
+++ b/docs/python/how-to-guides/predicate-pushdown.md
@@ -164,6 +164,8 @@ source = parquet.read(path="/data/examples/ParquetExamples/grades/grades.parquet
 result = source.where(filters="Class = `Math`")
 ```
 
+Filtering the dictionary costs time proportional to the number of unique dictionary entries, so it only pays off when the dictionary is small relative to the amount of data it can eliminate. Before filtering a region's dictionary, the engine compares the dictionary size to the number of rows still to be filtered in that region. The dictionary is used only when it holds fewer entries than [`QueryTable.dictionaryForWhereThreshold`](#tuning-predicate-pushdown-features) times the remaining row count. Otherwise, the engine skips the dictionary and leaves those rows to be filtered directly. The threshold defaults to `0.25`, so the dictionary must hold fewer entries than 25% of the remaining rows for the engine to use it.
+
 If desired, you can [disable](#disabling-predicate-pushdown-features) the use of dictionary encoding during pushdown operations:
 
 ## Disabling predicate pushdown features
@@ -175,6 +177,15 @@ Under certain circumstances, you may want to disable specific predicate pushdown
 - [`QueryTable.disableWherePushdownDataIndex`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DISABLE_WHERE_PUSHDOWN_DATA_INDEX) – disables the use of file-level Deephaven data indexes when filtering.
 - [`QueryTable.disableWherePushdownDictionary`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DISABLE_WHERE_PUSHDOWN_DICTIONARY) – disables the use of dictionary encoding when filtering.
 - [`QueryTable.disableWherePushdownSortedColumn`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DISABLE_WHERE_PUSHDOWN_SORTED_COLUMN_LOCATION) – disables the use of sorted column binary search when filtering.
+
+## Tuning predicate pushdown features
+
+Some pushdown techniques must build or scan an auxiliary structure (such as a data index table or a dictionary) before they can eliminate rows. That work is only worthwhile when the structure is small relative to the data it filters, so the engine applies a size-ratio test before using it. Both properties below are doubles that bound the size of the auxiliary structure as a fraction of the remaining rows to be filtered; when the structure is too large for its threshold, the engine skips the optimization and filters the rows directly.
+
+- [`QueryTable.dataIndexForWhereThreshold`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DATA_INDEX_FOR_WHERE_THRESHOLD) (default `0.25`) – the maximum ratio of data index table size to remaining row count for the engine to use a [data index](#deephaven-data-indexes) when filtering.
+- [`QueryTable.dictionaryForWhereThreshold`](https://docs.deephaven.io/core/javadoc/io/deephaven/engine/table/impl/QueryTable.html#DICTIONARY_FOR_WHERE_THRESHOLD) (default `0.25`) – the ratio of dictionary size to remaining row count that the dictionary must fall below for the engine to use [dictionary encoding](#dictionary-encoding) when filtering.
+
+Raising a threshold toward `1.0` makes the engine more willing to use the optimization on columns with many distinct values; lowering it restricts the optimization to highly repetitive data. Setting a threshold to `0` effectively disables that pushdown technique.
 
 For more information, see the [Query table configuration](../conceptual/query-table-configuration.md) documentation.
 

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/QueryTable.java
@@ -287,6 +287,16 @@ public class QueryTable extends BaseTable<QueryTable> {
                     false);
 
     /**
+     * Before using a dictionary for a where filter, ensure that the dictionary holds fewer entries than this fraction
+     * of the size of the rows remaining to be filtered. If the dictionary is at least that large, then the engine will
+     * ignore the dictionary and filter the rows directly. A dictionary sitting exactly on the fraction is therefore not
+     * used: at the default of 0.25, a 25-entry dictionary over 100 remaining rows is skipped, while a 24-entry one is
+     * read.
+     */
+    public static double DICTIONARY_FOR_WHERE_THRESHOLD =
+            Configuration.getInstance().getDoubleWithDefault("QueryTable.dictionaryForWhereThreshold", 0.25);
+
+    /**
      * Disable the usage of sorted column regions during push-down filtering.
      */
     public static boolean DISABLE_WHERE_PUSHDOWN_SORTED_COLUMN_LOCATION =

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/BinarySearchKernelHelper.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/BinarySearchKernelHelper.java
@@ -15,13 +15,6 @@ class BinarySearchKernelHelper {
     /**
      * Helper to convert array index to insertion index (and back again).
      */
-    static int insertionPoint(final int index) {
-        return -index - 1;
-    }
-
-    /**
-     * Helper to convert array index to insertion index (and back again).
-     */
     static long insertionPoint(final long index) {
         return -index - 1;
     }

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteColumnBinarySearchKernel.java
@@ -328,7 +328,7 @@ public class ByteColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value exceeds {@code min} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -387,7 +387,7 @@ public class ByteColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} â or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -448,7 +448,7 @@ public class ByteColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value falls below {@code max} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if all
      * values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
@@ -507,7 +507,7 @@ public class ByteColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} â or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -554,4 +554,3 @@ public class ByteColumnBinarySearchKernel {
         return insertionPoint(low);
     }
 }
-

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ByteRegionBinarySearchKernel.java
@@ -61,13 +61,13 @@ public class ByteRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < unboxed.length && firstKey <= lastKey; ++idx) {
                 final byte toFind = unboxed[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -76,13 +76,13 @@ public class ByteRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < unboxed.length && firstKey <= lastKey; ++searchIndex) {
                 final byte toFind = unboxed[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -117,30 +117,30 @@ public class ByteRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -172,18 +172,18 @@ public class ByteRegionBinarySearchKernel {
             final byte min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -214,19 +214,19 @@ public class ByteRegionBinarySearchKernel {
             final byte max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -246,7 +246,7 @@ public class ByteRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value exceeds {@code min} â or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -259,17 +259,17 @@ public class ByteRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionByte<?> region,
             final long firstKey,
             final long lastKey,
             final byte min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final byte midValue = region.getByte(mid);
             if (minInc ? ByteComparisons.geq(midValue, min) : ByteComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -296,7 +296,7 @@ public class ByteRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} â or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -308,17 +308,17 @@ public class ByteRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionByte<?> region,
             final long firstKey,
             final long lastKey,
             final byte max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final byte midValue = region.getByte(mid);
             if (maxInc ? ByteComparisons.leq(midValue, max) : ByteComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -346,7 +346,7 @@ public class ByteRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value falls below {@code max} â or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -359,17 +359,17 @@ public class ByteRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionByte<?> region,
             final long firstKey,
             final long lastKey,
             final byte max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final byte midValue = region.getByte(mid);
             if (maxInc ? ByteComparisons.leq(midValue, max) : ByteComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -396,7 +396,7 @@ public class ByteRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} â or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -408,17 +408,17 @@ public class ByteRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionByte<?> region,
             final long firstKey,
             final long lastKey,
             final byte min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final byte midValue = region.getByte(mid);
             if (minInc ? ByteComparisons.geq(midValue, min) : ByteComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharColumnBinarySearchKernel.java
@@ -328,7 +328,7 @@ public class CharColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point — the leftmost position whose value exceeds {@code min} — or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -387,7 +387,7 @@ public class CharColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} — or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -448,8 +448,8 @@ public class CharColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point — the leftmost position whose value falls below {@code max} — or {@code lastPos + 1} if all
-     * values in the range are &gt;= {@code max}.</li>
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if
+     * all values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
      * @param source The element source to search.
@@ -507,7 +507,7 @@ public class CharColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} — or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/CharRegionBinarySearchKernel.java
@@ -57,13 +57,13 @@ public class CharRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < unboxed.length && firstKey <= lastKey; ++idx) {
                 final char toFind = unboxed[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -72,13 +72,13 @@ public class CharRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < unboxed.length && firstKey <= lastKey; ++searchIndex) {
                 final char toFind = unboxed[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -113,30 +113,30 @@ public class CharRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -168,18 +168,18 @@ public class CharRegionBinarySearchKernel {
             final char min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -210,19 +210,19 @@ public class CharRegionBinarySearchKernel {
             final char max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -242,7 +242,7 @@ public class CharRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point — the leftmost position whose value exceeds {@code min} — or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -255,17 +255,17 @@ public class CharRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionChar<?> region,
             final long firstKey,
             final long lastKey,
             final char min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final char midValue = region.getChar(mid);
             if (minInc ? CharComparisons.geq(midValue, min) : CharComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -292,7 +292,7 @@ public class CharRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} — or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -304,17 +304,17 @@ public class CharRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionChar<?> region,
             final long firstKey,
             final long lastKey,
             final char max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final char midValue = region.getChar(mid);
             if (maxInc ? CharComparisons.leq(midValue, max) : CharComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -342,7 +342,7 @@ public class CharRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point — the leftmost position whose value falls below {@code max} — or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -355,17 +355,17 @@ public class CharRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionChar<?> region,
             final long firstKey,
             final long lastKey,
             final char max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final char midValue = region.getChar(mid);
             if (maxInc ? CharComparisons.leq(midValue, max) : CharComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -392,7 +392,7 @@ public class CharRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} — or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -404,17 +404,17 @@ public class CharRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionChar<?> region,
             final long firstKey,
             final long lastKey,
             final char min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final char midValue = region.getChar(mid);
             if (minInc ? CharComparisons.geq(midValue, min) : CharComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleColumnBinarySearchKernel.java
@@ -328,7 +328,7 @@ public class DoubleColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value exceeds {@code min} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -387,7 +387,7 @@ public class DoubleColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} â or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -448,7 +448,7 @@ public class DoubleColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value falls below {@code max} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if all
      * values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
@@ -507,7 +507,7 @@ public class DoubleColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} â or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -554,4 +554,3 @@ public class DoubleColumnBinarySearchKernel {
         return insertionPoint(low);
     }
 }
-

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/DoubleRegionBinarySearchKernel.java
@@ -61,13 +61,13 @@ public class DoubleRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < unboxed.length && firstKey <= lastKey; ++idx) {
                 final double toFind = unboxed[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -76,13 +76,13 @@ public class DoubleRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < unboxed.length && firstKey <= lastKey; ++searchIndex) {
                 final double toFind = unboxed[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -117,30 +117,30 @@ public class DoubleRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -172,18 +172,18 @@ public class DoubleRegionBinarySearchKernel {
             final double min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -214,19 +214,19 @@ public class DoubleRegionBinarySearchKernel {
             final double max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -246,7 +246,7 @@ public class DoubleRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value exceeds {@code min} â or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -259,17 +259,17 @@ public class DoubleRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionDouble<?> region,
             final long firstKey,
             final long lastKey,
             final double min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final double midValue = region.getDouble(mid);
             if (minInc ? DoubleComparisons.geq(midValue, min) : DoubleComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -296,7 +296,7 @@ public class DoubleRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} â or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -308,17 +308,17 @@ public class DoubleRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionDouble<?> region,
             final long firstKey,
             final long lastKey,
             final double max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final double midValue = region.getDouble(mid);
             if (maxInc ? DoubleComparisons.leq(midValue, max) : DoubleComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -346,7 +346,7 @@ public class DoubleRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value falls below {@code max} â or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -359,17 +359,17 @@ public class DoubleRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionDouble<?> region,
             final long firstKey,
             final long lastKey,
             final double max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final double midValue = region.getDouble(mid);
             if (maxInc ? DoubleComparisons.leq(midValue, max) : DoubleComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -396,7 +396,7 @@ public class DoubleRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} â or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -408,17 +408,17 @@ public class DoubleRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionDouble<?> region,
             final long firstKey,
             final long lastKey,
             final double min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final double midValue = region.getDouble(mid);
             if (minInc ? DoubleComparisons.geq(midValue, min) : DoubleComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatColumnBinarySearchKernel.java
@@ -328,7 +328,7 @@ public class FloatColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value exceeds {@code min} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -387,7 +387,7 @@ public class FloatColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} â or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -448,7 +448,7 @@ public class FloatColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value falls below {@code max} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if all
      * values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
@@ -507,7 +507,7 @@ public class FloatColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} â or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -554,4 +554,3 @@ public class FloatColumnBinarySearchKernel {
         return insertionPoint(low);
     }
 }
-

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/FloatRegionBinarySearchKernel.java
@@ -61,13 +61,13 @@ public class FloatRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < unboxed.length && firstKey <= lastKey; ++idx) {
                 final float toFind = unboxed[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -76,13 +76,13 @@ public class FloatRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < unboxed.length && firstKey <= lastKey; ++searchIndex) {
                 final float toFind = unboxed[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -117,30 +117,30 @@ public class FloatRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -172,18 +172,18 @@ public class FloatRegionBinarySearchKernel {
             final float min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -214,19 +214,19 @@ public class FloatRegionBinarySearchKernel {
             final float max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -246,7 +246,7 @@ public class FloatRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value exceeds {@code min} â or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -259,17 +259,17 @@ public class FloatRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionFloat<?> region,
             final long firstKey,
             final long lastKey,
             final float min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final float midValue = region.getFloat(mid);
             if (minInc ? FloatComparisons.geq(midValue, min) : FloatComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -296,7 +296,7 @@ public class FloatRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} â or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -308,17 +308,17 @@ public class FloatRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionFloat<?> region,
             final long firstKey,
             final long lastKey,
             final float max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final float midValue = region.getFloat(mid);
             if (maxInc ? FloatComparisons.leq(midValue, max) : FloatComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -346,7 +346,7 @@ public class FloatRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value falls below {@code max} â or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -359,17 +359,17 @@ public class FloatRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionFloat<?> region,
             final long firstKey,
             final long lastKey,
             final float max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final float midValue = region.getFloat(mid);
             if (maxInc ? FloatComparisons.leq(midValue, max) : FloatComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -396,7 +396,7 @@ public class FloatRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} â or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -408,17 +408,17 @@ public class FloatRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionFloat<?> region,
             final long firstKey,
             final long lastKey,
             final float min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final float midValue = region.getFloat(mid);
             if (minInc ? FloatComparisons.geq(midValue, min) : FloatComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntColumnBinarySearchKernel.java
@@ -328,7 +328,7 @@ public class IntColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value exceeds {@code min} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -387,7 +387,7 @@ public class IntColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} â or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -448,7 +448,7 @@ public class IntColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value falls below {@code max} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if all
      * values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
@@ -507,7 +507,7 @@ public class IntColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} â or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -554,4 +554,3 @@ public class IntColumnBinarySearchKernel {
         return insertionPoint(low);
     }
 }
-

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/IntRegionBinarySearchKernel.java
@@ -61,13 +61,13 @@ public class IntRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < unboxed.length && firstKey <= lastKey; ++idx) {
                 final int toFind = unboxed[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -76,13 +76,13 @@ public class IntRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < unboxed.length && firstKey <= lastKey; ++searchIndex) {
                 final int toFind = unboxed[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -117,30 +117,30 @@ public class IntRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -172,18 +172,18 @@ public class IntRegionBinarySearchKernel {
             final int min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -214,19 +214,19 @@ public class IntRegionBinarySearchKernel {
             final int max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -246,7 +246,7 @@ public class IntRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value exceeds {@code min} â or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -259,17 +259,17 @@ public class IntRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionInt<?> region,
             final long firstKey,
             final long lastKey,
             final int min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final int midValue = region.getInt(mid);
             if (minInc ? IntComparisons.geq(midValue, min) : IntComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -296,7 +296,7 @@ public class IntRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} â or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -308,17 +308,17 @@ public class IntRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionInt<?> region,
             final long firstKey,
             final long lastKey,
             final int max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final int midValue = region.getInt(mid);
             if (maxInc ? IntComparisons.leq(midValue, max) : IntComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -346,7 +346,7 @@ public class IntRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value falls below {@code max} â or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -359,17 +359,17 @@ public class IntRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionInt<?> region,
             final long firstKey,
             final long lastKey,
             final int max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final int midValue = region.getInt(mid);
             if (maxInc ? IntComparisons.leq(midValue, max) : IntComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -396,7 +396,7 @@ public class IntRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} â or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -408,17 +408,17 @@ public class IntRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionInt<?> region,
             final long firstKey,
             final long lastKey,
             final int min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final int midValue = region.getInt(mid);
             if (minInc ? IntComparisons.geq(midValue, min) : IntComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongColumnBinarySearchKernel.java
@@ -328,7 +328,7 @@ public class LongColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value exceeds {@code min} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -387,7 +387,7 @@ public class LongColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} â or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -448,7 +448,7 @@ public class LongColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value falls below {@code max} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if all
      * values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
@@ -507,7 +507,7 @@ public class LongColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} â or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -554,4 +554,3 @@ public class LongColumnBinarySearchKernel {
         return insertionPoint(low);
     }
 }
-

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/LongRegionBinarySearchKernel.java
@@ -61,13 +61,13 @@ public class LongRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < unboxed.length && firstKey <= lastKey; ++idx) {
                 final long toFind = unboxed[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -76,13 +76,13 @@ public class LongRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < unboxed.length && firstKey <= lastKey; ++searchIndex) {
                 final long toFind = unboxed[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -117,30 +117,30 @@ public class LongRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -172,18 +172,18 @@ public class LongRegionBinarySearchKernel {
             final long min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -214,19 +214,19 @@ public class LongRegionBinarySearchKernel {
             final long max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -246,7 +246,7 @@ public class LongRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value exceeds {@code min} â or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -259,17 +259,17 @@ public class LongRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionLong<?> region,
             final long firstKey,
             final long lastKey,
             final long min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final long midValue = region.getLong(mid);
             if (minInc ? LongComparisons.geq(midValue, min) : LongComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -296,7 +296,7 @@ public class LongRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} â or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -308,17 +308,17 @@ public class LongRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionLong<?> region,
             final long firstKey,
             final long lastKey,
             final long max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final long midValue = region.getLong(mid);
             if (maxInc ? LongComparisons.leq(midValue, max) : LongComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -346,7 +346,7 @@ public class LongRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value falls below {@code max} â or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -359,17 +359,17 @@ public class LongRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionLong<?> region,
             final long firstKey,
             final long lastKey,
             final long max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final long midValue = region.getLong(mid);
             if (maxInc ? LongComparisons.leq(midValue, max) : LongComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -396,7 +396,7 @@ public class LongRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} â or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -408,17 +408,17 @@ public class LongRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionLong<?> region,
             final long firstKey,
             final long lastKey,
             final long min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final long midValue = region.getLong(mid);
             if (minInc ? LongComparisons.geq(midValue, min) : LongComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectColumnBinarySearchKernel.java
@@ -334,7 +334,7 @@ public class ObjectColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value exceeds {@code min} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -393,7 +393,7 @@ public class ObjectColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} â or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -454,7 +454,7 @@ public class ObjectColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value falls below {@code max} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if all
      * values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
@@ -513,7 +513,7 @@ public class ObjectColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} â or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -560,4 +560,3 @@ public class ObjectColumnBinarySearchKernel {
         return insertionPoint(low);
     }
 }
-

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ObjectRegionBinarySearchKernel.java
@@ -62,13 +62,13 @@ public class ObjectRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < copiedValues.length && firstKey <= lastKey; ++idx) {
                 final Object toFind = copiedValues[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -77,13 +77,13 @@ public class ObjectRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < copiedValues.length && firstKey <= lastKey; ++searchIndex) {
                 final Object toFind = copiedValues[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -118,30 +118,30 @@ public class ObjectRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -173,18 +173,18 @@ public class ObjectRegionBinarySearchKernel {
             final Object min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -215,19 +215,19 @@ public class ObjectRegionBinarySearchKernel {
             final Object max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -247,7 +247,7 @@ public class ObjectRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value exceeds {@code min} â or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -260,17 +260,17 @@ public class ObjectRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionObject<?, ?> region,
             final long firstKey,
             final long lastKey,
             final Object min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final Object midValue = region.getObject(mid);
             if (minInc ? ObjectComparisons.geq(midValue, min) : ObjectComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -297,7 +297,7 @@ public class ObjectRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} â or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -309,17 +309,17 @@ public class ObjectRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionObject<?, ?> region,
             final long firstKey,
             final long lastKey,
             final Object max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final Object midValue = region.getObject(mid);
             if (maxInc ? ObjectComparisons.leq(midValue, max) : ObjectComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -347,7 +347,7 @@ public class ObjectRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value falls below {@code max} â or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -360,17 +360,17 @@ public class ObjectRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionObject<?, ?> region,
             final long firstKey,
             final long lastKey,
             final Object max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final Object midValue = region.getObject(mid);
             if (maxInc ? ObjectComparisons.leq(midValue, max) : ObjectComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -397,7 +397,7 @@ public class ObjectRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} â or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -409,17 +409,17 @@ public class ObjectRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionObject<?, ?> region,
             final long firstKey,
             final long lastKey,
             final Object min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final Object midValue = region.getObject(mid);
             if (minInc ? ObjectComparisons.geq(midValue, min) : ObjectComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortColumnBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortColumnBinarySearchKernel.java
@@ -328,7 +328,7 @@ public class ShortColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value exceeds {@code min} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastPos + 1} if all
      * values in the range are &lt;= {@code min}.</li>
      * </ul>
      *
@@ -387,7 +387,7 @@ public class ShortColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value exceeds {@code max} â or {@code firstPos} if all values in the range are &gt;
+     * the first position whose value exceeds {@code max}, or {@code firstPos} if all values in the range are &gt;
      * {@code max}.</li>
      * </ul>
      *
@@ -448,7 +448,7 @@ public class ShortColumnBinarySearchKernel {
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code max} is absent from the range, when
      * {@code maxInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the insertion point â the leftmost position whose value falls below {@code max} â or {@code lastPos + 1} if all
+     * the insertion point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastPos + 1} if all
      * values in the range are &gt;= {@code max}.</li>
      * </ul>
      *
@@ -507,7 +507,7 @@ public class ShortColumnBinarySearchKernel {
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases: when {@code min} is absent from the range, when
      * {@code minInc=false} (exclusive bound), or when no position satisfies the bound. In this case {@code -(p + 1)} is
-     * the first position whose value falls below {@code min} â or {@code firstPos} if all values in the range are &lt;=
+     * the first position whose value falls below {@code min}, or {@code firstPos} if all values in the range are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -554,4 +554,3 @@ public class ShortColumnBinarySearchKernel {
         return insertionPoint(low);
     }
 }
-

--- a/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernel.java
+++ b/engine/table/src/main/java/io/deephaven/engine/table/impl/sources/regioned/kernel/ShortRegionBinarySearchKernel.java
@@ -61,13 +61,13 @@ public class ShortRegionBinarySearchKernel {
         if (order.isAscending()) {
             for (int idx = 0; idx < unboxed.length && firstKey <= lastKey; ++idx) {
                 final short toFind = unboxed[idx];
-                final int startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundAscending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundAscending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -76,13 +76,13 @@ public class ShortRegionBinarySearchKernel {
         } else {
             for (int searchIndex = 0; searchIndex < unboxed.length && firstKey <= lastKey; ++searchIndex) {
                 final short toFind = unboxed[searchIndex];
-                final int startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
+                final long startResult = lowerBoundDescending(region, firstKey, lastKey, toFind, true);
                 if (startResult < 0) {
                     // Advance firstKey since we didn't find the value but eliminated some rows.
                     firstKey = insertionPoint(startResult);
                     continue;
                 }
-                final int endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
+                final long endResult = upperBoundDescending(region, startResult, lastKey, toFind, true);
                 if (endResult >= 0) {
                     builder.appendRange(startResult, endResult);
                     firstKey = endResult + 1;
@@ -117,30 +117,30 @@ public class ShortRegionBinarySearchKernel {
             final boolean minInc,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, offset, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
             if (start > lastKey) {
                 return RowSetFactory.empty();
             }
             final long offset = Math.max(start, firstKey);
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, offset, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -172,18 +172,18 @@ public class ShortRegionBinarySearchKernel {
             final short min,
             final boolean minInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
             // The beginning of the range is the first row that is > or >= min (depends on minInc)
-            final int startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
+            final long startResult = lowerBoundAscending(region, firstKey, lastKey, min, minInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         } else {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is > or >= min (depends on minInc)
-            final int endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
+            final long endResult = upperBoundDescending(region, firstKey, lastKey, min, minInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         }
 
@@ -214,19 +214,19 @@ public class ShortRegionBinarySearchKernel {
             final short max,
             final boolean maxInc) {
 
-        final int start;
-        final int end;
+        final long start;
+        final long end;
 
         if (sortColumn.isAscending()) {
-            start = Math.toIntExact(firstKey);
+            start = firstKey;
             // The end of the range is the last row that is < or <= max (depends on maxInc)
-            final int endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
+            final long endResult = upperBoundAscending(region, firstKey, lastKey, max, maxInc);
             end = endResult >= 0 ? endResult : insertionPoint(endResult) - 1;
         } else {
             // The beginning of the range is the first row that is < or <= max (depends on maxInc)
-            final int startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
+            final long startResult = lowerBoundDescending(region, firstKey, lastKey, max, maxInc);
             start = startResult >= 0 ? startResult : insertionPoint(startResult);
-            end = Math.toIntExact(lastKey);
+            end = lastKey;
         }
 
         if (start <= end) {
@@ -246,7 +246,7 @@ public class ShortRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value exceeds {@code min} â or {@code lastKey + 1} if all values are &lt;=
+     * point, i.e. the leftmost position whose value exceeds {@code min}, or {@code lastKey + 1} if all values are &lt;=
      * {@code min}.</li>
      * </ul>
      *
@@ -259,17 +259,17 @@ public class ShortRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundAscending(
+    private static long lowerBoundAscending(
             @NotNull final ColumnRegionShort<?> region,
             final long firstKey,
             final long lastKey,
             final short min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final short midValue = region.getShort(mid);
             if (minInc ? ShortComparisons.geq(midValue, min) : ShortComparisons.gt(midValue, min)) {
                 high = mid - 1;
@@ -296,7 +296,7 @@ public class ShortRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value exceeds {@code max} â or {@code firstKey} if all values are &gt; {@code max}.</li>
+     * position whose value exceeds {@code max}, or {@code firstKey} if all values are &gt; {@code max}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -308,17 +308,17 @@ public class ShortRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value exceeds {@code max}.
      */
-    private static int upperBoundAscending(
+    private static long upperBoundAscending(
             @NotNull final ColumnRegionShort<?> region,
             final long firstKey,
             final long lastKey,
             final short max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final short midValue = region.getShort(mid);
             if (maxInc ? ShortComparisons.leq(midValue, max) : ShortComparisons.lt(midValue, max)) {
                 low = mid + 1;
@@ -346,7 +346,7 @@ public class ShortRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code maxInc=true} and the value at the found position exactly
      * equals {@code max}. The returned value is the leftmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the insertion
-     * point â the leftmost position whose value falls below {@code max} â or {@code lastKey + 1} if all values are
+     * point, i.e. the leftmost position whose value falls below {@code max}, or {@code lastKey + 1} if all values are
      * &gt;= {@code max}.</li>
      * </ul>
      *
@@ -359,17 +359,17 @@ public class ShortRegionBinarySearchKernel {
      * @return A non-negative position if {@code maxInc=true} and {@code max} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the insertion point.
      */
-    private static int lowerBoundDescending(
+    private static long lowerBoundDescending(
             @NotNull final ColumnRegionShort<?> region,
             final long firstKey,
             final long lastKey,
             final short max,
             final boolean maxInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final short midValue = region.getShort(mid);
             if (maxInc ? ShortComparisons.leq(midValue, max) : ShortComparisons.lt(midValue, max)) {
                 high = mid - 1;
@@ -396,7 +396,7 @@ public class ShortRegionBinarySearchKernel {
      * <li>A non-negative value is returned only when {@code minInc=true} and the value at the found position exactly
      * equals {@code min}. The returned value is the rightmost such position.</li>
      * <li>A negative value {@code p} is returned in all other cases. In this case {@code -(p + 1)} is the first
-     * position whose value falls below {@code min} â or {@code firstKey} if all values are &gt;= {@code min}.</li>
+     * position whose value falls below {@code min}, or {@code firstKey} if all values are &gt;= {@code min}.</li>
      * </ul>
      *
      * @param region The column region to search.
@@ -408,17 +408,17 @@ public class ShortRegionBinarySearchKernel {
      * @return A non-negative position if {@code minInc=true} and {@code min} is found; otherwise a negative value
      *         {@code p} where {@code -(p + 1)} is the first position whose value falls below {@code min}.
      */
-    private static int upperBoundDescending(
+    private static long upperBoundDescending(
             @NotNull final ColumnRegionShort<?> region,
             final long firstKey,
             final long lastKey,
             final short min,
             final boolean minInc) {
-        int low = (int) firstKey;
-        int high = (int) lastKey;
+        long low = firstKey;
+        long high = lastKey;
 
         while (low <= high) {
-            final int mid = low + (high - low) / 2;
+            final long mid = low + (high - low) / 2;
             final short midValue = region.getShort(mid);
             if (minInc ? ShortComparisons.geq(midValue, min) : ShortComparisons.gt(midValue, min)) {
                 low = mid + 1;

--- a/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/RegionBinarySearchKernelLargeRowKeyTest.java
+++ b/engine/table/src/test/java/io/deephaven/engine/table/impl/sources/regioned/kernel/RegionBinarySearchKernelLargeRowKeyTest.java
@@ -1,0 +1,139 @@
+//
+// Copyright (c) 2016-2026 Deephaven Data Labs and Patent Pending
+//
+package io.deephaven.engine.table.impl.sources.regioned.kernel;
+
+import io.deephaven.api.ColumnName;
+import io.deephaven.api.SortColumn;
+import io.deephaven.chunk.WritableChunk;
+import io.deephaven.chunk.attributes.Values;
+import io.deephaven.engine.rowset.RowSequence;
+import io.deephaven.engine.rowset.RowSet;
+import io.deephaven.engine.table.impl.sources.regioned.ColumnRegionChar;
+import io.deephaven.engine.table.impl.sources.regioned.GenericColumnRegionBase;
+import io.deephaven.engine.table.impl.sources.regioned.RegionedColumnSource;
+import io.deephaven.engine.testutil.junit4.EngineCleanup;
+import io.deephaven.test.types.ParallelTest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the region binary search kernels operate correctly on row keys beyond the range of a 32-bit int. This
+ * is not covered by the replicated per-type tests, which materialize their data and so stay well below
+ * {@link Integer#MAX_VALUE}.
+ *
+ * <p>
+ * Only the char kernel is exercised: all of the primitive kernels are replicated from the same source, so the row key
+ * arithmetic under test is identical across types.
+ */
+@Category(ParallelTest.class)
+public class RegionBinarySearchKernelLargeRowKeyTest {
+    /** The first row key holding {@link #HIGH_VALUE}; chosen to sit just past {@link Integer#MAX_VALUE}. */
+    private static final long SPLIT = Integer.MAX_VALUE + 1L;
+    /** Row keys are searched over a small window straddling {@link #SPLIT}. */
+    private static final long WINDOW = 4;
+
+    private static final char LOW_VALUE = 'a';
+    private static final char HIGH_VALUE = 'b';
+
+    @Rule
+    public final EngineCleanup framework = new EngineCleanup();
+
+    /**
+     * An ascending-sorted region that computes its values from the row key, so that arbitrarily high row keys can be
+     * searched without materializing any data. Row keys below {@link #SPLIT} hold {@link #LOW_VALUE}; the rest hold
+     * {@link #HIGH_VALUE}.
+     */
+    private static final class SplitValueRegion extends GenericColumnRegionBase<Values>
+            implements ColumnRegionChar<Values> {
+
+        private SplitValueRegion() {
+            super(RegionedColumnSource.ROW_KEY_TO_SUB_REGION_ROW_INDEX_MASK);
+        }
+
+        @Override
+        public char getChar(final long elementIndex) {
+            assertTrue("Row key " + elementIndex + " is not a valid position", elementIndex >= 0);
+            return elementIndex < SPLIT ? LOW_VALUE : HIGH_VALUE;
+        }
+
+        @Override
+        public void fillChunk(@NotNull final FillContext context,
+                @NotNull final WritableChunk<? super Values> destination,
+                @NotNull final RowSequence rowSequence) {
+            throw new UnsupportedOperationException("Binary search should not fill chunks");
+        }
+
+        @Override
+        public void fillChunkAppend(@NotNull final FillContext context,
+                @NotNull final WritableChunk<? super Values> destination,
+                @NotNull final RowSequence.Iterator rowSequenceIterator) {
+            throw new UnsupportedOperationException("Binary search should not fill chunks");
+        }
+    }
+
+    private static final SortColumn ASCENDING = SortColumn.asc(ColumnName.of("test"));
+
+    private static final long FIRST_KEY = SPLIT - WINDOW;
+    private static final long LAST_KEY = SPLIT + WINDOW;
+
+    @Test
+    public void testBinarySearchMatchAboveIntRange() {
+        final ColumnRegionChar<Values> region = new SplitValueRegion();
+        try (final RowSet result = CharRegionBinarySearchKernel.binarySearchMatch(
+                region, FIRST_KEY, LAST_KEY, ASCENDING, new Character[] {HIGH_VALUE})) {
+            assertEquals(WINDOW + 1, result.size());
+            assertEquals(SPLIT, result.firstRowKey());
+            assertEquals(LAST_KEY, result.lastRowKey());
+        }
+    }
+
+    @Test
+    public void testBinarySearchMinAboveIntRange() {
+        final ColumnRegionChar<Values> region = new SplitValueRegion();
+        try (final RowSet result = CharRegionBinarySearchKernel.binarySearchMin(
+                region, FIRST_KEY, LAST_KEY, ASCENDING, HIGH_VALUE, true)) {
+            assertEquals(WINDOW + 1, result.size());
+            assertEquals(SPLIT, result.firstRowKey());
+            assertEquals(LAST_KEY, result.lastRowKey());
+        }
+    }
+
+    @Test
+    public void testBinarySearchMaxAboveIntRange() {
+        final ColumnRegionChar<Values> region = new SplitValueRegion();
+        try (final RowSet result = CharRegionBinarySearchKernel.binarySearchMax(
+                region, FIRST_KEY, LAST_KEY, ASCENDING, LOW_VALUE, true)) {
+            assertEquals(WINDOW, result.size());
+            assertEquals(FIRST_KEY, result.firstRowKey());
+            assertEquals(SPLIT - 1, result.lastRowKey());
+        }
+    }
+
+    @Test
+    public void testBinarySearchMinMaxAboveIntRange() {
+        final ColumnRegionChar<Values> region = new SplitValueRegion();
+        try (final RowSet result = CharRegionBinarySearchKernel.binarySearchMinMax(
+                region, FIRST_KEY, LAST_KEY, ASCENDING, HIGH_VALUE, HIGH_VALUE, true, true)) {
+            assertEquals(WINDOW + 1, result.size());
+            assertEquals(SPLIT, result.firstRowKey());
+            assertEquals(LAST_KEY, result.lastRowKey());
+        }
+    }
+
+    @Test
+    public void testBinarySearchMinMaxSpanningSplitAboveIntRange() {
+        final ColumnRegionChar<Values> region = new SplitValueRegion();
+        try (final RowSet result = CharRegionBinarySearchKernel.binarySearchMinMax(
+                region, FIRST_KEY, LAST_KEY, ASCENDING, LOW_VALUE, HIGH_VALUE, true, true)) {
+            assertEquals(2 * WINDOW + 1, result.size());
+            assertEquals(FIRST_KEY, result.firstRowKey());
+            assertEquals(LAST_KEY, result.lastRowKey());
+        }
+    }
+}

--- a/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
+++ b/extensions/parquet/table/src/main/java/io/deephaven/parquet/table/location/ParquetTableLocation.java
@@ -1008,6 +1008,14 @@ public class ParquetTableLocation extends AbstractTableLocation {
                     return;
                 }
 
+                // Filtering the dictionary costs O(dictionary size), might not be worth the overhead.
+                final long threshold = (long) (rs.size() * QueryTable.DICTIONARY_FOR_WHERE_THRESHOLD);
+                if (dictionaryChunk.size() >= threshold) {
+                    maybeBuilder.appendRowSequence(rs);
+                    maybeCount.add(rs.size());
+                    return;
+                }
+
                 // Run the filter on the dictionary to find which dictionary entries satisfy the filter and build an
                 // array of matching dictionary key IDs.
                 final long[] keyMatchArray;

--- a/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
+++ b/extensions/parquet/table/src/test/java/io/deephaven/parquet/table/ParquetTableFilterTest.java
@@ -12,6 +12,7 @@ import io.deephaven.engine.context.QueryScope;
 import io.deephaven.engine.table.*;
 import io.deephaven.engine.table.impl.AbstractColumnSource;
 import io.deephaven.engine.table.impl.PushdownFilterContext;
+import io.deephaven.engine.table.impl.PushdownPredicateManager;
 import io.deephaven.engine.table.impl.PushdownResult;
 import io.deephaven.engine.table.impl.QueryTable;
 import io.deephaven.engine.table.impl.indexer.DataIndexer;
@@ -70,6 +71,7 @@ public final class ParquetTableFilterTest {
 
     private static File rootFile;
     private boolean whereDataIndexEnabled;
+    private double configuredDictionaryThreshold;
 
     @Rule
     public final EngineCleanup framework = new EngineCleanup();
@@ -83,12 +85,16 @@ public final class ParquetTableFilterTest {
         // noinspection ResultOfMethodCallIgnored
         rootFile.mkdirs();
         whereDataIndexEnabled = QueryTable.USE_DATA_INDEX_FOR_WHERE;
+
+        configuredDictionaryThreshold = QueryTable.DICTIONARY_FOR_WHERE_THRESHOLD;
+        QueryTable.DICTIONARY_FOR_WHERE_THRESHOLD = Double.MAX_VALUE;
     }
 
     @After
     public void tearDown() {
         FileUtils.deleteRecursively(rootFile);
         QueryTable.USE_DATA_INDEX_FOR_WHERE = whereDataIndexEnabled;
+        QueryTable.DICTIONARY_FOR_WHERE_THRESHOLD = configuredDictionaryThreshold;
     }
 
     private Table[] splitTable(final Table source, int numSplits, boolean randomSizes) {
@@ -1875,6 +1881,127 @@ public final class ParquetTableFilterTest {
         filterAndVerifyResults(diskTable, memTable, ConditionFilter.createConditionFilter("animal = null"));
         filterAndVerifyResults(diskTable, memTable, ConditionFilter.createConditionFilter("animal != null"));
         filterAndVerifyResults(diskTable, memTable, ConditionFilter.createConditionFilter("animal == `Cat`"));
+    }
+
+    /** The value the threshold tests filter for; {@link #writeAndReadDictionaryTable} always includes it. */
+    private static final String THRESHOLD_MATCH_VALUE = "animal_0";
+
+    /** Rows in the threshold fixtures. The dictionary sizes below are derived from it, not hard-coded. */
+    private static final int THRESHOLD_ROW_COUNT = 100;
+
+    /**
+     * The fraction the boundary tests run at, in place of the configured one. The configured value cannot be relied on
+     * to express this boundary: {@code 0} is a documented setting that disables the optimization, and any fraction
+     * outside {@code [0.02, 1.0]} asks for a dictionary that {@link #THRESHOLD_ROW_COUNT} rows cannot hold — too few
+     * distinct entries to build a fixture at one end, more than one per row at the other. {@link #setUp} and
+     * {@link #tearDown} still save and restore whatever is configured.
+     */
+    private static final double THRESHOLD_TEST_FRACTION = 0.25;
+
+    /**
+     * The smallest dictionary {@link #THRESHOLD_TEST_FRACTION} declines to read for {@link #THRESHOLD_ROW_COUNT} rows.
+     * Pushdown is skipped once a dictionary holds at least {@code rows * fraction} entries, so this is 25 — meaning 25
+     * entries decline and 24 proceed.
+     */
+    private static int smallestDecliningDictionarySize() {
+        return (int) (THRESHOLD_ROW_COUNT * THRESHOLD_TEST_FRACTION);
+    }
+
+    /**
+     * Write {@code rowCount} rows drawn from a dictionary of {@code distinctValues} animals as a single
+     * dictionary-encoded row group without row group statistics, and read it back. Cycling keeps the column unsorted,
+     * and omitting the statistics keeps the cheaper metadata action from resolving anything, so the dictionary action
+     * decides the outcome.
+     */
+    private static Table writeAndReadDictionaryTable(
+            final String name,
+            final int rowCount,
+            final int distinctValues) {
+        final String[] animals = new String[rowCount];
+        for (int ii = 0; ii < rowCount; ii++) {
+            animals[ii] = "animal_" + (ii % distinctValues);
+        }
+        final ParquetInstructions writeInstructions = new ParquetInstructions.Builder()
+                .setWriteRowGroupStatistics(false)
+                .build();
+        final String destPath = Path.of(rootFile.getPath(), name) + ".parquet";
+        writeTable(TableTools.newTable(stringCol("animal", animals)), destPath, writeInstructions);
+        return ParquetTools.readTable(destPath).coalesce();
+    }
+
+    /**
+     * Run the pushdown actions available at or below the dictionary action's cost against {@code diskTable} and return
+     * what they resolved.
+     */
+    private static PushdownResult runPushdownThroughDictionary(final Table diskTable, final String filterExpr) {
+        final WhereFilter filter = getExpression(filterExpr);
+        filter.init(diskTable.getDefinition());
+        Assert.assertEquals("Expected a single column in the filter: " + filterExpr, 1, filter.getColumns().size());
+
+        final ColumnSource<?> columnSource = diskTable.getColumnSource(filter.getColumns().get(0));
+        final PushdownPredicateManager ppm = PushdownPredicateManager.getSharedPPM(List.of(columnSource));
+        Assert.assertNotNull("pushdown predicate manager", ppm);
+
+        try (final PushdownFilterContext context = ppm.makePushdownFilterContext(filter, List.of(columnSource))) {
+            final CompletableFuture<PushdownResult> resultFuture = new CompletableFuture<>();
+            ppm.pushdownFilter(
+                    filter,
+                    diskTable.getRowSet(),
+                    false,
+                    context,
+                    PushdownResult.REGION_DICTIONARY_DATA_COST,
+                    new ImmediateJobScheduler(),
+                    resultFuture::complete,
+                    resultFuture::completeExceptionally);
+            return resultFuture.join();
+        }
+    }
+
+    /**
+     * Reading and filtering a whole dictionary costs O(dictionary), so it only pays off when enough rows remain that
+     * filtering them directly would cost more. This test and {@link #dictionaryPushdownThresholdProceedsTest()} sit on
+     * the two dictionary sizes either side of that boundary — the smallest that declines and the largest that proceeds
+     * — at {@link #THRESHOLD_TEST_FRACTION}, the heuristic that the other dictionary tests here deliberately disable.
+     */
+    @Test
+    public void dictionaryPushdownThresholdDeclinesTest() {
+        // The smallest dictionary that declines: 100 * 0.25 = 25, and 25 >= 25, so reading the dictionary does not pay
+        // for itself and every row must be left for the filter to evaluate directly.
+        final Table diskTable = writeAndReadDictionaryTable(
+                "dictionaryThresholdDeclines", THRESHOLD_ROW_COUNT, smallestDecliningDictionarySize());
+        final String filterExpr = "animal == `" + THRESHOLD_MATCH_VALUE + "`";
+        final long expectedMatches = diskTable.where(filterExpr).size();
+        assertTrue(expectedMatches > 0);
+
+        // First with the heuristic still disabled, so that the assertions below pin the threshold rather than some
+        // other reason this fixture's dictionary could not be used.
+        try (final PushdownResult pinnedOpen = runPushdownThroughDictionary(diskTable, filterExpr)) {
+            assertEquals(expectedMatches, pinnedOpen.match().size());
+            assertTrue("maybeMatch should be empty", pinnedOpen.maybeMatch().isEmpty());
+        }
+
+        QueryTable.DICTIONARY_FOR_WHERE_THRESHOLD = THRESHOLD_TEST_FRACTION;
+        try (final PushdownResult result = runPushdownThroughDictionary(diskTable, filterExpr)) {
+            assertTrue("match should be empty", result.match().isEmpty());
+            assertEquals(diskTable.size(), result.maybeMatch().size());
+        }
+    }
+
+    @Test
+    public void dictionaryPushdownThresholdProceedsTest() {
+        QueryTable.DICTIONARY_FOR_WHERE_THRESHOLD = THRESHOLD_TEST_FRACTION;
+
+        // One entry fewer over the same hundred rows -- the largest dictionary that still proceeds: 100 * 0.25 = 25,
+        // and 24 < 25, so the dictionary is worth reading and resolves every row exactly.
+        final Table diskTable = writeAndReadDictionaryTable(
+                "dictionaryThresholdProceeds", THRESHOLD_ROW_COUNT, smallestDecliningDictionarySize() - 1);
+        final String filterExpr = "animal == `" + THRESHOLD_MATCH_VALUE + "`";
+        final long expectedMatches = diskTable.where(filterExpr).size();
+        assertTrue(expectedMatches > 0);
+        try (final PushdownResult result = runPushdownThroughDictionary(diskTable, filterExpr)) {
+            assertEquals(expectedMatches, result.match().size());
+            assertTrue("maybeMatch should be empty", result.maybeMatch().isEmpty());
+        }
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of 640d6e2a8627de58499df1111d360716afe0f0a2 from `main` (#8363).