### PR TITLE
feat: DH-23394: Add with_keys and with_unique_keys to the Python Table

### DIFF
--- a/py/server/deephaven/table.py
+++ b/py/server/deephaven/table.py
@@ -1119,6 +1119,44 @@ class Table(JObjectWrapper):
         except Exception as e:
             raise DHError(e, "failed to create a table without attributes.") from e
 
+    def with_keys(self, cols: Union[str, Sequence[str]]) -> Table:
+        """Returns a new Table that shares the underlying data and schema with this table and has the specified
+        columns marked as its key columns.
+
+        Args:
+            cols (Union[str, Sequence[str]]): the key column name(s), must name at least one existing column
+
+        Returns:
+            a new Table
+
+        Raises:
+            DHError
+        """
+        try:
+            cols = to_sequence(cols)
+            return Table(j_table=self.j_table.withKeys(*cols))
+        except Exception as e:
+            raise DHError(e, "failed to create a table with key columns.") from e
+
+    def with_unique_keys(self, cols: Union[str, Sequence[str]]) -> Table:
+        """Returns a new Table that shares the underlying data and schema with this table and has the specified
+        columns marked as its key columns, additionally indicating that each key set will be unique.
+
+        Args:
+            cols (Union[str, Sequence[str]]): the key column name(s), must name at least one existing column
+
+        Returns:
+            a new Table
+
+        Raises:
+            DHError
+        """
+        try:
+            cols = to_sequence(cols)
+            return Table(j_table=self.j_table.withUniqueKeys(*cols))
+        except Exception as e:
+            raise DHError(e, "failed to create a table with unique key columns.") from e
+
     def to_string(
         self, num_rows: int = 10, cols: Optional[Union[str, Sequence[str]]] = None
     ) -> str:

--- a/py/server/tests/test_table.py
+++ b/py/server/tests/test_table.py
@@ -1264,6 +1264,34 @@ class TableTestCase(BaseTestCase):
         self.assertEqual(len(attrs), len(rt_attrs) + 1)
         self.assertIn("BlinkTable", set(attrs.keys()) - set(rt_attrs.keys()))
 
+    def test_with_keys(self):
+        rt = self.test_table.with_keys("a")
+        self.assertEqual({"keyColumns": "a"}, rt.attributes())
+        self.assertEqual({}, self.test_table.attributes())
+
+        rt = self.test_table.with_keys(["a", "b"])
+        self.assertEqual({"keyColumns": "a,b"}, rt.attributes())
+
+        with self.assertRaises(DHError):
+            self.test_table.with_keys([])
+
+        with self.assertRaises(DHError):
+            self.test_table.with_keys("NotAColumn")
+
+    def test_with_unique_keys(self):
+        rt = self.test_table.with_unique_keys("a")
+        self.assertEqual({"keyColumns": "a", "uniqueKeys": True}, rt.attributes())
+        self.assertEqual({}, self.test_table.attributes())
+
+        rt = self.test_table.with_unique_keys(["a", "b"])
+        self.assertEqual({"keyColumns": "a,b", "uniqueKeys": True}, rt.attributes())
+
+        with self.assertRaises(DHError):
+            self.test_table.with_unique_keys([])
+
+        with self.assertRaises(DHError):
+            self.test_table.with_unique_keys("NotAColumn")
+
     def test_remove_blink(self):
         t_blink = time_table("PT1s", blink_table=True)
         t_no_blink = t_blink.remove_blink()


### PR DESCRIPTION
Fixes [DH-23394](https://deephaven.atlassian.net/browse/DH-23394).

`py/server/deephaven/table.py` had no wrapper for the Java `Table.withKeys` / `Table.withUniqueKeys`, so marking key columns from Python meant reaching for the low-level `with_attributes({"keyColumns": "Key"})` workaround.

## Changes

- `Table.with_keys(cols)` → `Table.withKeys(String...)`
- `Table.with_unique_keys(cols)` → `Table.withUniqueKeys(String...)`

Both follow the existing conventions in `table.py`: a `Union[str, Sequence[str]]` argument normalized with `to_sequence`, varargs unpacking into the Java call (as `to_string` already does), and `DHError` wrapping. Neither uses `auto_locking_ctx`, since both Java methods are `@ConcurrentMethod`.

Column validation is delegated to Java rather than duplicated: `BaseTable.formatKeyColumns` already rejects an empty column list and calls `checkAvailableColumns`, so bad input surfaces as a `DHError` wrapping the Java exception.

Scoped to `Table` only — `withKeys`/`withUniqueKeys` are declared on `Table` rather than `TableOperations`, so there is no `PartitionedTableProxy` equivalent to mirror.

## Testing

- Added `test_with_keys` and `test_with_unique_keys` to `py/server/tests/test_table.py`, asserting the resulting attributes (`keyColumns`, plus `uniqueKeys` for the unique variant), that the source table is left unmodified, and that empty and nonexistent column names raise.
- `ruff check` and `ruff format --check` pass.
- The Python suite (`:Integrations:test-py-deephaven`) was **not** run locally: `composeUp` could not bind ports 8081/5432, which were held by a local dev stack. Relying on CI for the runtime verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DH-23394]: https://deephaven.atlassian.net/browse/DH-23394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ