### PR TITLE
fix: DH-23437: Create the C++ client console lazily

### DIFF
--- a/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_manager_impl.h
+++ b/cpp-client/deephaven/dhclient/include/private/deephaven/client/impl/table_handle_manager_impl.h
@@ -28,11 +28,11 @@ class TableHandleManagerImpl final : public std::enable_shared_from_this<TableHa
 
 public:
   [[nodiscard]]
-  static std::shared_ptr<TableHandleManagerImpl> Create(std::optional<Ticket> console_id,
+  static std::shared_ptr<TableHandleManagerImpl> Create(std::string session_type,
       std::shared_ptr<ServerType> server, std::shared_ptr<ExecutorType> executor,
       std::shared_ptr<ExecutorType> flight_executor);
 
-  TableHandleManagerImpl(Private, std::optional<Ticket> &&console_id,
+  TableHandleManagerImpl(Private, std::string &&session_type,
       std::shared_ptr<ServerType> &&server, std::shared_ptr<ExecutorType> &&executor,
       std::shared_ptr<ExecutorType> &&flight_executor);
   TableHandleManagerImpl(const TableHandleManagerImpl &other) = delete;
@@ -68,8 +68,9 @@ public:
   void AddSubscriptionHandle(std::shared_ptr<SubscriptionHandle> handle);
   void RemoveSubscriptionHandle(const std::shared_ptr<SubscriptionHandle> &handle);
 
+  /** Returns the console Ticket, starting the console on first call. Throws if there is no script language. */
   [[nodiscard]]
-  const std::optional<Ticket> &ConsoleId() const { return consoleId_; }
+  const Ticket &EnsureConsoleId();
   [[nodiscard]]
   const std::shared_ptr<ServerType> &Server() const { return server_; }
   [[nodiscard]]
@@ -79,10 +80,15 @@ public:
 
 private:
   const std::string me_;  // useful printable object name for logging
-  std::optional<Ticket> consoleId_;
+  // Scripting language for this session; empty means console operations throw.
+  const std::string sessionType_;
   std::shared_ptr<ServerType> server_;
   std::shared_ptr<ExecutorType> executor_;
   std::shared_ptr<ExecutorType> flightExecutor_;
+  // Guards consoleId_. Not mutex_: starting the console makes an RPC under this lock.
+  std::mutex consoleMutex_;
+  // Lazily set by EnsureConsoleId(); never reset.
+  std::optional<Ticket> consoleId_;
   // Protects the below for concurrent access.
   std::mutex mutex_;
   // The SubscriptionHandles for the tables we have subscribed to. We keep these at the TableHandleManagerImpl level

--- a/cpp-client/deephaven/dhclient/src/impl/client_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/client_impl.cc
@@ -5,13 +5,8 @@
 
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <stdexcept>
 #include "deephaven/client/impl/table_handle_manager_impl.h"
-
-using io::deephaven::proto::backplane::grpc::Ticket;
-using io::deephaven::proto::backplane::script::grpc::StartConsoleRequest;
-using io::deephaven::proto::backplane::script::grpc::StartConsoleResponse;
 
 using deephaven::client::impl::TableHandleManagerImpl;
 using deephaven::client::server::Server;
@@ -24,20 +19,10 @@ std::shared_ptr<ClientImpl> ClientImpl::Create(
     std::shared_ptr<Executor> executor,
     std::shared_ptr<Executor> flight_executor,
     std::string session_type) {
-  std::optional<Ticket> console_ticket;
-  if (!session_type.empty()) {
-    StartConsoleRequest req;
-    *req.mutable_result_id() = server->NewTicket();
-    *req.mutable_session_type() = std::move(session_type);
-    StartConsoleResponse resp;
-    server->SendRpc([&](grpc::ClientContext *ctx) {
-      return server->ConsoleStub()->StartConsole(ctx, req, &resp);
-    });
-    console_ticket = std::move(*resp.mutable_result_id());
-  }
-
+  // No console here: TableHandleManagerImpl starts one on first use, keeping
+  // Client::Connect free of the ConsoleService.StartConsole RPC.
   auto thmi = TableHandleManagerImpl::Create(
-          std::move(console_ticket),
+          std::move(session_type),
           std::move(server),
           std::move(executor),
           std::move(flight_executor));

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_impl.cc
@@ -605,14 +605,8 @@ void TableHandleImpl::Unsubscribe(const std::shared_ptr<SubscriptionHandle> &han
 }
 
 void TableHandleImpl::BindToVariable(std::string variable) {
-  const auto &console_id = managerImpl_->ConsoleId();
-  if (!console_id.has_value()) {
-    auto message = DEEPHAVEN_LOCATION_STR(
-        "Client was created without specifying a script language");
-    throw std::runtime_error(message);
-  }
   BindTableToVariableRequest req;
-  *req.mutable_console_id() = *console_id;
+  *req.mutable_console_id() = managerImpl_->EnsureConsoleId();
   req.set_variable_name(std::move(variable));
   *req.mutable_table_id() = ticket_;
 

--- a/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
+++ b/cpp-client/deephaven/dhclient/src/impl/table_handle_manager_impl.cc
@@ -19,24 +19,26 @@ using io::deephaven::proto::backplane::grpc::TimeTableRequest;
 using io::deephaven::proto::backplane::grpc::Ticket;
 using io::deephaven::proto::backplane::script::grpc::ExecuteCommandRequest;
 using io::deephaven::proto::backplane::script::grpc::ExecuteCommandResponse;
+using io::deephaven::proto::backplane::script::grpc::StartConsoleRequest;
+using io::deephaven::proto::backplane::script::grpc::StartConsoleResponse;
 
 namespace deephaven::client::impl {
 namespace {
 Ticket MakeScopeReference(std::string_view table_name);
 }  // namespace
 
-std::shared_ptr<TableHandleManagerImpl> TableHandleManagerImpl::Create(std::optional<Ticket> console_id,
+std::shared_ptr<TableHandleManagerImpl> TableHandleManagerImpl::Create(std::string session_type,
     std::shared_ptr<ServerType> server, std::shared_ptr<ExecutorType> executor,
     std::shared_ptr<ExecutorType> flight_executor) {
-  return std::make_shared<TableHandleManagerImpl>(Private(), std::move(console_id),
+  return std::make_shared<TableHandleManagerImpl>(Private(), std::move(session_type),
       std::move(server), std::move(executor), std::move(flight_executor));
 }
 
-TableHandleManagerImpl::TableHandleManagerImpl(Private, std::optional<Ticket> &&console_id,
+TableHandleManagerImpl::TableHandleManagerImpl(Private, std::string &&session_type,
     std::shared_ptr<ServerType> &&server, std::shared_ptr<ExecutorType> &&executor,
     std::shared_ptr<ExecutorType> &&flight_executor) :
     me_(deephaven::dhcore::utility::ObjectId("TableHandleManagerImpl", this)),
-    consoleId_(std::move(console_id)),
+    sessionType_(std::move(session_type)),
     server_(std::move(server)),
     executor_(std::move(executor)),
     flightExecutor_(std::move(flight_executor)) {
@@ -140,13 +142,28 @@ std::shared_ptr<TableHandleImpl> TableHandleManagerImpl::InputTable(
   return TableHandleImpl::Create(shared_from_this(), std::move(resp));
 }
 
-void TableHandleManagerImpl::RunScript(std::string code) {
-  if (!consoleId_.has_value()) {
+const Ticket &TableHandleManagerImpl::EnsureConsoleId() {
+  if (sessionType_.empty()) {
     auto message = DEEPHAVEN_LOCATION_STR("Client was created without specifying a script language");
     throw std::runtime_error(message);
   }
+  std::unique_lock guard(consoleMutex_);
+  if (!consoleId_.has_value()) {
+    StartConsoleRequest req;
+    *req.mutable_result_id() = server_->NewTicket();
+    *req.mutable_session_type() = sessionType_;
+    StartConsoleResponse resp;
+    server_->SendRpc([&](grpc::ClientContext *ctx) {
+      return server_->ConsoleStub()->StartConsole(ctx, req, &resp);
+    });
+    consoleId_ = std::move(*resp.mutable_result_id());
+  }
+  return *consoleId_;
+}
+
+void TableHandleManagerImpl::RunScript(std::string code) {
   ExecuteCommandRequest req;
-  *req.mutable_console_id() = *consoleId_;
+  *req.mutable_console_id() = EnsureConsoleId();
   *req.mutable_code() = std::move(code);
   ExecuteCommandResponse resp;
   server_->SendRpc([&](grpc::ClientContext *ctx) {

--- a/cpp-client/deephaven/tests/src/script_test.cc
+++ b/cpp-client/deephaven/tests/src/script_test.cc
@@ -46,4 +46,27 @@ mytable = empty_table(16).update(["intData = (int)(ii - 8)", "longData = (long)(
   expected.AddColumn("longData", long_data);
   TableComparerForTests::Compare(expected, t);
 }
+
+TEST_CASE("Table operations do not need a console", "[script]") {
+  // Never runs a script, so no console should be needed.
+  auto client = TableMakerForTests::CreateClient();
+  auto thm = client.GetManager();
+
+  auto t = thm.EmptyTable(10);
+  CHECK(t.NumRows() == 10);
+}
+
+TEST_CASE("Console is reused across scripts", "[script]") {
+  auto client = TableMakerForTests::CreateClient();
+  auto thm = client.GetManager();
+
+  thm.RunScript("from deephaven import empty_table\nt1 = empty_table(3)");
+  auto t1 = thm.FetchTable("t1");
+  CHECK(t1.NumRows() == 3);
+
+  // t1 is only in scope if both scripts hit the same console.
+  thm.RunScript("t2 = t1.update([\"x = ii\"])");
+  auto t2 = thm.FetchTable("t2");
+  CHECK(t2.NumRows() == 3);
+}
 }  // namespace deephaven::client::tests


### PR DESCRIPTION
Fixes DH-23437.

## Problem

`Client::Connect` issued a `ConsoleService.StartConsole` RPC whenever the session type was non-empty — and `ClientOptions` defaults it to `"python"`. Deployments that restrict consoles to administrators therefore rejected the connection outright, even for clients that never run a script.

This surfaced in the Deephaven Enterprise Flight SQL ODBC driver: creating a DSN and clicking **Test Connection** failed for a user who is only a viewer on the target Persistent Query. The driver only needs the worker's `FlightClient`; the console ticket it was forced to obtain was never used.

## Why deferring is correct

`StartConsole` does not create the script session — the worker already has one (`scriptSessionProvider.get()` in `ConsoleServiceGrpcImpl#startConsole`). The RPC validates the requested language and mints a ticket naming that existing session. Nothing needs it at connect time.

Java (`SessionImpl.console` on first `executeCode`) and Python (`ConsoleService.start_console` from `run_script`) already create the console on first use. C++ was the outlier.

## Change

`TableHandleManagerImpl` now holds the session type and starts the console on first use, in `EnsureConsoleId()`, guarded by its own mutex (not the one protecting `subscriptions_`, since console creation makes an RPC under the lock). `RunScript` and `BindToVariable` are the only two consumers of the console ticket.

All changes are in private headers, so no public API changes.

## Behavior change

Console permission failures and the server's session-type check (`ConsoleServiceGrpcImpl.java` — `"session type 'x' is not supported"`) now surface at the first `RunScript`/`BindToVariable` instead of at `Connect`. The error message for a client created without a script language is unchanged, and the existing test that pins it (`script_test.cc`, "Script session error") passes untouched.

First `RunScript`/`BindToVariable` costs one extra round trip.

## Testing

Two tests added to `script_test.cc`:
- table operations succeed on a client that never runs a script, so connect no longer needs a console;
- two scripts on one client see each other's variables, so the lazily created console is cached rather than recreated.

The C++ client only builds on Linux and Windows, so I have not built or run these locally — relying on CI.