### PR TITLE
feat(csharp/client): DH-23198: Gradle support for testing C# client (#8295)

### DIFF
--- a/csharp/client/Dh_NetClientTests/Dh_NetClientTests.csproj
+++ b/csharp/client/Dh_NetClientTests/Dh_NetClientTests.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <!-- TUnit's package props set this anyway, but they are not loaded during a cold
+         restore; without it declared here, restore evaluates the project as a Library
+         and skips downloading the AppHost pack that the build then needs. -->
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -13,7 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="TUnit" Version="1.56.0" />
   </ItemGroup>
 

--- a/csharp/client/Dh_NetClientTests/global.json
+++ b/csharp/client/Dh_NetClientTests/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/csharp/client/Dockerfile
+++ b/csharp/client/Dockerfile
@@ -1,0 +1,18 @@
+# Builds the Dh_NetClientTests test suite. Built and run by the testCsharpClient task in
+# build.gradle, which stages the build context (sources under csharp/client/, backplane
+# .proto files under proto/) and provides the deephaven/dotnet* base images
+# (see docker/registry/dotnet and docker/registry/dotnet-runtime-8).
+FROM deephaven/dotnet:local-build
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+# The SDK image only carries the net10.0 runtime; graft in the net8.0 runtime from the
+# (digest-pinned) official runtime image so that both target frameworks of the test
+# project can execute.
+COPY --from=deephaven/dotnet-runtime-8:local-build /usr/share/dotnet/shared/Microsoft.NETCore.App /usr/share/dotnet/shared/Microsoft.NETCore.App/
+WORKDIR /project
+COPY . /project/
+RUN set -eux; \
+    mkdir /out; \
+    dotnet restore /project/csharp/client/Dh_NetClientTests/Dh_NetClientTests.csproj; \
+    dotnet build /project/csharp/client/Dh_NetClientTests/Dh_NetClientTests.csproj \
+      -c Release --no-restore

--- a/csharp/client/build.gradle
+++ b/csharp/client/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id 'com.bmuschko.docker-remote-api'
+    id 'io.deephaven.project.register'
+    id 'io.deephaven.deephaven-in-docker'
+}
+
+evaluationDependsOn Docker.registryProject('dotnet')
+evaluationDependsOn Docker.registryProject('dotnet-runtime-8')
+
+// start a grpc-api server
+String randomSuffix = UUID.randomUUID().toString();
+deephavenDocker {
+    envVars.set([
+            'START_OPTS':'-Xmx512m -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler'
+    ])
+    containerName.set "dh-server-for-csharp-${randomSuffix}"
+    networkName.set "csharp-test-network-${randomSuffix}"
+}
+
+def testCsharpClient = Docker.registerDockerTask(project, 'testCsharpClient') {
+    copyIn {
+        // Dh_NetClient.csproj references the backplane .proto files via a relative
+        // path (../../../proto/...), so lay things out just like the repo does.
+        from(layout.projectDirectory) {
+            include 'Dh_NetClient/**'
+            include 'Dh_NetClientTests/**'
+            exclude '**/bin/**'
+            exclude '**/obj/**'
+            into 'csharp/client'
+        }
+        from("${rootDir}/proto/proto-backplane-grpc/src/main/proto") {
+            into 'proto/proto-backplane-grpc/src/main/proto'
+        }
+    }
+    copyOut {
+        into layout.buildDirectory.dir('test-results')
+    }
+    dockerfile file('Dockerfile')
+    containerDependencies.dependsOn = [deephavenDocker.healthyTask]
+    containerDependencies.finalizedBy = deephavenDocker.endTask
+    network = deephavenDocker.networkName.get()
+    parentContainers = [ Docker.registryTask(project, 'dotnet'), Docker.registryTask(project, 'dotnet-runtime-8') ]
+    entrypoint = ['/bin/bash', '-c',
+                  """set -euxo pipefail
+                     export DH_HOST=${deephavenDocker.containerName.get()}
+                     export DH_PORT=10000
+                     # global.json opts dotnet test into Microsoft.Testing.Platform mode,
+                     # which runs the tests for every target framework in the project.
+                     cd /project/csharp/client/Dh_NetClientTests
+                     dotnet test -c Release --no-build --report-trx --results-directory /out"""]
+}
+deephavenDocker.shouldLogIfTaskFails testCsharpClient
+tasks.check.dependsOn(testCsharpClient)

--- a/csharp/client/gradle.properties
+++ b/csharp/client/gradle.properties
@@ -1,0 +1,1 @@
+io.deephaven.project.ProjectType=BASIC

--- a/docker/registry/dotnet-runtime-8/build.gradle
+++ b/docker/registry/dotnet-runtime-8/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'io.deephaven.project.register'
+}

--- a/docker/registry/dotnet-runtime-8/gradle.properties
+++ b/docker/registry/dotnet-runtime-8/gradle.properties
@@ -1,0 +1,3 @@
+io.deephaven.project.ProjectType=DOCKER_REGISTRY
+deephaven.registry.imageName=mcr.microsoft.com/dotnet/runtime:8.0
+deephaven.registry.imageId=mcr.microsoft.com/dotnet/runtime@sha256:4d0117b335477ad6c35cfa70c75424e72bbf05645a5d77c1f68a74fdd057676a

--- a/docker/registry/dotnet/build.gradle
+++ b/docker/registry/dotnet/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'io.deephaven.project.register'
+}

--- a/docker/registry/dotnet/gradle.properties
+++ b/docker/registry/dotnet/gradle.properties
@@ -1,0 +1,3 @@
+io.deephaven.project.ProjectType=DOCKER_REGISTRY
+deephaven.registry.imageName=mcr.microsoft.com/dotnet/sdk:10.0
+deephaven.registry.imageId=mcr.microsoft.com/dotnet/sdk@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664

--- a/settings.gradle
+++ b/settings.gradle
@@ -155,6 +155,9 @@ include(':codegen')
 
 include(':cpp-client')
 
+include(':csharp-client')
+project(':csharp-client').projectDir = file('csharp/client')
+
 include(':R')
 
 include(':replication-util')


### PR DESCRIPTION
Cherry-picking from `main` into `v42.x`.
